### PR TITLE
chore: add support for armv7 releases, both gnueabihf and musleabihf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,38 @@ jobs:
   # Building - Archives
   #
 
+  build-armv7-unknown-linux-gnueabihf-archive:
+    docker:
+      - image: timberiodev/vector-builder-armv7-unknown-linux-gnueabihf:latest
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Build archive
+          command: |
+            export VERSION=$(make version)
+            make build-archive FEATURES="jemallocator"
+      - persist_to_workspace:
+          root: target/artifacts
+          paths:
+            - "*-armv7-unknown-linux-gnueabihf.tar.gz"
+
+  build-armv7-unknown-linux-musleabihf-archive:
+    docker:
+      - image: timberiodev/vector-builder-armv7-unknown-linux-musleabihf:latest
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Build archive
+          command: |
+            export VERSION=$(make version)
+            make build-archive FEATURES="jemallocator"
+      - persist_to_workspace:
+          root: target/artifacts
+          paths:
+            - "*-armv7-unknown-linux-musleabihf.tar.gz"
+
   build-x86_64-apple-darwin-archive:
     resource_class: large
     macos:
@@ -156,7 +188,6 @@ jobs:
           root: target/artifacts
           paths:
             - "*-x86_64-unknown-linux-musl.tar.gz"
-            - "*-amd64.deb"
 
   #
   # Packaging
@@ -430,6 +461,8 @@ build-requires: &build-requires
 
 package-requires: &package-requires
   requires:
+    - build-armv7-unknown-linux-gnueabihf
+    - build-armv7-unknown-linux-musleabihf
     - build-x86_64-unknown-linux-gnu-archive
     - build-x86_64-unknown-linux-musl-archive
     - build-x86_64-apple-darwin-archive
@@ -467,6 +500,12 @@ workflows:
           <<: *test-filters
       - test-stable:
           <<: *test-filters
+      - build-armv7-unknown-linux-gnueabihf:
+          <<: *release-workflow-filters
+          <<: *build-requires
+      - build-armv7-unknown-linux-musleabihf:
+          <<: *release-workflow-filters
+          <<: *build-requires
       - build-x86_64-unknown-linux-gnu-archive:
           <<: *release-workflow-filters
           <<: *build-requires

--- a/docs/setup/installation/manual/from-archives.md
+++ b/docs/setup/installation/manual/from-archives.md
@@ -24,7 +24,9 @@ architectures. If you don't see an architecture, then we recommend
 | :------------| :-----: | :---- |
 | [`x86_64-apple-darwin`][url.vector_latest_x86_64-apple-darwin] | `latest` | 64-bit OSX (10.7+, Lion+) |
 | [`uknown-linux-gnu`][url.vector_latest_x86_64-unknown-linux-gnu] | `latest` | 64-bit Linux (2.6.18+) |
-| ⚠️ [`uknown-linux-musl`][url.vector_latest_x86_64-unknown-linux-musl] | `latest` | 64-bit Linux with MUSL |
+| [`uknown-linux-musl`][url.vector_latest_x86_64-unknown-linux-musl] ⚠️ | `latest` | 64-bit Linux with MUSL |
+| [`armv7-unknown-linux-gnueabihf`][url.vector_latest_armv7-unknown-linux-gnueabihf] ⚠️ | `latest` | ARMv7 Linux |
+| [`armv7-unknown-linux-musleabihf`][url.vector_latest_armv7-unknown-linux-musleabihf] ⚠️ | `latest` | ARMv7 Linux with MUSL |
 
 {% endtab %}
 {% tab title="Edge" %}
@@ -40,7 +42,9 @@ using them over the "latest" alternatives.
 | :------------| :-----: | :---- |
 | [`x86_64-apple-darwin`][url.vector_edge_x86_64-apple-darwin] | `edge` | 64-bit OSX (10.7+, Lion+) |
 | [`uknown-linux-gnu`][url.vector_edge_x86_64-unknown-linux-gnu] | `edge` | 64-bit Linux (2.6.18+) |
-| ⚠️ [`uknown-linux-musl`][url.vector_edge_x86_64-unknown-linux-musl] | `edge` | 64-bit Linux with MUSL |
+| [`uknown-linux-musl`][url.vector_edge_x86_64-unknown-linux-musl] ⚠️ | `edge` | 64-bit Linux with MUSL |
+| [`armv7-unknown-linux-gnueabihf`][url.vector_edge_armv7-unknown-linux-gnueabihf] ⚠️ | `edge` | ARMv7 Linux |
+| [`armv7-unknown-linux-musleabihf`][url.vector_edge_armv7-unknown-linux-musleabihf] ⚠️ | `edge` | ARMv7 Linux with MUSL |
 {% endtab %}
 {% endtabs %}
 

--- a/scripts/build-ci-docker-images.sh
+++ b/scripts/build-ci-docker-images.sh
@@ -44,6 +44,8 @@ function extend_cross_base_image() {
 
 # The following images are basic Docker images that do not extend a
 # cross base image.
+build_image "builder-armv7-unknown-linux-gnueabihf"
+build_image "builder-armv7-unknown-linux-musleabihf"
 build_image "builder-x86_64-unknown-linux-gnu"
 build_image "builder-x86_64-unknown-linux-musl"
 build_image "checker"

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,0 +1,18 @@
+FROM japaric/armv7-unknown-linux-gnueabihf:latest
+
+RUN apt-get update
+RUN apt-get install -y software-properties-common python-software-properties
+RUN apt-get update
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    openssh-server \
+    vim \
+    zlib1g-dev
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="$PATH:/root/.cargo/bin"
+ENV TARGET=armv7-unknown-linux-gnueabihf
+RUN rustup target add armv7-unknown-linux-gnueabihf

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,0 +1,18 @@
+FROM japaric/armv7-unknown-linux-musleabihf:latest
+
+RUN apt-get update
+RUN apt-get install -y software-properties-common python-software-properties
+RUN apt-get update
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    openssh-server \
+    vim \
+    zlib1g-dev
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="$PATH:/root/.cargo/bin"
+ENV TARGET=armv7-unknown-linux-musleabihf
+RUN rustup target add armv7-unknown-linux-musleabihf

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -15,6 +15,5 @@ RUN apt-get update && \
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 ENV PATH="$PATH:/root/.cargo/bin"
-RUN cargo install cargo-deb
 ENV TARGET=x86_64-unknown-linux-musl
 RUN rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
Adds support for armv7 releases.

Ref https://github.com/timberio/vector/issues/544