### PR TITLE
fix(operations): fix install script path export

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -138,6 +138,10 @@ install_from_archive() {
     need_cmd mkdir
     need_cmd rm
     need_cmd rmdir
+    need_cmd grep
+    need_cmd tar
+    need_cmd head
+    need_cmd sed
 
     get_architecture || return 1
     local _arch="$RETVAL"
@@ -171,12 +175,15 @@ install_from_archive() {
 
     printf "$_prompt Unpacking archive to $HOME/.vector ..."
     ensure mkdir -p "$HOME/.vector"
+    local _dir_name=$(tar -tzf ${_file} | head -1 | sed -e 's/\.\/\(.*\)\//\1/')
     ensure tar -xzf "$_file" --directory="$HOME/.vector" --strip-components=1
+
     printf " ✓\n"
 
     printf "$_prompt Adding Vector path to ~/.profile"
-    echo 'export PATH="$HOME/.vector/bin:$PATH"' >> $HOME/.profile
-    echo 'export PATH="$HOME/.vector/bin:$PATH"' >> $HOME/.zprofile
+    local _path="export PATH=\"\$HOME/.vector/${_dir_name}/bin:\$PATH\""
+    grep -qxF "${_path}" "${HOME}/.profile" || echo "${_path}" >> "${HOME}/.profile"
+    grep -qxF "${_path}" "${HOME}/.zprofile" || echo "${_path}" >> "${HOME}/.zprofile"
     printf " ✓\n"
 
     printf "$_prompt Install succeeded! 🚀\n"


### PR DESCRIPTION
While installing vector using the install script, I've noticed that the script duplicated the export path line.

It was because I have .zprofile symlinked to .profile.
But after investigation I realized that the script didn't check for the export instruction, so running the script multiple time would duplicate the line.

Additionally, the export line didn't take into account the archive directory name.

The added path was `$HOME/.vector/bin:$PATH` while the path in my computer should have been `$HOME/.vector/vector-0.3.0/bin` it's because tar extract the content in its root directory.

So my fix include:
- getting the archive root dir name (line 178)
- creating a variable _path with the export command (I just realized my naming is a bit messy here) (line 184)
- checking if the path export already exists in both .profile and .zprofile (line 185-186)

This fix does require a few additional commands:
- grep
- head
- sed

all of them being standard in most unix system (AFAIK)

It also assumes that we want to keep the tar behavior where it keeps a different directory per version,
This may (will) cause problem when installing multiple version of vector, as the PATH will contains different version.
Another solution would be to extract the archive without preserving the root directory, but this will override any previous version. Or we could try to make a sed command to replace the export PATH with an updated path, but I find it a bit too intrusive.

Signed-off-by: Cédric Da Fonseca <dafonseca.cedric@gmail.com>