### PR TITLE
feat(new transform): Add ansi stripper transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3422,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3521,7 @@ dependencies = [
  "snafu 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "syslog_rfc5424 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3539,6 +3553,14 @@ dependencies = [
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vte"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3947,6 +3969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum string_cache 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "89c058a82f9fd69b1becf8c274f412281038877c553182f1d02eb027045a2d67"
 "checksum string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
+"checksum strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
@@ -4025,11 +4048,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+"checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ shiplift = { git = "https://github.com/LucioFranco/shiplift", branch = "timber" 
 owning_ref = "0.4.0"
 listenfd = "0.3.3"
 inventory = "0.1"
+strip-ansi-escapes = "0.1.0"
 
 [build-dependencies]
 prost-build = "0.4.0"

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -90,6 +90,10 @@ impl LogEvent {
         self.fields.get(key).map(|v| &v.value)
     }
 
+    pub fn get_mut(&mut self, key: &Atom) -> Option<&mut ValueKind> {
+        self.fields.get_mut(key).map(|v| &mut v.value)
+    }
+
     pub fn contains(&self, key: &Atom) -> bool {
         self.fields.contains_key(key)
     }

--- a/src/transforms/ansi_stripper.rs
+++ b/src/transforms/ansi_stripper.rs
@@ -1,0 +1,127 @@
+use super::Transform;
+use crate::{
+    event::{self, ValueKind},
+    topology::config::{DataType, TransformConfig, TransformDescription},
+    Event,
+};
+use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AnsiStripperConfig {
+    field: Option<Atom>,
+}
+
+inventory::submit! {
+    TransformDescription::new_without_default::<AnsiStripperConfig>("ansi_stripper")
+}
+
+#[typetag::serde(name = "ansi_stripper")]
+impl TransformConfig for AnsiStripperConfig {
+    fn build(&self) -> crate::Result<Box<dyn Transform>> {
+        let field = self.field.as_ref().unwrap_or(&event::MESSAGE);
+
+        Ok(Box::new(AnsiStripper {
+            field: field.clone(),
+        }))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn transform_type(&self) -> &'static str {
+        "ansi_stripper"
+    }
+}
+
+pub struct AnsiStripper {
+    field: Atom,
+}
+
+impl Transform for AnsiStripper {
+    fn transform(&mut self, mut event: Event) -> Option<Event> {
+        let log = event.as_mut_log();
+
+        match log.get_mut(&self.field) {
+            None => debug!(
+                message = "Field does not exist.",
+                field = self.field.as_ref(),
+            ),
+            Some(ValueKind::Bytes(ref mut bytes)) => {
+                *bytes = match strip_ansi_escapes::strip(bytes.clone()) {
+                    Ok(b) => b.into(),
+                    Err(error) => {
+                        debug!(
+                            message = "Could not strip ANSI escape sequences.",
+                            field = self.field.as_ref(),
+                            %error,
+                            rate_limit_secs = 30,
+                        );
+                        return Some(event);
+                    }
+                };
+            }
+            _ => debug!(
+                message = "Field value must be a string.",
+                field = self.field.as_ref(),
+            ),
+        }
+
+        Some(event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnsiStripper;
+    use crate::{
+        event::{Event, ValueKind, MESSAGE},
+        transforms::Transform,
+    };
+
+    macro_rules! assert_foo_bar {
+        ($($in:expr),* $(,)?) => {
+            $(
+                let mut transform = AnsiStripper {
+                    field: "message".into(),
+                };
+
+                let event = Event::from($in);
+                let event = transform.transform(event).unwrap();
+
+                assert_eq!(
+                    event.into_log().into_value(&MESSAGE).unwrap(),
+                    ValueKind::from("foo bar")
+                );
+            )+
+        };
+    }
+
+    #[test]
+    fn ansi_stripper_transform() {
+        assert_foo_bar![
+            "\x1b[3;4Hfoo bar",
+            "\x1b[3;4ffoo bar",
+            "\x1b[3Afoo bar",
+            "\x1b[3Bfoo bar",
+            "\x1b[3Cfoo bar",
+            "\x1b[3Dfoo bar",
+            "\x1b[sfoo bar",
+            "\x1b[ufoo bar",
+            "\x1b[2Jfoo bar",
+            "\x1b[Kfoo bar",
+            "\x1b[32mfoo\x1b[m bar",
+            "\x1b[46mfoo\x1b[0m bar",
+            "foo \x1b[46;41mbar",
+            "\x1b[=3hfoo bar",
+            "\x1b[=3lfoo bar",
+            "foo bar",
+        ];
+    }
+}

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -3,6 +3,7 @@ use snafu::Snafu;
 
 pub mod add_fields;
 pub mod add_tags;
+pub mod ansi_stripper;
 pub mod coercer;
 pub mod field_filter;
 pub mod grok_parser;


### PR DESCRIPTION
Given a log field with ansi escape sequences such as:

    \x1b[32mhello\x1b[m world

The escape sequences are stripped from the string:

    hello world

This transformer only works on string-type fields, any other field type
will result in a warning and an unchanged value.

---

This does not yet add any documentation, or changes any benchmarks or integration tests.

Closes #908