### PR TITLE
fix(file source): Increase sleep interval in the tests for file source

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -380,7 +380,7 @@ mod tests {
     }
 
     fn sleep() {
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(std::time::Duration::from_millis(500));
     }
 
     #[test]


### PR DESCRIPTION
On some occurrences the sleep interval in tests for `file` source turns out to be too small, which makes the tests fail. This PR increases it 10x to make sure that that interval would be large enough for all test platforms.

Ref https://github.com/timberio/vector/pull/1054#issuecomment-547430448