### PR TITLE
Convert "-" into "nil"

### DIFF
--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,7 +1,6 @@
 use super::Transform;
 use crate::event::{self, Event};
 use crate::types::{parse_conversion_map, Conversion};
-use crate::event::ValueKind;
 use nom::{
     branch::alt,
     bytes::complete::{escaped, is_not, tag},
@@ -198,10 +197,7 @@ mod tests {
 
     #[test]
     fn dash_field() {
-        assert_eq!(
-            parse("foo - bar"),
-            &["foo", "-", "bar"]
-        );
+        assert_eq!(parse("foo - bar"), &["foo", "-", "bar"]);
     }
 
     #[test]
@@ -282,7 +278,13 @@ mod tests {
 
     #[test]
     fn tokenizer_keeps_dash_as_nil() {
-        let log = parse_log("1234 - foo", "code who why", None, false, &[("code", "integer"), ("who", "string"), ("why", "string")]);
+        let log = parse_log(
+            "1234 - foo",
+            "code who why",
+            None,
+            false,
+            &[("code", "integer"), ("who", "string"), ("why", "string")],
+        );
         assert_eq!(log[&"code".into()], ValueKind::Integer(1234));
         assert_eq!(log[&"who".into()], ValueKind::Bytes("nil".into()));
         assert_eq!(log[&"why".into()], ValueKind::Bytes("foo".into()));

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -81,9 +81,7 @@ impl Transform for Tokenizer {
             for ((name, conversion), value) in self.field_names.iter().zip(parse(value).into_iter())
             {
                 match conversion.convert(value.as_bytes().into()) {
-                    Ok(value) => match value {
-                        _ => event.as_mut_log().insert_explicit(name.clone(), value),
-                    },
+                    Ok(value) => event.as_mut_log().insert_explicit(name.clone(), value),
                     Err(err) => {
                         debug!(
                             message = "Could not convert types.",

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,6 +1,7 @@
 use super::Transform;
 use crate::event::{self, Event};
 use crate::types::{parse_conversion_map, Conversion};
+use crate::event::ValueKind;
 use nom::{
     branch::alt,
     bytes::complete::{escaped, is_not, tag},
@@ -80,7 +81,9 @@ impl Transform for Tokenizer {
             for ((name, conversion), value) in self.field_names.iter().zip(parse(value).into_iter())
             {
                 match conversion.convert(value.as_bytes().into()) {
-                    Ok(value) => event.as_mut_log().insert_explicit(name.clone(), value),
+                    Ok(value) => match value {
+                        _ => event.as_mut_log().insert_explicit(name.clone(), value),
+                    },
                     Err(err) => {
                         debug!(
                             message = "Could not convert types.",
@@ -116,10 +119,11 @@ pub fn parse(input: &str) -> Vec<&str> {
         escaped(is_not("]\\"), '\\', one_of("]\\")),
         tag("]"),
     );
+    let dash = tag("-");
 
     // fall back to returning the rest of the input, if any
     let remainder = verify(rest, |s: &str| s.len() > 0);
-    let field = alt((bracket, string, simple, remainder));
+    let field = alt((dash, bracket, string, simple, remainder));
 
     all_consuming(many0(terminated(field, space0)))(input)
         .expect("parser should always succeed")
@@ -192,6 +196,14 @@ mod tests {
             &["foo", "bar", "baz", ":", "quux"]
         );
         assert_eq!(parse("foo bar[baz quux"), &["foo", "bar", "[baz quux"]);
+    }
+
+    #[test]
+    fn dash_field() {
+        assert_eq!(
+            parse("foo - bar"),
+            &["foo", "-", "bar"]
+        );
     }
 
     #[test]
@@ -268,5 +280,13 @@ mod tests {
         assert_eq!(log[&"flag".into()], ValueKind::Boolean(true));
         assert_eq!(log[&"code".into()], ValueKind::Integer(1234));
         assert_eq!(log[&"rest".into()], ValueKind::Bytes("word".into()));
+    }
+
+    #[test]
+    fn tokenizer_keeps_dash_as_nil() {
+        let log = parse_log("1234 - foo", "code who why", None, false, &[("code", "integer"), ("who", "string"), ("why", "string")]);
+        assert_eq!(log[&"code".into()], ValueKind::Integer(1234));
+        assert_eq!(log[&"who".into()], ValueKind::Bytes("nil".into()));
+        assert_eq!(log[&"why".into()], ValueKind::Bytes("foo".into()));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,9 @@ impl Conversion {
     /// `value` is not currently a `ValueKind::Bytes`.
     pub fn convert(&self, value: ValueKind) -> Result<ValueKind, String> {
         let bytes = value.as_bytes();
+        if bytes == "-" {
+            return Ok(ValueKind::Bytes("nil".into()));
+        }
         match self {
             Conversion::Bytes => Ok(value),
             Conversion::Integer => String::from_utf8_lossy(&bytes)


### PR DESCRIPTION
### Description

The tokenizer transform converts a "-" in the input into a "nil", keeping
the field as outlined in #523.

<!--
Describe your changes. Please provide a thoughtful description
that respects the time of your reviewers.

Include any "Closes #123" or "Ref #123" statements.
-->