### PR TITLE
feat(data model): add tags into metrics model

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -39,6 +39,7 @@ message Counter {
   string name = 1;
   double val = 2;
   google.protobuf.Timestamp timestamp = 3;
+  map<string, string> tags = 4;
 }
 
 message Histogram {
@@ -46,6 +47,7 @@ message Histogram {
   double val = 2;
   uint32 sample_rate = 3;
   google.protobuf.Timestamp timestamp = 4;
+  map<string, string> tags = 5;
 }
 
 message Gauge {
@@ -58,10 +60,12 @@ message Gauge {
   }
   Direction direction = 3;
   google.protobuf.Timestamp timestamp = 4;
+  map<string, string> tags = 5;
 }
 
 message Set {
   string name = 1;
   string val = 2;
   google.protobuf.Timestamp timestamp = 3;
+  map<string, string> tags = 4;
 }

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -8,23 +9,27 @@ pub enum Metric {
         name: String,
         val: f64,
         timestamp: Option<DateTime<Utc>>,
+        tags: Option<HashMap<String, String>>,
     },
     Histogram {
         name: String,
         val: f64,
         sample_rate: u32,
         timestamp: Option<DateTime<Utc>>,
+        tags: Option<HashMap<String, String>>,
     },
     Gauge {
         name: String,
         val: f64,
         direction: Option<Direction>,
         timestamp: Option<DateTime<Utc>>,
+        tags: Option<HashMap<String, String>>,
     },
     Set {
         name: String,
         val: String,
         timestamp: Option<DateTime<Utc>>,
+        tags: Option<HashMap<String, String>>,
     },
 }
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -102,9 +102,14 @@ mod test {
             name: "foos".into(),
             val: 100.0,
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
+            tags: Some(
+                vec![("key".to_owned(), "value".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
         });
         assert_eq!(
-            Ok(r#"{"type":"counter","name":"foos","val":100.0,"timestamp":"2018-11-14T08:09:10.000000011Z"}"#.to_string()),
+            Ok(r#"{"type":"counter","name":"foos","val":100.0,"timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"key":"value"}}"#.to_string()),
             encode_event(event, &None)
         );
     }
@@ -116,9 +121,10 @@ mod test {
             val: 10.0,
             sample_rate: 1,
             timestamp: None,
+            tags: None,
         });
         assert_eq!(
-            Ok(r#"{"type":"histogram","name":"glork","val":10.0,"sample_rate":1,"timestamp":null}"#.to_string()),
+            Ok(r#"{"type":"histogram","name":"glork","val":10.0,"sample_rate":1,"timestamp":null,"tags":null}"#.to_string()),
             encode_event(event, &None)
         );
     }

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -305,11 +305,7 @@ impl Sink for PrometheusSink {
                     hist.observe(val);
                 }
             }),
-            Metric::Set {
-                name,
-                val,
-                timestamp: _,
-            } => {
+            Metric::Set { name, val, .. } => {
                 // Sets are implemented using promethius integer gauges.
                 self.with_set(name, move |&mut (ref mut counter, ref mut set)| {
                     // Check if counter was reseted

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -282,16 +282,14 @@ impl Sink for PrometheusSink {
         self.start_server_if_needed();
 
         match event.into_metric() {
-            Metric::Counter {
-                name,
-                val,
-                timestamp: _,
-            } => self.with_counter(name, |counter| counter.inc_by(val)),
+            Metric::Counter { name, val, .. } => {
+                self.with_counter(name, |counter| counter.inc_by(val))
+            }
             Metric::Gauge {
                 name,
                 val,
                 direction,
-                timestamp: _,
+                ..
             } => self.with_gauge(name, |gauge| match direction {
                 None => gauge.set(val),
                 Some(Direction::Plus) => gauge.add(val),
@@ -301,7 +299,7 @@ impl Sink for PrometheusSink {
                 name,
                 val,
                 sample_rate,
-                timestamp: _,
+                ..
             } => self.with_histogram(name, |hist| {
                 for _ in 0..sample_rate {
                     hist.observe(val);

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -2,6 +2,7 @@ use crate::event::{metric::Direction, Metric};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
+    collections::HashMap,
     error, fmt,
     num::{ParseFloatError, ParseIntError},
 };
@@ -12,6 +13,7 @@ lazy_static! {
 }
 
 pub fn parse(packet: &str) -> Result<Metric, ParseError> {
+    // https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#datagram-format
     let key_and_body = packet.splitn(2, ':').collect::<Vec<_>>();
     if key_and_body.len() != 2 {
         return Err(ParseError::Malformed(
@@ -26,38 +28,53 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             "body should have at least two pipe separated components",
         ));
     }
+
+    let name = sanitize_key(key);
     let metric_type = parts[1];
+
+    // sampling part is optional and comes after metric type part
+    let sampling = parts.get(2).filter(|s| s.starts_with('@'));
+    let sample_rate = if let Some(s) = sampling {
+        1.0 / sanitize_sampling(parse_sampling(s)?)
+    } else {
+        1.0
+    };
+
+    // tags are optional and could be found either after sampling of after metric type part
+    let tags = if sampling.is_none() {
+        parts.get(2)
+    } else {
+        parts.get(3)
+    };
+    let tags = tags.filter(|s| s.starts_with('#'));
+    let tags = if let Some(t) = tags {
+        Some(parse_tags(t)?)
+    } else {
+        None
+    };
 
     let metric = match metric_type {
         "c" => {
-            let sample_rate = if let Some(s) = parts.get(2) {
-                1.0 / sanitize_sampling(parse_sampling(s)?)
-            } else {
-                1.0
-            };
             let val: f64 = parts[0].parse()?;
             Metric::Counter {
-                name: sanitize_key(key),
+                name,
                 val: val * sample_rate,
                 timestamp: None,
+                tags,
             }
         }
         unit @ "h" | unit @ "ms" => {
-            let sample_rate = if let Some(s) = parts.get(2) {
-                1.0 / sanitize_sampling(parse_sampling(s)?)
-            } else {
-                1.0
-            };
             let val: f64 = parts[0].parse()?;
             Metric::Histogram {
-                name: sanitize_key(key),
+                name,
                 val: convert_to_base_units(unit, val),
                 sample_rate: sample_rate as u32,
                 timestamp: None,
+                tags,
             }
         }
         "g" => Metric::Gauge {
-            name: sanitize_key(key),
+            name,
             val: if parts[0]
                 .chars()
                 .next()
@@ -70,11 +87,13 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             },
             direction: parse_direction(parts[0])?,
             timestamp: None,
+            tags,
         },
         "s" => Metric::Set {
-            name: sanitize_key(key),
+            name,
             val: parts[0].into(),
             timestamp: None,
+            tags,
         },
         other => return Err(ParseError::UnknownMetricType(other.into())),
     };
@@ -84,7 +103,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
 fn parse_sampling(input: &str) -> Result<f64, ParseError> {
     if !input.starts_with('@') || input.len() < 2 {
         return Err(ParseError::Malformed(
-            "expected '@'-prefixed sampling component",
+            "expected non empty '@'-prefixed sampling component",
         ));
     }
 
@@ -94,6 +113,29 @@ fn parse_sampling(input: &str) -> Result<f64, ParseError> {
     } else {
         Err(ParseError::Malformed("sample rate can't be negative"))
     }
+}
+
+fn parse_tags(input: &str) -> Result<HashMap<String, String>, ParseError> {
+    if !input.starts_with('#') || input.len() < 2 {
+        return Err(ParseError::Malformed(
+            "expected non empty '#'-prefixed tags component",
+        ));
+    }
+
+    let mut result = HashMap::new();
+
+    let chunks = input[1..].split(',').collect::<Vec<_>>();
+    for chunk in chunks {
+        let pair: Vec<_> = chunk.split(':').collect();
+        let key = &pair[0];
+        // same as in telegraf plugin:
+        // if tag value is not provided, use "true"
+        // https://github.com/influxdata/telegraf/blob/master/plugins/inputs/statsd/datadog.go#L152
+        let value = pair.get(1).unwrap_or(&"true");
+        result.insert((*key).to_owned(), (*value).to_owned());
+    }
+
+    Ok(result)
 }
 
 fn parse_direction(input: &str) -> Result<Option<Direction>, ParseError> {
@@ -174,6 +216,27 @@ mod test {
                 name: "foo".into(),
                 val: 1.0,
                 timestamp: None,
+                tags: None,
+            }),
+        );
+    }
+
+    #[test]
+    fn tagged_counter() {
+        assert_eq!(
+            parse("foo:1|c|#tag1,tag2:value"),
+            Ok(Metric::Counter {
+                name: "foo".into(),
+                val: 1.0,
+                timestamp: None,
+                tags: Some(
+                    vec![
+                        ("tag1".to_owned(), "true".to_owned()),
+                        ("tag2".to_owned(), "value".to_owned()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
             }),
         );
     }
@@ -186,6 +249,7 @@ mod test {
                 name: "bar".into(),
                 val: 20.0,
                 timestamp: None,
+                tags: None,
             }),
         );
     }
@@ -198,6 +262,7 @@ mod test {
                 name: "bar".into(),
                 val: 2.0,
                 timestamp: None,
+                tags: None,
             }),
         );
     }
@@ -211,19 +276,29 @@ mod test {
                 val: 0.320,
                 sample_rate: 10,
                 timestamp: None,
+                tags: None,
             }),
         );
     }
 
     #[test]
-    fn sampled_histogram() {
+    fn sampled_tagged_histogram() {
         assert_eq!(
-            parse("glork:320|h|@0.1"),
+            parse("glork:320|h|@0.1|#region:us-west1,production,e:"),
             Ok(Metric::Histogram {
                 name: "glork".into(),
                 val: 320.0,
                 sample_rate: 10,
                 timestamp: None,
+                tags: Some(
+                    vec![
+                        ("region".to_owned(), "us-west1".to_owned()),
+                        ("production".to_owned(), "true".to_owned()),
+                        ("e".to_owned(), "".to_owned()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
             }),
         );
     }
@@ -237,6 +312,7 @@ mod test {
                 val: 333.0,
                 direction: None,
                 timestamp: None,
+                tags: None,
             }),
         );
     }
@@ -250,6 +326,7 @@ mod test {
                 val: 4.0,
                 direction: Some(Direction::Minus),
                 timestamp: None,
+                tags: None,
             }),
         );
         assert_eq!(
@@ -259,6 +336,7 @@ mod test {
                 val: 10.0,
                 direction: Some(Direction::Plus),
                 timestamp: None,
+                tags: None,
             }),
         );
     }
@@ -271,6 +349,7 @@ mod test {
                 name: "uniques".into(),
                 val: "765".into(),
                 timestamp: None,
+                tags: None,
             }),
         );
     }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -108,6 +108,9 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
         .and_then(ValueKind::as_timestamp)
         .cloned();
 
+    // https://github.com/timberio/vector/issues/684
+    let tags = None;
+
     match config {
         MetricConfig::Counter(counter) => {
             let val = log
@@ -128,6 +131,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 name,
                 val,
                 timestamp,
+                tags,
             })
         }
         MetricConfig::Histogram(hist) => {
@@ -145,6 +149,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 val,
                 sample_rate: 1,
                 timestamp,
+                tags,
             })
         }
         MetricConfig::Gauge(gauge) => {
@@ -162,6 +167,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 val,
                 direction: None,
                 timestamp,
+                tags,
             })
         }
         MetricConfig::Set(set) => {
@@ -175,6 +181,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 name,
                 val,
                 timestamp,
+                tags,
             })
         }
     }
@@ -252,6 +259,7 @@ mod tests {
                 name: "status".into(),
                 val: 1.0,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -277,6 +285,7 @@ mod tests {
                 name: "exception_total".into(),
                 val: 1.0,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -321,6 +330,7 @@ mod tests {
                 name: "amount_total".into(),
                 val: 33.99,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -347,6 +357,7 @@ mod tests {
                 val: 123.0,
                 direction: None,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -423,6 +434,7 @@ mod tests {
                 name: "exception_total".into(),
                 val: 1.0,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
         assert_eq!(
@@ -431,6 +443,7 @@ mod tests {
                 name: "status".into(),
                 val: 1.0,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -482,6 +495,7 @@ mod tests {
                 name: "xyz_exception_total".into(),
                 val: 1.0,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
         assert_eq!(
@@ -490,6 +504,7 @@ mod tests {
                 name: "local_abc_status_set".into(),
                 val: "42".into(),
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -515,6 +530,7 @@ mod tests {
                 name: "unique_user_ip".into(),
                 val: "1.2.3.4".into(),
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }
@@ -540,6 +556,7 @@ mod tests {
                 val: 2.5,
                 sample_rate: 1,
                 timestamp: Some(ts()),
+                tags: None,
             }
         );
     }


### PR DESCRIPTION
Closes #512.

This PR adds tags support for metrics. Conceptually tags are pairs of `key` and `value` strings. They are stored in a HashMap, however it is possible to reconsider the choice of data structure.

Statsd source was updated to parse tag components (in DataDog format), and CloudWatch metrics sink was updated to send tags into API endpoint.

Follow up issue #760