### PR TITLE
docs: Simpler, less noisy component options

### DIFF
--- a/.meta/sinks/aws_s3.toml
+++ b/.meta/sinks/aws_s3.toml
@@ -1,4 +1,5 @@
 [sinks.aws_s3]
+batch_is_simple = true
 batch_size = 10490000
 batch_timeout = 300
 beta = true
@@ -28,6 +29,7 @@ type = "string"
 category = "Requests"
 enum = ["gzip"]
 null = true
+simple = true
 description = "The compression type to use before writing data."
 
 [sinks.aws_s3.options.encoding]
@@ -35,6 +37,7 @@ type = "string"
 category = "Requests"
 enum = ["ndjson", "text"]
 null = true
+simple = true
 description = """\
 The encoding format used to serialize the events before flushing. The default \
 is dynamic based on if the event is structured or not.\
@@ -61,13 +64,6 @@ default = "%s"
 null = false
 description = "The format of the resulting object file name. [`strftime` specifiers][url.strftime_specifiers] are supported."
 
-[sinks.aws_s3.options.gzip]
-type = "bool"
-category = "Requests"
-default = false
-null = false
-description = "Whether to Gzip the content before writing or not. Please note, enabling this has a slight performance cost but significantly reduces bandwidth."
-
 [sinks.aws_s3.options.key_prefix]
 type = "string"
 category = "Object Names"
@@ -80,6 +76,7 @@ examples = [
 ]
 null = true
 partition_key = true
+simple = true
 templateable = true
 description = "A prefix to apply to all object key names. This should be used to partition your objects, and it's important to end this value with a `/` if you want this to be the root S3 \"folder\"."
 

--- a/.meta/sinks/clickhouse.toml
+++ b/.meta/sinks/clickhouse.toml
@@ -20,6 +20,7 @@ type = "string"
 category = "Requests"
 enum = ["gzip"]
 null = true
+simple = true
 description = "The compression type to use before writing data."
 
 [sinks.clickhouse.options.host]

--- a/.meta/sinks/http.toml
+++ b/.meta/sinks/http.toml
@@ -1,4 +1,5 @@
 [sinks.http]
+batch_is_simple = true
 batch_size = 1049000
 batch_timeout = 5
 buffer = true
@@ -36,12 +37,14 @@ description = "The basic authentication user name."
 type = "string"
 enum = ["gzip"]
 null = true
+simple = true
 description = "The compression strategy used to compress the payload before sending."
 
 [sinks.http.options.encoding]
 type = "string"
 enum = ["ndjson", "text"]
 null = false
+simple = true
 description = """\
 The encoding format used to serialize the events before flushing. The default \
 is dynamic based on if the event is structured or not.\

--- a/.meta/sources/file.toml
+++ b/.meta/sources/file.toml
@@ -27,7 +27,7 @@ Array of file patterns to include. [Globbing](#globbing) is supported.\
 [sources.file.options.exclude]
 type = "[string]"
 examples = [["/var/log/nginx/access.log"]]
-null = false
+null = true
 description = """\
 Array of file patterns to exclude. [Globbing](#globbing) is supported. \
 *Takes precedence over the `include` option.*\

--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -33,6 +33,7 @@ type = "[string]"
 null = true
 default = []
 examples = [["ntpd", "sysinit.target"]]
+simple = true
 description = """\
 The list of units names to monitor. \
 If empty or not present, all units are accepted. \

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1504,13 +1504,6 @@ end
   encoding = "ndjson"
   encoding = "text"
 
-  # Whether to Gzip the content before writing or not. Please note, enabling this
-  # has a slight performance cost but significantly reduces bandwidth.
-  # 
-  # * optional
-  # * default: false
-  gzip = false
-
   # The window used for the `request_rate_limit_num` option
   # 
   # * optional

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -52,13 +52,6 @@
   # * must be: "file"
   type = "file"
 
-  # Array of file patterns to exclude. Globbing is supported. *Takes precedence
-  # over the `include` option.*
-  # 
-  # * required
-  # * no default
-  exclude = ["/var/log/nginx/access.log"]
-
   # Array of file patterns to include. Globbing is supported.
   # 
   # * required
@@ -72,6 +65,13 @@
   # * optional
   # * no default
   data_dir = "/var/lib/vector"
+
+  # Array of file patterns to exclude. Globbing is supported. *Takes precedence
+  # over the `include` option.*
+  # 
+  # * optional
+  # * no default
+  exclude = ["/var/log/nginx/access.log"]
 
   # Delay between file discovery calls. This controls the interval at which
   # Vector searches for files.

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -27,81 +27,19 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "aws_cloudwatch_logs" # must be: "aws_cloudwatch_logs"
   inputs = ["my-source-id"]
   group_name = "{{ file }}"
   region = "us-east-1"
   stream_name = "{{ instance_id }}"
-  
-  # OPTIONAL - General
-  create_missing_group = true # default
-  create_missing_stream = true # default
-  healthcheck = true # default
-  hostname = "127.0.0.0:5000"
-  
-  # OPTIONAL - Batching
-  batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, seconds
-  
-  # OPTIONAL - Requests
-  encoding = "json" # no default, enum: "json" or "text"
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 5 # default
-  request_in_flight_limit = 5 # default
-  request_timeout_secs = 30 # default, seconds
-  retry_attempts = 5 # default
-  retry_backoff_secs = 5 # default, seconds
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "aws_cloudwatch_logs"
-  inputs = ["<string>", ...]
-  group_name = "<string>"
-  region = "<string>"
-  stream_name = "<string>"
-
-  # OPTIONAL - General
-  create_missing_group = <bool>
-  create_missing_stream = <bool>
-  healthcheck = <bool>
-  hostname = "<string>"
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  encoding = {"json" | "text"}
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.aws_cloudwatch_logs_sink]
   #
@@ -279,38 +217,6 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.log_
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "aws_cloudwatch_logs"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `group_name` | `string` | The [group name][url.aws_cw_logs_group_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "{{ file }}"` |
-| `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target CloudWatch Logs stream resides.<br />`required` `example: "us-east-1"` |
-| `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target CloudWatch Logs stream.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Partitioning](#partitioning) and [Template Syntax](#template-syntax) for more info.<br />`required` `example: "{{ instance_id }}"` |
-| **OPTIONAL** - General | | |
-| `create_missing_group` | `bool` | Dynamically create a [log group][url.aws_cw_logs_group_name] if it does not already exist. This will ignore `create_missing_stream` directly after creating the group and will create the first stream.<br />`default: true` |
-| `create_missing_stream` | `bool` | Dynamically create a [log stream][url.aws_cw_logs_stream_name] if it does not already exist.<br />`default: true` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 30` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
 
 ## Examples
 
@@ -538,16 +444,12 @@ issue, please:
 
 
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.configuration.template-syntax]: ../../../usage/configuration#template-syntax
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.aws_cloudwatch_logs_sink]: ../../../assets/aws_cloudwatch_logs-sink.svg
 [images.sink-flow-partitioned]: ../../../assets/sink-flow-partitioned.svg
@@ -559,10 +461,7 @@ issue, please:
 [url.aws_credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
 [url.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [url.aws_cw_logs]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html
-[url.aws_cw_logs_group_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
-[url.aws_cw_logs_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region
 [url.aws_cw_logs_service_limits]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
-[url.aws_cw_logs_stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 [url.iam_instance_profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [url.new_aws_cloudwatch_logs_sink_bug]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_cloudwatch_logs&labels=Type%3A+bug
 [url.new_aws_cloudwatch_logs_sink_enhancement]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_cloudwatch_logs&labels=Type%3A+enhancement

--- a/docs/usage/configuration/sinks/aws_kinesis_streams.md
+++ b/docs/usage/configuration/sinks/aws_kinesis_streams.md
@@ -27,77 +27,18 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "aws_kinesis_streams" # must be: "aws_kinesis_streams"
   inputs = ["my-source-id"]
   region = "us-east-1"
   stream_name = "my-stream"
-  
-  # OPTIONAL - General
-  healthcheck = true # default
-  hostname = "127.0.0.0:5000"
-  partition_key_field = "user_id" # no default
-  
-  # OPTIONAL - Batching
-  batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, seconds
-  
-  # OPTIONAL - Requests
-  encoding = "json" # no default, enum: "json" or "text"
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 5 # default
-  request_in_flight_limit = 5 # default
-  request_timeout_secs = 30 # default, seconds
-  retry_attempts = 5 # default
-  retry_backoff_secs = 5 # default, seconds
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "aws_kinesis_streams"
-  inputs = ["<string>", ...]
-  region = "<string>"
-  stream_name = "<string>"
-
-  # OPTIONAL - General
-  healthcheck = <bool>
-  hostname = "<string>"
-  partition_key_field = "<string>"
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  encoding = {"json" | "text"}
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.aws_kinesis_streams_sink]
   #
@@ -257,36 +198,6 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.log_
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "aws_kinesis_streams"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `region` | `string` | The [AWS region][url.aws_cw_logs_regions] of the target Kinesis stream resides.<br />`required` `example: "us-east-1"` |
-| `stream_name` | `string` | The [stream name][url.aws_cw_logs_stream_name] of the target Kinesis Logs stream.<br />`required` `example: "my-stream"` |
-| **OPTIONAL** - General | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
-| `partition_key_field` | `string` | The log field used as the Kinesis record's partition key value. See [Partitioning](#partitioning) for more info.<br />`no default` `example: "user_id"` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 30` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
 
 ## Examples
 
@@ -520,24 +431,18 @@ issue, please:
 
 [docs.add_fields_transform]: ../../../usage/configuration/transforms/add_fields.md
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring.logs]: ../../../usage/administration/monitoring.md#logs
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.aws_kinesis_streams_sink]: ../../../assets/aws_kinesis_streams-sink.svg
 [images.sink-flow-serial]: ../../../assets/sink-flow-serial.svg
 [url.aws_access_keys]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 [url.aws_credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
 [url.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
-[url.aws_cw_logs_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region
-[url.aws_cw_logs_stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 [url.aws_kinesis_data_streams]: https://aws.amazon.com/kinesis/data-streams/
 [url.aws_kinesis_partition_key]: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html#Streams-Type-PutRecordsRequestEntry-PartitionKey
 [url.aws_kinesis_service_limits]: https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -27,91 +27,18 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "aws_s3" # must be: "aws_s3"
   inputs = ["my-source-id"]
   bucket = "my-bucket"
   region = "us-east-1"
-  
-  # OPTIONAL - General
-  healthcheck = true # default
-  hostname = "127.0.0.0:5000"
-  
-  # OPTIONAL - Batching
-  batch_size = 10490000 # default, bytes
-  batch_timeout = 300 # default, seconds
-  
-  # OPTIONAL - Object Names
-  filename_append_uuid = true # default
-  filename_extension = "log" # default
-  filename_time_format = "%s" # default
-  key_prefix = "date=%F/"
-  
-  # OPTIONAL - Requests
-  compression = "gzip" # no default, must be: "gzip" (if supplied)
-  encoding = "ndjson" # no default, enum: "ndjson" or "text"
-  gzip = false # default
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 5 # default
-  request_in_flight_limit = 5 # default
-  request_timeout_secs = 30 # default, seconds
-  retry_attempts = 5 # default
-  retry_backoff_secs = 5 # default, seconds
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "aws_s3"
-  inputs = ["<string>", ...]
-  bucket = "<string>"
-  region = "<string>"
-
-  # OPTIONAL - General
-  healthcheck = <bool>
-  hostname = "<string>"
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Object Names
-  filename_append_uuid = <bool>
-  filename_extension = <bool>
-  filename_time_format = "<string>"
-  key_prefix = "<string>"
-
-  # OPTIONAL - Requests
-  compression = "gzip"
-  encoding = {"ndjson" | "text"}
-  gzip = <bool>
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.aws_s3_sink]
   #
@@ -314,42 +241,6 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "aws_s3"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `bucket` | `string` | The S3 bucket name. Do not include a leading `s3://` or a trailing `/`.<br />`required` `example: "my-bucket"` |
-| `region` | `string` | The [AWS region][url.aws_s3_regions] of the target S3 bucket.<br />`required` `example: "us-east-1"` |
-| **OPTIONAL** - General | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| `hostname` | `string` | Custom hostname to send requests to. Useful for testing.<br />`default: "<aws-service-hostname>"` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 10490000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 300` `unit: seconds` |
-| **OPTIONAL** - Object Names | | |
-| `filename_append_uuid` | `bool` | Whether or not to append a UUID v4 token to the end of the file. This ensures there are no name collisions high volume use cases. See [Object Naming](#object-naming) for more info.<br />`default: true` |
-| `filename_extension` | `bool` | The extension to use in the object name.<br />`default: "log"` |
-| `filename_time_format` | `string` | The format of the resulting object file name. [`strftime` specifiers][url.strftime_specifiers] are supported. See [Object Naming](#object-naming) for more info.<br />`default: "%s"` |
-| `key_prefix` | `string` | A prefix to apply to all object key names. This should be used to partition your objects, and it's important to end this value with a `/` if you want this to be the root S3 "folder".This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Object Naming](#object-naming), [Partitioning](#partitioning), and [Template Syntax](#template-syntax) for more info.<br />`default: "date=%F"` |
-| **OPTIONAL** - Requests | | |
-| `compression` | `string` | The compression type to use before writing data. See [Compression](#compression) for more info.<br />`no default` `must be: "gzip"` |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "ndjson" or "text"` |
-| `gzip` | `bool` | Whether to Gzip the content before writing or not. Please note, enabling this has a slight performance cost but significantly reduces bandwidth. See [Compression](#compression) for more info.<br />`default: false` |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 30` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
 
 ## Examples
 
@@ -678,16 +569,12 @@ issue, please:
 
 
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.configuration.template-syntax]: ../../../usage/configuration#template-syntax
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.aws_s3_sink]: ../../../assets/aws_s3-sink.svg
 [images.sink-flow-partitioned]: ../../../assets/sink-flow-partitioned.svg
@@ -697,7 +584,6 @@ issue, please:
 [url.aws_credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
 [url.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [url.aws_s3]: https://aws.amazon.com/s3/
-[url.aws_s3_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 [url.aws_s3_service_limits]: https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
 [url.aws_s3_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_s3%22+label%3A%22Type%3A+bug%22
 [url.aws_s3_sink_enhancements]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_s3%22+label%3A%22Type%3A+enhancement%22

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -30,10 +30,22 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
 {% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
+  # REQUIRED - General
   type = "aws_s3" # must be: "aws_s3"
   inputs = ["my-source-id"]
   bucket = "my-bucket"
   region = "us-east-1"
+  
+  # OPTIONAL - Batching
+  batch_size = 10490000 # default, bytes
+  batch_timeout = 300 # default, seconds
+  
+  # OPTIONAL - Object Names
+  key_prefix = "date=%F/"
+  
+  # OPTIONAL - Requests
+  compression = "gzip" # no default, must be: "gzip" (if supplied)
+  encoding = "ndjson" # no default, enum: "ndjson" or "text"
 
   # For a complete list of options see the "advanced" tab above.
 ```
@@ -155,13 +167,6 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events
   # * enum: "ndjson" or "text"
   encoding = "ndjson"
   encoding = "text"
-
-  # Whether to Gzip the content before writing or not. Please note, enabling this
-  # has a slight performance cost but significantly reduces bandwidth.
-  # 
-  # * optional
-  # * default: false
-  gzip = false
 
   # The window used for the `request_rate_limit_num` option
   # 

--- a/docs/usage/configuration/sinks/blackhole.md
+++ b/docs/usage/configuration/sinks/blackhole.md
@@ -20,26 +20,17 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
   type = "blackhole" # must be: "blackhole"
   inputs = ["my-source-id"]
   print_amount = 1000
-  
-  healthcheck = true # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  type = "blackhole"
-  inputs = ["<string>", ...]
-  print_amount = <int>
-  healthcheck = <bool>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.blackhole_sink]
   # The component type
@@ -71,17 +62,6 @@ The `blackhole` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "blackhole"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `print_amount` | `int` | The number of events that must be received in order to print a summary of activity.<br />`required` `example: 1000` |
-| **OPTIONAL** | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 
 ## How It Works
 
@@ -142,13 +122,10 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.blackhole_sink]: ../../../assets/blackhole-sink.svg
 [url.blackhole_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+blackhole%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -30,10 +30,14 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 {% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
+  # REQUIRED - General
   type = "clickhouse" # must be: "clickhouse"
   inputs = ["my-source-id"]
   host = "http://localhost:8123"
   table = "mytable"
+  
+  # OPTIONAL - Requests
+  compression = "gzip" # no default, must be: "gzip" (if supplied)
 
   # For a complete list of options see the "advanced" tab above.
 ```

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -27,61 +27,18 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "clickhouse" # must be: "clickhouse"
   inputs = ["my-source-id"]
   host = "http://localhost:8123"
   table = "mytable"
-  
-  # OPTIONAL - General
-  database = "mydatabase" # no default
-  healthcheck = true # default
-  
-  # OPTIONAL - Batching
-  batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, seconds
-  
-  # OPTIONAL - Requests
-  compression = "gzip" # no default, must be: "gzip" (if supplied)
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 5 # default
-  request_in_flight_limit = 5 # default
-  request_timeout_secs = 30 # default, seconds
-  retry_attempts = 9223372036854775807 # default
-  retry_backoff_secs = 9223372036854775807 # default, seconds
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "clickhouse"
-  inputs = ["<string>", ...]
-  host = "<string>"
-  table = "<string>"
-
-  # OPTIONAL - General
-  database = "<string>"
-  healthcheck = <bool>
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  compression = "gzip"
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.clickhouse_sink]
   #
@@ -198,30 +155,6 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "clickhouse"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `host` | `string` | The host url of the [Clickhouse][url.clickhouse] server.<br />`required` `example: "http://localhost:8123"` |
-| `table` | `string` | The table that data will be inserted into.<br />`required` `example: "mytable"` |
-| **OPTIONAL** - General | | |
-| `database` | `string` | The database that contains the stable that data will be inserted into.<br />`no default` `example: "mydatabase"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed.<br />`default: 1049000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed.<br />`default: 1` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `compression` | `string` | The compression type to use before writing data. See [Compression](#compression) for more info.<br />`no default` `must be: "gzip"` |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 30` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 9223372036854775807` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 9223372036854775807` `unit: seconds` |
-
 ## How It Works
 
 ### Compression
@@ -316,12 +249,9 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.clickhouse_sink]: ../../../assets/clickhouse-sink.svg
 [url.clickhouse]: https://clickhouse.yandex/

--- a/docs/usage/configuration/sinks/console.md
+++ b/docs/usage/configuration/sinks/console.md
@@ -20,28 +20,17 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
   type = "console" # must be: "console"
   inputs = ["my-source-id"]
   target = "stdout" # enum: "stdout" or "stderr"
-  
-  encoding = "json" # no default, enum: "json" or "text"
-  healthcheck = true # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  type = "console"
-  inputs = ["<string>", ...]
-  target = {"stdout" | "stderr"}
-  encoding = {"json" | "text"}
-  healthcheck = <bool>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.console_sink]
   # The component type
@@ -83,18 +72,6 @@ The `console` sink [streams](#streaming) [`log`][docs.log_event] and [`metric`][
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "console"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `target` | `string` | The [standard stream][url.standard_streams] to write to.<br />`required` `enum: "stdout" or "stderr"` |
-| **OPTIONAL** | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
 
 ## How It Works
 
@@ -179,14 +156,11 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.console_sink]: ../../../assets/console-sink.svg
 [url.console_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+console%22+label%3A%22Type%3A+bug%22
@@ -195,5 +169,4 @@ issue, please:
 [url.console_sink_source]: https://github.com/timberio/vector/tree/master/src/sinks/console.rs
 [url.new_console_sink_bug]: https://github.com/timberio/vector/issues/new?labels=sink%3A+console&labels=Type%3A+bug
 [url.new_console_sink_enhancement]: https://github.com/timberio/vector/issues/new?labels=sink%3A+console&labels=Type%3A+enhancement
-[url.standard_streams]: https://en.wikipedia.org/wiki/Standard_streams
 [url.vector_chat]: https://chat.vector.dev

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -27,103 +27,17 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "elasticsearch" # must be: "elasticsearch"
   inputs = ["my-source-id"]
   host = "http://10.24.32.122:9000"
-  
-  # OPTIONAL - General
-  doc_type = "_doc" # default
-  healthcheck = true # default
-  index = "vector-%Y-%m-%d"
-  provider = "default" # default, enum: "default" or "aws"
-  region = "us-east-1" # no default
-  
-  # OPTIONAL - Batching
-  batch_size = 10490000 # default, bytes
-  batch_timeout = 1 # default, seconds
-  
-  # OPTIONAL - Requests
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 5 # default
-  request_in_flight_limit = 5 # default
-  request_timeout_secs = 60 # default, seconds
-  retry_attempts = 5 # default
-  retry_backoff_secs = 5 # default, seconds
-  
-  # OPTIONAL - Basic auth
-  [sinks.my_sink_id.basic_auth]
-    password = "password"
-    user = "username"
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
-  
-  # OPTIONAL - Headers
-  [sinks.my_sink_id.headers]
-    X-Powered-By = "Vector"
-  
-  # OPTIONAL - Query
-  [sinks.my_sink_id.query]
-    X-Powered-By = "Vector"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "elasticsearch"
-  inputs = ["<string>", ...]
-  host = "<string>"
-
-  # OPTIONAL - General
-  doc_type = "<string>"
-  healthcheck = <bool>
-  index = "<string>"
-  provider = {"default" | "aws"}
-  region = "<string>"
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Basic auth
-  [sinks.<sink-id>.basic_auth]
-    password = "<string>"
-    user = "<string>"
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-
-  # OPTIONAL - Headers
-  [sinks.<sink-id>.headers]
-    * = "<string>"
-
-  # OPTIONAL - Query
-  [sinks.<sink-id>.query]
-    * = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.elasticsearch_sink]
   #
@@ -327,43 +241,6 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.log_event]
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "elasticsearch"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `host` | `string` | The host of your Elasticsearch cluster. This should be the full URL as shown in the example.<br />`required` `example: "http://10.24.32.122:9000"` |
-| **OPTIONAL** - General | | |
-| `doc_type` | `string` | The `doc_type` for your index data. This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to set this option since Elasticsearch has removed it.<br />`default: "_doc"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| `index` | `string` | Index name to write events to.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Template Syntax](#template-syntax) for more info.<br />`default: "vector-%F"` |
-| `provider` | `string` | The provider of the Elasticsearch service.<br />`default: "default"` `enum: "default" or "aws"` |
-| `region` | `string` | When using the AWS provider, the [AWS region][url.aws_cw_logs_regions] of the target Elasticsearch instance.<br />`no default` `example: "us-east-1"` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 10490000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 5` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 60` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Basic auth | | |
-| `basic_auth.password` | `string` | The basic authentication password.<br />`required` `example: "password"` |
-| `basic_auth.user` | `string` | The basic authentication user name.<br />`required` `example: "username"` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
-| **OPTIONAL** - Headers | | |
-| `headers.*` | `string` | A custom header to be added to each outgoing Elasticsearch request.<br />`required` `example: (see above)` |
-| **OPTIONAL** - Query | | |
-| `query.*` | `string` | A custom parameter to be added to each Elasticsearch request.<br />`required` `example: (see above)` |
-
 ## Examples
 
 The `elasticsearch` sink batches [`log`][docs.log_event] up to the `batch_size` or `batch_timeout` options. When flushed, Vector will write to [Elasticsearch][url.elasticsearch] via the [`_bulk` API endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html). The encoding is dictated by the `encoding` option. For example:
@@ -531,20 +408,15 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.configuration.template-syntax]: ../../../usage/configuration#template-syntax
 [docs.data_model]: ../../../about/data-model
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.elasticsearch_sink]: ../../../assets/elasticsearch-sink.svg
 [images.sink-flow-serial]: ../../../assets/sink-flow-serial.svg
-[url.aws_cw_logs_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region
 [url.elasticsearch]: https://www.elastic.co/products/elasticsearch
 [url.elasticsearch_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+elasticsearch%22+label%3A%22Type%3A+bug%22
 [url.elasticsearch_sink_enhancements]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+elasticsearch%22+label%3A%22Type%3A+enhancement%22

--- a/docs/usage/configuration/sinks/file.md
+++ b/docs/usage/configuration/sinks/file.md
@@ -20,30 +20,17 @@ The `file` sink [streams](#streaming) [`log`][docs.log_event] events to a file.
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
   type = "file" # must be: "file"
   inputs = ["my-source-id"]
   path = "vector-%Y-%m-%d.log"
-  
-  encoding = "ndjson" # no default, enum: "ndjson" or "text"
-  healthcheck = true # default
-  idle_timeout_secs = "30" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  type = "file"
-  inputs = ["<string>", ...]
-  path = "<string>"
-  encoding = {"ndjson" | "text"}
-  healthcheck = <bool>
-  idle_timeout_secs = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.file_sink]
   # The component type
@@ -91,19 +78,6 @@ The `file` sink [streams](#streaming) [`log`][docs.log_event] events to a file.
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "file"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `path` | `string` | File name to write events to.This option supports dynamic values via [Vector's template syntax][docs.configuration.template-syntax]. See [Template Syntax](#template-syntax) for more info.<br />`required` `example: "vector-%Y-%m-%d.log"` |
-| **OPTIONAL** | | |
-| `encoding` | `string` | The encoding format used to serialize the events before appending. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "ndjson" or "text"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start.<br />`default: true` |
-| `idle_timeout_secs` | `int` | The amount of time a file can be idle  and stay open. After not receiving any events for this timeout, the file will be flushed and closed.<br />`default: "30"` |
 
 ## How It Works
 
@@ -195,14 +169,11 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.configuration.template-syntax]: ../../../usage/configuration#template-syntax
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.file_sink]: ../../../assets/file-sink.svg
 [url.file_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+file%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -20,95 +20,18 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "http" # must be: "http"
   inputs = ["my-source-id"]
   encoding = "ndjson" # enum: "ndjson" or "text"
   uri = "https://10.22.212.22:9000/endpoint"
-  
-  # OPTIONAL - General
-  compression = "gzip" # no default, must be: "gzip" (if supplied)
-  healthcheck = true # default
-  healthcheck_uri = "https://10.22.212.22:9000/_health" # no default
-  verify_certificate = true # default
-  
-  # OPTIONAL - Batching
-  batch_size = 1049000 # default, bytes
-  batch_timeout = 5 # default, seconds
-  
-  # OPTIONAL - Requests
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 10 # default
-  request_in_flight_limit = 10 # default
-  request_timeout_secs = 30 # default, seconds
-  retry_attempts = 10 # default
-  retry_backoff_secs = 10 # default, seconds
-  
-  # OPTIONAL - Basic auth
-  [sinks.my_sink_id.basic_auth]
-    password = "password"
-    user = "username"
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
-  
-  # OPTIONAL - Headers
-  [sinks.my_sink_id.headers]
-    X-Powered-By = "Vector"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "http"
-  inputs = ["<string>", ...]
-  encoding = {"ndjson" | "text"}
-  uri = "<string>"
-
-  # OPTIONAL - General
-  compression = "gzip"
-  healthcheck = <bool>
-  healthcheck_uri = "<string>"
-  verify_certificate = <bool>
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Basic auth
-  [sinks.<sink-id>.basic_auth]
-    password = "<string>"
-    user = "<string>"
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-
-  # OPTIONAL - Headers
-  [sinks.<sink-id>.headers]
-    * = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.http_sink]
   #
@@ -302,41 +225,6 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "http"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`required` `enum: "ndjson" or "text"` |
-| `uri` | `string` | The full URI to make HTTP requests to. This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.<br />`required` `example: (see above)` |
-| **OPTIONAL** - General | | |
-| `compression` | `string` | The compression strategy used to compress the payload before sending. See [Compression](#compression) for more info.<br />`no default` `must be: "gzip"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| `healthcheck_uri` | `string` | A URI that Vector can request in order to determine the service health. See [Health Checks](#health-checks) for more info.<br />`no default` `example: (see above)` |
-| `verify_certificate` | `bool` | When making a connection to a HTTPS server, this controls if the TLS certificate presented by the server will be verified. Do not set this unless you know what you are doing. Turning this off introduces significant vulnerabilities.<br />`default: true` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 10` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 10` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 30` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 10` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 10` `unit: seconds` |
-| **OPTIONAL** - Basic auth | | |
-| `basic_auth.password` | `string` | The basic authentication password.<br />`required` `example: "password"` |
-| `basic_auth.user` | `string` | The basic authentication user name.<br />`required` `example: "username"` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
-| **OPTIONAL** - Headers | | |
-| `headers.*` | `string` | A custom header to be added to each outgoing HTTP request.<br />`required` `example: (see above)` |
-
 ## Examples
 
 The `http` sink batches [`log`][docs.log_event] up to the `batch_size` or
@@ -522,15 +410,11 @@ issue, please:
 
 
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.http_sink]: ../../../assets/http-sink.svg
 [images.sink-flow-serial]: ../../../assets/sink-flow-serial.svg

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -23,10 +23,18 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.log_event] events t
 {% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
+  # REQUIRED - General
   type = "http" # must be: "http"
   inputs = ["my-source-id"]
   encoding = "ndjson" # enum: "ndjson" or "text"
   uri = "https://10.22.212.22:9000/endpoint"
+  
+  # OPTIONAL - General
+  compression = "gzip" # no default, must be: "gzip" (if supplied)
+  
+  # OPTIONAL - Batching
+  batch_size = 1049000 # default, bytes
+  batch_timeout = 5 # default, seconds
 
   # For a complete list of options see the "advanced" tab above.
 ```

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -20,51 +20,19 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "kafka" # must be: "kafka"
   inputs = ["my-source-id"]
   bootstrap_servers = "10.14.22.123:9092,10.14.23.332:9092"
   key_field = "user_id"
   topic = "topic-1234"
-  
-  # OPTIONAL - General
-  encoding = "json" # no default, enum: "json" or "text"
-  healthcheck = true # default
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "kafka"
-  inputs = ["<string>", ...]
-  bootstrap_servers = "<string>"
-  key_field = "<string>"
-  topic = "<string>"
-
-  # OPTIONAL - General
-  encoding = {"json" | "text"}
-  healthcheck = <bool>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.kafka_sink]
   #
@@ -161,25 +129,6 @@ The `kafka` sink [streams](#streaming) [`log`][docs.log_event] events to [Apache
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "kafka"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `bootstrap_servers` | `string` | A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a "bootstrap" Kafka cluster that a Kafka client connects to initially to bootstrap itself<br />`required` `example: (see above)` |
-| `key_field` | `string` | The log field name to use for the topic key. If unspecified, the key will be randomly generated. If the field does not exist on the log, a blank value will be used.<br />`required` `example: "user_id"` |
-| `topic` | `string` | The Kafka topic name to write events to.<br />`required` `example: "topic-1234"` |
-| **OPTIONAL** - General | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
-
 ## How It Works
 
 ### Delivery Guarantee
@@ -263,14 +212,10 @@ issue, please:
 
 
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.kafka_sink]: ../../../assets/kafka-sink.svg
 [url.kafka]: https://kafka.apache.org/

--- a/docs/usage/configuration/sinks/prometheus.md
+++ b/docs/usage/configuration/sinks/prometheus.md
@@ -27,30 +27,18 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
   type = "prometheus" # must be: "prometheus"
   inputs = ["my-source-id"]
   address = "0.0.0.0:9598"
   namespace = "service"
-  
-  buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] # default, seconds
-  healthcheck = true # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  type = "prometheus"
-  inputs = ["<string>", ...]
-  address = "<string>"
-  namespace = "<string>"
-  buckets = [<float>, ...]
-  healthcheck = <bool>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.prometheus_sink]
   # The component type
@@ -95,20 +83,6 @@ The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.metric_e
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "prometheus"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `address` | `string` | The address to expose for scraping. See [Exposing & Scraping](#exposing-scraping) for more info.<br />`required` `example: "0.0.0.0:9598"` |
-| `namespace` | `string` | A prefix that will be added to all metric names.
-It should follow Prometheus [naming conventions][url.prometheus_metric_naming].<br />`required` `example: "service"` |
-| **OPTIONAL** | | |
-| `buckets` | `[float]` | Default buckets to use for [histogram][docs.metric_event.histogram] metrics. See [Histogram Buckets](#histogram-buckets) for more info.<br />`default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]` `unit: seconds` |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start.<br />`default: true` |
 
 ## Examples
 
@@ -384,7 +358,6 @@ discussion with your use case if you find this to be a problem.
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.metric_event.counter]: ../../../about/data-model/metric.md#counter
 [docs.metric_event.gauge]: ../../../about/data-model/metric.md#gauge
@@ -392,8 +365,6 @@ discussion with your use case if you find this to be a problem.
 [docs.metric_event.set]: ../../../about/data-model/metric.md#set
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.prometheus_sink]: ../../../assets/prometheus-sink.svg
 [url.issue_387]: https://github.com/timberio/vector/issues/387
@@ -406,7 +377,6 @@ discussion with your use case if you find this to be a problem.
 [url.prometheus_gauge]: https://prometheus.io/docs/concepts/metric_types/#gauge
 [url.prometheus_high_cardinality]: https://prometheus.io/docs/practices/naming/#labels
 [url.prometheus_histograms_guide]: https://prometheus.io/docs/practices/histograms/
-[url.prometheus_metric_naming]: https://prometheus.io/docs/practices/naming/#metric-names
 [url.prometheus_sink_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+prometheus%22+label%3A%22Type%3A+bug%22
 [url.prometheus_sink_enhancements]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+prometheus%22+label%3A%22Type%3A+enhancement%22
 [url.prometheus_sink_issues]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+prometheus%22

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -20,73 +20,18 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "splunk_hec" # must be: "splunk_hec"
   inputs = ["my-source-id"]
   host = "my-splunk-host.com"
   token = "A94A8FE5CCB19BA61C4C08"
-  
-  # OPTIONAL - General
-  healthcheck = true # default
-  
-  # OPTIONAL - Batching
-  batch_size = 1049000 # default, bytes
-  batch_timeout = 1 # default, seconds
-  
-  # OPTIONAL - Requests
-  encoding = "ndjson" # no default, enum: "ndjson" or "text"
-  rate_limit_duration = 1 # default, seconds
-  rate_limit_num = 10 # default
-  request_in_flight_limit = 10 # default
-  request_timeout_secs = 60 # default, seconds
-  retry_attempts = 5 # default
-  retry_backoff_secs = 5 # default, seconds
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "splunk_hec"
-  inputs = ["<string>", ...]
-  host = "<string>"
-  token = "<string>"
-
-  # OPTIONAL - General
-  healthcheck = <bool>
-
-  # OPTIONAL - Batching
-  batch_size = <int>
-  batch_timeout = <int>
-
-  # OPTIONAL - Requests
-  encoding = {"ndjson" | "text"}
-  rate_limit_duration = <int>
-  rate_limit_num = <int>
-  request_in_flight_limit = <int>
-  request_timeout_secs = <int>
-  retry_attempts = <int>
-  retry_backoff_secs = <int>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.splunk_hec_sink]
   #
@@ -234,34 +179,6 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.log_event] ev
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "splunk_hec"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `host` | `string` | Your Splunk HEC host.<br />`required` `example: "my-splunk-host.com"` |
-| `token` | `string` | Your Splunk HEC token.<br />`required` `example: "A94A8FE5CCB19BA61C4C08"` |
-| **OPTIONAL** - General | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| **OPTIONAL** - Batching | | |
-| `batch_size` | `int` | The maximum size of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1049000` `unit: bytes` |
-| `batch_timeout` | `int` | The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffers-batches) for more info.<br />`default: 1` `unit: seconds` |
-| **OPTIONAL** - Requests | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "ndjson" or "text"` |
-| `rate_limit_duration` | `int` | The window used for the `request_rate_limit_num` option See [Rate Limits](#rate-limits) for more info.<br />`default: 1` `unit: seconds` |
-| `rate_limit_num` | `int` | The maximum number of requests allowed within the `rate_limit_duration` window. See [Rate Limits](#rate-limits) for more info.<br />`default: 10` |
-| `request_in_flight_limit` | `int` | The maximum number of in-flight requests allowed at any given time. See [Rate Limits](#rate-limits) for more info.<br />`default: 10` |
-| `request_timeout_secs` | `int` | The maximum time a request can take before being aborted. See [Timeouts](#timeouts) for more info.<br />`default: 60` `unit: seconds` |
-| `retry_attempts` | `int` | The maximum number of retries to make for failed requests. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` |
-| `retry_backoff_secs` | `int` | The amount of time to wait before attempting a failed request again. See [Retry Policy](#retry-policy) for more info.<br />`default: 5` `unit: seconds` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
 
 ## How It Works
 
@@ -414,15 +331,11 @@ should supply to the `host` and `token` options.
 
 
 [docs.at_least_once_delivery]: ../../../about/guarantees.md#at-least-once-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.guarantees]: ../../../about/guarantees.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.sink-flow-serial]: ../../../assets/sink-flow-serial.svg
 [images.splunk_hec_sink]: ../../../assets/splunk_hec-sink.svg

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -20,69 +20,17 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "tcp" # must be: "tcp"
   inputs = ["my-source-id"]
   address = "92.12.333.224:5000"
-  
-  # OPTIONAL - General
-  healthcheck = true # default
-  
-  # OPTIONAL - Requests
-  encoding = "json" # no default, enum: "json" or "text"
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
-  
-  # OPTIONAL - Tls
-  [sinks.my_sink_id.tls]
-    enabled = false # default
-    verify = true # default
-    ca_file = "/path/to/certificate_authority.crt" # no default
-    crt_file = "/path/to/host_certificate.crt" # no default
-    key_file = "/path/to/host_certificate.key" # no default
-    key_phrase = "PassWord1" # no default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "tcp"
-  inputs = ["<string>", ...]
-  address = "<string>"
-
-  # OPTIONAL - General
-  healthcheck = <bool>
-
-  # OPTIONAL - Requests
-  encoding = {"json" | "text"}
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-
-  # OPTIONAL - Tls
-  [sinks.<sink-id>.tls]
-    enabled = <bool>
-    verify = <bool>
-    ca_file = "<string>"
-    crt_file = "<string>"
-    key_file = "<string>"
-    key_phrase = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.tcp_sink]
   #
@@ -212,31 +160,6 @@ The `tcp` sink [streams](#streaming) [`log`][docs.log_event] events to a TCP con
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "tcp"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `address` | `string` | The TCP address.<br />`required` `example: "92.12.333.224:5000"` |
-| **OPTIONAL** - General | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| **OPTIONAL** - Requests | | |
-| `encoding` | `string` | The encoding format used to serialize the events before flushing. The default is dynamic based on if the event is structured or not. See [Encodings](#encodings) for more info.<br />`no default` `enum: "json" or "text"` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
-| **OPTIONAL** - Tls | | |
-| `tls.enabled` | `bool` | Enable TLS during connections to the remote.<br />`default: false` |
-| `tls.verify` | `bool` | If `true`, Vector will force certificate validation. Do NOT set this to `false` unless you know the risks of not verifying the remote certificate.<br />`default: true` |
-| `tls.ca_file` | `string` | Absolute path to additional CA certificate file, in PEM format.<br />`no default` `example: (see above)` |
-| `tls.crt_file` | `string` | Absolute path to certificate file used to identify this connection, in PEM format. If this is set, `key_file` must also be set.<br />`no default` `example: (see above)` |
-| `tls.key_file` | `string` | Absolute path to key file used to identify this connection, in PEM format. If this is set, `crt_file` must also be set.<br />`no default` `example: (see above)` |
-| `tls.key_phrase` | `string` | Pass phrase to unlock the encrypted key file. This has no effect unless `key_file` above is set.<br />`no default` `example: "PassWord1"` |
-
 ## How It Works
 
 ### Delivery Guarantee
@@ -320,14 +243,10 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tcp_source]: ../../../usage/configuration/sources/tcp.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.tcp_sink]: ../../../assets/tcp-sink.svg
 [url.new_tcp_sink_bug]: https://github.com/timberio/vector/issues/new?labels=sink%3A+tcp&labels=Type%3A+bug

--- a/docs/usage/configuration/sinks/vector.md
+++ b/docs/usage/configuration/sinks/vector.md
@@ -20,45 +20,17 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED - General
   type = "vector" # must be: "vector"
   inputs = ["my-source-id"]
   address = "92.12.333.224:5000"
-  
-  # OPTIONAL - General
-  healthcheck = true # default
-  
-  # OPTIONAL - Buffer
-  [sinks.my_sink_id.buffer]
-    type = "memory" # default, enum: "memory" or "disk"
-    when_full = "block" # default, enum: "block" or "drop_newest"
-    max_size = 104900000 # no default, bytes, relevant when type = "disk"
-    num_items = 500 # default, events, relevant when type = "memory"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sinks.<sink-id>]
-  # REQUIRED - General
-  type = "vector"
-  inputs = ["<string>", ...]
-  address = "<string>"
-
-  # OPTIONAL - General
-  healthcheck = <bool>
-
-  # OPTIONAL - Buffer
-  [sinks.<sink-id>.buffer]
-    type = {"memory" | "disk"}
-    when_full = {"block" | "drop_newest"}
-    max_size = <int>
-    num_items = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.vector_sink]
   #
@@ -130,22 +102,6 @@ The `vector` sink [streams](#streaming) [`log`][docs.log_event] events to anothe
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "vector"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `address` | `string` | The downstream Vector address.<br />`required` `example: "92.12.333.224:5000"` |
-| **OPTIONAL** - General | | |
-| `healthcheck` | `bool` | Enables/disables the sink healthcheck upon start. See [Health Checks](#health-checks) for more info.<br />`default: true` |
-| **OPTIONAL** - Buffer | | |
-| `buffer.type` | `string` | The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.<br />`default: "memory"` `enum: "memory" or "disk"` |
-| `buffer.when_full` | `string` | The behavior when the buffer becomes full.<br />`default: "block"` `enum: "block" or "drop_newest"` |
-| `buffer.max_size` | `int` | The maximum size of the buffer on the disk. Only relevant when type = "disk"<br />`no default` `example: 104900000` `unit: bytes` |
-| `buffer.num_items` | `int` | The maximum number of [events][docs.event] allowed in the buffer. Only relevant when type = "memory"<br />`default: 500` `unit: events` |
-
 ## How It Works
 
 ### Delivery Guarantee
@@ -205,13 +161,9 @@ issue, please:
 
 
 [docs.best_effort_delivery]: ../../../about/guarantees.md#best-effort-delivery
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
-[docs.event]: ../../../about/data-model/README.md#event
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.vector_sink]: ../../../assets/vector-sink.svg
 [url.new_vector_sink_bug]: https://github.com/timberio/vector/issues/new?labels=sink%3A+vector&labels=Type%3A+bug

--- a/docs/usage/configuration/sources/journald.md
+++ b/docs/usage/configuration/sources/journald.md
@@ -27,28 +27,19 @@ The `journald` source ingests data through log records from journald and outputs
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
+  # REQUIRED
   type = "journald" # must be: "journald"
   
-  current_runtime_only = true # default
-  data_dir = "/var/lib/vector" # no default
-  local_only = true # default
+  # OPTIONAL
   units = ["ntpd", "sysinit.target"]
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  type = "journald"
-  current_runtime_only = <bool>
-  data_dir = "<string>"
-  local_only = <bool>
-  units = ["<string>", ...]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.journald_source]
   # The component type
@@ -88,18 +79,6 @@ The `journald` source ingests data through log records from journald and outputs
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "journald"` |
-| **OPTIONAL** | | |
-| `current_runtime_only` | `bool` | Include only entries from the current runtime (boot)<br />`default: true` |
-| `data_dir` | `string` | The directory used to persist the journal checkpoint position. By default, the global `data_dir` is used. Please make sure the Vector project has write permissions to this dir.<br />`no default` `example: "/var/lib/vector"` |
-| `local_only` | `bool` | Include only entries from the local system<br />`default: true` |
-| `units` | `[string]` | The list of units names to monitor. If empty or not present, all units are accepted. Unit names lacking a `"."` will have `".service"` appended to make them a valid service unit name.<br />`default: []` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/kafka.md
+++ b/docs/usage/configuration/sources/kafka.md
@@ -27,32 +27,18 @@ The `kafka` source ingests data through Kafka 0.9 or later and outputs [`log`][d
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
   type = "kafka" # must be: "kafka"
   bootstrap_servers = "10.14.22.123:9092,10.14.23.332:9092"
   group_id = "consumer-group-name"
   topics = ["topic-1", "topic-2", "^(prefix1|prefix2)-.+"]
-  
-  auto_offset_reset = "smallest"
-  key_field = "user_id" # no default
-  session_timeout_ms = 5000 # milliseconds
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  type = "kafka"
-  bootstrap_servers = "<string>"
-  group_id = "<string>"
-  topics = ["<string>", ...]
-  auto_offset_reset = "<string>"
-  key_field = "<string>"
-  session_timeout_ms = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.kafka_source]
   # The component type
@@ -114,20 +100,6 @@ The `kafka` source ingests data through Kafka 0.9 or later and outputs [`log`][d
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "kafka"` |
-| `bootstrap_servers` | `string` | A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a "bootstrap" Kafka cluster that a Kafka client connects to initially to bootstrap itself.<br />`required` `example: (see above)` |
-| `group_id` | `string` | The consumer group name to be used to consume events from Kafka.<br />`required` `example: "consumer-group-name"` |
-| `topics` | `[string]` | The Kafka topics names to read events from. Regex is supported if the topic begins with `^`.<br />`required` `example: (see above)` |
-| **OPTIONAL** | | |
-| `auto_offset_reset` | `string` | If offsets for consumer group do not exist, set them using this strategy. [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for `auto.offset.reset` option for explanation.<br />`default: "largest"` |
-| `key_field` | `string` | The log field name to use for the topic key. If unspecified, the key would not be added to the log event. If the message has null key, then this field would not be added to the log event.<br />`no default` `example: "user_id"` |
-| `session_timeout_ms` | `int` | The Kafka session timeout in milliseconds.<br />`default: 10000` `unit: milliseconds` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/statsd.md
+++ b/docs/usage/configuration/sources/statsd.md
@@ -27,21 +27,16 @@ The `statsd` source ingests data through the StatsD UDP protocol and outputs [`m
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
   type = "statsd" # must be: "statsd"
   address = "127.0.0.1:8126"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  type = "statsd"
-  address = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.statsd_source]
   # The component type
@@ -59,14 +54,6 @@ The `statsd` source ingests data through the StatsD UDP protocol and outputs [`m
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "statsd"` |
-| `address` | `string` | UDP socket address to bind to.<br />`required` `example: "127.0.0.1:8126"` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/stdin.md
+++ b/docs/usage/configuration/sources/stdin.md
@@ -20,33 +20,15 @@ The `stdin` source ingests data through standard input (STDIN) and outputs [`log
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
-  # REQUIRED - General
   type = "stdin" # must be: "stdin"
-  
-  # OPTIONAL - General
-  max_length = 102400 # default, bytes
-  
-  # OPTIONAL - Context
-  host_key = "host" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  # REQUIRED - General
-  type = "stdin"
-
-  # OPTIONAL - General
-  max_length = <int>
-
-  # OPTIONAL - Context
-  host_key = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.stdin_source]
   #
@@ -79,17 +61,6 @@ The `stdin` source ingests data through standard input (STDIN) and outputs [`log
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "stdin"` |
-| **OPTIONAL** - General | | |
-| `max_length` | `int` | The maxiumum bytes size of a message before it is discarded.<br />`default: 102400` `unit: bytes` |
-| **OPTIONAL** - Context | | |
-| `host_key` | `string` | The key name added to each event representing the current host. See [Context](#context) for more info.<br />`default: "host"` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/syslog.md
+++ b/docs/usage/configuration/sources/syslog.md
@@ -20,39 +20,16 @@ The `syslog` source ingests data through the Syslog 5424 protocol and outputs [`
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
-  # REQUIRED - General
   type = "syslog" # must be: "syslog"
   mode = "tcp" # enum: "tcp", "udp", and "unix"
-  
-  # OPTIONAL - General
-  address = "0.0.0.0:9000" # no default
-  max_length = 102400 # default, bytes
-  path = "/path/to/socket" # no default, relevant when mode = "unix"
-  
-  # OPTIONAL - Context
-  host_key = "host" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  # REQUIRED - General
-  type = "syslog"
-  mode = {"tcp" | "udp" | "unix"}
-
-  # OPTIONAL - General
-  address = "<string>"
-  max_length = <int>
-  path = "<string>"
-
-  # OPTIONAL - Context
-  host_key = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.syslog_source]
   #
@@ -106,20 +83,6 @@ The `syslog` source ingests data through the Syslog 5424 protocol and outputs [`
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "syslog"` |
-| `mode` | `string` | The input mode.<br />`required` `enum: "tcp", "udp", and "unix"` |
-| **OPTIONAL** - General | | |
-| `address` | `string` | The TCP or UDP address to listen on.<br />`no default` `example: "0.0.0.0:9000"` |
-| `max_length` | `int` | The maximum bytes size of incoming messages before they are discarded.<br />`default: 102400` `unit: bytes` |
-| `path` | `string` | The unix socket path. *This should be absolute path.* Only relevant when mode = "unix"<br />`no default` `example: "/path/to/socket"` |
-| **OPTIONAL** - Context | | |
-| `host_key` | `string` | The key name added to each event representing the current host. See [Context](#context) for more info.<br />`default: "host"` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/tcp.md
+++ b/docs/usage/configuration/sources/tcp.md
@@ -20,37 +20,16 @@ The `tcp` source ingests data through the TCP protocol and outputs [`log`][docs.
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
-  # REQUIRED - General
   type = "tcp" # must be: "tcp"
   address = "0.0.0.0:9000"
-  
-  # OPTIONAL - General
-  max_length = 102400 # default, bytes
-  shutdown_timeout_secs = 30 # default, seconds
-  
-  # OPTIONAL - Context
-  host_key = "host" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  # REQUIRED - General
-  type = "tcp"
-  address = "<string>"
-
-  # OPTIONAL - General
-  max_length = <int>
-  shutdown_timeout_secs = <int>
-
-  # OPTIONAL - Context
-  host_key = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.tcp_source]
   #
@@ -96,19 +75,6 @@ The `tcp` source ingests data through the TCP protocol and outputs [`log`][docs.
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "tcp"` |
-| `address` | `string` | The address to bind the socket to.<br />`required` `example: "0.0.0.0:9000"` |
-| **OPTIONAL** - General | | |
-| `max_length` | `int` | The maximum bytes size of incoming messages before they are discarded.<br />`default: 102400` `unit: bytes` |
-| `shutdown_timeout_secs` | `int` | The timeout before a connection is forcefully closed during shutdown.<br />`default: 30` `unit: seconds` |
-| **OPTIONAL** - Context | | |
-| `host_key` | `string` | The key name added to each event representing the current host. See [Context](#context) for more info.<br />`default: "host"` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/udp.md
+++ b/docs/usage/configuration/sources/udp.md
@@ -20,35 +20,16 @@ The `udp` source ingests data through the UDP protocol and outputs [`log`][docs.
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
-  # REQUIRED - General
   type = "udp" # must be: "udp"
   address = "0.0.0.0:9000"
-  
-  # OPTIONAL - General
-  max_length = 102400 # default, bytes
-  
-  # OPTIONAL - Context
-  host_key = "host" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  # REQUIRED - General
-  type = "udp"
-  address = "<string>"
-
-  # OPTIONAL - General
-  max_length = <int>
-
-  # OPTIONAL - Context
-  host_key = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.udp_source]
   #
@@ -87,18 +68,6 @@ The `udp` source ingests data through the UDP protocol and outputs [`log`][docs.
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "udp"` |
-| `address` | `string` | The address to bind the socket to.<br />`required` `example: "0.0.0.0:9000"` |
-| **OPTIONAL** - General | | |
-| `max_length` | `int` | The maximum bytes size of incoming messages before they are discarded.<br />`default: 102400` `unit: bytes` |
-| **OPTIONAL** - Context | | |
-| `host_key` | `string` | The key name added to each event representing the current host. See [Context](#context) for more info.<br />`default: "host"` |
 
 ## Examples
 

--- a/docs/usage/configuration/sources/vector.md
+++ b/docs/usage/configuration/sources/vector.md
@@ -27,24 +27,16 @@ The `vector` source ingests data through another upstream Vector instance and ou
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sources.my_source_id]
   type = "vector" # must be: "vector"
   address = "0.0.0.0:9000"
-  
-  shutdown_timeout_secs = 30 # default, seconds
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[sources.<source-id>]
-  type = "vector"
-  address = "<string>"
-  shutdown_timeout_secs = <int>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sources.vector_source]
   # The component type
@@ -69,16 +61,6 @@ The `vector` source ingests data through another upstream Vector instance and ou
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "vector"` |
-| `address` | `string` | The TCP address to bind to.<br />`required` `example: "0.0.0.0:9000"` |
-| **OPTIONAL** | | |
-| `shutdown_timeout_secs` | `int` | The timeout before a connection is forcefully closed during shutdown.<br />`default: 30` `unit: seconds` |
 
 ## How It Works
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -72,13 +72,6 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * must be: "file"
   type = "file"
 
-  # Array of file patterns to exclude. Globbing is supported. *Takes precedence
-  # over the `include` option.*
-  # 
-  # * required
-  # * no default
-  exclude = ["/var/log/nginx/access.log"]
-
   # Array of file patterns to include. Globbing is supported.
   # 
   # * required
@@ -92,6 +85,13 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * optional
   # * no default
   data_dir = "/var/lib/vector"
+
+  # Array of file patterns to exclude. Globbing is supported. *Takes precedence
+  # over the `include` option.*
+  # 
+  # * optional
+  # * no default
+  exclude = ["/var/log/nginx/access.log"]
 
   # Delay between file discovery calls. This controls the interval at which
   # Vector searches for files.

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1524,13 +1524,6 @@ end
   encoding = "ndjson"
   encoding = "text"
 
-  # Whether to Gzip the content before writing or not. Please note, enabling this
-  # has a slight performance cost but significantly reduces bandwidth.
-  # 
-  # * optional
-  # * default: false
-  gzip = false
-
   # The window used for the `request_rate_limit_num` option
   # 
   # * optional

--- a/docs/usage/configuration/transforms/add_fields.md
+++ b/docs/usage/configuration/transforms/add_fields.md
@@ -20,7 +20,7 @@ The `add_fields` transform accepts [`log`][docs.log_event] events and allows you
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   # REQUIRED - General
@@ -37,21 +37,11 @@ The `add_fields` transform accepts [`log`][docs.log_event] events and allows you
     my_timestamp_field = 1979-05-27T00:32:00.999998-07:00
     my_nested_fields = {key1 = "value1", key2 = "value2"}
     my_list = ["first", "second", "third"]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "add_fields"
-  inputs = ["<string>", ...]
 
-  # REQUIRED - Fields
-  [transforms.<transform-id>.fields]
-    * = {"<string>" | <int> | <float> | <bool> | <timestamp>}
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.add_fields_transform]
   #
@@ -93,16 +83,6 @@ The `add_fields` transform accepts [`log`][docs.log_event] events and allows you
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "add_fields"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| **REQUIRED** - Fields | | |
-| `fields.*` | `*` | A key/value pair representing the new log fields to be added. Accepts all [supported types][docs.config_value_types]. Use `.` for adding nested fields.<br />`required` `example: (see above)` |
 
 ## Examples
 
@@ -270,7 +250,6 @@ Finally, consider the following alternatives:
 * [**Source code**][url.add_fields_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.config_value_types]: ../../../usage/configuration/README.md#value-types
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.data_model]: ../../../about/data-model
@@ -280,8 +259,6 @@ Finally, consider the following alternatives:
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.remove_fields_transform]: ../../../usage/configuration/transforms/remove_fields.md
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.add_fields_transform]: ../../../assets/add_fields-transform.svg
 [url.add_fields_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_fields%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/add_tags.md
+++ b/docs/usage/configuration/transforms/add_tags.md
@@ -20,7 +20,7 @@ The `add_tags` transform accepts [`metric`][docs.metric_event] events and allows
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   # REQUIRED - General
@@ -31,21 +31,11 @@ The `add_tags` transform accepts [`metric`][docs.metric_event] events and allows
   [transforms.my_transform_id.tags]
     my_tag = "my value"
     my_env_tag = "${ENV_VAR}"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "add_tags"
-  inputs = ["<string>", ...]
 
-  # REQUIRED - Tags
-  [transforms.<transform-id>.tags]
-    * = {"<string>" | <int> | <float> | <bool> | <timestamp>}
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.add_tags_transform]
   #
@@ -80,16 +70,6 @@ The `add_tags` transform accepts [`metric`][docs.metric_event] events and allows
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "add_tags"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| **REQUIRED** - Tags | | |
-| `tags.*` | `*` | A key/value pair representing the new tag to be added.<br />`required` `example: (see above)` |
 
 ## How It Works
 
@@ -131,14 +111,11 @@ Finally, consider the following alternatives:
 * [**Source code**][url.add_tags_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.remove_tags_transform]: ../../../usage/configuration/transforms/remove_tags.md
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.add_tags_transform]: ../../../assets/add_tags-transform.svg
 [url.add_tags_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_tags%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/coercer.md
+++ b/docs/usage/configuration/transforms/coercer.md
@@ -20,37 +20,16 @@ The `coercer` transform accepts [`log`][docs.log_event] events and allows you to
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
-  # REQUIRED - General
   type = "coercer" # must be: "coercer"
   inputs = ["my-source-id"]
-  
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "coercer"
-  inputs = ["<string>", ...]
 
-  # OPTIONAL - Types
-  [transforms.<transform-id>.types]
-    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.coercer_transform]
   #
@@ -93,16 +72,6 @@ The `coercer` transform accepts [`log`][docs.log_event] events and allows you to
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "coercer"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| **OPTIONAL** - Types | | |
-| `types.*` | `string` | A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", and "timestamp\|strftime"` |
 
 ## Examples
 
@@ -227,13 +196,10 @@ Finally, consider the following alternatives:
 * [**Source code**][url.coercer_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.coercer_transform]: ../../../assets/coercer-transform.svg
 [url.coercer_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+coercer%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/field_filter.md
+++ b/docs/usage/configuration/transforms/field_filter.md
@@ -27,25 +27,18 @@ The `field_filter` transform accepts [`log`][docs.log_event] and [`metric`][docs
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "field_filter" # must be: "field_filter"
   inputs = ["my-source-id"]
   field = "file"
   value = "/var/log/nginx.log"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "field_filter"
-  inputs = ["<string>", ...]
-  field = "<string>"
-  value = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.field_filter_transform]
   # The component type
@@ -77,16 +70,6 @@ The `field_filter` transform accepts [`log`][docs.log_event] and [`metric`][docs
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "field_filter"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `field` | `string` | The target log field to compare against the `value`.<br />`required` `example: "file"` |
-| `value` | `string` | If the value of the specified `field` matches this value then the event will be permitted, otherwise it is dropped.<br />`required` `example: "/var/log/nginx.log"` |
 
 ## How It Works
 
@@ -135,14 +118,11 @@ Finally, consider the following alternatives:
 * [**Source code**][url.field_filter_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.field_filter_transform]: ../../../assets/field_filter-transform.svg
 [url.field_filter_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+field_filter%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -20,47 +20,17 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
-  # REQUIRED - General
   type = "grok_parser" # must be: "grok_parser"
   inputs = ["my-source-id"]
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
-  
-  # OPTIONAL - General
-  drop_field = true # default
-  field = "message" # default
-  
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "grok_parser"
-  inputs = ["<string>", ...]
-  pattern = "<string>"
-
-  # OPTIONAL - General
-  drop_field = <bool>
-  field = "<string>"
-
-  # OPTIONAL - Types
-  [transforms.<transform-id>.types]
-    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.grok_parser_transform]
   #
@@ -121,20 +91,6 @@ The `grok_parser` transform accepts [`log`][docs.log_event] events and allows yo
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "grok_parser"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `pattern` | `string` | The [Grok pattern][url.grok_patterns]<br />`required` `example: (see above)` |
-| **OPTIONAL** - General | | |
-| `drop_field` | `bool` | If `true` will drop the specified `field` after parsing.<br />`default: true` |
-| `field` | `string` | The log field to execute the `pattern` against. Must be a `string` value.<br />`default: "message"` |
-| **OPTIONAL** - Types | | |
-| `types.*` | `string` | A definition of mapped log field types. They key is the log field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", and "timestamp\|strftime"` |
 
 ## How It Works
 
@@ -230,17 +186,14 @@ Finally, consider the following alternatives:
 * [**Grok Patterns**][url.grok_patterns]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.performance]: ../../../performance.md
 [docs.regex_parser_transform]: ../../../usage/configuration/transforms/regex_parser.md
-[docs.sources]: ../../../usage/configuration/sources
 [docs.split_transform]: ../../../usage/configuration/transforms/split.md
 [docs.tokenizer_transform]: ../../../usage/configuration/transforms/tokenizer.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.grok_parser_transform]: ../../../assets/grok_parser-transform.svg
 [url.grok]: http://grokdebug.herokuapp.com/

--- a/docs/usage/configuration/transforms/json_parser.md
+++ b/docs/usage/configuration/transforms/json_parser.md
@@ -20,26 +20,17 @@ The `json_parser` transform accepts [`log`][docs.log_event] events and allows yo
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "json_parser" # must be: "json_parser"
   inputs = ["my-source-id"]
   drop_invalid = true
-  
-  field = "message" # default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "json_parser"
-  inputs = ["<string>", ...]
-  drop_invalid = <bool>
-  field = "<string>"
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.json_parser_transform]
   # The component type
@@ -71,17 +62,6 @@ The `json_parser` transform accepts [`log`][docs.log_event] events and allows yo
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "json_parser"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `drop_invalid` | `bool` | If `true` events with invalid JSON will be dropped, otherwise the event will be kept and passed through. See [Invalid JSON](#invalid-json) for more info.<br />`required` `example: true` |
-| **OPTIONAL** | | |
-| `field` | `string` | The log field to decode as JSON. Must be a `string` value type. See [Invalid JSON](#invalid-json) for more info.<br />`default: "message"` |
 
 ## Examples
 
@@ -242,14 +222,11 @@ Finally, consider the following alternatives:
 * [**Source code**][url.json_parser_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.correctness]: ../../../correctness.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.json_parser_transform]: ../../../assets/json_parser-transform.svg
 [url.json_parser_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+json_parser%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/log_to_metric.md
+++ b/docs/usage/configuration/transforms/log_to_metric.md
@@ -20,7 +20,7 @@ The `log_to_metric` transform accepts [`log`][docs.log_event] events and allows 
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   # REQUIRED - General
@@ -29,31 +29,19 @@ The `log_to_metric` transform accepts [`log`][docs.log_event] events and allows 
   
   # REQUIRED - Metrics
   [[transforms.my_transform_id.metrics]]
+    # REQUIRED
     type = "counter" # enum: "counter", "gauge", "histogram", and "set"
     field = "duration"
     name = "duration_total"
     
+    # OPTIONAL
     increment_by_value = false # default, relevant when type = "counter"
     tags = {host = "${HOSTNAME}", region = "us-east-1", status = "{{status}}"}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "log_to_metric"
-  inputs = ["<string>", ...]
 
-  # REQUIRED - Metrics
-  [[transforms.<transform-id>.metrics]]
-    type = {"counter" | "gauge" | "histogram" | "set"}
-    field = "<string>"
-    name = "<string>"
-    increment_by_value = <bool>
-    tags = {* = "<string>"}
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.log_to_metric_transform]
   #
@@ -120,20 +108,6 @@ The `log_to_metric` transform accepts [`log`][docs.log_event] events and allows 
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "log_to_metric"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| **REQUIRED** - Metrics | | |
-| `metrics.type` | `string` | The metric type.<br />`required` `enum: "counter", "gauge", "histogram", and "set"` |
-| `metrics.field` | `string` | The log field to use as the metric. See [Null Fields](#null-fields) for more info.<br />`required` `example: "duration"` |
-| `metrics.name` | `string` | The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`.<br />`required` `example: "duration_total"` |
-| `metrics.increment_by_value` | `bool` | If `true` the metric will be incremented by the `field` value. If `false` the metric will be incremented by 1 regardless of the `field` value. Only relevant when type = "counter"<br />`default: false` |
-| `metrics.tags.*` | `string` | Key/value pairs representing the metric tags.<br />`required` `example: (see above)` |
 
 ## Examples
 
@@ -501,14 +475,11 @@ issue, please:
 * [**Source code**][url.log_to_metric_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.prometheus_sink]: ../../../usage/configuration/sinks/prometheus.md
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.log_to_metric_transform]: ../../../assets/log_to_metric-transform.svg
 [url.log_to_metric_transform_bugs]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+log_to_metric%22+label%3A%22Type%3A+bug%22

--- a/docs/usage/configuration/transforms/lua.md
+++ b/docs/usage/configuration/transforms/lua.md
@@ -27,7 +27,7 @@ The `lua` transform accepts [`log`][docs.log_event] events and allows you to tra
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "lua" # must be: "lua"
@@ -44,20 +44,10 @@ if event["host"] == nil then
 end
 """
 
-  
-  search_dirs = ["/etc/vector/lua"] # no default
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "lua"
-  inputs = ["<string>", ...]
-  source = "<string>"
-  search_dirs = ["<string>", ...]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.lua_transform]
   # The component type
@@ -100,17 +90,6 @@ end
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "lua"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `source` | `string` | The inline Lua source to evaluate. See [Global Variables](#global-variables) for more info.<br />`required` `example: (see above)` |
-| **OPTIONAL** | | |
-| `search_dirs` | `[string]` | A list of directories search when loading a Lua file via the `require` function. See [Search Directories](#search-directories) for more info.<br />`no default` `example: ["/etc/vector/lua"]` |
 
 ## Examples
 
@@ -233,15 +212,12 @@ Finally, consider the following alternatives:
 * [**Lua Reference Manual**][url.lua_manual]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.data_model]: ../../../about/data-model
 [docs.default_schema]: ../../../about/data-model/log.md#default-schema
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.lua_transform]: ../../../assets/lua-transform.svg
 [url.lua]: https://www.lua.org/

--- a/docs/usage/configuration/transforms/regex_parser.md
+++ b/docs/usage/configuration/transforms/regex_parser.md
@@ -20,47 +20,17 @@ The `regex_parser` transform accepts [`log`][docs.log_event] events and allows y
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
-  # REQUIRED - General
   type = "regex_parser" # must be: "regex_parser"
   inputs = ["my-source-id"]
   regex = "^(?P<host>[\\w\\.]+) - (?P<user>[\\w]+) (?P<bytes_in>[\\d]+) \\[(?P<timestamp>.*)\\] \"(?P<method>[\\w]+) (?P<path>.*)\" (?P<status>[\\d]+) (?P<bytes_out>[\\d]+)$"
-  
-  # OPTIONAL - General
-  drop_field = true # default
-  field = "message" # default
-  
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "regex_parser"
-  inputs = ["<string>", ...]
-  regex = "<string>"
-
-  # OPTIONAL - General
-  drop_field = <bool>
-  field = "<string>"
-
-  # OPTIONAL - Types
-  [transforms.<transform-id>.types]
-    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.regex_parser_transform]
   #
@@ -121,20 +91,6 @@ The `regex_parser` transform accepts [`log`][docs.log_event] events and allows y
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "regex_parser"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `regex` | `string` | The Regular Expression to apply. Do not inlcude the leading or trailing `/`. See [Failed Parsing](#failed-parsing) and [Regex Debugger](#regex-debugger) for more info.<br />`required` `example: (see above)` |
-| **OPTIONAL** - General | | |
-| `drop_field` | `bool` | If the specified `field` should be dropped (removed) after parsing.<br />`default: true` |
-| `field` | `string` | The log field to parse. See [Failed Parsing](#failed-parsing) for more info.<br />`default: "message"` |
-| **OPTIONAL** - Types | | |
-| `types.*` | `string` | A definition of mapped log field types. They key is the log field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", and "timestamp\|strftime"` |
 
 ## Examples
 
@@ -332,17 +288,14 @@ Finally, consider the following alternatives:
 * [**Rust Regex Syntax**][url.rust_regex_syntax]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.grok_parser_transform]: ../../../usage/configuration/transforms/grok_parser.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.performance]: ../../../performance.md
-[docs.sources]: ../../../usage/configuration/sources
 [docs.split_transform]: ../../../usage/configuration/transforms/split.md
 [docs.tokenizer_transform]: ../../../usage/configuration/transforms/tokenizer.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.regex_parser_transform]: ../../../assets/regex_parser-transform.svg
 [url.new_regex_parser_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+regex_parser&labels=Type%3A+bug

--- a/docs/usage/configuration/transforms/remove_fields.md
+++ b/docs/usage/configuration/transforms/remove_fields.md
@@ -20,23 +20,17 @@ The `remove_fields` transform accepts [`log`][docs.log_event] events and allows 
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "remove_fields" # must be: "remove_fields"
   inputs = ["my-source-id"]
   fields = ["field1", "field2"]
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "remove_fields"
-  inputs = ["<string>", ...]
-  fields = ["<string>", ...]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.remove_fields_transform]
   # The component type
@@ -61,15 +55,6 @@ The `remove_fields` transform accepts [`log`][docs.log_event] events and allows 
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "remove_fields"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `fields` | `[string]` | The log field names to drop.<br />`required` `example: ["field1", "field2"]` |
 
 ## How It Works
 
@@ -112,13 +97,10 @@ Finally, consider the following alternatives:
 
 
 [docs.add_fields_transform]: ../../../usage/configuration/transforms/add_fields.md
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.remove_fields_transform]: ../../../assets/remove_fields-transform.svg
 [url.new_remove_fields_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+remove_fields&labels=Type%3A+bug

--- a/docs/usage/configuration/transforms/remove_tags.md
+++ b/docs/usage/configuration/transforms/remove_tags.md
@@ -20,23 +20,17 @@ The `remove_tags` transform accepts [`metric`][docs.metric_event] events and all
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "remove_tags" # must be: "remove_tags"
   inputs = ["my-source-id"]
   tags = ["tag1", "tag2"]
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "remove_tags"
-  inputs = ["<string>", ...]
-  tags = ["<string>", ...]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.remove_tags_transform]
   # The component type
@@ -61,15 +55,6 @@ The `remove_tags` transform accepts [`metric`][docs.metric_event] events and all
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "remove_tags"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `tags` | `[string]` | The tag names to drop.<br />`required` `example: ["tag1", "tag2"]` |
 
 ## How It Works
 
@@ -112,13 +97,10 @@ Finally, consider the following alternatives:
 
 
 [docs.add_tags_transform]: ../../../usage/configuration/transforms/add_tags.md
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.metric_event]: ../../../about/data-model/metric.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.remove_tags_transform]: ../../../assets/remove_tags-transform.svg
 [url.new_remove_tags_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+remove_tags&labels=Type%3A+bug

--- a/docs/usage/configuration/transforms/sampler.md
+++ b/docs/usage/configuration/transforms/sampler.md
@@ -27,26 +27,17 @@ The `sampler` transform accepts [`log`][docs.log_event] events and allows you to
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
   type = "sampler" # must be: "sampler"
   inputs = ["my-source-id"]
   rate = 10
-  
-  pass_list = ["[error]", "field2"] # no default
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  type = "sampler"
-  inputs = ["<string>", ...]
-  rate = <int>
-  pass_list = ["<string>", ...]
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.sampler_transform]
   # The component type
@@ -81,17 +72,6 @@ The `sampler` transform accepts [`log`][docs.log_event] events and allows you to
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** | | |
-| `type` | `string` | The component type<br />`required` `must be: "sampler"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `rate` | `int` | The rate at which events will be forwarded, expressed as 1/N. For example, `rate = 10` means 1 out of every 10 events will be forwarded and the rest will be dropped.<br />`required` `example: 10` |
-| **OPTIONAL** | | |
-| `pass_list` | `[string]` | A list of regular expression patterns to exclude events from sampling. If an event's `"message"` key matches _any_ of these patterns it will _not_ be sampled.<br />`no default` `example: ["[error]", "field2"]` |
 
 ## How It Works
 
@@ -132,13 +112,10 @@ Finally, consider the following alternatives:
 * [**Source code**][url.sampler_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
-[docs.sources]: ../../../usage/configuration/sources
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.sampler_transform]: ../../../assets/sampler-transform.svg
 [url.new_sampler_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+sampler&labels=Type%3A+bug

--- a/docs/usage/configuration/transforms/split.md
+++ b/docs/usage/configuration/transforms/split.md
@@ -20,49 +20,17 @@ The `split` transform accepts [`log`][docs.log_event] events and allows you to s
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
-  # REQUIRED - General
   type = "split" # must be: "split"
   inputs = ["my-source-id"]
   field_names = ["timestamp", "level", "message"]
-  
-  # OPTIONAL - General
-  drop_field = true # default
-  field = "message" # default
-  separator = ","
-  
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "split"
-  inputs = ["<string>", ...]
-  field_names = ["<string>", ...]
-
-  # OPTIONAL - General
-  drop_field = <bool>
-  field = "<string>"
-  separator = ["<string>", ...]
-
-  # OPTIONAL - Types
-  [transforms.<transform-id>.types]
-    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.split_transform]
   #
@@ -129,21 +97,6 @@ The `split` transform accepts [`log`][docs.log_event] events and allows you to s
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "split"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `field_names` | `[string]` | The field names assigned to the resulting tokens, in order.<br />`required` `example: (see above)` |
-| **OPTIONAL** - General | | |
-| `drop_field` | `bool` | If `true` the `field` will be dropped after parsing.<br />`default: true` |
-| `field` | `string` | The field to apply the split on.<br />`default: "message"` |
-| `separator` | `[string]` | The separator to split the field on. If no separator is given, it will split on whitespace.<br />`default: "whitespace"` |
-| **OPTIONAL** - Types | | |
-| `types.*` | `string` | A definition of mapped field types. They key is the field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", and "timestamp\|strftime"` |
 
 ## Examples
 
@@ -267,16 +220,13 @@ Finally, consider the following alternatives:
 * [**Source code**][url.split_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.grok_parser_transform]: ../../../usage/configuration/transforms/grok_parser.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.regex_parser_transform]: ../../../usage/configuration/transforms/regex_parser.md
-[docs.sources]: ../../../usage/configuration/sources
 [docs.tokenizer_transform]: ../../../usage/configuration/transforms/tokenizer.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.split_transform]: ../../../assets/split-transform.svg
 [url.new_split_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+split&labels=Type%3A+bug

--- a/docs/usage/configuration/transforms/tokenizer.md
+++ b/docs/usage/configuration/transforms/tokenizer.md
@@ -20,47 +20,17 @@ The `tokenizer` transform accepts [`log`][docs.log_event] events and allows you 
 ## Config File
 
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [transforms.my_transform_id]
-  # REQUIRED - General
   type = "tokenizer" # must be: "tokenizer"
   inputs = ["my-source-id"]
   field_names = ["timestamp", "level", "message"]
-  
-  # OPTIONAL - General
-  drop_field = true # default
-  field = "message" # default
-  
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
-```coffeescript
-[transforms.<transform-id>]
-  # REQUIRED - General
-  type = "tokenizer"
-  inputs = ["<string>", ...]
-  field_names = ["<string>", ...]
-
-  # OPTIONAL - General
-  drop_field = <bool>
-  field = "<string>"
-
-  # OPTIONAL - Types
-  [transforms.<transform-id>.types]
-    * = {"string" | "int" | "float" | "bool" | "timestamp|strftime"}
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [transforms.tokenizer_transform]
   #
@@ -121,20 +91,6 @@ The `tokenizer` transform accepts [`log`][docs.log_event] events and allows you 
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
-
-## Options
-
-| Key  | Type  | Description |
-|:-----|:-----:|:------------|
-| **REQUIRED** - General | | |
-| `type` | `string` | The component type<br />`required` `must be: "tokenizer"` |
-| `inputs` | `[string]` | A list of upstream [source][docs.sources] or [transform][docs.transforms] IDs. See [Config Composition][docs.config_composition] for more info.<br />`required` `example: ["my-source-id"]` |
-| `field_names` | `[string]` | The log field names assigned to the resulting tokens, in order.<br />`required` `example: (see above)` |
-| **OPTIONAL** - General | | |
-| `drop_field` | `bool` | If `true` the `field` will be dropped after parsing.<br />`default: true` |
-| `field` | `string` | The log field to tokenize.<br />`default: "message"` |
-| **OPTIONAL** - Types | | |
-| `types.*` | `string` | A definition of mapped log field types. They key is the log field name and the value is the type. [`strftime` specifiers][url.strftime_specifiers] are supported for the `timestamp` type.<br />`required` `enum: "string", "int", "float", "bool", and "timestamp\|strftime"` |
 
 ## Examples
 
@@ -273,16 +229,13 @@ Finally, consider the following alternatives:
 * [**Source code**][url.tokenizer_transform_source]
 
 
-[docs.config_composition]: ../../../usage/configuration/README.md#composition
 [docs.configuration.environment-variables]: ../../../usage/configuration#environment-variables
 [docs.grok_parser_transform]: ../../../usage/configuration/transforms/grok_parser.md
 [docs.log_event]: ../../../about/data-model/log.md
 [docs.lua_transform]: ../../../usage/configuration/transforms/lua.md
 [docs.monitoring_logs]: ../../../usage/administration/monitoring.md#logs
 [docs.regex_parser_transform]: ../../../usage/configuration/transforms/regex_parser.md
-[docs.sources]: ../../../usage/configuration/sources
 [docs.split_transform]: ../../../usage/configuration/transforms/split.md
-[docs.transforms]: ../../../usage/configuration/transforms
 [docs.troubleshooting]: ../../../usage/guides/troubleshooting.md
 [images.tokenizer_transform]: ../../../assets/tokenizer-transform.svg
 [url.new_tokenizer_transform_bug]: https://github.com/timberio/vector/issues/new?labels=transform%3A+tokenizer&labels=Type%3A+bug

--- a/scripts/generate/core_ext/open_struct.rb
+++ b/scripts/generate/core_ext/open_struct.rb
@@ -1,0 +1,5 @@
+class OpenStruct
+  def to_a
+    to_h.values
+  end
+end

--- a/scripts/generate/metadata/batching_sink.rb
+++ b/scripts/generate/metadata/batching_sink.rb
@@ -16,6 +16,7 @@ class BatchingSink < Sink
   def initialize(hash)
     super(hash)
 
+    batch_is_simple = hash["batch_is_simple"] == true
     @batch_size = hash.fetch("batch_size")
     @batch_timeout = hash.fetch("batch_timeout")
     @rate_limit_duration = hash.fetch("rate_limit_duration")
@@ -33,6 +34,7 @@ class BatchingSink < Sink
       "default" => @batch_size,
       "description" => "The maximum size of a batch before it is flushed.",
       "null" => false,
+      "simple" => batch_is_simple,
       "type" => "int",
       "unit" => "bytes"
     })
@@ -43,6 +45,7 @@ class BatchingSink < Sink
       "default" => @batch_timeout,
       "description" => "The maximum age of a batch before it is flushed.",
       "null" => false,
+      "simple" => batch_is_simple,
       "type" => "int",
       "unit" => "seconds"
     })

--- a/scripts/generate/metadata/component.rb
+++ b/scripts/generate/metadata/component.rb
@@ -65,11 +65,19 @@ class Component
   end
 
   def context_options
-    options.to_h.values.sort.select(&:context?)
+    options_list.select(&:context?)
+  end
+
+  def options_list
+    @options_list ||= options.to_h.values.sort
   end
 
   def partition_options
-    options.to_h.values.sort.select(&:partition_key?)
+    options_list.select(&:partition_key?)
+  end
+
+  def simple_options
+    options_list.select(&:simple?)
   end
 
   def sink?
@@ -81,7 +89,7 @@ class Component
   end
 
   def templateable_options
-    options.to_h.values.sort.select(&:templateable?)
+    options_list.select(&:templateable?)
   end
 
   def transform?

--- a/scripts/generate/metadata/option.rb
+++ b/scripts/generate/metadata/option.rb
@@ -40,6 +40,7 @@ class Option
     @null = hash.fetch("null")
     @partition_key = hash["partition_key"] == true
     @relevant_when = hash["relevant_when"]
+    @simple = hash["simple"] == true
     @templateable = hash["templateable"] == true
     @type = hash.fetch("type")
     @unit = hash["unit"]
@@ -114,6 +115,10 @@ class Option
 
   def required?
     default.nil? && null == false
+  end
+
+  def simple?
+    @simple == true || required?
   end
 
   def sort_token

--- a/scripts/generate/templates/_partials/_component_config_example.md.erb
+++ b/scripts/generate/templates/_partials/_component_config_example.md.erb
@@ -1,17 +1,14 @@
 {% code-tabs %}
-{% code-tabs-item title="vector.toml (example)" %}
+{% code-tabs-item title="vector.toml (simple)" %}
 ```toml
-<%= config_example(component.options.to_h.values.sort, path: "#{component.type.pluralize}.my_#{component.type}_id") %>
+<%= config_example(component.simple_options, path: "#{component.type.pluralize}.my_#{component.type}_id") %>
+
+  # For a complete list of options see the "advanced" tab above.
 ```
 {% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (schema)" %}
+{% code-tabs-item title="vector.toml (advanced)" %}
 ```toml
-<%= config_schema(component.options.to_h.values.sort, path: "#{component.type.pluralize}.<#{component.type}-id>") %>
-```
-{% endcode-tabs-item %}
-{% code-tabs-item title="vector.toml (specification)" %}
-```toml
-<%= config_spec(component.options.to_h.values.sort, path: "#{component.type.pluralize}.#{component.id}") %>
+<%= config_spec(component.options_list, path: "#{component.type.pluralize}.#{component.id}") %>
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}

--- a/scripts/generate/templates/_partials/_config_example.toml.erb
+++ b/scripts/generate/templates/_partials/_config_example.toml.erb
@@ -1,6 +1,6 @@
 <% if opts[:array] %>[[<%= opts[:path] %>]]<% else %>[<%= opts[:path] %>]<% end %>
 <% example.grouped.each do |title, options| -%>
-  <%- if example.categories.length > 1 -%>
+  <%- if example.grouped.length > 1 -%>
   # <%= title %>
   <%- end -%>
   <%- options.each do |option| -%>

--- a/scripts/generate/templates/_partials/_config_spec.toml.erb
+++ b/scripts/generate/templates/_partials/_config_spec.toml.erb
@@ -2,7 +2,7 @@
 <% if opts[:array] %>[[<%= opts[:path] %>]]<% else %>[<%= opts[:path] %>]<% end %>
 <%- end -%>
 <%- spec.grouped.each do |title, options| -%>
-  <%- if spec.categories.length > 1 -%>
+  <%- if spec.grouped.length > 1 -%>
   <%- if opts[:titles] -%>
   #
   # <%= title %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/aws_cloudwatch_logs.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/aws_cloudwatch_logs.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 ```http

--- a/scripts/generate/templates/docs/usage/configuration/sinks/aws_kinesis_streams.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/aws_kinesis_streams.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 The `aws_kinesis_streams` sink batches [`log`][docs.log_event] up to the `batch_size` or `batch_timeout` options. When flushed, Vector will write to [AWS Kinesis Data Stream][url.aws_kinesis_data_streams] via the [`PutRecords` API endpoint](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html). The encoding is dictated by the `encoding` option. For example:

--- a/scripts/generate/templates/docs/usage/configuration/sinks/aws_s3.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/aws_s3.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 The `aws_s3` sink batches [`log`][docs.log_event] up to the `batch_size` or

--- a/scripts/generate/templates/docs/usage/configuration/sinks/blackhole.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/blackhole.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/clickhouse.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/clickhouse.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/console.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/console.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/elasticsearch.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/elasticsearch.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 The `elasticsearch` sink batches [`log`][docs.log_event] up to the `batch_size` or `batch_timeout` options. When flushed, Vector will write to [Elasticsearch][url.elasticsearch] via the [`_bulk` API endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html). The encoding is dictated by the `encoding` option. For example:

--- a/scripts/generate/templates/docs/usage/configuration/sinks/file.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/file.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/http.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/http.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 The `http` sink batches [`log`][docs.log_event] up to the `batch_size` or

--- a/scripts/generate/templates/docs/usage/configuration/sinks/kafka.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/kafka.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/prometheus.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/prometheus.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 {% tabs %}

--- a/scripts/generate/templates/docs/usage/configuration/sinks/splunk_hec.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/splunk_hec.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/tcp.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/tcp.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sinks/vector.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sinks/vector.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/sources/file.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/file.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input:

--- a/scripts/generate/templates/docs/usage/configuration/sources/journald.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/journald.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following journald record:

--- a/scripts/generate/templates/docs/usage/configuration/sources/kafka.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/kafka.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following message in a Kafka topic:

--- a/scripts/generate/templates/docs/usage/configuration/sources/statsd.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/statsd.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 {% tabs %}

--- a/scripts/generate/templates/docs/usage/configuration/sources/stdin.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/stdin.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input line:

--- a/scripts/generate/templates/docs/usage/configuration/sources/syslog.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/syslog.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input line:

--- a/scripts/generate/templates/docs/usage/configuration/sources/tcp.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/tcp.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input line:

--- a/scripts/generate/templates/docs/usage/configuration/sources/udp.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/udp.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input line:

--- a/scripts/generate/templates/docs/usage/configuration/sources/vector.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/vector.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/add_fields.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/add_fields.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following configuration:

--- a/scripts/generate/templates/docs/usage/configuration/transforms/add_tags.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/add_tags.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/coercer.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/coercer.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following input event:

--- a/scripts/generate/templates/docs/usage/configuration/transforms/field_filter.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/field_filter.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/grok_parser.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/grok_parser.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/json_parser.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/json_parser.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 {% tabs %}

--- a/scripts/generate/templates/docs/usage/configuration/transforms/log_to_metric.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/log_to_metric.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 {% tabs %}

--- a/scripts/generate/templates/docs/usage/configuration/transforms/lua.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/lua.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 {% tabs %}

--- a/scripts/generate/templates/docs/usage/configuration/transforms/regex_parser.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/regex_parser.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following log line:

--- a/scripts/generate/templates/docs/usage/configuration/transforms/remove_fields.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/remove_fields.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/remove_tags.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/remove_tags.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/sampler.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/sampler.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## How It Works [[sort]]
 
 <%= component_sections(component) %>

--- a/scripts/generate/templates/docs/usage/configuration/transforms/split.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/split.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following log line:

--- a/scripts/generate/templates/docs/usage/configuration/transforms/tokenizer.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/tokenizer.md.erb
@@ -6,10 +6,6 @@
 
 <%= component_config_example(component) %>
 
-## Options
-
-<%= options_table(component.options.to_h.values.sort) %>
-
 ## Examples
 
 Given the following log line:


### PR DESCRIPTION
This change simplifies our component options documentation by:

1. Removing the 3 `example`, `schema`, and `specification` options in favor of just `simple` and `advanced`.
2. Removes the options table since all of this info is covered in the new `advanced` tab. Additionally, the tables were becoming unwieldy.

This more accurately reflects our simple-first mentality with Vector, allowing new users to copy the basic configuration items to get started and then dig into more advanced options as they need them. The goal, if possible, should be for the "advanced" options to have good enough defaults where they should not require adjustment.