### PR TITLE
Rename tokio-trace to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,26 +3238,8 @@ dependencies = [
  "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
@@ -3272,35 +3254,9 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-env-logger"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
-dependencies = [
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
 ]
 
 [[package]]
@@ -3316,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "tracing-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+source = "git+https://github.com/tokio-rs/tracing#3dc80c9196b8050cbb4912104a5e596b70e5e1f3"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3331,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "tracing-futures"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+source = "git+https://github.com/tokio-rs/tracing#3dc80c9196b8050cbb4912104a5e596b70e5e1f3"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3341,50 +3297,33 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
-dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
- "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.0.1"
 source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
 dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
-dependencies = [
- "tracing 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.0.1"
 source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
 dependencies = [
- "tracing 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-tower-http"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+source = "git+https://github.com/tokio-rs/tracing#3dc80c9196b8050cbb4912104a5e596b70e5e1f3"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower.git)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
@@ -3608,10 +3547,10 @@ dependencies = [
  "tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trace-metrics 0.1.0",
  "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
- "tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing)",
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4087,21 +4026,14 @@ dependencies = [
 "checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
-"checksum tracing 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
 "checksum tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff6ff2664f0b91870d297cd3e51be6980057273998844578fb392487cb93cfc1"
-"checksum tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
 "checksum tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5f34cae5ddd9e2dab25f17ff18acec0832b35c8d0ef9a9528737da74370b4b"
 "checksum tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
-"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
-"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
 "checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
-"checksum tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -740,7 +740,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1098,7 +1098,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2232,7 +2232,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2286,7 +2286,7 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2835,7 +2835,6 @@ dependencies = [
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3028,88 +3027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-trace"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-env-logger"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
-]
-
-[[package]]
-name = "tokio-trace-fmt"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-futures"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-log"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
-]
-
-[[package]]
-name = "tokio-trace-subscriber"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-tower-http"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery#3ef2b97cc63eeafecb12f684ca1ba2add8869fcb"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower.git)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-udp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower.git#82e7b8a27b7e10aac69533e382e42f89642c230e"
+source = "git+https://github.com/tower-rs/tower.git#03ec4aafa8a3a7237b5e2b23ac2b59a27987ab06"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3316,12 +3233,157 @@ dependencies = [
  "hotmic 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-env-logger 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-env-logger"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+]
+
+[[package]]
+name = "tracing-env-logger"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
+dependencies = [
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing-fmt"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "tracing 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing#1a02731ab09a0c568dd0aa67d6f7186911ea2fcc"
+dependencies = [
+ "tracing 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing-tower-http"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=fix-deps#869092ce2012d3009da1b8bec169f9b8dbbbb9ec"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.1.0 (git+https://github.com/tower-rs/tower.git)",
+ "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
 ]
 
 [[package]]
@@ -3534,21 +3596,21 @@ dependencies = [
  "structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog_rfc5424 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-test 0.1.0 (git+https://github.com/tokio-rs/tokio?branch=v0.1.x)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-env-logger 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
- "tokio-trace-tower-http 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trace-metrics 0.1.0",
+ "tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
+ "tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)",
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3991,7 +4053,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
-"checksum tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2ffcf4bcfc641413fa0f1427bf8f91dfc78f56a6559cbf50e04837ae442a87"
+"checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
@@ -4008,14 +4070,6 @@ dependencies = [
 "checksum tokio-test 0.1.0 (git+https://github.com/tokio-rs/tokio?branch=v0.1.x)" = "<none>"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
-"checksum tokio-trace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0660d8a4599af2d56ee3e4dde82835a6f26c80e4d60a35d639f97d2729658b31"
-"checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
-"checksum tokio-trace-env-logger 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
-"checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
-"checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
-"checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
-"checksum tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
-"checksum tokio-trace-tower-http 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery)" = "<none>"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
@@ -4032,6 +4086,21 @@ dependencies = [
 "checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
+"checksum tracing 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff6ff2664f0b91870d297cd3e51be6980057273998844578fb392487cb93cfc1"
+"checksum tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-core 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5f34cae5ddd9e2dab25f17ff18acec0832b35c8d0ef9a9528737da74370b4b"
+"checksum tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
+"checksum tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing?branch=fix-deps)" = "<none>"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ trace-metrics = { path = "lib/trace-metrics" }
 
 # Tokio / Futures
 futures = "0.1.25"
-tokio = { version = "0.1.22", features = ["io", "uds", "tcp", "rt-full"], default-features = false }
+tokio = { version = "0.1.22", features = ["io", "uds", "tcp", "rt-full", "experimental-tracing"], default-features = false }
 tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-threadpool = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,17 @@ trace-metrics = { path = "lib/trace-metrics" }
 
 # Tokio / Futures
 futures = "0.1.25"
-tokio = { version = "0.1.21", features = ["io", "uds", "tcp", "rt-full"], default-features = false }
+tokio = { version = "0.1.22", features = ["io", "uds", "tcp", "rt-full"], default-features = false }
 tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-threadpool = "0.1.8"
 
 # Tracing
-tokio-trace = "0.1"
-tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
-tokio-trace-fmt = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
-tokio-trace-env-logger = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
-tokio-trace-tower-http = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
+tracing = "0.1"
+tracing-futures = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-fmt = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-env-logger = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-tower-http = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
 
 # Metrics
 hotmic = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ tokio-threadpool = "0.1.8"
 
 # Tracing
 tracing = "0.1"
-tracing-futures = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
-tracing-fmt = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
-tracing-env-logger = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
-tracing-tower-http = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-futures = { git = "https://github.com/tokio-rs/tracing" }
+tracing-fmt = { git = "https://github.com/tokio-rs/tracing" }
+tracing-env-logger = { git = "https://github.com/tokio-rs/tracing" }
+tracing-tower-http = { git = "https://github.com/tokio-rs/tracing" }
 
 # Metrics
 hotmic = "0.8"

--- a/lib/codec/Cargo.toml
+++ b/lib/codec/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 bytes = { version = "0.4.10", features = ["serde"] }
 tokio-codec = "0.1"
-tokio-trace = "0.1"
+tracing = "0.1"
 serde_json = "1.0.33"

--- a/lib/codec/src/lib.rs
+++ b/lib/codec/src/lib.rs
@@ -2,7 +2,7 @@ extern crate bytes;
 extern crate tokio_codec;
 
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use std::{cmp, io, usize};

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -10,7 +10,7 @@ bytes = { version = "0.4.10", features = ["serde"] }
 crc = "1.8.1"
 glob = "0.2.11"
 futures = "0.1.25"
-tokio-trace = "0.1"
+tracing = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::mpsc::RecvTimeoutError;
 use std::time;
-use tokio_trace::field;
+use tracing::field;
 
 /// `FileServer` is a Source which cooperatively schedules reads over files,
 /// converting the lines of said files into `LogLine` structures. As

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 
 pub mod file_server;
 mod file_watcher;

--- a/lib/trace-metrics/Cargo.toml
+++ b/lib/trace-metrics/Cargo.toml
@@ -14,6 +14,6 @@ serde_json = "1.0"
 futures = "0.1.25"
 tokio = "0.1.21"
 hyper = "0.12.18"
-tracing-futures = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
-tracing-fmt = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-futures = { git = "https://github.com/tokio-rs/tracing" }
+tracing-fmt = { git = "https://github.com/tokio-rs/tracing" }
 tracing-env-logger = { git = "https://github.com/tokio-rs/tracing" }

--- a/lib/trace-metrics/Cargo.toml
+++ b/lib/trace-metrics/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["Lucio Franco <luciofranco14@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-tokio-trace-core = "0.2"
+tracing-core = "0.1"
 hotmic = "0.8"
 
 [dev-dependencies]
-tokio-trace = "0.1"
+tracing = "0.1"
 serde_json = "1.0"
 futures = "0.1.25"
 tokio = "0.1.21"
 hyper = "0.12.18"
-tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
-tokio-trace-fmt = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
-tokio-trace-env-logger = { git = "https://github.com/tokio-rs/tokio-trace-nursery" }
+tracing-futures = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-fmt = { git = "https://github.com/tokio-rs/tracing", branch = "fix-deps" }
+tracing-env-logger = { git = "https://github.com/tokio-rs/tracing" }

--- a/lib/trace-metrics/examples/yak_shave.rs
+++ b/lib/trace-metrics/examples/yak_shave.rs
@@ -1,16 +1,16 @@
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 extern crate hotmic;
 extern crate serde_json;
-extern crate tokio_trace_env_logger;
-extern crate tokio_trace_fmt;
 extern crate trace_metrics;
+extern crate tracing_env_logger;
+extern crate tracing_fmt;
 
 use hotmic::Receiver;
 use std::thread;
 
 fn shave(yak: usize) -> bool {
-    trace_span!("shave", yak = yak).enter(|| {
+    trace_span!("shave", yak = yak).in_scope(|| {
         debug!(
             message = "hello! I'm gonna shave a yak.",
             excitement = "yay!"
@@ -34,16 +34,16 @@ fn main() {
         receiver.run();
     });
 
-    let subscriber = tokio_trace_fmt::FmtSubscriber::builder().full().finish();
-    tokio_trace_env_logger::try_init().expect("init log adapter");
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
+    tracing_env_logger::try_init().expect("init log adapter");
     let subscriber = trace_metrics::MetricsSubscriber::new(subscriber, sink);
 
-    tokio_trace::subscriber::with_default(subscriber, || {
+    tracing::subscriber::with_default(subscriber, || {
         let number_of_yaks = 3;
         let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        trace_span!("shaving_yaks", yaks_to_shave = number_of_yaks).enter(|| {
+        trace_span!("shaving_yaks", yaks_to_shave = number_of_yaks).in_scope(|| {
             info!("shaving yaks");
 
             for yak in 1..=number_of_yaks {

--- a/lib/trace-metrics/src/lib.rs
+++ b/lib/trace-metrics/src/lib.rs
@@ -1,6 +1,6 @@
-//! A `tokio-trace` metrics based subscriber
+//! A `tracing` metrics based subscriber
 //!
-//! This subscriber takes another subscriber like `tokio-trace-fmt` and wraps it
+//! This subscriber takes another subscriber like `tracing-fmt` and wraps it
 //! with this basic subscriber. It will enable all spans and events that match the
 //! metric capturing criteria. This means every span is enabled regardless of its level
 //! and any event with a field name ending with `_counter` or `_gauge`.
@@ -8,13 +8,13 @@
 //! # Example
 //!
 //! ```
-//! # #[macro_use] extern crate tokio_trace;
-//! # extern crate tokio_trace_fmt;
+//! # #[macro_use] extern crate tracing;
+//! # extern crate tracing_fmt;
 //! # extern crate trace_metrics;
 //! # extern crate hotmic;
 //! # use hotmic::Receiver;
 //! # use trace_metrics::MetricsSubscriber;
-//! # use tokio_trace_fmt::FmtSubscriber;
+//! # use tracing_fmt::FmtSubscriber;
 //! // Get the metrics sink
 //! let mut receiver = Receiver::builder().build();
 //! let sink = receiver.get_sink();
@@ -23,14 +23,14 @@
 //! let fmt_subscriber = FmtSubscriber::builder().finish();
 //! let metric_subscriber = MetricsSubscriber::new(fmt_subscriber, sink);
 //!
-//! tokio_trace::subscriber::with_default(metric_subscriber, || {
+//! tracing::subscriber::with_default(metric_subscriber, || {
 //!     info!({ do_something_counter = 1 }, "Do some logging");
 //! })
 //! ```
 
 #[warn(missing_debug_implementations, missing_docs)]
 extern crate hotmic;
-extern crate tokio_trace_core;
+extern crate tracing_core;
 
 use hotmic::Sink;
 use std::{
@@ -38,7 +38,7 @@ use std::{
     fmt,
     sync::{Mutex, RwLock},
 };
-use tokio_trace_core::{
+use tracing_core::{
     field::{Field, Visit},
     span::{Attributes, Id, Record},
     Event, Interest, Metadata, Subscriber,
@@ -56,7 +56,7 @@ pub struct MetricsSubscriber<S> {
     collector: Collector,
 }
 
-/// A `tokio_trace_core::field::Visit` implementation that captures fields
+/// A `tracing_core::field::Visit` implementation that captures fields
 /// that contain `counter` or `gague` in their name and dispatches the `i64`
 /// or `u64` value to the underlying metrics sink.
 pub struct MetricVisitor {
@@ -164,7 +164,7 @@ impl<S: Subscriber> Subscriber for MetricsSubscriber<S> {
     }
 
     // extra non required fn
-    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if metadata.name().contains("event")
             && metadata
                 .fields()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::new_without_default, clippy::needless_pass_by_value)]
 
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 #[macro_use]
 extern crate prost_derive;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 
 use futures::{future, Future, Stream};
 use std::{
@@ -10,9 +10,9 @@ use std::{
 };
 use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
-use tokio_trace::{field, Dispatch};
-use tokio_trace_futures::Instrument;
 use trace_metrics::MetricsSubscriber;
+use tracing::{field, Dispatch};
+use tracing_futures::Instrument;
 use vector::{metrics, topology};
 
 #[derive(StructOpt, Debug)]
@@ -69,11 +69,10 @@ fn main() {
         levels.push_str(&additional_level);
     };
 
-    let subscriber = tokio_trace_fmt::FmtSubscriber::builder()
-        .with_filter(tokio_trace_fmt::filter::EnvFilter::from(levels.as_str()))
-        .full()
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .with_filter(tracing_fmt::filter::EnvFilter::from(levels.as_str()))
         .finish();
-    tokio_trace_env_logger::try_init().expect("init log adapter");
+    tracing_env_logger::try_init().expect("init log adapter");
 
     let (metrics_controller, metrics_sink) = metrics::build();
     let dispatch = if opts.metrics_addr.is_some() {
@@ -82,7 +81,7 @@ fn main() {
         Dispatch::new(subscriber)
     };
 
-    tokio_trace::dispatcher::with_default(&dispatch, || {
+    tracing::dispatcher::with_default(&dispatch, || {
         info!("Log level {:?} is enabled.", level);
 
         if let Some(threads) = opts.threads {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,7 +9,7 @@ use hyper::{
     Body, Request, Response, Server,
 };
 use std::net::SocketAddr;
-use tokio_trace::field;
+use tracing::field;
 
 /// Build the metrics receiver, controller and sink
 pub fn build() -> (Controller, Sink<&'static str>) {
@@ -32,7 +32,7 @@ pub fn serve(addr: &SocketAddr, controller: Controller) -> impl Future<Item = ()
         let controller = controller.clone();
 
         service_fn_ok(move |_: Request<Body>| {
-            connection_span.enter(|| {
+            connection_span.in_scope(|| {
                 debug!(message = "snapshotting metrics.");
                 let snapshot = controller.get_snapshot().unwrap();
                 let output = process_snapshot(snapshot).unwrap();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -16,9 +16,9 @@ use rusoto_kinesis::{
 };
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt, sync::Arc, time::Duration};
-use tokio_trace::field;
-use tokio_trace_futures::{Instrument, Instrumented};
 use tower::{Service, ServiceBuilder};
+use tracing::field;
+use tracing_futures::{Instrument, Instrumented};
 
 #[derive(Clone)]
 pub struct KinesisService {

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -18,9 +18,9 @@ use rusoto_s3::{
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::time::Duration;
-use tokio_trace::field;
-use tokio_trace_futures::{Instrument, Instrumented};
 use tower::{Service, ServiceBuilder};
+use tracing::field;
+use tracing_futures::{Instrument, Instrumented};
 use uuid::Uuid;
 
 #[derive(Clone)]

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -11,7 +11,7 @@ use prometheus::{Encoder, Registry, TextEncoder};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use stream_cancel::{Trigger, Tripwire};
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -129,7 +129,7 @@ impl PrometheusSink {
                     method = field::debug(req.method()),
                     path = field::debug(req.uri().path()),
                 )
-                .enter(|| handle(req, &registry))
+                .in_scope(|| handle(req, &registry))
             })
         };
 

--- a/src/sinks/tcp.rs
+++ b/src/sinks/tcp.rs
@@ -14,7 +14,7 @@ use tokio::{
     timer::Delay,
 };
 use tokio_retry::strategy::ExponentialBackoff;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -5,10 +5,10 @@ use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
 use std::sync::Arc;
 use tokio::executor::DefaultExecutor;
-use tokio_trace::field;
-use tokio_trace_tower_http::InstrumentedHttpService;
 use tower::Service;
 use tower_hyper::{body::Body, client::Client};
+use tracing::field;
+use tracing_tower_http::InstrumentedHttpService;
 
 type RequestBuilder = Box<dyn Fn(Vec<u8>) -> hyper::Request<Vec<u8>> + Sync + Send>;
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, SystemTime};
-use tokio_trace::{dispatcher, field};
+use tracing::{dispatcher, field};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields, default)]
@@ -97,7 +97,7 @@ pub fn file_source(config: &FileConfig, out: mpsc::Sender<Event>) -> super::Sour
         thread::spawn(move || {
             let dispatcher = dispatcher;
             dispatcher::with_default(&dispatcher, || {
-                span.enter(|| {
+                span.in_scope(|| {
                     file_server.run(out, shutdown_rx);
                 })
             });

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -8,7 +8,7 @@ use tokio::{
     codec::BytesCodec,
     net::{UdpFramed, UdpSocket},
 };
-use tokio_trace::field;
+use tracing::field;
 
 mod parser;
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -11,9 +11,9 @@ use tokio::{
     codec::{BytesCodec, FramedRead, LinesCodec},
     net::{UdpFramed, UdpSocket},
 };
-use tokio_trace::field;
-use tokio_trace_futures::Instrument;
 use tokio_uds::UnixListener;
+use tracing::field;
+use tracing_futures::Instrument;
 
 #[derive(Deserialize, Serialize, Debug)]
 // TODO: add back when serde-rs/serde#1358 is addressed

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -6,7 +6,7 @@ use futures::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use string_cache::DefaultAtom as Atom;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -6,7 +6,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tokio::codec::LengthDelimitedCodec;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -4,7 +4,7 @@ use futures::{sync::mpsc, Future, Stream};
 use std::{collections::HashMap, time::Duration};
 use stream_cancel::{Trigger, Tripwire};
 use tokio::util::FutureExt;
-use tokio_trace_futures::Instrument;
+use tracing_futures::Instrument;
 
 pub type Task = Box<dyn Future<Item = (), Error = ()> + Send>;
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -16,7 +16,7 @@ use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 use stream_cancel::Trigger;
 use tokio::timer;
-use tokio_trace_futures::Instrument;
+use tracing_futures::Instrument;
 
 #[allow(dead_code)]
 pub struct RunningTopology {

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -3,7 +3,7 @@ use crate::event::{self, Event, ValueKind};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use string_cache::DefaultAtom as Atom;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
 #[serde(deny_unknown_fields, default)]

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str;
 use string_cache::DefaultAtom as Atom;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(default, deny_unknown_fields)]

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str;
 use string_cache::DefaultAtom as Atom;
-use tokio_trace::field;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(default, deny_unknown_fields)]


### PR DESCRIPTION
`tokio-trace` has been renamed to `tracing`, this PR updates all our crates to point to the new github. Currently, waiting on this PR to fix certain crate issue internally within tracing.

Related https://github.com/tokio-rs/tracing/pull/139