### PR TITLE
chore: add build steps as part of overall testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,6 +502,12 @@ workflows:
           <<: *test-filters
       - test-stable:
           <<: *test-filters
+      - build-x86_64-unknown-linux-gnu-archive:
+          <<: *require-checks-and-tests
+      - build-x86_64-unknown-linux-musl-archive:
+          <<: *require-checks-and-tests
+      - build-x86_64-apple-darwin-archive:
+          <<: *require-checks-and-tests
 
   nightly:
     triggers:


### PR DESCRIPTION
I added our build steps as part of our general testing strategy to ensure changes do not break builds.

And, as you'll notice in this PR, there is a build that is broken.