### PR TITLE
feat(cli): Add generate subcommand

### DIFF
--- a/docs/usage/administration/starting.md
+++ b/docs/usage/administration/starting.md
@@ -60,6 +60,42 @@ vector list
 By default this prints a human readable representation of all components. You
 can view options for customizing the output of `list` with `vector list --help`.
 
+## Configuration
+
+In order to assist with writing a Vector configuration file it's possible to
+generate one containing a custom set of components with the subcommand
+`generate`:
+
+{% tabs %}
+{% tab title="List" %}
+```bash
+vector generate 'stdin|json_parser,add_fields|console'
+```
+{% endtab %}
+{% endtabs %}
+
+The format of a generate expression is three comma-separated lists of sources,
+transforms and sinks respectively, separated by pipes. If subsequent component
+types are not needed then their pipes can be omitted from the expression.
+
+Here are some examples:
+
+- `|json_parser` prints a `json_parser` transform.
+- `||file,http` prints a `file` and `http` sink.
+- `stdin||http` prints a `stdin` source and an `http` sink.
+
+Vector makes a best attempt at constructing a sensible topology. The first
+transform generated will consume from all sources and subsequent transforms
+will consume from their predecessor. All sinks will consume from the last
+transform or, if none are specified, from all sources. It is then up to you to
+restructure the `inputs` of each component to build the topology you need.
+
+Generated components are given incremental names (`source1`, `source2`, etc)
+which should be replaced in order to provide better context.
+
+You can view options for customizing the output of `generate` with
+`vector generate --help`.
+
 ## Daemonizing
 
 Vector does not _directly_ offer a way to daemonize the Vector process. We

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,0 +1,211 @@
+use crate::topology::config::{
+    component::ExampleError, GlobalOptions, SinkDescription, SourceDescription,
+    TransformDescription,
+};
+use indexmap::IndexMap;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+use toml::Value;
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Opts {
+    /// Generate expression, e.g. 'stdin|json_parser,add_fields|console'
+    ///
+    /// Three comma-separated lists of sources, transforms and sinks, separated
+    /// by pipes. If subsequent component types are not needed then their pipes
+    /// can be omitted from the expression.
+    ///
+    /// For example:
+    ///
+    /// `|json_parser` prints a `json_parser` transform.
+    ///
+    /// `||file,http` prints a `file` and `http` sink.
+    ///
+    /// `stdin||http` prints a `stdin` source and an `http` sink.
+    ///
+    /// Vector makes a best attempt at constructing a sensible topology. The
+    /// first transform generated will consume from all sources and subsequent
+    /// transforms will consume from their predecessor. All sinks will consume
+    /// from the last transform or, if none are specified, from all sources. It
+    /// is then up to you to restructure the `inputs` of each component to build
+    /// the topology you need.
+    ///
+    /// Generated components are given incremental names (`source1`, `source2`,
+    /// etc) which should be replaced in order to provide better context.
+    expression: String,
+}
+
+#[derive(Serialize)]
+pub struct SinkOuter {
+    pub healthcheck: bool,
+    pub inputs: Vec<String>,
+    #[serde(flatten)]
+    pub inner: Value,
+    pub buffer: crate::buffers::BufferConfig,
+}
+
+#[derive(Serialize)]
+pub struct TransformOuter {
+    pub inputs: Vec<String>,
+    #[serde(flatten)]
+    pub inner: Value,
+}
+
+#[derive(Serialize, Default)]
+pub struct Config {
+    #[serde(flatten)]
+    pub global: GlobalOptions,
+    pub sources: IndexMap<String, Value>,
+    pub transforms: IndexMap<String, TransformOuter>,
+    pub sinks: IndexMap<String, SinkOuter>,
+}
+
+pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
+    let components: Vec<Vec<String>> = opts
+        .expression
+        .split('|')
+        .map(|s| {
+            s.to_owned()
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| s.len() > 0)
+                .collect()
+        })
+        .collect();
+
+    let mut config = Config::default();
+    config.global.data_dir = crate::topology::config::default_data_dir();
+
+    let mut errs = Vec::new();
+
+    let mut i = 0;
+    let mut source_names = Vec::new();
+    components
+        .get(0)
+        .unwrap_or(&Vec::new())
+        .iter()
+        .for_each(|c| {
+            i += 1;
+            let name = format!("source{}", i);
+            source_names.push(name.clone());
+            config.sources.insert(name, {
+                let mut d = SourceDescription::example(c)
+                    .map_err(|e| {
+                        match e {
+                            ExampleError::MissingExample => {}
+                            _ => errs.push(e.clone()),
+                        }
+                        e
+                    })
+                    .unwrap_or(Value::Table(BTreeMap::new()));
+                d.as_table_mut().map(|s| {
+                    s.insert("type".to_owned(), c.to_owned().into());
+                    s
+                });
+                d
+            });
+        });
+
+    i = 0;
+    let mut transform_names = Vec::new();
+    components
+        .get(1)
+        .unwrap_or(&Vec::new())
+        .iter()
+        .for_each(|c| {
+            i += 1;
+            let name = format!("transform{}", i);
+            transform_names.push(name.clone());
+            let targets = if i == 1 {
+                source_names.clone()
+            } else {
+                vec![transform_names
+                    .get(i - 2)
+                    .unwrap_or(&"TODO".to_owned())
+                    .to_owned()]
+            };
+            config.transforms.insert(
+                name,
+                TransformOuter {
+                    inputs: targets,
+                    inner: {
+                        let mut d = TransformDescription::example(c)
+                            .map_err(|e| {
+                                match e {
+                                    ExampleError::MissingExample => {}
+                                    _ => errs.push(e.clone()),
+                                }
+                                e
+                            })
+                            .unwrap_or(Value::Table(BTreeMap::new()));
+                        d.as_table_mut().map(|s| {
+                            s.insert("type".to_owned(), c.to_owned().into());
+                            s
+                        });
+                        d
+                    },
+                },
+            );
+        });
+
+    i = 0;
+    components
+        .get(2)
+        .unwrap_or(&Vec::new())
+        .iter()
+        .for_each(|c| {
+            i += 1;
+            config.sinks.insert(
+                format!("sink{}", i),
+                SinkOuter {
+                    inputs: transform_names
+                        .last()
+                        .map(|s| vec![s.to_owned()])
+                        .or_else(|| {
+                            if source_names.len() > 0 {
+                                Some(source_names.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(vec!["TODO".to_owned()]),
+                    buffer: crate::buffers::BufferConfig::default(),
+                    healthcheck: true,
+                    inner: {
+                        let mut d = SinkDescription::example(c)
+                            .map_err(|e| {
+                                match e {
+                                    ExampleError::MissingExample => {}
+                                    _ => errs.push(e.clone()),
+                                }
+                                e
+                            })
+                            .unwrap_or(Value::Table(BTreeMap::new()));
+                        d.as_table_mut().map(|s| {
+                            s.insert("type".to_owned(), c.to_owned().into());
+                            s
+                        });
+                        d
+                    },
+                },
+            );
+        });
+
+    if errs.len() > 0 {
+        errs.iter().for_each(|e| eprintln!("Generate error: {}", e));
+        return exitcode::CONFIG;
+    }
+
+    match toml::to_string_pretty(&config) {
+        Ok(s) => {
+            println!("{}", s);
+            exitcode::OK
+        }
+        Err(e) => {
+            eprintln!("Failed to generate config: {}.", e);
+            exitcode::SOFTWARE
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub mod buffers;
 pub mod event;
+pub mod generate;
 pub mod list;
 pub mod metrics;
 pub mod region;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{list, metrics, runtime, topology, trace};
+use vector::{generate, list, metrics, runtime, topology, trace};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -82,6 +82,9 @@ enum SubCommand {
 
     /// List available components, then exit.
     List(list::Opts),
+
+    /// Generate a Vector configuration containing a list of components.
+    Generate(generate::Opts),
 }
 
 #[derive(StructOpt, Debug)]
@@ -196,6 +199,7 @@ fn main() {
         std::process::exit(match s {
             SubCommand::Validate(v) => validate(&v, &opts),
             SubCommand::List(l) => list::cmd(&l),
+            SubCommand::Generate(g) => generate::cmd(&g),
         })
     });
 

--- a/src/topology/config/component.rs
+++ b/src/topology/config/component.rs
@@ -4,7 +4,7 @@ use snafu::Snafu;
 use std::marker::PhantomData;
 use toml::Value;
 
-#[derive(Debug, Snafu, Clone)]
+#[derive(Debug, Snafu, Clone, PartialEq)]
 pub enum ExampleError {
     #[snafu(display("unable to create an example for this component"))]
     MissingExample,

--- a/src/topology/config/component.rs
+++ b/src/topology/config/component.rs
@@ -1,7 +1,16 @@
 use inventory;
 use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 use std::marker::PhantomData;
 use toml::Value;
+
+#[derive(Debug, Snafu, Clone)]
+pub enum ExampleError {
+    #[snafu(display("unable to create an example for this component"))]
+    MissingExample,
+    #[snafu(display("component type '{}' does not exist", type_str))]
+    DoesNotExist { type_str: String },
+}
 
 /// Describes a component plugin storing its type name, an example config, and
 /// other useful information about the plugin.
@@ -50,14 +59,14 @@ where
     }
 
     /// Returns an example config for a plugin identified by its type.
-    pub fn example(type_str: &str) -> Result<Value, String> {
+    pub fn example(type_str: &str) -> Result<Value, ExampleError> {
         inventory::iter::<ComponentDescription<T>>
             .into_iter()
             .find(|t| t.type_str == type_str)
-            .ok_or(format!("unrecognized type '{}'", type_str))
-            .and_then(|t| {
-                (t.example_value)().ok_or(format!("example not found for type '{}'", type_str))
+            .ok_or(ExampleError::DoesNotExist {
+                type_str: type_str.to_owned(),
             })
+            .and_then(|t| (t.example_value)().ok_or(ExampleError::MissingExample))
     }
 
     /// Returns a sorted Vec of all plugins registered of a type.

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -30,7 +30,7 @@ pub struct GlobalOptions {
     pub data_dir: Option<PathBuf>,
 }
 
-fn default_data_dir() -> Option<PathBuf> {
+pub fn default_data_dir() -> Option<PathBuf> {
     Some(PathBuf::from("/var/lib/vector/"))
 }
 


### PR DESCRIPTION
For most components this will simply generate an empty table with
boilerplate fields (`type`, `inputs`, etc). Eventually, however,
components will have curated examples written for them which are baked
into the Vector binary and can be used to generate more useful files.

Signed-off-by: Ashley Jeffs <ash@jeffail.uk>