### PR TITLE
chore(operations): Add git to musl build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,9 @@ jobs:
       - image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     resource_class: xlarge
     steps:
+      - run:
+          name: Install Git
+          command: apt-get install libssl-dev git
       - checkout
       - run:
           name: Build archive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,9 +175,6 @@ jobs:
       - image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     resource_class: xlarge
     steps:
-      - run:
-          name: Install Git
-          command: apt-get install -y --no-install-recommends libssl-dev git
       - checkout
       - run:
           name: Build archive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - run:
           name: Install Git
-          command: apt-get install libssl-dev git
+          command: apt-get install -y --no-install-recommends libssl-dev git
       - checkout
       - run:
           name: Build archive

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -274,7 +274,7 @@ ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX
 ENV PATH="$LIBS_PREFIX/bin:$PATH"
 
-RUN apt-get update && apt-get install -y build-essential pkg-config
+RUN apt-get update && apt-get install -y build-essential pkg-config libssl-dev git
 
 # Because the system GCC and binutils are shadowed by aliases, we need to
 # instruct Cargo and cc crate to use GCC on the host system. They are used to


### PR DESCRIPTION
This adds `git` to the musl build image, otherwise CI cannot checkout the code properly.

cc @a-rodin 