### PR TITLE
fix(observability): Improve topology tracing spans

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -162,6 +162,10 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "aws_cloudwatch_logs"
+    }
 }
 
 impl CloudwatchLogsPartitionSvc {

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -54,6 +54,10 @@ impl SinkConfig for CloudWatchMetricsSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn sink_type(&self) -> &'static str {
+        "aws_cloudwatch_metrics"
+    }
 }
 
 impl CloudWatchMetricsSvc {

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -70,6 +70,10 @@ impl SinkConfig for KinesisSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "aws_kinesis_streams"
+    }
 }
 
 impl KinesisService {

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -89,6 +89,10 @@ impl SinkConfig for S3SinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "aws_s3"
+    }
 }
 
 #[derive(Debug, Snafu)]

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -30,6 +30,10 @@ impl SinkConfig for BlackholeConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "blackhole"
+    }
 }
 
 fn healthcheck() -> impl Future<Item = (), Error = crate::Error> {

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -55,6 +55,10 @@ impl SinkConfig for ClickhouseConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "clickhouse"
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -60,6 +60,10 @@ impl SinkConfig for ConsoleSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Any
     }
+
+    fn sink_type(&self) -> &'static str {
+        "console"
+    }
 }
 
 fn encode_event(event: Event, encoding: &Encoding) -> Result<String, ()> {

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -96,6 +96,10 @@ impl SinkConfig for DatadogConfig {
     fn input_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn sink_type(&self) -> &'static str {
+        "datadog"
+    }
 }
 
 impl DatadogSvc {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -84,6 +84,10 @@ impl SinkConfig for ElasticSearchConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "elasticsearch"
+    }
 }
 
 struct ElasticSearchCommon {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -52,6 +52,10 @@ impl SinkConfig for FileSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "file"
+    }
 }
 
 #[derive(Debug, Default)]

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -105,6 +105,10 @@ impl SinkConfig for HttpSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "http"
+    }
 }
 
 fn http(

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -76,6 +76,10 @@ impl SinkConfig for KafkaSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "kafka"
+    }
 }
 
 impl KafkaSinkConfig {

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -85,6 +85,10 @@ impl SinkConfig for PrometheusSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn sink_type(&self) -> &'static str {
+        "prometheus"
+    }
 }
 
 struct PrometheusSink {

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -76,6 +76,10 @@ impl SinkConfig for HecSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "splunk_hec"
+    }
 }
 
 pub fn hec(config: HecSinkConfig, acker: Acker) -> crate::Result<super::RouterSink> {

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -67,6 +67,10 @@ impl SinkConfig for StatsdSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn sink_type(&self) -> &'static str {
+        "statsd"
+    }
 }
 
 impl StatsdSvc {

--- a/src/sinks/tcp.rs
+++ b/src/sinks/tcp.rs
@@ -107,6 +107,10 @@ impl SinkConfig for TcpSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "tcp"
+    }
 }
 
 pub struct TcpSink {

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -47,6 +47,10 @@ impl SinkConfig for VectorSinkConfig {
     fn input_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "vector"
+    }
 }
 
 pub fn vector(hostname: String, addr: SocketAddr, acker: Acker) -> super::RouterSink {

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -74,6 +74,10 @@ impl SourceConfig for DockerConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "docker"
+    }
 }
 
 struct DockerSourceCore {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -142,6 +142,10 @@ impl SourceConfig for FileConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "file"
+    }
 }
 
 pub fn file_source(

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -89,6 +89,10 @@ impl SourceConfig for JournaldConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "journald"
+    }
 }
 
 fn journald_source<J>(

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -65,6 +65,10 @@ impl SourceConfig for KafkaSourceConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "kafka"
+    }
 }
 
 fn kafka_source(

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -31,6 +31,10 @@ impl crate::topology::config::SourceConfig for StatsdConfig {
     fn output_type(&self) -> crate::topology::config::DataType {
         crate::topology::config::DataType::Metric
     }
+
+    fn source_type(&self) -> &'static str {
+        "statsd"
+    }
 }
 
 fn statsd(addr: SocketAddr, out: mpsc::Sender<Event>) -> super::Source {

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -46,6 +46,10 @@ impl SourceConfig for StdinConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "stdin"
+    }
 }
 
 pub fn stdin_source<R>(stdin: R, config: StdinConfig, out: mpsc::Sender<Event>) -> super::Source

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -79,6 +79,10 @@ impl SourceConfig for SyslogConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "syslog"
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -57,6 +57,10 @@ impl SourceConfig for TcpConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "tcp"
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sources/udp.rs
+++ b/src/sources/udp.rs
@@ -42,6 +42,10 @@ impl SourceConfig for UdpConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "udp"
+    }
 }
 
 pub fn udp(address: SocketAddr, host_key: Atom, out: mpsc::Sender<Event>) -> super::Source {

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -47,6 +47,10 @@ impl SourceConfig for VectorConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "vector"
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -115,6 +115,11 @@ pub trait SourceConfig: core::fmt::Debug {
     ) -> crate::Result<sources::Source>;
 
     fn output_type(&self) -> DataType;
+
+    fn source_type(&self) -> &'static str {
+        // TODO: remove default and impl on each sink
+        "test"
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -136,6 +141,11 @@ pub trait SinkConfig: core::fmt::Debug {
     ) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)>;
 
     fn input_type(&self) -> DataType;
+
+    fn sink_type(&self) -> &'static str {
+        // TODO: remove default and impl on each sink
+        "test"
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -152,6 +162,11 @@ pub trait TransformConfig: core::fmt::Debug {
     fn input_type(&self) -> DataType;
 
     fn output_type(&self) -> DataType;
+
+    fn transform_type(&self) -> &'static str {
+        // TODO: remove default and impl on each sink
+        "test"
+    }
 }
 
 // Helper methods for programming construction during tests

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -116,10 +116,7 @@ pub trait SourceConfig: core::fmt::Debug {
 
     fn output_type(&self) -> DataType;
 
-    fn source_type(&self) -> &'static str {
-        // TODO: remove default and impl on each sink
-        "test"
-    }
+    fn source_type(&self) -> &'static str;
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -142,10 +139,7 @@ pub trait SinkConfig: core::fmt::Debug {
 
     fn input_type(&self) -> DataType;
 
-    fn sink_type(&self) -> &'static str {
-        // TODO: remove default and impl on each sink
-        "test"
-    }
+    fn sink_type(&self) -> &'static str;
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -163,10 +157,7 @@ pub trait TransformConfig: core::fmt::Debug {
 
     fn output_type(&self) -> DataType;
 
-    fn transform_type(&self) -> &'static str {
-        // TODO: remove default and impl on each sink
-        "test"
-    }
+    fn transform_type(&self) -> &'static str;
 }
 
 // Helper methods for programming construction during tests

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -1,0 +1,49 @@
+use futures::{Future, Poll};
+use std::fmt;
+
+/// High level topology task.
+pub struct Task {
+    inner: Box<dyn Future<Item = (), Error = ()> + Send + 'static>,
+    name: String,
+    typetag: String,
+}
+
+impl Task {
+    pub fn new(
+        name: &str,
+        typetag: &str,
+        inner: impl Future<Item = (), Error = ()> + Send + 'static,
+    ) -> Self {
+        Self {
+            inner: Box::new(inner),
+            name: name.into(),
+            typetag: typetag.into(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn typetag(&self) -> &str {
+        &self.typetag
+    }
+}
+
+impl Future for Task {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+impl fmt::Debug for Task {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Task")
+            .field("name", &self.name)
+            .field("typetag", &self.typetag)
+            .finish()
+    }
+}

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -32,6 +32,10 @@ impl TransformConfig for AddFieldsConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "add_fields"
+    }
 }
 
 impl AddFields {

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -31,6 +31,10 @@ impl TransformConfig for AddTagsConfig {
     fn output_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn transform_type(&self) -> &'static str {
+        "add_tags"
+    }
 }
 
 impl AddTags {

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -28,6 +28,10 @@ impl crate::topology::config::TransformConfig for CoercerConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "coercer"
+    }
 }
 
 pub struct Coercer {

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -29,6 +29,10 @@ impl TransformConfig for FieldFilterConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "field_filter"
+    }
 }
 
 pub struct FieldFilter {

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -57,6 +57,10 @@ impl TransformConfig for GrokParserConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "grok_parser"
+    }
 }
 
 pub struct GrokParser {

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -30,6 +30,10 @@ impl TransformConfig for JsonParserConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "json_parser"
+    }
 }
 
 pub struct JsonParser {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -81,6 +81,10 @@ impl TransformConfig for LogToMetricConfig {
     fn output_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn transform_type(&self) -> &'static str {
+        "log_to_metric"
+    }
 }
 
 impl LogToMetric {

--- a/src/transforms/lua.rs
+++ b/src/transforms/lua.rs
@@ -36,6 +36,10 @@ impl TransformConfig for LuaConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "lua"
+    }
 }
 
 pub struct Lua {

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -63,6 +63,10 @@ impl TransformConfig for RegexParserConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "regex"
+    }
 }
 
 pub struct RegexParser {

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -29,6 +29,10 @@ impl TransformConfig for RemoveFieldsConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "remove_fields"
+    }
 }
 
 impl RemoveFields {

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -29,6 +29,10 @@ impl TransformConfig for RemoveTagsConfig {
     fn output_type(&self) -> DataType {
         DataType::Metric
     }
+
+    fn transform_type(&self) -> &'static str {
+        "remove_tags"
+    }
 }
 
 impl RemoveTags {

--- a/src/transforms/sampler.rs
+++ b/src/transforms/sampler.rs
@@ -30,6 +30,10 @@ impl TransformConfig for SamplerConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "sampler"
+    }
 }
 
 pub struct Sampler {

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -46,6 +46,10 @@ impl TransformConfig for SplitConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "split"
+    }
 }
 
 pub struct Split {

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -51,6 +51,10 @@ impl TransformConfig for TokenizerConfig {
     fn output_type(&self) -> DataType {
         DataType::Log
     }
+
+    fn transform_type(&self) -> &'static str {
+        "tokenizer"
+    }
 }
 
 pub struct Tokenizer {

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -28,6 +28,10 @@ impl config::SinkConfig for PanicSink {
     fn input_type(&self) -> config::DataType {
         config::DataType::Log
     }
+
+    fn sink_type(&self) -> &'static str {
+        "panic"
+    }
 }
 
 impl Sink for PanicSink {
@@ -99,6 +103,10 @@ impl config::SinkConfig for ErrorSink {
 
     fn input_type(&self) -> config::DataType {
         config::DataType::Log
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "panic"
     }
 }
 
@@ -173,6 +181,10 @@ impl config::SourceConfig for ErrorSourceConfig {
     fn output_type(&self) -> config::DataType {
         config::DataType::Log
     }
+
+    fn source_type(&self) -> &'static str {
+        "tcp"
+    }
 }
 
 #[test]
@@ -231,6 +243,10 @@ impl config::SourceConfig for PanicSourceConfig {
 
     fn output_type(&self) -> config::DataType {
         config::DataType::Log
+    }
+
+    fn source_type(&self) -> &'static str {
+        "tcp"
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -76,6 +76,10 @@ impl SourceConfig for MockSourceConfig {
     fn output_type(&self) -> DataType {
         DataType::Any
     }
+
+    fn source_type(&self) -> &'static str {
+        "mock"
+    }
 }
 
 pub struct MockTransform {
@@ -158,6 +162,10 @@ impl TransformConfig for MockTransformConfig {
     fn output_type(&self) -> DataType {
         DataType::Any
     }
+
+    fn transform_type(&self) -> &'static str {
+        "mock"
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -201,5 +209,9 @@ impl SinkConfig for MockSinkConfig {
 
     fn input_type(&self) -> DataType {
         DataType::Any
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "mock"
     }
 }


### PR DESCRIPTION
This change improves the output of tracing spans. Span's now include the source/transform/sink type.

![image](https://user-images.githubusercontent.com/5758045/67901529-66ee9780-fb3d-11e9-9787-8dc1cc396623.png)

This internally refactors our topology `Task` type to include metadata.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>