### PR TITLE
feat(data model): add timestamps into metrics

### DIFF
--- a/docs/about/data-model/README.md
+++ b/docs/about/data-model/README.md
@@ -6,8 +6,24 @@ description: 'A deeper look at Vector''s data model'
 
 ![][images.data-model]
 
-As shown above, Vector generalizes all data flowing through Vector as events.
-Events must be one of 2 types:
+As shown above, Vector generalizes all data flowing through Vector as events:
+
+{% code-tabs %}
+{% code-tabs-item title="event.proto" %}
+```coffeescript
+message EventWrapper {
+  oneof event {
+    Log log = 1;
+    Metric metric = 2;
+  }
+}
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+You can view a complete definition in the [event proto \
+definition][url.event_proto]. You'll notice that each event must be one of
+2 types:
 
 {% page-ref page="../data-model/log.md" %}
 
@@ -23,3 +39,4 @@ flowing through Vector.
 
 
 [images.data-model]: ../../assets/data-model.svg
+[url.event_proto]: https://github.com/timberio/vector/blob/master/proto/event.proto

--- a/docs/about/data-model/log.md
+++ b/docs/about/data-model/log.md
@@ -82,9 +82,9 @@ For example, if Vector ingests the following JSON data:
 Vector will represent this data internally as a `LogEvent`:
 
 {% code-tabs %}
-{% code-tabs-item title="internal LogEvent" %}
-```rust
-LogEvent {
+{% code-tabs-item title="internal log event" %}
+```javascript
+{
     "parent.child": "..."
 }
 ```
@@ -131,9 +131,9 @@ For example, if Vector ingests the following data:
 Vector will represent this data internally as a log event:
 
 {% code-tabs %}
-{% code-tabs-item title="internal LogEvent" %}
-```rust
-LogEvent {
+{% code-tabs-item title="internal log event" %}
+```javascript
+{
     "array[0]": "item1",
     "array[1]": "item2",
     "array[2]": "item3"
@@ -163,9 +163,9 @@ If vector receives flattened array items that contain a missing index during the
 unflatten process it will insert `null` values. For example:
 
 {% code-tabs %}
-{% code-tabs-item title="internal LogEvent" %}
-```rust
-LogEvent {
+{% code-tabs-item title="internal log event" %}
+```javascript
+{
     "array[0]": "item1",
     "array[2]": "item3"
 }

--- a/docs/about/data-model/log.md
+++ b/docs/about/data-model/log.md
@@ -14,31 +14,33 @@ Vector for your use case.
 
 ## Structure
 
-Vector characterizes a `LogEvent` as a _flat_ map of arbitrary fields:
+Vector characterizes a `log` as a _flat_ map of arbitrary fields:
 
 {% code-tabs %}
-{% code-tabs-item title="definition" %}
-```rust
-pub struct LogEvent {
-    structured: HashMap<Atom, Value>,
+{% code-tabs-item title="log.proto" %}
+```coffeescript
+message Log {
+  map<string, Value> structured = 1;
 }
 
-// Where Value is defined by
-pub enum ValueKind {
-    Bytes(Bytes),
-    Integer(i64),
-    Float(f64),
-    Boolean(bool),
-    Timestamp(chrono::DateTime<Utc>),
+message Value {
+  oneof kind {
+    bytes raw_bytes = 1;
+    google.protobuf.Timestamp timestamp = 2;
+    int64 integer = 4;
+    double float = 5;
+    bool boolean = 6;
+  }
+  bool explicit = 3;
 }
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="example" %}
-```rust
-LogEvent {
-    "timestamp": chrono::DateTime<2019-05-02T00:23:22Z>,
-    "parent.child": "..."
-    "message": "message"
+```javascript
+{
+    "timestamp": "2019-05-02T00:23:22Z",
+    "parent.child": "...",
+    "message": "message",
     "host": "my.host.com",
     "key": "value",
     "parent.child": "value"
@@ -47,8 +49,8 @@ LogEvent {
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-You can view a complete definition in the
-[log event source file][url.log_event_source].
+You can view a complete definition in the [event proto \
+definition][url.event_proto].
 
 You'll notice that Vector does not restrict your schema in any way, you are
 free to use whatever fields and shape you like. In places where Vector must
@@ -226,8 +228,8 @@ remove, or rename fields as desired.
 [docs.sources]: ../../usage/configuration/sources
 [docs.transforms]: ../../usage/configuration/transforms
 [images.data-model-log]: ../../assets/data-model-log.svg
+[url.event_proto]: https://github.com/timberio/vector/blob/master/proto/event.proto
 [url.issue_551]: https://github.com/timberio/vector/issues/551
 [url.json_types]: https://en.wikipedia.org/wiki/JSON#Data_types_and_syntax
-[url.log_event_source]: https://github.com/timberio/vector/blob/master/src/event/mod.rs
 [url.rust_date_time]: https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html
 [url.toml_types]: https://github.com/toml-lang/toml#table-of-contents

--- a/docs/about/data-model/metric.md
+++ b/docs/about/data-model/metric.md
@@ -66,12 +66,25 @@ message Set {
 }
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="example" %}
+{% code-tabs-item title="counter example" %}
 ```javascript
 {
   "counter": {
     "name": "login.count",
-    "val": 2.0
+    "val": 2.0,
+    "timestamp": "2019-05-02T12:44:21.433184Z" // optional
+  }
+}
+```
+{% endcode-tabs-item %}
+{% code-tabs-item title="histogram example" %}
+```javascript
+{
+  "histogram": {
+    "name": "duration_ms",
+    "val": 2.0,
+    "sample_rate": 1,
+    "timestamp": "2019-05-02T12:44:21.433184Z" // optional
   }
 }
 ```
@@ -88,130 +101,56 @@ A vector metric must be one of the following types: `Counter`, `Histogram`,
 
 ### Counter
 
-A counter is a single value that can _only_ be incremented, it cannot be
-decremented. For example:
+A `counter` is a single value that can _only_ be incremented, it cannot be
+decremented. Your downstream metrics [sink][docs.sinks] will receive this value
+and aggregate appropriately.
 
-{% code-tabs %}
-{% code-tabs-item title="example" %}
-```javascript
-{
-  "counter": {
-    "name": "login.invocations",
-    "val": 2.0
-  }
-}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="schema" %}
-```javascript
-{
-  "counter": {
-    "name": <string>,
-    "val": <float> // 32 bit
-  }
-}
-```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
-
-Your downstream metrics [sink][docs.sinks] will receive this value and
-increment appropriately.
+| Name        | Type        | Description                       |
+|:------------|:------------|:----------------------------------|
+| `name`      | `string`    | Counter metric name.              |
+| `val`       | `double`    | Amount to increment.              |
+| `timestamp` | `timestamp` | Time metric was created/ingested. |
 
 ### Histogram
 
-Also called a "timer". A histogram represents the frequency distribution of a
+Also called a "timer". A `histogram` represents the frequency distribution of a
 value. This is commonly used for timings, helping to understand quantiles, max,
 min, and other aggregations.
-
-{% code-tabs %}
-{% code-tabs-item title="example" %}
-```javascript
-{
-  "histogram": {
-    "name": "memory_rss",
-    "val": 201.0,
-    "sample_rate": 1
-  }
-}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="schema" %}
-```javascript
-{
-  "histogram": {
-    "name": "<string>",
-    "val": <float> // 32 bit,
-    "sample_rate": <int> // 32 bit
-  }
-}
-```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
 
 Depending on the downstream service Vector will aggregate histograms internally
 (such is the case for the [`prometheus` sink][docs.prometheus_sink]) or forward
 them immediately to the service for aggregation.
 
+| Name          | Type        | Description                                      |
+|:--------------|:------------|:-------------------------------------------------|
+| `name`        | `string`    | Histogram metric name.                           |
+| `val`         | `double`    | Specific value.                                  |
+| `sample_rate` | `int`       | The bucket/distribution the metric is a part of. |
+| `timestamp`   | `timestamp` | Time metric was created/ingested.                |
+
 ### Gauge
 
 A gauge represents a point-in-time value that can increase and decrease.
-Vector's internal gauge type represents changes to that value:
+Vector's internal gauge type represents changes to that value. Gauges should be
+used to track fluctuations in values, like current memory or CPU usage.
 
-{% code-tabs %}
-{% code-tabs-item title="example" %}
-```javascript
-{
-  "gauge": {
-    "name": "memory_rss",
-    "val": 222443.0,
-    "direction": "plus"
-  }
-}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="schema" %}
-```javascript
-{
-  "gauge": {
-    "name": "<string>",
-    "val": <float> // 32 bit,
-    "direction": {"plus"|"minus"}
-  }
-}
-```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
-
-Gauges should be used to track fluctuations in values, like current memory or
-CPU usage.
+| Name        | Type        | Description                                                                   |
+|:------------|:------------|:------------------------------------------------------------------------------|
+| `name`      | `string`    | Histogram metric name.                                                        |
+| `val`       | `double`    | Specific value.                                                               |
+| `direction` | `string`    | The value direction. If it should increase or descrease the aggregated value. |
+| `timestamp` | `timestamp` | Time metric was created/ingested.                                             |
 
 ### Set
 
 A set represents a count of unique values. The `val` attribute below represents
 that unique value.
 
-{% code-tabs %}
-{% code-tabs-item title="example" %}
-```javascript
-{
-  "set": {
-    "name": "memory_rss",
-    "val": "my_unique_value"
-  }
-}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="schema" %}
-```javascript
-{
-  "set": {
-    "name": "<string>",
-    "val": "<string>"
-  }
-}
-```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
+| Name        | Type        | Description                       |
+|:------------|:------------|:----------------------------------|
+| `name`      | `string`    | Set metric name.                  |
+| `val`       | `string`    | Specific value.                   |
+| `timestamp` | `timestamp` | Time metric was created/ingested. |
 
 
 [docs.configuration]: ../../usage/configuration

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -38,12 +38,14 @@ message Metric {
 message Counter {
   string name = 1;
   double val = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message Histogram {
   string name = 1;
   double val = 2;
   uint32 sample_rate = 3;
+  google.protobuf.Timestamp timestamp = 4;
 }
 
 message Gauge {
@@ -55,9 +57,11 @@ message Gauge {
     Minus = 2;
   }
   Direction direction = 3;
+  google.protobuf.Timestamp timestamp = 4;
 }
 
 message Set {
   string name = 1;
   string val = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }

--- a/scripts/generate/templates/docs/usage/configuration/sources/statsd.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/statsd.md.erb
@@ -28,7 +28,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "counter": {
     "name": "login.invocations",
-    "val": 1
+    "val": 1,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -51,7 +52,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "gauge": {
     "name": "gas_tank",
-    "val": 0.5
+    "val": 0.5,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -74,7 +76,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "set": {
     "name": "unique_users",
-    "val": 1
+    "val": 1,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -97,7 +100,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "timer": {
     "name": "login.time",
-    "val": 22
+    "val": 22,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -110,6 +114,13 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>
+
+### Timestamp
+
+You'll notice that each metric contains a `timestamp` field. This is an optional
+descriptive field that represents when the metric was received. It helps to
+more closely represent the metric's time in situations here it can be used. See
+the [metric][docs.metric_event] data model page for more info.
 
 ## Troubleshooting
 

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -6,20 +7,24 @@ pub enum Metric {
     Counter {
         name: String,
         val: f64,
+        timestamp: Option<DateTime<Utc>>,
     },
     Histogram {
         name: String,
         val: f64,
         sample_rate: u32,
+        timestamp: Option<DateTime<Utc>>,
     },
     Gauge {
         name: String,
         val: f64,
         direction: Option<Direction>,
+        timestamp: Option<DateTime<Utc>>,
     },
     Set {
         name: String,
         val: String,
+        timestamp: Option<DateTime<Utc>>,
     },
 }
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -88,6 +88,7 @@ fn encode_event(event: Event, encoding: &Option<Encoding>) -> Result<String, ()>
 mod test {
     use super::encode_event;
     use crate::{event::Metric, Event};
+    use chrono::{offset::TimeZone, Utc};
 
     #[test]
     fn encodes_raw_logs() {
@@ -96,13 +97,28 @@ mod test {
     }
 
     #[test]
-    fn encodes_metrics() {
+    fn encodes_counter() {
         let event = Event::Metric(Metric::Counter {
             name: "foos".into(),
             val: 100.0,
+            timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
         });
         assert_eq!(
-            Ok(r#"{"type":"counter","name":"foos","val":100.0}"#.to_string()),
+            Ok(r#"{"type":"counter","name":"foos","val":100.0,"timestamp":"2018-11-14T08:09:10.000000011Z"}"#.to_string()),
+            encode_event(event, &None)
+        );
+    }
+
+    #[test]
+    fn encodes_histogram_without_timestamp() {
+        let event = Event::Metric(Metric::Histogram {
+            name: "glork".into(),
+            val: 10.0,
+            sample_rate: 1,
+            timestamp: None,
+        });
+        assert_eq!(
+            Ok(r#"{"type":"histogram","name":"glork","val":10.0,"sample_rate":1,"timestamp":null}"#.to_string()),
             encode_event(event, &None)
         );
     }

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -186,11 +186,16 @@ impl Sink for PrometheusSink {
         self.start_server_if_needed();
 
         match event.into_metric() {
-            Metric::Counter { name, val } => self.with_counter(name, |counter| counter.inc_by(val)),
+            Metric::Counter {
+                name,
+                val,
+                timestamp: _,
+            } => self.with_counter(name, |counter| counter.inc_by(val)),
             Metric::Gauge {
                 name,
                 val,
                 direction,
+                timestamp: _,
             } => self.with_gauge(name, |gauge| match direction {
                 None => gauge.set(val),
                 Some(Direction::Plus) => gauge.add(val),
@@ -200,6 +205,7 @@ impl Sink for PrometheusSink {
                 name,
                 val,
                 sample_rate,
+                timestamp: _,
             } => self.with_histogram(name, |hist| {
                 for _ in 0..sample_rate {
                     hist.observe(val);

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -39,6 +39,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             Metric::Counter {
                 name: sanitize_key(key),
                 val: val * sample_rate,
+                timestamp: None,
             }
         }
         unit @ "h" | unit @ "ms" => {
@@ -52,6 +53,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 name: sanitize_key(key),
                 val: convert_to_base_units(unit, val),
                 sample_rate: sample_rate as u32,
+                timestamp: None,
             }
         }
         "g" => Metric::Gauge {
@@ -67,10 +69,12 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 parts[0][1..].parse()?
             },
             direction: parse_direction(parts[0])?,
+            timestamp: None,
         },
         "s" => Metric::Set {
             name: sanitize_key(key),
             val: parts[0].into(),
+            timestamp: None,
         },
         other => return Err(ParseError::UnknownMetricType(other.into())),
     };
@@ -169,6 +173,7 @@ mod test {
             Ok(Metric::Counter {
                 name: "foo".into(),
                 val: 1.0,
+                timestamp: None,
             }),
         );
     }
@@ -180,6 +185,7 @@ mod test {
             Ok(Metric::Counter {
                 name: "bar".into(),
                 val: 20.0,
+                timestamp: None,
             }),
         );
     }
@@ -191,6 +197,7 @@ mod test {
             Ok(Metric::Counter {
                 name: "bar".into(),
                 val: 2.0,
+                timestamp: None,
             }),
         );
     }
@@ -202,7 +209,8 @@ mod test {
             Ok(Metric::Histogram {
                 name: "glork".into(),
                 val: 0.320,
-                sample_rate: 10
+                sample_rate: 10,
+                timestamp: None,
             }),
         );
     }
@@ -214,7 +222,8 @@ mod test {
             Ok(Metric::Histogram {
                 name: "glork".into(),
                 val: 320.0,
-                sample_rate: 10
+                sample_rate: 10,
+                timestamp: None,
             }),
         );
     }
@@ -226,7 +235,8 @@ mod test {
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
                 val: 333.0,
-                direction: None
+                direction: None,
+                timestamp: None,
             }),
         );
     }
@@ -238,7 +248,8 @@ mod test {
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
                 val: 4.0,
-                direction: Some(Direction::Minus)
+                direction: Some(Direction::Minus),
+                timestamp: None,
             }),
         );
         assert_eq!(
@@ -246,7 +257,8 @@ mod test {
             Ok(Metric::Gauge {
                 name: "gaugor".into(),
                 val: 10.0,
-                direction: Some(Direction::Plus)
+                direction: Some(Direction::Plus),
+                timestamp: None,
             }),
         );
     }
@@ -258,6 +270,7 @@ mod test {
             Ok(Metric::Set {
                 name: "uniques".into(),
                 val: "765".into(),
+                timestamp: None,
             }),
         );
     }


### PR DESCRIPTION
Ref #707

As discussed [here](https://github.com/timberio/vector/pull/707#issuecomment-518248036), timestamp information should be added into metric events.