### PR TITLE
chore: Add vscode folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ sample.log
 miniodat
 .DS_Store
 .idea/
+.vscode/
 checkpoints/*
 *.iml


### PR DESCRIPTION
The `.vscode` folder contains the settings for the VSCode IDE. Similar to the `.idea` folder for JetBrains IDEs, we should ignore any changes in there to keep the repository clean.