### PR TITLE
docs: Add OpenSSL and pkg-config to development requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,13 @@ updated versions of Vector through various channels.
    curl https://sh.rustup.rs -sSf | sh
    ```
 
-2. [Install Docker](https://docs.docker.com/install/). Docker
+2. Install [OpenSSL 1.0.x](https://www.openssl.org/source/) and
+   [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/).
+
+3. [Install Docker](https://docs.docker.com/install/). Docker
    containers are used for mocking Vector's integrations.
 
-3. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
+4. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
    [Bundler 2](https://bundler.io/v2.0/guides/bundler_2_upgrade.html).
    They are used to build Vector's documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,12 @@ updated versions of Vector through various channels.
    curl https://sh.rustup.rs -sSf | sh
    ```
 
-2. Install [OpenSSL 1.0.x](https://www.openssl.org/source/) and
-   [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/).
+2. Install [OpenSSL 1.0.x](https://www.openssl.org/source/) and set two environment variables
+
+   ```
+   export OPENSSL_INCLUDE_DIR=<openssl prefix>/include
+   export OPENSSL_LIB_DIR=<openssl prefix>/lib
+   ```
 
 3. [Install Docker](https://docs.docker.com/install/). Docker
    containers are used for mocking Vector's integrations.


### PR DESCRIPTION
OpenSSL and pkg-config are required for successful build of Vector, so they are added to the requirements.