### PR TITLE
fix: Config validation

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -64,7 +64,7 @@ impl SourceConfig for FileConfig {
         // so that multiple sources can operate within the same given data_dir (e.g. the global one)
         // without the file servers' checkpointers interfering with each other
         data_dir.push(name);
-        if let Err(e) = DirBuilder::new().create(&data_dir) {
+        if let Err(e) = DirBuilder::new().recursive(true).create(&data_dir) {
             return Err(format!(
                 "could not create subdirectory '{}' inside of data_dir '{}': {}",
                 name,

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -8,6 +8,7 @@ mod validation;
 mod vars;
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub data_dir: Option<PathBuf>,
@@ -142,7 +143,18 @@ impl Config {
         }
         let with_vars = vars::interpolate(&source_string, &vars);
 
-        toml::from_str(&with_vars).map_err(|e| vec![e.to_string()])
+        toml::from_str(&with_vars)
+            .map_err(|e| vec![e.to_string()])
+            .and_then(|config: Config| {
+                if config.sources.is_empty() {
+                    return Err(vec!["No sources defined in the config.".to_owned()]);
+                }
+                if config.sinks.is_empty() {
+                    return Err(vec!["No sinks defined in the config.".to_owned()]);
+                }
+
+                Ok(config)
+            })
     }
 
     pub fn contains_cycle(&self) -> bool {


### PR DESCRIPTION
Couple of small fixes:
* Forbidding unknown fields at root level of configs.
* Validation of sinks and sources for non-emptiness.
* Removing error in case of initialized after prefious run data_dir.

Closes #603.