### PR TITLE
chore(operations): Remove $VERSION when building archives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
           name: Build archive
           command: |
             export PATH="$HOME/.cargo/bin:$PATH"
-            export VERSION=$(make version)
             make build-archive
       - persist_to_workspace:
           root: target/artifacts
@@ -126,9 +125,7 @@ jobs:
       - checkout
       - run:
           name: Build archive
-          command: |
-            export VERSION=$(make version)
-            make build-archive
+          command: make build-archive
       # We _must_ build the deb package on the same machine that created
       # the binary. `cargo deb` performs dependency calculation via `ldd`
       # and this process must happen on the same machine it was built in
@@ -153,7 +150,6 @@ jobs:
       - run:
           name: Build archive
           command: |
-            export VERSION=$(make version)
             export RUST_LTO="lto"
             export TARGET="x86_64-unknown-linux-musl"
             make build-archive

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -4,7 +4,7 @@
 #
 # SUMMARY
 #
-#   Used to build a tar.gz archive for the specified $TARGET and $VERSION
+#   Used to build a tar.gz archive for the specified $TARGET
 #
 # ENV VARS
 #
@@ -13,7 +13,6 @@
 #   $RUST_LTO - possible values are "lto", "lto=thin", ""
 #   $STRIP - whether or not to strip the binary
 #   $TARGET - a target triple. ex: x86_64-apple-darwin
-#   $VERSION - the version of Vector, can be obtained via `make version`
 
 NATIVE_BUILD=${NATIVE_BUILD:-}
 RUST_LTO=${RUST_LTO:-}
@@ -27,7 +26,6 @@ fi
 set -eu
 
 echo "Building Vector archive"
-echo "Version: $VERSION"
 echo "Target: $TARGET"
 echo "Native build: $NATIVE_BUILD"
 echo "Features: $FEATURES"


### PR DESCRIPTION
The `VERSION` variable is no longer needed when building archives since we no longer use the version in the resulting archive file.

This fixes the following error when building archives:

```
scripts/version.sh: line 21: git: command not found
```