### PR TITLE
docs: Add relevant when details to config spec

### DIFF
--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -195,6 +195,7 @@ data_dir = "/var/lib/vector"
     # The number of bytes read off the head of the file to generate a unique
     # fingerprint.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 256
     # * unit: bytes
@@ -203,6 +204,7 @@ data_dir = "/var/lib/vector"
     # The number of bytes to skip ahead (or ignore) when generating a unique
     # fingerprint. This is helpful if all files share a common header.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 0
     # * unit: bytes
@@ -386,6 +388,7 @@ data_dir = "/var/lib/vector"
 
   # The unix socket path. *This should be absolute path.*
   # 
+  # * only relevant when mode = "unix"
   # * optional
   # * no default
   path = "/path/to/socket"
@@ -778,6 +781,7 @@ data_dir = "/var/lib/vector"
     # If `true` the metric will be incremented by the `field` value. If `false` the
     # metric will be incremented by 1 regardless of the `field` value.
     # 
+    # * only relevant when type = "counter"
     # * optional
     # * default: false
     increment_by_value = false
@@ -1261,6 +1265,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1268,6 +1273,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -1457,6 +1463,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1464,6 +1471,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -1650,6 +1658,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1657,6 +1666,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2076,6 +2086,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2083,6 +2094,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2363,6 +2375,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2370,6 +2383,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2515,6 +2529,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2522,6 +2537,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2741,6 +2757,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2748,6 +2765,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2905,6 +2923,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2912,6 +2931,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -3029,6 +3049,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -3036,6 +3057,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -206,6 +206,7 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.data
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -213,6 +214,7 @@ The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.data
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/aws_kinesis_streams.md
+++ b/docs/usage/configuration/sinks/aws_kinesis_streams.md
@@ -187,6 +187,7 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.data
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -194,6 +195,7 @@ The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.data
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -234,6 +234,7 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] e
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -241,6 +242,7 @@ The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] e
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -204,6 +204,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -211,6 +212,7 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/http.md
+++ b/docs/usage/configuration/sinks/http.md
@@ -198,6 +198,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -205,6 +206,7 @@ The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model.log] eve
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/kafka.md
+++ b/docs/usage/configuration/sinks/kafka.md
@@ -113,6 +113,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -120,6 +121,7 @@ The `kafka` sink [streams](#streaming) [`log`][docs.data-model.log] events to [A
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/splunk_hec.md
+++ b/docs/usage/configuration/sinks/splunk_hec.md
@@ -168,6 +168,7 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -175,6 +176,7 @@ The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model.lo
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/tcp.md
+++ b/docs/usage/configuration/sinks/tcp.md
@@ -103,6 +103,7 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -110,6 +111,7 @@ The `tcp` sink [streams](#streaming) [`log`][docs.data-model.log] events to a TC
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sinks/vector.md
+++ b/docs/usage/configuration/sinks/vector.md
@@ -87,6 +87,7 @@ The `vector` sink [streams](#streaming) [`log`][docs.data-model.log] events to a
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -94,6 +95,7 @@ The `vector` sink [streams](#streaming) [`log`][docs.data-model.log] events to a
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/sources/file.md
+++ b/docs/usage/configuration/sources/file.md
@@ -169,6 +169,7 @@ The `file` source ingests data through one or more local files and outputs [`log
     # The number of bytes read off the head of the file to generate a unique
     # fingerprint.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 256
     # * unit: bytes
@@ -177,6 +178,7 @@ The `file` source ingests data through one or more local files and outputs [`log
     # The number of bytes to skip ahead (or ignore) when generating a unique
     # fingerprint. This is helpful if all files share a common header.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 0
     # * unit: bytes

--- a/docs/usage/configuration/sources/syslog.md
+++ b/docs/usage/configuration/sources/syslog.md
@@ -67,6 +67,7 @@ The `syslog` source ingests data through the Syslog 5424 protocol and outputs [`
 
   # The unix socket path. *This should be absolute path.*
   # 
+  # * only relevant when mode = "unix"
   # * optional
   # * no default
   path = "/path/to/socket"

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -215,6 +215,7 @@ data_dir = "/var/lib/vector"
     # The number of bytes read off the head of the file to generate a unique
     # fingerprint.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 256
     # * unit: bytes
@@ -223,6 +224,7 @@ data_dir = "/var/lib/vector"
     # The number of bytes to skip ahead (or ignore) when generating a unique
     # fingerprint. This is helpful if all files share a common header.
     # 
+    # * only relevant when strategy = "checksum"
     # * optional
     # * default: 0
     # * unit: bytes
@@ -406,6 +408,7 @@ data_dir = "/var/lib/vector"
 
   # The unix socket path. *This should be absolute path.*
   # 
+  # * only relevant when mode = "unix"
   # * optional
   # * no default
   path = "/path/to/socket"
@@ -798,6 +801,7 @@ data_dir = "/var/lib/vector"
     # If `true` the metric will be incremented by the `field` value. If `false` the
     # metric will be incremented by 1 regardless of the `field` value.
     # 
+    # * only relevant when type = "counter"
     # * optional
     # * default: false
     increment_by_value = false
@@ -1281,6 +1285,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1288,6 +1293,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -1477,6 +1483,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1484,6 +1491,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -1670,6 +1678,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -1677,6 +1686,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2096,6 +2106,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2103,6 +2114,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2383,6 +2395,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2390,6 +2403,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2535,6 +2549,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2542,6 +2557,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2761,6 +2777,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2768,6 +2785,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -2925,6 +2943,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -2932,6 +2951,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events
@@ -3049,6 +3069,7 @@ end
 
     # The maximum size of the buffer on the disk.
     # 
+    # * only relevant when type = "disk"
     # * optional
     # * no default
     # * unit: bytes
@@ -3056,6 +3077,7 @@ end
 
     # The maximum number of events allowed in the buffer.
     # 
+    # * only relevant when type = "memory"
     # * optional
     # * default: 500
     # * unit: events

--- a/docs/usage/configuration/transforms/log_to_metric.md
+++ b/docs/usage/configuration/transforms/log_to_metric.md
@@ -86,6 +86,7 @@ The `log_to_metric` transform accepts [`log`][docs.data-model.log] events and al
     # If `true` the metric will be incremented by the `field` value. If `false` the
     # metric will be incremented by 1 regardless of the `field` value.
     # 
+    # * only relevant when type = "counter"
     # * optional
     # * default: false
     increment_by_value = false

--- a/scripts/generate/templates/_partials/_config_spec.toml.erb
+++ b/scripts/generate/templates/_partials/_config_spec.toml.erb
@@ -17,6 +17,9 @@
 <%= config_spec(option.options, titles: false, path: "#{opts[:path]}.#{option.name}").indent(2) %>
     <%- else -%>
 <%= option.description.editorify(78).commentify.indent(2) %>
+      <%- if option.relevant_when -%>
+  # * only relevant when <%= option.relevant_when_kvs.to_sentence %>
+      <%- end -%>
       <%- spec.tags(option).each do |tag| -%>
   # * <%= tag %>
       <%- end -%>

--- a/scripts/generate/templates/options_table.rb
+++ b/scripts/generate/templates/options_table.rb
@@ -70,8 +70,7 @@ class Templates
       end
 
       if option.relevant_when
-        conditions = option.relevant_when.collect { |k,v| "#{k} = #{v.to_toml}" }
-        description << " Only relevant when #{conditions.to_sentence}"
+        description << " Only relevant when #{option.relevant_when_kvs.to_sentence}"
       end
 
       description << "[[references:#{option.name}]]"

--- a/scripts/util/metadata/option.rb
+++ b/scripts/util/metadata/option.rb
@@ -113,6 +113,10 @@ class Option
     partition_key == true
   end
 
+  def relevant_when_kvs
+    relevant_when.collect { |k,v| "#{k} = #{v.to_toml}" }
+  end
+
   def required?
     default.nil? && null == false
   end


### PR DESCRIPTION
This info was missing in the configuration specs.