### PR TITLE
fix(operations): Ensure released s3 files are public-read

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -34,6 +34,10 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   aws s3 rm --recursive "s3://packages.timber.io/vector/nightly/latest"
   aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/latest" --recursive --acl public-read
   echo "Uploaded archives"
+
+  # Verify that the files exist and can be downloaded
+  curl https://packages.timber.io/vector/nightly/$today/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/today.tar.gz"
+  curl https://packages.timber.io/vector/nightly/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz"
 elif [[ "$CHANNEL" == "latest" ]]; then
   # Upload the specific version
   echo "Uploading all artifacts to s3://packages.timber.io/vector/$VERSION/"
@@ -45,6 +49,10 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   aws s3 rm --recursive "s3://packages.timber.io/vector/latest/"
   aws s3 cp "$td" "s3://packages.timber.io/vector/latest/" --recursive --acl public-read
   echo "Uploaded archives"
+
+  # Verify that the files exist and can be downloaded
+  curl https://packages.timber.io/vector/$VERSION/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/$VERSION.tar.gz"
+  curl https://packages.timber.io/vector/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz"
 fi
 
 #

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -36,8 +36,8 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded
-  curl https://packages.timber.io/vector/nightly/$today/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/today.tar.gz"
-  curl https://packages.timber.io/vector/nightly/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz"
+  curl https://packages.timber.io/vector/nightly/$today/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/today.tar.gz" --fail
+  curl https://packages.timber.io/vector/nightly/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz" --fail
 elif [[ "$CHANNEL" == "latest" ]]; then
   # Upload the specific version
   echo "Uploading all artifacts to s3://packages.timber.io/vector/$VERSION/"
@@ -51,8 +51,8 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded
-  curl https://packages.timber.io/vector/$VERSION/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/$VERSION.tar.gz"
-  curl https://packages.timber.io/vector/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz"
+  curl https://packages.timber.io/vector/$VERSION/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/$VERSION.tar.gz" --fail
+  curl https://packages.timber.io/vector/latest/vector-x86_64-unknown-linux-musl.tar.gz --output "$td/latest.tar.gz" --fail
 fi
 
 #

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -26,24 +26,24 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   # Add nightly files with today's date for posterity
   today=$(date +"%F")
   echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/$today"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/$today" --recursive
+  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/$today" --recursive --acl public-read
   echo "Uploaded archives"
 
   # Add "latest" nightly files
   echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/latest"
   aws s3 rm --recursive "s3://packages.timber.io/vector/nightly/latest"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/latest" --recursive
+  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/latest" --recursive --acl public-read
   echo "Uploaded archives"
 elif [[ "$CHANNEL" == "latest" ]]; then
   # Upload the specific version
   echo "Uploading all artifacts to s3://packages.timber.io/vector/$VERSION/"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/$VERSION/" --recursive
+  aws s3 cp "$td" "s3://packages.timber.io/vector/$VERSION/" --recursive --acl public-read
   echo "Uploaded archives"
 
   # Update the "latest" files
   echo "Uploading all artifacts to s3://packages.timber.io/vector/latest/"
   aws s3 rm --recursive "s3://packages.timber.io/vector/latest/"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/latest/" --recursive
+  aws s3 cp "$td" "s3://packages.timber.io/vector/latest/" --recursive --acl public-read
   echo "Uploaded archives"
 fi
 

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -26,13 +26,13 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   # Add nightly files with today's date for posterity
   today=$(date +"%F")
   echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/$today"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/$today" --recursive --acl public-read
+  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/$today" --recursive --sse --acl public-read 
   echo "Uploaded archives"
 
   # Add "latest" nightly files
   echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/latest"
   aws s3 rm --recursive "s3://packages.timber.io/vector/nightly/latest"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/latest" --recursive --acl public-read
+  aws s3 cp "$td" "s3://packages.timber.io/vector/nightly/latest" --recursive --sse --acl public-read
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded
@@ -41,13 +41,13 @@ if [[ "$CHANNEL" == "nightly" ]]; then
 elif [[ "$CHANNEL" == "latest" ]]; then
   # Upload the specific version
   echo "Uploading all artifacts to s3://packages.timber.io/vector/$VERSION/"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/$VERSION/" --recursive --acl public-read
+  aws s3 cp "$td" "s3://packages.timber.io/vector/$VERSION/" --recursive --sse --acl public-read
   echo "Uploaded archives"
 
   # Update the "latest" files
   echo "Uploading all artifacts to s3://packages.timber.io/vector/latest/"
   aws s3 rm --recursive "s3://packages.timber.io/vector/latest/"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/latest/" --recursive --acl public-read
+  aws s3 cp "$td" "s3://packages.timber.io/vector/latest/" --recursive --sse --acl public-read
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded


### PR DESCRIPTION
This adds the `--acl public-read` flag when uploading Vector artifacts to S3. I also added a light verification step post-upload to ensure the files exist and can be read. This would have detected the permission issues.

Ref https://github.com/timberio/vector/issues/956