### PR TITLE
feat(observability): Add initial rework of rate limited logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,7 +3025,7 @@ dependencies = [
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3238,8 +3256,8 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower.git#40fbb85c4b0de82e1eb13055cc7ac22ae39c6c1d"
+version = "0.1.1"
+source = "git+https://github.com/tower-rs/tower.git#b7faef31e9290bb3d9b428abe8820cbe4c897875"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-buffer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3414,31 +3432,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-env-logger"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+source = "git+https://github.com/tokio-rs/tracing#215d0efdbf545026a6ccdb0a65c17a3d7ad71e1e"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-fmt"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+version = "0.0.1-alpha.3"
+source = "git+https://github.com/tokio-rs/tracing#215d0efdbf545026a6ccdb0a65c17a3d7ad71e1e"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3447,13 +3466,14 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-futures"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/tokio-rs/tracing#215d0efdbf545026a6ccdb0a65c17a3d7ad71e1e"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3467,20 +3487,21 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.0.1-alpha.3 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+version = "0.0.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3493,31 +3514,49 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.0.1-alpha.3 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1-alpha.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+version = "0.0.1-alpha.2"
+source = "git+https://github.com/tokio-rs/tracing#561c0c8353ebf6e04292b2531630e7fec30748a7"
 dependencies = [
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.0.1-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-tower-http"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#0a5ba16c5fea076f4902995bd59dedd99cac2755"
+source = "git+https://github.com/tokio-rs/tracing#215d0efdbf545026a6ccdb0a65c17a3d7ad71e1e"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower.git)",
+ "tower 0.1.1 (git+https://github.com/tower-rs/tower.git)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1-alpha.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
@@ -3748,8 +3787,8 @@ dependencies = [
  "tower-test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-fmt 0.0.1-alpha.3 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1-alpha.1 (git+https://github.com/tokio-rs/tracing)",
  "tracing-limit 0.1.0",
  "tracing-metrics 0.1.0",
  "tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing)",
@@ -4048,6 +4087,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum matrixmultiply 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfed72d871629daa12b25af198f110e8095d7650f5f4c61c5bac28364604f9b"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
@@ -4150,6 +4190,7 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e57803405f8ea0eb041c1567dac36127e0c8caa1251c843cb03d43fd767b3d50"
@@ -4243,7 +4284,7 @@ dependencies = [
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tokio01-test 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f552746ce9d11b2f7d175bfff335a8d7bd0e965d9e2974ce2c19b508bd0c1bb9"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-"checksum tower 0.1.0 (git+https://github.com/tower-rs/tower.git)" = "<none>"
+"checksum tower 0.1.1 (git+https://github.com/tower-rs/tower.git)" = "<none>"
 "checksum tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc72f33b6a72c75c9df0037afce313018bae845f0ec7fdb9201b8768427a917f"
 "checksum tower-buffer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c85c2bb3ca9acdb130fa879c2c7e052a7daa7dbd181f49ef246caf533c096df"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
@@ -4258,12 +4299,13 @@ dependencies = [
 "checksum tower-timeout 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c06bbc2fbd056f810940a8c6f0cc194557d36da3c22999a755a7a6612447da9"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
 "checksum tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9509c828e884d3289fb843055b1462be5f5b54e4b1f21d39e6cc465fe861f4fc"
-"checksum tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b15b1e1f124b19a23d87d54613077bf5249e5f13a5cd39e2f2a50afef938ca05"
+"checksum tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e94af5e2a5f1700cc58127f93d4b7e46c2b925856592066b9880aabce633b6d8"
 "checksum tracing-env-logger 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-fmt 0.0.1-alpha.3 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-futures 0.0.1-alpha.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5e73cad5d3da047803f3714aa0a34b47aee03e1e321e22968783dfc0208b97"
+"checksum tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00a4e1771dca8725b0e1630397d85eff67ac7632c999877562b65304dea04c6"
 "checksum tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 tracing-core = "0.1"
+# tracing-subscriber = "=0.0.1-alpha.2"
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing" }
 ansi_term = "0.11"
 
 [dev-dependencies]

--- a/lib/tracing-limit/examples/basic.rs
+++ b/lib/tracing-limit/examples/basic.rs
@@ -2,12 +2,15 @@
 extern crate tracing;
 
 use tracing::Dispatch;
-use tracing_limit::LimitSubscriber;
+use tracing_limit::Limit;
+use tracing_subscriber::layer::SubscriberExt;
 
 fn main() {
-    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
-    tracing_env_logger::try_init().expect("init log adapter");
-    let subscriber = LimitSubscriber::new(subscriber);
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .with_filter(tracing_fmt::filter::EnvFilter::from("trace"))
+        .finish()
+        .with(Limit::default());
+
     let dispatch = Dispatch::new(subscriber);
 
     tracing::dispatcher::with_default(&dispatch, || {
@@ -18,6 +21,7 @@ fn main() {
                 count = &i,
                 rate_limit_secs = 5 as u64
             );
+            trace!("this field is not rate limited!");
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }
     })

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -1,7 +1,6 @@
-use ansi_term::Colour;
+use std::fmt;
 use std::{
     collections::HashMap,
-    fmt,
     sync::{
         atomic::{AtomicUsize, Ordering},
         RwLock,
@@ -10,199 +9,204 @@ use std::{
 };
 use tracing_core::{
     callsite::Identifier,
-    field::{Field, Visit},
-    span::{Attributes, Id, Record},
-    Event, Interest, Level, Metadata, Subscriber,
+    field::{Field, Value, Visit},
+    subscriber::Interest,
+    Event, Metadata, Subscriber,
 };
+use tracing_subscriber::layer::{Context, Layer};
 
-pub struct LimitSubscriber<S> {
-    inner: S,
-    events: RwLock<HashMap<Identifier, (AtomicUsize, AtomicUsize)>>,
+const RATE_LIMIT_FIELD: &'static str = "rate_limit_secs";
+const MESSAGE_FIELD: &'static str = "message";
+
+#[derive(Debug, Default)]
+pub struct Limit {
+    events: RwLock<HashMap<Identifier, State>>,
+    callsite_store: RwLock<HashMap<Identifier, &'static Metadata<'static>>>,
 }
 
-#[derive(Default)]
-struct LimitVisitor {
-    limit: Option<usize>,
+#[derive(Debug)]
+struct State {
+    start: usize,
+    count: AtomicUsize,
+    limit: usize,
+    message: Option<String>,
 }
 
-impl LimitVisitor {
-    pub fn into_limit(self) -> Option<usize> {
-        self.limit
+impl Limit {
+    fn create_event<S: Subscriber>(&self, id: &Identifier, ctx: &Context<S>, message: String) {
+        let store = self.callsite_store.read().unwrap();
+        let metadata = store.get(id).unwrap();
+
+        let fields = metadata.fields();
+
+        let message = tracing_core::field::display(message);
+
+        let values = [
+            (
+                &fields.field("message").unwrap(),
+                Some(&message as &dyn Value),
+            ),
+            (
+                &fields.field(RATE_LIMIT_FIELD).unwrap(),
+                Some(&5 as &dyn Value),
+            ),
+        ];
+        let valueset = fields.value_set(&values);
+
+        let event = Event::new(metadata, &valueset);
+        ctx.event(&event);
+        drop(store);
     }
 }
 
-impl<S> LimitSubscriber<S> {
-    pub fn new(inner: S) -> Self {
-        Self {
-            inner,
-            events: RwLock::new(HashMap::new()),
-        }
-    }
-}
-
-impl<S: Subscriber> Subscriber for LimitSubscriber<S> {
-    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        self.inner.enabled(metadata)
-    }
-
-    fn new_span(&self, span: &Attributes<'_>) -> Id {
-        self.inner.new_span(span)
-    }
-
-    fn record(&self, span: &Id, values: &Record<'_>) {
-        self.inner.record(span, values);
-    }
-
-    fn record_follows_from(&self, span: &Id, follows: &Id) {
-        self.inner.record_follows_from(span, follows);
-    }
-
-    fn event(&self, event: &Event<'_>) {
-        if event.fields().any(|f| f.name() == "rate_limit_secs") {
-            let mut limit_visitor = LimitVisitor::default();
-            event.record(&mut limit_visitor);
-
-            let ts = SystemTime::now()
+impl<S> Layer<S> for Limit
+where
+    S: Subscriber,
+    Self: 'static,
+{
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        if metadata
+            .fields()
+            .iter()
+            .any(|f| f.name() == RATE_LIMIT_FIELD)
+        {
+            let start = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_secs() as usize;
 
-            if let Some(limit) = limit_visitor.into_limit() {
-                let id = event.metadata().callsite();
+            let id = metadata.callsite();
 
-                let events = self.events.read().unwrap();
-                if let Some((count, start)) = events.get(&id) {
-                    let local_count = count.fetch_add(1, Ordering::Relaxed);
-                    let start = start.load(Ordering::Relaxed);
+            let mut events = self.events.write().expect("lock poisoned!");
 
-                    if ts - start < limit {
-                        // If this log is being limited and we've seen it for
-                        // a second time within that window. We will log out that
-                        // we are now rate limiting this log.
-                        //
-                        // If we have seen this event more than twice,
-                        // then lets early return to avoid passing this
-                        // event to the inner subscriber.
-                        if local_count == 1 {
-                            let mut visitor = FmtVisitor::default();
-                            event.record(&mut visitor);
+            let state = State {
+                start,
+                count: AtomicUsize::new(0),
+                limit: 5,
+                message: None,
+            };
 
-                            let message = if let Some(message) = &visitor.message {
-                                &message
-                            } else {
-                                "unknown event"
-                            };
+            events.insert(id.clone(), state);
+            drop(events);
 
-                            let meta = event.metadata();
+            let mut callsite_store = self.callsite_store.write().unwrap();
+            callsite_store.insert(id, metadata);
+            drop(callsite_store);
 
-                            println!(
-                                "{} {} Limiting the output of \"{}\" for the next {} seconds",
-                                FmtLevel(&tracing_core::Level::INFO),
-                                meta.target(),
-                                message,
-                                limit
-                            );
-                            return;
-                        } else if local_count > 1 {
-                            return;
-                        }
-                    } else {
-                        drop(events);
+            Interest::sometimes()
+        } else {
+            Interest::always()
+        }
+    }
 
-                        let mut events = self.events.write().unwrap();
-                        events.remove(&id);
-                        drop(events);
+    fn enabled(&self, metadata: &Metadata, ctx: Context<S>) -> bool {
+        if is_limited(metadata) {
+            let id = metadata.callsite();
+            let events = self.events.read().expect("lock poisoned!");
 
-                        let meta = event.metadata();
+            // check if the event exists within the map, if it does
+            // that means we are currently rate limiting it.
+            if let Some(state) = events.get(&id) {
+                let ts = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as usize;
 
-                        let mut visitor = FmtVisitor::default();
-                        event.record(&mut visitor);
-
-                        let message = if let Some(message) = &visitor.message {
-                            &message
+                if ts - state.start < state.limit {
+                    if state.count.load(Ordering::SeqCst) == 1 {
+                        let message = if let Some(event_message) = &state.message {
+                            format!("{:?} is being rate limited.", event_message)
                         } else {
-                            "unknown event"
+                            format!("unknown message is being rate limited.")
                         };
 
-                        // We need to replicate the way that fmt logs events
-                        // because we currently can not create new fresh events.
-                        println!(
-                            "{} {} {:?} {:?} logs were rate limited.",
-                            FmtLevel(meta.level()),
-                            meta.target(),
-                            local_count,
-                            message
-                        );
+                        self.create_event(&id, &ctx, message);
+                    }
 
-                        return;
+                    let prev = state.count.fetch_add(1, Ordering::SeqCst);
+
+                    if prev == 0 {
+                        return true;
                     }
                 } else {
                     drop(events);
-                    let count = AtomicUsize::new(1);
-                    let ts = AtomicUsize::new(ts as usize);
-                    let mut map = self.events.write().unwrap();
-                    map.insert(id, (count, ts));
+
+                    let mut events = self.events.write().expect("lock poisoned!");
+
+                    if let Some(state) = events.remove(&id) {
+                        let message = if let Some(event_message) = &state.message {
+                            format!(
+                                "{:?} {:?} events were rate limited.",
+                                state.count, event_message
+                            )
+                        } else {
+                            format!("{:?} unknown messages were rate limited.", state.count)
+                        };
+
+                        self.create_event(&id, &ctx, message);
+                    }
                 }
+
+                false
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    }
+
+    fn on_event(&self, event: &Event, _ctx: Context<S>) {
+        if is_limited(event.metadata()) {
+            let mut limit_visitor = LimitVisitor::default();
+            event.record(&mut limit_visitor);
+
+            if let Some(limit) = limit_visitor.limit {
+                let start = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as usize;
+
+                let id = event.metadata().callsite();
+
+                let mut events = self.events.write().expect("lock poisoned!");
+
+                let state = State {
+                    start,
+                    count: AtomicUsize::new(1),
+                    limit,
+                    message: limit_visitor.message,
+                };
+
+                events.insert(id, state);
             }
         }
-
-        self.inner.event(event);
     }
+}
 
-    fn enter(&self, span: &Id) {
-        self.inner.enter(span);
-    }
+fn is_limited(metadata: &Metadata<'_>) -> bool {
+    metadata
+        .fields()
+        .iter()
+        .any(|f| f.name() == RATE_LIMIT_FIELD)
+}
 
-    fn exit(&self, span: &Id) {
-        self.inner.exit(span);
-    }
-
-    fn register_callsite(&self, metadata: &'static Metadata<'_>) -> Interest {
-        self.inner.register_callsite(metadata)
-    }
-
-    fn clone_span(&self, id: &Id) -> Id {
-        self.inner.clone_span(id)
-    }
-
-    fn try_close(&self, id: Id) -> bool {
-        self.inner.try_close(id.clone())
-    }
+#[derive(Default)]
+struct LimitVisitor {
+    pub limit: Option<usize>,
+    pub message: Option<String>,
 }
 
 impl Visit for LimitVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
-        if field.name() == "rate_limit_secs" {
+        if field.name() == RATE_LIMIT_FIELD {
             self.limit = Some(value as usize);
         }
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
-}
-
-struct FmtLevel<'a>(&'a Level);
-
-impl<'a> fmt::Display for FmtLevel<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self.0 {
-            Level::TRACE => write!(f, "{}", Colour::Purple.paint("TRACE")),
-            Level::DEBUG => write!(f, "{}", Colour::Blue.paint("DEBUG")),
-            Level::INFO => write!(f, "{}", Colour::Green.paint(" INFO")),
-            Level::WARN => write!(f, "{}", Colour::Yellow.paint(" WARN")),
-            Level::ERROR => write!(f, "{}", Colour::Red.paint("ERROR")),
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct FmtVisitor {
-    pub message: Option<String>,
-}
-
-impl Visit for FmtVisitor {
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.message = Some(value.to_owned());
+        if field.name() == MESSAGE_FIELD {
+            self.message = Some(value.to_string());
         }
     }
 


### PR DESCRIPTION
This updates the rate limit tracing subscriber to implement a [`Layer`](https://docs.rs/tracing-subscriber/0.0.1-alpha.2/tracing_subscriber/layer/trait.Layer.html) so avoid forward compatibility issues. This also builds a more robust version that allows us to create custom events and pass them back through any subscriber that is setup.

cc @hawkw

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>