### PR TITLE
enhancement(networking): Add support for systemd socket activation

### DIFF
--- a/.meta/sources/syslog.toml
+++ b/.meta/sources/syslog.toml
@@ -7,7 +7,7 @@ through_description = "the Syslog 5424 protocol"
 
 [sources.syslog.options.address]
 type = "string"
-examples = ["0.0.0.0:9000", "systemd#2"]
+examples = ["0.0.0.0:9000", "systemd", "systemd#2"]
 null = true
 relevant_when = {mode = ["tcp", "udp"]}
 simple = true

--- a/.meta/sources/syslog.toml
+++ b/.meta/sources/syslog.toml
@@ -7,10 +7,12 @@ through_description = "the Syslog 5424 protocol"
 
 [sources.syslog.options.address]
 type = "string"
-examples = ["0.0.0.0:9000"]
+examples = ["0.0.0.0:9000", "systemd#2"]
 null = true
 relevant_when = {mode = ["tcp", "udp"]}
-description = "The TCP or UDP address to listen on."
+description = """The TCP or UDP address to listen for connections on, \
+or "systemd#N" to use the Nth socket passed by systemd socket activation. \
+"""
 
 [sources.syslog.options.host_key]
 name = "host_key"

--- a/.meta/sources/tcp.toml
+++ b/.meta/sources/tcp.toml
@@ -7,9 +7,11 @@ through_description = "the TCP protocol"
 
 [sources.tcp.options.address]
 type = "string"
-examples = ["0.0.0.0:9000"]
+examples = ["0.0.0.0:9000", "systemd", "systemd#3"]
 null = false
-description = "The address to bind the socket to."
+description = """The address to listen for connections on, \
+or "systemd#N" to use the Nth socket passed by systemd socket activation. \
+"""
 
 [sources.tcp.options.host_key]
 name = "host_key"

--- a/.meta/sources/vector.toml
+++ b/.meta/sources/vector.toml
@@ -8,9 +8,11 @@ through_description = "another upstream Vector instance"
 
 [sources.vector.options.address]
 type = "string"
-examples = ["0.0.0.0:9000"]
+examples = ["0.0.0.0:9000", "systemd#1"]
 null = false
-description = "The TCP address to bind to."
+description = """The TCP address to listen for connections on, \
+or "systemd#N" to use the Nth socket passed by systemd socket activation. \
+"""
 
 [sources.vector.options.shutdown_timeout_secs]
 type = "int"

--- a/.meta/sources/vector.toml
+++ b/.meta/sources/vector.toml
@@ -8,7 +8,7 @@ through_description = "another upstream Vector instance"
 
 [sources.vector.options.address]
 type = "string"
-examples = ["0.0.0.0:9000", "systemd#1"]
+examples = ["0.0.0.0:9000", "systemd", "systemd#1"]
 null = false
 description = """The TCP address to listen for connections on, \
 or "systemd#N" to use the Nth socket passed by systemd socket activation. \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "listenfd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +3934,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4285,6 +4296,7 @@ dependencies = [
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7c91c4c7bbeb4f2f7c4e5be11e6a05bd6830bc37249c47ce1ad86ad453ff9c"
+"checksum listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ url = "1.7"
 base64 = "0.10.1"
 shiplift = { git = "https://github.com/LucioFranco/shiplift", branch = "timber" }
 owning_ref = "0.4.0"
+listenfd = "0.3.3"
 
 [build-dependencies]
 prost-build = "0.4.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -54,7 +54,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -100,7 +100,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -146,7 +146,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -193,7 +193,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -251,8 +251,8 @@ fn benchmark_interconnected(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1));
-                    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2));
+                    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1.into()));
+                    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2.into()));
                     config.add_sink(
                         "out1",
                         &["in1", "in2"],
@@ -308,7 +308,7 @@ fn benchmark_transforms(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_transform(
                         "parser",
                         &["in"],
@@ -417,8 +417,8 @@ fn benchmark_complex(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1));
-                    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2));
+                    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1.into()));
+                    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2.into()));
                     config.add_transform(
                         "parser",
                         &["in1", "in2"],

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -24,7 +24,7 @@ fn benchmark_buffers(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -59,7 +59,7 @@ fn benchmark_buffers(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],
@@ -96,7 +96,7 @@ fn benchmark_buffers(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut config = config::Config::empty();
-                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                     config.add_sink(
                         "out",
                         &["in"],

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -22,7 +22,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
         b.iter_with_setup(
             || {
                 let mut config = config::Config::empty();
-                config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                 config.add_sink(
                     "out",
                     &["in"],
@@ -70,7 +70,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
         b.iter_with_setup(
             || {
                 let mut config = config::Config::empty();
-                config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+                config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
                 config.add_sink(
                     "out",
                     &["in"],

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -414,13 +414,15 @@ data_dir = "/var/lib/vector"
   mode = "udp"
   mode = "unix"
 
-  # The TCP or UDP address to listen on.
+  # The TCP or UDP address to listen for connections on, or "systemd#N" to use
+  # the Nth socket passed by systemd socket activation.
   # 
   # * optional
   # * no default
   # * type: string
   # * relevant when mode = "tcp" or mode = "udp"
   address = "0.0.0.0:9000"
+  address = "systemd#2"
 
   # The maximum bytes size of incoming messages before they are discarded.
   # 
@@ -463,11 +465,14 @@ data_dir = "/var/lib/vector"
   # * must be: "tcp"
   type = "tcp"
 
-  # The address to bind the socket to.
+  # The address to listen for connections on, or "systemd#N" to use the Nth
+  # socket passed by systemd socket activation.
   # 
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd"
+  address = "systemd#3"
 
   # The maximum bytes size of incoming messages before they are discarded.
   # 
@@ -545,11 +550,13 @@ data_dir = "/var/lib/vector"
   # * must be: "vector"
   type = "vector"
 
-  # The TCP address to bind to.
+  # The TCP address to listen for connections on, or "systemd#N" to use the Nth
+  # socket passed by systemd socket activation.
   # 
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd#1"
 
   # The timeout before a connection is forcefully closed during shutdown.
   # 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -422,6 +422,7 @@ data_dir = "/var/lib/vector"
   # * type: string
   # * relevant when mode = "tcp" or mode = "udp"
   address = "0.0.0.0:9000"
+  address = "systemd"
   address = "systemd#2"
 
   # The maximum bytes size of incoming messages before they are discarded.
@@ -556,6 +557,7 @@ data_dir = "/var/lib/vector"
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd"
   address = "systemd#1"
 
   # The timeout before a connection is forcefully closed during shutdown.

--- a/docs/about/data-model/log.md
+++ b/docs/about/data-model/log.md
@@ -258,6 +258,7 @@ remove, or rename fields as desired.
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
+
 [assets.data-model-log]: ../../assets/data-model-log.svg
 [docs.configuration]: ../../usage/configuration
 [docs.data-model]: ../../about/data-model

--- a/docs/usage/configuration/sources/syslog.md
+++ b/docs/usage/configuration/sources/syslog.md
@@ -51,7 +51,7 @@ The `syslog` source ingests data through the Syslog 5424 protocol and outputs [`
 
 `optional` `no default` `type: string` `example: "0.0.0.0:9000"`
 
-The TCP or UDP address to listen on. Only relevant when mode = "tcp" or mode = "udp".
+The TCP or UDP address to listen for connections on, or "systemd#N" to use the Nth socket passed by systemd socket activation. Only relevant when mode = "tcp" or mode = "udp".
 
 ### host_key
 

--- a/docs/usage/configuration/sources/tcp.md
+++ b/docs/usage/configuration/sources/tcp.md
@@ -50,7 +50,7 @@ The `tcp` source ingests data through the TCP protocol and outputs [`log`][docs.
 
 `required` `type: string` `example: "0.0.0.0:9000"`
 
-The address to bind the socket to.
+The address to listen for connections on, or "systemd#N" to use the Nth socket passed by systemd socket activation.
 
 ### host_key
 

--- a/docs/usage/configuration/sources/vector.md
+++ b/docs/usage/configuration/sources/vector.md
@@ -53,7 +53,7 @@ The `vector` source ingests data through another upstream Vector instance and ou
 
 `required` `type: string` `example: "0.0.0.0:9000"`
 
-The TCP address to bind to.
+The TCP address to listen for connections on, or "systemd#N" to use the Nth socket passed by systemd socket activation.
 
 ### shutdown_timeout_secs
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -434,13 +434,15 @@ data_dir = "/var/lib/vector"
   mode = "udp"
   mode = "unix"
 
-  # The TCP or UDP address to listen on.
+  # The TCP or UDP address to listen for connections on, or "systemd#N" to use
+  # the Nth socket passed by systemd socket activation.
   # 
   # * optional
   # * no default
   # * type: string
   # * relevant when mode = "tcp" or mode = "udp"
   address = "0.0.0.0:9000"
+  address = "systemd#2"
 
   # The maximum bytes size of incoming messages before they are discarded.
   # 
@@ -483,11 +485,14 @@ data_dir = "/var/lib/vector"
   # * must be: "tcp"
   type = "tcp"
 
-  # The address to bind the socket to.
+  # The address to listen for connections on, or "systemd#N" to use the Nth
+  # socket passed by systemd socket activation.
   # 
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd"
+  address = "systemd#3"
 
   # The maximum bytes size of incoming messages before they are discarded.
   # 
@@ -565,11 +570,13 @@ data_dir = "/var/lib/vector"
   # * must be: "vector"
   type = "vector"
 
-  # The TCP address to bind to.
+  # The TCP address to listen for connections on, or "systemd#N" to use the Nth
+  # socket passed by systemd socket activation.
   # 
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd#1"
 
   # The timeout before a connection is forcefully closed during shutdown.
   # 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -442,6 +442,7 @@ data_dir = "/var/lib/vector"
   # * type: string
   # * relevant when mode = "tcp" or mode = "udp"
   address = "0.0.0.0:9000"
+  address = "systemd"
   address = "systemd#2"
 
   # The maximum bytes size of incoming messages before they are discarded.
@@ -576,6 +577,7 @@ data_dir = "/var/lib/vector"
   # * required
   # * type: string
   address = "0.0.0.0:9000"
+  address = "systemd"
   address = "systemd#1"
 
   # The timeout before a connection is forcefully closed during shutdown.

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1,4 +1,4 @@
-use super::util::TcpSource;
+use super::util::{SocketListenAddr, TcpSource};
 use crate::{
     event::{self, Event},
     topology::config::{DataType, GlobalOptions, SourceConfig},
@@ -33,7 +33,7 @@ pub struct SyslogConfig {
 #[derive(Deserialize, Serialize, Debug, Clone, is_enum_variant)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum Mode {
-    Tcp { address: SocketAddr },
+    Tcp { address: SocketListenAddr },
     Udp { address: SocketAddr },
     Unix { path: PathBuf },
 }

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -1,4 +1,4 @@
-use super::util::TcpSource;
+use super::util::{SocketListenAddr, TcpSource};
 use crate::{
     event::{self, Event},
     topology::config::{DataType, GlobalOptions, SourceConfig},
@@ -7,14 +7,13 @@ use bytes::Bytes;
 use codec::{self, BytesDelimitedCodec};
 use futures::sync::mpsc;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 use string_cache::DefaultAtom as Atom;
 use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TcpConfig {
-    pub address: SocketAddr,
+    pub address: SocketListenAddr,
     #[serde(default = "default_max_length")]
     pub max_length: usize,
     #[serde(default = "default_shutdown_timeout_secs")]
@@ -31,7 +30,7 @@ fn default_shutdown_timeout_secs() -> u64 {
 }
 
 impl TcpConfig {
-    pub fn new(address: SocketAddr) -> Self {
+    pub fn new(address: SocketListenAddr) -> Self {
         Self {
             address,
             max_length: default_max_length(),
@@ -110,7 +109,7 @@ mod test {
 
         let addr = next_addr();
 
-        let server = TcpConfig::new(addr)
+        let server = TcpConfig::new(addr.into())
             .build("default", &GlobalOptions::default(), tx)
             .unwrap();
         let mut rt = tokio::runtime::Runtime::new().unwrap();
@@ -151,7 +150,7 @@ mod test {
 
         let addr = next_addr();
 
-        let mut config = TcpConfig::new(addr);
+        let mut config = TcpConfig::new(addr.into());
         config.max_length = 10;
 
         let server = config

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,3 +1,3 @@
 mod tcp;
 
-pub use tcp::TcpSource;
+pub use tcp::{SocketListenAddr, TcpSource};

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -2,8 +2,9 @@ use crate::Event;
 use bytes::Bytes;
 use futures::{future, sync::mpsc, Future, Sink, Stream};
 use listenfd::ListenFd;
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{
-    io,
+    fmt, io,
     net::SocketAddr,
     time::{Duration, Instant},
 };
@@ -30,7 +31,7 @@ pub trait TcpSource: Clone + Send + 'static {
 
     fn run(
         self,
-        addr: SocketAddr,
+        addr: SocketListenAddr,
         shutdown_timeout_secs: u64,
         out: mpsc::Sender<Event>,
     ) -> crate::Result<crate::sources::Source> {
@@ -39,13 +40,19 @@ pub trait TcpSource: Clone + Send + 'static {
         let mut listenfd = ListenFd::from_env();
 
         let source = future::lazy(move || {
-            let listener = match listenfd.take_tcp_listener(0) {
-                Ok(Some(listener)) => TcpListener::from_std(listener, &Handle::default()),
-                Ok(None) => TcpListener::bind(&addr),
-                Err(err) => {
-                    error!("Failed to take listen FD: {}", err);
-                    return future::Either::B(future::err(()));
-                }
+            let listener = match addr {
+                SocketListenAddr::SocketAddr(addr) => TcpListener::bind(&addr),
+                SocketListenAddr::SystemdFd(offset) => match listenfd.take_tcp_listener(offset) {
+                    Ok(Some(listener)) => TcpListener::from_std(listener, &Handle::default()),
+                    Ok(None) => {
+                        error!("Failed to take listen FD, not open or already taken");
+                        return future::Either::B(future::err(()));
+                    }
+                    Err(err) => {
+                        error!("Failed to take listen FD: {}", err);
+                        return future::Either::B(future::err(()));
+                    }
+                },
             };
             let listener = match listener {
                 Ok(listener) => listener,
@@ -57,7 +64,12 @@ pub trait TcpSource: Clone + Send + 'static {
 
             info!(
                 message = "listening.",
-                addr = field::display(listener.local_addr().unwrap_or(addr))
+                addr = field::display(
+                    listener
+                        .local_addr()
+                        .map(|addr| SocketListenAddr::SocketAddr(addr))
+                        .unwrap_or(addr)
+                )
             );
 
             let (trigger, tripwire) = Tripwire::new();
@@ -123,5 +135,70 @@ pub trait TcpSource: Clone + Send + 'static {
         });
 
         Ok(Box::new(source))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum SocketListenAddr {
+    SocketAddr(SocketAddr),
+    #[serde(deserialize_with = "parse_systemd_fd")]
+    SystemdFd(usize),
+}
+
+impl fmt::Display for SocketListenAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::SocketAddr(ref addr) => addr.fmt(f),
+            Self::SystemdFd(offset) => write!(f, "systemd socket #{}", offset),
+        }
+    }
+}
+
+impl From<SocketAddr> for SocketListenAddr {
+    fn from(addr: SocketAddr) -> Self {
+        Self::SocketAddr(addr)
+    }
+}
+
+fn parse_systemd_fd<'de, D>(des: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &'de str = Deserialize::deserialize(des)?;
+    match s {
+        "systemd" => Ok(0),
+        s if s.starts_with("systemd#") => {
+            Ok(s[8..].parse::<usize>().map_err(de::Error::custom)? - 1)
+        }
+        _ => Err(de::Error::custom("must start with \"systemd\"")),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::Deserialize;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    #[derive(Debug, Deserialize)]
+    struct Config {
+        addr: SocketListenAddr,
+    }
+
+    #[test]
+    fn parse_socket_listen_addr() {
+        let test: Config = toml::from_str(r#"addr="127.1.2.3:1234""#).unwrap();
+        assert_eq!(
+            test.addr,
+            SocketListenAddr::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(127, 1, 2, 3),
+                1234
+            )))
+        );
+        let test: Config = toml::from_str(r#"addr="systemd""#).unwrap();
+        assert_eq!(test.addr, SocketListenAddr::SystemdFd(0));
+        let test: Config = toml::from_str(r#"addr="systemd#3""#).unwrap();
+        assert_eq!(test.addr, SocketListenAddr::SystemdFd(2));
     }
 }

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -1,4 +1,4 @@
-use super::util::TcpSource;
+use super::util::{SocketListenAddr, TcpSource};
 use crate::{
     event::proto,
     topology::config::{DataType, GlobalOptions, SourceConfig},
@@ -8,14 +8,13 @@ use bytes::{Bytes, BytesMut};
 use futures::sync::mpsc;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 use tokio::codec::LengthDelimitedCodec;
 use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfig {
-    pub address: SocketAddr,
+    pub address: SocketListenAddr,
     #[serde(default = "default_shutdown_timeout_secs")]
     pub shutdown_timeout_secs: u64,
 }
@@ -25,7 +24,7 @@ fn default_shutdown_timeout_secs() -> u64 {
 }
 
 impl VectorConfig {
-    pub fn new(address: SocketAddr) -> Self {
+    pub fn new(address: SocketListenAddr) -> Self {
         Self {
             address,
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
@@ -94,7 +93,7 @@ mod test {
         let (tx, rx) = mpsc::channel(100);
 
         let addr = next_addr();
-        let server = VectorConfig::new(addr.clone())
+        let server = VectorConfig::new(addr.into())
             .build("default", &GlobalOptions::default(), tx)
             .unwrap();
         let mut rt = tokio::runtime::Runtime::new().unwrap();

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -536,7 +536,7 @@ mod tests {
         use std::path::Path;
 
         let mut old_config = Config::empty();
-        old_config.add_source("in", TcpConfig::new(next_addr()));
+        old_config.add_source("in", TcpConfig::new(next_addr().into()));
         old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());
         let mut new_config = old_config.clone();
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -20,7 +20,7 @@ fn test_buffering() {
 
     // Run vector while sink server is not running, and then shut it down abruptly
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -48,7 +48,7 @@ fn test_buffering() {
 
     // Start sink server, then run vector again. It should send all of the lines from the first run.
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -111,7 +111,7 @@ fn test_max_size() {
 
     // Run vector while sink server is not running, and then shut it down abruptly
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -138,7 +138,7 @@ fn test_max_size() {
 
     // Start sink server, then run vector again. It should send the lines from the first run that fit in the limited space
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -181,8 +181,8 @@ fn test_max_size_resume() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1));
-    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2));
+    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1.into()));
+    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2.into()));
     config.add_sink(
         "out",
         &["in1", "in2"],
@@ -235,7 +235,7 @@ fn test_reclaim_disk_space() {
 
     // Run vector while sink server is not running, and then shut it down abruptly
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -272,7 +272,7 @@ fn test_reclaim_disk_space() {
 
     // Start sink server, then run vector again. It should send all of the lines from the first run.
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -54,7 +54,7 @@ fn test_sink_panic() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -126,7 +126,7 @@ fn test_sink_error() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -183,7 +183,7 @@ fn test_source_error() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_source("error", ErrorSourceConfig);
     config.add_sink(
         "out",
@@ -242,7 +242,7 @@ fn test_source_panic() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_source("panic", PanicSourceConfig);
     config.add_sink(
         "out",

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -24,7 +24,12 @@ fn test_tcp_syslog() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", SyslogConfig::new(Mode::Tcp { address: in_addr }));
+    config.add_source(
+        "in",
+        SyslogConfig::new(Mode::Tcp {
+            address: in_addr.into(),
+        }),
+    );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -17,7 +17,7 @@ fn pipe() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],
@@ -53,7 +53,7 @@ fn sample() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_transform(
         "sampler",
         &["in"],
@@ -110,8 +110,8 @@ fn merge() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1));
-    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2));
+    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1.into()));
+    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2.into()));
     config.add_sink(
         "out",
         &["in1", "in2"],
@@ -168,7 +168,7 @@ fn fork() {
     let out_addr2 = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out1",
         &["in"],
@@ -217,8 +217,8 @@ fn merge_and_fork() {
     // out1 receives both in1 and in2
     // out2 receives in2 only
     let mut config = config::Config::empty();
-    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1));
-    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2));
+    config.add_source("in1", sources::tcp::TcpConfig::new(in_addr1.into()));
+    config.add_source("in2", sources::tcp::TcpConfig::new(in_addr2.into()));
     config.add_sink(
         "out1",
         &["in1", "in2"],
@@ -283,7 +283,7 @@ fn reconnect() {
     let out_addr = next_addr();
 
     let mut config = config::Config::empty();
-    config.add_source("in", sources::tcp::TcpConfig::new(in_addr));
+    config.add_source("in", sources::tcp::TcpConfig::new(in_addr.into()));
     config.add_sink(
         "out",
         &["in"],


### PR DESCRIPTION
This adds support for systemd socket activation to all the sources that use the `TcpSource` framework. That is, the syslog, tcp, and vector sources. It adds support for a new address type that indicates the socket is being passed in by systemd (or equivalent).

Closes #950 

I am not particularly comfortable with the `systemd#N` address syntax, but it was the best compromise I could think up. It is possible to autodetect when socket activation is in play, but since both Vector and systemd support multiple sockets, this creates an ambiguity with the order in which the sockets are used. I welcome alternate suggestions how to make it work better.

I have tested this on the command line using [systemfd](https://github.com/mitsuhiko/systemfd), but no automated tests are present other than address parsing.