### PR TITLE
chore(operations): Properly verify that the Vector Systemd service started

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,6 +574,7 @@ require-verifications: &require-verifications
     - verify-rpm-artifact-on-amazon-linux-1
     - verify-rpm-artifact-on-amazon-linux-2
     - verify-rpm-artifact-on-centos-7
+    - verify-systemd-on-debian
 
 sync-filters: &sync-filters
   filters:
@@ -661,6 +662,8 @@ workflows:
           <<: *require-packages
       - verify-rpm-artifact-on-centos-7:
           <<: *require-packages
+      - verify-systemd-on-debian:
+          <<: *require-packages
 
       # Syncing
 
@@ -734,6 +737,8 @@ workflows:
       - verify-rpm-artifact-on-amazon-linux-2:
           <<: *require-packages
       - verify-rpm-artifact-on-centos-7:
+          <<: *require-packages
+      - verify-systemd-on-debian:
           <<: *require-packages
       - release-s3:
           <<: *require-verifications
@@ -824,6 +829,9 @@ workflows:
           <<: *release-filters
           <<: *require-packages
       - verify-rpm-artifact-on-centos-7:
+          <<: *release-filters
+          <<: *require-packages
+      - verify-systemd-on-debian:
           <<: *release-filters
           <<: *require-packages
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,6 +445,9 @@ jobs:
     steps:
       - *restore-artifacts-from-workspace
       - run:
+          name: Install systemd
+          command: sudo apt-get install systemd
+      - run:
           name: Install .deb package
           command: sudo dpkg -i $(find target/artifacts/ -name *-amd64.deb)
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,9 @@ jobs:
           command: sudo systemctl start vector
       - run:
           name: Verify that the Vector service has started
-          command: sudo systemctl is-active --quiet vector
+          command: |
+            sleep 5
+            sudo systemctl is-active vector
 
   #
   # Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ jobs:
       - *restore-artifacts-from-workspace
       - run:
           name: Install .deb package
-          command: dpkg -i $(find target/artifacts/ -name *-amd64.deb)
+          command: sudo dpkg -i $(find target/artifacts/ -name *-amd64.deb)
       - run:
           name: Start the Vector service
           command: sudo systemctl start vector

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,8 +448,11 @@ jobs:
           name: Install .deb package
           command: dpkg -i $(find target/artifacts/ -name *-amd64.deb)
       - run:
-          name: Verify Systemd starts the service
+          name: Start the Vector service
           command: sudo systemctl start vector
+      - run:
+          name: Verify that the Vector service has started
+          command: sudo systemctl is-active --quiet vector
 
   #
   # Release

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -8,9 +8,7 @@
 #
 # ------------------------------------------------------------------------------
 # Website: https://vector.dev
-# Docs: https://docs.vector.dev
-# Community: https://vector.dev/community
-# Repo: https://github.com/timberio/vector
+# Docs: https://docs.vector.dev/configuration
 # ------------------------------------------------------------------------------
 
 # Note: A full config spec is located at ./vector.spec.toml and examples
@@ -18,19 +16,11 @@
 
 data_dir = "/var/lib/vector"
 
-# Ingest data by tailing one or more files
-[sources.apache_logs]
-  type         = "file"
-  include      = ["/var/log/apache2/*.log"]
-  ignore_older = 86400 # 1 day
-
-# Structure and parse the data
-[transforms.apache_parser]
-  inputs       = ["apache_logs"]
-  type         = "regex_parser"
-  regex        = '^(?P<host>[w.]+) - (?P<user>[w]+) (?P<bytes_in>[d]+) [(?P<timestamp>.*)] "(?P<method>[w]+) (?P<path>.*)" (?P<status>[d]+) (?P<bytes_out>[d]+)$'
+# Input data. Change me to a valid input source.
+[sources.in]
+  type = "stdin"
 
 # Output data
-[sinks.print]
-  inputs       = ["apache_parser"]
-  type         = "console"
+[sinks.out]
+  inputs = ["in"]
+  type   = "console"


### PR DESCRIPTION
It turns out that this check wasn't actually verifying that the `vector` service started properly. Hence why https://github.com/timberio/vector/commit/4c9917754edd71a4ef53b9778d4540e3736d0abb was necessary.