### PR TITLE
fix(journald source): Re-fix journald cursor handling

### DIFF
--- a/lib/journald/src/lib.rs
+++ b/lib/journald/src/lib.rs
@@ -46,7 +46,7 @@ struct LibSystemd {
 }
 
 fn load_lib() -> Result<Container<LibSystemd>, dlopen::Error> {
-    unsafe { Container::load("libsystemd.so") }
+    unsafe { Container::load("libsystemd.so.0") }
 }
 
 /// A minimal systemd journald reader.


### PR DESCRIPTION
The fix for journald cursor handling in #1086 was broken by subsequent changes in #1106 due to the invalid internal state logic. This effectively reintroduced the same bug and is fixed here (along with another bug).