### PR TITLE
chore: use double for storing metric values

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -37,18 +37,18 @@ message Metric {
 
 message Counter {
   string name = 1;
-  float val = 2;
+  double val = 2;
 }
 
 message Histogram {
   string name = 1;
-  float val = 2;
+  double val = 2;
   uint32 sample_rate = 3;
 }
 
 message Gauge {
   string name = 1;
-  float val = 2;
+  double val = 2;
   enum Direction {
     None = 0;
     Plus = 1;

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -5,16 +5,16 @@ use serde::Serialize;
 pub enum Metric {
     Counter {
         name: String,
-        val: f32,
+        val: f64,
     },
     Histogram {
         name: String,
-        val: f32,
+        val: f64,
         sample_rate: u32,
     },
     Gauge {
         name: String,
-        val: f32,
+        val: f64,
         direction: Option<Direction>,
     },
     Set {

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -186,20 +186,15 @@ impl Sink for PrometheusSink {
         self.start_server_if_needed();
 
         match event.into_metric() {
-            Metric::Counter { name, val } => {
-                self.with_counter(name, |counter| counter.inc_by(val as f64))
-            }
+            Metric::Counter { name, val } => self.with_counter(name, |counter| counter.inc_by(val)),
             Metric::Gauge {
                 name,
                 val,
                 direction,
-            } => self.with_gauge(name, |gauge| {
-                let val = val as f64;
-                match direction {
-                    None => gauge.set(val),
-                    Some(Direction::Plus) => gauge.add(val),
-                    Some(Direction::Minus) => gauge.sub(val),
-                }
+            } => self.with_gauge(name, |gauge| match direction {
+                None => gauge.set(val),
+                Some(Direction::Plus) => gauge.add(val),
+                Some(Direction::Minus) => gauge.sub(val),
             }),
             Metric::Histogram {
                 name,
@@ -207,7 +202,7 @@ impl Sink for PrometheusSink {
                 sample_rate,
             } => self.with_histogram(name, |hist| {
                 for _ in 0..sample_rate {
-                    hist.observe(val as f64);
+                    hist.observe(val);
                 }
             }),
             Metric::Set { .. } => {

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -35,7 +35,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             } else {
                 1.0
             };
-            let val: f32 = parts[0].parse()?;
+            let val: f64 = parts[0].parse()?;
             Metric::Counter {
                 name: sanitize_key(key),
                 val: val * sample_rate,
@@ -47,7 +47,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             } else {
                 1.0
             };
-            let val: f32 = parts[0].parse()?;
+            let val: f64 = parts[0].parse()?;
             Metric::Histogram {
                 name: sanitize_key(key),
                 val: convert_to_base_units(unit, val),
@@ -77,14 +77,14 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
     Ok(metric)
 }
 
-fn parse_sampling(input: &str) -> Result<f32, ParseError> {
+fn parse_sampling(input: &str) -> Result<f64, ParseError> {
     if input.chars().next() != Some('@') || input.len() < 2 {
         return Err(ParseError::Malformed(
             "expected '@'-prefixed sampling component",
         ));
     }
 
-    let num: f32 = input[1..].parse()?;
+    let num: f64 = input[1..].parse()?;
     if num.is_sign_positive() {
         Ok(num)
     } else {
@@ -112,7 +112,7 @@ fn sanitize_key(key: &str) -> String {
     s.into()
 }
 
-fn sanitize_sampling(sampling: f32) -> f32 {
+fn sanitize_sampling(sampling: f64) -> f64 {
     if sampling == 0.0 {
         1.0
     } else {
@@ -120,7 +120,7 @@ fn sanitize_sampling(sampling: f32) -> f32 {
     }
 }
 
-fn convert_to_base_units(unit: &str, val: f32) -> f32 {
+fn convert_to_base_units(unit: &str, val: f64) -> f64 {
     match unit {
         "ms" => val / 1000.0,
         _ => val,


### PR DESCRIPTION
Seems like the general consensus is to prefer double precision floats for metric values. At least Graphite, Statsd, Prometheus and CloudWatch are all using double values, so I don't think we have reasons not to do the same.

Signed-off-by: Alexey Suslov <alexey.suslov@gmail.com>