### PR TITLE
chore: Restore rust-toolchain after building archive

### DIFF
--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -70,6 +70,7 @@ fi
 
 # Rename the rust-toolchain file so that we can use our custom version of rustc installed
 # on release containers.
+trap "mv rust-toolchain.bak rust-toolchain" EXIT
 mv rust-toolchain rust-toolchain.bak
 
 if [ "$FEATURES" != "default" ]; then


### PR DESCRIPTION
This PR restores `rust-toolchain` file on exit from the build script to keep the `make build-archive` command idempotent.