### PR TITLE
fix(elasticsearch sink): Wrap provider call with a tokio runtime

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -130,13 +130,17 @@ impl ElasticSearchCommon {
                 if region.is_none() {
                     return Err(ParseError::AWSRequiresRegion.into());
                 }
-                Some(
-                    DefaultCredentialsProvider::new()
-                        .context(AWSCredentialsProviderFailed)?
-                        .credentials()
-                        .wait()
-                        .context(AWSCredentialsGenerateFailed)?,
-                )
+
+                let provider =
+                    DefaultCredentialsProvider::new().context(AWSCredentialsProviderFailed)?;
+
+                let mut rt = tokio::runtime::current_thread::Runtime::new()?;
+
+                let credentials = rt
+                    .block_on(provider.credentials())
+                    .context(AWSCredentialsGenerateFailed)?;
+
+                Some(credentials)
             }
         };
 


### PR DESCRIPTION
This change fixes the usage of `rusoto`'s credentials
the issue arises when a user wants to fetch credentials
via the network with the `InstanceMetadataProvider` type.
This type sets a timer that depends on the `tokio-timer`
being set. Previously, this sink used the `wait` combinator
that _does_ not wrap the future with a tokio timer. Thus,
when a user tried to run this it would fail out because
the timer was not set. This changes the code to allow
the `credentials` fetch future to be wrapped in a tokio
timer.

Closes #1093

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>