### PR TITLE
feat(topology): Add sink healthcheck disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - coercer: New transform to convert fields into specified types.
 - file source: `data_dir` now falls back to global `data_dir` option if not specified
 - aws_kinesis_streams: Added configurable partition keys
+- topology: Added ability to disable individual sink healthchecks
 
 ### Changed
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -799,6 +799,18 @@ end
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
+
   #
   # Batching
   #
@@ -936,6 +948,18 @@ end
   # * required
   # * no default
   stream_name = "my-stream"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   # The event field used as the Kinesis record's partition key value.
   # 
@@ -1080,6 +1104,18 @@ end
   # * required
   # * no default
   region = "us-east-1"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1259,6 +1295,12 @@ end
   # * no default
   print_amount = 1000
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
 [sinks.console]
   # The component type
   # 
@@ -1290,6 +1332,12 @@ end
   # * enum: "json" or "text"
   encoding = "json"
   encoding = "text"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
 [sinks.elasticsearch]
   #
@@ -1324,6 +1372,12 @@ end
   # * optional
   # * default: "_doc"
   doc_type = "_doc"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # Index name to write events to.
   # 
@@ -1471,6 +1525,12 @@ end
   # * no default
   # * must be: "gzip" (if supplied)
   compression = "gzip"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # A URI that Vector can request in order to determine the service health.
   # 
@@ -1654,6 +1714,12 @@ end
   encoding = "json"
   encoding = "text"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
   #
   # Buffer
   #
@@ -1718,6 +1784,12 @@ end
   # * unit: seconds
   buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
 [sinks.splunk_hec]
   #
   # General
@@ -1748,6 +1820,12 @@ end
   # * required
   # * no default
   token = "A94A8FE5CCB19BA61C4C08"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Batching
@@ -1881,6 +1959,12 @@ end
   # * no default
   address = "92.12.333.224:5000"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
   #
   # Requests
   #
@@ -1954,6 +2038,12 @@ end
   # * required
   # * no default
   address = "92.12.333.224:5000"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Buffer

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -37,6 +37,10 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   region = "us-east-1"
   stream_name = "{{ instance_id }}"
   
+  # OPTIONAL - General
+  healthcheck = true # default
+  hostname = "127.0.0.0:5000"
+  
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
   batch_timeout = 1 # default, seconds
@@ -67,6 +71,10 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   group_name = "<string>"
   region = "<string>"
   stream_name = "<string>"
+
+  # OPTIONAL - General
+  healthcheck = <bool>
+  hostname = "<string>"
 
   # OPTIONAL - Batching
   batch_size = <int>
@@ -130,6 +138,18 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "{{ instance_id }}"
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -251,6 +271,9 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
 | `group_name` | `string` | The [group name][url.aws_cw_logs_group_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "/var/log/{{ file }}.log"` |
 | `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target CloudWatch Logs stream resides.<br />`required` `example: "us-east-1"` |
 | `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "{{ instance_id }}"` |
+| **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
+| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
 | `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
@@ -397,19 +420,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Partitioning
 
@@ -504,7 +527,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/aws_kinesis_streams.md
+++ b/docs/usage/configuration/sinks/aws_kinesis_streams.md
@@ -37,6 +37,8 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "my-stream"
   
   # OPTIONAL - General
+  healthcheck = true # default
+  hostname = "127.0.0.0:5000"
   partition_key_field = "user_id" # no default
   
   # OPTIONAL - Batching
@@ -70,6 +72,8 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "<string>"
 
   # OPTIONAL - General
+  healthcheck = <bool>
+  hostname = "<string>"
   partition_key_field = "<string>"
 
   # OPTIONAL - Batching
@@ -125,6 +129,18 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
   # * required
   # * no default
   stream_name = "my-stream"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   # The event field used as the Kinesis record's partition key value.
   # 
@@ -252,6 +268,8 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
 | `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target Kinesis stream resides.<br />`required` `example: "us-east-1"` |
 | `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target Kinesis Logs stream.<br />`required` `example: "my-stream"` |
 | **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
+| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
 | `partition_key_field` | `string` | The event field used as the Kinesis record's partition key value. See [Partitioning](#partitioning) for more info.<br />`no default` `example: "user_id"` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
@@ -397,19 +415,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Partitioning
 
@@ -510,7 +528,6 @@ issue, please:
 [docs.monitoring.logs]: ../../../usage/administration/monitoring.md#logs
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -36,6 +36,10 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
   bucket = "my-bucket"
   region = "us-east-1"
   
+  # OPTIONAL - General
+  healthcheck = true # default
+  hostname = "127.0.0.0:5000"
+  
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
   batch_timeout = 300 # default, seconds
@@ -73,6 +77,10 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
   inputs = ["<string>", ...]
   bucket = "<string>"
   region = "<string>"
+
+  # OPTIONAL - General
+  healthcheck = <bool>
+  hostname = "<string>"
 
   # OPTIONAL - Batching
   batch_size = <int>
@@ -135,6 +143,18 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
   # * required
   # * no default
   region = "us-east-1"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -304,6 +324,9 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `bucket` | `string` | The S3 bucket name. Do not include a leading `s3://` or a trailing `/`.<br />`required` `example: "my-bucket"` |
 | `region` | `string` | The [AWS region][url.aws_s3_regions] of the target S3 bucket.<br />`required` `example: "us-east-1"` |
+| **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
+| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 10490000` `unit: bytes` |
 | `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 300` `unit: seconds` |
@@ -476,19 +499,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Object Naming
 
@@ -666,7 +689,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/blackhole.md
+++ b/docs/usage/configuration/sinks/blackhole.md
@@ -26,6 +26,8 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
   type = "blackhole" # must be: "blackhole"
   inputs = ["my-source-id"]
   print_amount = 1000
+  
+  healthcheck = true # default
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (schema)" %}
@@ -34,6 +36,7 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
   type = "blackhole"
   inputs = ["<string>", ...]
   print_amount = <int>
+  healthcheck = <bool>
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (specification)" %}
@@ -59,6 +62,12 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
   # * required
   # * no default
   print_amount = 1000
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -71,6 +80,8 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
 | `type` | `string` | The component type<br />`required` `must be: "blackhole"` |
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `print_amount` | `int` | The number of events that must be received in order to print a summary of activity.<br />`required` `example: 1000` |
+| **OPTIONAL** | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 
 ## How It Works
 
@@ -90,19 +101,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Streaming
 
@@ -137,7 +148,6 @@ issue, please:
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.blackhole_sink]: ../../../assets/blackhole-sink.svg

--- a/docs/usage/configuration/sinks/console.md
+++ b/docs/usage/configuration/sinks/console.md
@@ -28,6 +28,7 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
   target = "stdout" # enum: "stdout" or "stderr"
   
   encoding = "json" # no default, enum: "json" or "text"
+  healthcheck = true # default
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (schema)" %}
@@ -37,6 +38,7 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
   inputs = ["<string>", ...]
   target = {"stdout" | "stderr"}
   encoding = {"json" | "text"}
+  healthcheck = <bool>
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (specification)" %}
@@ -72,6 +74,12 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
   # * enum: "json" or "text"
   encoding = "json"
   encoding = "text"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -86,6 +94,7 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
 | `target` | `string` | The [standard stream][url.standard_streams] to write to.<br />`required` `enum: "stdout" or "stderr"` |
 | **OPTIONAL** | | |
 | `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 
 ## How It Works
 
@@ -129,19 +138,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Streaming
 
@@ -176,7 +185,6 @@ issue, please:
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -37,6 +37,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
   
   # OPTIONAL - General
   doc_type = "_doc" # default
+  healthcheck = true # default
   index = "vector-%Y-%m-%d"
   
   # OPTIONAL - Batching
@@ -69,6 +70,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
 
   # OPTIONAL - General
   doc_type = "<string>"
+  healthcheck = <bool>
   index = "<string>"
 
   # OPTIONAL - Batching
@@ -126,6 +128,12 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
   # * optional
   # * default: "_doc"
   doc_type = "_doc"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # Index name to write events to.
   # 
@@ -245,6 +253,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
 | `host` | `string` | The host of your Elasticsearch cluster. This should be the full URL as shown in the example.<br />`required` `example: "http://10.24.32.122:9000"` |
 | **OPTIONAL** - General | | |
 | `doc_type` | `string` | The `doc_type` for your index data. This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to set this option since Elasticsearch has removed it.<br />`default: "_doc"` |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | `index` | `string` | Index name to write events to.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Template Syntax](#template-syntax) for more info.<br />`default: "vector-%F"` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 10490000` `unit: bytes` |
@@ -334,19 +343,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Nested Documents
 
@@ -434,7 +443,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.elasticsearch_sink]: ../../../assets/elasticsearch-sink.svg

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -31,6 +31,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   
   # OPTIONAL - General
   compression = "gzip" # no default, must be: "gzip" (if supplied)
+  healthcheck = true # default
   healthcheck_uri = "https://10.22.212.22:9000/_health" # no default
   
   # OPTIONAL - Batching
@@ -73,6 +74,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 
   # OPTIONAL - General
   compression = "gzip"
+  healthcheck = <bool>
   healthcheck_uri = "<string>"
 
   # OPTIONAL - Batching
@@ -147,6 +149,12 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   # * no default
   # * must be: "gzip" (if supplied)
   compression = "gzip"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # A URI that Vector can request in order to determine the service health.
   # 
@@ -294,6 +302,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 | `uri` | `string` | The full URI to make HTTP requests to. This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.<br />`required` `example: (see above)` |
 | **OPTIONAL** - General | | |
 | `compression` | `string` | The compression strategy used to compress the payload before sending. See [Compression](#compression) for more info.<br />`no default` `must be: "gzip"` |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | `healthcheck_uri` | `string` | A URI that Vector can request in order to determine the service health. See [Health Checks](#health-checks) for more info.<br />`no default` `example: (see above)` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
@@ -434,20 +443,21 @@ section.
 
 ### Health Checks
 
-If the `healthcheck_uri` option is provided, Vector will issue a request
-to this URI to ensure Vector can properly community with the service. This
-helps to ensure that data will be successfully delivered after Vector is
-started.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+In order to run this check you must provide a value for the `healthcheck_uri`
+option.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Rate Limits
 

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -32,6 +32,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
   
   # OPTIONAL - General
   encoding = "json" # no default, enum: "json" or "text"
+  healthcheck = true # default
   
   # OPTIONAL - Buffer
   [sinks.my_sink_id.buffer]
@@ -53,6 +54,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
 
   # OPTIONAL - General
   encoding = {"json" | "text"}
+  healthcheck = <bool>
 
   # OPTIONAL - Buffer
   [sinks.<sink-id>.buffer]
@@ -114,6 +116,12 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
   encoding = "json"
   encoding = "text"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
   #
   # Buffer
   #
@@ -165,6 +173,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
 | `topic` | `string` | The Kafka topic name to write events to.<br />`required` `example: "topic-1234"` |
 | **OPTIONAL** - General | | |
 | `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | **OPTIONAL** - Buffer | | |
 | `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
 | `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
@@ -213,19 +222,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Streaming
 
@@ -260,7 +269,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/prometheus.md
+++ b/docs/usage/configuration/sinks/prometheus.md
@@ -35,6 +35,7 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
   address = "0.0.0.0:9598"
   
   buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] # default, seconds
+  healthcheck = true # default
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (schema)" %}
@@ -44,6 +45,7 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
   inputs = ["<string>", ...]
   address = "<string>"
   buckets = [<float>, ...]
+  healthcheck = <bool>
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (specification)" %}
@@ -75,6 +77,12 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
   # * default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
   # * unit: seconds
   buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -89,6 +97,7 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
 | `address` | `string` | The address to expose for scraping. See [Exposing & Scraping](#exposing-scraping) for more info.<br />`required` `example: "0.0.0.0:9598"` |
 | **OPTIONAL** | | |
 | `buckets` | `[float]` | Default buckets to use for [histogram][docs.metric_event.histogram] metrics. See [Histogram Buckets](#histogram-buckets) for more info.<br />`default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]` `unit: seconds` |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start.<br />`default: true` |
 
 ## Examples
 

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -29,6 +29,9 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
   host = "my-splunk-host.com"
   token = "A94A8FE5CCB19BA61C4C08"
   
+  # OPTIONAL - General
+  healthcheck = true # default
+  
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
   batch_timeout = 1 # default, seconds
@@ -58,6 +61,9 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
   inputs = ["<string>", ...]
   host = "<string>"
   token = "<string>"
+
+  # OPTIONAL - General
+  healthcheck = <bool>
 
   # OPTIONAL - Batching
   batch_size = <int>
@@ -112,6 +118,12 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
   # * required
   # * no default
   token = "A94A8FE5CCB19BA61C4C08"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Batching
@@ -232,6 +244,8 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `host` | `string` | Your Splunk HEC host.<br />`required` `example: "my-splunk-host.com"` |
 | `token` | `string` | Your Splunk HEC token.<br />`required` `example: "A94A8FE5CCB19BA61C4C08"` |
+| **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
 | `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
@@ -327,19 +341,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Rate Limits
 
@@ -407,7 +421,6 @@ should supply to the `host` and `token` options.
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -28,6 +28,9 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
   inputs = ["my-source-id"]
   address = "92.12.333.224:5000"
   
+  # OPTIONAL - General
+  healthcheck = true # default
+  
   # OPTIONAL - Requests
   encoding = "json" # no default, enum: "json" or "text"
   
@@ -46,6 +49,9 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
   type = "tcp"
   inputs = ["<string>", ...]
   address = "<string>"
+
+  # OPTIONAL - General
+  healthcheck = <bool>
 
   # OPTIONAL - Requests
   encoding = {"json" | "text"}
@@ -84,6 +90,12 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
   # * required
   # * no default
   address = "92.12.333.224:5000"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Requests
@@ -145,6 +157,8 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
 | `type` | `string` | The component type<br />`required` `must be: "tcp"` |
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `address` | `string` | The TCP address.<br />`required` `example: "92.12.333.224:5000"` |
+| **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | **OPTIONAL** - Requests | | |
 | `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
 | **OPTIONAL** - Buffer | | |
@@ -195,19 +209,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Streaming
 
@@ -242,7 +256,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md

--- a/docs/usage/configuration/sinks/vector.md
+++ b/docs/usage/configuration/sinks/vector.md
@@ -28,6 +28,9 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
   inputs = ["my-source-id"]
   address = "92.12.333.224:5000"
   
+  # OPTIONAL - General
+  healthcheck = true # default
+  
   # OPTIONAL - Buffer
   [sinks.my_sink_id.buffer]
     type = "memory" # default, enum: "memory" or "disk"
@@ -43,6 +46,9 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
   type = "vector"
   inputs = ["<string>", ...]
   address = "<string>"
+
+  # OPTIONAL - General
+  healthcheck = <bool>
 
   # OPTIONAL - Buffer
   [sinks.<sink-id>.buffer]
@@ -78,6 +84,12 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
   # * required
   # * no default
   address = "92.12.333.224:5000"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Buffer
@@ -126,6 +138,8 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
 | `type` | `string` | The component type<br />`required` `must be: "vector"` |
 | `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
 | `address` | `string` | The downstream Vector address.<br />`required` `example: "92.12.333.224:5000"` |
+| **OPTIONAL** - General | | |
+| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | **OPTIONAL** - Buffer | | |
 | `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
 | `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
@@ -150,19 +164,19 @@ section.
 
 ### Health Checks
 
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 
 ### Streaming
 
@@ -197,7 +211,6 @@ issue, please:
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.sources]: ../../../usage/configuration/sources
-[docs.starting]: ../../../usage/administration/starting.md
 [docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.vector_sink]: ../../../assets/vector-sink.svg

--- a/docs/usage/configuration/sources/statsd.md
+++ b/docs/usage/configuration/sources/statsd.md
@@ -86,7 +86,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "counter": {
     "name": "login.invocations",
-    "val": 1
+    "val": 1,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -109,7 +110,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "gauge": {
     "name": "gas_tank",
-    "val": 0.5
+    "val": 0.5,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -132,7 +134,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "set": {
     "name": "unique_users",
-    "val": 1
+    "val": 1,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -155,7 +158,8 @@ A [`metric` event][docs.metric_event] will be emitted with the following structu
 {
   "timer": {
     "name": "login.time",
-    "val": 22
+    "val": 22,
+    "timestamp": "2019-05-02T12:22:46.658503Z" // current time / time ingested
   }
 }
 ```
@@ -180,6 +184,13 @@ will be replaced before being evaluated.
 
 You can learn more in the [Environment Variables][docs.configuration.environment-variables]
 section.
+
+### Timestamp
+
+You'll notice that each metric contains a `timestamp` field. This is an optional
+descriptive field that represents when the metric was received. It helps to
+more closely represent the metric's time in situations here it can be used. See
+the [metric][docs.metric_event] data model page for more info.
 
 ## Troubleshooting
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -819,6 +819,18 @@ end
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
+
   #
   # Batching
   #
@@ -956,6 +968,18 @@ end
   # * required
   # * no default
   stream_name = "my-stream"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   # The event field used as the Kinesis record's partition key value.
   # 
@@ -1100,6 +1124,18 @@ end
   # * required
   # * no default
   region = "us-east-1"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
+  # Custom hostname to send requests to. Useful for testing.
+  # 
+  # * optional
+  # * no default
+  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1279,6 +1315,12 @@ end
   # * no default
   print_amount = 1000
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
 [sinks.console]
   # The component type
   # 
@@ -1310,6 +1352,12 @@ end
   # * enum: "json" or "text"
   encoding = "json"
   encoding = "text"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
 [sinks.elasticsearch]
   #
@@ -1344,6 +1392,12 @@ end
   # * optional
   # * default: "_doc"
   doc_type = "_doc"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # Index name to write events to.
   # 
@@ -1491,6 +1545,12 @@ end
   # * no default
   # * must be: "gzip" (if supplied)
   compression = "gzip"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   # A URI that Vector can request in order to determine the service health.
   # 
@@ -1674,6 +1734,12 @@ end
   encoding = "json"
   encoding = "text"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
   #
   # Buffer
   #
@@ -1738,6 +1804,12 @@ end
   # * unit: seconds
   buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
 [sinks.splunk_hec]
   #
   # General
@@ -1768,6 +1840,12 @@ end
   # * required
   # * no default
   token = "A94A8FE5CCB19BA61C4C08"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Batching
@@ -1901,6 +1979,12 @@ end
   # * no default
   address = "92.12.333.224:5000"
 
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
+
   #
   # Requests
   #
@@ -1974,6 +2058,12 @@ end
   # * required
   # * no default
   address = "92.12.333.224:5000"
+
+  # Enables/disables the sink healthcheck upon start.
+  # 
+  # * optional
+  # * default: true
+  healthcheck = true
 
   #
   # Buffer

--- a/scripts/generate/metadata/sink.rb
+++ b/scripts/generate/metadata/sink.rb
@@ -39,10 +39,20 @@ class Sink < Component
       raise("#{self.class.name}#write_to_description cannot not end with a period")
     end
 
+    # Healthcheck option
+
+    @options.healthcheck = Option.new({
+      "name" => "healthcheck",
+      "default" => true,
+      "description" => "Enables/disables the sink healthcheck upon start.",
+      "null" => false,
+      "type" => "bool"
+    })
+
     # Hostname option
 
     if service_provider == "AWS"
-      buffer_option = Option.new({
+      @options.hostname = Option.new({
         "name" => "hostname",
         "examples" => ["127.0.0.0:5000"],
         "default" => "<aws-service-hostname>",

--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -147,26 +147,23 @@ accessible by the downstream service doing the scraping.
 
 ### Health Checks
 
+Health checks ensure that the downstream service is accessible and ready to
+accept data. This check is performed upon sink initialization.
 <%- if component.options.healthcheck_uri -%>
-If the `healthcheck_uri` option is provided, Vector will issue a request
-to this URI to ensure Vector can properly community with the service. This
-helps to ensure that data will be successfully delivered after Vector is
-started.
-<%- else -%>
-Upon [starting][docs.starting], Vector will perform a simple health check
-against this sink. The ensures that the downstream service is healthy and
-reachable.
+In order to run this check you must provide a value for the `healthcheck_uri`
+option.
 <%- end -%>
-By default, if the health check fails an error will be logged and
-Vector will proceed to start. If you'd like to exit immediately upomn healt
-check failure, you can pass the `--require-healthy` flag:
+
+If the health check fails an error will be logged and Vector will proceed to
+start. If you'd like to exit immediately upon health check failure, you can
+pass the `--require-healthy` flag:
 
 ```bash
 vector --config /etc/vector/vector.toml --require-healthy
 ```
 
-Be careful when doing this, one unhealthy sink can prevent other healthy sinks
-from processing data at all.
+And finally, if you'd like to disable health checks entirely for this sink
+you can set the `healthcheck` option to `false`.
 <%- end -%>
 <%- if component.partition_options.any? -%>
 

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -53,6 +53,8 @@ pub trait SourceConfig: core::fmt::Debug {
 pub struct SinkOuter {
     #[serde(default)]
     pub buffer: crate::buffers::BufferConfig,
+    #[serde(default = "healthcheck_default")]
+    pub healthcheck: bool,
     pub inputs: Vec<String>,
     #[serde(flatten)]
     pub inner: Box<SinkConfig>,
@@ -103,6 +105,7 @@ impl Config {
         let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
         let sink = SinkOuter {
             buffer: Default::default(),
+            healthcheck: true,
             inner: Box::new(sink),
             inputs,
         };
@@ -161,4 +164,8 @@ impl Clone for Config {
         let json = serde_json::to_vec(self).unwrap();
         serde_json::from_slice(&json[..]).unwrap()
     }
+}
+
+fn healthcheck_default() -> bool {
+    true
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1303,5 +1303,20 @@ mod tests {
             let received = block_on(receive).unwrap();
             assert_matches!(received, Either::A(_));
         }
+
+        // disable healthcheck
+        {
+            config.sinks["out"].inner = Box::new(TcpSinkConfig::new(out1_addr.to_string()));
+            config.sinks["out"].healthcheck = false;
+
+            topology.reload_config_and_respawn(config.clone(), &mut rt, false);
+
+            let receive = receive_one(&out1_addr, &out2_addr);
+
+            block_on(send_lines(in_addr, vec!["hello".to_string()].into_iter())).unwrap();
+
+            let received = block_on(receive).unwrap();
+            assert_matches!(received, Either::A(_));
+        }
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -369,3 +369,21 @@ fn cycle() {
 
     assert_eq!(errors, vec!["Configured topology contains a cycle"])
 }
+
+#[test]
+fn disabled_healthcheck() {
+    load(
+        r#"
+      [sources.in]
+      type = "tcp"
+      address = "127.0.0.1:1234"
+
+      [sinks.out]
+      type = "tcp"
+      inputs = ["in"]
+      address = "0.0.0.0:0"
+      healthcheck = false
+      "#,
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This adds the ability to disable individual sink healthchecks in the case that you want the healthcheck to pass but not to actually run.

Closes #621

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>