### PR TITLE
feat(journald source): Fix a couple minor issues with checkpointing

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -184,7 +184,7 @@ where
             }
             Ok(None) => {}
             Err(err) => error!(
-                message = "Could not retrieve journald checkpoint",
+                message = "Could not retrieve saved journald checkpoint",
                 error = field::display(&err)
             ),
         }
@@ -232,7 +232,7 @@ where
                         }
                     }
                     Err(err) => error!(
-                        message = "Could not retrieve journald checkpoint.",
+                        message = "Could not retrieve current journald checkpoint.",
                         error = field::display(&err)
                     ),
                 }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -190,6 +190,8 @@ where
         }
 
         loop {
+            let mut saw_records = false;
+
             loop {
                 let record = match self.journal.next() {
                     None => break,
@@ -202,6 +204,7 @@ where
                         break;
                     }
                 };
+                saw_records = true;
                 if !self.units.is_empty() {
                     // Make sure the systemd unit is exactly one of the specified units
                     if let Some(unit) = record.get("_SYSTEMD_UNIT") {
@@ -218,19 +221,21 @@ where
                 }
             }
 
-            match self.journal.cursor() {
-                Ok(cursor) => {
-                    if let Err(err) = self.checkpointer.set(&cursor) {
-                        error!(
-                            message = "Could not set journald checkpoint.",
-                            error = field::display(&err)
-                        );
+            if saw_records {
+                match self.journal.cursor() {
+                    Ok(cursor) => {
+                        if let Err(err) = self.checkpointer.set(&cursor) {
+                            error!(
+                                message = "Could not set journald checkpoint.",
+                                error = field::display(&err)
+                            );
+                        }
                     }
+                    Err(err) => error!(
+                        message = "Could not retrieve journald checkpoint.",
+                        error = field::display(&err)
+                    ),
                 }
-                Err(err) => error!(
-                    message = "Could not retrieve journald checkpoint.",
-                    error = field::display(&err)
-                ),
             }
 
             match self.shutdown.recv_timeout(timeout) {


### PR DESCRIPTION
This fixes two minor issues:

1. The checkpoint file is rewritten after each timeout, leading to a file write twice a second, even if no new records have been processed.

2. There are two identical error messages regarding retrieving the checkpoint in completely different contexts.