### PR TITLE
feat(grpc source): add new basic gRPC source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "codegen"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,14 +1194,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1831,15 +1831,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "prost"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1850,32 +1841,19 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1888,16 +1866,6 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2694,16 +2662,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3122,6 +3080,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-grpc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tower-grpc-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tower-http-util"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tower-request-modifier"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3543,7 +3540,6 @@ dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3572,7 +3568,10 @@ dependencies = [
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-request-modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
  "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
@@ -3750,6 +3749,7 @@ dependencies = [
 "checksum clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0113a8ae379a061c89a71d57a809439f5ce550b6a76063ab5ba2b1cb180971f"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf02acd61125952ee148207cd411f9b73c9e218eab4b901375a82e1a443b6238"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
@@ -3842,7 +3842,6 @@ dependencies = [
 "checksum inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
 "checksum inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jemalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bef0d4ce37578dfd80b466e3d8324bd9de788e249f1accebb0c472ea4b52bdc"
@@ -3917,12 +3916,9 @@ dependencies = [
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "760293453bee1de0a12987422d7c4885f7ee933e4417bb828ed23f7d05c3c390"
-"checksum prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f36c478cd43382388dfc3a3679af175c03d19ed8039e79a3e4447e944cd3f3"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
-"checksum prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6325275b85605f58f576456a47af44417edf5956a6f670bb59fbe12aff69597"
-"checksum prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9787d1977ea72e8066d58e46ae66100324a2815e677897fe78dfe54958f48252"
+"checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
-"checksum prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5644c57d56bc085f9570e113495c1f08d7185beca700dcc296cb4672f380a679"
 "checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 "checksum protobuf 2.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a151c11a92df0059d6ab446fafa3b21a1210aad4bc2293e1c946e8132b10db01"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
@@ -4009,7 +4005,6 @@ dependencies = [
 "checksum structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fa19a5a708e22bb5be31c1b6108a2a902f909c4b9ba85cba44c06632386bc0ff"
 "checksum structopt-derive 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d59d0ae8ef8de16e49e3ca7afa16024a3e0dfd974a75ef93fdc5464e34523f"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
@@ -4046,11 +4041,14 @@ dependencies = [
 "checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
+"checksum tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
+"checksum tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
 "checksum tower-http-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "442ba79e23bda499cdaa5ee52b3776bf08cb84a1d5ca6d3d82bfd4f12c1eefc3"
 "checksum tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "727d28cf51fc34a92c4201b08d53790608cb6edc0d285dfca260e043fa6529a5"
 "checksum tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 "checksum tower-limit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d3d0fe82c2373225025d50881794e0792e544df9752dec66288b644b40fbfe"
 "checksum tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04fbaf5bfb63d84204db87b9b2aeec61549613f2bbb8706dcc36f5f3ea8cd769"
+"checksum tower-request-modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6af257a01ba5f7a5c6190a70220cceebe832fa836e689cb8f73cb0e53112af5"
 "checksum tower-retry 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09e80588125061f276ed2a7b0939988b411e570a2dbb2965b1382ef4f71036f7"
 "checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ rusoto_credential = "0.16.0"
 # Tower
 tower = "0.1"
 tower-hyper = "0.1"
+tower-grpc = { version = "0.1", features = ["tower-hyper"] }
+tower-request-modifier = "0.1"
 
 # Serde
 serde = { version = "1.0.80", features = ["derive"] }
@@ -116,7 +118,7 @@ nom = "5.0.0-beta2"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 
 [build-dependencies]
-prost-build = "0.4.0"
+tower-grpc-build = { version = "0.1", features = ["tower-hyper"]}
 built = "0.3"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,13 @@
 fn main() {
-    println!("cargo:rerun-if-changed=proto/event.proto");
-    prost_build::compile_protos(&["proto/event.proto"], &["proto/"]).unwrap();
     built::write_built_file().unwrap();
+
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        // This will build both `event.proto` and `vector.proto`
+        // since `vector.proto` depends on `event.proto`
+        .build(&["proto/vector.proto"], &["proto/"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+
+    println!("cargo:rerun-if-changed=proto/event.proto");
 }

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -1,8 +1,7 @@
 syntax = "proto3";
+package event;
 
 import "google/protobuf/timestamp.proto";
-
-package event.proto;
 
 message EventWrapper {
   oneof event {

--- a/proto/vector.proto
+++ b/proto/vector.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package vector;
+
+import "event.proto";
+
+service VectorService {
+  rpc WriteEvents(WriteEventsRequest) returns (WriteEventsResponse) {}
+}
+
+message WriteEventsRequest {
+  repeated event.EventWrapper events = 1;
+}
+
+message WriteEventsResponse {}

--- a/src/buffers/disk.rs
+++ b/src/buffers/disk.rs
@@ -77,7 +77,9 @@ impl Sink for Writer {
         event: Self::SinkItem,
     ) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
         let mut value = vec![];
-        proto::EventWrapper::from(event).encode(&mut value).unwrap(); // This will not error when writing to a Vec
+        proto::event::EventWrapper::from(event)
+            .encode(&mut value)
+            .unwrap(); // This will not error when writing to a Vec
         let event_size = value.len();
 
         if self.current_size.fetch_add(event_size, Ordering::Relaxed) + (event_size / 2)
@@ -92,7 +94,7 @@ impl Sink for Writer {
 
             self.poll_complete()?;
 
-            let event = proto::EventWrapper::decode(value).unwrap().into();
+            let event = proto::event::EventWrapper::decode(value).unwrap().into();
             return Ok(AsyncSink::NotReady(event));
         }
 
@@ -180,7 +182,7 @@ impl Stream for Reader {
             self.unacked_sizes.push_back(value.len());
             self.read_offset += 1;
 
-            match proto::EventWrapper::decode(value) {
+            match proto::event::EventWrapper::decode(value) {
                 Ok(event) => {
                     let event = Event::from(event);
                     Ok(Async::Ready(Some(event)))

--- a/src/event/proto.rs
+++ b/src/event/proto.rs
@@ -1,0 +1,7 @@
+pub mod event {
+    include!(concat!(env!("OUT_DIR"), "/event.rs"));
+}
+
+pub mod grpc {
+    include!(concat!(env!("OUT_DIR"), "/vector.rs"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 #[macro_use]
 extern crate tracing;
 #[macro_use]
-extern crate prost_derive;
-#[macro_use]
 extern crate derivative;
 
 #[global_allocator]

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -60,7 +60,7 @@ pub fn vector_healthcheck(addr: SocketAddr) -> super::Healthcheck {
 }
 
 fn encode_event(event: Event) -> Result<Bytes, ()> {
-    let event = proto::EventWrapper::from(event);
+    let event = proto::event::EventWrapper::from(event);
     let event_len = event.encoded_len() as u32;
     let full_len = event_len + 4;
 

--- a/src/sources/grpc.rs
+++ b/src/sources/grpc.rs
@@ -1,6 +1,6 @@
 use crate::{
     event::{
-        proto::{server, WriteEventsRequest, WriteEventsResponse},
+        proto::grpc::{server, WriteEventsRequest, WriteEventsResponse},
         Event,
     },
     topology::config::SourceConfig,
@@ -76,7 +76,7 @@ mod tests {
     use super::*;
     use crate::{
         event::{
-            proto::{client::VectorService, WriteEventsRequest},
+            proto::grpc::{client::VectorService, WriteEventsRequest},
             Event,
         },
         test_util::{next_addr, random_events_with_stream, CollectCurrent},

--- a/src/sources/grpc.rs
+++ b/src/sources/grpc.rs
@@ -1,0 +1,185 @@
+use crate::{
+    event::{
+        proto::{server, WriteEventsRequest, WriteEventsResponse},
+        Event,
+    },
+    topology::config::SourceConfig,
+};
+use futures::{stream::iter_ok, sync::mpsc, Future, Sink, Stream};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tower_grpc::{Code, Request, Response, Status};
+use tower_hyper::server::{Http, Server};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct GrpcConfig {
+    pub address: SocketAddr,
+}
+
+#[typetag::serde(name = "grpc")]
+impl SourceConfig for GrpcConfig {
+    fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
+        let svc = server::VectorServiceServer::new(GrpcService { out });
+        let mut server = Server::new(svc);
+
+        let http = Http::new().http2_only(true).clone();
+
+        let bind = TcpListener::bind(&self.address).map_err(|e| format!("GrpcBindError: {}", e))?;
+
+        let serve = bind
+            .incoming()
+            .for_each(move |sock| {
+                if let Err(e) = sock.set_nodelay(true) {
+                    return Err(e);
+                }
+
+                let serve = server.serve_with(sock, http.clone());
+                tokio::spawn(serve.map_err(|e| error!("hyper error: {:?}", e)));
+
+                Ok(())
+            })
+            .map_err(|e| error!("Connection error: {}", e));
+
+        Ok(Box::new(serve))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GrpcService {
+    out: mpsc::Sender<Event>,
+}
+
+impl server::VectorService for GrpcService {
+    type WriteEventsFuture =
+        Box<dyn Future<Item = Response<WriteEventsResponse>, Error = Status> + Send + 'static>;
+
+    fn write_events(&mut self, request: Request<WriteEventsRequest>) -> Self::WriteEventsFuture {
+        let body = request.into_inner();
+        let events = iter_ok(body.events).map(|e| Event::from(e));
+
+        let fut = self.out.clone().send_all(events).then(|res| match res {
+            Ok(_) => Ok(Response::new(WriteEventsResponse {})),
+            Err(_) => {
+                error!("Sender dropped, most likely in the process of shutting down.");
+                Err(Status::new(Code::Unknown, "Server shutting down"))
+            }
+        });
+
+        Box::new(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        event::{
+            proto::{client::VectorService, WriteEventsRequest},
+            Event,
+        },
+        test_util::{next_addr, random_events_with_stream, CollectCurrent},
+    };
+    use futures::{sync::mpsc, Future};
+    use hyper::client::connect::HttpConnector;
+    use tokio::runtime::current_thread::Runtime;
+    use tower::MakeService;
+    use tower_grpc::{BoxBody, Code, Request, Status};
+    use tower_hyper::client::{self, Connect, Connection};
+    use tower_request_modifier::RequestModifier;
+
+    #[test]
+    fn write_events() {
+        let mut rt = Runtime::new().unwrap();
+
+        let address = next_addr();
+        let grpc = GrpcConfig { address };
+
+        let (tx, rx) = mpsc::channel(1000);
+        let fut = grpc.build(tx).unwrap();
+
+        rt.spawn(fut);
+
+        let (events, _) = random_events_with_stream(100, 100);
+
+        let events = events
+            .into_iter()
+            .map(|s| Event::from(s))
+            .collect::<Vec<_>>();
+
+        rt.block_on(make_request(address, events.clone())).unwrap();
+
+        let (_, output) = CollectCurrent::new(rx).wait().unwrap();
+
+        assert_eq!(events, output);
+    }
+
+    #[test]
+    fn write_events_shutdown() {
+        let mut rt = Runtime::new().unwrap();
+
+        let address = next_addr();
+        let grpc = GrpcConfig { address };
+
+        let (tx, rx) = mpsc::channel(1000);
+        let fut = grpc.build(tx).unwrap();
+
+        rt.spawn(fut);
+
+        let (events, _) = random_events_with_stream(100, 100);
+
+        let events = events
+            .into_iter()
+            .map(|s| Event::from(s))
+            .collect::<Vec<_>>();
+
+        drop(rx);
+        let err = rt
+            .block_on(make_request(address, events.clone()))
+            .unwrap_err();
+
+        assert_eq!(err.code(), Code::Unknown);
+        assert_eq!(err.message(), "Server shutting down");
+    }
+
+    fn make_request(
+        addr: SocketAddr,
+        events: Vec<Event>,
+    ) -> impl Future<Item = (), Error = Status> {
+        let events = events.into_iter().map(|e| e.into()).collect();
+
+        connect(addr)
+            .map_err(|s| Status::new(Code::Unavailable, s))
+            .and_then(move |mut svc| {
+                let req = Request::new(WriteEventsRequest { events });
+                svc.write_events(req).map(drop)
+            })
+    }
+
+    fn connect(
+        addr: SocketAddr,
+    ) -> impl Future<Item = VectorService<RequestModifier<Connection<BoxBody>, BoxBody>>, Error = String>
+    {
+        let uri: http::Uri = format!("http://{}", addr).parse().unwrap();
+
+        let dst = hyper::client::connect::Destination::try_from_uri(uri.clone()).unwrap();
+        let connector = tower_hyper::util::Connector::new(HttpConnector::new(4));
+        let settings = client::Builder::new().http2_only(true).clone();
+        let mut make_client = Connect::with_builder(connector, settings);
+
+        make_client
+            .make_service(dst)
+            .map_err(|e| format!("{}", e))
+            .and_then(|conn| {
+                let conn = tower_request_modifier::Builder::new()
+                    .set_origin(uri)
+                    .build(conn)
+                    .unwrap();
+
+                VectorService::new(conn)
+                    .ready()
+                    .map_err(|e| format!("{}", e))
+            })
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 
 pub mod file;
+pub mod grpc;
 pub mod statsd;
 pub mod stdin;
 pub mod syslog;

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -48,7 +48,7 @@ impl TcpSource for VectorSource {
     }
 
     fn build_event(&self, frame: BytesMut, _host: Option<Bytes>) -> Option<Event> {
-        match proto::EventWrapper::decode(frame).map(Event::from) {
+        match proto::event::EventWrapper::decode(frame).map(Event::from) {
             Ok(event) => {
                 trace!(
                     message = "Received one event.",

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -101,7 +101,7 @@ fn test_max_size() {
             let mut e = Event::from(line);
             e.as_mut_log()
                 .insert_implicit("host".into(), "127.0.0.1".into());
-            event::proto::EventWrapper::from(e)
+            event::proto::event::EventWrapper::from(e)
         })
         .map(|ew| ew.encoded_len())
         .sum();


### PR DESCRIPTION
This adds an inital gRPC source that provides non TLS based http2
access. It accepts a single unary rpc call that accepts a batch of
`EventWrapper`'s from the `event.proto`. These get translated directly
into `Event`.

Closes #573

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>