### PR TITLE
fix: Use a locked down version of localstack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           RUST_BACKTRACE: full
           AWS_ACCESS_KEY_ID: "fake-aws-key"
           AWS_SECRET_ACCESS_KEY: "fake-aws-key"
-      - image: localstack/localstack:latest
+      - image: localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
         environment:
           DATA_DIR: /tmp/localstack/data
           DEBUG: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     localstack:
-      image: localstack/localstack
+      image: localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
       ports:
         - "4568:4568"
       environment:


### PR DESCRIPTION
This fixes failed master builds due to a recent update to the localstack image. This forces us to use a specific version that we know will work.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>