### PR TITLE
enhancement(operations): Use vendored OpenSSL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,17 +133,10 @@ updated versions of Vector through various channels.
    curl https://sh.rustup.rs -sSf | sh
    ```
 
-2. Install [OpenSSL 1.0.x](https://www.openssl.org/source/) and set two environment variables
-
-   ```
-   export OPENSSL_INCLUDE_DIR=<openssl prefix>/include
-   export OPENSSL_LIB_DIR=<openssl prefix>/lib
-   ```
-
-3. [Install Docker](https://docs.docker.com/install/). Docker
+2. [Install Docker](https://docs.docker.com/install/). Docker
    containers are used for mocking Vector's integrations.
 
-4. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
+3. [Install Ruby](https://www.ruby-lang.org/en/downloads/) and
    [Bundler 2](https://bundler.io/v2.0/guides/bundler_2_upgrade.html).
    They are used to build Vector's documentation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl-src"
+version = "111.6.0+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1515,7 @@ dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.6.0+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2019,12 +2028,12 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.21.0"
-source = "git+https://github.com/fede1024/rust-rdkafka#47a5cc7442e4eb8815d6cfda79ae87aa9aaf2fbe"
+source = "git+https://github.com/timberio/rust-rdkafka#06ddd48dcabc507b0475e5dd2e0e611abe27fade"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)",
+ "rdkafka-sys 1.2.1 (git+https://github.com/timberio/rust-rdkafka)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2033,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.2.1"
-source = "git+https://github.com/fede1024/rust-rdkafka#47a5cc7442e4eb8815d6cfda79ae87aa9aaf2fbe"
+source = "git+https://github.com/timberio/rust-rdkafka#06ddd48dcabc507b0475e5dd2e0e611abe27fade"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3482,7 +3491,7 @@ dependencies = [
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)",
+ "rdkafka 0.21.0 (git+https://github.com/timberio/rust-rdkafka)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlua 0.16.4-alpha.0 (git+https://github.com/timberio/rlua)",
@@ -3825,6 +3834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-src 111.6.0+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)" = "b9c2da1de8a7a3f860919c01540b03a6db16de042405a8a07a5e9d0b4b825d9c"
 "checksum openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)" = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
@@ -3880,8 +3890,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03b418169fb9c46533f326efd6eed2576699c44ca92d3052a066214a8d828929"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
-"checksum rdkafka 0.21.0 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
-"checksum rdkafka-sys 1.2.1 (git+https://github.com/fede1024/rust-rdkafka)" = "<none>"
+"checksum rdkafka 0.21.0 (git+https://github.com/timberio/rust-rdkafka)" = "<none>"
+"checksum rdkafka-sys 1.2.1 (git+https://github.com/timberio/rust-rdkafka)" = "<none>"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ prometheus = "0.4.2"
 hyper = "0.12.35"
 hyper-tls = "0.3.2"
 native-tls = "0.2.3"
-openssl = "0.10.25"
+openssl = { version = "0.10.25", features = ["vendored"] }
 openssl-probe = "0.1.2"
 string_cache = "0.7.3"
 flate2 = "1.0.6"
@@ -109,7 +109,7 @@ derive_is_enum_variant = "0.1.1"
 leveldb = { version = "0.8.4", optional = true }
 db-key = "0.0.5"
 headers = "0.2.1"
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka", features = ["ssl"], optional = true }
+rdkafka = { git = "https://github.com/timberio/rust-rdkafka", features = ["ssl", "ssl_vendored"], optional = true }
 hostname = "0.1.5"
 seahash = "3.0.6"
 jemallocator = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Ref #1074 #1032.

This PR enables `vendored` feature for OpenSSL and uses a version of `rdkafka` from a fork with merged https://github.com/fede1024/rust-rdkafka/pull/169.

As a consequence, it allows us to remove OpenSSL from the list of development dependencies, thus reducing prerequisites for those who want to compile Vector locally, especially on macOS (see #1032 for details).