### PR TITLE
feat(cli): Add validate sub command

### DIFF
--- a/docs/usage/administration/validating.md
+++ b/docs/usage/administration/validating.md
@@ -4,7 +4,50 @@ description: Validate Vector's configuration
 
 # Validating
 
-Vector provides a `--dry-run` option to validate configuration only:
+Vector provides a subcommand `validate` which checks the validity of a
+configuration file and then exits:
+
+{% code-tabs %}
+{% code-tabs-item title="fields only" %}
+```bash
+vector validate --config /etc/vector/vector.toml
+```
+{% endcode-tabs-item %}
+{% code-tabs-item title="fields + topology" %}
+```bash
+vector validate --config /etc/vector/vector.toml --topology
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+The validate subcommand checks the correctness of fields for components defined
+within a configuration file, including:
+
+1. All [sources][docs.sources], [transforms][docs.transforms], and
+[sinks][docs.sinks] include all non-optional fields.
+2. All fields are of the proper [type][docs.configuration#value-types].
+
+If validation fails, Vector will exit with a `78`, and if validation succeeds
+Vector will exit with a `0`.
+
+These checks can be expanded with flags such as `--topology`, which causes
+`validate` to also verify that the configuration file contains a valid topology,
+expanding the above checks with the following:
+
+3. At least one [source][docs.sources] is defined.
+4. At least one [sink][docs.sinks] is defined.
+5. All `inputs` values contain at least one value (cannot be empty).
+6. All `inputs` values reference valid and upstream [source][docs.sources] or
+[transform][docs.transforms] components. See
+[composition][docs.configuration#composition] for more info.
+
+To see other customization options for the `validate` subcommand run
+`vector validate --help`.
+
+## Validating Environment
+
+Vector also provides a `--dry-run` option which prevents regular execution and
+instead validates a configuration file as well as the runtime environment:
 
 {% code-tabs %}
 {% code-tabs-item title="config only" %}
@@ -19,26 +62,18 @@ vector --config /etc/vector/vector.toml --dry-run --require-healthy
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-If validation fails, Vector will exit with a `78`, and if validation succeeds
-Vector will exit with a `0`.
+If a dry run fails, Vector will exit with a `78`, and if it succeeds Vector
+will exit with a `0`.
+
+A dry run expands upon the `validation` checks above with the following:
+
+7. All components are capable of running (data directories exist, are writable,
+etc).
 
 You'll notice in the second example above you can pass the `--require-healthy`
 flag to also run health checks for all defined sinks.
 
-This operation is useful to validate configuration changes before going live.
-
-## Checks
-
-For clarify, Vector validates the following:
-
-1. At least one [source][docs.sources] is defined.
-2. At least one [sink][docs.sinks] is defined.
-3. The all `inputs` values contain at least one value (cannot be empty).
-4. All `inputs` values reference valid and upstream [source][docs.sources] or [transform][docs.transforms] components. See [composition][docs.configuration#composition] for more info.
-5. All [sources][docs.sources], [tranforms][docs.transforms], and [sinks][docs.sinks] include required options.
-6. All options are of the proper [type][docs.configuration#value-types].
-7. All [sink][docs.sinks] health check if the `--require-healthy` option is supplied.
-
+8. All [sinks][docs.sinks] are able to connect to their targets.
 
 [docs.configuration#composition]: ../../usage/configuration#composition
 [docs.configuration#value-types]: ../../usage/configuration#value-types

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ struct Validate {
 
     /// Fail validation on warnings
     #[structopt(short, long)]
-    strict: bool,
+    deny_warnings: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -391,9 +391,9 @@ fn validate(opts: &Validate, root_opts: &RootOpts) {
             }
             Ok(warnings) => {
                 for warning in &warnings {
-                    error!("Topology warning: {}", warning);
+                    warn!("Topology warning: {}", warning);
                 }
-                if opts.strict && !warnings.is_empty() {
+                if opts.deny_warnings && !warnings.is_empty() {
                     std::process::exit(exitcode::CONFIG);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,12 +363,18 @@ fn open_config(path: &Path) -> Option<File> {
 }
 
 fn validate(opts: &Validate, root_opts: &RootOpts) -> exitcode::ExitCode {
-    if root_opts
-        .config_path
-        .to_str()
-        .map_or(false, |s| s != "/etc/vector/vector.toml")
-    {
-        error!("Config flag should appear after sub command.");
+    let (rconf, rconf_is_set) = root_opts.config_path.to_str().map_or(("", false), |s| {
+        let default_root_config = RootOpts::from_iter(vec![""]);
+        (
+            s,
+            s != default_root_config.config_path.to_str().unwrap_or(""),
+        )
+    });
+    if rconf_is_set {
+        error!(
+            "Config flag should appear after sub command: `vector validate -c {}`.",
+            rconf
+        );
         return exitcode::USAGE;
     }
 

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -14,7 +14,9 @@ mod vars;
 pub struct Config {
     #[serde(flatten)]
     pub global: GlobalOptions,
+    #[serde(default)]
     pub sources: IndexMap<String, Box<dyn SourceConfig>>,
+    #[serde(default)]
     pub sinks: IndexMap<String, SinkOuter>,
     #[serde(default)]
     pub transforms: IndexMap<String, TransformOuter>,
@@ -208,18 +210,7 @@ impl Config {
         }
         let with_vars = vars::interpolate(&source_string, &vars);
 
-        toml::from_str(&with_vars)
-            .map_err(|e| vec![e.to_string()])
-            .and_then(|config: Config| {
-                if config.sources.is_empty() {
-                    return Err(vec!["No sources defined in the config.".to_owned()]);
-                }
-                if config.sinks.is_empty() {
-                    return Err(vec!["No sinks defined in the config.".to_owned()]);
-                }
-
-                Ok(config)
-            })
+        toml::from_str(&with_vars).map_err(|e| vec![e.to_string()])
     }
 
     pub fn contains_cycle(&self) -> bool {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -526,7 +526,7 @@ fn handle_errors(
 
 #[cfg(test)]
 mod tests {
-    use crate::sinks::console::{ConsoleSinkConfig, Target};
+    use crate::sinks::console::{ConsoleSinkConfig, Encoding, Target};
     use crate::sources::tcp::TcpConfig;
     use crate::test_util::{next_addr, runtime};
     use crate::topology;
@@ -545,7 +545,7 @@ mod tests {
             &[&"in"],
             ConsoleSinkConfig {
                 target: Target::Stdout,
-                encoding: None,
+                encoding: Encoding::Text,
             },
         );
         old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -524,6 +524,7 @@ fn handle_errors(
 
 #[cfg(test)]
 mod tests {
+    use crate::sinks::console::{ConsoleSinkConfig, Target};
     use crate::sources::tcp::TcpConfig;
     use crate::test_util::{next_addr, runtime};
     use crate::topology;
@@ -537,6 +538,14 @@ mod tests {
 
         let mut old_config = Config::empty();
         old_config.add_source("in", TcpConfig::new(next_addr()));
+        old_config.add_sink(
+            "out",
+            &[&"in"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: None,
+            },
+        );
         old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());
         let mut new_config = old_config.clone();
 


### PR DESCRIPTION
Adds a sub command `validate` that performs linting of target configs.

The syntax for this subcommand is `vector -c ./foo.toml validate`, which is potentially a little confusing. Please refer to discussion within https://github.com/timberio/vector/issues/98.