### PR TITLE
enhancement(networking): Add support for non-PEM certificate formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,8 +1201,8 @@ dependencies = [
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2833,7 +2833,7 @@ dependencies = [
  "hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3255,7 +3255,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1828,7 +1828,8 @@ end
   #
 
   [sinks.clickhouse.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2115,7 +2116,8 @@ end
   #
 
   [sinks.elasticsearch.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2389,7 +2391,8 @@ end
   #
 
   [sinks.http.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2534,7 +2537,8 @@ end
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2752,7 +2756,8 @@ end
   #
 
   [sinks.splunk_hec.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2920,7 +2925,8 @@ end
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1835,8 +1835,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2123,8 +2123,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2398,8 +2398,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2544,8 +2544,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2763,8 +2763,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2932,8 +2932,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1836,7 +1836,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2124,7 +2125,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2399,7 +2401,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2545,7 +2548,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2764,7 +2768,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2933,7 +2938,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1843,7 +1843,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2131,7 +2131,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2406,7 +2406,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2552,7 +2552,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2771,7 +2771,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2940,7 +2940,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -178,7 +178,8 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
   #
 
   [sinks.clickhouse_sink.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -193,7 +193,7 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -186,7 +186,8 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/clickhouse.md
+++ b/docs/usage/configuration/sinks/clickhouse.md
@@ -185,8 +185,8 @@ The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -250,8 +250,8 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -251,7 +251,8 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -243,7 +243,8 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
   #
 
   [sinks.elasticsearch_sink.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -258,7 +258,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -233,8 +233,8 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -226,7 +226,8 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
   #
 
   [sinks.http_sink.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -241,7 +241,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -234,7 +234,8 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -136,7 +136,8 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -143,8 +143,8 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -151,7 +151,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -144,7 +144,8 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -193,7 +193,8 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -185,7 +185,8 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
   #
 
   [sinks.splunk_hec_sink.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -192,8 +192,8 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -200,7 +200,7 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -134,7 +134,8 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -141,7 +141,7 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -133,8 +133,8 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -126,7 +126,8 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1855,8 +1855,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2143,8 +2143,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2418,8 +2418,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2564,8 +2564,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2783,8 +2783,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2952,8 +2952,8 @@ end
     # * no default
     ca_path = "/path/to/certificate_authority.crt"
 
-    # Absolute path to a certificate file used to identify this connection, in PEM
-    # format. If this is set, `key_path` must also be set.
+    # Absolute path to a certificate file used to identify this connection, in DER
+    # or PEM format (X.509). If this is set, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1863,7 +1863,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2151,7 +2151,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2426,7 +2426,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2572,7 +2572,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2791,7 +2791,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2960,7 +2960,7 @@ end
     crt_path = "/path/to/host_certificate.crt"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # PEM format. If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1856,7 +1856,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2144,7 +2145,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2419,7 +2421,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2565,7 +2568,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2784,7 +2788,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default
@@ -2953,7 +2958,8 @@ end
     ca_path = "/path/to/certificate_authority.crt"
 
     # Absolute path to a certificate file used to identify this connection, in DER
-    # or PEM format (X.509). If this is set, `key_path` must also be set.
+    # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
+    # archive, `key_path` must also be set.
     # 
     # * optional
     # * no default

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -1848,7 +1848,8 @@ end
   #
 
   [sinks.clickhouse.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2135,7 +2136,8 @@ end
   #
 
   [sinks.elasticsearch.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2409,7 +2411,8 @@ end
   #
 
   [sinks.http.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2554,7 +2557,8 @@ end
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2772,7 +2776,8 @@ end
   #
 
   [sinks.splunk_hec.tls]
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default
@@ -2940,7 +2945,8 @@ end
     # * default: false
     enabled = false
 
-    # Absolute path to an additional CA certificate file, in PEM format.
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
     # 
     # * optional
     # * no default

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -143,7 +143,7 @@ class Sink < Component
         "type" => "string",
         "null" => true,
         "examples" => ["/path/to/host_certificate.crt"],
-        "description" => "Absolute path to a certificate file used to identify this connection, in DER or PEM format (X.509). If this is set, `key_path` must also be set."
+        "description" => "Absolute path to a certificate file used to identify this connection, in DER or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive, `key_path` must also be set."
       }
 
       options["key_path"] = {

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -150,7 +150,7 @@ class Sink < Component
         "type" => "string",
         "null" => true,
         "examples" => ["/path/to/host_certificate.key"],
-        "description" => "Absolute path to a certificate key file used to identify this connection, in PEM format. If this is set, `crt_path` must also be set."
+        "description" => "Absolute path to a certificate key file used to identify this connection, in DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set."
       }
 
       options["key_pass"] = {

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -143,7 +143,7 @@ class Sink < Component
         "type" => "string",
         "null" => true,
         "examples" => ["/path/to/host_certificate.crt"],
-        "description" => "Absolute path to a certificate file used to identify this connection, in PEM format. If this is set, `key_path` must also be set."
+        "description" => "Absolute path to a certificate file used to identify this connection, in DER or PEM format (X.509). If this is set, `key_path` must also be set."
       }
 
       options["key_path"] = {

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -136,7 +136,7 @@ class Sink < Component
         "type" => "string",
         "null" => true,
         "examples" => ["/path/to/certificate_authority.crt"],
-        "description" => "Absolute path to an additional CA certificate file, in PEM format."
+        "description" => "Absolute path to an additional CA certificate file, in DER or PEM format (X.509)."
       }
 
       options["crt_path"] = {

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -48,6 +48,11 @@ enum TlsError {
     },
     #[snafu(display("Could not build PKCS#12 archive for identity: {}", source))]
     Pkcs12Error { source: openssl::error::ErrorStack },
+    #[snafu(display("Could not parse identity in {:?}: {}", filename, source))]
+    IdentityParseError {
+        filename: PathBuf,
+        source: native_tls::Error,
+    },
 }
 
 /// Standard TLS connector options
@@ -71,7 +76,7 @@ pub struct TlsSettings {
 }
 
 #[derive(Clone)]
-pub struct IdentityStore(Vec<u8>);
+pub struct IdentityStore(Vec<u8>, String);
 
 impl TlsSettings {
     pub fn from_options(options: &Option<TlsOptions>) -> crate::Result<Self> {
@@ -85,7 +90,7 @@ impl TlsSettings {
             warn!("`verify_hostname` is DISABLED, this may lead to security vulnerabilities");
         }
 
-        if options.crt_path.is_some() != options.key_path.is_some() {
+        if options.key_path.is_some() && options.crt_path.is_none() {
             return Err(TlsError::MissingCrtKeyFile.into());
         }
 
@@ -97,21 +102,33 @@ impl TlsSettings {
         let identity = match options.crt_path {
             None => None,
             Some(ref crt_path) => {
-                let name = crt_path.to_string_lossy();
-                let crt = load_x509(crt_path)?;
-                let key_path = options.key_path.as_ref().unwrap();
-                let key = load_key(&key_path, &options.key_pass)?;
-                let pkcs12 = Pkcs12::builder()
-                    .build("", &name, &key, &crt)
-                    .context(Pkcs12Error)?;
-                let identity = pkcs12.to_der().context(DerExportError)?;
+                let name = crt_path.to_string_lossy().to_string();
+                let cert_data = open_read(crt_path, "certificate")?;
+                let key_pass: &str = options.key_pass.as_ref().map(|s| s.as_str()).unwrap_or("");
 
-                // Build the resulting Identity, but don't store it, as
-                // it cannot be cloned.  This is just for error
-                // checking.
-                let _identity = Identity::from_pkcs12(&identity, "").context(TlsIdentityError)?;
+                match Identity::from_pkcs12(&cert_data, key_pass) {
+                    Ok(_) => Some(IdentityStore(cert_data, key_pass.to_string())),
+                    Err(err) => {
+                        if options.key_path.is_some() {
+                            return Err(err.into());
+                        }
+                        let crt = load_x509(crt_path)?;
+                        let key_path = options.key_path.as_ref().unwrap();
+                        let key = load_key(&key_path, &options.key_pass)?;
+                        let pkcs12 = Pkcs12::builder()
+                            .build("", &name, &key, &crt)
+                            .context(Pkcs12Error)?;
+                        let identity = pkcs12.to_der().context(DerExportError)?;
 
-                Some(IdentityStore(identity))
+                        // Build the resulting Identity, but don't store it, as
+                        // it cannot be cloned.  This is just for error
+                        // checking.
+                        let _identity =
+                            Identity::from_pkcs12(&identity, "").context(TlsIdentityError)?;
+
+                        Some(IdentityStore(identity, "".into()))
+                    }
+                }
             }
         };
 
@@ -141,14 +158,14 @@ impl TlsConnectorExt for TlsConnectorBuilder {
             // all be reworked when `native_tls::Identity` gains the
             // Clone impl.
             let identity =
-                Identity::from_pkcs12(&identity.0, "").expect("Could not build identity");
+                Identity::from_pkcs12(&identity.0, &identity.1).expect("Could not build identity");
             self.identity(identity);
         }
         self
     }
 }
 
-/// Load a `native_tls::Certificate` from a named file
+/// Load a `native_tls::Certificate` (X.509) from a named file
 fn load_certificate(filename: &Path) -> crate::Result<Certificate> {
     let data = open_read(filename, "certificate")?;
     Ok(Certificate::from_der(&data)

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -174,7 +174,9 @@ fn load_key(filename: &Path, pass_phrase: &Option<String>) -> crate::Result<PKey
 /// Load an X.509 certificate from a named file
 fn load_x509(filename: &Path) -> crate::Result<X509> {
     let data = open_read(filename, "certificate")?;
-    Ok(X509::from_pem(&data).with_context(|| X509ParseError { filename })?)
+    Ok(X509::from_der(&data)
+        .or_else(|_| X509::from_pem(&data))
+        .with_context(|| X509ParseError { filename })?)
 }
 
 fn open_read(filename: &Path, note: &'static str) -> crate::Result<Vec<u8>> {

--- a/src/sinks/util/tls.rs
+++ b/src/sinks/util/tls.rs
@@ -151,7 +151,9 @@ impl TlsConnectorExt for TlsConnectorBuilder {
 /// Load a `native_tls::Certificate` from a named file
 fn load_certificate(filename: &Path) -> crate::Result<Certificate> {
     let data = open_read(filename, "certificate")?;
-    Ok(Certificate::from_pem(&data).with_context(|| CertificateParseError { filename })?)
+    Ok(Certificate::from_der(&data)
+        .or_else(|_| Certificate::from_pem(&data))
+        .with_context(|| CertificateParseError { filename })?)
 }
 
 /// Load a private key from a named file


### PR DESCRIPTION
The various sinks that support TLS all expect their certificate files to be in PEM format. This change add support for DER format certificate (X.509) and key (PKCS#8) files, and for PKCS#12 identity archives.

Closes #954 