### PR TITLE
fix(operations): Handle edge cases in the Cargo.toml version check

### DIFF
--- a/scripts/check-version.rb
+++ b/scripts/check-version.rb
@@ -42,7 +42,7 @@ git_version = git_tag.delete_prefix("v").to_version
 
 # determine minimal required Cargo version using commits since the last Git tag
 commit_messages = git.log.between(git_tag, "HEAD").map { |commit| commit.message.lines.first }
-min_cargo_version = commit_messages.map { |message| git_version.after_conventional_commit(message) }.max
+min_cargo_version = commit_messages.map { |message| git_version.after_conventional_commit(message) }.max || git_version
 
 puts "Latest tagged version: #{git_version}"
 puts "Version in Cargo.toml: #{cargo_version}"

--- a/scripts/check-version.rb
+++ b/scripts/check-version.rb
@@ -41,7 +41,7 @@ git_tag = git.describe("HEAD", { :tags => true, :abbrev => 0 })
 git_version = git_tag.delete_prefix("v").to_version
 
 # determine minimal required Cargo version using commits since the last Git tag
-commit_messages = git.log.since(git_tag).map { |commit| commit.message.lines.first }
+commit_messages = git.log.between(git_tag, "HEAD").map { |commit| commit.message.lines.first }
 min_cargo_version = commit_messages.map { |message| git_version.after_conventional_commit(message) }.max
 
 puts "Latest tagged version: #{git_version}"


### PR DESCRIPTION
A follow-up for #1102. Because commits in master don't have chronological order, `git.log.since` doesn't always return all commits since the tag.