### PR TITLE
chore(operations): Verify and check Homebrew install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,11 +393,22 @@ jobs:
       - *install-vector
       - *verify-install
 
-  verify-install-on-mac:
+  verify-install-on-mac-archive:
     macos:
       xcode: "9.0"
     steps:
       - checkout
+      - *install-vector
+      - *verify-install
+
+  verify-install-on-mac-homebrew:
+    macos:
+      xcode: "9.0"
+    steps:
+      - checkout
+      - run:
+          name: Install Homebrew
+          command: /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
       - *install-vector
       - *verify-install
 
@@ -550,7 +561,8 @@ require-verifications: &require-verifications
     - verify-install-on-deb-8
     - verify-install-on-deb-9
     - verify-install-on-deb-10
-    - verify-install-on-mac
+    - verify-install-on-mac-archive
+    - verify-install-on-mac-homebrew
     - verify-install-on-unbuntu-16-04
     - verify-install-on-unbuntu-18-04
     - verify-install-on-unbuntu-19-04
@@ -628,7 +640,9 @@ workflows:
           <<: *require-packages
       - verify-install-on-deb-10:
           <<: *require-packages
-      - verify-install-on-mac:
+      - verify-install-on-mac-archive:
+          <<: *require-packages
+      - verify-install-on-mac-homebrew:
           <<: *require-packages
       - verify-install-on-unbuntu-16-04:
           <<: *require-packages
@@ -700,7 +714,9 @@ workflows:
           <<: *require-packages
       - verify-install-on-deb-10:
           <<: *require-packages
-      - verify-install-on-mac:
+      - verify-install-on-mac-archive:
+          <<: *require-packages
+      - verify-install-on-mac-homebrew:
           <<: *require-packages
       - verify-install-on-unbuntu-16-04:
           <<: *require-packages
@@ -786,7 +802,9 @@ workflows:
           <<: *require-packages
       - verify-install-on-deb-10:
           <<: *require-packages
-      - verify-install-on-mac:
+      - verify-install-on-mac-archive:
+          <<: *require-packages
+      - verify-install-on-mac-homebrew:
           <<: *require-packages
       - verify-install-on-unbuntu-16-04:
           <<: *require-packages

--- a/scripts/release-homebrew.sh
+++ b/scripts/release-homebrew.sh
@@ -12,7 +12,7 @@ td=$(mktemp -d)
 pushd $td
 
 git config --global user.email "bradybot@timber.io"
-git config --global user.name "Brady"
+git config --global user.name "bradybot"
 
 git clone git@github.com:timberio/homebrew-brew.git
 cd homebrew-brew
@@ -22,7 +22,8 @@ package_sha256=$(curl -s $package_url | sha256sum | cut -d " " -f 1)
 
 new_content=$(cat Formula/vector.rb | \
   sed "s|url \".*\"|url \"$package_url\"|" | \
-  sed "s|sha256 \".*\"|sha256 \"$package_sha256\"|")
+  sed "s|sha256 \".*\"|sha256 \"$package_sha256\"|") | \
+  sed "s|version \".*\"|version \"$VERSION\"|")
 
 echo "$new_content" > Formula/vector.rb
 


### PR DESCRIPTION
Verifies and checks Vector install through Homebrew. This was previously broken and this should help prevent that in the future.