### PR TITLE
enhancement(operations): abstracts runtime into runtime.rs

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ use vector::test_util::{
 };
 use vector::topology::config::TransformConfig;
 use vector::topology::{self, config};
-use vector::{sinks, sources, transforms};
+use vector::{runtime, sinks, sources, transforms};
 
 mod batch;
 mod buffering;
@@ -61,7 +61,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
                         sinks::tcp::TcpSinkConfig::new(out_addr.to_string()),
                     );
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -107,7 +107,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
                         sinks::tcp::TcpSinkConfig::new(out_addr.to_string()),
                     );
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -153,7 +153,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
                         sinks::tcp::TcpSinkConfig::new(out_addr.to_string()),
                     );
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -200,7 +200,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
                         sinks::tcp::TcpSinkConfig::new(out_addr.to_string()),
                     );
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -264,7 +264,7 @@ fn benchmark_interconnected(c: &mut Criterion) {
                         sinks::tcp::TcpSinkConfig::new(out_addr2.to_string()),
                     );
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines1 = count_receive(&out_addr1);
                     let output_lines2 = count_receive(&out_addr2);
@@ -331,7 +331,7 @@ fn benchmark_transforms(c: &mut Criterion) {
                         &["filter"],
                         sinks::tcp::TcpSinkConfig::new(out_addr.to_string()),
                     );
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -485,7 +485,7 @@ fn benchmark_complex(c: &mut Criterion) {
                         &["filter_500"],
                         sinks::tcp::TcpSinkConfig::new(out_addr_500.to_string()),
                     );
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines_all = count_receive(&out_addr_all);
                     let output_lines_sampled = count_receive(&out_addr_sampled);

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -5,7 +5,7 @@ use vector::test_util::{
     block_on, count_receive, next_addr, send_lines, shutdown_on_idle, wait_for_tcp,
 };
 use vector::topology::{self, config};
-use vector::{runtime, buffers::BufferConfig, sinks, sources};
+use vector::{buffers::BufferConfig, runtime, sinks, sources};
 
 fn benchmark_buffers(c: &mut Criterion) {
     let num_lines: usize = 100_000;

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -5,7 +5,7 @@ use vector::test_util::{
     block_on, count_receive, next_addr, send_lines, shutdown_on_idle, wait_for_tcp,
 };
 use vector::topology::{self, config};
-use vector::{buffers::BufferConfig, sinks, sources};
+use vector::{runtime, buffers::BufferConfig, sinks, sources};
 
 fn benchmark_buffers(c: &mut Criterion) {
     let num_lines: usize = 100_000;
@@ -35,7 +35,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         when_full: Default::default(),
                     };
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -72,7 +72,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     .into();
                     config.global.data_dir = Some(data_dir.clone());
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 
@@ -108,7 +108,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     };
                     config.global.data_dir = Some(data_dir2.clone());
 
-                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+                    let mut rt = runtime::Runtime::new().unwrap();
 
                     let output_lines = count_receive(&out_addr);
 

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -7,7 +7,7 @@ use tokio::codec::{BytesCodec, FramedWrite};
 use tokio::fs::OpenOptions;
 use vector::test_util::random_lines;
 use vector::{
-    sinks, sources,
+    runtime, sinks, sources,
     topology::{self, config},
 };
 
@@ -54,7 +54,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
                     },
                 );
 
-                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let mut rt = runtime::Runtime::new().unwrap();
                 let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
                 let mut options = OpenOptions::new();

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -5,6 +5,7 @@ use hyper::{Body, Response, Server};
 use std::net::SocketAddr;
 use vector::test_util::{next_addr, random_lines, send_lines, wait_for_tcp};
 use vector::{
+    runtime,
     sinks, sources,
     topology::{self, config},
 };
@@ -33,7 +34,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
                     },
                 );
 
-                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let mut rt = runtime::Runtime::new().unwrap();
 
                 let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
                 wait_for_tcp(in_addr);
@@ -80,7 +81,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
                     },
                 );
 
-                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let mut rt = runtime::Runtime::new().unwrap();
 
                 let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
                 wait_for_tcp(in_addr);

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -5,8 +5,7 @@ use hyper::{Body, Response, Server};
 use std::net::SocketAddr;
 use vector::test_util::{next_addr, random_lines, send_lines, wait_for_tcp};
 use vector::{
-    runtime,
-    sinks, sources,
+    runtime, sinks, sources,
     topology::{self, config},
 };
 

--- a/lib/tracing-limit/benches/limit.rs
+++ b/lib/tracing-limit/benches/limit.rs
@@ -41,7 +41,7 @@ fn bench(c: &mut Criterion) {
     c.bench_function_over_inputs(
         "Limit 5 seconds",
         |b, n| {
-            let sub = VisitingSubscriber(Mutex::new(String::from(""))).with(Limit::default());;
+            let sub = VisitingSubscriber(Mutex::new(String::from(""))).with(Limit::default());
             let n = black_box(n);
             tracing::subscriber::with_default(sub, || {
                 b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod topology;
 pub mod trace;
 pub mod transforms;
 pub mod types;
+pub mod runtime;
 
 pub use event::Event;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod buffers;
 pub mod event;
 pub mod metrics;
 pub mod region;
+pub mod runtime;
 pub mod sinks;
 pub mod sources;
 pub mod template;
@@ -23,7 +24,6 @@ pub mod topology;
 pub mod trace;
 pub mod transforms;
 pub mod types;
-pub mod runtime;
 
 pub use event::Event;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{metrics, topology, trace, runtime};
+use vector::{metrics, runtime, topology, trace};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -206,7 +206,6 @@ fn main() {
     });
 
     let mut rt = {
-
         let threads = opts.threads.unwrap_or(max(1, num_cpus::get()));
         let num_threads = min(4, threads);
         runtime::Runtime::with_thread_count(num_threads).expect("Unable to create async runtime")

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{metrics, topology, trace};
+use vector::{metrics, topology, trace, runtime};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -206,12 +206,10 @@ fn main() {
     });
 
     let mut rt = {
-        let mut builder = tokio::runtime::Builder::new();
 
         let threads = opts.threads.unwrap_or(max(1, num_cpus::get()));
-        builder.core_threads(min(4, threads));
-
-        builder.build().expect("Unable to create async runtime")
+        let num_threads = min(4, threads);
+        runtime::Runtime::with_thread_count(num_threads).expect("Unable to create async runtime")
     };
 
     let (metrics_trigger, metrics_tripwire) = stream_cancel::Tripwire::new();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,13 +1,55 @@
 use std::io;
 
+use futures;
+use futures::future::Future;
+
+
+// TODO: I assume create a wrapper around this
+use tokio::runtime::{Builder, Shutdown, TaskExecutor};
+
 pub struct Runtime {
 	rt: tokio::runtime::Runtime,
 }
 
 impl Runtime {
     pub fn new() -> io::Result<Self> {
-        Ok(Runtime{
-            rt: tokio::runtime::Runtime::new()
-        })
+        Ok(Runtime{ rt: tokio::runtime::Runtime::new()? })
+    }
+
+    pub fn single_threaded() -> io::Result<Self> {
+        Self::with_thread_count(1)
+    }
+
+    pub fn with_thread_count(number: usize) -> io::Result<Self> {
+        Ok(Runtime { rt: Builder::new().core_threads(number).build()? })
+    }
+
+    pub fn spawn<F>(&mut self, future: F) -> &mut Self
+    where F: Future<Item=(), Error=()> + Send + 'static,
+    {
+        self.rt.spawn(future);
+        self
+    }
+
+    pub fn executor(&self) -> TaskExecutor {
+        self.rt.executor()
+    }
+
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: Send + 'static + Future<Item = R, Error = E>,
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        self.rt.block_on(future)
+    }
+
+    pub fn shutdown_on_idle(mut self) -> Shutdown {
+        // Breaks wrapper here
+        self.rt.shutdown_on_idle()
+    }
+
+    pub fn shutdown_now(mut self) -> Shutdown {
+        self.rt.shutdown_now()
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,13 @@
+use std::io;
+
+pub struct Runtime {
+	rt: tokio::runtime::Runtime,
+}
+
+impl Runtime {
+    pub fn new() -> io::Result<Self> {
+        Ok(Runtime{
+            rt: tokio::runtime::Runtime::new()
+        })
+    }
+}

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -2,6 +2,7 @@ use crate::{
     buffers::Acker,
     event::{self, Event},
     region::RegionOrEndpoint,
+    runtime,
     sinks::util::{
         retries::{FixedRetryPolicy, RetryLogic},
         BatchServiceSink, SinkExt,
@@ -322,6 +323,7 @@ mod integration_tests {
     use super::*;
     use crate::{
         buffers::Acker,
+        runtime,
         region::RegionOrEndpoint,
         test_util::{random_lines_with_stream, random_string},
     };
@@ -329,7 +331,6 @@ mod integration_tests {
     use rusoto_core::Region;
     use rusoto_kinesis::{Kinesis, KinesisClient};
     use std::sync::Arc;
-    use tokio::runtime::Runtime;
 
     #[test]
     fn kinesis_put_records() {
@@ -349,7 +350,7 @@ mod integration_tests {
             ..Default::default()
         };
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let sink = KinesisService::new(config, Acker::Null).unwrap();
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -2,7 +2,6 @@ use crate::{
     buffers::Acker,
     event::{self, Event},
     region::RegionOrEndpoint,
-    runtime,
     sinks::util::{
         retries::{FixedRetryPolicy, RetryLogic},
         BatchServiceSink, SinkExt,
@@ -323,8 +322,8 @@ mod integration_tests {
     use super::*;
     use crate::{
         buffers::Acker,
-        runtime,
         region::RegionOrEndpoint,
+        runtime,
         test_util::{random_lines_with_stream, random_string},
     };
     use futures::{Future, Sink};

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -397,6 +397,7 @@ mod integration_tests {
         assert_downcast_matches,
         event::Event,
         region::RegionOrEndpoint,
+        runtime::Runtime,
         sinks::aws_s3::{S3Sink, S3SinkConfig},
         test_util::{block_on, random_lines_with_stream, random_string},
     };
@@ -499,7 +500,7 @@ mod integration_tests {
         let (tx, rx) = futures::sync::mpsc::channel(1);
         let pump = sink.send_all(rx).map(|_| ()).map_err(|_| ());
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
         rt.spawn(pump);
 
         let mut tx = tx.wait();
@@ -585,7 +586,7 @@ mod integration_tests {
 
     #[test]
     fn s3_healthchecks() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
 
         let healthcheck = S3Sink::healthcheck(&config()).unwrap();
         rt.block_on(healthcheck).unwrap();
@@ -593,7 +594,7 @@ mod integration_tests {
 
     #[test]
     fn s3_healthchecks_invalid_bucket() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
 
         let config = S3SinkConfig {
             bucket: "asdflkjadskdaadsfadf".to_string(),

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -289,6 +289,7 @@ mod tests {
     use crate::buffers::Acker;
     use crate::{
         assert_downcast_matches,
+        runtime::Runtime,
         sinks::http::HttpSinkConfig,
         test_util::{next_addr, random_lines_with_stream, shutdown_on_idle},
         topology::config::SinkConfig,
@@ -383,7 +384,7 @@ mod tests {
         let (input_lines, events) = random_lines_with_stream(100, num_lines);
         let pump = sink.send_all(events);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
         rt.spawn(server);
 
         rt.block_on(pump).unwrap();
@@ -441,7 +442,7 @@ mod tests {
         let (input_lines, events) = random_lines_with_stream(100, num_lines);
         let pump = sink.send_all(events);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
         rt.spawn(server);
 
         rt.block_on(pump).unwrap();
@@ -499,7 +500,7 @@ mod tests {
         let (input_lines, events) = random_lines_with_stream(100, num_lines);
         let pump = sink.send_all(events);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = Runtime::new().unwrap();
         rt.spawn(server);
 
         rt.block_on(pump).unwrap();

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -224,7 +224,7 @@ mod test {
             .serve(new_service)
             .map_err(|e| eprintln!("server error: {}", e));
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = crate::runtime::Runtime::new().unwrap();
 
         rt.spawn(server);
 

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -222,7 +222,7 @@ mod test {
     use crate::test_util::wait_for;
     use futures::{stream, sync::oneshot, Future, Poll, Sink};
     use std::sync::{atomic::Ordering, Arc, Mutex};
-    use tokio::runtime::Runtime;
+    use crate::runtime::Runtime;
     use tower::Service;
 
     struct FakeService {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -219,10 +219,10 @@ where
 mod test {
     use super::BatchServiceSink;
     use crate::buffers::Acker;
+    use crate::runtime::Runtime;
     use crate::test_util::wait_for;
     use futures::{stream, sync::oneshot, Future, Poll, Sink};
     use std::sync::{atomic::Ordering, Arc, Mutex};
-    use crate::runtime::Runtime;
     use tower::Service;
 
     struct FakeService {

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -708,9 +708,10 @@ impl ContainerLogInfo {
 #[cfg(all(test, feature = "docker-integration-tests"))]
 mod tests {
     use super::*;
+    use crate::runtime;
     use crate::test_util::{self, collect_n, trace_init};
 
-    fn pull(image: &str, docker: &Docker, rt: &mut tokio::runtime::Runtime) {
+    fn pull(image: &str, docker: &Docker, rt: &mut runtime::Runtime) {
         let list_option = shiplift::ImageListOptions::builder()
             .filter_name(image)
             .build();
@@ -736,7 +737,7 @@ mod tests {
     fn source<'a, L: Into<Option<&'a str>>>(
         name: &str,
         label: L,
-    ) -> (mpsc::Receiver<Event>, tokio::runtime::Runtime) {
+    ) -> (mpsc::Receiver<Event>, runtime::Runtime) {
         let mut rt = test_util::runtime();
         let source = source_with(name, label, &mut rt);
         (source, rt)
@@ -746,7 +747,7 @@ mod tests {
     fn source_with<'a, L: Into<Option<&'a str>>>(
         name: &str,
         label: L,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> mpsc::Receiver<Event> {
         trace_init();
         let (sender, recv) = mpsc::channel(100);
@@ -772,7 +773,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> String {
         cmd_container(
             name,
@@ -791,7 +792,7 @@ mod tests {
         log: &str,
         delay: u32,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> String {
         cmd_container(
             name,
@@ -812,7 +813,7 @@ mod tests {
         label: L,
         cmd: Vec<String>,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> String {
         if let Some(id) = cmd_container_for_real(name, label, cmd, docker, rt) {
             id
@@ -832,7 +833,7 @@ mod tests {
         label: L,
         cmd: Vec<String>,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> Option<String> {
         pull("busybox", docker, rt);
         let mut options = shiplift::builder::ContainerOptions::builder("busybox");
@@ -857,7 +858,7 @@ mod tests {
     fn container_start(
         id: &str,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         let future = docker.containers().get(id).start();
         rt.block_on(future)
@@ -868,7 +869,7 @@ mod tests {
     fn container_wait(
         id: &str,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         let future = docker.containers().get(id).wait();
         rt.block_on(future)
@@ -880,13 +881,13 @@ mod tests {
     fn container_run(
         id: &str,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         container_start(id, docker, rt)?;
         container_wait(id, docker, rt)
     }
 
-    fn container_remove(id: &str, docker: &Docker, rt: &mut tokio::runtime::Runtime) {
+    fn container_remove(id: &str, docker: &Docker, rt: &mut runtime::Runtime) {
         let future = docker
             .containers()
             .get(id)
@@ -903,7 +904,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) {
         let id = log_container(name, label, log, docker, rt);
         for _ in 0..n {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -342,6 +342,7 @@ fn create_event(
 mod tests {
     use super::*;
     use crate::event;
+    use crate::runtime;
     use crate::sources::file;
     use crate::test_util::{block_on, shutdown_on_idle};
     use crate::topology::Config;
@@ -476,7 +477,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -537,7 +538,7 @@ mod tests {
         };
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -606,7 +607,7 @@ mod tests {
         };
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -678,7 +679,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -725,7 +726,7 @@ mod tests {
 
     #[test]
     fn file_file_key() {
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let (trigger, tripwire) = Tripwire::new();
 
@@ -845,7 +846,7 @@ mod tests {
         {
             let (tx, rx) = futures::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let mut rt = runtime::Runtime::new().unwrap();
             let (trigger, tripwire) = Tripwire::new();
             rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -867,7 +868,7 @@ mod tests {
         {
             let (tx, rx) = futures::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let mut rt = runtime::Runtime::new().unwrap();
             let (trigger, tripwire) = Tripwire::new();
             rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -894,7 +895,7 @@ mod tests {
             };
             let (tx, rx) = futures::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let mut rt = runtime::Runtime::new().unwrap();
             let (trigger, tripwire) = Tripwire::new();
             rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -930,7 +931,7 @@ mod tests {
         {
             let (tx, rx) = futures::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let mut rt = runtime::Runtime::new().unwrap();
             let (trigger, tripwire) = Tripwire::new();
             rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -956,7 +957,7 @@ mod tests {
         {
             let (tx, rx) = futures::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let mut rt = runtime::Runtime::new().unwrap();
             let (trigger, tripwire) = Tripwire::new();
             rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -982,7 +983,7 @@ mod tests {
         use std::os::unix::io::AsRawFd;
         use std::time::{Duration, SystemTime};
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         let (tx, rx) = futures::sync::mpsc::channel(10);
         let (trigger, tripwire) = Tripwire::new();
         let dir = tempdir().unwrap();
@@ -1080,7 +1081,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -1135,7 +1136,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
@@ -1220,7 +1221,7 @@ mod tests {
         sleep();
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
         sleep();
@@ -1279,7 +1280,7 @@ mod tests {
         sleep();
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), tx);
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 
         sleep();

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -98,6 +98,7 @@ impl TcpSource for RawTcpSource {
 mod test {
     use super::TcpConfig;
     use crate::event;
+    use crate::runtime;
     use crate::test_util::{block_on, next_addr, send_lines, wait_for_tcp};
     use crate::topology::config::{GlobalOptions, SourceConfig};
     use futures::sync::mpsc;
@@ -112,7 +113,7 @@ mod test {
         let server = TcpConfig::new(addr.into())
             .build("default", &GlobalOptions::default(), tx)
             .unwrap();
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         rt.spawn(server);
         wait_for_tcp(addr);
 
@@ -156,7 +157,7 @@ mod test {
         let server = config
             .build("default", &GlobalOptions::default(), tx)
             .unwrap();
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         rt.spawn(server);
         wait_for_tcp(addr);
 

--- a/src/sources/udp.rs
+++ b/src/sources/udp.rs
@@ -83,6 +83,7 @@ pub fn udp(address: SocketAddr, host_key: Atom, out: mpsc::Sender<Event>) -> sup
 mod test {
     use super::UdpConfig;
     use crate::event;
+    use crate::runtime;
     use crate::test_util::{collect_n, next_addr};
     use crate::topology::config::{GlobalOptions, SourceConfig};
     use futures::sync::mpsc;
@@ -120,13 +121,13 @@ mod test {
         bind
     }
 
-    fn init_udp(sender: mpsc::Sender<event::Event>) -> (SocketAddr, tokio::runtime::Runtime) {
+    fn init_udp(sender: mpsc::Sender<event::Event>) -> (SocketAddr, runtime::Runtime) {
         let addr = next_addr();
 
         let server = UdpConfig::new(addr)
             .build("default", &GlobalOptions::default(), sender)
             .unwrap();
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
         rt.spawn(server);
 
         // Wait for udp to start listening

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -96,7 +96,7 @@ mod test {
         let server = VectorConfig::new(addr.into())
             .build("default", &GlobalOptions::default(), tx)
             .unwrap();
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = crate::runtime::Runtime::new().unwrap();
         rt.spawn(server);
         wait_for_tcp(addr);
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,4 +1,6 @@
 use crate::Event;
+use crate::runtime::Runtime;
+
 use futures::{future, stream, sync::mpsc, try_ready, Async, Future, Poll, Sink, Stream};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -14,7 +16,6 @@ use std::sync::Arc;
 use stream_cancel::{StreamExt, Trigger, Tripwire};
 use tokio::codec::{FramedRead, FramedWrite, LinesCodec};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::runtime::{Builder, Runtime};
 use tokio::util::FutureExt;
 
 #[macro_export]
@@ -170,7 +171,7 @@ where
 }
 
 pub fn runtime() -> Runtime {
-    Builder::new().core_threads(1).build().unwrap()
+    Runtime::single_threaded().unwrap()
 }
 
 pub fn wait_for_tcp(addr: SocketAddr) {
@@ -290,7 +291,7 @@ impl CountReceiver {
 }
 
 pub fn count_receive(addr: &SocketAddr) -> CountReceiver {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
 
     let listener = TcpListener::bind(addr).unwrap();
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,5 @@
-use crate::Event;
 use crate::runtime::Runtime;
+use crate::Event;
 
 use futures::{future, stream, sync::mpsc, try_ready, Async, Future, Poll, Sink, Stream};
 use rand::distributions::Alphanumeric;

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -143,6 +143,7 @@ impl Sink for Fanout {
 #[cfg(test)]
 mod tests {
     use super::{ControlMessage, Fanout};
+    use crate::runtime;
     use crate::test_util::{self, CollectCurrent};
     use crate::Event;
     use futures::sync::mpsc;
@@ -195,7 +196,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -306,7 +307,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -346,7 +347,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -386,7 +387,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        let mut rt = runtime::Runtime::new().unwrap();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -7,6 +7,7 @@ pub use self::config::Config;
 use crate::topology::builder::Pieces;
 
 use crate::buffers;
+use crate::runtime;
 use futures::{
     future,
     sync::{mpsc, oneshot},
@@ -33,7 +34,7 @@ pub struct RunningTopology {
 
 pub fn start(
     config: Config,
-    rt: &mut tokio::runtime::Runtime,
+    rt: &mut runtime::Runtime,
     require_healthy: bool,
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     validate(&config).and_then(|pieces| start_validated(config, pieces, rt, require_healthy))
@@ -42,7 +43,7 @@ pub fn start(
 pub fn start_validated(
     config: Config,
     mut pieces: Pieces,
-    rt: &mut tokio::runtime::Runtime,
+    rt: &mut runtime::Runtime,
     require_healthy: bool,
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     let (abort_tx, abort_rx) = mpsc::unbounded();
@@ -157,7 +158,7 @@ impl RunningTopology {
     pub fn reload_config_and_respawn(
         &mut self,
         new_config: Config,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
         require_healthy: bool,
     ) -> bool {
         if self.config.global.data_dir != new_config.global.data_dir {
@@ -183,7 +184,7 @@ impl RunningTopology {
         &mut self,
         new_config: &Config,
         pieces: &mut Pieces,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
         require_healthy: bool,
     ) -> bool {
         let (_, sinks_to_change, sinks_to_add) =
@@ -216,7 +217,7 @@ impl RunningTopology {
         &mut self,
         new_config: Config,
         mut new_pieces: Pieces,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) {
         // Sources
         let (sources_to_remove, sources_to_change, sources_to_add) =
@@ -318,7 +319,7 @@ impl RunningTopology {
         &mut self,
         name: &str,
         new_pieces: &mut builder::Pieces,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let task = handle_errors(task, self.abort_tx.clone());
@@ -333,7 +334,7 @@ impl RunningTopology {
         &mut self,
         name: &str,
         new_pieces: &mut builder::Pieces,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let task = handle_errors(task, self.abort_tx.clone());
@@ -348,7 +349,7 @@ impl RunningTopology {
         &mut self,
         name: &str,
         new_pieces: &mut builder::Pieces,
-        rt: &mut tokio::runtime::Runtime,
+        rt: &mut runtime::Runtime,
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let task = handle_errors(task, self.abort_tx.clone());

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -213,12 +213,7 @@ impl RunningTopology {
         }
     }
 
-    fn spawn_all(
-        &mut self,
-        new_config: Config,
-        mut new_pieces: Pieces,
-        rt: &mut runtime::Runtime,
-    ) {
+    fn spawn_all(&mut self, new_config: Config, mut new_pieces: Pieces, rt: &mut runtime::Runtime) {
         // Sources
         let (sources_to_remove, sources_to_change, sources_to_add) =
             to_remove_change_add(&self.config.sources, &new_config.sources);

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -8,7 +8,8 @@ use vector::test_util::{
     block_on, next_addr, random_lines, receive, send_lines, shutdown_on_idle, wait_for_tcp,
 };
 use vector::topology::{self, config};
-use vector::{buffers::BufferConfig, sinks, sources};
+use vector::{buffers::BufferConfig, sinks, sources, runtime};
+
 
 #[test]
 fn test_buffering() {
@@ -34,7 +35,7 @@ fn test_buffering() {
     };
     config.global.data_dir = Some(data_dir.clone());
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     wait_for_tcp(in_addr);
@@ -62,7 +63,7 @@ fn test_buffering() {
     };
     config.global.data_dir = Some(data_dir);
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 
@@ -125,7 +126,7 @@ fn test_max_size() {
     };
     config.global.data_dir = Some(data_dir.clone());
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     wait_for_tcp(in_addr);
@@ -152,7 +153,7 @@ fn test_max_size() {
     };
     config.global.data_dir = Some(data_dir);
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 
@@ -196,7 +197,7 @@ fn test_max_size_resume() {
     };
     config.global.data_dir = Some(data_dir.clone());
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     wait_for_tcp(in_addr1);
@@ -250,7 +251,7 @@ fn test_reclaim_disk_space() {
     .into();
     config.global.data_dir = Some(data_dir.clone());
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     wait_for_tcp(in_addr);
@@ -286,7 +287,7 @@ fn test_reclaim_disk_space() {
     };
     config.global.data_dir = Some(data_dir.clone());
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -8,8 +8,7 @@ use vector::test_util::{
     block_on, next_addr, random_lines, receive, send_lines, shutdown_on_idle, wait_for_tcp,
 };
 use vector::topology::{self, config};
-use vector::{buffers::BufferConfig, sinks, sources, runtime};
-
+use vector::{buffers::BufferConfig, runtime, sinks, sources};
 
 #[test]
 fn test_buffering() {

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -12,8 +12,7 @@ use vector::test_util::{
 };
 use vector::topology::{self, config};
 use vector::{
-    runtime,
-    sinks,
+    runtime, sinks,
     sources::syslog::{Mode, SyslogConfig},
 };
 

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -12,6 +12,7 @@ use vector::test_util::{
 };
 use vector::topology::{self, config};
 use vector::{
+    runtime,
     sinks,
     sources::syslog::{Mode, SyslogConfig},
 };
@@ -32,7 +33,7 @@ fn test_tcp_syslog() {
     );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 
@@ -73,7 +74,7 @@ fn test_udp_syslog() {
     config.add_source("in", SyslogConfig::new(Mode::Udp { address: in_addr }));
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 
@@ -136,7 +137,7 @@ fn test_unix_stream_syslog() {
     );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
 
     let output_lines = receive(&out_addr);
 


### PR DESCRIPTION
https://github.com/timberio/vector/issues/1085

The `tokio` runtime is still leaking out via `Shutdown` and `TaskExecutor` types. I haven't taken time to investigate if those need to be wrapped or abstracted away in some other way.

Additionally, `test_utils` and `main.rs` used the `tokio::Builder`  api to control the runtime's threadcount. Instead of creating a new `Builder`, I just provided alternate constructor methods on `Runtime`.

And obviously, I haven't implemented a free standing `spawn` function yet.

But other than that, it compiles and tests are passing. Let me know what you think