### PR TITLE
chore: bundle install should print output on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ check-fmt: ## Checks code formatting correctness
 	@cargo fmt -- --check
 
 check-generate: ## Checks for pending `make generate` changes
-	@bundle install --gemfile=scripts/Gemfile > /dev/null
+	@bundle install --gemfile=scripts/Gemfile --quiet
 	@scripts/check-generate.sh
 
 CHECK_URLS=false
 export CHECK_URLS
 generate: ## Generates files across the repo using the data in /.meta
-	@bundle install --gemfile=scripts/Gemfile > /dev/null
+	@bundle install --gemfile=scripts/Gemfile --quiet
 	@scripts/generate.rb
 
 fmt: ## Format code
@@ -84,18 +84,18 @@ release-docker: ## Release to Docker Hub
 	@scripts/release-docker.sh
 
 release-github: ## Release to Github
-	@bundle install --gemfile=scripts/Gemfile > /dev/null
+	@bundle install --gemfile=scripts/Gemfile --quiet
 	@scripts/release-github.rb
 
 release-homebrew: ## Release to timberio Homebrew tap
 	@scripts/release-homebrew.sh
 
 release-meta: ## Prepares the release metadata
-	@bundle install --gemfile=scripts/Gemfile > /dev/null
+	@bundle install --gemfile=scripts/Gemfile --quiet
 	@scripts/release-meta.rb
 
 release-rollback:
-	@bundle install --gemfile=scripts/Gemfile > /dev/null
+	@bundle install --gemfile=scripts/Gemfile --quiet
 	@scripts/release-rollback.rb
 
 release-s3: ## Release artifacts to S3


### PR DESCRIPTION
Currently all outputs from `bundle install` including error messages are suppressed by `> /dev/null` pipe, which makes it difficult to figure which issue is causing the bundler to fail. I replaced the `> /dev/null` pipes with bundler's [--quiet](https://bundler.io/v1.2/bundle_install.html) option, which suppresses outputs only if the command succeeds. Hopefully this would help people when they're running into problems with bundle install.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->