### PR TITLE
chore(operations): Update rdkafka to fix rdkafka/cmake feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.21.0"
-source = "git+https://github.com/timberio/rust-rdkafka#06ddd48dcabc507b0475e5dd2e0e611abe27fade"
+source = "git+https://github.com/timberio/rust-rdkafka#9a7a7fd5d7d1e2bbef85241daca32377ae576ffa"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.2.1"
-source = "git+https://github.com/timberio/rust-rdkafka#06ddd48dcabc507b0475e5dd2e0e611abe27fade"
+source = "git+https://github.com/timberio/rust-rdkafka#9a7a7fd5d7d1e2bbef85241daca32377ae576ffa"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This PR updates `rdkafka` (more precisely, our fork of `rdkafka`) to use the recent fix of `rdkafka/cmake` feature (https://github.com/timberio/rust-rdkafka/commit/c7ee668afb43d662f0cc87af3b159c132d525419). Now it can be combined with `rdkafka/ssl_vendored` feature.

We need to use both features together for musl builds, which are currently possible only when `librdkafka` is built using `cmake`.