### PR TITLE
fix: retry HttpDispatch errors for s3 and kinesis

### DIFF
--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -164,6 +164,7 @@ impl RetryLogic for KinesisRetryLogic {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
+            PutRecordsError::HttpDispatch(_) => true,
             PutRecordsError::ProvisionedThroughputExceeded(_) => true,
             PutRecordsError::Unknown(res) if res.status.is_server_error() => true,
             _ => false,

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -245,6 +245,7 @@ impl RetryLogic for S3RetryLogic {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
+            PutObjectError::HttpDispatch(_) => true,
             PutObjectError::Unknown(res) if res.status.is_server_error() => true,
             _ => false,
         }


### PR DESCRIPTION
### Description

This makes IO errors like `Connection refused` retriable for the S3 and Kinesis sinks. There's a larger conversation to be had about the rest of the error type and the appropriate way to handle them, but this seemed like a no-brainer worth getting in immediately.

Addresses the immediate cause of #647

### TODO

- [x] All commits are signedoff (See CONTRIBUTING.md). Forgot? `make signoff`.
- [x] CHANGELOG.md has been updated to reflect noteworthy changes.
- [x] Documentation has been updated to reflect changes (see DOCUMENTING.md).