### PR TITLE
Docs: `geoip` transform documentation

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -40,6 +40,7 @@ scopes:
   - add_tags transform
   - coercer transform
   - field_filter transform
+  - geoip transform
   - grok_parser transform
   - json_parser transform
   - log_to_metric transform

--- a/.meta/transforms/geoip.toml
+++ b/.meta/transforms/geoip.toml
@@ -1,0 +1,26 @@
+[transforms.geoip]
+allow_you_to_description = "enrich events with geolocation data from the MaxMind GeoIP2 database"
+common = false
+function_category = "enrich"
+guides = []
+input_types = ["log"]
+output_types = ["log"]
+resources = []
+
+[transforms.geoip.options.field]
+type = "string"
+common = true
+examples = ["/path/to/database"]
+null = false
+description = """\
+Path to the MaxMind GeoIP2 database file.\
+"""
+
+[transforms.geoip.options.target]
+type = "string"
+common = true
+default = "default_geoip_target_field"
+null = false
+description = """\
+TODO: fill me in\
+"""

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Or view [platform specific installation instructions][docs.installation].
 | [**`add_tags`**][docs.transforms.add_tags] | Accepts [`metric`][docs.data-model#metric] events and allows you to add one or more metric tags. |
 | [**`coercer`**][docs.transforms.coercer] | Accepts [`log`][docs.data-model#log] events and allows you to coerce log fields into fixed types. |
 | [**`field_filter`**][docs.transforms.field_filter] | Accepts [`log`][docs.data-model#log] and [`metric`][docs.data-model#metric] events and allows you to filter events by a log field's value. |
+| [**`geoip`**][docs.transforms.geoip] | Accepts [`log`][docs.data-model#log] events and allows you to enrich events with geolocation data from the MaxMind GeoIP2 database. |
 | [**`grok_parser`**][docs.transforms.grok_parser] | Accepts [`log`][docs.data-model#log] events and allows you to parse a log field value with [Grok][urls.grok]. |
 | [**`json_parser`**][docs.transforms.json_parser] | Accepts [`log`][docs.data-model#log] events and allows you to parse a log field value as JSON. |
 | [**`log_to_metric`**][docs.transforms.log_to_metric] | Accepts [`log`][docs.data-model#log] events and allows you to convert logs into one or more metrics. |
@@ -254,6 +255,7 @@ the License.
 [docs.transforms.add_tags]: https://vector.dev/docs/components/transforms/add_tags
 [docs.transforms.coercer]: https://vector.dev/docs/components/transforms/coercer
 [docs.transforms.field_filter]: https://vector.dev/docs/components/transforms/field_filter
+[docs.transforms.geoip]: https://vector.dev/docs/components/transforms/geoip
 [docs.transforms.grok_parser]: https://vector.dev/docs/components/transforms/grok_parser
 [docs.transforms.json_parser]: https://vector.dev/docs/components/transforms/json_parser
 [docs.transforms.log_to_metric]: https://vector.dev/docs/components/transforms/log_to_metric

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -730,6 +730,36 @@ data_dir = "/var/lib/vector"
   # * type: string
   value = "/var/log/nginx.log"
 
+# Accepts `log` events and allows you to enrich events with geolocation data from the MaxMind GeoIP2 database.
+[transforms.geoip]
+  # The component type. This is a required field that tells Vector which
+  # component to use. The value _must_ be `geoip`.
+  # 
+  # * required
+  # * type: string
+  # * must be: "geoip"
+  type = "geoip"
+
+  # A list of upstream source or transform IDs. See Config Composition for more
+  # info.
+  # 
+  # * required
+  # * type: [string]
+  inputs = ["my-source-id"]
+
+  # Path to the MaxMind GeoIP2 database file.
+  # 
+  # * required
+  # * type: string
+  field = "/path/to/database"
+
+  # TODO: fill me in
+  # 
+  # * optional
+  # * default: "default_geoip_target_field"
+  # * type: string
+  target = "default_geoip_target_field"
+
 # Accepts `log` events and allows you to parse a log field value with Grok.
 [transforms.grok_parser]
   #

--- a/scripts/generate/templates/_partials/_component_default.md.erb.erb
+++ b/scripts/generate/templates/_partials/_component_default.md.erb.erb
@@ -19,7 +19,6 @@
 <%= source_output(:metric, component.output.metric, heading_depth: 3) %>
 <%- end -%>
 
-<%- end -%>
 <%- elsif component.sink? && component.output -%>
 ## Output
 

--- a/website/docs/components/specification.md
+++ b/website/docs/components/specification.md
@@ -744,6 +744,36 @@ data_dir = "/var/lib/vector"
   # * type: string
   value = "/var/log/nginx.log"
 
+# Accepts `log` events and allows you to enrich events with geolocation data from the MaxMind GeoIP2 database.
+[transforms.geoip]
+  # The component type. This is a required field that tells Vector which
+  # component to use. The value _must_ be `geoip`.
+  # 
+  # * required
+  # * type: string
+  # * must be: "geoip"
+  type = "geoip"
+
+  # A list of upstream source or transform IDs. See Config Composition for more
+  # info.
+  # 
+  # * required
+  # * type: [string]
+  inputs = ["my-source-id"]
+
+  # Path to the MaxMind GeoIP2 database file.
+  # 
+  # * required
+  # * type: string
+  field = "/path/to/database"
+
+  # TODO: fill me in
+  # 
+  # * optional
+  # * default: "default_geoip_target_field"
+  # * type: string
+  target = "default_geoip_target_field"
+
 # Accepts `log` events and allows you to parse a log field value with Grok.
 [transforms.grok_parser]
   #

--- a/website/docs/components/transforms/geoip.md
+++ b/website/docs/components/transforms/geoip.md
@@ -1,0 +1,109 @@
+---
+
+event_types: ["log"]
+issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+geoip%22
+sidebar_label: "geoip|[\"log\"]"
+source_url: https://github.com/timberio/vector/tree/master/src/transforms/geoip.rs
+status: "prod-ready"
+title: "geoip transform" 
+---
+
+The `geoip` transform accepts [`log`][docs.data-model#log] events and allows you to enrich events with geolocation data from the MaxMind GeoIP2 database.
+
+## Configuration
+
+import CodeHeader from '@site/src/components/CodeHeader';
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration"/ >
+
+```toml
+[transforms.my_transform_id]
+  # REQUIRED
+  type = "geoip" # example, must be: "geoip"
+  inputs = ["my-source-id"] # example
+  field = "/path/to/database" # example
+  
+  # OPTIONAL
+  target = "default_geoip_target_field" # default
+```
+
+## Options
+
+import Fields from '@site/src/components/Fields';
+
+import Field from '@site/src/components/Field';
+
+<Fields filters={true}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/database"]}
+  name={"field"}
+  nullable={false}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### field
+
+Path to the MaxMind GeoIP2 database file.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={"default_geoip_target_field"}
+  enumValues={null}
+  examples={["default_geoip_target_field"]}
+  name={"target"}
+  nullable={false}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### target
+
+TODO: fill me in
+
+
+</Field>
+
+
+</Fields>
+
+## How It Works
+
+### Database
+
+The `geoip` transform uses the Maxmind Geoip 2 database.
+
+TODO: Fill in with:
+
+1. How is the data enriched?
+2. Which fields are added?
+3. What happens if a look up fails?
+### Environment Variables
+
+Environment variables are supported through all of Vector's configuration.
+Simply add `${MY_ENV_VAR}` in your Vector configuration file and the variable
+will be replaced before being evaluated.
+
+You can learn more in the [Environment Variables][docs.configuration#environment-variables]
+section.
+
+
+[docs.configuration#environment-variables]: /docs/setup/configuration#environment-variables
+[docs.data-model#log]: /docs/about/data-model#log

--- a/website/docs/components/transforms/geoip.md.erb
+++ b/website/docs/components/transforms/geoip.md.erb
@@ -1,0 +1,25 @@
+<%- component = metadata.transforms.geoip -%>
+
+<%= component_header(component) %>
+
+## Configuration
+
+<%= component_config_example(component) %>
+
+## Options
+
+<%= options(component.specific_options_list, heading_depth: 3) %>
+
+## How It Works [[sort]]
+
+<%= component_sections(component) %>
+
+### Database
+
+The `geoip` transform uses the Maxmind Geoip 2 database.
+
+TODO: Fill in with:
+
+1. How is the data enriched?
+2. Which fields are added?
+3. What happens if a look up fails?

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -74,7 +74,7 @@ module.exports = {
     "version": "0.5.0"
   },
   "posts": [
-    "#<Post:0x00007fb83138f608>"
+    "#<Post:0x00007fc61749b2b0>"
   ],
   "sources": {
     "udp": {
@@ -246,6 +246,19 @@ module.exports = {
       "function_category": "parse",
       "id": "json_parser_transform",
       "name": "json_parser",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "geoip": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "enrich",
+      "id": "geoip_transform",
+      "name": "geoip",
       "service_provider": null,
       "status": "prod-ready",
       "type": "transform"

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -147,6 +147,8 @@ module.exports = {
             
               "components/transforms/field_filter",
             
+              "components/transforms/geoip",
+            
               "components/transforms/grok_parser",
             
               "components/transforms/json_parser",

--- a/website/src/components/PerformanceTests/styles.css
+++ b/website/src/components/PerformanceTests/styles.css
@@ -7,16 +7,12 @@
   --vector-switcher-color: var(--ifm-background-color);
   --vector-switcher-color-inverted: var(--ifm-color-emphasis-1000);
 
-  background: linear-gradient(to right, var(--ifm-color-primary), var(--ifm-color-pink));
+  background: linear-gradient(to right, var(--ifm-color-primary), var(--ifm-color-blue), var(--ifm-color-pink));
   border-radius: var(--ifm-global-radius);
   display: flex;
   justify-content: space-between;
   margin-bottom: calc( var(--ifm-spacing-vertical) * 2 );
   padding: calc( var(--ifm-spacing-vertical) / 3 ) calc( var(--ifm-spacing-horizontal) / 2 );
-}
-
-.performance-tests--switcher > * {
-
 }
 
 .performance-tests--switcher .react-select-container {


### PR DESCRIPTION
This kicks off the `geoip` docs. There's a lot that needs to be filled in here. There are 2 files where changes should be made:

1. `./meta/transforms/geoip.toml`
2. `/website/docs/components/transforms/geoip.md.erb`

The changes that need to be made are:

- [ ] Ensure all options are added to the `geopip.toml` file.
- [ ] Ensure the proper "How It Works" sections are added to the `geoip.md.erb` file.

Once changes have been made run:

```bash
make generate
```

**NOTE: do _not_ make changes to the `/website/docs/components/transforms/geoip.md` file. That file is generated and will be overwritten when `make generate` is run.**

Closes https://github.com/timberio/vector/issues/1214