### PR TITLE
fix(aws_cloudwatch_metrics sink): Fix metrics batch strategy in sinks

### DIFF
--- a/config/examples/file_to_cloudwatch_metrics.toml
+++ b/config/examples/file_to_cloudwatch_metrics.toml
@@ -25,6 +25,7 @@ type = "log_to_metric"
 type = "counter"
 increment_by_value = true
 field = "bytes_out"
+tags = {method = "{{method}}", status = "{{status}}"}
 
 # Output data
 [sinks.console_metrics]

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -96,7 +96,7 @@ impl CloudWatchMetricsSvc {
             .timeout(Duration::from_secs(timeout))
             .service(cloudwatch_metrics);
 
-        let sink = BatchServiceSink::new(svc, acker).batched_with_max(
+        let sink = BatchServiceSink::new(svc, acker).batched_with_min(
             MetricBuffer::new(),
             batch_size,
             Duration::from_secs(batch_timeout),

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -152,7 +152,7 @@ impl DatadogSvc {
             .timeout(Duration::from_secs(timeout))
             .service(datadog_http_service);
 
-        let sink = BatchServiceSink::new(service, acker).batched_with_max(
+        let sink = BatchServiceSink::new(service, acker).batched_with_min(
             MetricBuffer::new(),
             batch_size,
             Duration::from_secs(batch_timeout),

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -65,10 +65,6 @@ where
         Self::build(inner, batch, min_size, min_size, max_linger)
     }
 
-    pub fn new_max(inner: S, batch: B, max_size: usize, max_linger: Option<Duration>) -> Self {
-        Self::build(inner, batch, 0, max_size, max_linger)
-    }
-
     fn build(
         inner: S,
         batch: B,

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -173,7 +173,7 @@ mod test {
 
     #[test]
     fn metric_buffer_counters() {
-        let sink = BatchSink::new_max(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
         for i in 0..4 {
@@ -279,7 +279,7 @@ mod test {
 
     #[test]
     fn metric_buffer_gauges() {
-        let sink = BatchSink::new_max(vec![], MetricBuffer::new(), 4, Some(Duration::from_secs(1)));
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 4, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
         for i in 0..4 {
@@ -424,7 +424,7 @@ mod test {
 
     #[test]
     fn metric_buffer_sets() {
-        let sink = BatchSink::new_max(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
         for i in 0..4 {
@@ -488,7 +488,7 @@ mod test {
 
     #[test]
     fn metric_buffer_histograms() {
-        let sink = BatchSink::new_max(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
         for _i in 2..6 {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -40,13 +40,6 @@ where
         BatchSink::new_min(self, batch, min, Some(delay))
     }
 
-    fn batched_with_max(self, batch: T, max: usize, delay: Duration) -> BatchSink<T, Self>
-    where
-        T: Batch,
-    {
-        BatchSink::new_max(self, batch, max, Some(delay))
-    }
-
     fn partitioned_batched_with_min<K>(
         self,
         batch: T,


### PR DESCRIPTION
Undoing recently introduced `batched_with_max`, because it was not working as intended, and is basically not required.

Used with MetricBuffer, `batched_with_min` strategy will make sure the buffer sent out either when it contain `batch_size` metrics sharp, or it has timed out.

Ref #856 