### PR TITLE
docs: Use `strptime` instead of `strftime` in docs where appropriate

### DIFF
--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -682,7 +682,7 @@ data_dir = "/var/lib/vector"
 
   [transforms.coercer.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -773,7 +773,7 @@ data_dir = "/var/lib/vector"
 
   [transforms.grok_parser.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -991,7 +991,7 @@ end
 
   [transforms.regex_parser.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -1140,7 +1140,7 @@ end
 
   [transforms.split.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -1201,7 +1201,7 @@ end
 
   [transforms.tokenizer.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required

--- a/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
+++ b/docs/usage/configuration/sinks/aws_cloudwatch_logs.md
@@ -342,7 +342,7 @@ attempts and backoff rate with the `retry_attempts` and `retry_backoff_secs` opt
 The `group_name` and `stream_name` options
 support [Vector's template syntax][docs.configuration#template-syntax],
 enabling dynamic values derived from the event's data. This syntax accepts
-[strftime specifiers][urls.strftime_specifiers] as well as the
+[strptime specifiers][urls.strftime_specifiers] as well as the
 `{{ field_name }}` syntax for accessing event fields. For example:
 
 {% code-tabs %}

--- a/docs/usage/configuration/sinks/aws_s3.md
+++ b/docs/usage/configuration/sinks/aws_s3.md
@@ -447,7 +447,7 @@ S3.
 The `key_prefix` options
 support [Vector's template syntax][docs.configuration#template-syntax],
 enabling dynamic values derived from the event's data. This syntax accepts
-[strftime specifiers][urls.strftime_specifiers] as well as the
+[strptime specifiers][urls.strftime_specifiers] as well as the
 `{{ field_name }}` syntax for accessing event fields. For example:
 
 {% code-tabs %}

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -412,7 +412,7 @@ attempts and backoff rate with the `retry_attempts` and `retry_backoff_secs` opt
 The `index` options
 support [Vector's template syntax][docs.configuration#template-syntax],
 enabling dynamic values derived from the event's data. This syntax accepts
-[strftime specifiers][urls.strftime_specifiers] as well as the
+[strptime specifiers][urls.strftime_specifiers] as well as the
 `{{ field_name }}` syntax for accessing event fields. For example:
 
 {% code-tabs %}

--- a/docs/usage/configuration/sinks/file.md
+++ b/docs/usage/configuration/sinks/file.md
@@ -115,7 +115,7 @@ event-by-event basis. It does not batch data.
 The `path` options
 support [Vector's template syntax][docs.configuration#template-syntax],
 enabling dynamic values derived from the event's data. This syntax accepts
-[strftime specifiers][urls.strftime_specifiers] as well as the
+[strptime specifiers][urls.strftime_specifiers] as well as the
 `{{ field_name }}` syntax for accessing event fields. For example:
 
 {% code-tabs %}

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -702,7 +702,7 @@ data_dir = "/var/lib/vector"
 
   [transforms.coercer.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -793,7 +793,7 @@ data_dir = "/var/lib/vector"
 
   [transforms.grok_parser.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -1011,7 +1011,7 @@ end
 
   [transforms.regex_parser.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -1160,7 +1160,7 @@ end
 
   [transforms.split.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required
@@ -1221,7 +1221,7 @@ end
 
   [transforms.tokenizer.types]
     # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strftime` specifiers are supported for the
+    # and the value is the type. `strptime` specifiers are supported for the
     # `timestamp` type.
     # 
     # * required

--- a/docs/usage/configuration/transforms/coercer.md
+++ b/docs/usage/configuration/transforms/coercer.md
@@ -41,7 +41,7 @@ Key/Value pairs representing mapped log field types.
 
 `required` `type: string`
 
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
 
 The field is an enumeration and only accepts the following values:
 
@@ -51,7 +51,7 @@ The field is an enumeration and only accepts the following values:
 | `"float"` | Coerce to a 64 bit float. |
 | `"int"` | Coerce to a 64 bit integer. |
 | `"string"` | Coerce to a string. |
-| `"timestamp"` | Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
+| `"timestamp"` | Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
 
 ## Input/Output
 

--- a/docs/usage/configuration/transforms/grok_parser.md
+++ b/docs/usage/configuration/transforms/grok_parser.md
@@ -83,7 +83,7 @@ Key/Value pairs representing mapped log field types.
 
 `required` `type: string`
 
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
 
 The field is an enumeration and only accepts the following values:
 
@@ -93,7 +93,7 @@ The field is an enumeration and only accepts the following values:
 | `"float"` | Coerce to a 64 bit float. |
 | `"int"` | Coerce to a 64 bit integer. |
 | `"string"` | Coerce to a string. |
-| `"timestamp"` | Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
+| `"timestamp"` | Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
 
 ## How It Works
 

--- a/docs/usage/configuration/transforms/regex_parser.md
+++ b/docs/usage/configuration/transforms/regex_parser.md
@@ -83,7 +83,7 @@ Key/Value pairs representing mapped log field types.
 
 `required` `type: string`
 
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
 
 The field is an enumeration and only accepts the following values:
 
@@ -93,7 +93,7 @@ The field is an enumeration and only accepts the following values:
 | `"float"` | Coerce to a 64 bit float. |
 | `"int"` | Coerce to a 64 bit integer. |
 | `"string"` | Coerce to a string. |
-| `"timestamp"` | Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
+| `"timestamp"` | Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
 
 ## Input/Output
 

--- a/docs/usage/configuration/transforms/split.md
+++ b/docs/usage/configuration/transforms/split.md
@@ -90,7 +90,7 @@ Key/Value pairs representing mapped log field types.
 
 `required` `type: string`
 
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
 
 The field is an enumeration and only accepts the following values:
 
@@ -100,7 +100,7 @@ The field is an enumeration and only accepts the following values:
 | `"float"` | Coerce to a 64 bit float. |
 | `"int"` | Coerce to a 64 bit integer. |
 | `"string"` | Coerce to a string. |
-| `"timestamp"` | Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
+| `"timestamp"` | Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
 
 ## Input/Output
 

--- a/docs/usage/configuration/transforms/tokenizer.md
+++ b/docs/usage/configuration/transforms/tokenizer.md
@@ -83,7 +83,7 @@ Key/Value pairs representing mapped log field types.
 
 `required` `type: string`
 
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.
 
 The field is an enumeration and only accepts the following values:
 
@@ -93,7 +93,7 @@ The field is an enumeration and only accepts the following values:
 | `"float"` | Coerce to a 64 bit float. |
 | `"int"` | Coerce to a 64 bit integer. |
 | `"string"` | Coerce to a string. |
-| `"timestamp"` | Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
+| `"timestamp"` | Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string. |
 
 ## Input/Output
 

--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -150,7 +150,7 @@ event-by-event basis. It does not batch data.
 The <%= option_names(component.templateable_options).to_sentence %> options
 support [Vector's template syntax][docs.configuration#template-syntax],
 enabling dynamic values derived from the event's data. This syntax accepts
-[strftime specifiers][urls.strftime_specifiers] as well as the
+[strptime specifiers][urls.strftime_specifiers] as well as the
 `{{ field_name }}` syntax for accessing event fields. For example:
 
 {% code-tabs %}

--- a/scripts/util/metadata/transform.rb
+++ b/scripts/util/metadata/transform.rb
@@ -39,7 +39,7 @@ class Transform < Component
             "float" => "Coerce to a 64 bit float.",
             "int" => "Coerce to a 64 bit integer.",
             "string" => "Coerce to a string.",
-            "timestamp" => "Coerces to a Vector timestamp. [`strftime` specificiers][urls.strftime_specifiers] must be used to parse the string."
+            "timestamp" => "Coerces to a Vector timestamp. [`strptime` specificiers][urls.strftime_specifiers] must be used to parse the string."
           },
           "examples" => [
             {"name" => "status", "value" => "int"},
@@ -48,9 +48,9 @@ class Transform < Component
             {"name" => "timestamp", "value" => "timestamp|%s", "comment" => "unix"},
             {"name" => "timestamp", "value" => "timestamp|%+", "comment" => "iso8601 (date and time)"},
             {"name" => "timestamp", "value" => "timestamp|%F", "comment" => "iso8601 (date)"},
-            {"name" => "timestamp", "value" => "timestamp|%a %b %e %T %Y", "comment" => "custom strftime format"},
+            {"name" => "timestamp", "value" => "timestamp|%a %b %e %T %Y", "comment" => "custom strptime format"},
           ],
-          "description" => "A definition of log field type conversions. They key is the log field name and the value is the type. [`strftime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.",
+          "description" => "A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strftime_specifiers] are supported for the `timestamp` type.",
           "null" => false,
           "simple" => true,
           "type" => "string"


### PR DESCRIPTION
In the docs, we call the [`strftime/strptime`](https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html) format `strftime` everywhere. However, in places where the timestamps are parsed from strings it would be more clear to call the format `strptime`, as what we do is similar to `strptime` function as opposed to `strftime`.

This PR updates this.