### PR TITLE
feat: reusable templating system for event values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod metrics;
 pub mod region;
 pub mod sinks;
 pub mod sources;
-pub mod templating;
+pub mod template;
 pub mod test_util;
 pub mod topology;
 pub mod transforms;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod metrics;
 pub mod region;
 pub mod sinks;
 pub mod sources;
+pub mod templating;
 pub mod test_util;
 pub mod topology;
 pub mod transforms;

--- a/src/sinks/aws_cloudwatch_logs.rs
+++ b/src/sinks/aws_cloudwatch_logs.rs
@@ -3,11 +3,11 @@ use crate::{
     event::{self, Event, LogEvent, ValueKind},
     region::RegionOrEndpoint,
     sinks::util::{BatchServiceSink, PartitionBuffer, PartitionInnerBuffer, SinkExt},
+    templating::{parse_template, Template},
     topology::config::{DataType, SinkConfig},
 };
 use bytes::Bytes;
 use futures::{stream::iter_ok, sync::oneshot, try_ready, Async, Future, Poll, Sink};
-use regex::bytes::{Captures, Regex};
 use rusoto_core::RusotoFuture;
 use rusoto_logs::{
     CloudWatchLogs, CloudWatchLogsClient, CreateLogStreamError, CreateLogStreamRequest,
@@ -17,7 +17,6 @@ use rusoto_logs::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryInto, fmt, time::Duration};
-use string_cache::DefaultAtom as Atom;
 use tower::{
     buffer::Buffer,
     limit::{
@@ -35,15 +34,6 @@ pub struct CloudwatchLogsSvc {
     encoding: Option<Encoding>,
     stream_name: String,
     group_name: String,
-}
-
-#[derive(Debug, Clone)]
-enum Partition {
-    /// A static field that doesn't create dynamic partitions
-    Static(Bytes),
-    /// Represents the ability to extract a key/value from the event
-    /// via the provided interpolated stream name.
-    Field(Regex, Bytes, Atom),
 }
 
 type Svc = Buffer<ConcurrencyLimit<RateLimit<Timeout<CloudwatchLogsSvc>>>, Vec<Event>>;
@@ -111,7 +101,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
         let batch_size = self.batch_size.unwrap_or(1000);
 
         let log_group = self.group_name.clone().into();
-        let log_stream = interpolate(&self.stream_name);
+        let log_stream = parse_template(&self.stream_name);
 
         let svc = CloudwatchLogsPartitionSvc::new(self.clone())?;
 
@@ -375,39 +365,19 @@ pub struct CloudwatchKey {
     stream: Bytes,
 }
 
-fn interpolate(s: &str) -> Partition {
-    let r = Regex::new(r"\{\{(?P<key>\D+)\}\}").unwrap();
-
-    if let Some(cap) = r.captures(s.as_bytes()) {
-        if let Some(m) = cap.name("key") {
-            // TODO(lucio): clean up unwrap
-            let key = String::from_utf8(Vec::from(m.as_bytes())).unwrap();
-            return Partition::Field(r, s.into(), key.into());
-        }
-    }
-
-    Partition::Static(s.into())
-}
-
 fn partition(
     event: Event,
     group: &Bytes,
-    stream: &Partition,
+    stream: &Template,
 ) -> Option<PartitionInnerBuffer<Event, CloudwatchKey>> {
-    let stream = match stream {
-        Partition::Static(g) => g.clone(),
-        Partition::Field(regex, stream, key) => {
-            if let Some(val) = event.as_log().get(&key) {
-                let cap = regex.replace(stream, |_cap: &Captures| val.as_bytes().clone());
-                Bytes::from(&cap[..])
-            } else {
-                warn!(
-                    message =
-                        "Event key does not exist on the event and the event will be dropped.",
-                    key = field::debug(key)
-                );
-                return None;
-            }
+    let stream = match stream.render(&event) {
+        Ok(b) => b,
+        Err(key) => {
+            warn!(
+                message = "Event key does not exist on the event and the event will be dropped.",
+                key = field::debug(key)
+            );
+            return None;
         }
     };
 
@@ -508,27 +478,9 @@ mod tests {
     use string_cache::DefaultAtom as Atom;
 
     #[test]
-    fn interpolate_event() {
-        if let Partition::Field(_, _, key) = interpolate("{{some_key}}") {
-            assert_eq!(key, "some_key".to_string());
-        } else {
-            panic!("Expected Partition::Field");
-        }
-    }
-
-    #[test]
-    fn interpolate_static() {
-        if let Partition::Static(key) = interpolate("static_key") {
-            assert_eq!(key, "static_key".to_string());
-        } else {
-            panic!("Expected Partition::Static");
-        }
-    }
-
-    #[test]
     fn partition_static() {
         let event = Event::from("hello world");
-        let stream = Partition::Static("stream".into());
+        let stream = Template::Static("stream".into());
         let group = "group".into();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
@@ -549,7 +501,7 @@ mod tests {
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
 
-        let stream = interpolate("{{log_stream}}");
+        let stream = parse_template("{{log_stream}}");
         let group = "group".into();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
@@ -570,7 +522,7 @@ mod tests {
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
 
-        let stream = interpolate("abcd-{{log_stream}}");
+        let stream = parse_template("abcd-{{log_stream}}");
         let group = "group".into();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
@@ -591,7 +543,7 @@ mod tests {
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
 
-        let stream = interpolate("{{log_stream}}-abcd");
+        let stream = parse_template("{{log_stream}}-abcd");
         let group = "group".into();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
@@ -608,7 +560,7 @@ mod tests {
     fn partition_no_key_event() {
         let event = Event::from("hello world");
 
-        let stream = interpolate("{{log_stream}}");
+        let stream = parse_template("{{log_stream}}");
         let group = "group".into();
 
         let stream_val = partition(event, &group, &stream);

--- a/src/sinks/aws_cloudwatch_logs.rs
+++ b/src/sinks/aws_cloudwatch_logs.rs
@@ -372,10 +372,10 @@ fn partition(
 ) -> Option<PartitionInnerBuffer<Event, CloudwatchKey>> {
     let stream = match stream.render(&event) {
         Ok(b) => b,
-        Err(key) => {
+        Err(missing_keys) => {
             warn!(
-                message = "Event key does not exist on the event and the event will be dropped.",
-                key = field::debug(key)
+                message = "Keys do not exist on the event. Dropping event.",
+                keys = field::debug(missing_keys)
             );
             return None;
         }
@@ -480,7 +480,7 @@ mod tests {
     #[test]
     fn partition_static() {
         let event = Event::from("hello world");
-        let stream = Template::Static("stream".into());
+        let stream = Template::from("stream");
         let group = "group".into();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();

--- a/src/template.rs
+++ b/src/template.rs
@@ -11,16 +11,24 @@ lazy_static! {
 #[derive(Debug, Clone)]
 pub struct Template {
     src: Bytes,
+    dynamic: bool,
 }
 
 impl From<&str> for Template {
     fn from(src: &str) -> Template {
-        Template { src: src.into() }
+        Template {
+            src: src.into(),
+            dynamic: RE.is_match(src.as_bytes()),
+        }
     }
 }
 
 impl Template {
     pub fn render(&self, event: &Event) -> Result<Bytes, Vec<Atom>> {
+        if !self.dynamic {
+            return Ok(self.src.clone());
+        }
+
         let mut missing_fields = Vec::new();
         let out = RE
             .replace_all(self.src.as_ref(), |caps: &Captures| {

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,25 +5,24 @@ use string_cache::DefaultAtom as Atom;
 
 #[derive(Debug, Clone)]
 pub enum Template {
-    /// A static field that doesn't create dynamic partitions
     Static(Bytes),
-    /// Represents the ability to extract a key/value from the event
-    /// via the provided interpolated stream name.
-    Field(Regex, Bytes, Atom),
+    Dynamic(Regex, Bytes, Atom),
 }
 
-pub fn parse_template(src: &str) -> Template {
-    let r = Regex::new(r"\{\{(?P<key>\D+)\}\}").unwrap();
+impl From<&str> for Template {
+    fn from(src: &str) -> Template {
+        let r = Regex::new(r"\{\{(?P<key>\D+)\}\}").unwrap();
 
-    if let Some(cap) = r.captures(src.as_bytes()) {
-        if let Some(m) = cap.name("key") {
-            // TODO(lucio): clean up unwrap
-            let key = String::from_utf8(Vec::from(m.as_bytes())).unwrap();
-            return Template::Field(r, src.into(), key.into());
+        if let Some(cap) = r.captures(src.as_bytes()) {
+            if let Some(m) = cap.name("key") {
+                // TODO(lucio): clean up unwrap
+                let key = String::from_utf8(Vec::from(m.as_bytes())).unwrap();
+                return Template::Dynamic(r, src.into(), key.into());
+            }
         }
-    }
 
-    Template::Static(src.into())
+        Template::Static(src.into())
+    }
 }
 
 impl Template {
@@ -31,9 +30,9 @@ impl Template {
     pub fn render(&self, event: &Event) -> Result<Bytes, &Atom> {
         match self {
             Template::Static(g) => Ok(g.clone()),
-            Template::Field(regex, stream, key) => {
+            Template::Dynamic(regex, src, key) => {
                 if let Some(val) = event.as_log().get(&key) {
-                    let cap = regex.replace(stream, |_cap: &Captures| val.as_bytes().clone());
+                    let cap = regex.replace(src, |_cap: &Captures| val.as_bytes().clone());
                     Ok(Bytes::from(&cap[..]))
                 } else {
                     Err(key)
@@ -48,17 +47,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn interpolate_event() {
-        if let Template::Field(_, _, key) = parse_template("{{some_key}}") {
+    fn parse_dynamic() {
+        if let Template::Dynamic(_, _, key) = Template::from("{{some_key}}") {
             assert_eq!(key, "some_key".to_string());
         } else {
-            panic!("Expected Template::Field");
+            panic!("Expected Template::Dynamic");
         }
     }
 
     #[test]
-    fn interpolate_static() {
-        if let Template::Static(key) = parse_template("static_key") {
+    fn parse_static() {
+        if let Template::Static(key) = Template::from("static_key") {
             assert_eq!(key, "static_key".to_string());
         } else {
             panic!("Expected Template::Static");
@@ -66,7 +65,7 @@ mod tests {
     }
 
     #[test]
-    fn partition_static() {
+    fn render_static() {
         let event = Event::from("hello world");
         let template = Template::Static("foo".into());
 
@@ -74,42 +73,42 @@ mod tests {
     }
 
     #[test]
-    fn partition_event() {
+    fn render_dynamic() {
         let mut event = Event::from("hello world");
         event
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
-        let template = parse_template("{{log_stream}}");
+        let template = Template::from("{{log_stream}}");
 
         assert_eq!(Ok(Bytes::from("stream")), template.render(&event))
     }
 
     #[test]
-    fn partition_event_with_prefix() {
+    fn render_dynamic_with_prefix() {
         let mut event = Event::from("hello world");
         event
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
-        let template = parse_template("abcd-{{log_stream}}");
+        let template = Template::from("abcd-{{log_stream}}");
 
         assert_eq!(Ok(Bytes::from("abcd-stream")), template.render(&event))
     }
 
     #[test]
-    fn partition_event_with_postfix() {
+    fn render_dynamic_with_postfix() {
         let mut event = Event::from("hello world");
         event
             .as_mut_log()
             .insert_implicit("log_stream".into(), "stream".into());
-        let template = parse_template("{{log_stream}}-abcd");
+        let template = Template::from("{{log_stream}}-abcd");
 
         assert_eq!(Ok(Bytes::from("stream-abcd")), template.render(&event))
     }
 
     #[test]
-    fn partition_no_key_event() {
+    fn render_dynamic_missing_key() {
         let event = Event::from("hello world");
-        let template = parse_template("{{log_stream}}");
+        let template = Template::from("{{log_stream}}");
 
         assert_eq!(Err(&Atom::from("log_stream")), template.render(&event));
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -40,7 +40,7 @@ impl Template {
         if missing_fields.is_empty() {
             Ok(out.into())
         } else {
-            Err(missing_fields.clone())
+            Err(missing_fields)
         }
     }
 }

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -1,0 +1,116 @@
+use crate::Event;
+use bytes::Bytes;
+use regex::bytes::{Captures, Regex};
+use string_cache::DefaultAtom as Atom;
+
+#[derive(Debug, Clone)]
+pub enum Template {
+    /// A static field that doesn't create dynamic partitions
+    Static(Bytes),
+    /// Represents the ability to extract a key/value from the event
+    /// via the provided interpolated stream name.
+    Field(Regex, Bytes, Atom),
+}
+
+pub fn parse_template(src: &str) -> Template {
+    let r = Regex::new(r"\{\{(?P<key>\D+)\}\}").unwrap();
+
+    if let Some(cap) = r.captures(src.as_bytes()) {
+        if let Some(m) = cap.name("key") {
+            // TODO(lucio): clean up unwrap
+            let key = String::from_utf8(Vec::from(m.as_bytes())).unwrap();
+            return Template::Field(r, src.into(), key.into());
+        }
+    }
+
+    Template::Static(src.into())
+}
+
+impl Template {
+    // TODO: return error
+    pub fn render(&self, event: &Event) -> Result<Bytes, &Atom> {
+        match self {
+            Template::Static(g) => Ok(g.clone()),
+            Template::Field(regex, stream, key) => {
+                if let Some(val) = event.as_log().get(&key) {
+                    let cap = regex.replace(stream, |_cap: &Captures| val.as_bytes().clone());
+                    Ok(Bytes::from(&cap[..]))
+                } else {
+                    Err(key)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpolate_event() {
+        if let Template::Field(_, _, key) = parse_template("{{some_key}}") {
+            assert_eq!(key, "some_key".to_string());
+        } else {
+            panic!("Expected Template::Field");
+        }
+    }
+
+    #[test]
+    fn interpolate_static() {
+        if let Template::Static(key) = parse_template("static_key") {
+            assert_eq!(key, "static_key".to_string());
+        } else {
+            panic!("Expected Template::Static");
+        }
+    }
+
+    #[test]
+    fn partition_static() {
+        let event = Event::from("hello world");
+        let template = Template::Static("foo".into());
+
+        assert_eq!(Ok(Bytes::from("foo")), template.render(&event))
+    }
+
+    #[test]
+    fn partition_event() {
+        let mut event = Event::from("hello world");
+        event
+            .as_mut_log()
+            .insert_implicit("log_stream".into(), "stream".into());
+        let template = parse_template("{{log_stream}}");
+
+        assert_eq!(Ok(Bytes::from("stream")), template.render(&event))
+    }
+
+    #[test]
+    fn partition_event_with_prefix() {
+        let mut event = Event::from("hello world");
+        event
+            .as_mut_log()
+            .insert_implicit("log_stream".into(), "stream".into());
+        let template = parse_template("abcd-{{log_stream}}");
+
+        assert_eq!(Ok(Bytes::from("abcd-stream")), template.render(&event))
+    }
+
+    #[test]
+    fn partition_event_with_postfix() {
+        let mut event = Event::from("hello world");
+        event
+            .as_mut_log()
+            .insert_implicit("log_stream".into(), "stream".into());
+        let template = parse_template("{{log_stream}}-abcd");
+
+        assert_eq!(Ok(Bytes::from("stream-abcd")), template.render(&event))
+    }
+
+    #[test]
+    fn partition_no_key_event() {
+        let event = Event::from("hello world");
+        let template = parse_template("{{log_stream}}");
+
+        assert_eq!(Err(&Atom::from("log_stream")), template.render(&event));
+    }
+}


### PR DESCRIPTION
### Description

Extracts a simple templating system from the Cloudwatch implementation, cleans it up, and adds support for things like multiple keys.

I'm not in love with the name `Template`, so please feel free to propose any alternatives.

Basis for #522

### TODO

- [ ] All commits are signedoff (See CONTRIBUTING.md). Forgot? `make signoff`.
- [ ] Documentation has been updated to reflect changes (see DOCUMENTING.md).