### PR TITLE
feat(grok_parser transform): add type coercion

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -399,6 +399,29 @@ examples = ["%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:messa
 null = false
 description = "The [Grok pattern][url.grok_patterns]"
 
+[transforms.grok_parser.options.types]
+type = "table"
+null = true
+description = "Key/Value pairs representing mapped field types."
+
+[transforms.grok_parser.options.types.options."*"]
+type = "string"
+enum = ["string", "int", "float", "bool", "timestamp|strftime"]
+examples = [
+  {name = "status", value = "int"},
+  {name = "duration", value = "float"},
+  {name = "success", value = "bool"},
+  {name = "timestamp", value = "timestamp|%s", comment = "unix"},
+  {name = "timestamp", value = "timestamp|%+", comment = "iso8601 (date and time)"},
+  {name = "timestamp", value = "timestamp|%F", comment = "iso8601 (date)"},
+  {name = "timestamp", value = "timestamp|%a %b %e %T %Y", comment = "custom strftime format"},
+]
+null = false
+description = """\
+A definition of mapped field types. They key is the field name and the value \
+is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.\
+"""
+
 # ------------------------------------------------------------------------------
 # transforms.json_parser
 # ------------------------------------------------------------------------------

--- a/config/examples/transforms/grok_parser.toml
+++ b/config/examples/transforms/grok_parser.toml
@@ -12,3 +12,11 @@
   # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [transforms.my_grok_parser_transform.types]
+    level = "int"
+    timestamp = "timestamp|%s" # unix
+    timestamp = "timestamp|%+" # iso8601 (date and time)
+    timestamp = "timestamp|%F" # iso8601 (date)
+    timestamp = "timestamp|%a %b %e %T %Y" # custom strftime format

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -359,6 +359,10 @@
   value = "/var/log/nginx.log"
 
 [transforms.grok_parser]
+  #
+  # General
+  #
+
   # The component type
   # 
   # * required
@@ -390,6 +394,25 @@
   # * optional
   # * default: "message"
   field = "message"
+
+  #
+  # Types
+  #
+
+  [transforms.grok_parser.types]
+    # A definition of mapped field types. They key is the field name and the value
+    # is the type. `strftime` specifiers are supported for the `timestamp` type.
+    # 
+    # * required
+    # * no default
+    # * enum: "string", "int", "float", "bool", "timestamp|strftime"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 [transforms.json_parser]
   # The component type

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -379,6 +379,10 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   value = "/var/log/nginx.log"
 
 [transforms.grok_parser]
+  #
+  # General
+  #
+
   # The component type
   # 
   # * required
@@ -410,6 +414,25 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * optional
   # * default: "message"
   field = "message"
+
+  #
+  # Types
+  #
+
+  [transforms.grok_parser.types]
+    # A definition of mapped field types. They key is the field name and the value
+    # is the type. `strftime` specifiers are supported for the `timestamp` type.
+    # 
+    # * required
+    # * no default
+    # * enum: "string", "int", "float", "bool", "timestamp|strftime"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 [transforms.json_parser]
   # The component type

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -23,6 +23,7 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
 {% code-tabs-item title="vector.toml (example)" %}
 ```coffeescript
 [transforms.my_grok_parser_transform_id]
+  # REQUIRED - General
   type = "grok_parser" # must be: "grok_parser"
   inputs = ["my-source-id"]
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
@@ -32,7 +33,7 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
   field = "message" # default
   
   # OPTIONAL - Types
-  [sinks.my_grok_parser_transform_id.types]
+  [transforms.my_grok_parser_transform_id.types]
     status = "int"
     duration = "float"
     success = "bool"
@@ -45,6 +46,7 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
 {% code-tabs-item title="vector.toml (schema)" %}
 ```coffeescript
 [transforms.<transform-id>]
+  # REQUIRED - General
   type = "grok_parser"
   inputs = ["<string>", ...]
   pattern = "<string>"
@@ -54,7 +56,7 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
   field = "<string>"
 
   # OPTIONAL - Types
-  [sinks.<sink-id>.types]
+  [transforms.<transform-id>.types]
     * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
 ```
 {% endcode-tabs-item %}

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -30,7 +30,7 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
   # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
-
+  
   # OPTIONAL - Types
   [sinks.my_grok_parser_transform_id.types]
     status = "int"
@@ -103,6 +103,18 @@ We plan to add a [performance test][docs.performance] for this in the future.
 While this is still plenty fast for most use cases we recommend using the
 [`regex_parser` transform][docs.regex_parser_transform] if you are experiencing
 performance issues.
+
+### Types
+
+You can coerce your extract values into types via the `types` table
+as shown in the examples above. The supported types are:
+
+| Type     | Desription                                                                            |
+|:---------|:--------------------------------------------------------------------------------------|
+| `string` | Coerces to a string. Generally not necessary since values are extracted as strings.   |
+| `int`    | Coerce to a 64 bit integer.                                                           |
+| `float`  | Coerce to 64 bit floats.                                                              |
+| `bool`   | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced. |
 
 ## Troubleshooting
 

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -106,15 +106,34 @@ performance issues.
 
 ### Types
 
-You can coerce your extract values into types via the `types` table
-as shown in the examples above. The supported types are:
+By default, extracted (parsed) fields all contain `string` values. You can
+coerce these values into types via the `types` table as shown in the
+[Config File](#config-file) example above. For example:
 
-| Type     | Desription                                                                            |
-|:---------|:--------------------------------------------------------------------------------------|
-| `string` | Coerces to a string. Generally not necessary since values are extracted as strings.   |
-| `int`    | Coerce to a 64 bit integer.                                                           |
-| `float`  | Coerce to 64 bit floats.                                                              |
-| `bool`   | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced. |
+```coffeescript
+[transforms.my_transform_id]
+  # ...
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
+```
+
+The available types are:
+
+| Type        | Desription                                                                                                          |
+|:------------|:--------------------------------------------------------------------------------------------------------------------|
+| `bool`      | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced.                               |
+| `float`     | Coerce to 64 bit floats.                                                                                            |
+| `int`       | Coerce to a 64 bit integer.                                                                                         |
+| `string`    | Coerces to a string. Generally not necessary since values are extracted as strings.                                 |
+| `timestamp` | Coerces to a Vector timestamp. [`strftime` specificiers][url.strftime_specifiers] must be used to parse the string. |
 
 ## Troubleshooting
 

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -27,8 +27,19 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
   inputs = ["my-source-id"]
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
   
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [sinks.my_grok_parser_transform_id.types]
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (schema)" %}
@@ -37,8 +48,14 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
   type = "grok_parser"
   inputs = ["<string>", ...]
   pattern = "<string>"
+
+  # OPTIONAL - General
   drop_field = <bool>
   field = "<string>"
+
+  # OPTIONAL - Types
+  [sinks.<sink-id>.types]
+    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -47,13 +64,15 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
 
 | Key  | Type  | Description |
 |:-----|:-----:|:------------|
-| **REQUIRED** | | |
+| **REQUIRED** - General | | |
 | `type` | `string` | The component type<br />`required` `enum: "grok_parser"` |
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `pattern` | `string` | The [Grok pattern][url.grok_patterns]<br />`required` `example: (see above)` |
-| **OPTIONAL** | | |
+| **OPTIONAL** - General | | |
 | `drop_field` | `bool` | If `true` will drop the `field` after parsing.<br />`default: true` |
 | `field` | `string` | The field to execute the `pattern` against. Must be a `string` value.<br />`default: "message"` |
+| **OPTIONAL** - Types | | |
+| `types.*` | `string` | A definition of mapped field types. They key is the field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", "timestamp\|strftime"` |
 
 ## How It Works
 
@@ -138,3 +157,4 @@ Finally, consider the following alternatives:
 [url.grok_patterns]: https://github.com/daschl/grok/tree/master/patterns
 [url.rust_grok_library]: https://github.com/daschl/grok
 [url.search_forum]: https://forum.vector.dev/search?expanded=true
+[url.strftime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/docs/usage/configuration/transforms/regex_parser.md
+++ b/docs/usage/configuration/transforms/regex_parser.md
@@ -210,15 +210,34 @@ documentation][url.regex_grouping_and_flags].
 
 ### Types
 
-You can coerce your extract values into types via the `types` table
-as shown in the examples above. The supported types are:
+By default, extracted (parsed) fields all contain `string` values. You can
+coerce these values into types via the `types` table as shown in the
+[Config File](#config-file) example above. For example:
 
-| Type     | Desription                                                                            |
-|:---------|:--------------------------------------------------------------------------------------|
-| `string` | Coerces to a string. Generally not necessary since values are extracted as strings.   |
-| `int`    | Coerce to a 64 bit integer.                                                           |
-| `float`  | Coerce to 64 bit floats.                                                              |
-| `bool`   | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced. |
+```coffeescript
+[transforms.my_transform_id]
+  # ...
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
+```
+
+The available types are:
+
+| Type        | Desription                                                                                                          |
+|:------------|:--------------------------------------------------------------------------------------------------------------------|
+| `bool`      | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced.                               |
+| `float`     | Coerce to 64 bit floats.                                                                                            |
+| `int`       | Coerce to a 64 bit integer.                                                                                         |
+| `string`    | Coerces to a string. Generally not necessary since values are extracted as strings.                                 |
+| `timestamp` | Coerces to a Vector timestamp. [`strftime` specificiers][url.strftime_specifiers] must be used to parse the string. |
 
 ## Troubleshooting
 

--- a/docs/usage/configuration/transforms/tokenizer.md
+++ b/docs/usage/configuration/transforms/tokenizer.md
@@ -153,15 +153,34 @@ certain characters as special. These characters will be discarded:
 
 ### Types
 
-You can coerce your extract values into types via the `types` table
-as shown in the examples above. The supported types are:
+By default, extracted (parsed) fields all contain `string` values. You can
+coerce these values into types via the `types` table as shown in the
+[Config File](#config-file) example above. For example:
 
-| Type     | Desription                                                                            |
-|:---------|:--------------------------------------------------------------------------------------|
-| `string` | Coerces to a string. Generally not necessary since values are extracted as strings.   |
-| `int`    | Coerce to a 64 bit integer.                                                           |
-| `float`  | Coerce to 64 bit floats.                                                              |
-| `bool`   | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced. |
+```coffeescript
+[transforms.my_transform_id]
+  # ...
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
+```
+
+The available types are:
+
+| Type        | Desription                                                                                                          |
+|:------------|:--------------------------------------------------------------------------------------------------------------------|
+| `bool`      | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced.                               |
+| `float`     | Coerce to 64 bit floats.                                                                                            |
+| `int`       | Coerce to a 64 bit integer.                                                                                         |
+| `string`    | Coerces to a string. Generally not necessary since values are extracted as strings.                                 |
+| `timestamp` | Coerces to a Vector timestamp. [`strftime` specificiers][url.strftime_specifiers] must be used to parse the string. |
 
 ## Troubleshooting
 

--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -216,13 +216,32 @@ and result in deuplicate data downstream.
 
 ### Types
 
-You can coerce your extract values into types via the `types` table
-as shown in the examples above. The supported types are:
+By default, extracted (parsed) fields all contain `string` values. You can
+coerce these values into types via the `types` table as shown in the
+[Config File](#config-file) example above. For example:
 
-| Type     | Desription                                                                            |
-|:---------|:--------------------------------------------------------------------------------------|
-| `string` | Coerces to a string. Generally not necessary since values are extracted as strings.   |
-| `int`    | Coerce to a 64 bit integer.                                                           |
-| `float`  | Coerce to 64 bit floats.                                                              |
-| `bool`   | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced. |
-<%- end -%>
+```toml
+[transforms.my_transform_id]
+  # ...
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
+```
+
+The available types are:
+
+| Type        | Desription                                                                                                          |
+|:------------|:--------------------------------------------------------------------------------------------------------------------|
+| `bool`      | Coerces to a `true`/`false` boolean. The `1`/`0` and `t`/`f` values are also coerced.                               |
+| `float`     | Coerce to 64 bit floats.                                                                                            |
+| `int`       | Coerce to a 64 bit integer.                                                                                         |
+| `string`    | Coerces to a string. Generally not necessary since values are extracted as strings.                                 |
+| `timestamp` | Coerces to a Vector timestamp. [`strftime` specificiers][url.strftime_specifiers] must be used to parse the string. |
+<% end -%>

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -1,9 +1,12 @@
 use super::Transform;
 use crate::event::{self, Event};
+use crate::types::{parse_conversion_map, Conversion};
 use grok::Pattern;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::str;
 use string_cache::DefaultAtom as Atom;
+use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Derivative)]
 #[serde(deny_unknown_fields, default)]
@@ -13,6 +16,7 @@ pub struct GrokParserConfig {
     pub field: Option<Atom>,
     #[derivative(Default(value = "true"))]
     pub drop_field: bool,
+    pub types: HashMap<Atom, String>,
 }
 
 #[typetag::serde(name = "grok_parser")]
@@ -22,6 +26,8 @@ impl crate::topology::config::TransformConfig for GrokParserConfig {
 
         let mut grok = grok::Grok::with_patterns();
 
+        let types = parse_conversion_map(&self.types)?;
+
         grok.compile(&self.pattern, true)
             .map_err(|err| format!("Grok pattern failed to compile: {}", err))
             .map::<Box<dyn Transform>, _>(|p| {
@@ -29,6 +35,7 @@ impl crate::topology::config::TransformConfig for GrokParserConfig {
                     pattern: p,
                     field: field.clone(),
                     drop_field: self.drop_field,
+                    types,
                 })
             })
     }
@@ -38,6 +45,7 @@ pub struct GrokParser {
     pattern: Pattern,
     field: Atom,
     drop_field: bool,
+    types: HashMap<Atom, Conversion>,
 }
 
 impl Transform for GrokParser {
@@ -48,7 +56,18 @@ impl Transform for GrokParser {
         if let Some(value) = value {
             if let Some(matches) = self.pattern.match_against(&value) {
                 for (name, value) in matches.iter() {
-                    event.insert_explicit(name.into(), value.into());
+                    let name: Atom = name.into();
+                    let conv = self.types.get(&name).unwrap_or(&Conversion::Bytes);
+                    match conv.convert(value.into()) {
+                        Ok(value) => event.insert_explicit(name, value),
+                        Err(err) => {
+                            debug!(
+                                message = "Could not convert types.",
+                                name = &name[..],
+                                error = &field::display(err),
+                            );
+                        }
+                    }
                 }
 
                 if self.drop_field {
@@ -76,12 +95,19 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
-    fn parse_log(event: &str, pattern: &str, field: Option<&str>, drop_field: bool) -> LogEvent {
+    fn parse_log(
+        event: &str,
+        pattern: &str,
+        field: Option<&str>,
+        drop_field: bool,
+        types: &[(&str, &str)],
+    ) -> LogEvent {
         let event = Event::from(event);
         let mut parser = GrokParserConfig {
             pattern: pattern.into(),
             field: field.map(|s| s.into()),
             drop_field,
+            types: types.iter().map(|&(k, v)| (k.into(), v.into())).collect(),
         }
         .build()
         .unwrap();
@@ -95,6 +121,7 @@ mod tests {
             "%{HTTPD_COMMONLOG}",
             None,
             true,
+            &[],
         );
 
         let expected = json!({
@@ -120,6 +147,7 @@ mod tests {
             "%{HTTPD_COMMONLOG}",
             None,
             true,
+            &[],
         );
 
         assert_eq!(2, event.keys().count());
@@ -137,6 +165,7 @@ mod tests {
             "%{HTTPD_COMMONLOG}",
             None,
             false,
+            &[],
         );
 
         let expected = json!({
@@ -158,7 +187,13 @@ mod tests {
 
     #[test]
     fn grok_parser_does_nothing_on_missing_field() {
-        let event = parse_log("i am the only field", "^(?<foo>.*)", Some("bar"), false);
+        let event = parse_log(
+            "i am the only field",
+            "^(?<foo>.*)",
+            Some("bar"),
+            false,
+            &[],
+        );
 
         assert_eq!(2, event.keys().count());
         assert_eq!(
@@ -166,5 +201,31 @@ mod tests {
             event[&event::MESSAGE]
         );
         assert!(event[&event::TIMESTAMP].to_string_lossy().len() > 0);
+    }
+
+    #[test]
+    fn grok_parser_coerces_types() {
+        let event = parse_log(
+            r#"109.184.11.34 - - [12/Dec/2015:18:32:56 +0100] "GET /administrator/ HTTP/1.1" 200 4263"#,
+            "%{HTTPD_COMMONLOG}",
+            None,
+            true,
+            &[("response", "int"), ("bytes", "int")],
+        );
+
+        let expected = json!({
+            "clientip": "109.184.11.34",
+            "ident": "-",
+            "auth": "-",
+            "timestamp": "12/Dec/2015:18:32:56 +0100",
+            "verb": "GET",
+            "request": "/administrator/",
+            "httpversion": "1.1",
+            "rawrequest": "",
+            "response": 200,
+            "bytes": 4263,
+        });
+
+        assert_eq!(expected, serde_json::to_value(&event.all_fields()).unwrap());
     }
 }

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -1,6 +1,6 @@
 use super::Transform;
 use crate::event::{self, Event, ValueKind};
-use crate::types::{parse_conversion_map, Conversion};
+use crate::types::{parse_check_conversion_map, Conversion};
 use regex::bytes::{CaptureLocations, Regex};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -26,7 +26,7 @@ impl crate::topology::config::TransformConfig for RegexParserConfig {
 
         let regex = Regex::new(&self.regex).map_err(|err| err.to_string())?;
 
-        let types = parse_conversion_map(
+        let types = parse_check_conversion_map(
             &self.types,
             &regex
                 .capture_names()

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,6 +1,6 @@
 use super::Transform;
 use crate::event::{self, Event};
-use crate::types::{parse_conversion_map, Conversion};
+use crate::types::{parse_check_conversion_map, Conversion};
 use nom::{
     branch::alt,
     bytes::complete::{escaped, is_not, tag},
@@ -29,7 +29,7 @@ impl crate::topology::config::TransformConfig for TokenizerConfig {
     fn build(&self) -> Result<Box<dyn Transform>, String> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
-        let types = parse_conversion_map(&self.types, &self.field_names)?;
+        let types = parse_check_conversion_map(&self.types, &self.field_names)?;
 
         // don't drop the source field if it's getting overwritten by a parsed value
         let drop_field = self.drop_field && !self.field_names.iter().any(|f| f == field);

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,7 +55,8 @@ impl FromStr for Conversion {
     }
 }
 
-pub fn parse_conversion_map(
+/// Helper function to parse a conversion map and check against a list of names
+pub fn parse_check_conversion_map(
     types: &HashMap<Atom, String>,
     names: &Vec<Atom>,
 ) -> Result<HashMap<Atom, Conversion>, String> {
@@ -70,6 +71,13 @@ pub fn parse_conversion_map(
         }
     }
 
+    parse_conversion_map(types)
+}
+
+/// Helper function to parse a mapping of conversion descriptions into actual Conversion values.
+pub fn parse_conversion_map(
+    types: &HashMap<Atom, String>,
+) -> Result<HashMap<Atom, Conversion>, String> {
     types
         .into_iter()
         .map(|(field, typename)| {


### PR DESCRIPTION
### Description

The same as #406 but for the `grok_parser` transform.

Closes #477

### TODO

The Rust grok crate provides no way to list the target field names like the regex parser and tokenizer can, so this change is unable to verify the field names. I have filed an issue with the grok crate.