### PR TITLE
fix(http sink)!: Unflatten basic_auth options

### DIFF
--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -42,7 +42,6 @@ pub struct HttpSinkConfig {
     pub uri: String,
     pub method: Option<HttpMethod>,
     pub healthcheck_uri: Option<String>,
-    #[serde(flatten)]
     pub basic_auth: Option<BasicAuth>,
     pub headers: Option<IndexMap<String, String>>,
     pub batch_size: Option<usize>,


### PR DESCRIPTION
This unflattens the `http` sink basic auth `username` and `password` options to be consistent with the `elasticsearch` and `clickhouse` sink. In general, we're moving towards nesting similar options anyway and I find this syntax to be clearer anyway.

Closes https://github.com/timberio/vector/issues/1040.