### PR TITLE
enhancement(cli): Allow >1 config targets for validate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check-generate: ## Checks for pending `make generate` changes
 	@scripts/check-generate.sh
 
 check-examples: ## Validates the config examples
-	@find ./config/examples -name "*.toml" | xargs -I{} sh -c "cargo run -q -- validate --topology --deny-warnings -c {} || exit 255"
+	@cargo run -q -- validate --topology --deny-warnings ./config/examples/*.toml
 
 check-version: ## Checks that the version in Cargo.toml is up-to-date
 	@bundle install --gemfile=scripts/Gemfile --quiet

--- a/website/docs/administration/validating.md
+++ b/website/docs/administration/validating.md
@@ -3,23 +3,37 @@ title: Validating
 description: Validate Vector's configuration
 ---
 
-# Validating
+Vector provides a subcommand `validate` which checks the validity of any number
+of configuration files and then exits:
 
-Vector provides a subcommand `validate` which checks the validity of a
-configuration file and then exits:
+import Tabs from '@theme/Tabs';
 
-{% code-tabs %}
-{% code-tabs-item title="fields only" %}
+<Tabs
+  block={true}
+  defaultValue="fields"
+  values={[
+    { label: 'Fields Only', value: 'fields', },
+    { label: 'Fields and Topology', value: 'topology', },
+  ]
+}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="fields">
+
 ```bash
-vector validate --config /etc/vector/vector.toml
+vector validate /etc/vector/vector.toml
 ```
-{% endcode-tabs-item %}
-{% code-tabs-item title="fields + topology" %}
+
+</TabItem>
+<TabItem value="topology">
+
 ```bash
-vector validate --config /etc/vector/vector.toml --topology
+vector validate --topology /etc/vector/*.toml
 ```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
+
+</TabItem>
+</Tabs>
 
 The validate subcommand checks the correctness of fields for components defined
 within a configuration file, including:
@@ -50,18 +64,14 @@ To see other customization options for the `validate` subcommand run
 Vector also provides a `--dry-run` option which prevents regular execution and
 instead validates a configuration file as well as the runtime environment:
 
-import Tabs from '@theme/Tabs';
-
 <Tabs
   block={true}
-  defaultValue="manual"
+  defaultValue="config"
   values={[
     { label: 'Config Only', value: 'config', },
     { label: 'Config + Healthchecks', value: 'config_healthchecks', },
   ]
 }>
-
-import TabItem from '@theme/TabItem';
 
 <TabItem value="config">
 


### PR DESCRIPTION
The config targets for the validate command are now unadorned strings,
making it possible to utilize wildcard paths to validate multiple config
files in one command:

`vector validate ./configs/*.toml ./and/also/this.toml`

This also makes it more consistent with the new `test` subcommand.