### PR TITLE
feat(http sink): Add support for unverified HTTPS

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -1399,6 +1399,15 @@ examples = ["https://10.22.212.22:9000/endpoint"]
 null = false
 description = "The full URI to make HTTP requests to. This should include the protocol and host, but can also include the port, path, and any other valid part of a URI."
 
+[sinks.http.options.verify_certificate]
+type = "bool"
+null = true
+default = true
+description = """When making a connection to a HTTPS server, this \
+controls if the TLS certificate presented by the server will be \
+verified. Do not set this unless you know what you are doing. Turning \
+this off introduces significant vulnerabilities."""
+
 # ------------------------------------------------------------------------------
 # sinks.kafka
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1840,6 +1840,15 @@ end
   # * no default
   healthcheck_uri = "https://10.22.212.22:9000/_health"
 
+  # When making a connection to a HTTPS server, this controls if the TLS
+  # certificate presented by the server will be verified. Do not set this unless
+  # you know what you are doing. Turning this off introduces significant
+  # vulnerabilities.
+  # 
+  # * optional
+  # * default: true
+  verify_certificate = true
+
   #
   # Batching
   #

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -33,6 +33,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   compression = "gzip" # no default, must be: "gzip" (if supplied)
   healthcheck = true # default
   healthcheck_uri = "https://10.22.212.22:9000/_health" # no default
+  verify_certificate = true # default
   
   # OPTIONAL - Batching
   batch_size = 1049000 # default, bytes
@@ -76,6 +77,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   compression = "gzip"
   healthcheck = <bool>
   healthcheck_uri = "<string>"
+  verify_certificate = <bool>
 
   # OPTIONAL - Batching
   batch_size = <int>
@@ -161,6 +163,15 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
   # * optional
   # * no default
   healthcheck_uri = "https://10.22.212.22:9000/_health"
+
+  # When making a connection to a HTTPS server, this controls if the TLS
+  # certificate presented by the server will be verified. Do not set this unless
+  # you know what you are doing. Turning this off introduces significant
+  # vulnerabilities.
+  # 
+  # * optional
+  # * default: true
+  verify_certificate = true
 
   #
   # Batching
@@ -304,6 +315,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 | `compression` | `string` | The compression strategy used to compress the payload before sending. See [Compression](#compression) for more info.<br />`no default` `must be: "gzip"` |
 | `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 | `healthcheck_uri` | `string` | A URI that Vector can request in order to determine the service health. See [Health Checks](#health-checks) for more info.<br />`no default` `example: (see above)` |
+| `verify_certificate` | `bool` | When making a connection to a HTTPS server, this controls if the TLS certificate presented by the server will be verified. Do not set this unless you know what you are doing. Turning this off introduces significant vulnerabilities.<br />`default: true` |
 | **OPTIONAL** - Batching | | |
 | `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
 | `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 5` `unit: seconds` |

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1860,6 +1860,15 @@ end
   # * no default
   healthcheck_uri = "https://10.22.212.22:9000/_health"
 
+  # When making a connection to a HTTPS server, this controls if the TLS
+  # certificate presented by the server will be verified. Do not set this unless
+  # you know what you are doing. Turning this off introduces significant
+  # vulnerabilities.
+  # 
+  # * optional
+  # * default: true
+  verify_certificate = true
+
   #
   # Batching
   #

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -42,6 +42,8 @@ pub struct HttpSinkConfig {
     pub request_rate_limit_num: Option<u64>,
     pub request_retry_attempts: Option<usize>,
     pub request_retry_backoff_secs: Option<u64>,
+
+    pub verify_certificate: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -108,6 +110,7 @@ fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, Strin
     let headers = config.headers.clone();
     let basic_auth = config.basic_auth.clone();
     let method = config.method.clone().unwrap_or(HttpMethod::Post);
+    let verify = config.verify_certificate.unwrap_or(true);
 
     let policy = FixedRetryPolicy::new(
         retry_attempts,
@@ -115,41 +118,44 @@ fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, Strin
         HttpRetryLogic,
     );
 
-    let http_service = HttpService::new(move |body: Vec<u8>| {
-        let mut builder = hyper::Request::builder();
+    let http_service =
+        HttpService::builder()
+            .verify_certificate(verify)
+            .build(move |body: Vec<u8>| {
+                let mut builder = hyper::Request::builder();
 
-        let method = match method {
-            HttpMethod::Post => Method::POST,
-            HttpMethod::Put => Method::PUT,
-        };
+                let method = match method {
+                    HttpMethod::Post => Method::POST,
+                    HttpMethod::Put => Method::PUT,
+                };
 
-        builder.method(method);
+                builder.method(method);
 
-        builder.uri(uri.clone());
+                builder.uri(uri.clone());
 
-        match encoding {
-            Encoding::Text => builder.header("Content-Type", "text/plain"),
-            Encoding::Ndjson => builder.header("Content-Type", "application/x-ndjson"),
-        };
+                match encoding {
+                    Encoding::Text => builder.header("Content-Type", "text/plain"),
+                    Encoding::Ndjson => builder.header("Content-Type", "application/x-ndjson"),
+                };
 
-        if gzip {
-            builder.header("Content-Encoding", "gzip");
-        }
+                if gzip {
+                    builder.header("Content-Encoding", "gzip");
+                }
 
-        if let Some(headers) = &headers {
-            for (header, value) in headers.iter() {
-                builder.header(header.as_str(), value.as_str());
-            }
-        }
+                if let Some(headers) = &headers {
+                    for (header, value) in headers.iter() {
+                        builder.header(header.as_str(), value.as_str());
+                    }
+                }
 
-        let mut request = builder.body(body).unwrap();
+                let mut request = builder.body(body).unwrap();
 
-        if let Some(auth) = &basic_auth {
-            auth.apply(request.headers_mut());
-        }
+                if let Some(auth) = &basic_auth {
+                    auth.apply(request.headers_mut());
+                }
 
-        request
-    });
+                request
+            });
 
     let service = ServiceBuilder::new()
         .concurrency_limit(in_flight_limit)

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -118,6 +118,12 @@ fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, Strin
         HttpRetryLogic,
     );
 
+    if !verify {
+        warn!(
+            message = "Turning off verify_certificate in http sink can introduce security vulnerabilities"
+        );
+    }
+
     let http_service =
         HttpService::builder()
             .verify_certificate(verify)

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -120,7 +120,7 @@ fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, Strin
 
     if !verify {
         warn!(
-            message = "Turning off verify_certificate in http sink can introduce security vulnerabilities"
+            message = "`verify_certificate` in http sink is DISABLED, this may lead to security vulnerabilities"
         );
     }
 


### PR DESCRIPTION
Closes #796 

Note that this contains no additional tests, as Vector currently has no tests for HTTPS behavior, and I could not see an simple way of turning existing HTTP tests into HTTPS.