### PR TITLE
chore: Introduce crate-level `Result` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,5 @@ pub mod types;
 pub use event::Event;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -128,7 +128,7 @@ pub enum CloudwatchError {
 
 #[typetag::serde(name = "aws_cloudwatch_logs")]
 impl SinkConfig for CloudwatchLogsSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let batch_timeout = self.batch_timeout.unwrap_or(1);
         let batch_size = self.batch_size.unwrap_or(1000);
 
@@ -163,7 +163,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 }
 
 impl CloudwatchLogsPartitionSvc {
-    pub fn new(config: CloudwatchLogsSinkConfig) -> Result<Self, crate::Error> {
+    pub fn new(config: CloudwatchLogsSinkConfig) -> crate::Result<Self> {
         let timeout_secs = config.request_timeout_secs.unwrap_or(60);
         let rate_limit_duration_secs = config.request_rate_limit_duration_secs.unwrap_or(1);
         let rate_limit_num = config.request_rate_limit_num.unwrap_or(5);
@@ -249,10 +249,7 @@ impl Service<PartitionInnerBuffer<Vec<Event>, CloudwatchKey>> for CloudwatchLogs
 }
 
 impl CloudwatchLogsSvc {
-    pub fn new(
-        config: &CloudwatchLogsSinkConfig,
-        key: &CloudwatchKey,
-    ) -> Result<Self, crate::Error> {
+    pub fn new(config: &CloudwatchLogsSinkConfig, key: &CloudwatchKey) -> crate::Result<Self> {
         let region = config.region.clone().try_into()?;
         let client = create_client(region)?;
 
@@ -409,7 +406,7 @@ enum HealthcheckError {
     GroupNameMismatch { expected: String, name: String },
 }
 
-fn healthcheck(config: CloudwatchLogsSinkConfig) -> Result<super::Healthcheck, crate::Error> {
+fn healthcheck(config: CloudwatchLogsSinkConfig) -> crate::Result<super::Healthcheck> {
     if config.group_name.is_dynamic() {
         info!("cloudwatch group_name is dynamic; skipping healthcheck.");
         return Ok(Box::new(future::ok(())));
@@ -460,7 +457,7 @@ fn healthcheck(config: CloudwatchLogsSinkConfig) -> Result<super::Healthcheck, c
     Ok(Box::new(fut))
 }
 
-fn create_client(region: Region) -> Result<CloudWatchLogsClient, crate::Error> {
+fn create_client(region: Region) -> crate::Result<CloudWatchLogsClient> {
     let http = HttpClient::new().context(HttpClientError)?;
     let creds = DefaultCredentialsProvider::new().context(InvalidCloudwatchCredentials)?;
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -51,7 +51,7 @@ pub struct CloudWatchMetricsSinkConfig {
 
 #[typetag::serde(name = "aws_cloudwatch_metrics")]
 impl SinkConfig for CloudWatchMetricsSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = CloudWatchMetricsSvc::new(self.clone(), acker)?;
         let healthcheck = CloudWatchMetricsSvc::healthcheck(self)?;
         Ok((sink, healthcheck))
@@ -66,7 +66,7 @@ impl CloudWatchMetricsSvc {
     pub fn new(
         config: CloudWatchMetricsSinkConfig,
         acker: Acker,
-    ) -> Result<super::RouterSink, crate::Error> {
+    ) -> crate::Result<super::RouterSink> {
         let client = Self::create_client(config.region.clone().try_into()?)?;
 
         let batch_size = config.batch_size.unwrap_or(20);
@@ -109,9 +109,7 @@ impl CloudWatchMetricsSvc {
         Ok(Box::new(sink))
     }
 
-    fn healthcheck(
-        config: &CloudWatchMetricsSinkConfig,
-    ) -> Result<super::Healthcheck, crate::Error> {
+    fn healthcheck(config: &CloudWatchMetricsSinkConfig) -> crate::Result<super::Healthcheck> {
         let client = Self::create_client(config.region.clone().try_into()?)?;
 
         let datum = MetricDatum {
@@ -130,7 +128,7 @@ impl CloudWatchMetricsSvc {
         Ok(Box::new(healthcheck))
     }
 
-    fn create_client(region: Region) -> Result<CloudWatchClient, crate::Error> {
+    fn create_client(region: Region) -> crate::Result<CloudWatchClient> {
         #[cfg(test)]
         {
             // Moto (used for mocking AWS) doesn't recognize 'custom' as valid region name

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -57,7 +57,7 @@ pub enum Encoding {
 
 #[typetag::serde(name = "aws_kinesis_streams")]
 impl SinkConfig for KinesisSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let config = self.clone();
         let sink = KinesisService::new(config, acker)?;
         let healthcheck = healthcheck(self.clone())?;
@@ -73,7 +73,7 @@ impl KinesisService {
     pub fn new(
         config: KinesisSinkConfig,
         acker: Acker,
-    ) -> Result<impl Sink<SinkItem = Event, SinkError = ()>, crate::Error> {
+    ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
         let client = Arc::new(KinesisClient::new(config.region.clone().try_into()?));
 
         let batch_size = config.batch_size.unwrap_or(bytesize::mib(1u64) as usize);
@@ -177,7 +177,7 @@ enum HealthcheckError {
     NoMatchingStreamName { stream_name: String },
 }
 
-fn healthcheck(config: KinesisSinkConfig) -> Result<super::Healthcheck, crate::Error> {
+fn healthcheck(config: KinesisSinkConfig) -> crate::Result<super::Healthcheck> {
     let client = KinesisClient::new(config.region.try_into()?);
     let stream_name = config.stream_name;
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -82,7 +82,7 @@ impl Default for Compression {
 
 #[typetag::serde(name = "aws_s3")]
 impl SinkConfig for S3SinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = S3Sink::new(self, acker)?;
         let healthcheck = S3Sink::healthcheck(self)?;
 
@@ -105,7 +105,7 @@ enum HealthcheckError {
 }
 
 impl S3Sink {
-    pub fn new(config: &S3SinkConfig, acker: Acker) -> Result<super::RouterSink, crate::Error> {
+    pub fn new(config: &S3SinkConfig, acker: Acker) -> crate::Result<super::RouterSink> {
         let timeout = config.request_timeout_secs.unwrap_or(60);
         let in_flight_limit = config.request_in_flight_limit.unwrap_or(25);
         let rate_limit_duration = config.request_rate_limit_duration_secs.unwrap_or(1);
@@ -162,7 +162,7 @@ impl S3Sink {
         Ok(Box::new(sink))
     }
 
-    pub fn healthcheck(config: &S3SinkConfig) -> Result<super::Healthcheck, crate::Error> {
+    pub fn healthcheck(config: &S3SinkConfig) -> crate::Result<super::Healthcheck> {
         let client = Self::create_client(config.region.clone().try_into()?);
 
         let request = HeadBucketRequest {

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -20,7 +20,7 @@ pub struct BlackholeConfig {
 
 #[typetag::serde(name = "blackhole")]
 impl SinkConfig for BlackholeConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = Box::new(BlackholeSink::new(self.clone(), acker));
         let healthcheck = Box::new(healthcheck());
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -39,7 +39,7 @@ pub struct ClickhouseConfig {
 
 #[typetag::serde(name = "clickhouse")]
 impl SinkConfig for ClickhouseConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = clickhouse(self.clone(), acker)?;
         let healtcheck = healthcheck(self.host.clone());
 
@@ -51,7 +51,7 @@ impl SinkConfig for ClickhouseConfig {
     }
 }
 
-fn clickhouse(config: ClickhouseConfig, acker: Acker) -> Result<super::RouterSink, crate::Error> {
+fn clickhouse(config: ClickhouseConfig, acker: Acker) -> crate::Result<super::RouterSink> {
     let host = config.host.clone();
     let database = config.database.clone().unwrap_or("default".into());
     let table = config.table.clone();
@@ -136,7 +136,7 @@ fn healthcheck(host: String) -> super::Healthcheck {
     Box::new(healthcheck)
 }
 
-fn encode_uri(host: &str, database: &str, table: &str) -> Result<Uri, crate::Error> {
+fn encode_uri(host: &str, database: &str, table: &str) -> crate::Result<Uri> {
     let query = url::form_urlencoded::Serializer::new(String::new())
         .append_pair(
             "query",

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -41,7 +41,7 @@ pub enum Encoding {
 
 #[typetag::serde(name = "console")]
 impl SinkConfig for ConsoleSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let encoding = self.encoding.clone();
 
         let output: Box<dyn io::AsyncWrite + Send> = match self.target {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -69,7 +69,7 @@ pub enum Provider {
 
 #[typetag::serde(name = "elasticsearch")]
 impl SinkConfig for ElasticSearchConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let common = ElasticSearchCommon::parse_config(&self)?;
         let healthcheck = healthcheck(&common);
         let sink = es(self, common, acker);
@@ -102,7 +102,7 @@ enum ParseError {
 }
 
 impl ElasticSearchCommon {
-    fn parse_config(config: &ElasticSearchConfig) -> Result<Self, crate::Error> {
+    fn parse_config(config: &ElasticSearchConfig) -> crate::Result<Self> {
         // Test the configured host, but ignore the result
         let uri = format!("{}/_test", config.host);
         uri.parse::<Uri>().with_context(|| InvalidHost {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -31,7 +31,7 @@ pub enum Encoding {
 
 #[typetag::serde(name = "file")]
 impl SinkConfig for FileSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = PartitionedFileSink {
             path: self.path.clone(),
             idle_timeout_secs: self.idle_timeout_secs.unwrap_or(30),

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -88,7 +88,7 @@ pub struct BasicAuth {
 
 #[typetag::serde(name = "http")]
 impl SinkConfig for HttpSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         validate_headers(&self.headers)?;
         let sink = http(self.clone(), acker)?;
 
@@ -105,7 +105,7 @@ impl SinkConfig for HttpSinkConfig {
     }
 }
 
-fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, crate::Error> {
+fn http(config: HttpSinkConfig, acker: Acker) -> crate::Result<super::RouterSink> {
     let uri = build_uri(&config.uri)?;
 
     let gzip = match config.compression.unwrap_or(Compression::None) {
@@ -197,7 +197,7 @@ fn http(config: HttpSinkConfig, acker: Acker) -> Result<super::RouterSink, crate
     Ok(Box::new(sink))
 }
 
-fn healthcheck(uri: String, auth: Option<BasicAuth>) -> Result<super::Healthcheck, crate::Error> {
+fn healthcheck(uri: String, auth: Option<BasicAuth>) -> crate::Result<super::Healthcheck> {
     let uri = build_uri(&uri)?;
     let mut request = Request::head(&uri).body(Body::empty()).unwrap();
 
@@ -230,7 +230,7 @@ impl BasicAuth {
     }
 }
 
-fn validate_headers(headers: &Option<IndexMap<String, String>>) -> Result<(), crate::Error> {
+fn validate_headers(headers: &Option<IndexMap<String, String>>) -> crate::Result<()> {
     if let Some(map) = headers {
         for (name, value) in map {
             HeaderName::from_bytes(name.as_bytes()).with_context(|| InvalidHeaderName { name })?;
@@ -241,7 +241,7 @@ fn validate_headers(headers: &Option<IndexMap<String, String>>) -> Result<(), cr
     Ok(())
 }
 
-fn build_uri(raw: &str) -> Result<Uri, crate::Error> {
+fn build_uri(raw: &str) -> crate::Result<Uri> {
     let base: Uri = raw.parse().context(super::UriParseError)?;
     Ok(Uri::builder()
         .scheme(base.scheme_str().unwrap_or("http"))

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -55,7 +55,7 @@ pub struct KafkaSink {
 
 #[typetag::serde(name = "kafka")]
 impl SinkConfig for KafkaSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = KafkaSink::new(self.clone(), acker)?;
         let hc = healthcheck(self.clone());
         Ok((Box::new(sink), hc))
@@ -76,7 +76,7 @@ impl KafkaSinkConfig {
 }
 
 impl KafkaSink {
-    fn new(config: KafkaSinkConfig, acker: Acker) -> Result<Self, crate::Error> {
+    fn new(config: KafkaSinkConfig, acker: Acker) -> crate::Result<Self> {
         let producer = config.to_rdkafka().create().context(KafkaCreateFailed)?;
         Ok(KafkaSink {
             producer,

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -67,7 +67,7 @@ pub fn default_flush_period() -> Duration {
 
 #[typetag::serde(name = "prometheus")]
 impl SinkConfig for PrometheusSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         // Checks
         if self.flush_period < Duration::from_millis(MIN_FLUSH_PERIOD_MS) {
             return Err(Box::new(BuildError::FlushPeriodTooShort {

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -60,7 +60,7 @@ fn default_host_field() -> Atom {
 
 #[typetag::serde(name = "splunk_hec")]
 impl SinkConfig for HecSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         validate_host(&self.host)?;
         let sink = hec(self.clone(), acker)?;
         let healthcheck = healthcheck(self.token.clone(), self.host.clone())?;
@@ -73,7 +73,7 @@ impl SinkConfig for HecSinkConfig {
     }
 }
 
-pub fn hec(config: HecSinkConfig, acker: Acker) -> Result<super::RouterSink, crate::Error> {
+pub fn hec(config: HecSinkConfig, acker: Acker) -> crate::Result<super::RouterSink> {
     let host = config.host.clone();
     let token = config.token.clone();
     let host_field = config.host_field;
@@ -146,7 +146,7 @@ enum HealthcheckError {
     QueuesFull,
 }
 
-pub fn healthcheck(token: String, host: String) -> Result<super::Healthcheck, crate::Error> {
+pub fn healthcheck(token: String, host: String) -> crate::Result<super::Healthcheck> {
     let uri = format!("{}/services/collector/health/1.0", host)
         .parse::<Uri>()
         .context(super::UriParseError)?;
@@ -172,7 +172,7 @@ pub fn healthcheck(token: String, host: String) -> Result<super::Healthcheck, cr
     Ok(Box::new(healthcheck))
 }
 
-pub fn validate_host(host: &String) -> Result<(), crate::Error> {
+pub fn validate_host(host: &String) -> crate::Result<()> {
     let uri = Uri::try_from(host).context(super::UriParseError)?;
 
     match uri.scheme_part() {

--- a/src/sinks/tcp.rs
+++ b/src/sinks/tcp.rs
@@ -109,7 +109,7 @@ impl TcpSinkConfig {
 
 #[typetag::serde(name = "tcp")]
 impl SinkConfig for TcpSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let addr = self
             .address
             .to_socket_addrs()
@@ -171,7 +171,7 @@ impl SinkConfig for TcpSinkConfig {
     }
 }
 
-fn load_certificate<T: AsRef<Path> + Debug>(filename: T) -> Result<Certificate, crate::Error> {
+fn load_certificate<T: AsRef<Path> + Debug>(filename: T) -> crate::Result<Certificate> {
     let filename = filename.as_ref();
     let data = open_read(filename, "certificate authority")?;
     Ok(Certificate::from_pem(&data).with_context(|| CertificateParseError { filename })?)
@@ -180,7 +180,7 @@ fn load_certificate<T: AsRef<Path> + Debug>(filename: T) -> Result<Certificate, 
 fn load_key<T: AsRef<Path> + Debug>(
     filename: T,
     pass_phrase: &Option<String>,
-) -> Result<PKey<Private>, crate::Error> {
+) -> crate::Result<PKey<Private>> {
     let filename = filename.as_ref();
     let data = open_read(filename, "key")?;
     match pass_phrase {
@@ -195,16 +195,13 @@ fn load_key<T: AsRef<Path> + Debug>(
     }
 }
 
-fn load_x509<T: AsRef<Path> + Debug>(filename: T) -> Result<X509, crate::Error> {
+fn load_x509<T: AsRef<Path> + Debug>(filename: T) -> crate::Result<X509> {
     let filename = filename.as_ref();
     let data = open_read(filename, "certificate")?;
     Ok(X509::from_pem(&data).with_context(|| X509ParseError { filename })?)
 }
 
-fn open_read<F: AsRef<Path> + Debug>(
-    filename: F,
-    note: &'static str,
-) -> Result<Vec<u8>, crate::Error> {
+fn open_read<F: AsRef<Path> + Debug>(filename: F, note: &'static str) -> crate::Result<Vec<u8>> {
     let mut text = Vec::<u8>::new();
     let filename = filename.as_ref();
 
@@ -245,7 +242,7 @@ pub struct TcpSinkTls {
 }
 
 impl TcpSinkTls {
-    fn make_connector(&self) -> Result<TlsConnector, crate::Error> {
+    fn make_connector(&self) -> crate::Result<TlsConnector> {
         let mut connector = native_tls::TlsConnector::builder();
         connector.danger_accept_invalid_certs(!self.verify);
         if let Some(ref certificate) = self.add_ca {

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -28,7 +28,7 @@ impl VectorSinkConfig {
 
 #[typetag::serde(name = "vector")]
 impl SinkConfig for VectorSinkConfig {
-    fn build(&self, acker: Acker) -> Result<(super::RouterSink, super::Healthcheck), crate::Error> {
+    fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let addr = self
             .address
             .to_socket_addrs()

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -125,7 +125,7 @@ impl SourceConfig for FileConfig {
         name: &str,
         globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         // add the source name as a subdir, so that multiple sources can
         // operate within the same given data_dir (e.g. the global one)
         // without the file servers' checkpointers interfering with each

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Error, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::sync::mpsc::RecvTimeoutError;
@@ -145,15 +145,15 @@ fn create_event(record: Record) -> Event {
 }
 
 trait JournalCursor {
-    fn cursor(&self) -> Result<String, Error>;
-    fn seek_cursor(&mut self, cursor: &str) -> Result<(), Error>;
+    fn cursor(&self) -> Result<String, io::Error>;
+    fn seek_cursor(&mut self, cursor: &str) -> Result<(), io::Error>;
 }
 
 impl JournalCursor for Journal {
-    fn cursor(&self) -> Result<String, Error> {
+    fn cursor(&self) -> Result<String, io::Error> {
         Journal::cursor(self)
     }
-    fn seek_cursor(&mut self, cursor: &str) -> Result<(), Error> {
+    fn seek_cursor(&mut self, cursor: &str) -> Result<(), io::Error> {
         Journal::seek_cursor(self, cursor)
     }
 }
@@ -252,7 +252,7 @@ struct Checkpointer {
 }
 
 impl Checkpointer {
-    fn new(mut filename: PathBuf) -> Result<Self, Error> {
+    fn new(mut filename: PathBuf) -> Result<Self, io::Error> {
         filename.push(CHECKPOINT_FILENAME);
         let file = OpenOptions::new()
             .read(true)
@@ -262,13 +262,13 @@ impl Checkpointer {
         Ok(Checkpointer { file })
     }
 
-    fn set(&mut self, token: &str) -> Result<(), Error> {
+    fn set(&mut self, token: &str) -> Result<(), io::Error> {
         self.file.seek(SeekFrom::Start(0))?;
         self.file.write(format!("{}\n", token).as_bytes())?;
         Ok(())
     }
 
-    fn get(&mut self) -> Result<Option<String>, Error> {
+    fn get(&mut self) -> Result<Option<String>, io::Error> {
         let mut buf = Vec::<u8>::new();
         self.file.seek(SeekFrom::Start(0))?;
         self.file.read_to_end(&mut buf)?;
@@ -333,7 +333,7 @@ mod tests {
     use super::*;
     use crate::test_util::{block_on, runtime, shutdown_on_idle};
     use futures::stream::Stream;
-    use std::io::Error;
+    use std::io;
     use std::iter::FromIterator;
     use std::time::{Duration, SystemTime};
     use stream_cancel::Tripwire;
@@ -363,7 +363,7 @@ mod tests {
     }
 
     impl Iterator for FakeJournal {
-        type Item = Result<Record, Error>;
+        type Item = Result<Record, io::Error>;
         fn next(&mut self) -> Option<Self::Item> {
             self.cursor += 1;
             self.records.pop().map(|item| Ok(item))
@@ -372,10 +372,10 @@ mod tests {
 
     impl JournalCursor for FakeJournal {
         // The fake journal cursor is just a line number
-        fn cursor(&self) -> Result<String, Error> {
+        fn cursor(&self) -> Result<String, io::Error> {
             Ok(format!("{}", self.cursor))
         }
-        fn seek_cursor(&mut self, cursor: &str) -> Result<(), Error> {
+        fn seek_cursor(&mut self, cursor: &str) -> Result<(), io::Error> {
             let cursor = cursor.parse::<usize>().expect("Invalid cursor");
             for _ in 0..cursor {
                 self.records.pop();

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -48,7 +48,7 @@ impl SourceConfig for JournaldConfig {
         name: &str,
         globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         let local_only = self.local_only.unwrap_or(true);
         let runtime_only = self.current_runtime_only.unwrap_or(true);
         let data_dir = globals.resolve_and_make_data_subdir(self.data_dir.as_ref(), name)?;

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -52,7 +52,7 @@ impl SourceConfig for KafkaSourceConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         kafka_source(self.clone(), out)
     }
 
@@ -64,7 +64,7 @@ impl SourceConfig for KafkaSourceConfig {
 fn kafka_source(
     config: KafkaSourceConfig,
     out: mpsc::Sender<Event>,
-) -> Result<super::Source, crate::Error> {
+) -> crate::Result<super::Source> {
     let consumer = Arc::new(create_consumer(config.clone())?);
     let source = future::lazy(move || {
         let consumer_ref = Arc::clone(&consumer);
@@ -118,7 +118,7 @@ fn kafka_source(
     Ok(Box::new(source))
 }
 
-fn create_consumer(config: KafkaSourceConfig) -> Result<StreamConsumer, crate::Error> {
+fn create_consumer(config: KafkaSourceConfig) -> crate::Result<StreamConsumer> {
     let consumer: StreamConsumer = ClientConfig::new()
         .set("group.id", &config.group_id)
         .set("bootstrap.servers", &config.bootstrap_servers)

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -24,7 +24,7 @@ impl crate::topology::config::SourceConfig for StatsdConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         Ok(statsd(self.address, out))
     }
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -39,7 +39,7 @@ impl SourceConfig for StdinConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         Ok(stdin_source(stdin(), self.clone(), out))
     }
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -59,7 +59,7 @@ impl SourceConfig for SyslogConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         let host_key = self.host_key.clone().unwrap_or(event::HOST.to_string());
 
         match self.mode.clone() {

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -48,7 +48,7 @@ impl SourceConfig for TcpConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         let tcp = RawTcpSource {
             config: self.clone(),
         };

--- a/src/sources/udp.rs
+++ b/src/sources/udp.rs
@@ -34,7 +34,7 @@ impl SourceConfig for UdpConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         let host_key = self.host_key.clone().unwrap_or(event::HOST.clone());
         Ok(udp(self.address, host_key, out))
     }

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -31,7 +31,7 @@ pub trait TcpSource: Clone + Send + 'static {
         addr: SocketAddr,
         shutdown_timeout_secs: u64,
         out: mpsc::Sender<Event>,
-    ) -> Result<crate::sources::Source, crate::Error> {
+    ) -> crate::Result<crate::sources::Source> {
         let out = out.sink_map_err(|e| error!("error sending event: {:?}", e));
 
         let source = future::lazy(move || {

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -40,7 +40,7 @@ impl SourceConfig for VectorConfig {
         _name: &str,
         _globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<super::Source, crate::Error> {
+    ) -> crate::Result<super::Source> {
         let vector = VectorSource;
         vector.run(self.address, self.shutdown_timeout_secs, out)
     }

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -58,7 +58,7 @@ impl GlobalOptions {
     pub fn resolve_and_validate_data_dir(
         &self,
         local_data_dir: Option<&PathBuf>,
-    ) -> Result<PathBuf, crate::Error> {
+    ) -> crate::Result<PathBuf> {
         let data_dir = local_data_dir
             .or(self.data_dir.as_ref())
             .ok_or_else(|| DataDirError::MissingDataDir)
@@ -83,7 +83,7 @@ impl GlobalOptions {
         &self,
         local: Option<&PathBuf>,
         subdir: &str,
-    ) -> Result<PathBuf, crate::Error> {
+    ) -> crate::Result<PathBuf> {
         let data_dir = self.resolve_and_validate_data_dir(local)?;
 
         let mut data_subdir = data_dir.clone();
@@ -111,7 +111,7 @@ pub trait SourceConfig: core::fmt::Debug {
         name: &str,
         globals: &GlobalOptions,
         out: mpsc::Sender<Event>,
-    ) -> Result<sources::Source, crate::Error>;
+    ) -> crate::Result<sources::Source>;
 
     fn output_type(&self) -> DataType;
 }
@@ -132,7 +132,7 @@ pub trait SinkConfig: core::fmt::Debug {
     fn build(
         &self,
         acker: crate::buffers::Acker,
-    ) -> Result<(sinks::RouterSink, sinks::Healthcheck), crate::Error>;
+    ) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)>;
 
     fn input_type(&self) -> DataType;
 }
@@ -146,7 +146,7 @@ pub struct TransformOuter {
 
 #[typetag::serde(tag = "type")]
 pub trait TransformConfig: core::fmt::Debug {
-    fn build(&self) -> Result<Box<dyn transforms::Transform>, crate::Error>;
+    fn build(&self) -> crate::Result<Box<dyn transforms::Transform>>;
 
     fn input_type(&self) -> DataType;
 

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -21,7 +21,7 @@ pub struct AddFields {
 
 #[typetag::serde(name = "augmenter")]
 impl TransformConfig for AddFieldsConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(AddFields::new(self.fields.clone())))
     }
 

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -20,7 +20,7 @@ pub struct AddTags {
 
 #[typetag::serde(name = "add_tags")]
 impl TransformConfig for AddTagsConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(AddTags::new(self.tags.clone())))
     }
 

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -16,7 +16,7 @@ pub struct CoercerConfig {
 
 #[typetag::serde(name = "coercer")]
 impl crate::topology::config::TransformConfig for CoercerConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         let types = parse_conversion_map(&self.types)?;
         Ok(Box::new(Coercer { types }))
     }

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -15,7 +15,7 @@ pub struct FieldFilterConfig {
 
 #[typetag::serde(name = "field_filter")]
 impl TransformConfig for FieldFilterConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(FieldFilter::new(
             self.field.clone(),
             self.value.clone(),

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -30,7 +30,7 @@ pub struct GrokParserConfig {
 
 #[typetag::serde(name = "grok_parser")]
 impl TransformConfig for GrokParserConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
         let mut grok = grok::Grok::with_patterns();

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -19,7 +19,7 @@ pub struct JsonParserConfig {
 
 #[typetag::serde(name = "json_parser")]
 impl TransformConfig for JsonParserConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(JsonParser::from(self.clone())))
     }
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -70,7 +70,7 @@ pub struct LogToMetric {
 
 #[typetag::serde(name = "log_to_metric")]
 impl TransformConfig for LogToMetricConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(LogToMetric::new(self.clone())))
     }
 

--- a/src/transforms/lua.rs
+++ b/src/transforms/lua.rs
@@ -22,7 +22,7 @@ pub struct LuaConfig {
 
 #[typetag::serde(name = "lua")]
 impl TransformConfig for LuaConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Lua::new(&self.source, self.search_dirs.clone()).map(|l| {
             let b: Box<dyn Transform> = Box::new(l);
             b
@@ -43,7 +43,7 @@ pub struct Lua {
 }
 
 impl Lua {
-    pub fn new(source: &str, search_dirs: Vec<String>) -> Result<Self, crate::Error> {
+    pub fn new(source: &str, search_dirs: Vec<String>) -> crate::Result<Self> {
         let lua = rlua::Lua::new();
 
         let additional_paths = search_dirs

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -24,7 +24,7 @@ pub struct RegexParserConfig {
 
 #[typetag::serde(name = "regex_parser")]
 impl TransformConfig for RegexParserConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
         let regex = Regex::new(&self.regex).context(super::InvalidRegex)?;

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -18,7 +18,7 @@ pub struct RemoveFields {
 
 #[typetag::serde(name = "remove_fields")]
 impl TransformConfig for RemoveFieldsConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(RemoveFields::new(self.fields.clone())))
     }
 

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -18,7 +18,7 @@ pub struct RemoveTags {
 
 #[typetag::serde(name = "remove_tags")]
 impl TransformConfig for RemoveTagsConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(RemoveTags::new(self.tags.clone())))
     }
 

--- a/src/transforms/sampler.rs
+++ b/src/transforms/sampler.rs
@@ -17,7 +17,7 @@ pub struct SamplerConfig {
 
 #[typetag::serde(name = "sampler")]
 impl TransformConfig for SamplerConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         Ok(RegexSet::new(&self.pass_list)
             .map::<Box<dyn Transform>, _>(|regex_set| Box::new(Sampler::new(self.rate, regex_set)))
             .context(super::InvalidRegex)?)

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -21,7 +21,7 @@ pub struct SplitConfig {
 
 #[typetag::serde(name = "split")]
 impl TransformConfig for SplitConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
         let types = parse_check_conversion_map(&self.types, &self.field_names)

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -28,7 +28,7 @@ pub struct TokenizerConfig {
 
 #[typetag::serde(name = "tokenizer")]
 impl TransformConfig for TokenizerConfig {
-    fn build(&self) -> Result<Box<dyn Transform>, crate::Error> {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
         let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
 
         let types = parse_check_conversion_map(&self.types, &self.field_names)?;


### PR DESCRIPTION
@LucioFranco suggested Vector could use a top-level `Result` type. I think this caught all relevant users.

Ref #883 