### PR TITLE
chore(operations): Use leveldb dependency from a fork with portable char type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,10 @@ jobs:
       - checkout
       - *install-rust
       - run:
+          name: Install CMake
+          command: |
+            brew install cmake
+      - run:
           name: Build archive
           command: |
             export PATH="$HOME/.cargo/bin:$PATH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,10 +140,12 @@ updated versions of Vector through various channels.
    export OPENSSL_LIB_DIR=<openssl prefix>/lib
    ```
 
-3. [Install Docker](https://docs.docker.com/install/). Docker
+3. [Install CMake](https://cmake.org/download/).
+
+4. [Install Docker](https://docs.docker.com/install/). Docker
    containers are used for mocking Vector's integrations.
 
-4. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
+5. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
    [Bundler 2](https://bundler.io/v2.0/guides/bundler_2_upgrade.html).
    They are used to build Vector's documentation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "codec"
 version = "0.1.0"
 dependencies = [
@@ -1369,20 +1377,22 @@ dependencies = [
 
 [[package]]
 name = "leveldb"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.9.0"
+source = "git+https://github.com/timberio/leveldb?branch=v0.9.0#af7651ebb3a7cb6ac48b238b96a25330da54f4ba"
 dependencies = [
  "db-key 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "leveldb-sys 3.0.0 (git+https://github.com/timberio/leveldb-sys?branch=v3.0.0)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "leveldb-sys"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "3.0.0"
+source = "git+https://github.com/timberio/leveldb-sys?branch=v3.0.0#8830af18e7776fd2627bc8166300b5ad0f589fd5"
 dependencies = [
+ "cmake 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3926,7 +3936,7 @@ dependencies = [
  "jemallocator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "journald 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "leveldb 0.9.0 (git+https://github.com/timberio/leveldb?branch=v0.9.0)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4173,6 +4183,7 @@ dependencies = [
 "checksum clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0113a8ae379a061c89a71d57a809439f5ce550b6a76063ab5ba2b1cb180971f"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cmake 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3c84c596dcf125d6781f58e3f4254677ec2a6d8aa56e8501ac277100990b3229"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
@@ -4281,8 +4292,8 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8438a36a31c982ac399c4477d7e3c62cc7a6bf91bb6f42837b7e1033359fcbad"
-"checksum leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71f46429bb70612c3e939aaeed27ffd31a24a773d21728a1a426e4089d6778d2"
+"checksum leveldb 0.9.0 (git+https://github.com/timberio/leveldb?branch=v0.9.0)" = "<none>"
+"checksum leveldb-sys 3.0.0 (git+https://github.com/timberio/leveldb-sys?branch=v3.0.0)" = "<none>"
 "checksum lexical-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e82e023e062f1d25f807ad182008fba1b46538e999f908a08cc0c29e084462e"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ toml = "0.4"
 syslog_rfc5424 = "0.6.1"
 tokio-uds = "0.2.5"
 derive_is_enum_variant = "0.1.1"
-leveldb = { version = "0.8.4", optional = true }
+leveldb = { git = "https://github.com/timberio/leveldb", branch = "v0.9.0", optional = true }
 db-key = "0.0.5"
 headers = "0.2.1"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka", features = ["ssl"], optional = true }

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
   curl \
   git \
   openssh-server \
-  vim
+  vim \
+  cmake
 
 # Note: We do not compile or install leveldb or rdkafka libraries because
 #       those Rust creates automatically build and link the libraries for

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -274,7 +274,7 @@ ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX
 ENV PATH="$LIBS_PREFIX/bin:$PATH"
 
-RUN apt-get update && apt-get install -y build-essential pkg-config libssl-dev git
+RUN apt-get update && apt-get install -y build-essential cmake pkg-config libssl-dev git
 
 # Because the system GCC and binutils are shadowed by aliases, we need to
 # instruct Cargo and cc crate to use GCC on the host system. They are used to


### PR DESCRIPTION
Ref #1056 #1054

This PR uses the most recent versions of LevelDB and Snappy from our forks of [leveldb](https://github.com/timberio/leveldb/tree/v0.9.0) and [leveldb-sys](https://github.com/timberio/leveldb-sys/tree/v3.0.0) crates.

Because newer versions of LevelDB completely switched from Autotools to CMake, I've also added CMake dependency to docs and our builders.