### PR TITLE
chore(operations): Add relese-meta make target for preparing release metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ release-github: ## Release to Github
 release-homebrew: ## Release to timberio Homebrew tap
 	@scripts/release-homebrew.sh
 
+release-meta: ## Prepares the release metadata
+	@bundle install --gemfile=scripts/release-meta/Gemfile > /dev/null
+	@scripts/release-meta.rb
+
 release-rpm: ## Release .rpm via Package Cloud
 	@scripts/release-rpm.sh
 

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -23,9 +23,10 @@ require "rubygems"
 require "bundler"
 Bundler.require(:default)
 
+require_relative "util/core_ext/object"
+
 require_relative "generate/context"
 require_relative "generate/core_ext/hash"
-require_relative "generate/core_ext/object"
 require_relative "generate/core_ext/string"
 require_relative "generate/post_processors/component_presence_checker"
 require_relative "generate/post_processors/link_checker"

--- a/scripts/release-meta.rb
+++ b/scripts/release-meta.rb
@@ -1,0 +1,209 @@
+#!/usr/bin/env ruby
+
+# release-meta.rb
+#
+# SUMMARY
+#
+#   A script that prepares the release .meta/releases/vX.X.X.toml file.
+#   Afterwards, the `make generate` command should be used to refresh
+#   the generated files against the new release metadata.
+
+#
+# Setup
+#
+
+# Changes into the release-meta directory so that we can load the
+# Bundler dependencies. Unfortunately, Bundler does not provide a way
+# load a Gemfile outside of the cwd.
+Dir.chdir "scripts/release-meta"
+
+#
+# Requires
+#
+
+require "rubygems"
+require "bundler"
+Bundler.require(:default)
+
+require "time"
+require_relative "util/core_ext/object"
+require_relative "util/printer"
+require_relative "util/version"
+
+#
+# Includes
+#
+
+include Printer
+
+#
+# Constants
+#
+
+ROOT_DIR = Pathname.new("#{Dir.pwd}/../..").cleanpath
+RELEASE_META_DIR = "#{ROOT_DIR}/.meta/releases"
+TYPES = ["chore", "docs", "feat", "fix", "improvement", "perf"]
+TYPES_THAT_REQUIRE_SCOPES = ["feat", "improvement", "fix"]
+
+#
+# Functions
+#
+
+def create_release_meta_file!(last_version, new_version)
+  release_meta_path = "#{RELEASE_META_DIR}/v#{new_version}.toml"
+
+  existing_release =
+    if File.exists?(release_meta_path)
+      TomlRB.parse(File.read(release_meta_path)).fetch("releases").fetch(new_version.to_s)
+    else
+      {"commits" => []}
+    end
+
+  existing_commits = existing_release.fetch("commits")
+  current_commits = get_commits(last_version, new_version)
+
+  new_commits =
+    current_commits.select do |current_commit|
+      !existing_commits.any? do |existing_commit|
+        existing_commit.fetch("sha") == current_commit.fetch("sha")
+      end
+    end
+
+  if new_commits.any?
+    commits = existing_commits + new_commits
+
+    File.open(release_meta_path, 'w+') do |file|
+      file.write(
+        <<~EOF
+        [releases."#{new_version}"]
+        date = #{Time.now.utc.to_date.to_toml}
+        commits = #{commits.to_toml}
+        EOF
+      )
+    end
+
+    words =
+      <<~EOF
+      I found #{new_commits.length} new commits for this release, and I've placed them in:
+
+        #{release_meta_path}
+
+      Please modify and reword as necessary.
+
+      Ready to proceed?
+      EOF
+
+    if get(words, ["y", "n"]) == "n"
+      error!("Ok, re-run this command when you're ready.")
+    end
+  else
+    words =
+      <<~EOF
+      No new commits found for this release. Existing commits can be found in:
+
+        #{release_meta_path}
+
+      Ready to proceed?
+      EOF
+
+    if get(words, ["y", "n"]) == "n"
+      error!("Ok, re-run this command when you're ready.")
+    end
+  end
+
+  true
+end
+
+def get_commit_log(last_version, new_version)
+  last_commit = `git rev-parse HEAD`.chomp
+  range = "v#{last_version}...#{last_commit}"
+  `git log #{range} --no-merges --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
+end
+
+def get_commits(last_version, new_version)
+  commit_log = get_commit_log(last_version, new_version)
+  commit_lines = commit_log.split("\n").reverse
+
+  commit_lines.collect do |commit_line|
+    parse_commit_line!(commit_line)
+  end
+end
+
+def get_commit_stats(sha)
+  `git show --shortstat --oneline #{sha}`.split("\n").last
+end
+
+def get_new_version(last_version)
+  version_string = get("What is the next version you are releasing? (current version is #{last_version})")
+
+  version =
+    begin
+      Version.new(version_string)
+    rescue ArgumentError => e
+      invalid("It looks like the version you entered is invalid: #{e.message}")
+      get_new_version(last_version)
+    end
+
+  if last_version.bump_type(version).nil?
+    invalid("The version you entered must be a single patch, minor, or major bump")
+    get_new_version(last_version)
+  else
+    version
+  end
+end
+
+def parse_commit_line!(commit_line)
+  # Parse the full commit line
+  line_parts = commit_line.split("\t")
+
+  attributes =
+    {
+      "sha" =>  line_parts.fetch(0),
+      "message" => line_parts.fetch(1),
+      "author" => line_parts.fetch(2),
+      "date" => Time.parse(line_parts.fetch(3))
+    }
+
+  # Parse the stats
+  stats = get_commit_stats(attributes.fetch("sha"))
+  stats_attributes = parse_commit_stats!(stats)
+  attributes.merge!(stats_attributes)
+
+  attributes
+end
+
+def parse_commit_stats!(stats)
+  attributes = {}
+
+  stats.split(", ").each do |stats_part|
+    stats_part.strip!
+
+    key =
+      case stats_part
+      when /insertions?/
+        "insertions_count"
+      when /deletions?/
+        "deletions_count"
+      when /files? changed/
+        "files_count"
+      else
+        raise "Invalid commit stat: #{stats_part}"
+      end
+
+    count = stats_part.match(/^(?<count>[0-9]*) /)[:count].to_i
+    attributes[key] = count
+  end
+
+  attributes
+end
+
+#
+# Execute
+#
+
+title("Creating release meta file...")
+
+last_tag = `git describe --abbrev=0`.chomp
+last_version = Version.new(last_tag.gsub(/^v/, ''))
+new_version = get_new_version(last_version)
+create_release_meta_file!(last_version, new_version)

--- a/scripts/release-meta/Gemfile
+++ b/scripts/release-meta/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'paint', '~> 2.1'
+gem 'toml-rb', '~> 1.1'

--- a/scripts/release-meta/Gemfile.lock
+++ b/scripts/release-meta/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    citrus (3.0.2)
+    paint (2.1.1)
+    toml-rb (1.1.2)
+      citrus (~> 3.0, > 3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  paint (~> 2.1)
+  toml-rb (~> 1.1)
+
+BUNDLED WITH
+   2.0.2

--- a/scripts/util/core_ext/object.rb
+++ b/scripts/util/core_ext/object.rb
@@ -14,15 +14,24 @@ class Object
       "{" + values.join(", ") + "}"
     elsif is_a?(Array)
       values = collect { |value| value.to_toml }
-      "[" + values.join(", ") + "]"
+      if any? { |v| v.is_a?(Hash) }
+        "[\n" + values.join(",\n") + "\n]"
+      else
+        "[" + values.join(", ") + "]"
+      end
+    elsif is_a?(Date)
+      iso8601()
     elsif is_a?(Time)
       iso8601(6)
     elsif is_a?(String) && include?("\n")
-      <<~EOF
-      """
-      #{self}
-      """
-      EOF
+      result =
+        <<~EOF
+        """
+        #{self}
+        """
+        EOF
+
+      result.chomp
     elsif is_primitive_type?
       inspect
     else

--- a/scripts/util/printer.rb
+++ b/scripts/util/printer.rb
@@ -1,0 +1,70 @@
+module Printer
+  PROMPT = "---> "
+  INDENT = "     "
+  SEPARATOR = "-" * 80
+  TITLE_PROMPT = "#### "
+
+  extend self
+
+  def error!(message)
+    say(message, color: :red)
+    exit(1)
+  end
+
+  def get(words, choices = nil)
+    question = "#{words.strip}"
+
+    if !choices.nil?
+      question += " (" + choices.join("/") + ")"
+    end
+
+    say(question)
+
+    print INDENT
+
+    input = gets().chomp
+
+    if choices && !choices.include?(input)
+      say("You must enter one of #{choices.join(", ")}", color: :red)
+      get(words, choices)
+    else
+      input
+    end
+  end
+
+  def invalid(words)
+    say(words, color: :yellow)
+  end
+
+  def say(words, color: nil, new: true, prompt: PROMPT)
+    prefix = new ? prompt : INDENT
+
+    if color
+      words = Paint[prefix + words, color]
+    else
+      words = prefix + words
+    end
+
+    puts words.gsub("\n", "\n#{INDENT}")
+  end
+
+  def separate(color: nil)
+    string = SEPARATOR
+
+    if color
+      string = Paint[string, color]
+    end
+
+    puts ""
+    puts string
+  end
+
+  def success(words)
+    say(words, color: :green)
+  end
+
+  def title(words)
+    separate(color: :cyan)
+    say(words, color: :cyan, prompt: TITLE_PROMPT)
+  end
+end

--- a/scripts/util/version.rb
+++ b/scripts/util/version.rb
@@ -1,0 +1,35 @@
+class Version < Gem::Version
+  def bump_type(other_version)
+    # Return nil if the other version is not greater than the current version
+    if other_version <= self
+      return nil
+    end
+
+    bumped_version = bump
+    next_major = segments.first + 1
+
+    if other_version.prerelease?
+      "pre"
+    elsif other_version < bumped_version
+      "patch"
+    elsif other_version == bumped_version
+      "minor"
+    elsif other_version.segments.first == next_major
+      "major"
+    else
+      nil
+    end
+  end
+
+  def major
+    segments[0]
+  end
+
+  def minor
+    segments[1]
+  end
+
+  def patch
+    segments[2]
+  end
+end


### PR DESCRIPTION
This adds a new `release-meta` make target. The purpose of this command is to prepare a `.meta/releases/X.X.X.toml` file that looks something like:

```toml
[releases."0.4.0"]
date = 2019-09-20
commits = [
{sha = "e53c86c0895ef0dfa48dbe8a4c572ea1c9d87a84", message = "Start v0.4.0-dev", author = "Ben Johnson", date = 2019-07-02T02:03:58.000000-04:00, files_count = 2, insertions_count = 14, deletions_count = 14},
{sha = "15d6b26409761aa5eb15c70082fc02f83d1e949c", message = "Ensure new bumped version uses -dev", author = "Ben Johnson", date = 2019-07-02T02:04:50.000000-04:00, files_count = 2, insertions_count = 2, deletions_count = 2}
]
```

This strategy has a number of benefits:

1. It becomes an efficient source of truth for release metadata.
2. It follows the same process and conventions for other project metadata.
3. This information is easily incorporated into `make generate` which we can use in docs, the README, etc.
4. It provides the operator an opportunity to clean up and improve commit messages before releasing.