### PR TITLE
chore(operations): Set version before compiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
           name: Build archive
           command: |
             export PATH="$HOME/.cargo/bin:$PATH"
+            make set-version
             make build-archive
       - persist_to_workspace:
           root: target/artifacts
@@ -142,7 +143,7 @@ jobs:
       - run:
           name: Build .deb package
           command: |
-            export VERSION=$(make version)
+            make set-version
             make package-deb
       - persist_to_workspace:
           root: target/artifacts
@@ -161,6 +162,7 @@ jobs:
           command: |
             export RUST_LTO="lto"
             export TARGET="x86_64-unknown-linux-musl"
+            make set-version
             make build-archive
       - persist_to_workspace:
           root: target/artifacts
@@ -188,7 +190,7 @@ jobs:
       - run:
           name: Build x86_64-unknown-linux-gnu .rpm package
           command: |
-            export VERSION=$(make version)
+            make set-version
             make package-rpm
           environment:
             TARGET: x86_64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vector"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vector"
-version = "0.4.0"
+version = "0.4.0-dev"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ release-rpm: ## Release .rpm via Package Cloud
 release-s3: ## Release artifacts to S3
 	@scripts/release-s3.sh
 
-set-version:
+set-version: ## Updates the Vector version to the result of `make version`
 	@export VERSION=$(_latest_version); scripts/set-version.rb
 
 version: ## Get the current Vector version

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ build-ci-docker-images: ## Build the various Docker images used for CI
 	@scripts/build-ci-docker-images.sh
 
 package-deb: ## Create a .deb package from artifacts created via `build`
-	@scripts/package-deb.sh
+	@export VERSION=$(_latest_version); scripts/package-deb.sh
 
 package-rpm: ## Create a .rpm package from artifacts created via `build`
-	@scripts/package-rpm.sh
+	@export VERSION=$(_latest_version); scripts/package-rpm.sh
 
 release-commit: ## Commits release changes
 	@scripts/release-commit.rb
@@ -101,6 +101,9 @@ release-rpm: ## Release .rpm via Package Cloud
 
 release-s3: ## Release artifacts to S3
 	@scripts/release-s3.sh
+
+set-version:
+	@export VERSION=$(_latest_version); scripts/set-version.rb
 
 version: ## Get the current Vector version
 	@echo $(_version)

--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -74,20 +74,6 @@ else
   end
 
   commands.chomp.split("\n").each do |command|
-    system(command)
-
-    if !$?.success?
-      error!(
-        <<~EOF
-        Command failed!
-
-          #{command}
-
-        Produced the following error:
-
-          #{$?.inspect}
-        EOF
-      )
-    end
+    execute!(command)
   end
 end

--- a/scripts/set-version.rb
+++ b/scripts/set-version.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+# set-version.rb
+#
+# SUMMARY
+#
+#   Sets the Vector version to the passed version. This is used to ensure
+#   the proper version is reflected in Vector's resulting binary.
+
+require_relative "setup"
+
+# The version is expected to be set
+VERSION = ENV.fetch("VERSION")
+
+say("Setting Vector version to #{VERSION}")
+
+# Bump the version in the Cargo.toml file
+cargo_content = File.read("#{ROOT_DIR}/Cargo.toml")
+
+new_cargo_content =
+  cargo_content.sub(
+    /name = "vector"\nversion = "([a-z0-9.-]*)"\n/,
+    "name = \"vector\"\nversion = \"#{VERSION}\"\n"
+  )
+
+File.write("#{ROOT_DIR}/Cargo.toml", new_cargo_content)
+
+success("Cargo.toml updated")
+execute!("cargo check")
+success("Cargo.lock updated")

--- a/scripts/setup.rb
+++ b/scripts/setup.rb
@@ -44,6 +44,26 @@ TEMPLATES_DIR = File.join(ROOT_DIR, "scripts", "generate", "templates")
 # Functions
 #
 
+def execute!(command)
+  system(command)
+
+  if !$?.success?
+    error!(
+      <<~EOF
+      Command failed!
+
+        #{command}
+
+      Produced the following error:
+
+        #{$?.inspect}
+      EOF
+    )
+  end
+
+  true
+end
+
 def load_templates!
   Templates.new(TEMPLATES_DIR, metadata)
 end


### PR DESCRIPTION
If you run `vector --version` on the recently released binary it prints `vector 0.4.0-dev`. This change fixes that. In addition, this will use version triples for nightly builds (ex: `0.4.0-29-ga5f72d2`).