### PR TITLE
Turn one event into multiple metrics

### DIFF
--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -13,4 +13,10 @@ pub mod tokenizer;
 
 pub trait Transform: Send {
     fn transform(&mut self, event: Event) -> Option<Event>;
+
+    fn transform_into(&mut self, output: &mut Vec<Event>, event: Event) {
+        if let Some(transformed) = self.transform(event) {
+            output.push(transformed);
+        }
+    }
 }


### PR DESCRIPTION
This is a little funky, but it seemed to hit the right spot of non-invasive, flexible, and no perf impact (I was worried but the benches say I'm ok). Basically, transforms now have the option to implement a `transform_into` method where they can push as many events as they want into an output vec. The weird part is that this "overrides" the `transform` function but you still have to implement it.

Reasons I didn't do other things:
* Returning a vec from `transform` required a bunch of changes and made most transforms more annoying to write, plus required allocating that vec no matter what
* Passing in the output channel would mean transforms have to become more complicated stream adapters since `send` is async
* Making a whole new stream adapter so we could reuse the same output vec would have been a lot more work and the benchmarks showed that we're not any slower than before
* Doing a properly layered two-trait thing for `transform` and `transform` into would have gotten rid of the weirdness, but that also seemed like too much work for the moment. I think it's more likely that we rework this before too long than someone gets confused about the two methods.

Closes #379 