### PR TITLE
feat(cli): Add list subcommand

### DIFF
--- a/docs/usage/administration/starting.md
+++ b/docs/usage/administration/starting.md
@@ -44,6 +44,22 @@ brew services start vector
 | `-v, --verbose` | Drops the log level to `debug`. |
 | `-vv` | Drops the log level to `trace`, the lowest level possible. |
 
+## Discovery
+
+In order to help you explore its features Vector provides a subcommand `list`
+that lists all available sources, transforms and sinks:
+
+{% tabs %}
+{% tab title="List" %}
+```bash
+vector list
+```
+{% endtab %}
+{% endtabs %}
+
+By default this prints a human readable representation of all components. You
+can view options for customizing the output of `list` with `vector list --help`.
+
 ## Daemonizing
 
 Vector does not _directly_ offer a way to daemonize the Vector process. We

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub mod buffers;
 pub mod event;
+pub mod list;
 pub mod metrics;
 pub mod region;
 pub mod runtime;

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,0 +1,76 @@
+use crate::topology::config::{SinkDescription, SourceDescription, TransformDescription};
+use serde::Serialize;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Opts {
+    /// Format the list in an encoding scheme.
+    ///
+    /// Options: `text`, `json`
+    #[structopt(long, default_value = "text")]
+    format: Format,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Format {
+    Text,
+    Json,
+}
+
+impl std::str::FromStr for Format {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(Format::Text),
+            "json" => Ok(Format::Json),
+            s => Err(format!(
+                "{} is not a valid option, expected `text` or `json`",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct EncodedList {
+    sources: Vec<&'static str>,
+    transforms: Vec<&'static str>,
+    sinks: Vec<&'static str>,
+}
+
+pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
+    let sources = SourceDescription::types();
+    let transforms = TransformDescription::types();
+    let sinks = SinkDescription::types();
+
+    match opts.format {
+        Format::Text => {
+            println!("Sources:");
+            for name in sources {
+                println!("- {}", name);
+            }
+
+            println!("\nTransforms:");
+            for name in transforms {
+                println!("- {}", name);
+            }
+
+            println!("\nSinks:");
+            for name in sinks {
+                println!("- {}", name);
+            }
+        }
+        Format::Json => {
+            let list = EncodedList {
+                sources: sources,
+                transforms: transforms,
+                sinks: sinks,
+            };
+            println!("{}", serde_json::to_string(&list).unwrap());
+        }
+    }
+
+    exitcode::OK
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{metrics, runtime, topology, trace};
+use vector::{list, metrics, runtime, topology, trace};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -79,6 +79,9 @@ struct RootOpts {
 enum SubCommand {
     /// Validate the target config, then exit.
     Validate(Validate),
+
+    /// List available components, then exit.
+    List(list::Opts),
 }
 
 #[derive(StructOpt, Debug)]
@@ -192,6 +195,7 @@ fn main() {
     sub_command.map(|s| {
         std::process::exit(match s {
             SubCommand::Validate(v) => validate(&v, &opts),
+            SubCommand::List(l) => list::cmd(&l),
         })
     });
 


### PR DESCRIPTION
This PR adds a subcommand `list` to Vector that prints out all available plugins for each component type in a specified format (currently supports plain text or json).

Closes #931.