### PR TITLE
chore(operations): Improve CI efficiency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,8 +557,6 @@ all-filters: &all-filters
 
 release-filters: &release-filters
   filters:
-    branches:
-      ignore: /.*/
     tags:
       only: /v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,7 +562,7 @@ release-filters: &release-filters
     tags:
       only: /v.*/
 
-release-requires: &require-requires
+release-requires: &release-requires
   requires:
     - check-code
     - check-fmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,7 +562,7 @@ release-filters: &release-filters
     tags:
       only: /v.*/
 
-release-requires: &require-verifications
+release-requires: &require-requires
   requires:
     - check-code
     - check-fmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 #
-# Run macros
+# Job Macros
 #
 
 install-rust: &install-rust
@@ -560,7 +560,7 @@ release-filters: &release-filters
     tags:
       only: /v.*/
 
-release-requires: &release-requires
+require-tests-checks-and-verifications: &require-tests-checks-and-verifications
   requires:
     - check-code
     - check-fmt
@@ -588,78 +588,128 @@ release-requires: &release-requires
 workflows:
   version: 2
 
-  vector:
+  test:
     jobs:
+      - check-code
+      - check-fmt
+      - check-generate
+      - test-stable
 
-      # Check and test
+      # Build & verify
 
-      - check-code:
-          <<: *all-filters
-      - check-fmt:
-          <<: *all-filters
-      - check-generate:
-          <<: *all-filters
-      - test-stable:
-          <<: *all-filters
-
-      # Build
-
-      - build-x86_64-unknown-linux-gnu-archive-and-deb-package:
-          <<: *all-filters
-      - build-x86_64-unknown-linux-musl-archive:
-          <<: *all-filters
-      - build-x86_64-apple-darwin-archive:
-          <<: *all-filters
-      - package-rpm:
-          <<: *all-filters
+      - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - build-x86_64-unknown-linux-musl-archive
+      - build-x86_64-apple-darwin-archive
+      - package-rpm
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 
       # Verify
 
       - verify-deb-artifact-on-deb-8:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-deb-9:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-deb-10:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-16-04:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-18-04:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-19-04:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-docker:
-          <<: *all-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
             - build-x86_64-unknown-linux-musl-archive
       - verify-rpm-artifact-on-amazon-linux-1:
-          <<: *all-filters
           requires:
             - package-rpm
       - verify-rpm-artifact-on-amazon-linux-2:
-          <<: *all-filters
           requires:
             - package-rpm
       - verify-rpm-artifact-on-centos-7:
-          <<: *all-filters
           requires:
             - package-rpm
       - verify-systemd-on-debian:
-          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+
+  release:
+    jobs:
+      - check-code:
+          <<: *release-filters
+      - check-fmt:
+          <<: *release-filters
+      - check-generate:
+          <<: *release-filters
+      - test-stable:
+          <<: *release-filters
+
+      # Build & verify
+
+      - build-x86_64-unknown-linux-gnu-archive-and-deb-package:
+          <<: *release-filters
+      - build-x86_64-unknown-linux-musl-archive:
+          <<: *release-filters
+      - build-x86_64-apple-darwin-archive:
+          <<: *release-filters
+      - package-rpm:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+
+      # Verify
+
+      - verify-deb-artifact-on-deb-8:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-deb-9:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-deb-10:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-16-04:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-18-04:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-19-04:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-docker:
+          <<: *release-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+            - build-x86_64-unknown-linux-musl-archive
+      - verify-rpm-artifact-on-amazon-linux-1:
+          <<: *release-filters
+          requires:
+            - package-rpm
+      - verify-rpm-artifact-on-amazon-linux-2:
+          <<: *release-filters
+          requires:
+            - package-rpm
+      - verify-rpm-artifact-on-centos-7:
+          <<: *release-filters
+          requires:
+            - package-rpm
+      - verify-systemd-on-debian:
+          <<: *release-filters
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 
@@ -667,17 +717,91 @@ workflows:
 
       - release-docker:
           <<: *release-filters
-          <<: *release-requires
+          <<: *require-tests-checks-and-verifications
       - release-github:
           <<: *release-filters
-          <<: *release-requires
+          <<: *require-tests-checks-and-verifications
       - release-s3:
           <<: *release-filters
-          <<: *release-requires
+          <<: *require-tests-checks-and-verifications
 
       # Must come after S3 since Homebrew installs from S3
       - release-homebrew:
           <<: *release-filters
+          requires:
+            - release-s3
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
+
+    jobs:
+      - check-code
+      - check-fmt
+      - check-generate
+      - test-stable
+
+      # Build & verify
+
+      - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - build-x86_64-unknown-linux-musl-archive
+      - build-x86_64-apple-darwin-archive
+      - package-rpm
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+
+      # Verify
+
+      - verify-deb-artifact-on-deb-8:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-deb-9:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-deb-10:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-16-04:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-18-04:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-deb-artifact-on-ubuntu-19-04:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+      - verify-docker:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+            - build-x86_64-unknown-linux-musl-archive
+      - verify-rpm-artifact-on-amazon-linux-1:
+          requires:
+            - package-rpm
+      - verify-rpm-artifact-on-amazon-linux-2:
+          requires:
+            - package-rpm
+      - verify-rpm-artifact-on-centos-7:
+          requires:
+            - package-rpm
+      - verify-systemd-on-debian:
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+
+      # Release
+
+      - release-docker:
+          <<: *require-tests-checks-and-verifications
+      - release-github:
+          <<: *require-tests-checks-and-verifications
+      - release-s3:
+          <<: *require-tests-checks-and-verifications
+
+      # Must come after S3 since Homebrew installs from S3
+      - release-homebrew:
           requires:
             - release-s3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           paths:
             - "*-x86_64-apple-darwin.tar.gz"
 
-  build-x86_64-unknown-linux-gnu-archive:
+  build-x86_64-unknown-linux-gnu-archive-and-deb-package:
     docker:
       - image: timberiodev/vector-builder-x86_64-unknown-linux-gnu:latest
     resource_class: xlarge
@@ -550,34 +550,17 @@ jobs:
 # Workflow Macros
 #
 
+all-filters: &all-filters
+  filters:
+    tags:
+      only: /v.*/
+
 release-filters: &release-filters
   filters:
     branches:
       ignore: /.*/
     tags:
       only: /v.*/
-
-require-builds: &require-builds
-  requires:
-    - check-code
-    - check-fmt
-    - check-generate
-    - test-install-script-on-amazon-linux-1
-    - test-install-script-on-amazon-linux-2
-    - test-install-script-on-centos-7
-    - test-install-script-on-deb-8
-    - test-install-script-on-deb-9
-    - test-install-script-on-deb-10
-    - test-install-script-on-mac-archive
-    - test-install-script-on-mac-homebrew
-    - test-install-script-on-unbuntu-16-04
-    - test-install-script-on-unbuntu-18-04
-    - test-install-script-on-unbuntu-19-04
-    - test-install-script-without-sudo
-    - test-stable
-    - build-x86_64-unknown-linux-gnu-archive
-    - build-x86_64-unknown-linux-musl-archive
-    - build-x86_64-apple-darwin-archive
 
 require-packages: &require-packages
   requires:
@@ -619,87 +602,7 @@ test-filters: &test-filters
 workflows:
   version: 2
 
-  test:
-    jobs:
-      - check-code:
-          <<: *test-filters
-      - check-fmt:
-          <<: *test-filters
-      - check-generate:
-          <<: *test-filters
-      - test-stable:
-          <<: *test-filters
-
-      # Install script testing
-
-      - test-install-script-on-amazon-linux-1:
-          <<: *test-filters
-      - test-install-script-on-amazon-linux-2:
-          <<: *test-filters
-      - test-install-script-on-centos-7:
-          <<: *test-filters
-      - test-install-script-on-deb-8:
-          <<: *test-filters
-      - test-install-script-on-deb-9:
-          <<: *test-filters
-      - test-install-script-on-deb-10:
-          <<: *test-filters
-      - test-install-script-on-mac-archive:
-          <<: *test-filters
-      - test-install-script-on-mac-homebrew:
-          <<: *test-filters
-      - test-install-script-on-unbuntu-16-04:
-          <<: *test-filters
-      - test-install-script-on-unbuntu-18-04:
-          <<: *test-filters
-      - test-install-script-on-unbuntu-19-04:
-          <<: *test-filters
-      - test-install-script-without-sudo:
-          <<: *test-filters
-
-      # Building & packaging
-
-      - build-x86_64-unknown-linux-gnu-archive:
-          <<: *test-filters
-      - build-x86_64-unknown-linux-musl-archive:
-          <<: *test-filters
-      - build-x86_64-apple-darwin-archive:
-          <<: *test-filters
-      - package-rpm:
-          <<: *require-builds
-
-      # Verifying
-
-      - verify-deb-artifact-on-deb-8:
-          <<: *require-packages
-      - verify-deb-artifact-on-deb-9:
-          <<: *require-packages
-      - verify-deb-artifact-on-deb-10:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-16-04:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-18-04:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-19-04:
-          <<: *require-packages
-      - verify-docker:
-          <<: *require-packages
-      - verify-rpm-artifact-on-amazon-linux-1:
-          <<: *require-packages
-      - verify-rpm-artifact-on-amazon-linux-2:
-          <<: *require-packages
-      - verify-rpm-artifact-on-centos-7:
-          <<: *require-packages
-      - verify-systemd-on-debian:
-          <<: *require-packages
-
-      # Syncing
-
-      - sync-install:
-          <<: *sync-filters
-          <<: *require-verifications
-
-  nightly:
+  vector:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -708,161 +611,80 @@ workflows:
               only: master
 
     jobs:
-      - check-code
-      - check-fmt
-      - check-generate
-      - test-stable
 
-      # Install script testing
+      # Check and test
 
-      - test-install-script-on-amazon-linux-1
-      - test-install-script-on-amazon-linux-2
-      - test-install-script-on-centos-7
-      - test-install-script-on-deb-8
-      - test-install-script-on-deb-9
-      - test-install-script-on-deb-10
-      - test-install-script-on-mac-archive
-      - test-install-script-on-mac-homebrew
-      - test-install-script-on-unbuntu-16-04
-      - test-install-script-on-unbuntu-18-04
-      - test-install-script-on-unbuntu-19-04
-      - test-install-script-without-sudo
-
-      # Building & packaging
-
-      - build-x86_64-unknown-linux-gnu-archive
-      - build-x86_64-unknown-linux-musl-archive
-      - build-x86_64-apple-darwin-archive
-      - package-rpm:
-          <<: *require-builds
-
-      # Verifying
-
-      - verify-deb-artifact-on-deb-8:
-          <<: *require-packages
-      - verify-deb-artifact-on-deb-9:
-          <<: *require-packages
-      - verify-deb-artifact-on-deb-10:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-16-04:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-18-04:
-          <<: *require-packages
-      - verify-deb-artifact-on-ubuntu-19-04:
-          <<: *require-packages
-      - verify-docker:
-          <<: *require-packages
-      - verify-rpm-artifact-on-amazon-linux-1:
-          <<: *require-packages
-      - verify-rpm-artifact-on-amazon-linux-2:
-          <<: *require-packages
-      - verify-rpm-artifact-on-centos-7:
-          <<: *require-packages
-      - verify-systemd-on-debian:
-          <<: *require-packages
-      - release-docker:
-          <<: *require-verifications
-      - release-s3:
-          <<: *require-verifications
-
-  remote-checks:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only: master
-
-    jobs:
-      - check-remote-install-script
-
-  release:
-    jobs:
       - check-code:
-          <<: *release-filters
+          <<: *all-filters
       - check-fmt:
-          <<: *release-filters
+          <<: *all-filters
       - check-generate:
-          <<: *release-filters
+          <<: *all-filters
       - test-stable:
-          <<: *release-filters
+          <<: *all-filters
 
-      # Install script testing
+      # Build
 
-      - test-install-script-on-amazon-linux-1:
-          <<: *release-filters
-      - test-install-script-on-amazon-linux-2:
-          <<: *release-filters
-      - test-install-script-on-centos-7:
-          <<: *release-filters
-      - test-install-script-on-deb-8:
-          <<: *release-filters
-      - test-install-script-on-deb-9:
-          <<: *release-filters
-      - test-install-script-on-deb-10:
-          <<: *release-filters
-      - test-install-script-on-mac-archive:
-          <<: *release-filters
-      - test-install-script-on-mac-homebrew:
-          <<: *release-filters
-      - test-install-script-on-unbuntu-16-04:
-          <<: *release-filters
-      - test-install-script-on-unbuntu-18-04:
-          <<: *release-filters
-      - test-install-script-on-unbuntu-19-04:
-          <<: *release-filters
-      - test-install-script-without-sudo:
-          <<: *release-filters
-
-      # Building & packaging
-
-      - build-x86_64-unknown-linux-gnu-archive:
-          <<: *release-filters
+      - build-x86_64-unknown-linux-gnu-archive-and-deb-package:
+          <<: *all-filters
       - build-x86_64-unknown-linux-musl-archive:
-          <<: *release-filters
+          <<: *all-filters
       - build-x86_64-apple-darwin-archive:
-          <<: *release-filters
+          <<: *all-filters
       - package-rpm:
-          <<: *release-filters
-          <<: *require-builds
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 
-      # Verifying
+      # Verify
 
       - verify-deb-artifact-on-deb-8:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-deb-9:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-deb-10:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-16-04:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-18-04:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-deb-artifact-on-ubuntu-19-04:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - verify-docker:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
+            - build-x86_64-unknown-linux-musl-archive
       - verify-rpm-artifact-on-amazon-linux-1:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - package-rpm
       - verify-rpm-artifact-on-amazon-linux-2:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - package-rpm
       - verify-rpm-artifact-on-centos-7:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - package-rpm
       - verify-systemd-on-debian:
-          <<: *release-filters
-          <<: *require-packages
+          <<: *all-filters
+          requires:
+            - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 
-      # Releasing
+      # Release
 
       - release-docker:
           <<: *release-filters
@@ -879,6 +701,51 @@ workflows:
           <<: *release-filters
           requires:
             - release-s3
+
+  install-script:
+    jobs:
+      - test-install-script-on-amazon-linux-1
+      - test-install-script-on-amazon-linux-2
+      - test-install-script-on-centos-7
+      - test-install-script-on-deb-8
+      - test-install-script-on-deb-9
+      - test-install-script-on-deb-10
+      - test-install-script-on-mac-archive
+      - test-install-script-on-mac-homebrew
+      - test-install-script-on-unbuntu-16-04
+      - test-install-script-on-unbuntu-18-04
+      - test-install-script-on-unbuntu-19-04
+      - test-install-script-without-sudo
+
+      - sync-install:
+          filters:
+            branches:
+              only: master
+
+          requires:
+            - test-install-script-on-amazon-linux-1
+            - test-install-script-on-amazon-linux-2
+            - test-install-script-on-centos-7
+            - test-install-script-on-deb-8
+            - test-install-script-on-deb-9
+            - test-install-script-on-deb-10
+            - test-install-script-on-mac-archive
+            - test-install-script-on-mac-homebrew
+            - test-install-script-on-unbuntu-16-04
+            - test-install-script-on-unbuntu-18-04
+            - test-install-script-on-unbuntu-19-04
+            - test-install-script-without-sudo
+
+  remote-checks:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
+
+    jobs:
+      - check-remote-install-script
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,7 +600,7 @@ workflows:
       - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - build-x86_64-unknown-linux-musl-archive
       - build-x86_64-apple-darwin-archive
-      - package-rpm
+      - package-rpm:
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 
@@ -750,7 +750,7 @@ workflows:
       - build-x86_64-unknown-linux-gnu-archive-and-deb-package
       - build-x86_64-unknown-linux-musl-archive
       - build-x86_64-apple-darwin-archive
-      - package-rpm
+      - package-rpm:
           requires:
             - build-x86_64-unknown-linux-gnu-archive-and-deb-package
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,13 +550,10 @@ jobs:
 # Workflow Macros
 #
 
-all-filters: &all-filters
-  filters:
-    tags:
-      only: /v.*/
-
 release-filters: &release-filters
   filters:
+    branches:
+      ignore: /.*/
     tags:
       only: /v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,13 +603,6 @@ workflows:
   version: 2
 
   vector:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only: master
-
     jobs:
 
       # Check and test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,12 +562,14 @@ release-filters: &release-filters
     tags:
       only: /v.*/
 
-require-packages: &require-packages
+release-requires: &require-verifications
   requires:
-    - package-rpm
-
-require-verifications: &require-verifications
-  requires:
+    - check-code
+    - check-fmt
+    - check-generate
+    - test-stable
+    - build-x86_64-unknown-linux-musl-archive
+    - build-x86_64-apple-darwin-archive
     - verify-deb-artifact-on-deb-8
     - verify-deb-artifact-on-deb-9
     - verify-deb-artifact-on-deb-10
@@ -579,20 +581,6 @@ require-verifications: &require-verifications
     - verify-rpm-artifact-on-amazon-linux-2
     - verify-rpm-artifact-on-centos-7
     - verify-systemd-on-debian
-
-sync-filters: &sync-filters
-  filters:
-    branches:
-      only: master
-    tags:
-      ignore: /.*/
-
-test-filters: &test-filters
-  filters:
-    branches:
-      only: /.*/
-    tags:
-      ignore: /.*/
 
 
 #
@@ -681,13 +669,13 @@ workflows:
 
       - release-docker:
           <<: *release-filters
-          <<: *require-verifications
+          <<: *release-requires
       - release-github:
           <<: *release-filters
-          <<: *require-verifications
+          <<: *release-requires
       - release-s3:
           <<: *release-filters
-          <<: *require-verifications
+          <<: *release-requires
 
       # Must come after S3 since Homebrew installs from S3
       - release-homebrew:

--- a/scripts/check-generate.sh
+++ b/scripts/check-generate.sh
@@ -14,6 +14,14 @@ echo "Checking for pending generation changes..."
 
 changes=$(scripts/generate.rb --dry-run | grep 'Will be changed' || true)
 
+if [[ "$?" != "0" ]]; then
+  echo 'The `scripts/generate.rb --dry-run` command returned an error:'
+  echo ''
+  echo "$changes"
+  echo ''
+  exit 1
+fi
+
 if [[ -n "$changes" ]]; then
   echo 'It looks like the following files would change if `make generate` was run:'
   echo ''

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -31,6 +31,12 @@ require_relative "generate/core_ext/hash"
 require_relative "generate/core_ext/string"
 
 #
+# Flags
+#
+
+dry_run = ARGV.include?("--dry-run")
+
+#
 # Functions
 #
 
@@ -165,14 +171,18 @@ Dir.glob("#{TEMPLATES_DIR}/**/*.erb", File::FNM_DOTMATCH).
     current_content = File.read(target_path)
 
     if current_content != content
-      action = false ? "Will be changed" : "Changed"
+      action = dry_run ? "Will be changed" : "Changed"
       say("#{action} - #{target_file}", color: :green)
-      File.write(target_path, content)
+      File.write(target_path, content) if !dry_run
     else
-      action = false ? "Will not be changed" : "Not changed"
+      action = dry_run ? "Will not be changed" : "Not changed"
       say("#{action} - #{target_file}", color: :blue)
     end
   end
+
+if dry_run
+  return
+end
 
 #
 # Post process individual docs


### PR DESCRIPTION
This cleans up our CircleCI build process by:

1. Moves the install script testing and releasing into its own workflow.
2. Cleans up the job dependencies to be more specific to allow for quicker testing and building. For example, `verify-deb-artifact-on-deb-10` simply requires `build-x86_64-unknown-linux-gnu-archive-and-deb-package` instead of requiring all of the `check-*`, `test-*`, and `build-*` jobs. 
3. Fixes a bug when checking if there are pending `make generate` changes.

A note about Circle's frustrating synax: (this should further explain why this is so verbose):

1. Tags workflows are not enabled by default, you must explicitly enable tag workflows for each and every job in the workflow.
2. Because YAML does not allow the merging of arrays, it makes it impossible to reuse sections within workflow definitions.
3. Scheduled workflows cannot also be triggered by a commit. Therefore, nightly workflows must be duplicative of testing and releasing workflows.
4. Because of the above restrictions I felt it easier to _separately_ define workflows for testing, releasing, and nightly.