### PR TITLE
chore(operations): Remove debian cache to reduce image size

### DIFF
--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY vector-amd64.deb .
 RUN dpkg -i vector-amd64.deb


### PR DESCRIPTION
Following best practices from docker doc.
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->