### PR TITLE
feat(aws_cloudwatch_logs sink): Add dynamic group creation

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -764,7 +764,7 @@ is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for 
 """
 
 # ------------------------------------------------------------------------------
-# sinks.aws_cloudwatch_logs
+
 # ------------------------------------------------------------------------------
 [sinks.aws_cloudwatch_logs]
 batch_size = 1049000
@@ -823,6 +823,23 @@ null = false
 partition_key = true
 templateable = true
 description = "The [stream name][url.aws_cw_logs_stream_name] of the target CloudWatch Logs stream."
+
+[sinks.aws_cloudwatch_logs.options.create_missing_group]
+type = "bool"
+default = true
+null = true
+description = """
+Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore
+`create_missing_stream` directly after creating the group and will create the first stream.
+"""
+
+[sinks.aws_cloudwatch_logs.options.create_missing_stream]
+type = "bool"
+default = true
+null = true
+description = """
+Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist.
+"""
 
 # ------------------------------------------------------------------------------
 # sinks.aws_kinesis_streams

--- a/.metadata.toml
+++ b/.metadata.toml
@@ -828,18 +828,16 @@ description = "The [stream name][url.aws_cw_logs_stream_name] of the target Clou
 type = "bool"
 default = true
 null = true
-description = """
-Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore
-`create_missing_stream` directly after creating the group and will create the first stream.
+description = """\
+Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore \
+`create_missing_stream` directly after creating the group and will create the first stream. \
 """
 
 [sinks.aws_cloudwatch_logs.options.create_missing_stream]
 type = "bool"
 default = true
 null = true
-description = """
-Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist.
-"""
+description = "Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist."
 
 # ------------------------------------------------------------------------------
 # sinks.aws_kinesis_streams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - file source: `data_dir` now falls back to global `data_dir` option if not specified
 - aws_kinesis_streams: Added configurable partition keys
 - topology: Added ability to disable individual sink healthchecks
+- aws_cloudwatch_logs: Add dynamic group and stream creation
 
 ### Changed
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -799,6 +799,20 @@ end
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
 
+  # Dynamically create a log group if it does not already exist. This will ignore
+  # `create_missing_stream` directly after creating the group and will create the
+  # first stream.
+  # 
+  # * optional
+  # * default: true
+  create_missing_group = true
+
+  # Dynamically create a log stream if it does not already exist.
+  # 
+  # * optional
+  # * default: true
+  create_missing_stream = true
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -290,8 +290,7 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
 | `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target CloudWatch Logs stream resides.<br />`required` `example: "us-east-1"` |
 | `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "{{ instance_id }}"` |
 | **OPTIONAL** - General | | |
-| `create_missing_group` | `bool` | Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore
-`create_missing_stream` directly after creating the group and will create the first stream.<br />`default: true` |
+| `create_missing_group` | `bool` | Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore `create_missing_stream` directly after creating the group and will create the first stream.<br />`default: true` |
 | `create_missing_stream` | `bool` | Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist.<br />`default: true` |
 | `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -38,6 +38,8 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "{{ instance_id }}"
   
   # OPTIONAL - General
+  create_missing_group = true # default
+  create_missing_stream = true # default
   healthcheck = true # default
   hostname = "127.0.0.0:5000"
   
@@ -73,6 +75,8 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "<string>"
 
   # OPTIONAL - General
+  create_missing_group = <bool>
+  create_missing_stream = <bool>
   healthcheck = <bool>
   hostname = "<string>"
 
@@ -138,6 +142,20 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
   stream_name = "{{ instance_id }}"
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
+
+  # Dynamically create a log group if it does not already exist. This will ignore
+  # `create_missing_stream` directly after creating the group and will create the
+  # first stream.
+  # 
+  # * optional
+  # * default: true
+  create_missing_group = true
+
+  # Dynamically create a log stream if it does not already exist.
+  # 
+  # * optional
+  # * default: true
+  create_missing_stream = true
 
   # Enables/disables the sink healthcheck upon start.
   # 
@@ -272,6 +290,9 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
 | `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target CloudWatch Logs stream resides.<br />`required` `example: "us-east-1"` |
 | `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "{{ instance_id }}"` |
 | **OPTIONAL** - General | | |
+| `create_missing_group` | `bool` | Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore
+`create_missing_stream` directly after creating the group and will create the first stream.<br />`default: true` |
+| `create_missing_stream` | `bool` | Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist.<br />`default: true` |
 | `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
 | **OPTIONAL** - Batching | | |

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -819,6 +819,20 @@ end
   stream_name = "stream-name"
   stream_name = "%Y-%m-%d"
 
+  # Dynamically create a log group if it does not already exist. This will ignore
+  # `create_missing_stream` directly after creating the group and will create the
+  # first stream.
+  # 
+  # * optional
+  # * default: true
+  create_missing_group = true
+
+  # Dynamically create a log stream if it does not already exist.
+  # 
+  # * optional
+  # * default: true
+  create_missing_stream = true
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -19,8 +19,8 @@ use rusoto_core::{
 };
 use rusoto_credential::DefaultCredentialsProvider;
 use rusoto_logs::{
-    CloudWatchLogs, CloudWatchLogsClient, CreateLogStreamError, DescribeLogGroupsRequest,
-    DescribeLogStreamsError, InputLogEvent, PutLogEventsError,
+    CloudWatchLogs, CloudWatchLogsClient, CreateLogGroupError, CreateLogStreamError,
+    DescribeLogGroupsRequest, DescribeLogStreamsError, InputLogEvent, PutLogEventsError,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryInto, fmt, time::Duration};
@@ -103,6 +103,7 @@ pub enum CloudwatchError {
     Put(PutLogEventsError),
     Describe(DescribeLogStreamsError),
     CreateStream(CreateLogStreamError),
+    CreateGroup(CreateLogGroupError),
     NoStreamsFound,
     ServiceDropped,
     MakeService,
@@ -523,6 +524,7 @@ impl fmt::Display for CloudwatchError {
             CloudwatchError::Put(e) => write!(f, "CloudwatchError::Put: {}", e),
             CloudwatchError::Describe(e) => write!(f, "CloudwatchError::Describe: {}", e),
             CloudwatchError::CreateStream(e) => write!(f, "CloudwatchError::CreateStream: {}", e),
+            CloudwatchError::CreateGroup(e) => write!(f, "CloudwatchError::CreateGroup: {}", e),
             CloudwatchError::NoStreamsFound => write!(f, "CloudwatchError: No Streams Found"),
             CloudwatchError::ServiceDropped => write!(
                 f,

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -721,7 +721,7 @@ mod integration_tests {
     fn cloudwatch_insert_log_event() {
         let mut rt = Runtime::new().unwrap();
 
-        let stream_name = gen_stream();
+        let stream_name = gen_name();
 
         let region = Region::Custom {
             name: "localstack".into(),
@@ -770,7 +770,8 @@ mod integration_tests {
     fn cloudwatch_dynamic_group_and_stream_creation() {
         let mut rt = Runtime::new().unwrap();
 
-        let stream_name = gen_stream();
+        let group_name = gen_name();
+        let stream_name = gen_name();
 
         let region = Region::Custom {
             name: "localstack".into(),
@@ -779,7 +780,7 @@ mod integration_tests {
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: stream_name.clone().into(),
-            group_name: GROUP_NAME.into(),
+            group_name: group_name.clone().into(),
             region: RegionOrEndpoint::with_endpoint("http://localhost:6000".into()),
             ..Default::default()
         };
@@ -797,7 +798,7 @@ mod integration_tests {
 
         let mut request = GetLogEventsRequest::default();
         request.log_stream_name = stream_name.clone().into();
-        request.log_group_name = GROUP_NAME.into();
+        request.log_group_name = group_name;
         request.start_time = Some(timestamp.timestamp_millis());
 
         let client = create_client(region).unwrap();
@@ -818,7 +819,8 @@ mod integration_tests {
     fn cloudwatch_insert_log_event_batched() {
         let mut rt = Runtime::new().unwrap();
 
-        let stream_name = gen_stream();
+        let group_name = gen_name();
+        let stream_name = gen_name();
 
         let region = Region::Custom {
             name: "localstack".into(),
@@ -828,7 +830,7 @@ mod integration_tests {
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: stream_name.clone().into(),
-            group_name: GROUP_NAME.into(),
+            group_name: group_name.clone().into(),
             region: RegionOrEndpoint::with_endpoint("http://localhost:6000".into()),
             batch_size: Some(2),
             ..Default::default()
@@ -847,7 +849,7 @@ mod integration_tests {
 
         let mut request = GetLogEventsRequest::default();
         request.log_stream_name = stream_name.clone().into();
-        request.log_group_name = GROUP_NAME.into();
+        request.log_group_name = group_name.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
         let client = create_client(region).unwrap();
@@ -868,7 +870,7 @@ mod integration_tests {
     fn cloudwatch_insert_log_event_partitioned() {
         let mut rt = Runtime::new().unwrap();
 
-        let stream_name = gen_stream();
+        let stream_name = gen_name();
 
         let region = Region::Custom {
             name: "localstack".into(),
@@ -985,7 +987,7 @@ mod integration_tests {
         };
     }
 
-    fn gen_stream() -> String {
+    fn gen_name() -> String {
         format!("test-{}", random_string(10).to_lowercase())
     }
 }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -353,8 +353,8 @@ fn partition(
         Ok(b) => b,
         Err(missing_keys) => {
             warn!(
-                message = "group keys do not exist on the event; dropping event.",
-                keys = ?missing_keys
+                message = "keys in group template do not exist on the event; dropping event.",
+                ?missing_keys
             );
             return None;
         }
@@ -364,8 +364,8 @@ fn partition(
         Ok(b) => b,
         Err(missing_keys) => {
             warn!(
-                message = "stream keys do not exist on the event; dropping event.",
-                keys = ?missing_keys
+                message = "keys in stream template do not exist on the event; dropping event.",
+                ?missing_keys
             );
             return None;
         }

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -11,6 +11,8 @@ use rusoto_logs::{
 pub struct CloudwatchFuture {
     client: Client,
     state: State,
+    create_missing_group: bool,
+    create_missing_stream: bool,
     events: Option<Vec<InputLogEvent>>,
     token_tx: Option<oneshot::Sender<Option<String>>>,
 }
@@ -33,6 +35,8 @@ impl CloudwatchFuture {
         client: CloudWatchLogsClient,
         stream_name: String,
         group_name: String,
+        create_missing_group: bool,
+        create_missing_stream: bool,
         events: Vec<InputLogEvent>,
         token: Option<String>,
         token_tx: oneshot::Sender<Option<String>>,
@@ -56,6 +60,8 @@ impl CloudwatchFuture {
             events,
             state,
             token_tx: Some(token_tx),
+            create_missing_group,
+            create_missing_stream,
         }
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -17,7 +17,7 @@ lazy_static! {
     static ref RE: Regex = Regex::new(r"\{\{(?P<key>[^\}]+)\}\}").unwrap();
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Template {
     src: String,
     src_bytes: Bytes,
@@ -33,6 +33,12 @@ impl From<&str> for Template {
             has_ts: StrftimeItems::new(src).count() > 0,
             has_fields: RE.is_match(src),
         }
+    }
+}
+
+impl From<String> for Template {
+    fn from(s: String) -> Self {
+        Template::from(s.as_str())
     }
 }
 
@@ -52,6 +58,14 @@ impl Template {
     pub fn render_string(&self, event: &Event) -> Result<String, Vec<Atom>> {
         self.render(event)
             .map(|bytes| String::from_utf8(Vec::from(bytes.as_ref())).expect("this is a bug"))
+    }
+
+    pub fn is_dynamic(&self) -> bool {
+        !(self.has_fields && self.has_ts)
+    }
+
+    pub fn get_ref(&self) -> &Bytes {
+        &self.src_bytes
     }
 }
 


### PR DESCRIPTION
This is the first step for #683 and implements dynamic group creation. It also implements configuration for enabling and disabling dynamically creating groups and streams.