### PR TITLE
fix(elasticsearch sink): Flatten out region configuration

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -39,6 +39,7 @@ pub struct ElasticSearchConfig {
     pub batch_timeout: Option<u64>,
     pub compression: Option<Compression>,
     pub provider: Option<Provider>,
+    #[serde(flatten)]
     pub region: Option<RegionOrEndpoint>,
 
     // Tower Request based configuration


### PR DESCRIPTION
All the other sinks that use a `RegionOrEndpoint` in their settings do
so with `serde(flatten)` to avoid requiring `region.region` in the
configuration. The elasticsearch sink was missing this directive.

Signed-off-by: Bruce Guenter <bruce@untroubled.org>

Ref: #1099 