### PR TITLE
fix: only notify on master builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,3 +611,8 @@ workflows:
           <<: *tag-workflow-filters
           requires:
             - release-s3
+experimental:
+  notify:
+    branches:
+      only:
+        - master


### PR DESCRIPTION
Update CircleCI configuration to only notify on master builds to reduce noise from pull requests.