### PR TITLE
Rate limiting syslog warnings about incorrect format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,6 +3854,7 @@ dependencies = [
  "tracing-futures 0.0.1-alpha.1 (git+https://github.com/tokio-rs/tracing)",
  "tracing-limit 0.1.0",
  "tracing-metrics 0.1.0",
+ "tracing-subscriber 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-tower-http 0.1.0 (git+https://github.com/tokio-rs/tracing)",
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-futures = { git = "https://github.com/tokio-rs/tracing" }
 tracing-fmt = { git = "https://github.com/tokio-rs/tracing" }
 tracing-env-logger = { git = "https://github.com/tokio-rs/tracing" }
 tracing-tower-http = { git = "https://github.com/tokio-rs/tracing" }
+tracing-subscriber = "0.1.1"
 
 # Metrics
 hotmic = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing::{field, Dispatch};
 use tracing_futures::Instrument;
+use tracing_limit::Limit;
 use tracing_metrics::MetricsSubscriber;
+use tracing_subscriber::layer::SubscriberExt;
 use vector::{metrics, topology};
 
 #[derive(StructOpt, Debug)]
@@ -118,7 +120,8 @@ fn main() {
     let subscriber = tracing_fmt::FmtSubscriber::builder()
         .with_ansi(color)
         .with_filter(tracing_fmt::filter::EnvFilter::from(levels.as_str()))
-        .finish();
+        .finish()
+        .with(Limit::default());
     tracing_env_logger::try_init().expect("init log adapter");
 
     let (metrics_controller, metrics_sink) = metrics::build();

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -242,7 +242,12 @@ fn event_from_str(
 
             event
         })
-        .map_err(|_| warn!("Problem parsing incoming message, check syslog format"))
+        .map_err(|_| {
+            warn!(
+                message = "Problem parsing incoming message, check syslog format",
+                rate_limit_secs = 4 as u64
+            )
+        })
         .ok()
 }
 


### PR DESCRIPTION
Added rate-limited warning to inform user about invalid or unsupported format.

Ref #741