### PR TITLE
fix(testing): Increase wait timeouts in tests which otherwise fail on slow CPUs

### DIFF
--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -107,7 +107,7 @@ mod test {
                 address: out_addr,
                 namespace: "vector".into(),
                 buckets: vec![1.0, 2.0, 4.0],
-                flush_period: Duration::from_millis(100),
+                flush_period: Duration::from_millis(1000),
             },
         );
 
@@ -126,11 +126,11 @@ mod test {
                 )
                 .unwrap();
             // Space things out slightly to try to avoid dropped packets
-            thread::sleep(Duration::from_millis(1));
+            thread::sleep(Duration::from_millis(10));
         }
 
         // Give packets some time to flow through
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(100));
 
         let client = hyper::Client::new();
         let response =
@@ -176,7 +176,7 @@ mod test {
         // Flush test
         {
             // Wait for flush to happen
-            thread::sleep(Duration::from_millis(200));
+            thread::sleep(Duration::from_millis(2000));
 
             let response =
                 block_on(client.get(format!("http://{}/metrics", out_addr).parse().unwrap()))
@@ -196,9 +196,9 @@ mod test {
 
             socket.send_to(b"set:0|s\nset:1|s\n", &in_addr).unwrap();
             // Space things out slightly to try to avoid dropped packets
-            thread::sleep(Duration::from_millis(1));
-            // Give packets some time to flow through
             thread::sleep(Duration::from_millis(10));
+            // Give packets some time to flow through
+            thread::sleep(Duration::from_millis(100));
 
             let response =
                 block_on(client.get(format!("http://{}/metrics", out_addr).parse().unwrap()))

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -90,11 +90,11 @@ fn test_udp_syslog() {
     for line in input_lines.iter() {
         socket.send_to(line.as_bytes(), &in_addr).unwrap();
         // Space things out slightly to try to avoid dropped packets
-        thread::sleep(Duration::from_nanos(200_000));
+        thread::sleep(Duration::from_millis(2));
     }
 
     // Give packets some time to flow through
-    thread::sleep(Duration::from_millis(30));
+    thread::sleep(Duration::from_millis(300));
 
     // Shut down server
     block_on(topology.stop()).unwrap();


### PR DESCRIPTION
This PR increases wait timeouts for `syslog` and `statsd` tests in order to let them pass on QEMU emulation of ARMv7.

See also #1180.