### PR TITLE
feat(new sink): Initial `aws_kinesis_firehose` sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Vector follows the [conventional commits specification][urls.conventional_commit
 * *[`kafka` sink][docs.sinks.kafka]*: Add support for tls (ssl) ([#912][urls.pr_912])
 * *[`kafka` sink][docs.sinks.kafka]*: Use pkcs#12 keys instead of jks ([#934][urls.pr_934])
 * *new sink*: Initial `statsd` implementation ([#821][urls.pr_821])
+* *new sink*: New `aws_kinesis_firehose` sink
 * *new source*: Initial [`docker` source][docs.sources.docker] implementation ([#787][urls.pr_787])
 * *[observability][docs.monitoring]*: Add rate limited debug messages ([#971][urls.pr_971])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_firehose"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusoto_kinesis"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +3963,7 @@ dependencies = [
  "rusoto_cloudwatch 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_firehose 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_kinesis 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_logs 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4410,6 +4423,7 @@ dependencies = [
 "checksum rusoto_cloudwatch 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df33c962e9624149eb51a10c0737964b6a62eb160434c7c3bcc07be1bd677080"
 "checksum rusoto_core 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b03958c1f00c85d038f7c3532f33381cf3cda93e88ad745cc5dcdb3d9675bb6"
 "checksum rusoto_credential 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00d75d9360c522cc29d80eaa5ecdd8fa56d811578118d6cf8ec083c035343baa"
+"checksum rusoto_firehose 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdecb16b661e919eb8e9467d6ae68a22e8c9a5bbe4d02189b2011043d9d1b7b"
 "checksum rusoto_kinesis 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "230b3b8eda2d8f5b82c14d7f1e9e40fb7a496b847f95cdb6ebf0dfdce4efa143"
 "checksum rusoto_logs 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1df7f6acf01ffcfd8ecde1fdd4a568d179e7ef5d42b398679e2af54e08cbed3b"
 "checksum rusoto_s3 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "deec58d788a92ea7a5711815dba59e80e4f58b870707f3892e6904c0f9f07023"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rusoto_s3 = "0.37.0"
 rusoto_logs = "0.37.0"
 rusoto_cloudwatch = "0.37.0"
 rusoto_kinesis = "0.37.0"
+rusoto_firehose = "0.37.0"
 rusoto_credential = "0.16.0"
 
 # Tower

--- a/config/examples/sinks/aws_kinesis_firehose.toml
+++ b/config/examples/sinks/aws_kinesis_firehose.toml
@@ -1,0 +1,34 @@
+# `aws_kinesis_streams` Sink Example
+# ------------------------------------------------------------------------------
+# A simple example demonstrating the `aws_kinesis_streams` sink
+# Docs: https://docs.vector.dev/usage/configuration/sinks/aws_kinesis_streams
+
+[sinks.my_aws_kinesis_firehose_sink]
+  # REQUIRED - General
+  type = "aws_kinesis_firehose" # must be: aws_kinesis_streams
+  inputs = ["my-source-id"]
+  region = "us-east-1"
+  delivery_stream_name = "my-stream"
+
+  # OPTIONAL - General
+  encoding = "json" # no default, enum: json, text
+
+  # OPTIONAL - Batching
+  batch_size = 1049000 # default, bytes
+  batch_timeout = 1 # default, seconds
+
+  # OPTIONAL - Requests
+  [sinks.my_aws_kinesis_firehose_sink.request]
+    rate_limit_duration_secs = 1 # default, seconds
+    rate_limit_num = 5 # default
+    in_flight_limit = 5 # default
+    timeout_secs = 30 # default, seconds
+    retry_attempts = 5 # default
+    retry_backoff_secs = 5 # default, seconds
+
+  # OPTIONAL - Buffer
+  [sinks.my_aws_kinesis_firehose_sink.buffer]
+    type = "memory" # default, enum: memory, disk
+    when_full = "block" # default, enum: block, drop_newest
+    max_size = 104900000 # no default
+    num_items = 500 # default

--- a/config/examples/sinks/aws_kinesis_streams.toml
+++ b/config/examples/sinks/aws_kinesis_streams.toml
@@ -1,0 +1,34 @@
+# `aws_kinesis_streams` Sink Example
+# ------------------------------------------------------------------------------
+# A simple example demonstrating the `aws_kinesis_streams` sink
+# Docs: https://docs.vector.dev/usage/configuration/sinks/aws_kinesis_streams
+
+[sinks.my_aws_kinesis_streams_sink]
+  # REQUIRED - General
+  type = "aws_kinesis_streams" # must be: aws_kinesis_streams
+  inputs = ["my-source-id"]
+  region = "us-east-1"
+  stream_name = "my-stream"
+
+  # OPTIONAL - General
+  encoding = "json" # no default, enum: json, text
+
+  # OPTIONAL - Batching
+  batch_size = 1049000 # default, bytes
+  batch_timeout = 1 # default, seconds
+
+  # OPTIONAL - Requests
+  [sinks.my_aws_kinesis_streams_sink.request]
+    rate_limit_duration_secs = 1 # default, seconds
+    rate_limit_num = 5 # default
+    in_flight_limit = 5 # default
+    timeout_secs = 30 # default, seconds
+    retry_attempts = 5 # default
+    retry_backoff_secs = 5 # default, seconds
+
+  # OPTIONAL - Buffer
+  [sinks.my_aws_kinesis_streams_sink.buffer]
+    type = "memory" # default, enum: memory, disk
+    when_full = "block" # default, enum: block, drop_newest
+    max_size = 104900000 # no default
+    num_items = 500 # default

--- a/scripts/check-generate.sh
+++ b/scripts/check-generate.sh
@@ -29,7 +29,7 @@ if [[ -n "$changes" ]]; then
   echo ''
   echo 'This usually means that auto-generated sections were updated. '
   echo 'Instead, you should update the files in the /.meta dir and then run '
-  ecgo '`make generate`. See the ./DOCUMENTING.md guide for more info.'
+  echo '`make generate`. See the ./DOCUMENTING.md guide for more info.'
   exit 1
 else
   echo 'Nice! No generation changes detected.'

--- a/src/sinks/aws_kinesis/data_firehose.rs
+++ b/src/sinks/aws_kinesis/data_firehose.rs
@@ -1,0 +1,187 @@
+use crate::{
+    buffers::Acker,
+    event::Event,
+    region::RegionOrEndpoint,
+    sinks::{
+        util::retries::{FixedRetryPolicy, RetryLogic},
+        Healthcheck, RouterSink,
+    },
+    topology::config::{DataType, SinkConfig},
+};
+use futures::{Future, Poll, Sink};
+use rusoto_core::RusotoFuture;
+use rusoto_firehose::{
+    DescribeDeliveryStreamError::{self, ResourceNotFound},
+    DescribeDeliveryStreamInput, KinesisFirehose, KinesisFirehoseClient, PutRecordBatchError,
+    PutRecordBatchInput, PutRecordBatchOutput, Record,
+};
+use serde::{Deserialize, Serialize};
+use std::{convert::TryInto, fmt, sync::Arc, time::Duration};
+use tower::Service;
+use tracing_futures::{Instrument, Instrumented};
+
+use super::{CoreSinkConfig, Encoding, TowerRequestConfig};
+
+#[derive(Clone)]
+pub struct FirehoseService {
+    delivery_stream_name: String,
+    client: Arc<KinesisFirehoseClient>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FirehoseConfig {
+    pub delivery_stream_name: String,
+    #[serde(flatten)]
+    pub region: RegionOrEndpoint,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub struct FirehoseSinkConfig {
+    #[serde(default, flatten)]
+    pub core_config: CoreSinkConfig,
+    #[serde(flatten)]
+    pub firehose_config: FirehoseConfig,
+    #[serde(default, rename = "request")]
+    pub request_config: TowerRequestConfig,
+}
+
+#[typetag::serde(name = "aws_kinesis_firehose")]
+impl SinkConfig for FirehoseSinkConfig {
+    fn build(&self, acker: Acker) -> crate::Result<(RouterSink, Healthcheck)> {
+        let config = self.clone();
+        let sink = FirehoseService::new(config, acker)?;
+        let healthcheck = healthcheck(self.firehose_config.clone())?;
+        Ok((Box::new(sink), healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+}
+
+impl FirehoseService {
+    pub fn new(
+        config: FirehoseSinkConfig,
+        acker: Acker,
+    ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
+        let firehose_config = config.firehose_config;
+        let request_config = config.request_config;
+        let core_config = config.core_config;
+
+        let client = Arc::new(KinesisFirehoseClient::new(
+            firehose_config.region.clone().try_into()?,
+        ));
+
+        let policy = FixedRetryPolicy::new(
+            request_config.retry_attempts,
+            Duration::from_secs(request_config.retry_backoff_secs),
+            FirehoseRetryLogic,
+        );
+
+        let firehose = FirehoseService {
+            delivery_stream_name: firehose_config.delivery_stream_name,
+            client,
+        };
+
+        super::construct(
+            core_config,
+            request_config,
+            firehose,
+            acker,
+            policy,
+            encode_event,
+        )
+    }
+}
+
+fn encode_event(event: Event, encoding: &Encoding) -> Option<Record> {
+    let data = super::encode_event(event, encoding);
+    Some(Record { data })
+}
+
+impl Service<Vec<Record>> for FirehoseService {
+    type Response = PutRecordBatchOutput;
+    type Error = PutRecordBatchError;
+    type Future = Instrumented<RusotoFuture<PutRecordBatchOutput, PutRecordBatchError>>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, records: Vec<Record>) -> Self::Future {
+        debug!(
+            message = "sending records.",
+            events = %records.len(),
+        );
+
+        let request = PutRecordBatchInput {
+            records,
+            delivery_stream_name: self.delivery_stream_name.clone(),
+        };
+
+        self.client
+            .put_record_batch(request)
+            .instrument(info_span!("request"))
+    }
+}
+
+impl fmt::Debug for FirehoseService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FirehoseService")
+            .field("delivery_stream_name", &self.delivery_stream_name)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FirehoseRetryLogic;
+
+impl RetryLogic for FirehoseRetryLogic {
+    type Error = PutRecordBatchError;
+    type Response = PutRecordBatchOutput;
+
+    fn is_retriable_error(&self, error: &Self::Error) -> bool {
+        match error {
+            PutRecordBatchError::HttpDispatch(_) => true,
+            PutRecordBatchError::ServiceUnavailable(_) => true,
+            PutRecordBatchError::Unknown(res) if res.status.is_server_error() => true,
+            _ => false,
+        }
+    }
+}
+
+type HealthcheckError = super::HealthcheckError<DescribeDeliveryStreamError>;
+
+fn healthcheck(config: FirehoseConfig) -> crate::Result<crate::sinks::Healthcheck> {
+    let client = KinesisFirehoseClient::new(config.region.try_into()?);
+    let stream_name = config.delivery_stream_name;
+
+    let fut = client
+        .describe_delivery_stream(DescribeDeliveryStreamInput {
+            delivery_stream_name: stream_name,
+            exclusive_start_destination_id: None,
+            limit: Some(0),
+        })
+        .map_err(|source| match source {
+            ResourceNotFound(resource) => HealthcheckError::NoMatchingStreamName {
+                stream_name: resource,
+            }
+            .into(),
+            other => HealthcheckError::StreamRetrievalFailed { source: other }.into(),
+        })
+        .and_then(move |res| {
+            let description = res.delivery_stream_description;
+            let status = &description.delivery_stream_status[..];
+
+            match status {
+                "CREATING" | "DELETING" => Err(HealthcheckError::StreamIsNotReady {
+                    stream_name: description.delivery_stream_name,
+                }
+                .into()),
+                _ => Ok(()),
+            }
+        });
+
+    Ok(Box::new(fut))
+}

--- a/src/sinks/aws_kinesis/mod.rs
+++ b/src/sinks/aws_kinesis/mod.rs
@@ -1,0 +1,168 @@
+pub mod data_firehose;
+pub mod data_streams;
+
+use crate::{
+    buffers::Acker,
+    event::{self, Event},
+    sinks::util::{
+        retries::{FixedRetryPolicy, RetryLogic},
+        BatchServiceSink, SinkExt,
+    },
+};
+use futures::{stream::iter_ok, Sink};
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use std::error::Error;
+use std::time::Duration;
+use tower::{Service, ServiceBuilder};
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
+#[serde(rename_all = "snake_case")]
+#[derivative(Default)]
+pub enum Encoding {
+    #[derivative(Default)]
+    Text,
+    Json,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CoreSinkConfig {
+    pub encoding: Encoding,
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    #[serde(default = "default_batch_timeout")]
+    pub batch_timeout: u64,
+}
+
+impl Default for CoreSinkConfig {
+    fn default() -> Self {
+        CoreSinkConfig {
+            encoding: Encoding::Text,
+            batch_size: default_batch_size(),
+            batch_timeout: default_batch_timeout(),
+        }
+    }
+}
+
+pub fn default_batch_size() -> usize {
+    bytesize::mib(1u64) as usize
+}
+pub fn default_batch_timeout() -> u64 {
+    1
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TowerRequestConfig {
+    #[serde(default = "default_in_flight_limit")]
+    pub in_flight_limit: usize,
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+    #[serde(default = "default_rate_limit_duration_secs")]
+    pub rate_limit_duration_secs: u64,
+    #[serde(default = "default_rate_limit_num")]
+    pub rate_limit_num: u64,
+    #[serde(default = "default_retry_backoff_secs")]
+    pub retry_backoff_secs: u64,
+    #[serde(default = "default_retry_attempts")]
+    pub retry_attempts: usize,
+}
+
+impl Default for TowerRequestConfig {
+    fn default() -> Self {
+        TowerRequestConfig {
+            in_flight_limit: default_in_flight_limit(),
+            timeout_secs: default_timeout_secs(),
+            rate_limit_duration_secs: default_rate_limit_duration_secs(),
+            rate_limit_num: default_rate_limit_num(),
+            retry_backoff_secs: default_retry_backoff_secs(),
+            retry_attempts: default_retry_attempts(),
+        }
+    }
+}
+
+pub fn default_in_flight_limit() -> usize {
+    5
+}
+pub fn default_timeout_secs() -> u64 {
+    30
+}
+pub fn default_rate_limit_duration_secs() -> u64 {
+    1
+}
+pub fn default_rate_limit_num() -> u64 {
+    5
+}
+pub fn default_retry_backoff_secs() -> u64 {
+    5
+}
+pub fn default_retry_attempts() -> usize {
+    usize::max_value()
+}
+
+#[derive(Debug, Snafu)]
+pub enum HealthcheckError<E: Error>
+where
+    E: 'static,
+{
+    #[snafu(display("Retrieval of stream description failed: {}", source))]
+    StreamRetrievalFailed { source: E },
+    #[snafu(display("The stream {} is not found", stream_name))]
+    NoMatchingStreamName { stream_name: String },
+    #[snafu(display("The stream {} is not ready to receive input", stream_name))]
+    StreamIsNotReady { stream_name: String },
+}
+
+fn construct<L, T, S, F>(
+    core_config: CoreSinkConfig,
+    request_config: TowerRequestConfig,
+    service: S,
+    acker: Acker,
+    policy: FixedRetryPolicy<L>,
+    encode_event: F,
+) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>>
+where
+    T: Clone,
+    L: RetryLogic<Response = S::Response>,
+    F: Fn(Event, &Encoding) -> Option<T>,
+    S: Service<Vec<T>> + Clone + Sync,
+    S::Error: 'static + std::error::Error + Send + Sync,
+    S::Response: std::fmt::Debug,
+{
+    let service = ServiceBuilder::new()
+        .concurrency_limit(request_config.in_flight_limit)
+        .rate_limit(
+            request_config.rate_limit_num,
+            Duration::from_secs(request_config.rate_limit_duration_secs),
+        )
+        .retry(policy)
+        .timeout(Duration::from_secs(request_config.timeout_secs))
+        .service(service);
+
+    let encoding = core_config.encoding.clone();
+    let sink = BatchServiceSink::new(service, acker)
+        .batched_with_min(
+            Vec::new(),
+            core_config.batch_size,
+            Duration::from_secs(core_config.batch_timeout),
+        )
+        .with_flat_map(move |e| iter_ok(encode_event(e, &encoding)));
+
+    Ok(sink)
+}
+
+fn encode_event(event: Event, encoding: &Encoding) -> Vec<u8> {
+    let log = event.into_log();
+
+    match encoding {
+        Encoding::Json => {
+            serde_json::to_vec(&log.unflatten()).expect("Error encoding event as json.")
+        }
+
+        Encoding::Text => log
+            .get(&event::MESSAGE)
+            .map(|v| v.as_bytes().to_vec())
+            .unwrap_or_default(),
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -3,7 +3,7 @@ use snafu::Snafu;
 
 pub mod aws_cloudwatch_logs;
 pub mod aws_cloudwatch_metrics;
-pub mod aws_kinesis_streams;
+pub mod aws_kinesis;
 pub mod aws_s3;
 pub mod blackhole;
 pub mod clickhouse;


### PR DESCRIPTION
The new sink for working with AWS Kinesis Firehose.

Esentially is very similar to AWS Kinesis Streams, so these two modules unified under `aws_kinesis` folder. Also they share now common configuration fields and service wrapper.

Closes #559 

