### PR TITLE
feat(console sink): accept both logs and metrics

### DIFF
--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -1,4 +1,7 @@
-#[derive(Debug, Clone, PartialEq)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Metric {
     Counter {
         name: String,
@@ -20,7 +23,7 @@ pub enum Metric {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Direction {
     Plus,
     Minus,

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -6,6 +6,7 @@ use crate::{
         retries::{FixedRetryPolicy, RetryLogic},
         BatchServiceSink, SinkExt,
     },
+    topology::config::{DataType, SinkConfig},
 };
 use futures::{Future, Poll, Sink};
 use rand::random;
@@ -53,12 +54,16 @@ pub enum Encoding {
 }
 
 #[typetag::serde(name = "aws_kinesis_streams")]
-impl crate::topology::config::SinkConfig for KinesisSinkConfig {
+impl SinkConfig for KinesisSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let config = self.clone();
         let sink = KinesisService::new(config, acker)?;
         let healthcheck = healthcheck(self.clone())?;
         Ok((Box::new(sink), healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -6,6 +6,7 @@ use crate::{
         retries::{FixedRetryPolicy, RetryLogic},
         BatchServiceSink, Buffer, PartitionBuffer, PartitionInnerBuffer, SinkExt,
     },
+    topology::config::{DataType, SinkConfig},
 };
 use bytes::Bytes;
 use chrono::Utc;
@@ -79,12 +80,16 @@ impl Default for Compression {
 }
 
 #[typetag::serde(name = "aws_s3")]
-impl crate::topology::config::SinkConfig for S3SinkConfig {
+impl SinkConfig for S3SinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let sink = S3Sink::new(self, acker)?;
         let healthcheck = S3Sink::healthcheck(self)?;
 
         Ok((sink, healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -1,5 +1,8 @@
-use crate::buffers::Acker;
-use crate::event::{self, Event};
+use crate::{
+    buffers::Acker,
+    event::{self, Event},
+    topology::config::{DataType, SinkConfig},
+};
 use futures::{future, AsyncSink, Future, Poll, Sink, StartSend};
 use serde::{Deserialize, Serialize};
 
@@ -16,12 +19,16 @@ pub struct BlackholeConfig {
 }
 
 #[typetag::serde(name = "blackhole")]
-impl crate::topology::config::SinkConfig for BlackholeConfig {
+impl SinkConfig for BlackholeConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let sink = Box::new(BlackholeSink::new(self.clone(), acker));
         let healthcheck = Box::new(healthcheck());
 
         Ok((sink, healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -100,10 +100,9 @@ mod test {
         let event = Event::Metric(Metric::Counter {
             name: "foos".into(),
             val: 100.0,
-            sampling: None,
         });
         assert_eq!(
-            Ok(r#"{"type":"counter","name":"foos","val":100.0,"sampling":null}"#.to_string()),
+            Ok(r#"{"type":"counter","name":"foos","val":100.0}"#.to_string()),
             encode_event(event, &None)
         );
     }

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -1,10 +1,15 @@
 use super::util::SinkExt;
-use crate::buffers::Acker;
-use crate::event::{self, Event};
+use crate::{
+    buffers::Acker,
+    event::{self, Event},
+    topology::config::{DataType, SinkConfig},
+};
 use futures::{future, Sink};
 use serde::{Deserialize, Serialize};
-use tokio::codec::{FramedWrite, LinesCodec};
-use tokio::io;
+use tokio::{
+    codec::{FramedWrite, LinesCodec},
+    io,
+};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -35,7 +40,7 @@ pub enum Encoding {
 }
 
 #[typetag::serde(name = "console")]
-impl crate::topology::config::SinkConfig for ConsoleSinkConfig {
+impl SinkConfig for ConsoleSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let encoding = self.encoding.clone();
 
@@ -50,6 +55,10 @@ impl crate::topology::config::SinkConfig for ConsoleSinkConfig {
             .with(move |event| encode_event(event, &encoding));
 
         Ok((Box::new(sink), Box::new(future::ok(()))))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -6,6 +6,7 @@ use crate::{
         retries::FixedRetryPolicy,
         BatchServiceSink, Buffer, Compression, SinkExt,
     },
+    topology::config::{DataType, SinkConfig},
 };
 use chrono::format::strftime::StrftimeItems;
 use chrono::Utc;
@@ -39,12 +40,16 @@ pub struct ElasticSearchConfig {
 }
 
 #[typetag::serde(name = "elasticsearch")]
-impl crate::topology::config::SinkConfig for ElasticSearchConfig {
+impl SinkConfig for ElasticSearchConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let sink = es(self.clone(), acker);
         let healtcheck = healthcheck(self.host.clone());
 
         Ok((sink, healtcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -6,6 +6,7 @@ use crate::{
         retries::FixedRetryPolicy,
         BatchServiceSink, Buffer, Compression, SinkExt,
     },
+    topology::config::{DataType, SinkConfig},
 };
 use futures::{future, Future, Sink};
 use headers::HeaderMapExt;
@@ -69,7 +70,7 @@ pub struct BasicAuth {
 }
 
 #[typetag::serde(name = "http")]
-impl crate::topology::config::SinkConfig for HttpSinkConfig {
+impl SinkConfig for HttpSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         validate_headers(&self.headers)?;
         let sink = http(self.clone(), acker)?;
@@ -80,6 +81,10 @@ impl crate::topology::config::SinkConfig for HttpSinkConfig {
         } else {
             Ok((sink, Box::new(future::ok(()))))
         }
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -2,6 +2,7 @@ use crate::{
     buffers::Acker,
     event::{self, Event},
     sinks::util::MetadataFuture,
+    topology::config::{DataType, SinkConfig},
 };
 use futures::{
     future::{self, poll_fn, IntoFuture},
@@ -46,11 +47,15 @@ pub struct KafkaSink {
 }
 
 #[typetag::serde(name = "kafka")]
-impl crate::topology::config::SinkConfig for KafkaSinkConfig {
+impl SinkConfig for KafkaSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let sink = KafkaSink::new(self.clone(), acker)?;
         let hc = healthcheck(self.clone());
         Ok((Box::new(sink), hc))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -1,6 +1,7 @@
 use crate::{
     buffers::Acker,
     event::{metric::Direction, Metric},
+    topology::config::{DataType, SinkConfig},
     Event,
 };
 use futures::{future, Async, AsyncSink, Future, Sink};
@@ -27,7 +28,7 @@ pub fn default_address() -> SocketAddr {
 }
 
 #[typetag::serde(name = "prometheus")]
-impl crate::topology::config::SinkConfig for PrometheusSinkConfig {
+impl SinkConfig for PrometheusSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let sink = Box::new(PrometheusSink::new(self.address, acker));
         let healthcheck = Box::new(future::ok(()));
@@ -35,8 +36,8 @@ impl crate::topology::config::SinkConfig for PrometheusSinkConfig {
         Ok((sink, healthcheck))
     }
 
-    fn input_type(&self) -> crate::topology::config::DataType {
-        crate::topology::config::DataType::Metric
+    fn input_type(&self) -> DataType {
+        DataType::Metric
     }
 }
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -6,6 +6,7 @@ use crate::{
         retries::FixedRetryPolicy,
         BatchServiceSink, Buffer, Compression, SinkExt,
     },
+    topology::config::{DataType, SinkConfig},
 };
 use bytes::Bytes;
 use futures::{Future, Sink};
@@ -51,13 +52,17 @@ fn default_host_field() -> Atom {
 }
 
 #[typetag::serde(name = "splunk_hec")]
-impl crate::topology::config::SinkConfig for HecSinkConfig {
+impl SinkConfig for HecSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         validate_host(&self.host)?;
         let sink = hec(self.clone(), acker)?;
         let healtcheck = healthcheck(self.token.clone(), self.host.clone())?;
 
         Ok((sink, healtcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/tcp.rs
+++ b/src/sinks/tcp.rs
@@ -2,6 +2,7 @@ use crate::{
     buffers::Acker,
     event::{self, Event},
     sinks::util::SinkExt,
+    topology::config::{DataType, SinkConfig},
 };
 use bytes::Bytes;
 use futures::{future, try_ready, Async, AsyncSink, Future, Poll, Sink, StartSend};
@@ -40,7 +41,7 @@ impl TcpSinkConfig {
 }
 
 #[typetag::serde(name = "tcp")]
-impl crate::topology::config::SinkConfig for TcpSinkConfig {
+impl SinkConfig for TcpSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let addr = self
             .address
@@ -53,6 +54,10 @@ impl crate::topology::config::SinkConfig for TcpSinkConfig {
         let healthcheck = tcp_healthcheck(addr);
 
         Ok((sink, healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -2,6 +2,7 @@ use crate::{
     buffers::Acker,
     event::proto,
     sinks::{tcp::TcpSink, util::SinkExt},
+    topology::config::{DataType, SinkConfig},
     Event,
 };
 use bytes::{BufMut, Bytes, BytesMut};
@@ -24,7 +25,7 @@ impl VectorSinkConfig {
 }
 
 #[typetag::serde(name = "vector")]
-impl crate::topology::config::SinkConfig for VectorSinkConfig {
+impl SinkConfig for VectorSinkConfig {
     fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), String> {
         let addr = self
             .address
@@ -37,6 +38,10 @@ impl crate::topology::config::SinkConfig for VectorSinkConfig {
         let healthcheck = super::tcp::tcp_healthcheck(addr);
 
         Ok((sink, healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,4 +1,7 @@
-use crate::event::{self, Event};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, SourceConfig},
+};
 use bytes::Bytes;
 use file_source::FileServer;
 use futures::{future, sync::mpsc, Future, Sink};
@@ -48,10 +51,14 @@ impl Default for FileConfig {
 }
 
 #[typetag::serde(name = "file")]
-impl crate::topology::config::SourceConfig for FileConfig {
+impl SourceConfig for FileConfig {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
         // TODO: validate paths
         Ok(file_source(self, out))
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -1,6 +1,6 @@
 use crate::{
     event::{self, Event},
-    topology::config::SourceConfig,
+    topology::config::{DataType, SourceConfig},
 };
 use bytes::Bytes;
 use codec::BytesDelimitedCodec;
@@ -36,6 +36,10 @@ fn default_max_length() -> usize {
 impl SourceConfig for StdinConfig {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
         Ok(stdin_source(stdin(), self.clone(), out))
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1,5 +1,8 @@
 use super::util::TcpSource;
-use crate::event::{self, Event};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, SourceConfig},
+};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use derive_is_enum_variant::is_enum_variant;
@@ -49,7 +52,7 @@ impl SyslogConfig {
 }
 
 #[typetag::serde(name = "syslog")]
-impl crate::topology::config::SourceConfig for SyslogConfig {
+impl SourceConfig for SyslogConfig {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
         let host_key = self.host_key.clone().unwrap_or(event::HOST.to_string());
 
@@ -65,6 +68,10 @@ impl crate::topology::config::SourceConfig for SyslogConfig {
             Mode::Udp { address } => Ok(udp(address, self.max_length, host_key, out)),
             Mode::Unix { path } => Ok(unix(path, self.max_length, host_key, out)),
         }
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -1,5 +1,8 @@
 use super::util::TcpSource;
-use crate::event::{self, Event};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, SourceConfig},
+};
 use bytes::Bytes;
 use codec::{self, BytesDelimitedCodec};
 use futures::sync::mpsc;
@@ -39,12 +42,16 @@ impl TcpConfig {
 }
 
 #[typetag::serde(name = "tcp")]
-impl crate::topology::config::SourceConfig for TcpConfig {
+impl SourceConfig for TcpConfig {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
         let tcp = RawTcpSource {
             config: self.clone(),
         };
         tcp.run(self.address, self.shutdown_timeout_secs, out)
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -1,5 +1,9 @@
 use super::util::TcpSource;
-use crate::{event::proto, Event};
+use crate::{
+    event::proto,
+    topology::config::{DataType, SourceConfig},
+    Event,
+};
 use bytes::{Bytes, BytesMut};
 use futures::sync::mpsc;
 use prost::Message;
@@ -30,10 +34,14 @@ impl VectorConfig {
 }
 
 #[typetag::serde(name = "vector")]
-impl crate::topology::config::SourceConfig for VectorConfig {
+impl SourceConfig for VectorConfig {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<super::Source, String> {
         let vector = VectorSource;
         vector.run(self.address, self.shutdown_timeout_secs, out)
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -60,13 +60,9 @@ pub struct TransformOuter {
 pub trait TransformConfig: core::fmt::Debug {
     fn build(&self) -> Result<Box<dyn transforms::Transform>, String>;
 
-    fn input_type(&self) -> DataType {
-        DataType::Log
-    }
+    fn input_type(&self) -> DataType;
 
-    fn output_type(&self) -> DataType {
-        DataType::Log
-    }
+    fn output_type(&self) -> DataType;
 }
 
 // Helper methods for programming construction during tests

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -27,9 +27,7 @@ pub enum DataType {
 pub trait SourceConfig: core::fmt::Debug {
     fn build(&self, out: mpsc::Sender<Event>) -> Result<sources::Source, String>;
 
-    fn output_type(&self) -> DataType {
-        DataType::Log
-    }
+    fn output_type(&self) -> DataType;
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -46,9 +46,7 @@ pub trait SinkConfig: core::fmt::Debug {
         acker: crate::buffers::Acker,
     ) -> Result<(sinks::RouterSink, sinks::Healthcheck), String>;
 
-    fn input_type(&self) -> DataType {
-        DataType::Log
-    }
+    fn input_type(&self) -> DataType;
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -19,6 +19,7 @@ pub struct Config {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
+    Any,
     Log,
     Metric,
 }

--- a/src/topology/config/validation.rs
+++ b/src/topology/config/validation.rs
@@ -111,11 +111,14 @@ impl Graph {
 
     fn edges(&self) -> HashSet<(String, String)> {
         let mut edges = HashSet::new();
+        let valid_names = self.nodes.keys().collect::<HashSet<_>>();
         for (name, node) in self.nodes.iter() {
             match node {
                 Node::Transform { inputs, .. } | Node::Sink { inputs, .. } => {
                     for i in inputs {
-                        edges.insert((i.clone(), name.clone()));
+                        if valid_names.contains(i) {
+                            edges.insert((i.clone(), name.clone()));
+                        }
                     }
                 }
                 Node::Source { .. } => {}

--- a/src/topology/config/validation.rs
+++ b/src/topology/config/validation.rs
@@ -140,9 +140,9 @@ impl Graph {
             .collect::<Vec<String>>();
         while let Some(node) = no_incoming.pop() {
             let outgoing = edges
-                .clone()
-                .into_iter()
+                .iter()
                 .filter(|(tail, _head)| *tail == node)
+                .cloned()
                 .collect::<Vec<_>>();
             for edge in outgoing {
                 edges.remove(&edge);

--- a/src/topology/config/validation.rs
+++ b/src/topology/config/validation.rs
@@ -1,6 +1,14 @@
 use crate::topology::{config::DataType, Config};
 use std::collections::{HashMap, HashSet};
 
+pub fn typecheck(config: &Config) -> Result<(), Vec<String>> {
+    Graph::from(config).typecheck()
+}
+
+pub fn contains_cycle(config: &Config) -> bool {
+    Graph::from(config).contains_cycle()
+}
+
 #[derive(Debug, Clone)]
 enum Node {
     Source {
@@ -17,82 +25,165 @@ enum Node {
     },
 }
 
-pub fn typecheck(config: &Config) -> Result<(), Vec<String>> {
-    let mut nodes = HashMap::new();
+#[derive(Default)]
+struct Graph {
+    nodes: HashMap<String, Node>,
+}
 
-    // TODO: validate that node names are unique across sources/transforms/sinks?
-    for (name, config) in config.sources.iter() {
-        nodes.insert(
-            name,
-            Node::Source {
-                ty: config.output_type(),
-            },
-        );
+impl Graph {
+    fn add_source(&mut self, name: &str, ty: DataType) {
+        self.nodes.insert(name.to_string(), Node::Source { ty });
     }
 
-    for (name, config) in config.transforms.iter() {
-        nodes.insert(
-            name,
+    fn add_transform(
+        &mut self,
+        name: &str,
+        in_ty: DataType,
+        out_ty: DataType,
+        inputs: Vec<impl Into<String>>,
+    ) {
+        let inputs = self.clean_inputs(inputs);
+        self.nodes.insert(
+            name.to_string(),
             Node::Transform {
-                in_ty: config.inner.input_type(),
-                out_ty: config.inner.output_type(),
-                inputs: config.inputs.clone(),
+                in_ty,
+                out_ty,
+                inputs,
             },
         );
     }
 
-    for (name, config) in config.sinks.iter() {
-        nodes.insert(
-            name,
-            Node::Sink {
-                ty: config.inner.input_type(),
-                inputs: config.inputs.clone(),
-            },
-        );
+    fn add_sink(&mut self, name: &str, ty: DataType, inputs: Vec<impl Into<String>>) {
+        let inputs = self.clean_inputs(inputs);
+        self.nodes
+            .insert(name.to_string(), Node::Sink { ty, inputs });
     }
 
-    let paths = config
-        .sinks
-        .keys()
-        .flat_map(|node| paths(&nodes, node, Vec::new()))
-        .collect::<Vec<_>>();
+    fn paths(&self) -> Vec<Vec<String>> {
+        self.nodes
+            .iter()
+            .filter_map(|(name, node)| match node {
+                Node::Sink { .. } => Some(name),
+                _ => None,
+            })
+            .flat_map(|node| paths_rec(&self.nodes, node, Vec::new()))
+            .collect()
+    }
 
-    let mut errors = Vec::new();
+    fn clean_inputs(&self, inputs: Vec<impl Into<String>>) -> Vec<String> {
+        inputs.into_iter().map(Into::into).collect()
+    }
 
-    for path in paths {
-        for pair in path.windows(2) {
-            let (x, y) = (&pair[0], &pair[1]);
-            if nodes.get(x).is_none() || nodes.get(y).is_none() {
-                continue;
-            }
-            match (nodes[&x].clone(), nodes[&y].clone()) {
-                (Node::Source { ty: ty1 }, Node::Sink { ty: ty2, .. })
-                | (Node::Source { ty: ty1 }, Node::Transform { in_ty: ty2, .. })
-                | (Node::Transform { out_ty: ty1, .. }, Node::Transform { in_ty: ty2, .. })
-                | (Node::Transform { out_ty: ty1, .. }, Node::Sink { ty: ty2, .. }) => {
-                    if ty1 != ty2 {
-                        errors.push(format!(
-                            "Data type mismatch between {} ({:?}) and {} ({:?})",
-                            x, ty1, y, ty2
-                        ));
-                    }
+    fn typecheck(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        for path in self.paths() {
+            for pair in path.windows(2) {
+                let (x, y) = (&pair[0], &pair[1]);
+                if self.nodes.get(x).is_none() || self.nodes.get(y).is_none() {
+                    continue;
                 }
-                (Node::Sink { .. }, _) | (_, Node::Source { .. }) => unreachable!(),
+                match (self.nodes[x].clone(), self.nodes[y].clone()) {
+                    (Node::Source { ty: ty1 }, Node::Sink { ty: ty2, .. })
+                    | (Node::Source { ty: ty1 }, Node::Transform { in_ty: ty2, .. })
+                    | (Node::Transform { out_ty: ty1, .. }, Node::Transform { in_ty: ty2, .. })
+                    | (Node::Transform { out_ty: ty1, .. }, Node::Sink { ty: ty2, .. }) => {
+                        if ty1 != ty2 && ty2 != DataType::Any {
+                            errors.push(format!(
+                                "Data type mismatch between {} ({:?}) and {} ({:?})",
+                                x, ty1, y, ty2
+                            ));
+                        }
+                    }
+                    (Node::Sink { .. }, _) | (_, Node::Source { .. }) => unreachable!(),
+                }
             }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            errors.sort();
+            errors.dedup();
+            Err(errors)
         }
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        errors.sort();
-        errors.dedup();
-        Err(errors)
+    fn edges(&self) -> HashSet<(String, String)> {
+        let mut edges = HashSet::new();
+        for (name, node) in self.nodes.iter() {
+            match node {
+                Node::Transform { inputs, .. } | Node::Sink { inputs, .. } => {
+                    for i in inputs {
+                        edges.insert((i.clone(), name.clone()));
+                    }
+                }
+                Node::Source { .. } => {}
+            }
+        }
+        edges
+    }
+
+    // Modified version of Kahn's topological sort algorithm that ignores the actual sorted output and
+    // only cares if the sort was possible (i.e. whether or not there was a cycle in the input graph).
+    fn contains_cycle(&self) -> bool {
+        let nodes = self
+            .nodes
+            .keys()
+            .map(|k| k.to_string())
+            .collect::<HashSet<_>>();
+        let mut edges = self.edges();
+
+        let mut no_incoming = nodes
+            .into_iter()
+            .filter(|n| !edges.iter().any(|(_t, h)| h == n))
+            .collect::<Vec<String>>();
+        while let Some(node) = no_incoming.pop() {
+            let outgoing = edges
+                .clone()
+                .into_iter()
+                .filter(|(tail, _head)| *tail == node)
+                .collect::<Vec<_>>();
+            for edge in outgoing {
+                edges.remove(&edge);
+                let successor = edge.1;
+                if edges.iter().filter(|(_t, head)| head == &successor).count() == 0 {
+                    no_incoming.push(successor);
+                }
+            }
+        }
+        !edges.is_empty()
     }
 }
 
-fn paths(nodes: &HashMap<&String, Node>, node: &String, mut path: Vec<String>) -> Vec<Vec<String>> {
-    path.push(node.clone());
+impl From<&Config> for Graph {
+    fn from(config: &Config) -> Self {
+        let mut graph = Graph::default();
+
+        // TODO: validate that node names are unique across sources/transforms/sinks?
+        for (name, config) in config.sources.iter() {
+            graph.add_source(name, config.output_type());
+        }
+
+        for (name, config) in config.transforms.iter() {
+            graph.add_transform(
+                name,
+                config.inner.input_type(),
+                config.inner.output_type(),
+                config.inputs.clone(),
+            );
+        }
+
+        for (name, config) in config.sinks.iter() {
+            graph.add_sink(name, config.inner.input_type(), config.inputs.clone());
+        }
+
+        graph
+    }
+}
+
+fn paths_rec(nodes: &HashMap<String, Node>, node: &str, mut path: Vec<String>) -> Vec<Vec<String>> {
+    path.push(node.to_string());
     match nodes.get(node).clone() {
         Some(Node::Source { .. }) | None => {
             path.reverse();
@@ -100,160 +191,81 @@ fn paths(nodes: &HashMap<&String, Node>, node: &String, mut path: Vec<String>) -
         }
         Some(Node::Transform { inputs, .. }) | Some(Node::Sink { inputs, .. }) => inputs
             .iter()
-            .flat_map(|input| paths(nodes, input, path.clone()))
+            .flat_map(|input| paths_rec(nodes, input, path.clone()))
             .collect(),
     }
 }
 
-// Modified version of Kahn's topological sort algorithm that ignores the actual sorted output and
-// only cares if the sort was possible (i.e. whether or not there was a cycle in the input graph).
-pub fn contains_cycle(config: &Config) -> bool {
-    let nodes = config
-        .sources
-        .keys()
-        .chain(config.transforms.keys())
-        .chain(config.sinks.keys())
-        .collect::<HashSet<_>>();
-
-    let mut edges = HashSet::new();
-    for (name, transform) in config.transforms.iter() {
-        for input in transform.inputs.iter() {
-            if nodes.contains(input) {
-                edges.insert((input, name));
-            }
-        }
-    }
-    for (name, sink) in config.sinks.iter() {
-        for input in sink.inputs.iter() {
-            if nodes.contains(input) {
-                edges.insert((input, name));
-            }
-        }
-    }
-
-    let mut no_incoming = nodes
-        .into_iter()
-        .filter(|n| !edges.iter().any(|(_t, h)| h == n))
-        .collect::<Vec<_>>();
-    while let Some(node) = no_incoming.pop() {
-        let outgoing = edges
-            .clone()
-            .into_iter()
-            .filter(|(tail, _head)| tail == &node)
-            .collect::<Vec<_>>();
-        for edge in outgoing {
-            edges.remove(&edge);
-            let successor = edge.1;
-            if edges.iter().filter(|(_t, head)| head == &successor).count() == 0 {
-                no_incoming.push(successor);
-            }
-        }
-    }
-    !edges.is_empty()
-}
-
 #[cfg(test)]
 mod test {
-    use super::{contains_cycle, typecheck};
-    use crate::topology::Config;
+    use super::Graph;
+    use crate::topology::config::DataType;
 
     #[test]
     fn detects_cycles() {
-        let cyclic = Config::load(
-            r#"
-            [sources.in]
-            type = "tcp"
-            address = "127.0.0.1:1235"
+        let mut graph = Graph::default();
+        graph.add_source("in", DataType::Log);
+        graph.add_transform("one", DataType::Log, DataType::Log, vec!["in", "three"]);
+        graph.add_transform("two", DataType::Log, DataType::Log, vec!["one"]);
+        graph.add_transform("three", DataType::Log, DataType::Log, vec!["two"]);
+        graph.add_sink("out", DataType::Log, vec!["three"]);
 
-            [transforms.one]
-            type = "sampler"
-            inputs = ["in", "three"]
-            rate = 10
-            pass_list = []
-
-            [transforms.two]
-            type = "sampler"
-            inputs = ["one"]
-            rate = 10
-            pass_list = []
-
-            [transforms.three]
-            type = "sampler"
-            inputs = ["two"]
-            rate = 10
-            pass_list = []
-
-            [sinks.out]
-            type = "tcp"
-            inputs = ["three"]
-            address = "127.0.0.1:9999"
-          "#
-            .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(true, contains_cycle(&cyclic));
+        assert_eq!(true, graph.contains_cycle());
     }
 
     #[test]
     fn doesnt_detect_noncycles() {
-        let acyclic = Config::load(
-            r#"
-            [sources.in]
-            type = "tcp"
-            address = "127.0.0.1:1235"
+        let mut graph = Graph::default();
+        graph.add_source("in", DataType::Log);
+        graph.add_transform("one", DataType::Log, DataType::Log, vec!["in"]);
+        graph.add_transform("two", DataType::Log, DataType::Log, vec!["in"]);
+        graph.add_transform("three", DataType::Log, DataType::Log, vec!["one", "two"]);
+        graph.add_sink("out", DataType::Log, vec!["three"]);
 
-            [transforms.one]
-            type = "sampler"
-            inputs = ["in"]
-            rate = 10
-            pass_list = []
-
-            [transforms.two]
-            type = "sampler"
-            inputs = ["in"]
-            rate = 10
-            pass_list = []
-
-            [transforms.three]
-            type = "sampler"
-            inputs = ["one", "two"]
-            rate = 10
-            pass_list = []
-
-            [sinks.out]
-            type = "tcp"
-            inputs = ["three"]
-            address = "127.0.0.1:9999"
-          "#
-            .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(false, contains_cycle(&acyclic));
+        assert_eq!(false, graph.contains_cycle());
     }
 
     #[test]
     fn detects_type_mismatches() {
-        let badly_typed = Config::load(
-            r#"
-            [sources.in]
-            type = "tcp"
-            address = "127.0.0.1:1235"
-
-            [sinks.out]
-            type = "prometheus"
-            inputs = ["in"]
-          "#
-            .as_bytes(),
-        )
-        .unwrap();
+        let mut graph = Graph::default();
+        graph.add_source("in", DataType::Log);
+        graph.add_sink("out", DataType::Metric, vec!["in"]);
 
         assert_eq!(
             Err(vec![
                 "Data type mismatch between in (Log) and out (Metric)".into()
             ]),
-            typecheck(&badly_typed)
+            graph.typecheck()
+        );
+    }
+
+    #[test]
+    fn allows_log_or_metric_into_any() {
+        let mut graph = Graph::default();
+        graph.add_source("log_source", DataType::Log);
+        graph.add_source("metric_source", DataType::Metric);
+        graph.add_sink(
+            "any_sink",
+            DataType::Any,
+            vec!["log_source", "metric_source"],
+        );
+
+        assert_eq!(Ok(()), graph.typecheck());
+    }
+
+    #[test]
+    fn doesnt_allow_any_into_log_or_metric() {
+        let mut graph = Graph::default();
+        graph.add_source("any_source", DataType::Any);
+        graph.add_sink("log_sink", DataType::Log, vec!["any_source"]);
+        graph.add_sink("metric_sink", DataType::Metric, vec!["any_source"]);
+
+        assert_eq!(
+            Err(vec![
+                "Data type mismatch between any_source (Any) and log_sink (Log)".into(),
+                "Data type mismatch between any_source (Any) and metric_sink (Metric)".into(),
+            ]),
+            graph.typecheck()
         );
     }
 }

--- a/src/topology/config/validation.rs
+++ b/src/topology/config/validation.rs
@@ -235,41 +235,6 @@ mod test {
 
     #[test]
     fn detects_type_mismatches() {
-        // Define a "minimal" Metric-typed sink so our example config can trigger a type error. As
-        // soon as we've actually implemented a Metric-typed sink or transform, we can get rid of
-        // this and just use one of those.
-        // TODO: remove all this once we have an actual non-Log component
-        use crate::{
-            buffers::Acker,
-            sinks::{
-                blackhole::{BlackholeConfig, BlackholeSink},
-                Healthcheck, RouterSink,
-            },
-            topology::config::DataType,
-        };
-        use serde::{Deserialize, Serialize};
-
-        #[derive(Deserialize, Serialize, Debug)]
-        pub struct MetricsSinkConfig;
-
-        #[typetag::serde(name = "metrics_sink")]
-        impl crate::topology::config::SinkConfig for MetricsSinkConfig {
-            fn build(&self, acker: Acker) -> Result<(RouterSink, Healthcheck), String> {
-                Ok((
-                    Box::new(BlackholeSink::new(
-                        BlackholeConfig { print_amount: 1 },
-                        acker,
-                    )),
-                    Box::new(futures::future::ok(())),
-                ))
-            }
-
-            fn input_type(&self) -> DataType {
-                DataType::Metric
-            }
-        }
-        // End of stuff to delete
-
         let badly_typed = Config::load(
             r#"
             [sources.in]
@@ -277,7 +242,7 @@ mod test {
             address = "127.0.0.1:1235"
 
             [sinks.out]
-            type = "metrics_sink"
+            type = "prometheus"
             inputs = ["in"]
           "#
             .as_bytes(),

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::event::{Event, ValueKind};
+use crate::{
+    event::{Event, ValueKind},
+    topology::config::{DataType, TransformConfig},
+};
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -17,9 +20,17 @@ pub struct AddFields {
 }
 
 #[typetag::serde(name = "augmenter")]
-impl crate::topology::config::TransformConfig for AddFieldsConfig {
+impl TransformConfig for AddFieldsConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Ok(Box::new(AddFields::new(self.fields.clone())))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::Event;
+use crate::{
+    topology::config::{DataType, TransformConfig},
+    Event,
+};
 use serde::{Deserialize, Serialize};
 use string_cache::DefaultAtom as Atom;
 
@@ -11,12 +14,20 @@ pub struct FieldFilterConfig {
 }
 
 #[typetag::serde(name = "field_filter")]
-impl crate::topology::config::TransformConfig for FieldFilterConfig {
+impl TransformConfig for FieldFilterConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Ok(Box::new(FieldFilter::new(
             self.field.clone(),
             self.value.clone(),
         )))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -1,6 +1,9 @@
 use super::Transform;
-use crate::event::{self, Event};
-use crate::types::{parse_conversion_map, Conversion};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, TransformConfig},
+    types::{parse_conversion_map, Conversion},
+};
 use grok::Pattern;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -20,7 +23,7 @@ pub struct GrokParserConfig {
 }
 
 #[typetag::serde(name = "grok_parser")]
-impl crate::topology::config::TransformConfig for GrokParserConfig {
+impl TransformConfig for GrokParserConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
@@ -38,6 +41,14 @@ impl crate::topology::config::TransformConfig for GrokParserConfig {
                     types,
                 })
             })
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::event::{self, Event, ValueKind};
+use crate::{
+    event::{self, Event, ValueKind},
+    topology::config::{DataType, TransformConfig},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use string_cache::DefaultAtom as Atom;
@@ -16,9 +19,17 @@ pub struct JsonParserConfig {
 }
 
 #[typetag::serde(name = "json_parser")]
-impl crate::topology::config::TransformConfig for JsonParserConfig {
+impl TransformConfig for JsonParserConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Ok(Box::new(JsonParser::from(self.clone())))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1,5 +1,9 @@
 use super::Transform;
-use crate::{event::metric::Metric, Event};
+use crate::{
+    event::metric::Metric,
+    topology::config::{DataType, TransformConfig},
+    Event,
+};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use string_cache::DefaultAtom as Atom;
@@ -48,17 +52,17 @@ pub struct LogToMetric {
 }
 
 #[typetag::serde(name = "log_to_metric")]
-impl crate::topology::config::TransformConfig for LogToMetricConfig {
+impl TransformConfig for LogToMetricConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Ok(Box::new(LogToMetric::new(self)))
     }
 
-    fn input_type(&self) -> crate::topology::config::DataType {
-        crate::topology::config::DataType::Log
+    fn input_type(&self) -> DataType {
+        DataType::Log
     }
 
-    fn output_type(&self) -> crate::topology::config::DataType {
-        crate::topology::config::DataType::Metric
+    fn output_type(&self) -> DataType {
+        DataType::Metric
     }
 }
 

--- a/src/transforms/lua.rs
+++ b/src/transforms/lua.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::event::Event;
+use crate::{
+    event::Event,
+    topology::config::{DataType, TransformConfig},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -11,12 +14,20 @@ pub struct LuaConfig {
 }
 
 #[typetag::serde(name = "lua")]
-impl crate::topology::config::TransformConfig for LuaConfig {
+impl TransformConfig for LuaConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Lua::new(&self.source, self.search_dirs.clone()).map(|l| {
             let b: Box<dyn Transform> = Box::new(l);
             b
         })
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -1,6 +1,9 @@
 use super::Transform;
-use crate::event::{self, Event, ValueKind};
-use crate::types::{parse_check_conversion_map, Conversion};
+use crate::{
+    event::{self, Event, ValueKind},
+    topology::config::{DataType, TransformConfig},
+    types::{parse_check_conversion_map, Conversion},
+};
 use regex::bytes::{CaptureLocations, Regex};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -20,7 +23,7 @@ pub struct RegexParserConfig {
 }
 
 #[typetag::serde(name = "regex_parser")]
-impl crate::topology::config::TransformConfig for RegexParserConfig {
+impl TransformConfig for RegexParserConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
@@ -41,6 +44,14 @@ impl crate::topology::config::TransformConfig for RegexParserConfig {
             self.drop_failed,
             types,
         )))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::Event;
+use crate::{
+    topology::config::{DataType, TransformConfig},
+    Event,
+};
 use serde::{Deserialize, Serialize};
 use string_cache::DefaultAtom as Atom;
 
@@ -14,9 +17,17 @@ pub struct RemoveFields {
 }
 
 #[typetag::serde(name = "remove_fields")]
-impl crate::topology::config::TransformConfig for RemoveFieldsConfig {
+impl TransformConfig for RemoveFieldsConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         Ok(Box::new(RemoveFields::new(self.fields.clone())))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/sampler.rs
+++ b/src/transforms/sampler.rs
@@ -1,5 +1,8 @@
 use super::Transform;
-use crate::event::{self, Event};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, TransformConfig},
+};
 use regex::RegexSet; // TODO: use regex::bytes
 use serde::{Deserialize, Serialize};
 use string_cache::DefaultAtom as Atom;
@@ -12,11 +15,19 @@ pub struct SamplerConfig {
 }
 
 #[typetag::serde(name = "sampler")]
-impl crate::topology::config::TransformConfig for SamplerConfig {
+impl TransformConfig for SamplerConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         RegexSet::new(&self.pass_list)
             .map_err(|err| err.to_string())
             .map::<Box<dyn Transform>, _>(|regex_set| Box::new(Sampler::new(self.rate, regex_set)))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,6 +1,9 @@
 use super::Transform;
-use crate::event::{self, Event};
-use crate::types::{parse_check_conversion_map, Conversion};
+use crate::{
+    event::{self, Event},
+    topology::config::{DataType, TransformConfig},
+    types::{parse_check_conversion_map, Conversion},
+};
 use nom::{
     branch::alt,
     bytes::complete::{escaped, is_not, tag},
@@ -25,7 +28,7 @@ pub struct TokenizerConfig {
 }
 
 #[typetag::serde(name = "tokenizer")]
-impl crate::topology::config::TransformConfig for TokenizerConfig {
+impl TransformConfig for TokenizerConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
@@ -40,6 +43,14 @@ impl crate::topology::config::TransformConfig for TokenizerConfig {
             drop_field,
             types,
         )))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
     }
 }
 


### PR DESCRIPTION
### Description

The console sink was documented to accept both logs and metrics, which it should, but we hadn't done the work to support that yet. These changes expand the type system to support a new `Any` type for components that accept logs or metrics, clean up a bunch of stuff around type checking, and add basic support for metric events to the console sink. It'd be best to read them commit-by-commit.

### TODO

- [ ] All commits are signedoff (See CONTRIBUTING.md). Forgot? `make signoff`.
- [ ] CHANGELOG.md has been updated to reflect noteworthy changes.
- [ ] Documentation has been updated to reflect changes (see DOCUMENTING.md).