### PR TITLE
chore(operations): verify builds by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,26 @@ workflows:
           <<: *require-checks-and-tests
       - build-x86_64-apple-darwin-archive:
           <<: *require-checks-and-tests
+      - package-rpm:
+          <<: *require-builds
+      - verify-amazon-linux-1:
+          <<: *require-packages
+      - verify-amazon-linux-2:
+          <<: *require-packages
+      - verify-centos-7:
+          <<: *require-packages
+      - verify-deb-8:
+          <<: *require-packages
+      - verify-deb-9:
+          <<: *require-packages
+      - verify-deb-10:
+          <<: *require-packages
+      - verify-ubuntu-16-04:
+          <<: *require-packages
+      - verify-ubuntu-18-04:
+          <<: *require-packages
+      - verify-ubuntu-19-04:
+          <<: *require-packages
 
   nightly:
     triggers:

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,16 +2,20 @@
 titleOnly: true
 
 scopes:
+  - buffers
   - cli
   - config
-  - data model
+  - log data model
+  - metric data model
+  - networking
   - new source
   - new transform
   - new sink
   - observability
+  - operations
+  - security
   - testing
   - topology
-  - workflow
   # sources
   - file source
   - journald source

--- a/scripts/generate/templates/.github/semantic.yml.erb
+++ b/scripts/generate/templates/.github/semantic.yml.erb
@@ -2,16 +2,20 @@
 titleOnly: true
 
 scopes:
+  - buffers
   - cli
   - config
-  - data model
+  - log data model
+  - metric data model
+  - networking
   - new source
   - new transform
   - new sink
   - observability
+  - operations
+  - security
   - testing
   - topology
-  - workflow
   # sources
   <%- metadata.sources.to_h.values.sort.each do |source| -%>
   - <%= source.name %> source


### PR DESCRIPTION
This adds the `verify-*` build steps to the overall test process to ensure our built binaries work across various targets. These steps generally execute in under 30 seconds so I don't see a problem enabling these by default.