### PR TITLE
enhancement(config): Refactor the sinks' request_* configuration

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -189,7 +189,7 @@ impl CloudwatchLogsPartitionSvc {
 
 impl Service<PartitionInnerBuffer<Vec<Event>, CloudwatchKey>> for CloudwatchLogsPartitionSvc {
     type Response = ();
-    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Error = crate::Error;
     type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -186,16 +186,15 @@ impl Service<PartitionInnerBuffer<Vec<Event>, CloudwatchKey>> for CloudwatchLogs
             timeout,
             rate_limit_duration,
             rate_limit_num,
-            retry_attempts,
-            retry_backoff,
+            retry_attempts: _,
+            retry_backoff: _,
         } = self.request_settings;
 
         let svc = if let Some(svc) = &mut self.clients.get_mut(&key) {
             svc.clone()
         } else {
             let svc = {
-                let policy =
-                    FixedRetryPolicy::new(retry_attempts, retry_backoff, CloudwatchRetryLogic);
+                let policy = self.request_settings.retry_policy(CloudwatchRetryLogic);
 
                 let cloudwatch = CloudwatchLogsSvc::new(&self.config, &key).unwrap();
                 let timeout = Timeout::new(cloudwatch, timeout);

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     sinks::util::{
         retries::{FixedRetryPolicy, RetryLogic},
         BatchConfig, BatchServiceSink, PartitionBuffer, PartitionInnerBuffer, SinkExt,
+        TowerRequestConfig, TowerRequestSettings,
     },
     template::Template,
     topology::config::{DataType, SinkConfig},
@@ -24,7 +25,7 @@ use rusoto_logs::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::{collections::HashMap, convert::TryInto, fmt, time::Duration};
+use std::{collections::HashMap, convert::TryInto, fmt};
 use tower::{
     buffer::Buffer,
     limit::{
@@ -60,15 +61,18 @@ pub struct CloudwatchLogsSinkConfig {
     pub create_missing_stream: Option<bool>,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-
-    // Tower Request based configuration
-    pub request_in_flight_limit: Option<usize>,
-    pub request_timeout_secs: Option<u64>,
-    pub request_rate_limit_duration_secs: Option<u64>,
-    pub request_rate_limit_num: Option<u64>,
-    pub request_retry_attempts: Option<usize>,
-    pub request_retry_backoff_secs: Option<u64>,
+    #[serde(default, flatten)]
+    pub request: TowerRequestConfig,
 }
+
+const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+    request_in_flight_limit: Some(5),
+    request_timeout_secs: None,
+    request_rate_limit_duration_secs: Some(1),
+    request_rate_limit_num: Some(5),
+    request_retry_attempts: None,
+    request_retry_backoff_secs: None,
+};
 
 pub struct CloudwatchLogsSvc {
     client: CloudWatchLogsClient,
@@ -96,7 +100,7 @@ type Svc = Buffer<
 pub struct CloudwatchLogsPartitionSvc {
     config: CloudwatchLogsSinkConfig,
     clients: HashMap<CloudwatchKey, Svc>,
-    request_config: RequestConfig,
+    request_settings: TowerRequestSettings,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -106,15 +110,6 @@ pub enum Encoding {
     #[derivative(Default)]
     Text,
     Json,
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct RequestConfig {
-    timeout_secs: u64,
-    rate_limit_duration_secs: u64,
-    rate_limit_num: u64,
-    retry_attempts: usize,
-    retry_backoff_secs: u64,
 }
 
 #[derive(Debug)]
@@ -132,14 +127,13 @@ pub enum CloudwatchError {
 impl SinkConfig for CloudwatchLogsSinkConfig {
     fn build(&self, acker: Acker) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let batch = self.batch.unwrap_or(1000, 1);
+        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let log_group = self.group_name.clone();
         let log_stream = self.stream_name.clone();
 
-        let in_flight_limit = self.request_in_flight_limit.unwrap_or(5);
-
         let svc = ServiceBuilder::new()
-            .concurrency_limit(in_flight_limit)
+            .concurrency_limit(request.in_flight_limit)
             .service(CloudwatchLogsPartitionSvc::new(self.clone())?);
 
         let sink = {
@@ -165,24 +159,12 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 
 impl CloudwatchLogsPartitionSvc {
     pub fn new(config: CloudwatchLogsSinkConfig) -> crate::Result<Self> {
-        let timeout_secs = config.request_timeout_secs.unwrap_or(60);
-        let rate_limit_duration_secs = config.request_rate_limit_duration_secs.unwrap_or(1);
-        let rate_limit_num = config.request_rate_limit_num.unwrap_or(5);
-        let retry_attempts = config.request_retry_attempts.unwrap_or(usize::max_value());
-        let retry_backoff_secs = config.request_retry_backoff_secs.unwrap_or(1);
-
-        let request_config = RequestConfig {
-            timeout_secs,
-            rate_limit_duration_secs,
-            rate_limit_num,
-            retry_attempts,
-            retry_backoff_secs,
-        };
+        let request_settings = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         Ok(Self {
             config,
             clients: HashMap::new(),
-            request_config,
+            request_settings,
         })
     }
 }
@@ -199,37 +181,29 @@ impl Service<PartitionInnerBuffer<Vec<Event>, CloudwatchKey>> for CloudwatchLogs
     fn call(&mut self, req: PartitionInnerBuffer<Vec<Event>, CloudwatchKey>) -> Self::Future {
         let (events, key) = req.into_parts();
 
-        let RequestConfig {
-            timeout_secs,
-            rate_limit_duration_secs,
+        let TowerRequestSettings {
+            in_flight_limit: _,
+            timeout,
+            rate_limit_duration,
             rate_limit_num,
             retry_attempts,
-            retry_backoff_secs,
-        } = self.request_config;
+            retry_backoff,
+        } = self.request_settings;
 
         let svc = if let Some(svc) = &mut self.clients.get_mut(&key) {
             svc.clone()
         } else {
             let svc = {
-                let policy = FixedRetryPolicy::new(
-                    retry_attempts,
-                    Duration::from_secs(retry_backoff_secs),
-                    CloudwatchRetryLogic,
-                );
+                let policy =
+                    FixedRetryPolicy::new(retry_attempts, retry_backoff, CloudwatchRetryLogic);
 
                 let cloudwatch = CloudwatchLogsSvc::new(&self.config, &key).unwrap();
-                let timeout = Timeout::new(cloudwatch, Duration::from_secs(timeout_secs));
+                let timeout = Timeout::new(cloudwatch, timeout);
 
                 let buffer = Buffer::new(timeout, 1);
                 let retry = Retry::new(policy, buffer);
 
-                let rate = RateLimit::new(
-                    retry,
-                    Rate::new(
-                        rate_limit_num,
-                        Duration::from_secs(rate_limit_duration_secs),
-                    ),
-                );
+                let rate = RateLimit::new(retry, Rate::new(rate_limit_num, rate_limit_duration));
                 let concurrency = ConcurrencyLimit::new(rate, 1);
 
                 Buffer::new(concurrency, 1)

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{future, stream::iter_ok, sync::oneshot, Async, Future, Poll, Sink};
+use lazy_static::lazy_static;
 use rusoto_core::{
     request::{BufferedHttpResponse, HttpClient},
     Region, RusotoError,
@@ -65,14 +66,11 @@ pub struct CloudwatchLogsSinkConfig {
     pub request: TowerRequestConfig,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: None,
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(5),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        ..Default::default()
+    };
+}
 
 pub struct CloudwatchLogsSvc {
     client: CloudWatchLogsClient,

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -62,7 +62,7 @@ pub struct CloudwatchLogsSinkConfig {
     pub create_missing_stream: Option<bool>,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
 }
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -17,7 +17,7 @@ use rusoto_core::{Region, RusotoError, RusotoFuture};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryInto;
-use tower::{Service, ServiceBuilder};
+use tower::Service;
 
 #[derive(Clone)]
 pub struct CloudWatchMetricsSvc {
@@ -79,12 +79,7 @@ impl CloudWatchMetricsSvc {
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };
 
-        let svc = ServiceBuilder::new()
-            .concurrency_limit(request.in_flight_limit)
-            .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-            .retry(request.retry_policy(CloudWatchMetricsRetryLogic))
-            .timeout(request.timeout)
-            .service(cloudwatch_metrics);
+        let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
 
         let sink = BatchServiceSink::new(svc, acker).batched_with_min(MetricBuffer::new(), &batch);
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -2,10 +2,7 @@ use crate::{
     buffers::Acker,
     event::metric::{Metric, MetricKind, MetricValue},
     region::RegionOrEndpoint,
-    sinks::util::{
-        retries::RetryLogic, BatchConfig, BatchServiceSink, MetricBuffer, SinkExt,
-        TowerRequestConfig,
-    },
+    sinks::util::{retries::RetryLogic, BatchConfig, MetricBuffer, SinkExt, TowerRequestConfig},
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -79,9 +76,9 @@ impl CloudWatchMetricsSvc {
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };
 
-        let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
-
-        let sink = BatchServiceSink::new(svc, acker).batched_with_min(MetricBuffer::new(), &batch);
+        let sink = request
+            .batch_sink(CloudWatchMetricsRetryLogic, cloudwatch_metrics, acker)
+            .batched_with_min(MetricBuffer::new(), &batch);
 
         Ok(Box::new(sink))
     }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use chrono::{DateTime, SecondsFormat, Utc};
 use futures::{Future, Poll};
+use lazy_static::lazy_static;
 use rusoto_cloudwatch::{
     CloudWatch, CloudWatchClient, Dimension, MetricDatum, PutMetricDataError, PutMetricDataInput,
 };
@@ -34,14 +35,13 @@ pub struct CloudWatchMetricsSinkConfig {
     pub request: TowerRequestConfig,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: Some(30),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(150),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_timeout_secs: Some(30),
+        request_rate_limit_num: Some(150),
+        ..Default::default()
+    };
+}
 
 inventory::submit! {
     SinkDescription::new::<CloudWatchMetricsSinkConfig>("aws_cloudwatch_metrics")

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -31,7 +31,7 @@ pub struct CloudWatchMetricsSinkConfig {
     pub region: RegionOrEndpoint,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
 }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -3,8 +3,7 @@ use crate::{
     event::{self, Event},
     region::RegionOrEndpoint,
     sinks::util::{
-        retries::{FixedRetryPolicy, RetryLogic},
-        BatchConfig, BatchServiceSink, SinkExt, TowerRequestConfig,
+        retries::RetryLogic, BatchConfig, BatchServiceSink, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -95,18 +94,12 @@ impl KinesisService {
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();
 
-        let policy = FixedRetryPolicy::new(
-            request.retry_attempts,
-            request.retry_backoff,
-            KinesisRetryLogic,
-        );
-
         let kinesis = KinesisService { client, config };
 
         let svc = ServiceBuilder::new()
             .concurrency_limit(request.in_flight_limit)
             .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-            .retry(policy)
+            .retry(request.retry_policy(KinesisRetryLogic))
             .timeout(request.timeout)
             .service(kinesis);
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -2,9 +2,7 @@ use crate::{
     buffers::Acker,
     event::{self, Event},
     region::RegionOrEndpoint,
-    sinks::util::{
-        retries::RetryLogic, BatchConfig, BatchServiceSink, SinkExt, TowerRequestConfig,
-    },
+    sinks::util::{retries::RetryLogic, BatchConfig, SinkExt, TowerRequestConfig},
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
 use bytes::Bytes;
@@ -96,9 +94,8 @@ impl KinesisService {
 
         let kinesis = KinesisService { client, config };
 
-        let svc = request.service(KinesisRetryLogic, kinesis);
-
-        let sink = BatchServiceSink::new(svc, acker)
+        let sink = request
+            .batch_sink(KinesisRetryLogic, kinesis, acker)
             .batched_with_min(Vec::new(), &batch)
             .with_flat_map(move |e| iter_ok(encode_event(e, &partition_key_field, &encoding)));
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -4,7 +4,7 @@ use crate::{
     region::RegionOrEndpoint,
     sinks::util::{
         retries::{FixedRetryPolicy, RetryLogic},
-        BatchConfig, BatchServiceSink, SinkExt,
+        BatchConfig, BatchServiceSink, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -18,7 +18,7 @@ use rusoto_kinesis::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::{convert::TryInto, fmt, sync::Arc, time::Duration};
+use std::{convert::TryInto, fmt, sync::Arc};
 use string_cache::DefaultAtom as Atom;
 use tower::{Service, ServiceBuilder};
 use tracing_futures::{Instrument, Instrumented};
@@ -39,15 +39,18 @@ pub struct KinesisSinkConfig {
     pub encoding: Encoding,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-
-    // Tower Request based configuration
-    pub request_in_flight_limit: Option<usize>,
-    pub request_timeout_secs: Option<u64>,
-    pub request_rate_limit_duration_secs: Option<u64>,
-    pub request_rate_limit_num: Option<u64>,
-    pub request_retry_attempts: Option<usize>,
-    pub request_retry_backoff_secs: Option<u64>,
+    #[serde(default, flatten)]
+    pub request: TowerRequestConfig,
 }
+
+const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+    request_in_flight_limit: Some(5),
+    request_timeout_secs: Some(30),
+    request_rate_limit_duration_secs: Some(1),
+    request_rate_limit_num: Some(5),
+    request_retry_attempts: None,
+    request_retry_backoff_secs: None,
+};
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]
@@ -88,29 +91,23 @@ impl KinesisService {
         let client = Arc::new(KinesisClient::new(config.region.clone().try_into()?));
 
         let batch = config.batch.unwrap_or(bytesize::mib(1u64), 1);
-
-        let timeout = config.request_timeout_secs.unwrap_or(30);
-        let in_flight_limit = config.request_in_flight_limit.unwrap_or(5);
-        let rate_limit_duration = config.request_rate_limit_duration_secs.unwrap_or(1);
-        let rate_limit_num = config.request_rate_limit_num.unwrap_or(5);
-        let retry_attempts = config.request_retry_attempts.unwrap_or(usize::max_value());
-        let retry_backoff_secs = config.request_retry_backoff_secs.unwrap_or(1);
+        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();
 
         let policy = FixedRetryPolicy::new(
-            retry_attempts,
-            Duration::from_secs(retry_backoff_secs),
+            request.retry_attempts,
+            request.retry_backoff,
             KinesisRetryLogic,
         );
 
         let kinesis = KinesisService { client, config };
 
         let svc = ServiceBuilder::new()
-            .concurrency_limit(in_flight_limit)
-            .rate_limit(rate_limit_num, Duration::from_secs(rate_limit_duration))
+            .concurrency_limit(request.in_flight_limit)
+            .rate_limit(request.rate_limit_num, request.rate_limit_duration)
             .retry(policy)
-            .timeout(Duration::from_secs(timeout))
+            .timeout(request.timeout)
             .service(kinesis);
 
         let sink = BatchServiceSink::new(svc, acker)

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -37,7 +37,7 @@ pub struct KinesisSinkConfig {
     pub encoding: Encoding,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
 }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{stream::iter_ok, Future, Poll, Sink};
+use lazy_static::lazy_static;
 use rand::random;
 use rusoto_core::{RusotoError, RusotoFuture};
 use rusoto_kinesis::{
@@ -40,14 +41,12 @@ pub struct KinesisSinkConfig {
     pub request: TowerRequestConfig,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: Some(30),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(5),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_timeout_secs: Some(30),
+        ..Default::default()
+    };
+}
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -3,8 +3,8 @@ use crate::{
     event::{self, Event},
     region::RegionOrEndpoint,
     sinks::util::{
-        retries::RetryLogic, BatchConfig, BatchServiceSink, Buffer, PartitionBuffer,
-        PartitionInnerBuffer, SinkExt, TowerRequestConfig,
+        retries::RetryLogic, BatchConfig, Buffer, PartitionBuffer, PartitionInnerBuffer, SinkExt,
+        TowerRequestConfig,
     },
     template::Template,
     topology::config::{DataType, SinkConfig, SinkDescription},
@@ -139,9 +139,8 @@ impl S3Sink {
             filename_extension: config.filename_extension.clone(),
         };
 
-        let svc = request.service(S3RetryLogic, s3);
-
-        let sink = BatchServiceSink::new(svc, acker)
+        let sink = request
+            .batch_sink(S3RetryLogic, s3, acker)
             .partitioned_batched_with_min(PartitionBuffer::new(Buffer::new(compression)), &batch)
             .with_flat_map(move |e| iter_ok(encode_event(e, &key_prefix, &encoding)));
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -3,9 +3,8 @@ use crate::{
     event::{self, Event},
     region::RegionOrEndpoint,
     sinks::util::{
-        retries::{FixedRetryPolicy, RetryLogic},
-        BatchConfig, BatchServiceSink, Buffer, PartitionBuffer, PartitionInnerBuffer, SinkExt,
-        TowerRequestConfig,
+        retries::RetryLogic, BatchConfig, BatchServiceSink, Buffer, PartitionBuffer,
+        PartitionInnerBuffer, SinkExt, TowerRequestConfig,
     },
     template::Template,
     topology::config::{DataType, SinkConfig, SinkDescription},
@@ -117,9 +116,6 @@ impl S3Sink {
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 
-        let policy =
-            FixedRetryPolicy::new(request.retry_attempts, request.retry_backoff, S3RetryLogic);
-
         let compression = match config.compression {
             Compression::Gzip => true,
             Compression::None => false,
@@ -146,7 +142,7 @@ impl S3Sink {
         let svc = ServiceBuilder::new()
             .concurrency_limit(request.in_flight_limit)
             .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-            .retry(policy)
+            .retry(request.retry_policy(S3RetryLogic))
             .timeout(request.timeout)
             .service(s3);
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -12,6 +12,7 @@ use crate::{
 use bytes::Bytes;
 use chrono::Utc;
 use futures::{stream::iter_ok, Future, Poll, Sink};
+use lazy_static::lazy_static;
 use rusoto_core::{Region, RusotoError, RusotoFuture};
 use rusoto_s3::{
     HeadBucketRequest, PutObjectError, PutObjectOutput, PutObjectRequest, S3Client, S3,
@@ -52,14 +53,13 @@ pub struct S3SinkConfig {
     pub request: TowerRequestConfig,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(25),
-    request_timeout_secs: None,
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(25),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_in_flight_limit: Some(25),
+        request_rate_limit_num: Some(25),
+        ..Default::default()
+    };
+}
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -49,7 +49,7 @@ pub struct S3SinkConfig {
     pub compression: Compression,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
 }
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -5,7 +5,7 @@ use crate::{
         http::{HttpRetryLogic, HttpService, Response},
         retries::{FixedRetryPolicy, RetryLogic},
         tls::{TlsOptions, TlsSettings},
-        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt,
+        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -18,7 +18,6 @@ use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::borrow::Cow;
-use std::time::Duration;
 use tower::ServiceBuilder;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -31,17 +30,19 @@ pub struct ClickhouseConfig {
     pub basic_auth: Option<ClickHouseBasicAuthConfig>,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-
-    // Tower Request based configuration
-    pub request_in_flight_limit: Option<usize>,
-    pub request_timeout_secs: Option<u64>,
-    pub request_rate_limit_duration_secs: Option<u64>,
-    pub request_rate_limit_num: Option<u64>,
-    pub request_retry_attempts: Option<usize>,
-    pub request_retry_backoff_secs: Option<u64>,
-
+    #[serde(default, flatten)]
+    pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }
+
+const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+    request_in_flight_limit: Some(5),
+    request_timeout_secs: Some(60),
+    request_rate_limit_duration_secs: Some(1),
+    request_rate_limit_num: Some(5),
+    request_retry_attempts: None,
+    request_retry_backoff_secs: None,
+};
 
 inventory::submit! {
     SinkDescription::new::<ClickhouseConfig>("clickhouse")
@@ -90,19 +91,13 @@ fn clickhouse(config: ClickhouseConfig, acker: Acker) -> crate::Result<super::Ro
     };
 
     let batch = config.batch.unwrap_or(bytesize::mib(10u64), 1);
-
-    let timeout = config.request_timeout_secs.unwrap_or(60);
-    let in_flight_limit = config.request_in_flight_limit.unwrap_or(5);
-    let rate_limit_duration = config.request_rate_limit_duration_secs.unwrap_or(1);
-    let rate_limit_num = config.request_rate_limit_num.unwrap_or(5);
-    let retry_attempts = config.request_retry_attempts.unwrap_or(usize::max_value());
-    let retry_backoff_secs = config.request_retry_backoff_secs.unwrap_or(1);
+    let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
     let basic_auth = config.basic_auth.clone();
 
     let policy = FixedRetryPolicy::new(
-        retry_attempts,
-        Duration::from_secs(retry_backoff_secs),
+        request.retry_attempts,
+        request.retry_backoff,
         ClickhouseRetryLogic {
             inner: HttpRetryLogic,
         },
@@ -135,10 +130,10 @@ fn clickhouse(config: ClickhouseConfig, acker: Acker) -> crate::Result<super::Ro
             });
 
     let service = ServiceBuilder::new()
-        .concurrency_limit(in_flight_limit)
-        .rate_limit(rate_limit_num, Duration::from_secs(rate_limit_duration))
+        .concurrency_limit(request.in_flight_limit)
+        .rate_limit(request.rate_limit_num, request.rate_limit_duration)
         .retry(policy)
-        .timeout(Duration::from_secs(timeout))
+        .timeout(request.timeout)
         .service(http_service);
 
     let sink = BatchServiceSink::new(service, acker)
@@ -280,7 +275,10 @@ mod integration_tests {
                 batch_size: Some(1),
                 batch_timeout: None,
             },
-            request_retry_attempts: Some(1),
+            request: TowerRequestConfig {
+                request_retry_attempts: Some(1),
+                ..Default::default()
+            },
             ..Default::default()
         };
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -30,7 +30,7 @@ pub struct ClickhouseConfig {
     pub basic_auth: Option<ClickHouseBasicAuthConfig>,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -15,6 +15,7 @@ use http::StatusCode;
 use http::{Method, Uri};
 use hyper::{Body, Client, Request};
 use hyper_tls::HttpsConnector;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::borrow::Cow;
@@ -34,14 +35,11 @@ pub struct ClickhouseConfig {
     pub tls: Option<TlsOptions>,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: Some(60),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(5),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        ..Default::default()
+    };
+}
 
 inventory::submit! {
     SinkDescription::new::<ClickhouseConfig>("clickhouse")

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -12,6 +12,7 @@ use futures::{Future, Poll};
 use http::{uri::InvalidUri, Method, StatusCode, Uri};
 use hyper;
 use hyper_tls::HttpsConnector;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
@@ -48,14 +49,12 @@ pub struct DatadogConfig {
     pub request: TowerRequestConfig,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: Some(60),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(5),
-    request_retry_attempts: Some(5),
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_retry_attempts: Some(5),
+        ..Default::default()
+    };
+}
 
 pub fn default_host() -> String {
     String::from("https://api.datadoghq.com")

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -3,7 +3,7 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     sinks::util::{
         http::{Error as HttpError, HttpRetryLogic, HttpService, Response as HttpResponse},
-        BatchConfig, BatchServiceSink, MetricBuffer, SinkExt, TowerRequestConfig,
+        BatchConfig, MetricBuffer, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -133,10 +133,9 @@ impl DatadogSvc {
             inner: http_service,
         };
 
-        let service = request.service(HttpRetryLogic, datadog_http_service);
-
-        let sink =
-            BatchServiceSink::new(service, acker).batched_with_min(MetricBuffer::new(), &batch);
+        let sink = request
+            .batch_sink(HttpRetryLogic, datadog_http_service, acker)
+            .batched_with_min(MetricBuffer::new(), &batch);
 
         Ok(Box::new(sink))
     }

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -45,7 +45,7 @@ pub struct DatadogConfig {
     pub api_key: String,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
 }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -5,7 +5,7 @@ use crate::{
     sinks::util::{
         http::{https_client, HttpRetryLogic, HttpService},
         tls::{TlsOptions, TlsSettings},
-        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
+        BatchConfig, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
     template::Template,
     topology::config::{DataType, SinkConfig, SinkDescription},
@@ -286,9 +286,8 @@ fn es(
             }
         });
 
-    let service = request.service(HttpRetryLogic, http_service);
-
-    let sink = BatchServiceSink::new(service, acker)
+    let sink = request
+        .batch_sink(HttpRetryLogic, http_service, acker)
         .batched_with_min(Buffer::new(gzip), &batch)
         .with_flat_map(move |e| iter_ok(encode_event(e, &index, &doc_type, &id_key)));
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -4,7 +4,6 @@ use crate::{
     region::{self, RegionOrEndpoint},
     sinks::util::{
         http::{https_client, HttpRetryLogic, HttpService},
-        retries::FixedRetryPolicy,
         tls::{TlsOptions, TlsSettings},
         BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
@@ -218,12 +217,6 @@ fn es(
     };
     let doc_type = config.doc_type.clone().unwrap_or("_doc".into());
 
-    let policy = FixedRetryPolicy::new(
-        request.retry_attempts,
-        request.retry_backoff,
-        HttpRetryLogic,
-    );
-
     let headers = config
         .headers
         .as_ref()
@@ -297,7 +290,7 @@ fn es(
     let service = ServiceBuilder::new()
         .concurrency_limit(request.in_flight_limit)
         .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-        .retry(policy)
+        .retry(request.retry_policy(HttpRetryLogic))
         .timeout(request.timeout)
         .service(http_service);
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -16,6 +16,7 @@ use hyper::{
     header::{HeaderName, HeaderValue},
     Body, Request,
 };
+use lazy_static::lazy_static;
 use rusoto_core::signature::{SignedRequest, SignedRequestPayload};
 use rusoto_core::{DefaultCredentialsProvider, ProvideAwsCredentials, Region};
 use rusoto_credential::{AwsCredentials, CredentialsError};
@@ -51,14 +52,11 @@ pub struct ElasticSearchConfig {
     pub tls: Option<TlsOptions>,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(5),
-    request_timeout_secs: Some(60),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(5),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        ..Default::default()
+    };
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -42,7 +42,7 @@ pub struct ElasticSearchConfig {
     // passed. See https://github.com/timberio/vector/issues/1160
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
     pub basic_auth: Option<ElasticSearchBasicAuthConfig>,
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -18,7 +18,6 @@ use hyper::{Body, Request};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use tower::ServiceBuilder;
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -180,12 +179,7 @@ fn http(
                 request
             });
 
-    let service = ServiceBuilder::new()
-        .concurrency_limit(request.in_flight_limit)
-        .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-        .retry(request.retry_policy(HttpRetryLogic))
-        .timeout(request.timeout)
-        .service(http_service);
+    let service = request.service(HttpRetryLogic, http_service);
 
     let encoding = config.encoding.clone();
     let sink = BatchServiceSink::new(service, acker)

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -3,7 +3,6 @@ use crate::{
     event::{self, Event},
     sinks::util::{
         http::{https_client, HttpRetryLogic, HttpService},
-        retries::FixedRetryPolicy,
         tls::{TlsOptions, TlsSettings},
         BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
@@ -136,12 +135,6 @@ fn http(
     let basic_auth = config.basic_auth.clone();
     let method = config.method.clone().unwrap_or(HttpMethod::Post);
 
-    let policy = FixedRetryPolicy::new(
-        request.retry_attempts,
-        request.retry_backoff,
-        HttpRetryLogic,
-    );
-
     let http_service =
         HttpService::builder()
             .tls_settings(tls_settings)
@@ -190,7 +183,7 @@ fn http(
     let service = ServiceBuilder::new()
         .concurrency_limit(request.in_flight_limit)
         .rate_limit(request.rate_limit_num, request.rate_limit_duration)
-        .retry(policy)
+        .retry(request.retry_policy(HttpRetryLogic))
         .timeout(request.timeout)
         .service(http_service);
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -16,6 +16,7 @@ use http::{
 };
 use hyper::{Body, Request};
 use indexmap::IndexMap;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
@@ -51,14 +52,14 @@ pub struct HttpSinkConfig {
     pub tls: Option<TlsOptions>,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(10),
-    request_timeout_secs: Some(30),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(10),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_in_flight_limit: Some(10),
+        request_timeout_secs: Some(30),
+        request_rate_limit_num: Some(10),
+        ..Default::default()
+    };
+}
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -47,7 +47,7 @@ pub struct HttpSinkConfig {
     pub encoding: Encoding,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -4,7 +4,7 @@ use crate::{
     sinks::util::{
         http::{https_client, HttpRetryLogic, HttpService},
         tls::{TlsOptions, TlsSettings},
-        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
+        BatchConfig, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -179,10 +179,9 @@ fn http(
                 request
             });
 
-    let service = request.service(HttpRetryLogic, http_service);
-
     let encoding = config.encoding.clone();
-    let sink = BatchServiceSink::new(service, acker)
+    let sink = request
+        .batch_sink(HttpRetryLogic, http_service, acker)
         .batched_with_min(Buffer::new(gzip), &batch)
         .with_flat_map(move |event| iter_ok(encode_event(event, &encoding)));
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -5,7 +5,7 @@ use crate::{
         http::{https_client, HttpRetryLogic, HttpService},
         retries::FixedRetryPolicy,
         tls::{TlsOptions, TlsSettings},
-        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt,
+        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -19,7 +19,6 @@ use hyper::{Body, Request};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::time::Duration;
 use tower::ServiceBuilder;
 
 #[derive(Debug, Snafu)]
@@ -49,17 +48,19 @@ pub struct HttpSinkConfig {
     pub encoding: Encoding,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-
-    // Tower Request based configuration
-    pub request_in_flight_limit: Option<usize>,
-    pub request_timeout_secs: Option<u64>,
-    pub request_rate_limit_duration_secs: Option<u64>,
-    pub request_rate_limit_num: Option<u64>,
-    pub request_retry_attempts: Option<usize>,
-    pub request_retry_backoff_secs: Option<u64>,
-
+    #[serde(default, flatten)]
+    pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }
+
+const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+    request_in_flight_limit: Some(10),
+    request_timeout_secs: Some(30),
+    request_rate_limit_duration_secs: Some(1),
+    request_rate_limit_num: Some(10),
+    request_retry_attempts: None,
+    request_retry_backoff_secs: None,
+};
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]
@@ -128,21 +129,16 @@ fn http(
         Compression::Gzip => true,
     };
     let batch = config.batch.unwrap_or(bytesize::mib(10u64), 1);
+    let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
-    let timeout = config.request_timeout_secs.unwrap_or(30);
-    let in_flight_limit = config.request_in_flight_limit.unwrap_or(10);
-    let rate_limit_duration = config.request_rate_limit_duration_secs.unwrap_or(1);
-    let rate_limit_num = config.request_rate_limit_num.unwrap_or(10);
-    let retry_attempts = config.request_retry_attempts.unwrap_or(usize::max_value());
-    let retry_backoff_secs = config.request_retry_backoff_secs.unwrap_or(1);
     let encoding = config.encoding.clone();
     let headers = config.headers.clone();
     let basic_auth = config.basic_auth.clone();
     let method = config.method.clone().unwrap_or(HttpMethod::Post);
 
     let policy = FixedRetryPolicy::new(
-        retry_attempts,
-        Duration::from_secs(retry_backoff_secs),
+        request.retry_attempts,
+        request.retry_backoff,
         HttpRetryLogic,
     );
 
@@ -192,10 +188,10 @@ fn http(
             });
 
     let service = ServiceBuilder::new()
-        .concurrency_limit(in_flight_limit)
-        .rate_limit(rate_limit_num, Duration::from_secs(rate_limit_duration))
+        .concurrency_limit(request.in_flight_limit)
+        .rate_limit(request.rate_limit_num, request.rate_limit_duration)
         .retry(policy)
-        .timeout(Duration::from_secs(timeout))
+        .timeout(request.timeout)
         .service(http_service);
 
     let encoding = config.encoding.clone();

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -4,7 +4,7 @@ use crate::{
     sinks::util::{
         http::{HttpRetryLogic, HttpService},
         tls::{TlsOptions, TlsSettings},
-        BatchConfig, BatchServiceSink, Buffer, Compression, SinkExt, TowerRequestConfig,
+        BatchConfig, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkDescription},
 };
@@ -124,9 +124,8 @@ pub fn hec(config: HecSinkConfig, acker: Acker) -> crate::Result<super::RouterSi
                 builder.body(body).unwrap()
             });
 
-    let service = request.service(HttpRetryLogic, http_service);
-
-    let sink = BatchServiceSink::new(service, acker)
+    let sink = request
+        .batch_sink(HttpRetryLogic, http_service, acker)
         .batched_with_min(Buffer::new(gzip), &batch)
         .with_flat_map(move |e| iter_ok(encode_event(&host_field, e, &encoding)));
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -36,7 +36,7 @@ pub struct HecSinkConfig {
     pub compression: Option<Compression>,
     #[serde(default, flatten)]
     pub batch: BatchConfig,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -13,6 +13,7 @@ use futures::{stream::iter_ok, Future, Sink};
 use http::{HttpTryFrom, Method, Request, StatusCode, Uri};
 use hyper::{Body, Client};
 use hyper_tls::HttpsConnector;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use snafu::{ResultExt, Snafu};
@@ -40,14 +41,13 @@ pub struct HecSinkConfig {
     pub tls: Option<TlsOptions>,
 }
 
-const REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-    request_in_flight_limit: Some(10),
-    request_timeout_secs: Some(60),
-    request_rate_limit_duration_secs: Some(1),
-    request_rate_limit_num: Some(10),
-    request_retry_attempts: None,
-    request_retry_backoff_secs: None,
-};
+lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        request_in_flight_limit: Some(10),
+        request_rate_limit_num: Some(10),
+        ..Default::default()
+    };
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -137,12 +137,10 @@ where
     }
 }
 
-type Error = Box<dyn std::error::Error + 'static + Send + Sync>;
-
 impl<T, S, B> Sink for BatchServiceSink<T, S, B>
 where
     S: Service<T>,
-    S::Error: Into<Error>,
+    S::Error: Into<crate::Error>,
     S::Response: std::fmt::Debug,
     B: Batch<Output = T>,
 {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -12,7 +12,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::time::Duration;
-use tower::Service;
+use tower::{
+    limit::{concurrency::ConcurrencyLimit, rate::RateLimit},
+    retry::Retry,
+    timeout::Timeout,
+    Service, ServiceBuilder,
+};
 
 pub use batch::{Batch, BatchConfig, BatchSettings, BatchSink};
 pub use buffer::metrics::MetricBuffer;
@@ -374,5 +379,30 @@ pub struct TowerRequestSettings {
 impl TowerRequestSettings {
     pub fn retry_policy<L: RetryLogic>(&self, logic: L) -> FixedRetryPolicy<L> {
         FixedRetryPolicy::new(self.retry_attempts, self.retry_backoff, logic)
+    }
+
+    pub fn service<L, R, S>(
+        &self,
+        retry_logic: L,
+        service: S,
+    ) -> ConcurrencyLimit<RateLimit<Retry<FixedRetryPolicy<L>, Timeout<S>>>>
+    // Would like to return `impl Service<R>` here, but that doesn't
+    // work with later calls to `BatchServiceSink::batched_with_min`
+    // (via `trait SinkExt` above), as it is missing a bound on the
+    // associated types that cannot be expressed in stable Rust.
+    where
+        L: RetryLogic<Error = S::Error, Response = S::Response>,
+        S: Clone + Service<R>,
+        S::Error: 'static + std::error::Error + Send + Sync,
+        S::Response: std::fmt::Debug,
+        R: Clone,
+    {
+        let policy = self.retry_policy(retry_logic);
+        ServiceBuilder::new()
+            .concurrency_limit(self.in_flight_limit)
+            .rate_limit(self.rate_limit_num, self.rate_limit_duration)
+            .retry(policy)
+            .timeout(self.timeout)
+            .service(service)
     }
 }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -18,6 +18,7 @@ pub use batch::{Batch, BatchConfig, BatchSettings, BatchSink};
 pub use buffer::metrics::MetricBuffer;
 pub use buffer::partition::{Partition, PartitionedBatchSink};
 pub use buffer::{Buffer, Compression, PartitionBuffer, PartitionInnerBuffer};
+use retries::{FixedRetryPolicy, RetryLogic};
 
 pub trait SinkExt<T>
 where
@@ -368,4 +369,10 @@ pub struct TowerRequestSettings {
     pub rate_limit_num: u64,
     pub retry_attempts: usize,
     pub retry_backoff: Duration,
+}
+
+impl TowerRequestSettings {
+    pub fn retry_policy<L: RetryLogic>(&self, logic: L) -> FixedRetryPolicy<L> {
+        FixedRetryPolicy::new(self.retry_attempts, self.retry_backoff, logic)
+    }
 }

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -1,4 +1,4 @@
-use super::Error;
+use crate::Error;
 use futures::{try_ready, Async, Future, Poll};
 use std::borrow::Cow;
 use std::time::{Duration, Instant};

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -402,3 +402,61 @@ fn disabled_healthcheck() {
     )
     .unwrap();
 }
+
+#[test]
+fn parses_sink_no_request() {
+    load(
+        r#"
+        [sources.in]
+        type = "stdin"
+
+        [sinks.out]
+        type = "http"
+        inputs = ["in"]
+        uri = "https://localhost"
+        encoding = "json"
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn parses_sink_partial_request() {
+    load(
+        r#"
+        [sources.in]
+        type = "stdin"
+
+        [sinks.out]
+        type = "http"
+        inputs = ["in"]
+        uri = "https://localhost"
+        encoding = "json"
+        request_in_flight_limit = 42
+        "#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn parses_sink_full_request() {
+    load(
+        r#"
+        [sources.in]
+        type = "stdin"
+
+        [sinks.out]
+        type = "http"
+        inputs = ["in"]
+        uri = "https://localhost"
+        encoding = "json"
+        request_in_flight_limit = 42
+        request_timeout_secs = 2
+        request_rate_limit_duration_secs = 3
+        request_rate_limit_num = 4
+        request_retry_attempts = 5
+        request_retry_backoff_secs = 6
+        "#,
+    )
+    .unwrap();
+}


### PR DESCRIPTION
I wanted to get more eyes on this work. This is most of issue #1090, but I have a few questions.

Is the transform I made to the clickhouse sink valid (ref `with_flat_map`) or should the conversion go the other way on the other sinks (into `with`)?

Should the retry policy be handled separately (ref #1022)?

Am I going the wrong way with `TowerRequestSettings::batch_sink` trying to cram too much into one function? My thinking was to bundle as much of the common code as I could in one place, but look at that return type, yuck.