### PR TITLE
fix(journald source): Cursor/checkpoint fixes

### DIFF
--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -12,6 +12,15 @@ null = true
 default = true
 description = "Include only entries from the current boot."
 
+[sources.journald.options.batch_size]
+type = "int"
+null = true
+default = 16
+description = """\
+The systemd journal is read in batches, and a checkpoint is set at the \
+end of each batch. This option limits the size of the batch.\
+"""
+
 [sources.journald.options.data_dir]
 type = "string"
 examples = ["/var/lib/vector"]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -247,6 +247,14 @@ data_dir = "/var/lib/vector"
   # * must be: "journald"
   type = "journald"
 
+  # The systemd journal is read in batches, and a checkpoint is set at the end of
+  # each batch. This option limits the size of the batch.
+  # 
+  # * optional
+  # * default: 16
+  # * type: int
+  batch_size = 16
+
   # Include only entries from the current boot.
   # 
   # * optional

--- a/docs/usage/configuration/sources/journald.md
+++ b/docs/usage/configuration/sources/journald.md
@@ -44,6 +44,7 @@ The `journald` source ingests data through log records from journald and outputs
   type = "journald" # must be: "journald"
   
   # OPTIONAL
+  batch_size = 16 # default
   current_boot_only = true # default
   data_dir = "/var/lib/vector" # no default
   local_only = true # default
@@ -53,6 +54,12 @@ The `journald` source ingests data through log records from journald and outputs
 {% endcode-tabs %}
 
 ## Options
+
+### batch_size
+
+`optional` `default: 16` `type: int`
+
+The systemd journal is read in batches, and a checkpoint is set at the end of each batch. This option limits the size of the batch.
 
 ### current_boot_only
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -267,6 +267,14 @@ data_dir = "/var/lib/vector"
   # * must be: "journald"
   type = "journald"
 
+  # The systemd journal is read in batches, and a checkpoint is set at the end of
+  # each batch. This option limits the size of the batch.
+  # 
+  # * optional
+  # * default: 16
+  # * type: int
+  batch_size = 16
+
   # Include only entries from the current boot.
   # 
   # * optional

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -20,6 +20,8 @@ use std::time;
 use string_cache::DefaultAtom as Atom;
 use tracing::{dispatcher, field};
 
+const DEFAULT_BATCH_SIZE: usize = 16;
+
 lazy_static! {
     static ref MESSAGE: Atom = Atom::from("MESSAGE");
     static ref TIMESTAMP: Atom = Atom::from("_SOURCE_REALTIME_TIMESTAMP");
@@ -39,6 +41,7 @@ pub struct JournaldConfig {
     pub local_only: Option<bool>,
     pub units: Vec<String>,
     pub data_dir: Option<PathBuf>,
+    pub batch_size: Option<usize>,
 }
 
 #[typetag::serde(name = "journald")]
@@ -55,6 +58,7 @@ impl SourceConfig for JournaldConfig {
         if self.current_boot_only.unwrap_or(true) {
             journal.seek_boot()?;
         }
+        let batch_size = self.batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
         // Map the given unit names into valid systemd units by
         // appending ".service" if no extension is present.
@@ -73,7 +77,13 @@ impl SourceConfig for JournaldConfig {
         let checkpointer = Checkpointer::new(data_dir)
             .map_err(|err| format!("Unable to open checkpoint file: {}", err))?;
 
-        Ok(journald_source(journal, out, checkpointer, units))
+        Ok(journald_source(
+            journal,
+            out,
+            checkpointer,
+            units,
+            batch_size,
+        ))
     }
 
     fn output_type(&self) -> DataType {
@@ -86,6 +96,7 @@ fn journald_source<J>(
     out: mpsc::Sender<Event>,
     checkpointer: Checkpointer,
     units: HashSet<String>,
+    batch_size: usize,
 ) -> super::Source
 where
     J: Iterator<Item = Result<Record, io::Error>> + JournalCursor + Send + 'static,
@@ -105,6 +116,7 @@ where
             channel: out,
             shutdown: shutdown_rx,
             checkpointer,
+            batch_size,
         };
         let span = info_span!("journald-server");
         let dispatcher = dispatcher::get_default(|d| d.clone());
@@ -163,6 +175,7 @@ struct JournaldServer<J, T> {
     channel: T,
     shutdown: std::sync::mpsc::Receiver<()>,
     checkpointer: Checkpointer,
+    batch_size: usize,
 }
 
 impl<J, T> JournaldServer<J, T>
@@ -199,11 +212,15 @@ where
         }
 
         loop {
-            let mut saw_records = false;
+            use LoopState::*;
+            let mut state = NoOp;
 
-            loop {
+            for _ in 0..self.batch_size {
                 let record = match self.journal.next() {
-                    None => break,
+                    None => {
+                        state = AtEnd;
+                        break;
+                    }
                     Some(Ok(record)) => record,
                     Some(Err(err)) => {
                         error!(
@@ -213,7 +230,7 @@ where
                         break;
                     }
                 };
-                saw_records = true;
+                state = SawRecord;
                 if !self.units.is_empty() {
                     // Make sure the systemd unit is exactly one of the specified units
                     if let Some(unit) = record.get("_SYSTEMD_UNIT") {
@@ -230,7 +247,7 @@ where
                 }
             }
 
-            if saw_records {
+            if state != NoOp {
                 match self.journal.cursor() {
                     Ok(cursor) => {
                         if let Err(err) = self.checkpointer.set(&cursor) {
@@ -247,13 +264,22 @@ where
                 }
             }
 
-            match self.shutdown.recv_timeout(timeout) {
-                Ok(()) => unreachable!(), // The sender should never actually send
-                Err(RecvTimeoutError::Timeout) => {}
-                Err(RecvTimeoutError::Disconnected) => return,
+            if state == AtEnd {
+                match self.shutdown.recv_timeout(timeout) {
+                    Ok(()) => unreachable!(), // The sender should never actually send
+                    Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => return,
+                }
             }
         }
     }
+}
+
+#[derive(PartialEq)]
+enum LoopState {
+    NoOp,
+    AtEnd,
+    SawRecord,
 }
 
 const CHECKPOINT_FILENAME: &str = "checkpoint.txt";
@@ -415,7 +441,7 @@ mod tests {
         }
 
         let journal = fake_journal();
-        let source = journald_source(journal, tx, checkpointer, units);
+        let source = journald_source(journal, tx, checkpointer, units, DEFAULT_BATCH_SIZE);
         let mut rt = runtime();
         rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -182,6 +182,13 @@ where
                         message = "Could not seek journald to stored cursor",
                         error = field::display(&err)
                     );
+                // The cursor now points to the last successfully read
+                // record, so skip past it to any newer records.
+                } else if let Some(Err(err)) = self.journal.next() {
+                    error!(
+                        message = "Could not fetch next record after seeking to cursor",
+                        error = field::display(&err)
+                    );
                 }
             }
             Ok(None) => {}
@@ -381,7 +388,7 @@ mod tests {
         }
         fn seek_cursor(&mut self, cursor: &str) -> Result<(), io::Error> {
             let cursor = cursor.parse::<usize>().expect("Invalid cursor");
-            for _ in 0..cursor {
+            for _ in 1..cursor {
                 self.records.pop();
             }
             Ok(())


### PR DESCRIPTION
This fixes a couple of issues with the journald source checkpoint handling discovered while dealing with #1097 / #1105.

1. After restarting, the last handled record in the journal would be repeated due to a one-off bug in the cursor handling.
2. The checkpoint is not updated during a stream of records, which could cause repeated records if Vector is interrupted.