### PR TITLE
fix(journald source): Flush and reset any current filter before applying new filter

### DIFF
--- a/lib/journald/src/lib.rs
+++ b/lib/journald/src/lib.rs
@@ -159,13 +159,13 @@ impl Journal {
 
         // Journald does not guarantee that the following records are
         // only from the current boot, so a filter is also needed.
+        self.lib.sd_journal_flush_matches(self.journal);
         let filter = format!("_BOOT_ID={}", boot_str);
         sd_result(self.lib.sd_journal_add_match(
             self.journal,
             filter.as_ptr() as *const c_void,
             filter.len(),
         ))?;
-        self.lib.sd_journal_flush_matches(self.journal);
 
         Ok(())
     }


### PR DESCRIPTION
As per systemd man: `sd_journal_flush_matches()` may be used to flush all matches, disjunction and conjunction terms again. After this call all filtering is removed and all entries in the journal will be iterated again.

So reset the filter and then apply the `_BOOT_ID` filter.

Discussion in #1081 