### PR TITLE
fix(cli): Corrected tarball URL address for Linux installation script

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -160,12 +160,12 @@ install_from_archive() {
             ;;
     esac
 
-    local _url="${PACKAGE_ROOT}/latest/vector-latest-${_archive_arch}.tar.gz"
+    local _url="${PACKAGE_ROOT}/latest/vector-${_archive_arch}.tar.gz"
 
     local _dir
     _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t vector-install)"
 
-    local _file="${_dir}/vector-latest-${_archive_arch}.tar.gz"
+    local _file="${_dir}/vector-${_archive_arch}.tar.gz"
 
     ensure mkdir -p "$_dir"
 


### PR DESCRIPTION
Otherwise it's returning 404 on x86_64 Linux:
```
$ curl https://sh.vector.dev -sSf | sh
                                   __   __  __  
                                   \ \ / / / /
                                    \ V / / /
                                     \_/  \/

                                   V E C T O R
                                    Installer


--------------------------------------------------------------------------------
Website: https://vector.dev
Docs: https://docs.vector.dev
Community: https://vector.dev/community
--------------------------------------------------------------------------------

>>> Downloading Vector...
>>> command failed: downloader https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz /tmp/tmp.etSKmFja5Q/vector-latest-x86_64-unknown-linux-gnu.tar.gz

--------------------------------------------------------------------------------

curl: (22) The requested URL returned error: 404 
```