### PR TITLE
Cloudwatch config encoding = "text" now works as expected

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -664,24 +664,23 @@ mod tests {
         assert!(stream_val.is_none());
     }
 
-    #[test]
-    fn cloudwatch_encode_log() {
+    fn svc(config: CloudwatchLogsSinkConfig) -> CloudwatchLogsSvc {
         let config = CloudwatchLogsSinkConfig {
             region: RegionOrEndpoint::with_endpoint("http://localhost:6000".into()),
-            ..Default::default()
+            ..config
         };
         let key = CloudwatchKey {
             stream: "stream".into(),
             group: "group".into(),
         };
+        CloudwatchLogsSvc::new(&config, &key).unwrap()
+    }
 
-        let svc = CloudwatchLogsSvc::new(&config, &key).unwrap();
-
+    #[test]
+    fn cloudwatch_encoded_event_retains_timestamp() {
         let mut event = Event::from("hello world").into_log();
-
         event.insert_explicit("key".into(), "value".into());
-
-        let input_event = svc.encode_log(event.clone());
+        let encoded = svc(Default::default()).encode_log(event.clone());
 
         let ts = if let ValueKind::Timestamp(ts) = event[&event::TIMESTAMP] {
             ts.timestamp_millis()
@@ -689,12 +688,23 @@ mod tests {
             panic!()
         };
 
-        assert_eq!(input_event.timestamp, ts);
+        assert_eq!(encoded.timestamp, ts);
+    }
 
-        let bytes = input_event.message;
+    #[test]
+    fn cloudwatch_encode_log_with_implicit_value() {
+        let mut event = Event::from("hello world").into_log();
+        event.insert_implicit("key".into(), "value".into());
+        let encoded = svc(Default::default()).encode_log(event.clone());
+        assert_eq!(encoded.message, "hello world");
+    }
 
-        let map: HashMap<Atom, String> = serde_json::from_str(&bytes[..]).unwrap();
-
+    #[test]
+    fn cloudwatch_encode_log_with_explicit_value() {
+        let mut event = Event::from("hello world").into_log();
+        event.insert_explicit("key".into(), "value".into());
+        let encoded = svc(Default::default()).encode_log(event.clone());
+        let map: HashMap<Atom, String> = serde_json::from_str(&encoded.message[..]).unwrap();
         assert!(map.get(&event::TIMESTAMP).is_none());
     }
 }


### PR DESCRIPTION
I tried to set up a file source> -> lua transform -> cloudwatch sink pipeline. Because my transform added a value to the event, the cloudwatch sink stored the event as a JSON string, which is according to the documentation. However, setting `encoding: text` on the sink had no effect, which is not according to docs. The reason for this is an unfortunate match statement. With this fix, it is now possible to get Cloudwatch events with just the message string.

The use case I want to address is that I have an unknown number of log files in a directory and I want each to be a separate log group. For reference, here is a stylized version of the config.
```
data_dir = "/var/lib/vector"
[sources.source__crons]
  type = "file"
  include = ["/ze/log/*.cron.log"]
  file_key = "logpath"

[transforms.filename__crons]
  type = "lua"
  inputs = ["source__crons"]
  source = """event["filename"] = string.gsub(event["logpath"], ".+/(.+)", "%1")"""

[sinks.sink__crons]
  type = "aws_cloudwatch_logs"
  encoding = "text"
  inputs = ["filename__crons"]
  group_name = "/logs/{{filename}}"
  region = "eu-west-1"
  stream_name = "ze-instance"
```

The PR splits and clarifies the test cases a bit. I introduced a helper for creating the actual service, but since this test mod contains tests for both helper functions and the Svc, I'm not sure where best to put the helper. Please advise.