### PR TITLE
docs: replace some references to "sink" with `component.type`

### DIFF
--- a/scripts/generate/templates/_partials/_component_header.md.erb
+++ b/scripts/generate/templates/_partials/_component_header.md.erb
@@ -8,7 +8,7 @@ description: <%= component_description(component).remove_markdown_links %>
 
 <% if component.beta? -%>
 {% hint style="warning" %}
-The `<%= component.name %>` sink is in beta. Please see the current
+The `<%= component.name %>` <%= component.type %> is in beta. Please see the current
 [enhancements][url.<%= component.id %>_enhancements] and
 [bugs][url.<%= component.id %>_bugs] for known issues.
 We kindly ask that you [add any missing issues][url.new_<%= component.id %>_issue]

--- a/scripts/generate/templates/_partials/_component_troubleshooting.md.erb
+++ b/scripts/generate/templates/_partials/_component_troubleshooting.md.erb
@@ -6,7 +6,7 @@ The best place to start with troubleshooting is to check the
 If the [Troubleshooting Guide][docs.troubleshooting] does not resolve your
 issue, please:
 
-1. Check for any [open sink issues][url.<%= component.id %>_issues].
+1. Check for any [open <%= component.type %> issues][url.<%= component.id %>_issues].
 2. [Search the forum][url.search_forum] for any similar issues.
 2. Reach out to the [community][url.community] for help.
 


### PR DESCRIPTION
Signed-off-by: Denis Andrejew <da.colonel@gmail.com>

### Description

<!--
Describe your changes. Please provide a thoughtful description
that respects the time of your reviewers.

Include any "Closes #123" or "Ref #123" statements.
-->

### TODO

- [x] All commits are signedoff (See CONTRIBUTING.md). Forgot? `make signoff`.
- [ ] CHANGELOG.md has been updated to reflect noteworthy changes.
- [ ] Documentation has been updated to reflect changes (see DOCUMENTING.md).