### PR TITLE
fix(prometheus sink): Update use of Metric::Set

### DIFF
--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -307,7 +307,11 @@ impl Sink for PrometheusSink {
                     hist.observe(val);
                 }
             }),
-            Metric::Set { name, val } => {
+            Metric::Set {
+                name,
+                val,
+                timestamp: _,
+            } => {
                 // Sets are implemented using promethius integer gauges.
                 self.with_set(name, move |&mut (ref mut counter, ref mut set)| {
                     // Check if counter was reseted


### PR DESCRIPTION
Update of #733 caused by changes made in #726.



<!--
1, Describe your changes in a way that respects the time of your reviewer(s).
2. Reference the appropriate issues via `Closes #123` or `Ref #123`.
3. Use `make signoff` to sign your commits. See CONTRIBUTING.md for more info.
4. Your PR title should follow the conventional commits format. See CONTRIBUTING.md for more info.
-->