### PR TITLE
chore(operations): Bump version in Cargo.toml before releasing

### DIFF
--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -62,7 +62,7 @@ else
 
   bump_cargo_version(release.version)
 
-  success("Bumped the version in Cargo.toml to #{release.version}")
+  success("Bumped the version in Cargo.toml & Cargo.lock to #{release.version}")
   
   branch_name = "#{release.version.major}.#{release.version.minor}"
 

--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -13,15 +13,22 @@ require_relative "setup"
 #
 
 def bump_cargo_version(version)
-  cargo_content = File.read("#{ROOT_DIR}/Cargo.toml")
+  # Cargo.toml
+  content = File.read("#{ROOT_DIR}/Cargo.toml")
+  new_content = bump_version(content, version)
+  File.write("#{ROOT_DIR}/Cargo.toml", new_content)
 
-  new_cargo_content =
-    cargo_content.sub(
-      /name = "vector"\nversion = "([a-z0-9.-]*)"\n/,
-      "name = \"vector\"\nversion = \"#{version}\"\n"
-    )
+  # Cargo.lock
+  content = File.read("#{ROOT_DIR}/Cargo.lock")
+  new_content = bump_version(content, version)
+  File.write("#{ROOT_DIR}/Cargo.lock", new_content)
+end
 
-  File.write("#{ROOT_DIR}/Cargo.toml", new_cargo_content)
+def bump_version(content, version)
+  content.sub(
+    /name = "vector"\nversion = "([a-z0-9.-]*)"\n/,
+    "name = \"vector\"\nversion = \"#{version}\"\n"
+  )
 end
 
 def release_exists?(release)

--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -12,6 +12,18 @@ require_relative "setup"
 # Functions
 #
 
+def bump_cargo_version(version)
+  cargo_content = File.read("#{ROOT_DIR}/Cargo.toml")
+
+  new_cargo_content =
+    cargo_content.sub(
+      /name = "vector"\nversion = "([a-z0-9.-]*)"\n/,
+      "name = \"vector\"\nversion = \"#{version}\"\n"
+    )
+
+  File.write("#{ROOT_DIR}/Cargo.toml", new_cargo_content)
+end
+
 def release_exists?(release)
   errors = `git rev-parse v#{release.version} 2>&1 >/dev/null`
   errors == ""
@@ -40,6 +52,10 @@ if release_exists?(release)
   )
 else
   title("Committing and tagging release")
+
+  bump_cargo_version(release.version)
+
+  success("Bumped the version in Cargo.toml to #{release.version}")
   
   branch_name = "#{release.version.major}.#{release.version.minor}"
 


### PR DESCRIPTION
This bumps the Vector version in the `Cargo.toml` file during the release process. This ensures that the version included in the resulting binary matches.

Closes https://github.com/timberio/vector/issues/1010
Closes https://github.com/timberio/vector/issues/1021