### PR TITLE
feat: Add `jemallocator` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ headers = "0.2.1"
 rdkafka = { version = "0.20.0", optional = true }
 hostname = "0.1.5"
 seahash = "3.0.6"
-jemallocator = "0.3.0"
+jemallocator = { version = "0.3.0", optional = true }
 lazy_static = "1.3.0"
 rlua = "0.16.3"
 num_cpus = "1.10.0"
@@ -134,7 +134,7 @@ pretty_assertions = "0.6.1"
 tokio-test = { git = "https://github.com/tokio-rs/tokio", branch = "v0.1.x" }
 
 [features]
-default = ["rdkafka", "leveldb"]
+default = ["rdkafka", "leveldb", "jemallocator"]
 docker = [
   "cloudwatch-integration-tests",
   "es-integration-tests",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate prost_derive;
 #[macro_use]
 extern crate derivative;
 
+#[cfg(feature = "jemallocator")]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
This adds the ability to create vector builds that do not include jemalloc and will instead use the default systems allocator. The goal for this is to provide the ability to make vector more portable since jemalloc is not supported everywhere. 

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>