### PR TITLE
docs(lua transform): Put example of iterating over all fields out of the autogenerated file

### DIFF
--- a/docs/usage/configuration/transforms/lua.md
+++ b/docs/usage/configuration/transforms/lua.md
@@ -164,6 +164,19 @@ variable representing the event:
 Note, a Lua `table` is an associative array. You can read more about
 [Lua types][urls.lua_types] in the [Lua docs][urls.lua_docs].
 
+### Iterate over fields
+
+To iterate over all fields of an `event` use the `pairs` method.  For example:
+
+```lua
+# Remove all fields where the value is "-"
+for f,v in pairs(event) do
+  if v == "-" then
+    event[f] = nil
+  end
+end
+```
+
 ### Nested Fields
 
 As described in the [Data Model document][docs.data_model], Vector flatten
@@ -184,19 +197,6 @@ event["parent.child"] = nil
 Vector provides a `search_dirs` option that allows you to specify absolute
 paths that will searched when using the [Lua `require`
 function][urls.lua_require].
-
-### Iterate over fields
-
-To iterate over all fields of an `event` use the `pairs` method.  For example:
-
-```lua
-# Remove all fields where the value is "-"
-for f,v in pairs(event) do
-  if v == "-" then
-    event[f] = nil
-  end
-end
-```
 
 ## Troubleshooting
 

--- a/scripts/generate/templates/docs/usage/configuration/transforms/lua.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/lua.md.erb
@@ -89,6 +89,19 @@ event["parent.child"] = "nested value"
 event["parent.child"] = nil
 ```
 
+### Iterate over fields
+
+To iterate over all fields of an `event` use the `pairs` method.  For example:
+
+```lua
+# Remove all fields where the value is "-"
+for f,v in pairs(event) do
+  if v == "-" then
+    event[f] = nil
+  end
+end
+```
+
 ### Search Directories
 
 Vector provides a `search_dirs` option that allows you to specify absolute


### PR DESCRIPTION
Previously the documentation was put into an auto-generated file, which made `check-generate` test fail.