### PR TITLE
fix(journald source): Rework option to limit records to current boot

### DIFF
--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -6,11 +6,11 @@ output_types = ["log"]
 resources = []
 through_description = "log records from journald"
 
-[sources.journald.options.current_runtime_only]
+[sources.journald.options.current_boot_only]
 type = "bool"
 null = true
 default = true
-description = "Include only entries from the current runtime (boot)"
+description = "Include only entries from the current boot."
 
 [sources.journald.options.data_dir]
 type = "string"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -247,12 +247,12 @@ data_dir = "/var/lib/vector"
   # * must be: "journald"
   type = "journald"
 
-  # Include only entries from the current runtime (boot)
+  # Include only entries from the current boot.
   # 
   # * optional
   # * default: true
   # * type: bool
-  current_runtime_only = true
+  current_boot_only = true
 
   # The directory used to persist the journal checkpoint position. By default,
   # the global `data_dir` is used. Please make sure the Vector project has write

--- a/docs/usage/administration/validating.md
+++ b/docs/usage/administration/validating.md
@@ -75,6 +75,7 @@ flag to also run health checks for all defined sinks.
 
 8. All [sinks][docs.sinks] are able to connect to their targets.
 
+
 [docs.configuration#composition]: ../../usage/configuration#composition
 [docs.configuration#value-types]: ../../usage/configuration#value-types
 [docs.sinks]: ../../usage/configuration/sinks

--- a/docs/usage/configuration/sources/journald.md
+++ b/docs/usage/configuration/sources/journald.md
@@ -44,7 +44,7 @@ The `journald` source ingests data through log records from journald and outputs
   type = "journald" # must be: "journald"
   
   # OPTIONAL
-  current_runtime_only = true # default
+  current_boot_only = true # default
   data_dir = "/var/lib/vector" # no default
   local_only = true # default
   units = ["ntpd", "sysinit.target"] # default
@@ -54,11 +54,11 @@ The `journald` source ingests data through log records from journald and outputs
 
 ## Options
 
-### current_runtime_only
+### current_boot_only
 
 `optional` `default: true` `type: bool`
 
-Include only entries from the current runtime (boot)
+Include only entries from the current boot.
 
 ### data_dir
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -267,12 +267,12 @@ data_dir = "/var/lib/vector"
   # * must be: "journald"
   type = "journald"
 
-  # Include only entries from the current runtime (boot)
+  # Include only entries from the current boot.
   # 
   # * optional
   # * default: true
   # * type: bool
-  current_runtime_only = true
+  current_boot_only = true
 
   # The directory used to persist the journal checkpoint position. By default,
   # the global `data_dir` is used. Please make sure the Vector project has write


### PR DESCRIPTION
This replaces the misleading `current_runtime_only` option with a
`current_boot_only` option.

Signed-off-by: Bruce Guenter <bruce@untroubled.org>

Closes #1097 