### PR TITLE
chore(operations): Control which version of leveldb-sys to use with features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "leveldb"
 version = "0.8.4"
-source = "git+https://github.com/timberio/leveldb#d4c929b57d724ca789fbc64ff6f07e7ea0fbeb2e"
+source = "git+https://github.com/timberio/leveldb#64265815bcf1b69f30e6cb35bf687fbd6dd64afb"
 dependencies = [
  "db-key 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ toml = "0.4"
 syslog_rfc5424 = "0.6.1"
 tokio-uds = "0.2.5"
 derive_is_enum_variant = "0.1.1"
-leveldb = { git = "https://github.com/timberio/leveldb", optional = true }
+leveldb = { git = "https://github.com/timberio/leveldb", optional = true, default-features = false }
 db-key = "0.0.5"
 headers = "0.2.1"
 rdkafka = { git = "https://github.com/timberio/rust-rdkafka", features = ["ssl", "ssl_vendored"], optional = true }
@@ -148,7 +148,7 @@ tokio01-test = "0.1.1"
 tower-test = "0.1"
 
 [features]
-default = ["rdkafka", "leveldb", "jemallocator"]
+default = ["rdkafka", "leveldb", "leveldb/leveldb-sys-2", "jemallocator"]
 docker = [
   "cloudwatch-logs-integration-tests",
   "cloudwatch-metrics-integration-tests",


### PR DESCRIPTION
This is a yet another PR related to making Vector more portable.

Currently, as I see it, we have two objectives related to our build process and dependencies:

1. Provide pre-compiled binaries for a variety of platforms, including those [listed here](https://github.com/timberio/vector/milestone/18). Because we build them ourselves in CI, there are no constraints on number of build-time dependencies.
2. Streamline build process for first-time contributors, ideally making building Vector as easy as just installing [rustup](https://rustup.rs/), cloning Vector's repository and running `make build` or `cargo build`. It is fair to assume that the two most popular platforms among them are `x86_64-unknown-linux-gnu` and `x86_64-apple-darwin`.

While most of our dependencies can meet these requirements simultaneously, at least after modification, `leveldb-sys` is an exception. Older versions of LevelDB/Snappy can be compiled without additional dependencies on `x86_64-unknown-linux-gnu`/`x86_64-apple-darwin` because they use Autotools, but they don't support other architectures such as AArch64. On the other hand, newer versions support more targets but require `cmake` as a build dependency.

So as a solution, I propose to do the following:

1. Use version which doesn't require `cmake` by default, so that on `x86_64-unknown-linux-gnu`/`x86_64-apple-darwin` Vector could be built by just installing `rustup` and running `cargo build`. This is expressed as `leveldb/leveldb-sys-2` feature enabled by default.
2. Use newer version which requires `cmake` with a feature. So compiling Vector for AArch64 and other targets supported only by newer versions of LevelDB and Snappy would require runnning `cargo build --no-default-features --features="jemallocator rdkafka leveldb leveldb/leveldb-sys-3".

Features `leveldb-sys-2` and `leveldb-sys-3` allowing to chose between version were added to a  branch in our fork in https://github.com/timberio/leveldb/commit/64265815bcf1b69f30e6cb35bf687fbd6dd64afb.