### PR TITLE
fix(journald source): Limit journald records to the current boot

### DIFF
--- a/lib/journald/src/lib.rs
+++ b/lib/journald/src/lib.rs
@@ -24,19 +24,21 @@ struct sd_id128_t {
 
 #[derive(WrapperApi)]
 struct LibSystemd {
-    sd_journal_open: extern "C" fn(ret: *mut *mut sd_journal, flags: c_int) -> c_int,
+    sd_id128_get_boot: extern "C" fn(ret: *mut sd_id128_t) -> c_int,
+    sd_id128_to_string: extern "C" fn(sd: sd_id128_t, s: *mut [c_uchar; 33]) -> *mut c_char,
+
     sd_journal_close: extern "C" fn(j: *mut sd_journal),
-    sd_journal_next: extern "C" fn(j: *mut sd_journal) -> c_int,
-    sd_journal_seek_head: extern "C" fn(j: *mut sd_journal) -> c_int,
-    sd_journal_restart_data: extern "C" fn(j: *mut sd_journal),
     sd_journal_enumerate_data:
         extern "C" fn(j: *mut sd_journal, data: *const *mut u8, l: *mut size_t) -> c_int,
-    sd_journal_seek_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const c_char) -> c_int,
     sd_journal_get_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const *mut c_char) -> c_int,
-    sd_journal_test_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const c_char) -> c_int,
-    sd_id128_get_boot: extern "C" fn(ret: *mut sd_id128_t) -> c_int,
+    sd_journal_next: extern "C" fn(j: *mut sd_journal) -> c_int,
+    sd_journal_open: extern "C" fn(ret: *mut *mut sd_journal, flags: c_int) -> c_int,
+    sd_journal_restart_data: extern "C" fn(j: *mut sd_journal),
+    sd_journal_seek_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const c_char) -> c_int,
+    sd_journal_seek_head: extern "C" fn(j: *mut sd_journal) -> c_int,
     sd_journal_seek_monotonic_usec:
         extern "C" fn(j: *mut sd_journal, boot_id: sd_id128_t, usec: u64) -> c_int,
+    sd_journal_test_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const c_char) -> c_int,
 }
 
 fn load_lib() -> Result<Container<LibSystemd>, dlopen::Error> {

--- a/lib/journald/src/lib.rs
+++ b/lib/journald/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::io;
 use std::iter;
-use std::os::raw::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int, c_uchar, c_void};
 use std::ptr::null_mut;
 
 const SD_JOURNAL_LOCAL_ONLY: c_int = 1;
@@ -18,6 +18,7 @@ enum sd_journal {}
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
+#[derive(Clone, Copy)]
 struct sd_id128_t {
     pub bytes: [u8; 16],
 }
@@ -27,9 +28,12 @@ struct LibSystemd {
     sd_id128_get_boot: extern "C" fn(ret: *mut sd_id128_t) -> c_int,
     sd_id128_to_string: extern "C" fn(sd: sd_id128_t, s: *mut [c_uchar; 33]) -> *mut c_char,
 
+    sd_journal_add_match:
+        extern "C" fn(j: *mut sd_journal, data: *const c_void, size: size_t) -> c_int,
     sd_journal_close: extern "C" fn(j: *mut sd_journal),
     sd_journal_enumerate_data:
         extern "C" fn(j: *mut sd_journal, data: *const *mut u8, l: *mut size_t) -> c_int,
+    sd_journal_flush_matches: extern "C" fn(j: *mut sd_journal),
     sd_journal_get_cursor: extern "C" fn(j: *mut sd_journal, cursor: *const *mut c_char) -> c_int,
     sd_journal_next: extern "C" fn(j: *mut sd_journal) -> c_int,
     sd_journal_open: extern "C" fn(ret: *mut *mut sd_journal, flags: c_int) -> c_int,
@@ -138,14 +142,31 @@ impl Journal {
         Ok(())
     }
 
-    /// Seek the journal to the first record in the current boot.
-    pub fn seek_boot(&self) -> io::Result<()> {
+    /// Limit the returned records to those from the current boot.
+    pub fn setup_current_boot(&self) -> io::Result<()> {
         let mut boot_id = sd_id128_t { bytes: [0; 16] };
         sd_result(self.lib.sd_id128_get_boot(&mut boot_id))?;
+
+        let mut boot_str = [0u8; 33];
+        self.lib.sd_id128_to_string(boot_id, &mut boot_str);
+        let boot_str = String::from_utf8_lossy(&boot_str[0..32]);
+
+        // Seek to the first record of the current boot.
         sd_result(
             self.lib
                 .sd_journal_seek_monotonic_usec(self.journal, boot_id, 0),
         )?;
+
+        // Journald does not guarantee that the following records are
+        // only from the current boot, so a filter is also needed.
+        let filter = format!("_BOOT_ID={}", boot_str);
+        sd_result(self.lib.sd_journal_add_match(
+            self.journal,
+            filter.as_ptr() as *const c_void,
+            filter.len(),
+        ))?;
+        self.lib.sd_journal_flush_matches(self.journal);
+
         Ok(())
     }
 }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -56,7 +56,7 @@ impl SourceConfig for JournaldConfig {
         let data_dir = globals.resolve_and_make_data_subdir(self.data_dir.as_ref(), name)?;
         let journal = Journal::open(local_only, false).context(JournaldError)?;
         if self.current_boot_only.unwrap_or(true) {
-            journal.seek_boot()?;
+            journal.setup_current_boot()?;
         }
         let batch_size = self.batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 


### PR DESCRIPTION
Apparently journald does not guarantee that records following the current boot marker will only be from that boot, so Vector needs to add a filter to force that.