### PR TITLE
fix: Add missing clickhouse integration test feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ default = ["rdkafka", "leveldb", "jemallocator"]
 docker = [
   "cloudwatch-logs-integration-tests",
   "cloudwatch-metrics-integration-tests",
+  "clickhouse-integration-tests",
   "es-integration-tests",
   "kafka-integration-tests",
   "kinesis-integration-tests",
@@ -159,6 +160,7 @@ docker = [
 ]
 cloudwatch-logs-integration-tests = []
 cloudwatch-metrics-integration-tests = []
+clickhouse-integration-tests = []
 es-integration-tests = []
 kafka-integration-tests = []
 kinesis-integration-tests = []


### PR DESCRIPTION
Refs bed79bbaf9ed5ac566b1765ff989a4cbdd5aefcc

While working on #730 I noticed that the `clickhouse-integration-tests` was used in the code but not defined in the `Cargo.toml`. Thus running `cargo test --features clickhouse-integration-tests` fails:

```
$ cargo test --features clickhouse-integration-tests
error: Package `vector v0.4.0-dev (/home/markus/Coding/vector)` does not have these features: `clickhouse-integration-tests`
```