### PR TITLE
enhancement(metric data model)!: Reorganise metric model

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -27,45 +27,51 @@ message Value {
 }
 
 message Metric {
+  string name = 1;
+  google.protobuf.Timestamp timestamp = 2;
+  map<string, string> tags = 3;
+  enum Kind {
+    Incremental = 0;
+    Absolute = 1;
+  }
+  Kind kind = 4;
   oneof metric {
-    Counter counter = 1;
-    Histogram histogram = 2;
-    Gauge gauge = 3;
-    Set set = 4;
+    Counter counter = 5;
+    Gauge gauge = 6;
+    Set set = 7;
+    Distribution distribution = 8;
+    AggregatedHistogram aggregated_histogram = 9;
+    AggregatedSummary aggregated_summary = 10;
   }
 }
 
 message Counter {
-  string name = 1;
-  double val = 2;
-  google.protobuf.Timestamp timestamp = 3;
-  map<string, string> tags = 4;
-}
-
-message Histogram {
-  string name = 1;
-  double val = 2;
-  uint32 sample_rate = 3;
-  google.protobuf.Timestamp timestamp = 4;
-  map<string, string> tags = 5;
+  double value = 1;
 }
 
 message Gauge {
-  string name = 1;
-  double val = 2;
-  enum Direction {
-    None = 0;
-    Plus = 1;
-    Minus = 2;
-  }
-  Direction direction = 3;
-  google.protobuf.Timestamp timestamp = 4;
-  map<string, string> tags = 5;
+  double value = 1;
 }
 
 message Set {
-  string name = 1;
-  string val = 2;
-  google.protobuf.Timestamp timestamp = 3;
-  map<string, string> tags = 4;
+  repeated string values = 1;
+}
+
+message Distribution {
+  repeated double values = 1;
+  repeated uint32 sample_rates = 2;
+}
+
+message AggregatedHistogram {
+  repeated double buckets = 1;
+  repeated uint32 counts = 2;
+  uint32 count = 3;
+  double sum = 4;
+}
+
+message AggregatedSummary {
+  repeated double quantiles = 1;
+  repeated double values = 2;
+  uint32 count = 3;
+  double sum = 4;
 }

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -62,7 +62,7 @@ impl CheckFieldsPredicate for EqualsPredicate {
                 },
             }),
             Event::Metric(m) => m
-                .tags()
+                .tags
                 .as_ref()
                 .and_then(|t| t.get(self.target.as_ref()))
                 .map_or(false, |v| match &self.arg {
@@ -106,7 +106,7 @@ impl CheckFieldsPredicate for NotEqualsPredicate {
                 .map(|f| f.as_bytes())
                 .map_or(false, |b| b != self.arg.as_bytes()),
             Event::Metric(m) => m
-                .tags()
+                .tags
                 .as_ref()
                 .and_then(|t| t.get(self.target.as_ref()))
                 .map_or(false, |v| v.as_bytes() != self.arg.as_bytes()),
@@ -142,7 +142,7 @@ impl CheckFieldsPredicate for ExistsPredicate {
         (match event {
             Event::Log(l) => l.get(&self.target).is_some(),
             Event::Metric(m) => m
-                .tags()
+                .tags
                 .as_ref()
                 .map_or(false, |t| t.contains_key(self.target.as_ref())),
         }) == self.arg

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -91,7 +91,8 @@ fn encode_event(event: Event, encoding: &Encoding) -> Result<String, ()> {
 #[cfg(test)]
 mod test {
     use super::{encode_event, Encoding};
-    use crate::{event::Metric, Event};
+    use crate::event::metric::{Metric, MetricKind, MetricValue};
+    use crate::event::Event;
     use chrono::{offset::TimeZone, Utc};
 
     #[test]
@@ -102,33 +103,37 @@ mod test {
 
     #[test]
     fn encodes_counter() {
-        let event = Event::Metric(Metric::Counter {
+        let event = Event::Metric(Metric {
             name: "foos".into(),
-            val: 100.0,
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
             tags: Some(
                 vec![("key".to_owned(), "value".to_owned())]
                     .into_iter()
                     .collect(),
             ),
+            kind: MetricKind::Incremental,
+            value: MetricValue::Counter { value: 100.0 },
         });
         assert_eq!(
-            Ok(r#"{"type":"counter","name":"foos","val":100.0,"timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"key":"value"}}"#.to_string()),
+            Ok(r#"{"name":"foos","timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"key":"value"},"kind":"incremental","value":{"type":"counter","value":100.0}}"#.to_string()),
             encode_event(event, &Encoding::Text)
         );
     }
 
     #[test]
     fn encodes_histogram_without_timestamp() {
-        let event = Event::Metric(Metric::Histogram {
+        let event = Event::Metric(Metric {
             name: "glork".into(),
-            val: 10.0,
-            sample_rate: 1,
             timestamp: None,
             tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Distribution {
+                values: vec![10.0],
+                sample_rates: vec![1],
+            },
         });
         assert_eq!(
-            Ok(r#"{"type":"histogram","name":"glork","val":10.0,"sample_rate":1,"timestamp":null,"tags":null}"#.to_string()),
+            Ok(r#"{"name":"glork","timestamp":null,"tags":null,"kind":"incremental","value":{"type":"distribution","values":[10.0],"sample_rates":[1]}}"#.to_string()),
             encode_event(event, &Encoding::Text)
         );
     }

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffers::Acker,
-    event::Metric,
+    event::metric::{Metric, MetricKind, MetricValue},
     sinks::util::{
         http::{Error as HttpError, HttpRetryLogic, HttpService, Response as HttpResponse},
         retries::FixedRetryPolicy,
@@ -217,65 +217,52 @@ fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> i64 {
     }
 }
 
-fn encode_namespace(namespace: &str, name: String) -> String {
+fn encode_namespace(namespace: &str, name: &str) -> String {
     if !namespace.is_empty() {
         format!("{}.{}", namespace, name)
     } else {
-        name
+        name.to_string()
     }
 }
 
 fn encode_events(events: Vec<Metric>, interval: i64, namespace: &str) -> DatadogRequest {
     let series: Vec<_> = events
         .into_iter()
-        .filter_map(|event| match event {
-            Metric::Counter {
-                name,
-                val,
-                timestamp,
-                tags,
-            } => Some(DatadogMetric {
-                metric: encode_namespace(namespace, name),
-                r#type: DatadogMetricType::Count,
-                interval: Some(interval),
-                points: vec![DatadogPoint(encode_timestamp(timestamp), val)],
-                tags: tags.map(encode_tags),
-            }),
-            Metric::Gauge {
-                name,
-                val,
-                direction: None,
-                timestamp,
-                tags,
-            } => Some(DatadogMetric {
-                metric: encode_namespace(namespace, name),
-                r#type: DatadogMetricType::Gauge,
-                interval: None,
-                points: vec![DatadogPoint(encode_timestamp(timestamp), val)],
-                tags: tags.map(encode_tags),
-            }),
-            Metric::Histogram {
-                name,
-                val,
-                sample_rate,
-                timestamp,
-                tags,
-            } => {
-                let mut points = Vec::new();
-                for _ in 0..sample_rate {
-                    let point = DatadogPoint(encode_timestamp(timestamp), val);
-                    points.push(point);
-                }
-                Some(DatadogMetric {
-                    metric: encode_namespace(namespace, name),
-                    r#type: DatadogMetricType::Count,
-                    interval: Some(interval),
-                    points,
-                    tags: tags.map(encode_tags),
-                })
+        .filter_map(|event| {
+            let fullname = encode_namespace(namespace, &event.name);
+            let ts = encode_timestamp(event.timestamp);
+            let tags = event.tags.clone().map(encode_tags);
+            match event.kind {
+                MetricKind::Incremental => match event.value {
+                    MetricValue::Counter { value } => Some(vec![DatadogMetric {
+                        metric: fullname,
+                        r#type: DatadogMetricType::Count,
+                        interval: Some(interval),
+                        points: vec![DatadogPoint(ts, value)],
+                        tags,
+                    }]),
+                    MetricValue::Set { values } => Some(vec![DatadogMetric {
+                        metric: fullname,
+                        r#type: DatadogMetricType::Gauge,
+                        interval: None,
+                        points: vec![DatadogPoint(ts, values.len() as f64)],
+                        tags: tags.clone(),
+                    }]),
+                    _ => None,
+                },
+                MetricKind::Absolute => match event.value {
+                    MetricValue::Gauge { value } => Some(vec![DatadogMetric {
+                        metric: fullname,
+                        r#type: DatadogMetricType::Gauge,
+                        interval: None,
+                        points: vec![DatadogPoint(ts, value)],
+                        tags,
+                    }]),
+                    _ => None,
+                },
             }
-            _ => None,
         })
+        .flatten()
         .collect();
 
     DatadogRequest { series }
@@ -284,7 +271,7 @@ fn encode_events(events: Vec<Metric>, interval: i64, namespace: &str) -> Datadog
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::metric::Metric;
+    use crate::event::metric::{Metric, MetricKind, MetricValue};
     use chrono::offset::TimeZone;
     use pretty_assertions::assert_eq;
 
@@ -321,17 +308,26 @@ mod tests {
         let now = Utc::now().timestamp();
         let interval = 60;
         let events = vec![
-            Metric::Counter {
+            Metric {
                 name: "total".into(),
-                val: 1.5,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.5 },
             },
-            Metric::Counter {
+            Metric {
                 name: "check".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
+            },
+            Metric {
+                name: "unsupported".into(),
+                timestamp: Some(ts()),
+                tags: Some(tags()),
+                kind: MetricKind::Absolute,
+                value: MetricValue::Counter { value: 1.0 },
             },
         ];
         let input = encode_events(events, interval, "ns");
@@ -345,13 +341,22 @@ mod tests {
 
     #[test]
     fn encode_gauge() {
-        let events = vec![Metric::Gauge {
-            name: "volume".into(),
-            val: -1.1,
-            direction: None,
-            timestamp: Some(ts()),
-            tags: None,
-        }];
+        let events = vec![
+            Metric {
+                name: "unsupported".into(),
+                timestamp: Some(ts()),
+                tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: 0.1 },
+            },
+            Metric {
+                name: "volume".into(),
+                timestamp: Some(ts()),
+                tags: None,
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge { value: -1.1 },
+            },
+        ];
         let input = encode_events(events, 60, "");
         let json = serde_json::to_string(&input).unwrap();
 
@@ -362,20 +367,22 @@ mod tests {
     }
 
     #[test]
-    fn encode_histogram() {
-        let events = vec![Metric::Histogram {
-            name: "login".into(),
-            val: 1.0,
-            sample_rate: 2,
+    fn encode_set() {
+        let events = vec![Metric {
+            name: "users".into(),
             timestamp: Some(ts()),
             tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Set {
+                values: vec!["alice".into(), "bob".into()].into_iter().collect(),
+            },
         }];
         let input = encode_events(events, 60, "");
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
             json,
-            r#"{"series":[{"metric":"login","type":"count","interval":60,"points":[[1542182950,1.0],[1542182950,1.0]],"tags":null}]}"#
+            r#"{"series":[{"metric":"users","type":"gauge","interval":null,"points":[[1542182950,2.0]],"tags":null}]}"#
         );
     }
 }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -1,4 +1,5 @@
-use crate::event::{Event, Metric};
+use crate::event::metric::{Metric, MetricKind, MetricValue};
+use crate::event::Event;
 use crate::sinks::util::Batch;
 use std::collections::{hash_map::DefaultHasher, HashSet};
 use std::hash::{Hash, Hasher};
@@ -10,29 +11,28 @@ impl Eq for MetricEntry {}
 
 impl Hash for MetricEntry {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(&self.0).hash(state);
-
-        match &self.0 {
-            Metric::Counter { name, .. } => {
-                name.hash(state);
-            }
-            Metric::Gauge { name, .. } => {
-                name.hash(state);
-            }
-            Metric::Set { name, val, .. } => {
-                name.hash(state);
-                val.hash(state);
-            }
-            Metric::Histogram { name, val, .. } => {
-                name.hash(state);
-                val.to_bits().hash(state);
-            }
-        }
-
-        self.0
-            .tags()
+        let metric = &self.0;
+        std::mem::discriminant(metric).hash(state);
+        metric.name.hash(state);
+        metric.kind.hash(state);
+        metric
+            .tags
             .as_ref()
             .map(|ts| ts.iter().for_each(|t| t.hash(state)));
+
+        match &metric.value {
+            MetricValue::AggregatedHistogram { buckets, .. } => {
+                for bucket in buckets {
+                    bucket.to_bits().hash(state);
+                }
+            }
+            MetricValue::AggregatedSummary { quantiles, .. } => {
+                for quantile in quantiles {
+                    quantile.to_bits().hash(state);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -57,6 +57,40 @@ pub struct MetricBuffer {
 }
 
 impl MetricBuffer {
+    // Metric buffer is a data structure for creating normalised
+    // batched metrics data from the flow of datapoints.
+    //
+    // Batching mostly means that we will aggregate away timestamp information, and
+    // apply metric-specific compression to improve the performance of the pipeline.
+    // For example, multiple counter observations will be summed up into single observation.
+    //
+    // Normalisation is required to make sure Sources and Sinks are exchanging compatible data
+    // structures. For instance, delta gauges produced by Statsd source cannot be directly
+    // sent to Datadog API. In this case the buffer will keep the state of a gauge value, and
+    // produce absolute values gauges that are well supported by Datadog.
+    //
+    // Another example of normalisation is disaggregation of counters. Most sinks would expect we send
+    // them delta counters (e.g. how many events occured during the flush period). And most sources are
+    // producting exactly this kind of counters, with Prometheus being a notable exception. If the counter
+    // comes allready aggregated inside the source, the buffer will compare it's values with the previous
+    // known and calculate the delta.
+    //
+    // This table will summarise how metrics are transforming inside the buffer:
+    //
+    // Normalised and accumulated metrics
+    //   Counter                      => Counter
+    //   Absolute Counter             => Counter
+    //   Gauge                        => Absolute Gauge
+    //   Distribution                 => Distribution
+    //   Set                          => Set
+    //
+    // Deduplicated metrics
+    //   Absolute Gauge               => Absolute Gauge
+    //   AggregatedHistogram          => AggregatedHistogram
+    //   AggregatedSummary            => AggregatedSummary
+    //   Absolute AggregatedHistogram => Absolute AggregatedHistogram
+    //   Absolute AggregatedSummary   => Absolute AggregatedSummary
+    //
     pub fn new() -> Self {
         Self {
             state: HashSet::new(),
@@ -75,42 +109,72 @@ impl Batch for MetricBuffer {
 
     fn push(&mut self, item: Self::Input) {
         let item = item.into_metric();
-        let new = MetricEntry(item.clone());
 
-        match item {
-            // gauges are special because gauge values could come
-            // in deltas - relative increments or decrements
-            Metric::Gauge { ref name, .. } => {
+        match &item.value {
+            MetricValue::Counter { value } if item.kind.is_absolute() => {
+                let new = MetricEntry(item.clone());
+                if let Some(MetricEntry(Metric {
+                    value: MetricValue::Counter { value: value0, .. },
+                    ..
+                })) = self.state.get(&new)
+                {
+                    // Counters are disaggregated. We take the previoud value from the state
+                    // and emit the difference between previous and current as a Counter
+                    let delta = MetricEntry(Metric {
+                        name: item.name.to_string(),
+                        timestamp: item.timestamp.clone(),
+                        tags: item.tags.clone(),
+                        kind: MetricKind::Incremental,
+                        value: MetricValue::Counter {
+                            value: value - value0,
+                        },
+                    });
+
+                    // The resulting Counters could be added up normally
+                    if let Some(MetricEntry(mut existing)) = self.metrics.take(&delta) {
+                        existing.add(&item);
+                        self.metrics.insert(MetricEntry(existing));
+                    } else {
+                        self.metrics.insert(delta);
+                    }
+                    self.state.replace(new);
+                } else {
+                    self.state.insert(new);
+                }
+            }
+            MetricValue::Gauge { .. } if item.kind.is_incremental() => {
+                let new = MetricEntry(item.clone().into_absolute());
                 if let Some(MetricEntry(mut existing)) = self.metrics.take(&new) {
-                    existing.merge(&item);
+                    existing.add(&item);
                     self.metrics.insert(MetricEntry(existing));
                 } else {
-                    // if the gauge is not present in active batch,
+                    // If the metric is not present in active batch,
                     // then we look it up in permanent state, where we keep track
-                    // of gauge values throughout the entire application uptime
+                    // of its values throughout the entire application uptime
                     let mut initial = if let Some(default) = self.state.get(&new) {
                         default.0.clone()
                     } else {
-                        // otherwise we start from absolute 0
-                        Metric::Gauge {
-                            name: name.clone(),
-                            val: 0.0,
-                            direction: None,
-                            timestamp: None,
-                            tags: None,
+                        // Otherwise we start from zero value
+                        Metric {
+                            name: item.name.to_string(),
+                            timestamp: item.timestamp.clone(),
+                            tags: item.tags.clone(),
+                            kind: MetricKind::Absolute,
+                            value: MetricValue::Gauge { value: 0.0 },
                         }
                     };
-                    initial.merge(&item);
+                    initial.add(&item);
                     self.metrics.insert(MetricEntry(initial));
                 }
             }
-            // set observations are simply deduplicated
-            Metric::Set { .. } => {
-                self.metrics.insert(new);
+            _metric if item.kind.is_absolute() => {
+                let new = MetricEntry(item);
+                self.metrics.replace(new);
             }
             _ => {
+                let new = MetricEntry(item.clone());
                 if let Some(MetricEntry(mut existing)) = self.metrics.take(&new) {
-                    existing.merge(&item);
+                    existing.add(&item);
                     self.metrics.insert(MetricEntry(existing));
                 } else {
                     self.metrics.insert(new);
@@ -126,8 +190,10 @@ impl Batch for MetricBuffer {
     fn fresh(&self) -> Self {
         let mut state = self.state.clone();
         for entry in self.metrics.iter() {
-            if entry.0.is_gauge() {
-                state.insert(entry.clone());
+            if (entry.0.value.is_gauge() || entry.0.value.is_counter())
+                && entry.0.kind.is_absolute()
+            {
+                state.replace(entry.clone());
             }
         }
 
@@ -151,7 +217,7 @@ mod test {
     use super::*;
     use crate::sinks::util::batch::BatchSink;
     use crate::{
-        event::metric::{Direction, Metric},
+        event::metric::{Metric, MetricValue},
         Event,
     };
     use futures::{future::Future, stream, Sink};
@@ -177,31 +243,34 @@ mod test {
 
         let mut events = Vec::new();
         for i in 0..4 {
-            let event = Event::Metric(Metric::Counter {
+            let event = Event::Metric(Metric {
                 name: "counter-0".into(),
-                val: i as f64,
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: i as f64 },
             });
             events.push(event);
         }
 
         for i in 0..4 {
-            let event = Event::Metric(Metric::Counter {
+            let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
-                val: i as f64,
                 timestamp: None,
                 tags: Some(tag("staging")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: i as f64 },
             });
             events.push(event);
         }
 
         for i in 0..4 {
-            let event = Event::Metric(Metric::Counter {
+            let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
-                val: i as f64,
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: i as f64 },
             });
             events.push(event);
         }
@@ -219,41 +288,47 @@ mod test {
         assert_eq!(
             sorted(&buffer[0].clone().finish()),
             [
-                Metric::Counter {
+                Metric {
                     name: "counter-0".into(),
-                    val: 0.0,
-                    timestamp: None,
-                    tags: Some(tag("staging")),
-                },
-                Metric::Counter {
-                    name: "counter-0".into(),
-                    val: 6.0,
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 6.0 }
                 },
-                Metric::Counter {
-                    name: "counter-1".into(),
-                    val: 1.0,
-                    timestamp: None,
-                    tags: Some(tag("production")),
-                },
-                Metric::Counter {
-                    name: "counter-1".into(),
-                    val: 1.0,
+                Metric {
+                    name: "counter-0".into(),
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 0.0 },
                 },
-                Metric::Counter {
+                Metric {
+                    name: "counter-1".into(),
+                    timestamp: None,
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 1.0 },
+                },
+                Metric {
+                    name: "counter-1".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 1.0 },
+                },
+                Metric {
                     name: "counter-2".into(),
-                    val: 2.0,
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 2.0 },
                 },
-                Metric::Counter {
+                Metric {
                     name: "counter-3".into(),
-                    val: 3.0,
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 3.0 },
                 },
             ]
         );
@@ -261,56 +336,49 @@ mod test {
         assert_eq!(
             sorted(&buffer[1].clone().finish()),
             [
-                Metric::Counter {
+                Metric {
                     name: "counter-2".into(),
-                    val: 2.0,
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 2.0 },
                 },
-                Metric::Counter {
+                Metric {
                     name: "counter-3".into(),
-                    val: 3.0,
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 3.0 },
                 },
             ]
         );
     }
 
     #[test]
-    fn metric_buffer_gauges() {
-        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 4, Some(Duration::from_secs(1)));
+    fn metric_buffer_aggregated_counters() {
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
         for i in 0..4 {
-            let event = Event::Metric(Metric::Gauge {
-                name: "gauge-0".into(),
-                val: i as f64,
-                direction: None,
+            let event = Event::Metric(Metric {
+                name: format!("counter-{}", i),
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::Counter { value: i as f64 },
             });
             events.push(event);
         }
 
-        for i in 0..5 {
-            let event = Event::Metric(Metric::Gauge {
-                name: format!("gauge-{}", i),
-                val: i as f64,
-                direction: None,
+        for i in 0..4 {
+            let event = Event::Metric(Metric {
+                name: format!("counter-{}", i),
                 timestamp: None,
-                tags: Some(tag("staging")),
-            });
-            events.push(event);
-        }
-
-        for i in 0..5 {
-            let event = Event::Metric(Metric::Gauge {
-                name: format!("gauge-{}", i),
-                val: i as f64,
-                direction: Some(Direction::Plus),
-                timestamp: None,
-                tags: Some(tag("staging")),
+                tags: Some(tag("production")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::Counter {
+                    value: i as f64 * 3.0,
+                },
             });
             events.push(event);
         }
@@ -321,102 +389,203 @@ mod test {
             .unwrap();
 
         let buffer = buffer.into_inner();
-        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.len(), 1);
         assert_eq!(buffer[0].len(), 4);
-        assert_eq!(buffer[1].len(), 4);
-        assert_eq!(buffer[2].len(), 3);
 
         assert_eq!(
             sorted(&buffer[0].clone().finish()),
             [
-                Metric::Gauge {
-                    name: "gauge-0".into(),
-                    val: 0.0,
-                    direction: None,
-                    timestamp: None,
-                    tags: Some(tag("staging")),
-                },
-                Metric::Gauge {
-                    name: "gauge-0".into(),
-                    val: 3.0,
-                    direction: None,
+                Metric {
+                    name: "counter-0".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 0.0 },
                 },
-                Metric::Gauge {
-                    name: "gauge-1".into(),
-                    val: 1.0,
-                    direction: None,
+                Metric {
+                    name: "counter-1".into(),
                     timestamp: None,
-                    tags: Some(tag("staging")),
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 2.0 },
                 },
-                Metric::Gauge {
-                    name: "gauge-2".into(),
-                    val: 2.0,
-                    direction: None,
+                Metric {
+                    name: "counter-2".into(),
                     timestamp: None,
-                    tags: Some(tag("staging")),
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 4.0 },
                 },
-            ]
-        );
-
-        assert_eq!(
-            sorted(&buffer[1].clone().finish()),
-            [
-                Metric::Gauge {
-                    name: "gauge-0".into(),
-                    val: 0.0,
-                    direction: None,
+                Metric {
+                    name: "counter-3".into(),
                     timestamp: None,
-                    tags: Some(tag("staging")),
-                },
-                Metric::Gauge {
-                    name: "gauge-1".into(),
-                    val: 1.0 + 1.0,
-                    direction: None,
-                    timestamp: None,
-                    tags: Some(tag("staging")),
-                },
-                Metric::Gauge {
-                    name: "gauge-3".into(),
-                    val: 3.0,
-                    direction: None,
-                    timestamp: None,
-                    tags: Some(tag("staging")),
-                },
-                Metric::Gauge {
-                    name: "gauge-4".into(),
-                    val: 4.0,
-                    direction: None,
-                    timestamp: None,
-                    tags: Some(tag("staging")),
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Counter { value: 6.0 },
                 },
             ]
         );
+    }
+
+    #[test]
+    fn metric_buffer_gauges() {
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+
+        let mut events = Vec::new();
+        for i in 1..5 {
+            let event = Event::Metric(Metric {
+                name: format!("gauge-{}", i),
+                timestamp: None,
+                tags: Some(tag("staging")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: i as f64 },
+            });
+            events.push(event);
+        }
+
+        for i in 1..5 {
+            let event = Event::Metric(Metric {
+                name: format!("gauge-{}", i),
+                timestamp: None,
+                tags: Some(tag("staging")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: i as f64 },
+            });
+            events.push(event);
+        }
+
+        let (buffer, _) = sink
+            .send_all(stream::iter_ok(events.into_iter()))
+            .wait()
+            .unwrap();
+
+        let buffer = buffer.into_inner();
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer[0].len(), 4);
 
         assert_eq!(
-            sorted(&buffer[2].clone().finish()),
+            sorted(&buffer[0].clone().finish()),
             [
-                Metric::Gauge {
+                Metric {
+                    name: "gauge-1".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 2.0 },
+                },
+                Metric {
                     name: "gauge-2".into(),
-                    val: 2.0 + 2.0,
-                    direction: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 4.0 },
                 },
-                Metric::Gauge {
+                Metric {
                     name: "gauge-3".into(),
-                    val: 3.0 + 3.0,
-                    direction: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 6.0 },
                 },
-                Metric::Gauge {
+                Metric {
                     name: "gauge-4".into(),
-                    val: 4.0 + 4.0,
-                    direction: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 8.0 },
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn metric_buffer_aggregated_gauges() {
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+
+        let mut events = Vec::new();
+        for i in 3..6 {
+            let event = Event::Metric(Metric {
+                name: format!("gauge-{}", i),
+                timestamp: None,
+                tags: Some(tag("staging")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge {
+                    value: i as f64 * 10.0,
+                },
+            });
+            events.push(event);
+        }
+
+        for i in 1..4 {
+            let event = Event::Metric(Metric {
+                name: format!("gauge-{}", i),
+                timestamp: None,
+                tags: Some(tag("staging")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: i as f64 },
+            });
+            events.push(event);
+        }
+
+        for i in 2..5 {
+            let event = Event::Metric(Metric {
+                name: format!("gauge-{}", i),
+                timestamp: None,
+                tags: Some(tag("staging")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge {
+                    value: i as f64 * 2.0,
+                },
+            });
+            events.push(event);
+        }
+
+        let (buffer, _) = sink
+            .send_all(stream::iter_ok(events.into_iter()))
+            .wait()
+            .unwrap();
+
+        let buffer = buffer.into_inner();
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer[0].len(), 5);
+
+        assert_eq!(
+            sorted(&buffer[0].clone().finish()),
+            [
+                Metric {
+                    name: "gauge-1".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 1.0 },
+                },
+                Metric {
+                    name: "gauge-2".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 4.0 },
+                },
+                Metric {
+                    name: "gauge-3".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 6.0 },
+                },
+                Metric {
+                    name: "gauge-4".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 8.0 },
+                },
+                Metric {
+                    name: "gauge-5".into(),
+                    timestamp: None,
+                    tags: Some(tag("staging")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value: 50.0 },
                 },
             ]
         );
@@ -428,21 +597,84 @@ mod test {
 
         let mut events = Vec::new();
         for i in 0..4 {
-            let event = Event::Metric(Metric::Set {
+            let event = Event::Metric(Metric {
                 name: "set-0".into(),
-                val: format!("{}", i),
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec![format!("{}", i)].into_iter().collect(),
+                },
             });
             events.push(event);
         }
 
         for i in 0..4 {
-            let event = Event::Metric(Metric::Set {
+            let event = Event::Metric(Metric {
                 name: "set-0".into(),
-                val: format!("{}", i),
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec![format!("{}", i)].into_iter().collect(),
+                },
+            });
+            events.push(event);
+        }
+
+        let (buffer, _) = sink
+            .send_all(stream::iter_ok(events.into_iter()))
+            .wait()
+            .unwrap();
+
+        let buffer = buffer.into_inner();
+        assert_eq!(buffer.len(), 1);
+
+        assert_eq!(
+            sorted(&buffer[0].clone().finish()),
+            [Metric {
+                name: "set-0".into(),
+                timestamp: None,
+                tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec!["0".into(), "1".into(), "2".into(), "3".into()]
+                        .into_iter()
+                        .collect(),
+                },
+            },]
+        );
+    }
+
+    #[test]
+    fn metric_buffer_distributions() {
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+
+        let mut events = Vec::new();
+        for _ in 2..6 {
+            let event = Event::Metric(Metric {
+                name: "dist-2".into(),
+                timestamp: None,
+                tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![2.0],
+                    sample_rates: vec![10],
+                },
+            });
+            events.push(event);
+        }
+
+        for i in 2..6 {
+            let event = Event::Metric(Metric {
+                name: format!("dist-{}", i),
+                timestamp: None,
+                tags: Some(tag("production")),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![i as f64],
+                    sample_rates: vec![10],
+                },
             });
             events.push(event);
         }
@@ -458,57 +690,83 @@ mod test {
         assert_eq!(
             sorted(&buffer[0].clone().finish()),
             [
-                Metric::Set {
-                    name: "set-0".into(),
-                    val: "0".into(),
+                Metric {
+                    name: "dist-2".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Distribution {
+                        values: vec![2.0, 2.0, 2.0, 2.0, 2.0],
+                        sample_rates: vec![10, 10, 10, 10, 10],
+                    },
                 },
-                Metric::Set {
-                    name: "set-0".into(),
-                    val: "1".into(),
+                Metric {
+                    name: "dist-3".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Distribution {
+                        values: vec![3.0],
+                        sample_rates: vec![10],
+                    },
                 },
-                Metric::Set {
-                    name: "set-0".into(),
-                    val: "2".into(),
+                Metric {
+                    name: "dist-4".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Distribution {
+                        values: vec![4.0],
+                        sample_rates: vec![10],
+                    },
                 },
-                Metric::Set {
-                    name: "set-0".into(),
-                    val: "3".into(),
+                Metric {
+                    name: "dist-5".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Distribution {
+                        values: vec![5.0],
+                        sample_rates: vec![10],
+                    }
                 },
             ]
         );
     }
 
     #[test]
-    fn metric_buffer_histograms() {
+    fn metric_buffer_aggregated_histograms() {
         let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
 
         let mut events = Vec::new();
-        for _i in 2..6 {
-            let event = Event::Metric(Metric::Histogram {
-                name: "hist-2".into(),
-                val: 2.0,
-                sample_rate: 10,
+        for _ in 2..5 {
+            let event = Event::Metric(Metric {
+                name: "buckets-2".into(),
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::AggregatedHistogram {
+                    buckets: vec![1.0, 2.0, 4.0],
+                    counts: vec![1, 2, 4],
+                    count: 6,
+                    sum: 10.0,
+                },
             });
             events.push(event);
         }
 
-        for i in 2..6 {
-            let event = Event::Metric(Metric::Histogram {
-                name: format!("hist-{}", i),
-                val: i as f64,
-                sample_rate: 10,
+        for i in 2..5 {
+            let event = Event::Metric(Metric {
+                name: format!("buckets-{}", i),
                 timestamp: None,
                 tags: Some(tag("production")),
+                kind: MetricKind::Absolute,
+                value: MetricValue::AggregatedHistogram {
+                    buckets: vec![1.0, 2.0, 4.0],
+                    counts: vec![1 * i, 2 * i, 4 * i],
+                    count: 6 * i,
+                    sum: 10.0,
+                },
             });
             events.push(event);
         }
@@ -524,34 +782,116 @@ mod test {
         assert_eq!(
             sorted(&buffer[0].clone().finish()),
             [
-                Metric::Histogram {
-                    name: "hist-2".into(),
-                    val: 2.0,
-                    sample_rate: 50,
+                Metric {
+                    name: "buckets-2".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedHistogram {
+                        buckets: vec![1.0, 2.0, 4.0],
+                        counts: vec![2, 4, 8],
+                        count: 12,
+                        sum: 10.0,
+                    },
                 },
-                Metric::Histogram {
-                    name: "hist-3".into(),
-                    val: 3.0,
-                    sample_rate: 10,
+                Metric {
+                    name: "buckets-3".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedHistogram {
+                        buckets: vec![1.0, 2.0, 4.0],
+                        counts: vec![3, 6, 12],
+                        count: 6 * 3,
+                        sum: 10.0,
+                    },
                 },
-                Metric::Histogram {
-                    name: "hist-4".into(),
-                    val: 4.0,
-                    sample_rate: 10,
+                Metric {
+                    name: "buckets-4".into(),
                     timestamp: None,
                     tags: Some(tag("production")),
-                },
-                Metric::Histogram {
-                    name: "hist-5".into(),
-                    val: 5.0,
-                    sample_rate: 10,
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedHistogram {
+                        buckets: vec![1.0, 2.0, 4.0],
+                        counts: vec![4, 8, 16],
+                        count: 6 * 4,
+                        sum: 10.0,
+                    },
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn metric_buffer_aggregated_summaries() {
+        let sink = BatchSink::new_min(vec![], MetricBuffer::new(), 6, Some(Duration::from_secs(1)));
+
+        let mut events = Vec::new();
+        for _ in 0..10 {
+            for i in 2..5 {
+                let event = Event::Metric(Metric {
+                    name: format!("quantiles-{}", i),
                     timestamp: None,
                     tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedSummary {
+                        quantiles: vec![1.0, 2.0, 4.0],
+                        values: vec![(1 * i) as f64, (2 * i) as f64, (4 * i) as f64],
+                        count: 6 * i,
+                        sum: 10.0,
+                    },
+                });
+                events.push(event);
+            }
+        }
+
+        let (buffer, _) = sink
+            .send_all(stream::iter_ok(events.into_iter()))
+            .wait()
+            .unwrap();
+
+        let buffer = buffer.into_inner();
+        assert_eq!(buffer.len(), 1);
+
+        assert_eq!(
+            sorted(&buffer[0].clone().finish()),
+            [
+                Metric {
+                    name: "quantiles-2".into(),
+                    timestamp: None,
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedSummary {
+                        quantiles: vec![1.0, 2.0, 4.0],
+                        values: vec![2.0, 4.0, 8.0],
+                        count: 6 * 2,
+                        sum: 10.0,
+                    },
                 },
+                Metric {
+                    name: "quantiles-3".into(),
+                    timestamp: None,
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedSummary {
+                        quantiles: vec![1.0, 2.0, 4.0],
+                        values: vec![3.0, 6.0, 12.0],
+                        count: 6 * 3,
+                        sum: 10.0,
+                    },
+                },
+                Metric {
+                    name: "quantiles-4".into(),
+                    timestamp: None,
+                    tags: Some(tag("production")),
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::AggregatedSummary {
+                        quantiles: vec![1.0, 2.0, 4.0],
+                        values: vec![4.0, 8.0, 16.0],
+                        count: 6 * 4,
+                        sum: 10.0,
+                    },
+                }
             ]
         );
     }

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -1,4 +1,4 @@
-use crate::event::{metric::Direction, Metric};
+use crate::event::metric::{Metric, MetricKind, MetricValue};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
@@ -56,26 +56,31 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
     let metric = match metric_type {
         "c" => {
             let val: f64 = parts[0].parse()?;
-            Metric::Counter {
+            Metric {
                 name,
-                val: val * sample_rate,
                 timestamp: None,
                 tags,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter {
+                    value: val * sample_rate,
+                },
             }
         }
         unit @ "h" | unit @ "ms" => {
             let val: f64 = parts[0].parse()?;
-            Metric::Histogram {
+            Metric {
                 name,
-                val: convert_to_base_units(unit, val),
-                sample_rate: sample_rate as u32,
                 timestamp: None,
                 tags,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![convert_to_base_units(unit, val)],
+                    sample_rates: vec![sample_rate as u32],
+                },
             }
         }
-        "g" => Metric::Gauge {
-            name,
-            val: if parts[0]
+        "g" => {
+            let value = if parts[0]
                 .chars()
                 .next()
                 .map(|c| c.is_ascii_digit())
@@ -84,16 +89,35 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 parts[0].parse()?
             } else {
                 parts[0][1..].parse()?
-            },
-            direction: parse_direction(parts[0])?,
-            timestamp: None,
-            tags,
-        },
-        "s" => Metric::Set {
+            };
+
+            match parse_direction(parts[0])? {
+                None => Metric {
+                    name,
+                    timestamp: None,
+                    tags,
+                    kind: MetricKind::Absolute,
+                    value: MetricValue::Gauge { value },
+                },
+                Some(sign) => Metric {
+                    name,
+                    timestamp: None,
+                    tags,
+                    kind: MetricKind::Incremental,
+                    value: MetricValue::Gauge {
+                        value: value * sign,
+                    },
+                },
+            }
+        }
+        "s" => Metric {
             name,
-            val: parts[0].into(),
             timestamp: None,
             tags,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Set {
+                values: vec![parts[0].into()].into_iter().collect(),
+            },
         },
         other => return Err(ParseError::UnknownMetricType(other.into())),
     };
@@ -138,14 +162,14 @@ fn parse_tags(input: &str) -> Result<HashMap<String, String>, ParseError> {
     Ok(result)
 }
 
-fn parse_direction(input: &str) -> Result<Option<Direction>, ParseError> {
+fn parse_direction(input: &str) -> Result<Option<f64>, ParseError> {
     match input
         .chars()
         .next()
         .ok_or_else(|| ParseError::Malformed("empty body component"))?
     {
-        '+' => Ok(Some(Direction::Plus)),
-        '-' => Ok(Some(Direction::Minus)),
+        '+' => Ok(Some(1.0)),
+        '-' => Ok(Some(-1.0)),
         c if c.is_ascii_digit() => Ok(None),
         _other => Err(ParseError::Malformed("invalid gauge value prefix")),
     }
@@ -206,17 +230,18 @@ impl From<ParseFloatError> for ParseError {
 #[cfg(test)]
 mod test {
     use super::{parse, sanitize_key, sanitize_sampling};
-    use crate::event::{metric::Direction, Metric};
+    use crate::event::metric::{Metric, MetricKind, MetricValue};
 
     #[test]
     fn basic_counter() {
         assert_eq!(
             parse("foo:1|c"),
-            Ok(Metric::Counter {
+            Ok(Metric {
                 name: "foo".into(),
-                val: 1.0,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }),
         );
     }
@@ -225,9 +250,8 @@ mod test {
     fn tagged_counter() {
         assert_eq!(
             parse("foo:1|c|#tag1,tag2:value"),
-            Ok(Metric::Counter {
+            Ok(Metric {
                 name: "foo".into(),
-                val: 1.0,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -237,6 +261,8 @@ mod test {
                     .into_iter()
                     .collect(),
                 ),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }),
         );
     }
@@ -245,11 +271,12 @@ mod test {
     fn sampled_counter() {
         assert_eq!(
             parse("bar:2|c|@0.1"),
-            Ok(Metric::Counter {
+            Ok(Metric {
                 name: "bar".into(),
-                val: 20.0,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 20.0 },
             }),
         );
     }
@@ -258,11 +285,12 @@ mod test {
     fn zero_sampled_counter() {
         assert_eq!(
             parse("bar:2|c|@0"),
-            Ok(Metric::Counter {
+            Ok(Metric {
                 name: "bar".into(),
-                val: 2.0,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 2.0 },
             }),
         );
     }
@@ -271,12 +299,15 @@ mod test {
     fn sampled_timer() {
         assert_eq!(
             parse("glork:320|ms|@0.1"),
-            Ok(Metric::Histogram {
+            Ok(Metric {
                 name: "glork".into(),
-                val: 0.320,
-                sample_rate: 10,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![0.320],
+                    sample_rates: vec![10],
+                },
             }),
         );
     }
@@ -285,10 +316,8 @@ mod test {
     fn sampled_tagged_histogram() {
         assert_eq!(
             parse("glork:320|h|@0.1|#region:us-west1,production,e:"),
-            Ok(Metric::Histogram {
+            Ok(Metric {
                 name: "glork".into(),
-                val: 320.0,
-                sample_rate: 10,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -299,6 +328,11 @@ mod test {
                     .into_iter()
                     .collect(),
                 ),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![320.0],
+                    sample_rates: vec![10],
+                },
             }),
         );
     }
@@ -307,12 +341,12 @@ mod test {
     fn simple_gauge() {
         assert_eq!(
             parse("gaugor:333|g"),
-            Ok(Metric::Gauge {
+            Ok(Metric {
                 name: "gaugor".into(),
-                val: 333.0,
-                direction: None,
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge { value: 333.0 },
             }),
         );
     }
@@ -321,22 +355,22 @@ mod test {
     fn signed_gauge() {
         assert_eq!(
             parse("gaugor:-4|g"),
-            Ok(Metric::Gauge {
+            Ok(Metric {
                 name: "gaugor".into(),
-                val: 4.0,
-                direction: Some(Direction::Minus),
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: -4.0 },
             }),
         );
         assert_eq!(
             parse("gaugor:+10|g"),
-            Ok(Metric::Gauge {
+            Ok(Metric {
                 name: "gaugor".into(),
-                val: 10.0,
-                direction: Some(Direction::Plus),
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Gauge { value: 10.0 },
             }),
         );
     }
@@ -345,11 +379,14 @@ mod test {
     fn sets() {
         assert_eq!(
             parse("uniques:765|s"),
-            Ok(Metric::Set {
+            Ok(Metric {
                 name: "uniques".into(),
-                val: "765".into(),
                 timestamp: None,
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec!["765".into()].into_iter().collect()
+                },
             }),
         );
     }

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -593,11 +593,13 @@ mod tests {
     insert_at = "foo"
     type = "metric"
     [tests.input.metric]
-      type = "counter"
+      kind = "incremental"
       name = "foometric"
-      val = 7
       [tests.input.metric.tags]
         tagfoo = "valfoo"
+      [tests.input.metric.value]
+        type = "counter"
+        value = 100.0
 
   [[tests.outputs]]
     extract_from = "foo"

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -50,7 +50,7 @@ impl AddTags {
 impl Transform for AddTags {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
         if !self.tags.is_empty() {
-            let tags = event.as_mut_metric().tags_mut();
+            let ref mut tags = event.as_mut_metric().tags;
 
             if tags.is_none() {
                 *tags = Some(HashMap::new());
@@ -69,18 +69,22 @@ impl Transform for AddTags {
 #[cfg(test)]
 mod tests {
     use super::AddTags;
-    use crate::{event::Event, event::Metric, transforms::Transform};
+    use crate::{
+        event::metric::{Metric, MetricKind, MetricValue},
+        event::Event,
+        transforms::Transform,
+    };
     use indexmap::IndexMap;
     use string_cache::DefaultAtom as Atom;
 
     #[test]
     fn add_tags() {
-        let event = Event::Metric(Metric::Gauge {
+        let event = Event::Metric(Metric {
             name: "bar".into(),
-            val: 10.0,
-            direction: None,
             timestamp: None,
             tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Gauge { value: 10.0 },
         });
 
         let map: IndexMap<Atom, String> = vec![
@@ -92,7 +96,7 @@ mod tests {
 
         let mut transform = AddTags::new(map);
         let metric = transform.transform(event).unwrap().into_metric();
-        let tags = metric.tags().as_ref().unwrap();
+        let tags = metric.tags.unwrap();
 
         assert_eq!(tags.len(), 2);
         assert_eq!(tags.get("region"), Some(&"us-east-1".to_owned()));

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1,6 +1,6 @@
 use super::Transform;
 use crate::{
-    event::metric::Metric,
+    event::metric::{Metric, MetricKind, MetricValue},
     event::{self, ValueKind},
     template::Template,
     topology::config::{DataType, TransformConfig, TransformDescription},
@@ -146,11 +146,12 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
     match config {
         MetricConfig::Counter(counter) => {
-            let val = log
+            let value = log
                 .get(&counter.field)
                 .ok_or(TransformError::FieldNotFound)?;
-            let val = if counter.increment_by_value {
-                val.to_string_lossy()
+            let value = if counter.increment_by_value {
+                value
+                    .to_string_lossy()
                     .parse()
                     .map_err(|_| TransformError::ParseError("counter value"))?
             } else {
@@ -162,16 +163,17 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             let tags = render_tags(&counter.tags, &event);
 
-            Ok(Metric::Counter {
+            Ok(Metric {
                 name,
-                val,
                 timestamp,
                 tags,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value },
             })
         }
         MetricConfig::Histogram(hist) => {
-            let val = log.get(&hist.field).ok_or(TransformError::FieldNotFound)?;
-            let val = val
+            let value = log.get(&hist.field).ok_or(TransformError::FieldNotFound)?;
+            let value = value
                 .to_string_lossy()
                 .parse()
                 .map_err(|_| TransformError::ParseError("histogram value"))?;
@@ -181,17 +183,20 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             let tags = render_tags(&hist.tags, &event);
 
-            Ok(Metric::Histogram {
+            Ok(Metric {
                 name,
-                val,
-                sample_rate: 1,
                 timestamp,
                 tags,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![value],
+                    sample_rates: vec![1],
+                },
             })
         }
         MetricConfig::Gauge(gauge) => {
-            let val = log.get(&gauge.field).ok_or(TransformError::FieldNotFound)?;
-            let val = val
+            let value = log.get(&gauge.field).ok_or(TransformError::FieldNotFound)?;
+            let value = value
                 .to_string_lossy()
                 .parse()
                 .map_err(|_| TransformError::ParseError("gauge value"))?;
@@ -201,28 +206,31 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             let tags = render_tags(&gauge.tags, &event);
 
-            Ok(Metric::Gauge {
+            Ok(Metric {
                 name,
-                val,
-                direction: None,
                 timestamp,
                 tags,
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge { value },
             })
         }
         MetricConfig::Set(set) => {
-            let val = log.get(&set.field).ok_or(TransformError::FieldNotFound)?;
-            let val = val.to_string_lossy();
+            let value = log.get(&set.field).ok_or(TransformError::FieldNotFound)?;
+            let value = value.to_string_lossy();
 
             let name = set.name.as_ref().unwrap_or(&set.field);
             let name = render_template(&name, &event)?;
 
             let tags = render_tags(&set.tags, &event);
 
-            Ok(Metric::Set {
+            Ok(Metric {
                 name,
-                val,
                 timestamp,
                 tags,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec![value].into_iter().collect(),
+                },
             })
         }
     }
@@ -258,9 +266,9 @@ impl Transform for LogToMetric {
 mod tests {
     use super::{LogToMetric, LogToMetricConfig};
     use crate::{
-        event::{self, Metric},
+        event::metric::{Metric, MetricKind, MetricValue},
+        event::{self, Event},
         transforms::Transform,
-        Event,
     };
     use chrono::{offset::TimeZone, DateTime, Utc};
 
@@ -296,11 +304,12 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "status".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
     }
@@ -330,9 +339,8 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "http_requests_total".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: Some(
                     vec![
@@ -343,6 +351,8 @@ mod tests {
                     .into_iter()
                     .collect(),
                 ),
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
     }
@@ -364,11 +374,12 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "exception_total".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
     }
@@ -409,11 +420,12 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "amount_total".into(),
-                val: 33.99,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 33.99 },
             }
         );
     }
@@ -435,12 +447,12 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Gauge {
+            Metric {
                 name: "memory_rss_bytes".into(),
-                val: 123.0,
-                direction: None,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Absolute,
+                value: MetricValue::Gauge { value: 123.0 },
             }
         );
     }
@@ -513,20 +525,22 @@ mod tests {
         assert_eq!(2, output.len());
         assert_eq!(
             output.pop().unwrap().into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "exception_total".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
         assert_eq!(
             output.pop().unwrap().into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "status".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
     }
@@ -574,20 +588,24 @@ mod tests {
         assert_eq!(2, output.len());
         assert_eq!(
             output.pop().unwrap().into_metric(),
-            Metric::Counter {
+            Metric {
                 name: "xyz_exception_total".into(),
-                val: 1.0,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Counter { value: 1.0 },
             }
         );
         assert_eq!(
             output.pop().unwrap().into_metric(),
-            Metric::Set {
+            Metric {
                 name: "local_abc_status_set".into(),
-                val: "42".into(),
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec!["42".into()].into_iter().collect()
+                },
             }
         );
     }
@@ -609,11 +627,14 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Set {
+            Metric {
                 name: "unique_user_ip".into(),
-                val: "1.2.3.4".into(),
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Set {
+                    values: vec!["1.2.3.4".into()].into_iter().collect()
+                },
             }
         );
     }
@@ -634,12 +655,15 @@ mod tests {
 
         assert_eq!(
             metric.into_metric(),
-            Metric::Histogram {
+            Metric {
                 name: "response_time".into(),
-                val: 2.5,
-                sample_rate: 1,
                 timestamp: Some(ts()),
                 tags: None,
+                kind: MetricKind::Incremental,
+                value: MetricValue::Distribution {
+                    values: vec![2.5],
+                    sample_rates: vec![1],
+                },
             }
         );
     }


### PR DESCRIPTION
This PR implements a new metric model, with the following improvements
- `Metric` enum is turned into struct, to make code less repetitive
- Relative (Incremental) and Absolute metrics are clearly separated using dedicated `kind` field
- It became possible to aggregate all basic metrics types (except for Aggregated* ones)

This is a breaking change.

Closes #920, #747, #1025
