### PR TITLE
docs: Add bundler to requirements

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,4 +14,10 @@ rbenv install 2.6.3
 rbenv global 2.6.3
 ```
 
-This is currently the only requirement.
+We also need bundler
+
+```
+gem install bundler
+```
+
+These are currently the only requirements.


### PR DESCRIPTION
I got an error message about `bundler` being missing when I ran `make generate`. We should mention that additional requirement in the documentation.