### PR TITLE
Fix typo "guage" -> "gauge"

### DIFF
--- a/docs/about/data-model.md
+++ b/docs/about/data-model.md
@@ -177,7 +177,7 @@ to address core issues such as supporting [histograms][url.issue_384] and
 {% endhint %}
 
 Vector characterizes a "metric" as an individual measurement with any number
-of labels. The measure must either be a `counter`, `guage`, `set`, or `timer`.
+of labels. The measure must either be a `counter`, `gauge`, `set`, or `timer`.
 
 For example:
 
@@ -195,7 +195,7 @@ For example:
 {% code-tabs-item title="gauge" %}
 ```javascript
 {
-  "guage": {
+  "gauge": {
     "name": "gas_tank",
     "val": 0.5
   }

--- a/docs/usage/configuration/sources/statsd.md
+++ b/docs/usage/configuration/sources/statsd.md
@@ -89,7 +89,7 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {% endcode-tabs %}
 
 {% endtab %}
-{% tab title="Guage" %}
+{% tab title="Gauge" %}
 Given the following Statsd guage:
 
 ```

--- a/scripts/metadata.toml
+++ b/scripts/metadata.toml
@@ -366,9 +366,9 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 """
 
 [[sources.statsd.examples]]
-name = "Guage"
+name = "Gauge"
 body = """\
-Given the following Statsd guage:
+Given the following Statsd gauge:
 
 ```
 gas_tank:0.50|g
@@ -380,7 +380,7 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {% code-tabs-item title="metric" %}
 ```javascript
 {
-  "guage": {
+  "gauge": {
     "name": "gas_tank",
     "val": 0.5
   }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -260,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn memory_usage_guage() {
+    fn memory_usage_gauge() {
         let config: LogToMetricConfig = toml::from_str(
             r##"
             [[metrics]]


### PR DESCRIPTION
### Description

Browsed the docs and found this typo. I guess it should be `gauge`.

### TODO

- [ ] `CHANGELOG.md` has been updated to reflect noteworthy changes
- [ ] `scripts/metadata.toml` has been updated to reflect configuration changes