### PR TITLE
chore(operations): Bump version in Cargo.toml to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.4.0-dev"
+version = "0.6.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "A High-Performance Logs, Metrics, and Events Router"


### PR DESCRIPTION
Bump version in `Cargo.toml` to pass the version check from https://github.com/timberio/vector/issues/1083.