### PR TITLE
Initial rate limit subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "trace-limit"
+version = "0.1.0"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-env-logger 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
+ "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
+]
+
+[[package]]
 name = "trace-metrics"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   ".",
   "lib/file-source",
   "lib/trace-metrics",
+  "lib/trace-limit",
   "lib/codec",
 ]
 

--- a/lib/trace-limit/Cargo.toml
+++ b/lib/trace-limit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "trace-limit"
+version = "0.1.0"
+authors = ["Lucio Franco <luciofranco14@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+tokio-trace-core = "0.2"
+ansi_term = "0.11"
+
+[dev-dependencies]
+tokio-trace = "0.1"
+tokio-trace-fmt = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
+tokio-trace-env-logger = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
+criterion = "0.2"
+
+[[bench]]
+name = "limit"
+harness = false

--- a/lib/trace-limit/benches/limit.rs
+++ b/lib/trace-limit/benches/limit.rs
@@ -1,0 +1,141 @@
+#[macro_use]
+extern crate tokio_trace;
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{black_box, Criterion};
+
+use std::{
+    fmt,
+    sync::{Mutex, MutexGuard},
+};
+use tokio_trace::{field, span, Event, Id, Metadata};
+use trace_limit::LimitSubscriber;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("basline_record", |b| {
+        let sub = VisitingSubscriber(Mutex::new(String::from("")));
+        let n = black_box(5000);
+        tokio_trace::subscriber::with_default(sub, || {
+            b.iter(|| {
+                for _ in 0..n {
+                    info!(
+                        message = "hello world",
+                        foo = "foo",
+                        bar = "bar",
+                        baz = 3,
+                        quuux = tokio_trace::field::debug(0.99)
+                    )
+                }
+            })
+        });
+    });
+
+    c.bench_function("limit_record_5", |b| {
+        let sub = LimitSubscriber::new(VisitingSubscriber(Mutex::new(String::from(""))));
+        let n = black_box(5000);
+        tokio_trace::subscriber::with_default(sub, || {
+            b.iter(|| {
+                for _ in 0..n {
+                    info!(
+                        message = "hello world",
+                        foo = "foo",
+                        bar = "bar",
+                        baz = 3,
+                        quuux = tokio_trace::field::debug(0.99),
+                        rate_limit = 5
+                    )
+                }
+            })
+        });
+    });
+
+    c.bench_function("limit_record_100", |b| {
+        let sub = LimitSubscriber::new(VisitingSubscriber(Mutex::new(String::from(""))));
+        let n = black_box(5000);
+        tokio_trace::subscriber::with_default(sub, || {
+            b.iter(|| {
+                for _ in 0..n {
+                    info!(
+                        message = "hello world",
+                        foo = "foo",
+                        bar = "bar",
+                        baz = 3,
+                        quuux = tokio_trace::field::debug(0.99),
+                        rate_limit = 100
+                    )
+                }
+            })
+        });
+    });
+
+    c.bench_function("limit_record_1000", |b| {
+        let sub = LimitSubscriber::new(VisitingSubscriber(Mutex::new(String::from(""))));
+        let n = black_box(5000);
+        tokio_trace::subscriber::with_default(sub, || {
+            b.iter(|| {
+                for _ in 0..n {
+                    info!(
+                        message = "hello world",
+                        foo = "foo",
+                        bar = "bar",
+                        baz = 3,
+                        quuux = tokio_trace::field::debug(0.99),
+                        rate_limit = 1000
+                    )
+                }
+            })
+        });
+    });
+}
+
+/// Simulates a subscriber that records span data.
+struct VisitingSubscriber(Mutex<String>);
+
+struct Visitor<'a>(MutexGuard<'a, String>);
+
+impl<'a> field::Visit for Visitor<'a> {
+    fn record_debug(&mut self, _field: &field::Field, value: &dyn fmt::Debug) {
+        use std::fmt::Write;
+        let _ = write!(&mut *self.0, "{:?}", value);
+    }
+}
+
+impl tokio_trace::Subscriber for VisitingSubscriber {
+    fn new_span(&self, span: &span::Attributes) -> Id {
+        let mut visitor = Visitor(self.0.lock().unwrap());
+        span.record(&mut visitor);
+        Id::from_u64(0xDEADFACE)
+    }
+
+    fn record(&self, _span: &Id, values: &span::Record) {
+        let mut visitor = Visitor(self.0.lock().unwrap());
+        values.record(&mut visitor);
+    }
+
+    fn event(&self, event: &Event) {
+        let mut visitor = Visitor(self.0.lock().unwrap());
+        event.record(&mut visitor);
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        let _ = (span, follows);
+    }
+
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        let _ = metadata;
+        true
+    }
+
+    fn enter(&self, span: &Id) {
+        let _ = span;
+    }
+
+    fn exit(&self, span: &Id) {
+        let _ = span;
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/lib/trace-limit/examples/basic.rs
+++ b/lib/trace-limit/examples/basic.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate tokio_trace;
+
+use tokio_trace::Dispatch;
+use trace_limit::LimitSubscriber;
+
+fn main() {
+    let subscriber = tokio_trace_fmt::FmtSubscriber::builder().full().finish();
+    tokio_trace_env_logger::try_init().expect("init log adapter");
+    let subscriber = LimitSubscriber::new(subscriber);
+    let dispatch = Dispatch::new(subscriber);
+
+    tokio_trace::dispatcher::with_default(&dispatch, || {
+        // This should print every 2 events
+        for i in 0..40 {
+            std::thread::sleep(std::time::Duration::from_millis(333));
+            info!(message = "hello, world!", count = &i, rate_limit = 3 as u64);
+        }
+    })
+}

--- a/lib/trace-limit/src/lib.rs
+++ b/lib/trace-limit/src/lib.rs
@@ -1,0 +1,185 @@
+use ansi_term::Colour;
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        RwLock,
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tokio_trace_core::{
+    callsite::Identifier,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+    Event, Interest, Level, Metadata, Subscriber,
+};
+
+pub struct LimitSubscriber<S> {
+    inner: S,
+    events: RwLock<HashMap<Identifier, (AtomicUsize, AtomicUsize)>>,
+}
+
+#[derive(Default)]
+struct LimitVisitor {
+    limit: Option<usize>,
+}
+
+impl LimitVisitor {
+    pub fn into_limit(self) -> Option<usize> {
+        self.limit
+    }
+}
+
+impl<S> LimitSubscriber<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            events: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl<S: Subscriber> Subscriber for LimitSubscriber<S> {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn new_span(&self, span: &Attributes) -> Id {
+        self.inner.new_span(span)
+    }
+
+    fn record(&self, span: &Id, values: &Record) {
+        self.inner.record(span, values);
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        self.inner.record_follows_from(span, follows);
+    }
+
+    fn event(&self, event: &Event) {
+        if event.fields().any(|f| f.name() == "rate_limit") {
+            let mut limit_visitor = LimitVisitor::default();
+            event.record(&mut limit_visitor);
+
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as usize;
+
+            if let Some(limit) = limit_visitor.into_limit() {
+                let id = event.metadata().callsite();
+
+                let events = self.events.read().unwrap();
+                if let Some((count, start)) = events.get(&id) {
+                    let local_count = count.fetch_add(1, Ordering::Relaxed);
+
+                    if ts - start.load(Ordering::Relaxed) < limit {
+                        // If we have seen this event more than once,
+                        // then lets early return to avoid passing this
+                        // event to the inner subscriber.
+                        if local_count >= 1 {
+                            return;
+                        }
+                    } else {
+                        drop(events);
+
+                        let mut events = self.events.write().unwrap();
+                        events.remove(&id);
+                        drop(events);
+
+                        let meta = event.metadata();
+
+                        let mut visitor = FmtVisitor::default();
+                        event.record(&mut visitor);
+
+                        let message = if let Some(message) = &visitor.message {
+                            &message
+                        } else {
+                            "unknown event"
+                        };
+
+                        // We need to replicate the way that fmt logs events
+                        // because we currently can not create new fresh events.
+                        println!(
+                            "{} {} {:?} {:?} logs were rate limited.",
+                            FmtLevel(meta.level()),
+                            meta.target(),
+                            local_count,
+                            message
+                        );
+
+                        return;
+                    }
+                } else {
+                    drop(events);
+                    let count = AtomicUsize::new(1);
+                    let ts = AtomicUsize::new(ts as usize);
+                    let mut map = self.events.write().unwrap();
+                    map.insert(id, (count, ts));
+                }
+            }
+        }
+
+        self.inner.event(event);
+    }
+
+    fn enter(&self, span: &Id) {
+        self.inner.enter(span);
+    }
+
+    fn exit(&self, span: &Id) {
+        self.inner.exit(span);
+    }
+
+    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+        self.inner.register_callsite(metadata)
+    }
+
+    fn clone_span(&self, id: &Id) -> Id {
+        self.inner.clone_span(id)
+    }
+
+    fn drop_span(&self, id: Id) {
+        self.inner.drop_span(id.clone());
+    }
+}
+
+impl Visit for LimitVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "rate_limit" {
+            self.limit = Some(value as usize);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &fmt::Debug) {}
+}
+
+struct FmtLevel<'a>(&'a Level);
+
+impl<'a> fmt::Display for FmtLevel<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self.0 {
+            Level::TRACE => write!(f, "{}", Colour::Purple.paint("TRACE")),
+            Level::DEBUG => write!(f, "{}", Colour::Blue.paint("DEBUG")),
+            Level::INFO => write!(f, "{}", Colour::Green.paint(" INFO")),
+            Level::WARN => write!(f, "{}", Colour::Yellow.paint(" WARN")),
+            Level::ERROR => write!(f, "{}", Colour::Red.paint("ERROR")),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct FmtVisitor {
+    pub message: Option<String>,
+}
+
+impl Visit for FmtVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &fmt::Debug) {}
+}


### PR DESCRIPTION
This implements a wrapper subscriber for tokio-trace and the tokio-trace-fmt subscriber. The goal here is to allow us to rate limit certain noisy logs. This only implements the wrapper sub, benchmarks, and an example. This does not include its use in vector that will come in a follow-up PR.

@lukesteensen I believe we've discussed this enough over slack that you should understand it but feel free to ping me with any questions.

Closes #418