### PR TITLE
feat(config): support default variable values

### DIFF
--- a/src/topology/config/vars.rs
+++ b/src/topology/config/vars.rs
@@ -47,5 +47,6 @@ mod test {
         assert_eq!("dogs", interpolate("${FOO:-cats}", &vars));
         assert_eq!("dogcats", interpolate("${NOT:-dogcats}", &vars));
         assert_eq!("dogs and cats", interpolate("${NOT:-dogs and cats}", &vars));
+        assert_eq!("${:-cats}", interpolate("${:-cats}", &vars));
     }
 }

--- a/src/topology/config/vars.rs
+++ b/src/topology/config/vars.rs
@@ -48,5 +48,6 @@ mod test {
         assert_eq!("dogcats", interpolate("${NOT:-dogcats}", &vars));
         assert_eq!("dogs and cats", interpolate("${NOT:-dogs and cats}", &vars));
         assert_eq!("${:-cats}", interpolate("${:-cats}", &vars));
+        assert_eq!("", interpolate("${NOT:-}", &vars));
     }
 }

--- a/src/topology/config/vars.rs
+++ b/src/topology/config/vars.rs
@@ -5,7 +5,7 @@ pub fn interpolate(input: &str, vars: &HashMap<String, String>) -> String {
     let re = Regex::new(r"\$\$|\$(\w+)|\$\{(\w+)(?::-([^}]+)?)?\}").unwrap();
     re.replace_all(input, |caps: &Captures<'_>| {
         caps.get(1)
-            .or(caps.get(2))
+            .or_else(|| caps.get(2))
             .map(|m| m.as_str())
             .map(|name| {
                 vars.get(name).map(|val| val.as_str()).unwrap_or_else(|| {

--- a/src/topology/config/vars.rs
+++ b/src/topology/config/vars.rs
@@ -2,15 +2,17 @@ use regex::{Captures, Regex};
 use std::collections::HashMap;
 
 pub fn interpolate(input: &str, vars: &HashMap<String, String>) -> String {
-    let re = Regex::new(r"\$\$|\$(\w+)|\$\{(\w+)\}").unwrap();
+    let re = Regex::new(r"\$\$|\$(\w+)|\$\{(\w+)(?::-([^}]+)?)?\}").unwrap();
     re.replace_all(input, |caps: &Captures<'_>| {
         caps.get(1)
             .or(caps.get(2))
             .map(|m| m.as_str())
             .map(|name| {
                 vars.get(name).map(|val| val.as_str()).unwrap_or_else(|| {
-                    warn!("unknown env var in config: {:?}", name);
-                    ""
+                    caps.get(3).map(|m| m.as_str()).unwrap_or_else(|| {
+                        warn!("unknown env var in config: {:?}", name);
+                        ""
+                    })
                 })
             })
             .unwrap_or("$")
@@ -42,5 +44,8 @@ mod test {
         assert_eq!("-FOO", interpolate("$NOT-FOO", &vars));
         assert_eq!("${FOO x", interpolate("${FOO x", &vars));
         assert_eq!("${}", interpolate("${}", &vars));
+        assert_eq!("dogs", interpolate("${FOO:-cats}", &vars));
+        assert_eq!("dogcats", interpolate("${NOT:-dogcats}", &vars));
+        assert_eq!("dogs and cats", interpolate("${NOT:-dogs and cats}", &vars));
     }
 }


### PR DESCRIPTION
Before this change, you could reference environment variables in your
configuration like so:
    
    $FOO
    ${FOO}
    
After this change, you can add a default value to that second style,
which is used when the provided environment variable does not exist:

    ${FOO:-my default value}

All characters except `}` are allowed in the default value. Perhaps we should
limit the allowed set of characters, to be on the safe side, or alternatively
add support for double `}}` to be interpreted as a single `}`?