### PR TITLE
chore: Fix missed `cargo fmt` run on elasticsearch sink

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -486,7 +486,9 @@ mod tests {
         // credentials error, but that is valid too.
         match result {
             Ok(_) => (),
-            Err(err) => assert_downcast_matches!(err, ParseError, ParseError::AWSCredentialsGenerateFailed { .. }),
+            Err(err) => {
+                assert_downcast_matches!(err, ParseError, ParseError::AWSCredentialsGenerateFailed { .. })
+            }
         }
     }
 


### PR DESCRIPTION
I missed running `cargo fmt` when resolving the merge conflict.

Signed-off-by: Bruce Guenter <bruce@untroubled.org>