### PR TITLE
feat(elasticsearch sink): Add support for TLS options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,14 @@ jobs:
       - image: elasticsearch:6.6.2
         environment:
           - discovery.type=single-node
+      - image: timberiodev/elasticsearch-test-https:6.6.2-1
+        environment:
+          - discovery.type=single-node
+          - xpack.security.enabled=true
+          - xpack.security.http.ssl.enabled=true
+          - xpack.security.transport.ssl.enabled=true
+          - xpack.ssl.certificate=certs/localhost.crt
+          - xpack.ssl.key=certs/localhost.key
       - image: yandex/clickhouse-server:19
     steps:
       - checkout

--- a/.meta/sinks/elasticsearch.toml
+++ b/.meta/sinks/elasticsearch.toml
@@ -90,3 +90,43 @@ type = "string"
 examples = ["us-east-1"]
 null = true
 description = "When using the AWS provider, the [AWS region][urls.aws_cw_logs_regions] of the target Elasticsearch instance."
+
+[sinks.elasticsearch.options.tls]
+type = "table"
+null = true
+description = "Options for TLS (HTTPS) connections"
+
+[sinks.elasticsearch.options.tls.options.verify]
+type = "bool"
+null = true
+default = true
+description = """If `true`, Vector will force certificate validation. \
+Do NOT set this to `false` unless you know the risks of not verifying \
+the remote certificate."""
+
+[sinks.elasticsearch.options.tls.options.ca_path]
+type = "string"
+null = true
+description = "Absolute path to an additional CA certificate file, in PEM format."
+examples = ["/path/to/certificate_authority.crt"]
+
+[sinks.elasticsearch.options.tls.options.crt_path]
+type = "string"
+null = true
+description = """Absolute path to certificate file used to identify this \
+connection, in PEM format. If this is set, `key_path` must also be set."""
+examples = ["/path/to/host_certificate.crt"]
+
+[sinks.elasticsearch.options.tls.options.key_path]
+type = "string"
+null = true
+description = """Absolute path to key file used to identify this \
+connection, in PEM format. If this is set, `crt_path` must also be set."""
+examples = ["/path/to/host_certificate.key"]
+
+[sinks.elasticsearch.options.tls.options.key_pass]
+type = "string"
+null = true
+description = """Pass phrase to unlock the encrypted key file. \
+This has no effect unless `key_path` above is set."""
+examples = ["PassWord1"]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2005,6 +2005,45 @@ end
     # * no default
     X-Powered-By = "Vector"
 
+  #
+  # Tls
+  #
+
+  [sinks.elasticsearch.tls]
+    # If `true`, Vector will force certificate validation. Do NOT set this to
+    # `false` unless you know the risks of not verifying the remote certificate.
+    # 
+    # * optional
+    # * default: true
+    verify = true
+
+    # Absolute path to an additional CA certificate file, in PEM format.
+    # 
+    # * optional
+    # * no default
+    ca_path = "/path/to/certificate_authority.crt"
+
+    # Absolute path to certificate file used to identify this connection, in PEM
+    # format. If this is set, `key_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    crt_path = "/path/to/host_certificate.crt"
+
+    # Absolute path to key file used to identify this connection, in PEM format. If
+    # this is set, `crt_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    key_path = "/path/to/host_certificate.key"
+
+    # Pass phrase to unlock the encrypted key file. This has no effect unless
+    # `key_path` above is set.
+    # 
+    # * optional
+    # * no default
+    key_pass = "PassWord1"
+
 # Streams `log` events to a file.
 [sinks.file]
   # The component type

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,20 @@ services:
         - "9300:9300"
       environment:
         - discovery.type=single-node
+    elasticsearch-tls:
+      image: elasticsearch:6.6.2
+      ports:
+        - "9201:9200"
+        - "9301:9300"
+      environment:
+        - discovery.type=single-node
+        - xpack.security.enabled=true
+        - xpack.security.http.ssl.enabled=true
+        - xpack.security.transport.ssl.enabled=true
+        - xpack.ssl.certificate=certs/localhost.crt
+        - xpack.ssl.key=certs/localhost.key
+      volumes:
+        - ./tests/data:/usr/share/elasticsearch/config/certs:ro
     clickhouse:
       image: yandex/clickhouse-server:19
       ports:

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -237,6 +237,45 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
     # * required
     # * no default
     X-Powered-By = "Vector"
+
+  #
+  # Tls
+  #
+
+  [sinks.elasticsearch_sink.tls]
+    # If `true`, Vector will force certificate validation. Do NOT set this to
+    # `false` unless you know the risks of not verifying the remote certificate.
+    # 
+    # * optional
+    # * default: true
+    verify = true
+
+    # Absolute path to an additional CA certificate file, in PEM format.
+    # 
+    # * optional
+    # * no default
+    ca_path = "/path/to/certificate_authority.crt"
+
+    # Absolute path to certificate file used to identify this connection, in PEM
+    # format. If this is set, `key_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    crt_path = "/path/to/host_certificate.crt"
+
+    # Absolute path to key file used to identify this connection, in PEM format. If
+    # this is set, `crt_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    key_path = "/path/to/host_certificate.key"
+
+    # Pass phrase to unlock the encrypted key file. This has no effect unless
+    # `key_path` above is set.
+    # 
+    # * optional
+    # * no default
+    key_pass = "PassWord1"
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -2025,6 +2025,45 @@ end
     # * no default
     X-Powered-By = "Vector"
 
+  #
+  # Tls
+  #
+
+  [sinks.elasticsearch.tls]
+    # If `true`, Vector will force certificate validation. Do NOT set this to
+    # `false` unless you know the risks of not verifying the remote certificate.
+    # 
+    # * optional
+    # * default: true
+    verify = true
+
+    # Absolute path to an additional CA certificate file, in PEM format.
+    # 
+    # * optional
+    # * no default
+    ca_path = "/path/to/certificate_authority.crt"
+
+    # Absolute path to certificate file used to identify this connection, in PEM
+    # format. If this is set, `key_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    crt_path = "/path/to/host_certificate.crt"
+
+    # Absolute path to key file used to identify this connection, in PEM format. If
+    # this is set, `crt_path` must also be set.
+    # 
+    # * optional
+    # * no default
+    key_path = "/path/to/host_certificate.key"
+
+    # Pass phrase to unlock the encrypted key file. This has no effect unless
+    # `key_path` above is set.
+    # 
+    # * optional
+    # * no default
+    key_pass = "PassWord1"
+
 # Streams `log` events to a file.
 [sinks.file]
   # The component type

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -94,7 +94,7 @@ fn clickhouse(config: ClickhouseConfig, acker: Acker) -> crate::Result<super::Ro
         }
 
         builder.body(body).unwrap()
-    });
+    })?;
 
     let service = ServiceBuilder::new()
         .concurrency_limit(in_flight_limit)

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -162,11 +162,13 @@ impl ElasticSearchCommon {
     }
 
     fn make_client(&self) -> crate::Result<Client<HttpsConnector<HttpConnector>>> {
+        let mut http = HttpConnector::new(1);
+        http.enforce_http(false);
         let tls_settings = TlsSettings::try_from(&self.tls_options)?;
         let tls = TlsConnector::builder()
             .use_tls_settings(tls_settings)
             .build()?;
-        let https = HttpsConnector::from((HttpConnector::new(1), tls));
+        let https = HttpsConnector::from((http, tls));
         Ok(Client::builder().build(https))
     }
 }

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -546,15 +546,17 @@ mod integration_tests {
         let index = gen_index();
         config.index = Some(index.clone());
 
-        let (sink, _hc) = config.build(Acker::Null).unwrap();
+        let (sink, healthcheck) = config.build(Acker::Null).unwrap();
+
+        block_on(healthcheck).expect("Health check failed");
 
         let (input, events) = random_events_with_stream(100, 100);
 
         let pump = sink.send_all(events);
-        block_on(pump).unwrap();
+        block_on(pump).expect("Sending events failed");
 
         // make sure writes all all visible
-        block_on(flush(&config.host)).unwrap();
+        block_on(flush(&config.host)).expect("Flushing writes failed");
 
         let client = SyncClientBuilder::new()
             .static_node(config.host)

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -117,6 +117,11 @@ impl ElasticSearchCommon {
             host: config.host.clone(),
         })?;
 
+        config
+            .tls
+            .as_ref()
+            .map(|tls| tls.check_warnings("elasticsearch"));
+
         let authorization = config.basic_auth.as_ref().map(|auth| {
             let token = format!("{}:{}", auth.user, auth.password);
             format!("Basic {}", base64::encode(token.as_bytes()))

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -126,7 +126,6 @@ fn http(config: HttpSinkConfig, acker: Acker) -> crate::Result<super::RouterSink
     let headers = config.headers.clone();
     let basic_auth = config.basic_auth.clone();
     let method = config.method.clone().unwrap_or(HttpMethod::Post);
-    let verify_certificate = config.verify_certificate.unwrap_or(true);
 
     let policy = FixedRetryPolicy::new(
         retry_attempts,
@@ -134,14 +133,14 @@ fn http(config: HttpSinkConfig, acker: Acker) -> crate::Result<super::RouterSink
         HttpRetryLogic,
     );
 
-    if !verify_certificate {
+    if config.verify_certificate == Some(false) {
         warn!(
             message = "`verify_certificate` in http sink is DISABLED, this may lead to security vulnerabilities"
         );
     }
 
     let tls_options = TlsOptions {
-        verify_certificate,
+        verify_certificate: config.verify_certificate,
         ..Default::default()
     };
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -134,16 +134,11 @@ fn http(config: HttpSinkConfig, acker: Acker) -> crate::Result<super::RouterSink
         HttpRetryLogic,
     );
 
-    if config.verify_certificate == Some(false) {
-        warn!(
-            message = "`verify_certificate` in http sink is DISABLED, this may lead to security vulnerabilities"
-        );
-    }
-
     let tls_options = TlsOptions {
         verify_certificate: config.verify_certificate,
         ..Default::default()
     };
+    tls_options.check_warnings("http");
 
     let http_service = HttpService::builder()
         .tls_settings(tls_options.try_into()?)

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -176,7 +176,7 @@ fn http(config: HttpSinkConfig, acker: Acker) -> crate::Result<super::RouterSink
                 }
 
                 request
-            });
+            })?;
 
     let service = ServiceBuilder::new()
         .concurrency_limit(in_flight_limit)

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -120,7 +120,7 @@ pub fn hec(config: HecSinkConfig, acker: Acker) -> crate::Result<super::RouterSi
         builder.header("Authorization", token.clone());
 
         builder.body(body).unwrap()
-    });
+    })?;
 
     let service = ServiceBuilder::new()
         .concurrency_limit(in_flight_limit)

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -1,6 +1,6 @@
 use super::{
     retries::RetryLogic,
-    tls::{TlsConnectorExt, TlsOptions},
+    tls::{TlsConnectorExt, TlsSettings},
 };
 use bytes::Bytes;
 use futures::{Future, Poll, Stream};
@@ -8,7 +8,6 @@ use http::StatusCode;
 use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
 use std::borrow::Cow;
-use std::convert::TryInto;
 use std::sync::Arc;
 use tokio::executor::DefaultExecutor;
 use tower::Service;
@@ -42,7 +41,7 @@ impl HttpService {
 #[derive(Default)]
 pub struct HttpServiceBuilder {
     threads: usize,
-    tls_options: Option<TlsOptions>,
+    tls_settings: Option<TlsSettings>,
 }
 
 impl HttpServiceBuilder {
@@ -61,8 +60,8 @@ impl HttpServiceBuilder {
         let mut http = HttpConnector::new(self.threads);
         http.enforce_http(false);
         let mut tls = native_tls::TlsConnector::builder();
-        if let Some(ref options) = self.tls_options {
-            tls.use_tls_settings(options.try_into()?);
+        if let Some(settings) = self.tls_settings {
+            tls.use_tls_settings(settings);
         }
         let tls = tls.build().expect("TLS initialization failed");
         let https = HttpsConnector::from((http, tls));
@@ -82,9 +81,9 @@ impl HttpServiceBuilder {
         self
     }
 
-    /// Set the standard TLS options
-    pub fn tls_options(mut self, options: TlsOptions) -> Self {
-        self.tls_options = Some(options);
+    /// Set the standard TLS settings
+    pub fn tls_settings(mut self, settings: TlsSettings) -> Self {
+        self.tls_settings = Some(settings);
         self
     }
 }

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -8,6 +8,7 @@ use http::StatusCode;
 use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::sync::Arc;
 use tokio::executor::DefaultExecutor;
 use tower::Service;
@@ -61,7 +62,7 @@ impl HttpServiceBuilder {
         http.enforce_http(false);
         let mut tls = native_tls::TlsConnector::builder();
         if let Some(ref options) = self.tls_options {
-            tls.use_tls_options(options)?;
+            tls.use_tls_settings(options.try_into()?);
         }
         let tls = tls.build().expect("TLS initialization failed");
         let https = HttpsConnector::from((http, tls));

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -54,7 +54,7 @@ impl HttpServiceBuilder {
     }
 
     /// Build the configured `HttpService`
-    pub fn build<F>(&self, request_builder: F) -> crate::Result<HttpService>
+    pub fn build<F>(self, request_builder: F) -> crate::Result<HttpService>
     where
         F: Fn(Vec<u8>) -> hyper::Request<Vec<u8>> + Sync + Send + 'static,
     {
@@ -77,13 +77,13 @@ impl HttpServiceBuilder {
     }
 
     /// Set the number of threads used by the `HttpService`
-    pub fn threads(&mut self, threads: usize) -> &mut Self {
+    pub fn threads(mut self, threads: usize) -> Self {
         self.threads = threads;
         self
     }
 
     /// Set the standard TLS options
-    pub fn tls_options(&mut self, options: TlsOptions) -> &mut Self {
+    pub fn tls_options(mut self, options: TlsOptions) -> Self {
         self.tls_options = Some(options);
         self
     }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -3,6 +3,7 @@ pub mod buffer;
 pub mod http;
 pub mod partition;
 pub mod retries;
+pub mod tls;
 
 use crate::buffers::Acker;
 use futures::{

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -1,0 +1,107 @@
+use native_tls::Certificate;
+use openssl::{
+    pkcs12::Pkcs12,
+    pkey::{PKey, Private},
+    x509::X509,
+};
+use snafu::{ResultExt, Snafu};
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Snafu)]
+enum TlsError {
+    #[snafu(display("Could not open {} file {:?}: {}", note, filename, source))]
+    FileOpenFailed {
+        note: &'static str,
+        filename: PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Could not read {} file {:?}: {}", note, filename, source))]
+    FileReadFailed {
+        note: &'static str,
+        filename: PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Could not parse certificate in {:?}: {}", filename, source))]
+    CertificateParseError {
+        filename: PathBuf,
+        source: native_tls::Error,
+    },
+    #[snafu(display("Could not parse X509 certificate in {:?}: {}", filename, source))]
+    X509ParseError {
+        filename: PathBuf,
+        source: openssl::error::ErrorStack,
+    },
+    #[snafu(display("Could not parse private key in {:?}: {}", filename, source))]
+    PrivateKeyParseError {
+        filename: PathBuf,
+        source: openssl::error::ErrorStack,
+    },
+    #[snafu(display("Could not build PKCS#12 archive for identity: {}", source))]
+    Pkcs12Error { source: openssl::error::ErrorStack },
+}
+
+/// Load a `native_tls::Certificate` from a named file
+pub fn load_certificate<T: AsRef<Path> + Debug>(filename: T) -> crate::Result<Certificate> {
+    let filename = filename.as_ref();
+    let data = open_read(filename, "certificate")?;
+    Ok(Certificate::from_pem(&data).with_context(|| CertificateParseError { filename })?)
+}
+
+/// Load a private key from a named file
+pub fn load_key<T: AsRef<Path> + Debug>(
+    filename: T,
+    pass_phrase: &Option<String>,
+) -> crate::Result<PKey<Private>> {
+    let filename = filename.as_ref();
+    let data = open_read(filename, "key")?;
+    match pass_phrase {
+        None => {
+            Ok(PKey::private_key_from_pem(&data)
+                .with_context(|| PrivateKeyParseError { filename })?)
+        }
+        Some(phrase) => Ok(
+            PKey::private_key_from_pem_passphrase(&data, phrase.as_bytes())
+                .with_context(|| PrivateKeyParseError { filename })?,
+        ),
+    }
+}
+
+/// Load an X.509 certificate from a named file
+pub fn load_x509<T: AsRef<Path> + Debug>(filename: T) -> crate::Result<X509> {
+    let filename = filename.as_ref();
+    let data = open_read(filename, "certificate")?;
+    Ok(X509::from_pem(&data).with_context(|| X509ParseError { filename })?)
+}
+
+/// Load a key and certificate from a pair of files and build a PKCS#12 archive from them
+pub fn load_build_pkcs12<P1, P2>(
+    key_path: P1,
+    key_pass: &Option<String>,
+    crt_path: P2,
+) -> crate::Result<Pkcs12>
+where
+    P1: AsRef<Path> + Debug,
+    P2: AsRef<Path> + Debug,
+{
+    let crt_name = crt_path.as_ref().to_string_lossy();
+    let key = load_key(key_path, key_pass)?;
+    let crt = load_x509(crt_path.as_ref())?;
+    Ok(Pkcs12::builder()
+        .build("", &crt_name, &key, &crt)
+        .context(Pkcs12Error)?)
+}
+
+fn open_read<F: AsRef<Path> + Debug>(filename: F, note: &'static str) -> crate::Result<Vec<u8>> {
+    let mut text = Vec::<u8>::new();
+    let filename = filename.as_ref();
+
+    File::open(filename)
+        .with_context(|| FileOpenFailed { note, filename })?
+        .read_to_end(&mut text)
+        .with_context(|| FileReadFailed { note, filename })?;
+
+    Ok(text)
+}

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -61,6 +61,16 @@ pub struct TlsOptions {
     pub key_pass: Option<String>,
 }
 
+impl TlsOptions {
+    pub fn check_warnings(&self, sink: &str) {
+        if self.verify_certificate == Some(false) {
+            warn!(
+                "`verify_certificate` in {} sink is DISABLED, this may lead to security vulnerabilities", sink
+            );
+        }
+    }
+}
+
 /// Directly usable settings for TLS connectors
 pub struct TlsSettings {
     verify_certificate: bool,

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -176,7 +176,10 @@ where
         .context(Pkcs12Error)?)
 }
 
-fn open_read<F: AsRef<Path> + Debug>(filename: F, note: &'static str) -> crate::Result<Vec<u8>> {
+pub fn open_read<F: AsRef<Path> + Debug>(
+    filename: F,
+    note: &'static str,
+) -> crate::Result<Vec<u8>> {
     let mut text = Vec::<u8>::new();
     let filename = filename.as_ref();
 

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -52,11 +52,9 @@ enum TlsError {
 }
 
 /// Standard TLS connector options
-#[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TlsOptions {
-    #[derivative(Default(value = "true"))]
-    pub verify_certificate: bool,
+    pub verify_certificate: Option<bool>,
     pub ca_path: Option<PathBuf>,
     pub crt_path: Option<PathBuf>,
     pub key_path: Option<PathBuf>,
@@ -64,10 +62,7 @@ pub struct TlsOptions {
 }
 
 /// Directly usable settings for TLS connectors
-#[derive(Derivative)]
-#[derivative(Default)]
 pub struct TlsSettings {
-    #[derivative(Default(value = "true"))]
     verify_certificate: bool,
     authority: Option<Certificate>,
     identity: Option<Identity>,
@@ -101,7 +96,7 @@ impl TryFrom<&TlsOptions> for TlsSettings {
         };
 
         Ok(Self {
-            verify_certificate: options.verify_certificate,
+            verify_certificate: options.verify_certificate.unwrap_or(true),
             authority,
             identity,
         })

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -4,6 +4,7 @@ use openssl::{
     pkey::{PKey, Private},
     x509::X509,
 };
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::convert::TryFrom;
 use std::fmt::Debug;
@@ -51,7 +52,7 @@ enum TlsError {
 }
 
 /// Standard TLS connector options
-#[derive(Clone, Derivative)]
+#[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 pub struct TlsOptions {
     #[derivative(Default(value = "true"))]

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -103,6 +103,13 @@ impl TryFrom<&TlsOptions> for TlsSettings {
     }
 }
 
+impl TryFrom<TlsOptions> for TlsSettings {
+    type Error = crate::Error;
+    fn try_from(options: TlsOptions) -> Result<Self, Self::Error> {
+        Self::try_from(&options)
+    }
+}
+
 pub trait TlsConnectorExt {
     fn use_tls_settings(&mut self, settings: TlsSettings) -> &mut Self;
 }


### PR DESCRIPTION
This adds support for a standard set of TLS options to the Elasticsearch sink, as well as fixing some issues with other aspects of HTTPS support in that sink (the health check would not have worked as it was with some services).

Closes issue #887 