### PR TITLE
chore: release nightly instead of on each commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,8 +489,8 @@ release-requires: &release-requires
 workflows:
   version: 2
 
-  build:
-    test:
+  test:
+    jobs:
       - check-code:
           <<: *test-filters
       - check-fmt:
@@ -500,14 +500,15 @@ workflows:
       - test-stable:
           <<: *test-filters
 
-    build:
-      triggers:
-        - schedule:
-            cron: "0 0 * * *"
-            filters:
-              branches:
-                only: master
+  build:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
 
+    jobs:
       - check-code:
           <<: *release-workflow-filters
       - check-fmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,13 +447,6 @@ test-filters: &test-filters
 release-workflow-filters: &release-workflow-filters
   filters:
     branches:
-      only: master
-    tags:
-      only: /v.*/
-
-tag-release-workflow-filters: &tag-release-workflow-filters
-  filters:
-    branches:
       ignore: /.*/
     tags:
       only: /v.*/
@@ -497,7 +490,7 @@ workflows:
   version: 2
 
   build:
-    jobs:
+    test:
       - check-code:
           <<: *test-filters
       - check-fmt:
@@ -506,6 +499,23 @@ workflows:
           <<: *test-filters
       - test-stable:
           <<: *test-filters
+
+    build:
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only: master
+
+      - check-code:
+          <<: *release-workflow-filters
+      - check-fmt:
+          <<: *release-workflow-filters
+      - check-generate:
+          <<: *release-workflow-filters
+      - test-stable:
+          <<: *release-workflow-filters
       - build-armv7-unknown-linux-gnueabihf-archive:
           <<: *release-workflow-filters
           <<: *build-requires
@@ -552,24 +562,24 @@ workflows:
           <<: *release-workflow-filters
           <<: *verify-requires
       - release-deb:
-          <<: *tag-release-workflow-filters
+          <<: *release-workflow-filters
           <<: *release-requires
       - release-github:
-          <<: *tag-release-workflow-filters
+          <<: *release-workflow-filters
           <<: *release-requires
       - release-rpm:
-          <<: *tag-release-workflow-filters
+          <<: *release-workflow-filters
           <<: *release-requires
       - release-s3:
           <<: *release-workflow-filters
           <<: *release-requires
       # Installs directly from S3
       - release-docker:
-          <<: *tag-release-workflow-filters
+          <<: *release-workflow-filters
           requires:
             - release-s3
       # Installs directly from S3
       - release-homebrew:
-          <<: *tag-release-workflow-filters
+          <<: *release-workflow-filters
           requires:
             - release-s3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,7 +442,7 @@ test-filters: &test-filters
     branches:
       only: /.*/
     tags:
-      only: /.*/
+      ignore: /.*/
 
 release-workflow-filters: &release-workflow-filters
   filters:

--- a/docs/setup/installation/manual/from-archives.md
+++ b/docs/setup/installation/manual/from-archives.md
@@ -1,5 +1,5 @@
 ---
-description: Install Vector from pre-built archives
+description: Install Vector from pre-compiled archives
 ---
 
 # Install From Archives
@@ -28,9 +28,8 @@ architectures. If you don't see an architecture, then we recommend
 | [`armv7-unknown-linux-gnueabihf`][url.vector_latest_armv7-unknown-linux-gnueabihf] ⚠️ | `latest` | ARMv7 Linux |
 
 {% endtab %}
-{% tab title="Edge" %}
-"Edge" builds are continuous and built after every change merged into
-the [`master` repo branch][url.vector_repo].
+{% tab title="Nightly" %}
+"Nightly" builds released nightly from the [`master` repo branch][url.vector_repo].
 
 {% hint style="warning" %}
 This release could have bugs or other issues. Please think carefully before
@@ -39,10 +38,10 @@ using them over the "latest" alternatives.
 
 | Architecture | Channel | Notes |
 | :------------| :-----: | :---- |
-| [`x86_64-apple-darwin`][url.vector_edge_x86_64-apple-darwin] | `edge` | 64-bit OSX (10.7+, Lion+) |
-| [`uknown-linux-musl`][url.vector_edge_x86_64-unknown-linux-musl] | `edge` | 64-bit Linux with MUSL. Recommended for Linux. |
-| [`uknown-linux-gnu`][url.vector_edge_x86_64-unknown-linux-gnu] | `edge` | 64-bit Linux (2.6.18+) |
-| [`armv7-unknown-linux-gnueabihf`][url.vector_edge_armv7-unknown-linux-gnueabihf] ⚠️ | `edge` | ARMv7 Linux |
+| [`x86_64-apple-darwin`][url.vector_nightly_x86_64-apple-darwin] | `nightly` | 64-bit OSX (10.7+, Lion+) |
+| [`uknown-linux-musl`][url.vector_nightly_x86_64-unknown-linux-musl] | `nightly` | 64-bit Linux with MUSL. Recommended for Linux. |
+| [`uknown-linux-gnu`][url.vector_nightly_x86_64-unknown-linux-gnu] | `nightly` | 64-bit Linux (2.6.18+) |
+| [`armv7-unknown-linux-gnueabihf`][url.vector_nightly_armv7-unknown-linux-gnueabihf] ⚠️ | `nightly` | ARMv7 Linux |
 {% endtab %}
 {% endtabs %}
 
@@ -180,12 +179,12 @@ Simply follow the same [installation instructions above](#installation).
 [url.leveldb]: https://github.com/google/leveldb
 [url.rdkafka]: https://github.com/edenhill/librdkafka
 [url.releases]: https://github.com/timberio/vector/releases
-[url.vector_edge_armv7-unknown-linux-gnueabihf]: https://packages.timber.io/vector/edge/vector-edge-armv7-unknown-linux-gnueabihf.tar.gz
-[url.vector_edge_x86_64-apple-darwin]: https://packages.timber.io/vector/edge/vector-edge-x86_64-apple-darwin.tar.gz
-[url.vector_edge_x86_64-unknown-linux-gnu]: https://packages.timber.io/vector/edge/vector-edge-x86_64-unknown-linux-gnu.tar.gz
-[url.vector_edge_x86_64-unknown-linux-musl]: https://packages.timber.io/vector/edge/vector-edge-x86_64-unknown-linux-musl.tar.gz
 [url.vector_latest_armv7-unknown-linux-gnueabihf]: https://packages.timber.io/vector/latest/vector-latest-armv7-unknown-linux-gnueabihf.tar.gz
 [url.vector_latest_x86_64-apple-darwin]: https://packages.timber.io/vector/latest/vector-latest-x86_64-apple-darwin.tar.gz
 [url.vector_latest_x86_64-unknown-linux-gnu]: https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz
 [url.vector_latest_x86_64-unknown-linux-musl]: https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-musl.tar.gz
+[url.vector_nightly_armv7-unknown-linux-gnueabihf]: https://packages.timber.io/vector/nightly/vector-nightly-armv7-unknown-linux-gnueabihf.tar.gz
+[url.vector_nightly_x86_64-apple-darwin]: https://packages.timber.io/vector/nightly/vector-nightly-x86_64-apple-darwin.tar.gz
+[url.vector_nightly_x86_64-unknown-linux-gnu]: https://packages.timber.io/vector/nightly/vector-nightly-x86_64-unknown-linux-gnu.tar.gz
+[url.vector_nightly_x86_64-unknown-linux-musl]: https://packages.timber.io/vector/nightly/vector-nightly-x86_64-unknown-linux-musl.tar.gz
 [url.vector_repo]: https://github.com/timberio/vector

--- a/docs/setup/installation/manual/from-archives.md
+++ b/docs/setup/installation/manual/from-archives.md
@@ -23,8 +23,8 @@ architectures. If you don't see an architecture, then we recommend
 | Architecture | Channel | Notes |
 | :------------| :-----: | :---- |
 | [`x86_64-apple-darwin`][url.vector_latest_x86_64-apple-darwin] | `latest` | 64-bit OSX (10.7+, Lion+) |
+| [`uknown-linux-musl`][url.vector_latest_x86_64-unknown-linux-musl] | `latest` | 64-bit Linux with MUSL. Recommended for Linux. |
 | [`uknown-linux-gnu`][url.vector_latest_x86_64-unknown-linux-gnu] | `latest` | 64-bit Linux (2.6.18+) |
-| [`uknown-linux-musl`][url.vector_latest_x86_64-unknown-linux-musl] ⚠️ | `latest` | 64-bit Linux with MUSL |
 | [`armv7-unknown-linux-gnueabihf`][url.vector_latest_armv7-unknown-linux-gnueabihf] ⚠️ | `latest` | ARMv7 Linux |
 
 {% endtab %}
@@ -40,8 +40,8 @@ using them over the "latest" alternatives.
 | Architecture | Channel | Notes |
 | :------------| :-----: | :---- |
 | [`x86_64-apple-darwin`][url.vector_edge_x86_64-apple-darwin] | `edge` | 64-bit OSX (10.7+, Lion+) |
+| [`uknown-linux-musl`][url.vector_edge_x86_64-unknown-linux-musl] | `edge` | 64-bit Linux with MUSL. Recommended for Linux. |
 | [`uknown-linux-gnu`][url.vector_edge_x86_64-unknown-linux-gnu] | `edge` | 64-bit Linux (2.6.18+) |
-| [`uknown-linux-musl`][url.vector_edge_x86_64-unknown-linux-musl] ⚠️ | `edge` | 64-bit Linux with MUSL |
 | [`armv7-unknown-linux-gnueabihf`][url.vector_edge_armv7-unknown-linux-gnueabihf] ⚠️ | `edge` | ARMv7 Linux |
 {% endtab %}
 {% endtabs %}
@@ -95,7 +95,7 @@ That's it! You can start vector with:
 vector --config config/vector.toml
 ```
 
-That's it! Proceed to [configure](#configuring) Vector for your use case.
+Proceed to [configure](#configuring) Vector for your use case.
 
 
 ## Configuring

--- a/scripts/generate/metadata/links.rb
+++ b/scripts/generate/metadata/links.rb
@@ -323,7 +323,7 @@ class Links
         type_label = "Type: #{issue_type.titleize}"
         VECTOR_ISSUES_ROOT + "/new?" + {"labels" => [component_label, type_label]}.to_query
 
-      when /^url\.vector_(edge|latest)_(.*)/
+      when /^url\.vector_(latest|nightly)_(.*)/
         channel = $1
         target = $2
         "https://packages.timber.io/vector/#{channel}/vector-#{channel}-#{target}.tar.gz"

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -10,15 +10,15 @@ set -eu
 
 CHANNEL=""
 if [[ $VERSION == *"-"* ]]; then
-  CHANNEL="edge"
-  echo "Version ($VERSION) is an edge version, only releasing to edge channels"
+  CHANNEL="nightly"
+  echo "Version ($VERSION) is a nightly version, only releasing to nightly channels"
 else
   CHANNEL="latest"
   echo "Version ($VERSION) is a release version, releasing to latest channels"
 fi
 
 if [ -z "$CHANNEL" ]; then
-  echo 'The CHANNEL env var must be set to "edge" or "latest"'
+  echo 'The CHANNEL env var must be set to "nightly" or "latest"'
   exit 1
 fi
 
@@ -31,18 +31,18 @@ escaped_version=$(echo $VERSION | sed "s/\./\\\./g")
 echo "Uploading all artifacts to s3://packages.timber.io/vector/$VERSION/"
 aws s3 cp "target/artifacts/" "s3://packages.timber.io/vector/$VERSION/" --recursive
 
-# Update the "edge" files
-echo "Uploading all artifacts to s3://packages.timber.io/vector/edge/"
+# Update the "nightly" files
+echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/"
 td=$(mktemp -d)
 
 cp -a "target/artifacts/." "$td"
-rename -v "s/$escaped_version/edge/" $td/*
-echo "Renamed all builds: via \"s/$escaped_version/edge/\""
+rename -v "s/$escaped_version/nightly/" $td/*
+echo "Renamed all builds: via \"s/$escaped_version/nightly/\""
 ls $td
-aws s3 rm --recursive "s3://packages.timber.io/vector/edge/"
-aws s3 cp "$td" "s3://packages.timber.io/vector/edge/" --recursive
+aws s3 rm --recursive "s3://packages.timber.io/vector/nightly/"
+aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/" --recursive
 rm -rf $td
-echo "Uploaded edge archives"
+echo "Uploaded nightly archives"
 
 if [[ "$CHANNEL" == "latest" ]]; then
   # Update the "latest" files


### PR DESCRIPTION
This changes moves the build process to a nightly job instead of on every commit to master. I've updated our release URLs from `edge` to `nightly` as well.