### PR TITLE
fix: Use correct units in example batch timeouts

### DIFF
--- a/config/examples/sinks/aws_cloudwatch_logs.toml
+++ b/config/examples/sinks/aws_cloudwatch_logs.toml
@@ -13,7 +13,7 @@
 
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
 
   # OPTIONAL - Requests
   encoding = "json" # no default, enum: json, text

--- a/config/examples/sinks/aws_kinesis_streams.toml
+++ b/config/examples/sinks/aws_kinesis_streams.toml
@@ -12,7 +12,7 @@
 
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
 
   # OPTIONAL - Requests
   encoding = "json" # no default, enum: json, text

--- a/config/examples/sinks/aws_s3.toml
+++ b/config/examples/sinks/aws_s3.toml
@@ -12,7 +12,7 @@
 
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
-  batch_timeout = 300 # default, bytes
+  batch_timeout = 300 # default, seconds
 
   # OPTIONAL - Object Names
   filename_append_uuid = true # default

--- a/config/examples/sinks/elasticsearch.toml
+++ b/config/examples/sinks/elasticsearch.toml
@@ -15,7 +15,7 @@
 
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
 
   # OPTIONAL - Requests
   rate_limit_duration = 1 # default, seconds

--- a/config/examples/sinks/http.toml
+++ b/config/examples/sinks/http.toml
@@ -16,7 +16,7 @@
 
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 5 # default, bytes
+  batch_timeout = 5 # default, seconds
 
   # OPTIONAL - Requests
   rate_limit_duration = 1 # default, seconds

--- a/config/examples/sinks/splunk_hec.toml
+++ b/config/examples/sinks/splunk_hec.toml
@@ -14,7 +14,7 @@
 
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
 
   # OPTIONAL - Requests
   encoding = "ndjson" # no default, enum: ndjson, text

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -39,7 +39,7 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
   
   # OPTIONAL - Requests
   encoding = "json" # default, enum: "json", "text"

--- a/docs/usage/configuration/sinks/aws_kinesis_streams.md
+++ b/docs/usage/configuration/sinks/aws_kinesis_streams.md
@@ -38,7 +38,7 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
   
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
   
   # OPTIONAL - Requests
   encoding = "json" # default, enum: "json", "text"

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -41,7 +41,7 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
   
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
-  batch_timeout = 300 # default, bytes
+  batch_timeout = 300 # default, seconds
   
   # OPTIONAL - Object Names
   filename_append_uuid = true # default

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -41,7 +41,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
   
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
   
   # OPTIONAL - Requests
   rate_limit_duration = 1 # default, seconds

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -35,7 +35,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 5 # default, bytes
+  batch_timeout = 5 # default, seconds
   
   # OPTIONAL - Requests
   rate_limit_duration = 1 # default, seconds

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -31,7 +31,7 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
   
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, bytes
+  batch_timeout = 1 # default, seconds
   
   # OPTIONAL - Requests
   encoding = "ndjson" # default, enum: "ndjson", "text"


### PR DESCRIPTION
The units for `batch_timeout` in docs and examples should be `seconds`, not `bytes`. This PR fixes it.