### PR TITLE
docs: fix s3 compression and endpoint options

### DIFF
--- a/.meta/sinks/aws_s3.toml
+++ b/.meta/sinks/aws_s3.toml
@@ -27,7 +27,8 @@ description = "The S3 bucket name. Do not include a leading `s3://` or a trailin
 [sinks.aws_s3.options.compression]
 type = "string"
 category = "Requests"
-enum = ["gzip"]
+enum = ["gzip", "none"]
+default = "gzip"
 null = true
 simple = true
 description = "The compression type to use before writing data."

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1129,17 +1129,17 @@ end
   # * default: true
   create_missing_stream = true
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1280,17 +1280,17 @@ end
   # * no default
   stream_name = "my-stream"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   # The log field used as the Kinesis record's partition key value.
   # 
@@ -1437,17 +1437,17 @@ end
   # * no default
   region = "us-east-1"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1509,9 +1509,10 @@ end
   # The compression type to use before writing data.
   # 
   # * optional
-  # * no default
-  # * must be: "gzip" (if supplied)
+  # * default: "gzip"
+  # * enum: "gzip" or "none"
   compression = "gzip"
+  compression = "none"
 
   # The encoding format used to serialize the events before flushing. The default
   # is dynamic based on if the event is structured or not.

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -96,17 +96,17 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.data
   # * default: true
   create_missing_stream = true
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching

--- a/docs/usage/configuration/sinks/aws_kinesis_streams.md
+++ b/docs/usage/configuration/sinks/aws_kinesis_streams.md
@@ -71,17 +71,17 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.data
   # * no default
   stream_name = "my-stream"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   # The log field used as the Kinesis record's partition key value.
   # 

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -44,7 +44,7 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] e
   key_prefix = "date=%F/"
   
   # OPTIONAL - Requests
-  compression = "gzip" # no default, must be: "gzip" (if supplied)
+  compression = "gzip" # default, enum: "gzip" or "none"
   encoding = "ndjson" # no default, enum: "ndjson" or "text"
 
   # For a complete list of options see the "advanced" tab above.
@@ -83,17 +83,17 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] e
   # * no default
   region = "us-east-1"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -155,9 +155,10 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] e
   # The compression type to use before writing data.
   # 
   # * optional
-  # * no default
-  # * must be: "gzip" (if supplied)
+  # * default: "gzip"
+  # * enum: "gzip" or "none"
   compression = "gzip"
+  compression = "none"
 
   # The encoding format used to serialize the events before flushing. The default
   # is dynamic based on if the event is structured or not.
@@ -354,6 +355,7 @@ type is described in more detail below:
 | Compression | Description |
 |:------------|:------------|
 | `gzip` | The payload will be compressed in [Gzip][urls.gzip] format before being sent. |
+| `none` | The payload will not compressed at all. |
 
 ### Delivery Guarantee
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1149,17 +1149,17 @@ end
   # * default: true
   create_missing_stream = true
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1300,17 +1300,17 @@ end
   # * no default
   stream_name = "my-stream"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   # The log field used as the Kinesis record's partition key value.
   # 
@@ -1457,17 +1457,17 @@ end
   # * no default
   region = "us-east-1"
 
+  # Custom endpoint for use with AWS-compatible services.
+  # 
+  # * optional
+  # * no default
+  endpoint = "127.0.0.0:5000"
+
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   healthcheck = true
-
-  # Custom hostname to send requests to. Useful for testing.
-  # 
-  # * optional
-  # * no default
-  hostname = "127.0.0.0:5000"
 
   #
   # Batching
@@ -1529,9 +1529,10 @@ end
   # The compression type to use before writing data.
   # 
   # * optional
-  # * no default
-  # * must be: "gzip" (if supplied)
+  # * default: "gzip"
+  # * enum: "gzip" or "none"
   compression = "gzip"
+  compression = "none"
 
   # The encoding format used to serialize the events before flushing. The default
   # is dynamic based on if the event is structured or not.

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -49,15 +49,14 @@ class Sink < Component
       "type" => "bool"
     })
 
-    # Hostname option
+    # Endpoint option
 
     if service_provider == "AWS"
       @options.hostname = Option.new({
-        "name" => "hostname",
+        "name" => "endpoint",
         "examples" => ["127.0.0.0:5000"],
-        "default" => "<aws-service-hostname>",
-        "description" => "Custom hostname to send requests to. Useful for testing.",
-        "null" => false,
+        "description" => "Custom endpoint for use with AWS-compatible services.",
+        "null" => true,
         "type" => "string"
       })
     end


### PR DESCRIPTION
Ran into some incorrect docs when setting up the S3 sink.