### PR TITLE
chore: Update nom from 0.5.0-beta2 to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.0.0-beta2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lexical-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3602,7 +3602,7 @@ dependencies = [
  "leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 5.0.0-beta2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3950,7 +3950,7 @@ dependencies = [
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum nom 5.0.0-beta2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa215de9f747c2b3290ceee185976eb6ffc936087e19d810b57ba3ff85ae28c"
+"checksum nom 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9761d859320e381010a4f7f8ed425f2c924de33ad121ace447367c713ad561b"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "107b9be86cd2481930688277b675b0114578227f034674726605b8a482d8baf8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ rlua = "0.16.3"
 num_cpus = "1.10.0"
 bytesize = "1.0.0"
 grok = "1.0.0"
-nom = "5.0.0-beta2"
+nom = "5.0.0"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 exitcode = "1.1.2"
 

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -8,7 +8,7 @@ use nom::{
     branch::alt,
     bytes::complete::{escaped, is_not, tag},
     character::complete::{one_of, space0},
-    combinator::{all_consuming, rest, verify},
+    combinator::{all_consuming, map, opt, rest, verify},
     multi::many0,
     sequence::{delimited, terminated},
 };
@@ -119,12 +119,16 @@ pub fn parse(input: &str) -> Vec<&str> {
     let simple = is_not::<_, _, (&str, nom::error::ErrorKind)>(" \t[\"");
     let string = delimited(
         tag("\""),
-        escaped(is_not("\"\\"), '\\', one_of("\"\\")),
+        map(opt(escaped(is_not("\"\\"), '\\', one_of("\"\\"))), |o| {
+            o.unwrap_or("")
+        }),
         tag("\""),
     );
     let bracket = delimited(
         tag("["),
-        escaped(is_not("]\\"), '\\', one_of("]\\")),
+        map(opt(escaped(is_not("]\\"), '\\', one_of("]\\"))), |o| {
+            o.unwrap_or("")
+        }),
         tag("]"),
     );
 
@@ -166,6 +170,11 @@ mod tests {
     }
 
     #[test]
+    fn empty_quotes() {
+        assert_eq!(parse(r#"foo """#), &["foo", ""]);
+    }
+
+    #[test]
     fn escaped_quotes() {
         assert_eq!(
             parse(r#"foo "bar \" \" baz""#),
@@ -181,6 +190,11 @@ mod tests {
     #[test]
     fn brackets() {
         assert_eq!(parse("[foo.bar = baz] quux"), &["foo.bar = baz", "quux"],);
+    }
+
+    #[test]
+    fn empty_brackets() {
+        assert_eq!(parse("[] quux"), &["", "quux"],);
     }
 
     #[test]


### PR DESCRIPTION
Since we brought in nom they have finally released to the 0.5 version.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>