### PR TITLE
fix: don't serialize MapValue::Null as a string

### DIFF
--- a/docs/about/data-model/log.md
+++ b/docs/about/data-model/log.md
@@ -132,9 +132,9 @@ Vector will represent this data internally as a log event:
 {% code-tabs-item title="internal LogEvent" %}
 ```rust
 LogEvent {
-    "array.0": "item1",
-    "array.1": "item2",
-    "array.2": "item3"
+    "array[0]": "item1",
+    "array[1]": "item2",
+    "array[2]": "item3"
 }
 ```
 {% endcode-tabs-item %}
@@ -156,6 +156,32 @@ back into it's original structure:
 This normalizes the event structure and simplifies data processing throughout
 the Vector pipeline. This not only helps with performance, but it helps to
 avoid type human error when configuring Vector.
+
+If vector receives flattened array items that contain a missing index during the 
+unflatten process it will insert `null` values. For example:
+
+{% code-tabs %}
+{% code-tabs-item title="internal LogEvent" %}
+```rust
+LogEvent {
+    "array[0]": "item1",
+    "array[2]": "item3"
+}
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+The output will contain a `null` value for `array[1]` like so:
+
+{% code-tabs %}
+{% code-tabs-item title="output" %}
+```javascript
+{
+    "array": ["item1", null, "item3"]
+}
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Special Characters
 

--- a/src/event/unflatten.rs
+++ b/src/event/unflatten.rs
@@ -192,7 +192,7 @@ impl Serialize for MapValue {
             MapValue::Value(v) => v.serialize(serializer),
             MapValue::Map(m) => serializer.collect_map(m.clone()),
             MapValue::Array(a) => serializer.collect_seq(a.clone()),
-            MapValue::Null => serializer.serialize_str("null"),
+            MapValue::Null => serializer.serialize_none(),
         }
     }
 }


### PR DESCRIPTION
The serde::Serialize trait implementation for MapValue::Null (added in fbed6bdddddc627f6400bf36a075fcd897a8b09a) used to serialize to `"null"` (a string). However, the correct approach would be to serialize it as `null` to be able to distinguish between a missing value and a string with the value `null`.

Closes #724
Ref #678