### PR TITLE
fix(config): make global options actually use default

### DIFF
--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -70,7 +70,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         when_full: Default::default(),
                     }
                     .into();
-                    config.data_dir = Some(data_dir.clone());
+                    config.global.data_dir = Some(data_dir.clone());
 
                     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -106,7 +106,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         max_size: 10_000,
                         when_full: Default::default(),
                     };
-                    config.data_dir = Some(data_dir2.clone());
+                    config.global.data_dir = Some(data_dir2.clone());
 
                     let mut rt = tokio::runtime::Runtime::new().unwrap();
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -432,19 +432,18 @@ mod tests {
         let local_dir = tempdir().unwrap();
 
         let mut config = Config::empty();
-        config.data_dir = global_dir.into_path().into();
+        config.global.data_dir = global_dir.into_path().into();
 
         // local path given -- local should win
-        let res = GlobalOptions::from(&config)
+        let res = config
+            .global
             .resolve_and_validate_data_dir(test_default_file_config(&local_dir).data_dir.as_ref())
             .unwrap();
         assert_eq!(res, local_dir.path());
 
         // no local path given -- global fallback should be in effect
-        let res = GlobalOptions::from(&config)
-            .resolve_and_validate_data_dir(None)
-            .unwrap();
-        assert_eq!(res, config.data_dir.unwrap());
+        let res = config.global.resolve_and_validate_data_dir(None).unwrap();
+        assert_eq!(res, config.global.data_dir.unwrap());
     }
 
     #[test]

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -160,8 +160,8 @@ impl RunningTopology {
         rt: &mut tokio::runtime::Runtime,
         require_healthy: bool,
     ) -> bool {
-        if self.config.data_dir != new_config.data_dir {
-            error!("data_dir cannot be changed while reloading config file; reload aborted. Current value: {:?}", self.config.data_dir);
+        if self.config.global.data_dir != new_config.global.data_dir {
+            error!("data_dir cannot be changed while reloading config file; reload aborted. Current value: {:?}", self.config.global.data_dir);
             return false;
         }
 
@@ -537,17 +537,17 @@ mod tests {
 
         let mut old_config = Config::empty();
         old_config.add_source("in", TcpConfig::new(next_addr()));
-        old_config.data_dir = Some(Path::new("/asdf").to_path_buf());
+        old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());
         let mut new_config = old_config.clone();
 
         let (mut topology, _crash) = topology::start(old_config, &mut rt, false).unwrap();
 
-        new_config.data_dir = Some(Path::new("/qwerty").to_path_buf());
+        new_config.global.data_dir = Some(Path::new("/qwerty").to_path_buf());
 
         topology.reload_config_and_respawn(new_config, &mut rt, false);
 
         assert_eq!(
-            topology.config.data_dir,
+            topology.config.global.data_dir,
             Some(Path::new("/asdf").to_path_buf())
         );
     }

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -30,7 +30,7 @@ fn test_buffering() {
         max_size: 10_000,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir.clone());
+    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -58,7 +58,7 @@ fn test_buffering() {
         max_size: 10_000,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir);
+    config.global.data_dir = Some(data_dir);
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -121,7 +121,7 @@ fn test_max_size() {
         max_size,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir.clone());
+    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -148,7 +148,7 @@ fn test_max_size() {
         max_size,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir);
+    config.global.data_dir = Some(data_dir);
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -192,7 +192,7 @@ fn test_max_size_resume() {
         max_size,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir.clone());
+    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -246,7 +246,7 @@ fn test_reclaim_disk_space() {
         when_full: Default::default(),
     }
     .into();
-    config.data_dir = Some(data_dir.clone());
+    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -282,7 +282,7 @@ fn test_reclaim_disk_space() {
         max_size: 1_000_000_000,
         when_full: Default::default(),
     };
-    config.data_dir = Some(data_dir.clone());
+    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 


### PR DESCRIPTION
It turns out #995 was not a complete fix to #979, due to the roundabout way we were using `GlobalOptions`. This simplifies the way that we're using it and adds a test to ensure we actually are setting the default data dir to `/var/lib/vector`.