### PR TITLE
feat(metrics): add sampling

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -38,13 +38,12 @@ message Metric {
 message Counter {
   string name = 1;
   float val = 2;
-  float sampling = 3;
 }
 
 message Timer {
   string name = 1;
   float val = 2;
-  float sampling = 3;
+  float count = 3;
 }
 
 message Gauge {

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -43,7 +43,7 @@ message Counter {
 message Timer {
   string name = 1;
   float val = 2;
-  float count = 3;
+  uint32 sample_rate = 3;
 }
 
 message Gauge {

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -32,6 +32,7 @@ message Metric {
     Timer timer = 2;
     Gauge gauge = 3;
     Set set = 4;
+    Histogram histogram = 5;
   }
 }
 
@@ -60,4 +61,10 @@ message Gauge {
 message Set {
   string name = 1;
   string val = 2;
+}
+
+message Histogram {
+  string name = 1;
+  float val = 2;
+  uint32 sample_rate = 3;
 }

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -3,12 +3,11 @@ pub enum Metric {
     Counter {
         name: String,
         val: f32,
-        sampling: Option<f32>,
     },
     Timer {
         name: String,
         val: f32,
-        sampling: Option<f32>,
+        count: f32,
     },
     Gauge {
         name: String,

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -7,7 +7,7 @@ pub enum Metric {
     Timer {
         name: String,
         val: f32,
-        count: f32,
+        sample_rate: u32,
     },
     Gauge {
         name: String,

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -9,6 +9,11 @@ pub enum Metric {
         val: f32,
         sample_rate: u32,
     },
+    Histogram {
+        name: String,
+        val: f32,
+        sample_rate: u32,
+    },
     Gauge {
         name: String,
         val: f32,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -315,30 +315,15 @@ impl From<proto::EventWrapper> for Event {
             EventProto::Metric(proto) => {
                 let metric = proto.metric.unwrap();
                 match metric {
-                    MetricProto::Counter(counter) => {
-                        let sampling = if counter.sampling == 0f32 {
-                            None
-                        } else {
-                            Some(counter.sampling)
-                        };
-                        Event::Metric(Metric::Counter {
-                            name: counter.name,
-                            val: counter.val,
-                            sampling,
-                        })
-                    }
-                    MetricProto::Timer(timer) => {
-                        let sampling = if timer.sampling == 0f32 {
-                            None
-                        } else {
-                            Some(timer.sampling)
-                        };
-                        Event::Metric(Metric::Timer {
-                            name: timer.name,
-                            val: timer.val,
-                            sampling,
-                        })
-                    }
+                    MetricProto::Counter(counter) => Event::Metric(Metric::Counter {
+                        name: counter.name,
+                        val: counter.val,
+                    }),
+                    MetricProto::Timer(timer) => Event::Metric(Metric::Timer {
+                        name: timer.name,
+                        val: timer.val,
+                        count: timer.count,
+                    }),
                     MetricProto::Gauge(gauge) => {
                         let direction = match gauge.direction() {
                             proto::gauge::Direction::None => None,
@@ -397,31 +382,15 @@ impl From<Event> for proto::EventWrapper {
 
                 proto::EventWrapper { event: Some(event) }
             }
-            Event::Metric(Metric::Counter {
-                name,
-                val,
-                sampling,
-            }) => {
-                let counter = proto::Counter {
-                    name,
-                    val,
-                    sampling: sampling.unwrap_or(0f32),
-                };
+            Event::Metric(Metric::Counter { name, val }) => {
+                let counter = proto::Counter { name, val };
                 let event = EventProto::Metric(proto::Metric {
                     metric: Some(MetricProto::Counter(counter)),
                 });
                 proto::EventWrapper { event: Some(event) }
             }
-            Event::Metric(Metric::Timer {
-                name,
-                val,
-                sampling,
-            }) => {
-                let timer = proto::Timer {
-                    name,
-                    val,
-                    sampling: sampling.unwrap_or(0f32),
-                };
+            Event::Metric(Metric::Timer { name, val, count }) => {
+                let timer = proto::Timer { name, val, count };
                 let event = EventProto::Metric(proto::Metric {
                     metric: Some(MetricProto::Timer(timer)),
                 });

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -324,6 +324,11 @@ impl From<proto::EventWrapper> for Event {
                         val: timer.val,
                         sample_rate: timer.sample_rate,
                     }),
+                    MetricProto::Histogram(hist) => Event::Metric(Metric::Histogram {
+                        name: hist.name,
+                        val: hist.val,
+                        sample_rate: hist.sample_rate,
+                    }),
                     MetricProto::Gauge(gauge) => {
                         let direction = match gauge.direction() {
                             proto::gauge::Direction::None => None,
@@ -401,6 +406,21 @@ impl From<Event> for proto::EventWrapper {
                 };
                 let event = EventProto::Metric(proto::Metric {
                     metric: Some(MetricProto::Timer(timer)),
+                });
+                proto::EventWrapper { event: Some(event) }
+            }
+            Event::Metric(Metric::Histogram {
+                name,
+                val,
+                sample_rate,
+            }) => {
+                let hist = proto::Histogram {
+                    name,
+                    val,
+                    sample_rate,
+                };
+                let event = EventProto::Metric(proto::Metric {
+                    metric: Some(MetricProto::Histogram(hist)),
                 });
                 proto::EventWrapper { event: Some(event) }
             }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -322,7 +322,7 @@ impl From<proto::EventWrapper> for Event {
                     MetricProto::Timer(timer) => Event::Metric(Metric::Timer {
                         name: timer.name,
                         val: timer.val,
-                        count: timer.count,
+                        sample_rate: timer.sample_rate,
                     }),
                     MetricProto::Gauge(gauge) => {
                         let direction = match gauge.direction() {
@@ -389,8 +389,16 @@ impl From<Event> for proto::EventWrapper {
                 });
                 proto::EventWrapper { event: Some(event) }
             }
-            Event::Metric(Metric::Timer { name, val, count }) => {
-                let timer = proto::Timer { name, val, count };
+            Event::Metric(Metric::Timer {
+                name,
+                val,
+                sample_rate,
+            }) => {
+                let timer = proto::Timer {
+                    name,
+                    val,
+                    sample_rate,
+                };
                 let event = EventProto::Metric(proto::Metric {
                     metric: Some(MetricProto::Timer(timer)),
                 });

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -156,12 +156,9 @@ impl Sink for PrometheusSink {
         self.start_server_if_needed();
 
         match event.into_metric() {
-            Metric::Counter {
-                name,
-                val,
-                // TODO: take sampling into account
-                sampling: _,
-            } => self.with_counter(name, |counter| counter.inc_by(val as f64)),
+            Metric::Counter { name, val } => {
+                self.with_counter(name, |counter| counter.inc_by(val as f64))
+            }
             Metric::Gauge {
                 name,
                 val,

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -82,12 +82,10 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 direction: parse_direction(parts[0])?,
             }
         }
-        "s" => {
-            Metric::Set {
-                name: sanitize_key(key),
-                val: parts[0].into(),
-            }
-        }
+        "s" => Metric::Set {
+            name: sanitize_key(key),
+            val: parts[0].into(),
+        },
         other => return Err(ParseError::UnknownMetricType(other.into())),
     };
     Ok(metric)

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -30,31 +30,29 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
 
     let metric = match metric_type {
         "c" => {
-            let count = if let Some(s) = parts.get(2) {
+            let sample_rate = if let Some(s) = parts.get(2) {
                 1.0 / sanitize_sampling(parse_sampling(s)?)
             } else {
                 1.0
             };
             let val: f32 = parts[0].parse()?;
-            let metric = Metric::Counter {
+            Metric::Counter {
                 name: sanitize_key(key),
-                val: val * count,
-            };
-            metric
+                val: val * sample_rate,
+            }
         }
         "h" | "ms" => {
-            let count = if let Some(s) = parts.get(2) {
+            let sample_rate = if let Some(s) = parts.get(2) {
                 1.0 / sanitize_sampling(parse_sampling(s)?)
             } else {
                 1.0
             };
             let val: f32 = parts[0].parse()?;
-            let metric = Metric::Timer {
+            Metric::Timer {
                 name: sanitize_key(key),
-                val: val * count,
-                count,
-            };
-            metric
+                val,
+                sample_rate: sample_rate as u32,
+            }
         }
         "g" => {
             let val = if parts[0]
@@ -203,8 +201,8 @@ mod test {
             parse("glork:320|ms|@0.1"),
             Ok(Metric::Timer {
                 name: "glork".into(),
-                val: 3200.0,
-                count: 10.0
+                val: 320.0,
+                sample_rate: 10
             }),
         );
     }

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -76,19 +76,17 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             } else {
                 parts[0][1..].parse()?
             };
-            let metric = Metric::Gauge {
+            Metric::Gauge {
                 name: sanitize_key(key),
                 val,
                 direction: parse_direction(parts[0])?,
-            };
-            metric
+            }
         }
         "s" => {
-            let metric = Metric::Set {
+            Metric::Set {
                 name: sanitize_key(key),
                 val: parts[0].into(),
-            };
-            metric
+            }
         }
         other => return Err(ParseError::UnknownMetricType(other.into())),
     };

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -109,7 +109,6 @@ impl Transform for LogToMetric {
                                 output.push(Event::Metric(Metric::Counter {
                                     name: counter.sanitized_name.to_string(),
                                     val,
-                                    sampling: None,
                                 }));
                             } else {
                                 trace!("failed to parse counter value");
@@ -118,7 +117,6 @@ impl Transform for LogToMetric {
                             output.push(Event::Metric(Metric::Counter {
                                 name: counter.sanitized_name.to_string(),
                                 val: 1.0,
-                                sampling: None,
                             }));
                         };
                     }
@@ -170,7 +168,6 @@ mod tests {
             Metric::Counter {
                 name: "status_total".into(),
                 val: 1.0,
-                sampling: None
             }
         );
     }
@@ -200,7 +197,6 @@ mod tests {
             Metric::Counter {
                 name: "exception_total".into(),
                 val: 1.0,
-                sampling: None
             }
         );
     }
@@ -254,7 +250,6 @@ mod tests {
             Metric::Counter {
                 name: "amount_total".into(),
                 val: 33.99,
-                sampling: None
             }
         );
     }
@@ -366,7 +361,6 @@ mod tests {
             Metric::Counter {
                 name: "exception_total".into(),
                 val: 1.0,
-                sampling: None
             }
         );
         assert_eq!(
@@ -374,7 +368,6 @@ mod tests {
             Metric::Counter {
                 name: "status_total".into(),
                 val: 1.0,
-                sampling: None
             }
         );
     }


### PR DESCRIPTION
Here `sampling` is removed from `Metric` and a new wrapper `MetricPack` type introduced. When I was thinking about Statsd sampling it looked a lot like a compression technic which should be external to the measurement itself. The new types emphasise this idea.

Upon receiving sampled Statsd counter we do value correction inplace, because the semantics is straightforward, and for sampled timer we take an approach similar to [this](https://github.com/prometheus/statsd_exporter/blob/master/bridge_test.go#L224) - multiple events are emitted.

Ref #540 