### PR TITLE
Use floats for metrics values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vector"
-version = "0.3.0-dev"
+version = "0.4.0-dev"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -37,19 +37,19 @@ message Metric {
 
 message Counter {
   string name = 1;
-  uint32 val = 2;
+  float val = 2;
   float sampling = 3;
 }
 
 message Timer {
   string name = 1;
-  uint32 val = 2;
+  float val = 2;
   float sampling = 3;
 }
 
 message Gauge {
   string name = 1;
-  uint32 val = 2;
+  float val = 2;
   enum Direction {
     None = 0;
     Plus = 1;

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -2,17 +2,17 @@
 pub enum Metric {
     Counter {
         name: String,
-        val: u32,
+        val: f32,
         sampling: Option<f32>,
     },
     Timer {
         name: String,
-        val: u32,
+        val: f32,
         sampling: Option<f32>,
     },
     Gauge {
         name: String,
-        val: u32,
+        val: f32,
         direction: Option<Direction>,
     },
     Set {

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -146,7 +146,7 @@ mod test {
             parse("foo:1|c"),
             Ok(Metric::Counter {
                 name: "foo".into(),
-                val: 1,
+                val: 1.0,
                 sampling: None
             }),
         );
@@ -158,7 +158,7 @@ mod test {
             parse("bar:2|c|@0.1"),
             Ok(Metric::Counter {
                 name: "bar".into(),
-                val: 2,
+                val: 2.0,
                 sampling: Some(0.1)
             }),
         );
@@ -170,7 +170,7 @@ mod test {
             parse("glork:320|ms|@0.1"),
             Ok(Metric::Timer {
                 name: "glork".into(),
-                val: 320,
+                val: 320.0,
                 sampling: Some(0.1)
             }),
         );
@@ -182,7 +182,7 @@ mod test {
             parse("gaugor:333|g"),
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
-                val: 333,
+                val: 333.0,
                 direction: None
             }),
         );
@@ -194,7 +194,7 @@ mod test {
             parse("gaugor:-4|g"),
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
-                val: 4,
+                val: 4.0,
                 direction: Some(Direction::Minus)
             }),
         );
@@ -202,7 +202,7 @@ mod test {
             parse("gaugor:+10|g"),
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
-                val: 10,
+                val: 10.0,
                 direction: Some(Direction::Plus)
             }),
         );

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -101,7 +101,7 @@ impl Transform for LogToMetric {
                             if let Ok(val) = val.to_string_lossy().parse::<f32>() {
                                 return Some(Event::Metric(Metric::Counter {
                                     name: counter.sanitized_name.to_string(),
-                                    val: val as u32,
+                                    val,
                                     sampling: None,
                                 }));
                             } else {
@@ -111,7 +111,7 @@ impl Transform for LogToMetric {
                         } else {
                             return Some(Event::Metric(Metric::Counter {
                                 name: counter.sanitized_name.to_string(),
-                                val: 1,
+                                val: 1.0,
                                 sampling: None,
                             }));
                         };
@@ -166,7 +166,7 @@ mod tests {
             metric.into_metric(),
             Metric::Counter {
                 name: "status_total".into(),
-                val: 1,
+                val: 1.0,
                 sampling: None
             }
         );
@@ -196,7 +196,7 @@ mod tests {
             metric.into_metric(),
             Metric::Counter {
                 name: "exception_total".into(),
-                val: 1,
+                val: 1.0,
                 sampling: None
             }
         );
@@ -241,7 +241,7 @@ mod tests {
 
         let mut log = Event::from("i am a log");
         log.as_mut_log()
-            .insert_explicit("amount".into(), "33.95".into());
+            .insert_explicit("amount".into(), "33.99".into());
 
         let mut transform = LogToMetric::new(&config);
 
@@ -250,7 +250,7 @@ mod tests {
             metric.into_metric(),
             Metric::Counter {
                 name: "amount_total".into(),
-                val: 33,
+                val: 33.99,
                 sampling: None
             }
         );
@@ -280,7 +280,7 @@ mod tests {
             metric.into_metric(),
             Metric::Gauge {
                 name: "memory_rss_bytes".into(),
-                val: 123,
+                val: 123.0,
                 direction: None,
             }
         );


### PR DESCRIPTION
This is to conform to Prom, Statsd and Graphite (and probably many others) metrics protocols which are using `float` types for passing values around.

Relates to #540