### PR TITLE
feat(cli): Add unit test subcmd and condition component type

### DIFF
--- a/.meta/sinks/elasticsearch.toml
+++ b/.meta/sinks/elasticsearch.toml
@@ -66,7 +66,7 @@ type = "table"
 null = true
 description = "Options for custom headers."
 
-[sinks.elasticsearch.options.headers.options."*"]
+[sinks.elasticsearch.options.headers.options."`<header-name>`"]
 type = "string"
 examples = [
   {name = "Authorization", value = "${TOKEN_ENV_VAR}"},
@@ -95,7 +95,7 @@ type = "table"
 null = true
 description = "Custom parameters to Elasticsearch query string."
 
-[sinks.elasticsearch.options.query.options."*"]
+[sinks.elasticsearch.options.query.options."`<parameter-name>`"]
 type = "string"
 examples = [{ name = "X-Powered-By", value = "Vector"}]
 null = false

--- a/.meta/testing.toml
+++ b/.meta/testing.toml
@@ -1,0 +1,193 @@
+[testing.tests]
+type = "[table]"
+common = true
+null = false
+description = "A table that defines a unit test."
+
+[testing.tests.options.name]
+type = "string"
+examples = ["foo test"]
+common = true
+null = false
+description = "A unique identifier for this test."
+
+[testing.tests.options.input]
+type = "table"
+common = true
+null = false
+description = "A table that defines a unit test input event."
+
+[testing.tests.options.input.options.insert_at]
+type = "string"
+examples = ["foo"]
+common = true
+null = false
+description = """\
+The name of a transform, the input event will be delivered to this transform in\
+order to begin the test.\
+"""
+
+[testing.tests.options.input.options.type]
+type = "string"
+examples = ["raw", "log", "metric"]
+null = false
+common = true
+description = "The event type."
+
+[testing.tests.options.input.options.type.enum]
+raw = "Creates a log event where the message contents are specified in the field 'value'."
+log = "Creates a log event where log fields are specified in the table 'log_fields'."
+metric = "Creates a metric event, where its type and fields are specified in the table 'metric'."
+
+[testing.tests.options.input.options.value]
+type = "string"
+examples = ["some message contents"]
+relevant_when = {type = "raw"}
+null = true
+common = true
+description = "Specifies the log message field contents when the input type is 'raw'."
+
+[testing.tests.options.input.options.log_fields]
+type = "table"
+null = true
+common = false
+relevant_when = {type = "log"}
+description = "Specifies the log fields when the input type is 'log'."
+
+[testing.tests.options.input.options.log_fields.options."*"]
+type = "*"
+null = false
+examples = [
+  {name = "message", value = "some message contents"},
+  {name = "host", value = "myhost"},
+]
+description = """\
+A key/value pair representing a field to be added to the input event.\
+"""
+
+[testing.tests.options.input.options.metric]
+type = "table"
+null = true
+common = false
+relevant_when = {type = "metric"}
+description = "Specifies the metric type when the input type is 'metric'."
+
+[testing.tests.options.input.options.metric.options.type]
+type = "string"
+null = false
+examples = ["counter"]
+common = true
+description = "The metric type."
+
+[testing.tests.options.input.options.metric.options.type.enum]
+counter = "A [counter metric type][docs.data-model#counters]."
+gauge = "A [gauge metric type][docs.data-model#gauges]."
+histogram = "A [histogram metric type][docs.data-model#histograms]."
+set = "A [set metric type][docs.data-model#sets]."
+
+[testing.tests.options.input.options.metric.options.name]
+type = "string"
+examples = ["duration_total"]
+null = false
+common = true
+description = """\
+The name of the metric. Defaults to `<field>_total` for `counter` and \
+`<field>` for `gauge`.\
+"""
+
+[testing.tests.options.input.options.metric.options.tags]
+type = "table"
+null = true
+common = true
+description = "Key/value pairs representing [metric tags][docs.data-model#tags]."
+
+[testing.tests.options.input.options.metric.options.tags.options."*"]
+type = "string"
+examples = [
+  {name = "host", value = "foohost"},
+  {name = "region", value = "us-east-1"},
+]
+null = false
+common = true
+description = """\
+Key/value pairs representing [metric tags][docs.data-model#tags].\
+"""
+
+[testing.tests.options.input.options.metric.options.val]
+type = "float"
+examples = [10.2]
+optional = false
+null = false
+description = """\
+Amount to increment/decrement or gauge.\
+"""
+
+[testing.tests.options.input.options.metric.options.timestamp]
+type = "string"
+examples = ["2019-11-01T21:15:47.443232Z"]
+optional = false
+null = false
+description = """\
+Time metric was created/ingested.\
+"""
+
+[testing.tests.options.input.options.metric.options.sample_rate]
+type = "float"
+examples = [1]
+null = true
+description = """\
+The bucket/distribution the metric is a part of.\
+"""
+
+[testing.tests.options.input.options.metric.options.direction]
+type = "string"
+null = true
+description = """\
+The direction to increase or decrease the gauge value.\
+"""
+
+[testing.tests.options.input.options.metric.options.direction.enum]
+plus = "Increase the gauge"
+minus = "Decrease the gauge"
+
+[testing.tests.options.outputs]
+type = "[table]"
+common = true
+null = false
+description = "A table that defines a unit test expected output."
+
+[testing.tests.options.outputs.options.extract_from]
+type = "string"
+examples = ["bar"]
+common = true
+null = false
+description = """\
+The name of a transform, at the end of the test events extracted from this\
+transform will be checked against a table of conditions.\
+"""
+
+[testing.tests.options.outputs.options.conditions]
+type = "table"
+common = true
+null = false
+description = """\
+A table that defines a collection of conditions to check against the output of a\
+transform. A test is considered to have passed when each condition has resolved\
+true for one or more events extracted from the target transform.\
+"""
+
+[testing.tests.options.outputs.options.conditions.options."*"]
+type = "table"
+null = false
+common = true
+description = """\
+A key/value pair representing a condition to be checked on the output of a\
+transform. Keys should be an identifier for the condition that gives context as\
+to what it is checking for.\
+"""
+
+[[testing.tests.options.outputs.options.conditions.options."*".examples]]
+  key = "check message is a thing"
+  [testing.tests.options.outputs.options.conditions.options."*".examples.value]
+    type = "check_fields"
+    "message.equals" = "a thing"

--- a/.meta/testing.toml
+++ b/.meta/testing.toml
@@ -23,7 +23,7 @@ examples = ["foo"]
 common = true
 null = false
 description = """\
-The name of a transform, the input event will be delivered to this transform in\
+The name of a transform, the input event will be delivered to this transform in \
 order to begin the test.\
 """
 
@@ -162,32 +162,60 @@ examples = ["bar"]
 common = true
 null = false
 description = """\
-The name of a transform, at the end of the test events extracted from this\
+The name of a transform, at the end of the test events extracted from this \
 transform will be checked against a table of conditions.\
 """
 
 [testing.tests.options.outputs.options.conditions]
-type = "table"
+type = "[table]"
 common = true
 null = false
 description = """\
-A table that defines a collection of conditions to check against the output of a\
-transform. A test is considered to have passed when each condition has resolved\
+A table that defines a collection of conditions to check against the output of a \
+transform. A test is considered to have passed when each condition has resolved \
 true for one or more events extracted from the target transform.\
 """
 
-[testing.tests.options.outputs.options.conditions.options."*"]
-type = "table"
+[testing.tests.options.outputs.options.conditions.options.type]
+type = "string"
 null = false
+examples = ["check_fields"]
 common = true
 description = """\
-A key/value pair representing a condition to be checked on the output of a\
-transform. Keys should be an identifier for the condition that gives context as\
-to what it is checking for.\
+The type of the condition to execute. Currently only the `check_fields` type is \
+available.\
 """
 
-[[testing.tests.options.outputs.options.conditions.options."*".examples]]
-  key = "check message is a thing"
-  [testing.tests.options.outputs.options.conditions.options."*".examples.value]
-    type = "check_fields"
-    "message.equals" = "a thing"
+[testing.tests.options.outputs.options.conditions.options."`<field_name>`.eq"]
+type = "string"
+null = true
+examples = [
+  { name = "message.eq", value = "this is the content to match against" }
+]
+common = true
+description = """\
+Check whether a fields contents exactly matches the value specified.\
+"""
+
+[testing.tests.options.outputs.options.conditions.options."`<field_name>`.neq"]
+type = "string"
+null = true
+examples = [
+  { name = "method.neq", value = "POST" }
+]
+common = true
+description = """\
+Check whether a fields contents does not match the value specified.\
+"""
+
+[testing.tests.options.outputs.options.conditions.options."`<field_name>`.exists"]
+type = "bool"
+null = true
+examples = [
+  { name = "host.exists", value = true }
+]
+common = true
+description = """\
+Check whether a field exists or does not exist, depending on the provided value\
+being `true` or `false` respectively.\
+"""

--- a/.meta/testing.toml
+++ b/.meta/testing.toml
@@ -54,7 +54,7 @@ common = false
 relevant_when = {type = "log"}
 description = "Specifies the log fields when the input type is 'log'."
 
-[testing.tests.options.input.options.log_fields.options."*"]
+[testing.tests.options.input.options.log_fields.options."`<field-name>`"]
 type = "*"
 null = false
 examples = [
@@ -101,7 +101,7 @@ null = true
 common = true
 description = "Key/value pairs representing [metric tags][docs.data-model#tags]."
 
-[testing.tests.options.input.options.metric.options.tags.options."*"]
+[testing.tests.options.input.options.metric.options.tags.options."`<tag-name>`"]
 type = "string"
 examples = [
   {name = "host", value = "foohost"},

--- a/.meta/transforms/add_fields.toml
+++ b/.meta/transforms/add_fields.toml
@@ -16,7 +16,7 @@ A table of key/value pairs representing the keys to be added to the \
 event.\
 """
 
-[transforms.add_fields.options.fields.options."*"]
+[transforms.add_fields.options.fields.options."`<field-name>`"]
 type = "*"
 null = false
 examples = [
@@ -30,6 +30,7 @@ examples = [
   {name = "my_list", value = ["first", "second", "third"]},
 ]
 description = """\
-A key/value pair representing the new log fields to be added. Accepts all \
-[supported types][docs.configuration#value_types]. Use `.` for adding nested fields.\
+The name of the field to add. Accepts all \
+[supported types][docs.configuration#value_types]. Use `.` for adding nested \
+fields.\
 """

--- a/.meta/transforms/add_tags.toml
+++ b/.meta/transforms/add_tags.toml
@@ -16,13 +16,14 @@ A table of key/value pairs representing the tags to be added to the \
 metric.\
 """
 
-[transforms.add_tags.options.tags.options."*"]
-type = "*"
+[transforms.add_tags.options.tags.options."`<tag-name>`"]
+type = "string"
 null = false
 examples = [
   {name = "my_tag", value = "my value"},
   {name = "my_env_tag", value = "${ENV_VAR}"},
 ]
 description = """\
-A key/value pair representing the new tag to be added.\
+The name of the tag to add. Due to the nature of metric tags, the value \
+must be a string.\
 """

--- a/.meta/transforms/log_to_metric.toml
+++ b/.meta/transforms/log_to_metric.toml
@@ -62,7 +62,7 @@ null = true
 common = true
 description = "Key/value pairs representing [metric tags][docs.data-model#tags]."
 
-[transforms.log_to_metric.options.metrics.options.tags.options."*"]
+[transforms.log_to_metric.options.metrics.options.tags.options."`<tag-name>`"]
 type = "string"
 examples = [
   {name = "host", value = "${HOSTNAME}"},

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3485,7 @@ dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "codec 0.1.0",
+ "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "db-key 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3734,6 +3745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "433e7ac7d511768127ed85b0c4947f47a254131e37864b2dc13f52aa32cd37e5"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ listenfd = "0.3.3"
 inventory = "0.1"
 maxminddb = "0.13.0"
 strip-ansi-escapes = "0.1.0"
+colored = "1.9"
 
 [target.'cfg(unix)'.dependencies]
 atty = "0.2"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -611,8 +611,8 @@ data_dir = "/var/lib/vector"
   #
 
   [transforms.add_fields.fields]
-    # A key/value pair representing the new log fields to be added. Accepts all
-    # supported types. Use `.` for adding nested fields.
+    # The name of the field to add. Accepts all supported types. Use `.` for adding
+    # nested fields.
     # 
     # * required
     # * type: *
@@ -650,10 +650,11 @@ data_dir = "/var/lib/vector"
   #
 
   [transforms.add_tags.tags]
-    # A key/value pair representing the new tag to be added.
+    # The name of the tag to add. Due to the nature of metric tags, the value must
+    # be a string.
     # 
     # * required
-    # * type: *
+    # * type: string
     my_tag = "my value"
     my_env_tag = "${ENV_VAR}"
 

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -9,7 +9,8 @@ command.
 To start, you should be familiar with the Vector [`/.meta`](/.meta) directory.
 This directory contains various metadata about the Vector project as a whole,
 mostly configuration details but also link definitions and more. This file is
-loaded via the [`metadata.rb`](metadata.rb) file and represented as an object.
+loaded via the [`./util/metadata.rb`](./util/metadata.rb) file and represented
+as an object.
 
 ## Templates
 

--- a/scripts/util/metadata.rb
+++ b/scripts/util/metadata.rb
@@ -36,6 +36,7 @@ class Metadata
     :log_fields,
     :metric_fields,
     :options,
+    :testing,
     :posts,
     :releases,
     :sinks,
@@ -52,6 +53,7 @@ class Metadata
     @sinks = OpenStruct.new()
     @sources = OpenStruct.new()
     @transforms = OpenStruct.new()
+    @testing = OpenStruct.new()
 
     # installation
 
@@ -127,6 +129,16 @@ class Metadata
       ))
 
       @options.send("#{option_name}=", option)
+    end
+
+    # testing
+
+    hash.fetch("testing").each do |option_name, option_hash|
+      option = Option.new(
+        option_hash.merge({"name" => option_name})
+      )
+
+      @testing.send("#{option_name}=", option)
     end
 
     # links

--- a/scripts/util/metadata/field.rb
+++ b/scripts/util/metadata/field.rb
@@ -68,7 +68,7 @@ class Field
   end
 
   def <=>(other)
-    if name == "*"
+    if wildcard? && !other.wildcard?
       1
     else
       name <=> other.name
@@ -93,5 +93,9 @@ class Field
 
   def required?
     !optional?
+  end
+
+  def wildcard?
+    name.start_with?("`<")
   end
 end

--- a/scripts/util/metadata/option.rb
+++ b/scripts/util/metadata/option.rb
@@ -83,7 +83,11 @@ class Option
   end
 
   def <=>(other)
-    name <=> other.name
+    if wildcard? && !other.wildcard?
+      1
+    else
+      name <=> other.name
+    end
   end
 
   def advanced?
@@ -214,6 +218,6 @@ class Option
   end
 
   def wildcard?
-    name == "*"
+    name.start_with?("`<")
   end
 end

--- a/scripts/util/metadata/transform.rb
+++ b/scripts/util/metadata/transform.rb
@@ -30,7 +30,7 @@ class Transform < Component
     if types_coercion
       wildcard_option =
         {
-          "name" => "*",
+          "name" => "`<field-name>`",
           "category" => "requests",
           "enum" => {
             "bool" => "Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.",
@@ -60,7 +60,7 @@ class Transform < Component
           "common" => true,
           "description" => "Key/Value pairs representing mapped log field types.",
           "null" => true,
-          "options" => {"*" => wildcard_option},
+          "options" => {"`<field-name>`" => wildcard_option},
           "type" => "table"
         })
     end

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -1,0 +1,381 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
+
+use crate::{
+    conditions::{Condition, ConditionConfig, ConditionDescription},
+    event::ValueKind,
+    Event,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum CheckFieldsPredicateArg {
+    String(String),
+    Integer(i64),
+    Float(f64),
+    Boolean(bool),
+}
+
+pub trait CheckFieldsPredicate: std::fmt::Debug + Send + Sync {
+    fn check(&self, e: &Event) -> bool;
+}
+
+//------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct EqualsPredicate {
+    target: Atom,
+    arg: CheckFieldsPredicateArg,
+}
+
+impl EqualsPredicate {
+    pub fn new(
+        target: String,
+        arg: &CheckFieldsPredicateArg,
+    ) -> Result<Box<dyn CheckFieldsPredicate>, String> {
+        Ok(Box::new(Self {
+            target: target.into(),
+            arg: arg.clone(),
+        }))
+    }
+}
+
+impl CheckFieldsPredicate for EqualsPredicate {
+    fn check(&self, event: &Event) -> bool {
+        match event {
+            Event::Log(l) => l.get(&self.target).map_or(false, |v| match &self.arg {
+                CheckFieldsPredicateArg::String(s) => s.as_bytes() == v.as_bytes(),
+                CheckFieldsPredicateArg::Integer(i) => match v {
+                    ValueKind::Integer(vi) => *i == *vi,
+                    ValueKind::Float(vf) => *i == *vf as i64,
+                    _ => false,
+                },
+                CheckFieldsPredicateArg::Float(f) => match v {
+                    ValueKind::Float(vf) => *f == *vf,
+                    ValueKind::Integer(vi) => *f == *vi as f64,
+                    _ => false,
+                },
+                CheckFieldsPredicateArg::Boolean(b) => match v {
+                    ValueKind::Boolean(vb) => *b == *vb,
+                    _ => false,
+                },
+            }),
+            Event::Metric(m) => m
+                .tags()
+                .as_ref()
+                .and_then(|t| t.get(self.target.as_ref()))
+                .map_or(false, |v| match &self.arg {
+                    CheckFieldsPredicateArg::String(s) => s.as_bytes() == v.as_bytes(),
+                    _ => false,
+                }),
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct NotEqualsPredicate {
+    target: Atom,
+    arg: String,
+}
+
+impl NotEqualsPredicate {
+    pub fn new(
+        target: String,
+        arg: &CheckFieldsPredicateArg,
+    ) -> Result<Box<dyn CheckFieldsPredicate>, String> {
+        Ok(Box::new(Self {
+            target: target.into(),
+            arg: match arg {
+                CheckFieldsPredicateArg::String(s) => s.clone(),
+                CheckFieldsPredicateArg::Integer(a) => format!("{}", a),
+                CheckFieldsPredicateArg::Float(a) => format!("{}", a),
+                CheckFieldsPredicateArg::Boolean(a) => format!("{}", a),
+            },
+        }))
+    }
+}
+
+impl CheckFieldsPredicate for NotEqualsPredicate {
+    fn check(&self, event: &Event) -> bool {
+        match event {
+            Event::Log(l) => l
+                .get(&self.target)
+                .map(|f| f.as_bytes())
+                .map_or(false, |b| b != self.arg.as_bytes()),
+            Event::Metric(m) => m
+                .tags()
+                .as_ref()
+                .and_then(|t| t.get(self.target.as_ref()))
+                .map_or(false, |v| v.as_bytes() != self.arg.as_bytes()),
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct ExistsPredicate {
+    target: Atom,
+    arg: bool,
+}
+
+impl ExistsPredicate {
+    pub fn new(
+        target: String,
+        arg: &CheckFieldsPredicateArg,
+    ) -> Result<Box<dyn CheckFieldsPredicate>, String> {
+        match arg {
+            CheckFieldsPredicateArg::Boolean(b) => Ok(Box::new(Self {
+                target: target.into(),
+                arg: *b,
+            })),
+            _ => Err("exists predicate requires a boolean argument".to_owned()),
+        }
+    }
+}
+
+impl CheckFieldsPredicate for ExistsPredicate {
+    fn check(&self, event: &Event) -> bool {
+        (match event {
+            Event::Log(l) => l.get(&self.target).is_some(),
+            Event::Metric(m) => m
+                .tags()
+                .as_ref()
+                .map_or(false, |t| t.contains_key(self.target.as_ref())),
+        }) == self.arg
+    }
+}
+
+//------------------------------------------------------------------------------
+
+fn build_predicate(
+    predicate: &str,
+    target: String,
+    arg: &CheckFieldsPredicateArg,
+) -> Result<Box<dyn CheckFieldsPredicate>, String> {
+    match predicate {
+        "eq" | "equals" => EqualsPredicate::new(target, arg),
+        "neq" | "not_equals" => NotEqualsPredicate::new(target, arg),
+        "exists" => ExistsPredicate::new(target, arg),
+        _ => Err(format!("predicate type '{}' not recognized", predicate)),
+    }
+}
+
+fn build_predicates(
+    map: &IndexMap<String, CheckFieldsPredicateArg>,
+) -> Result<Vec<Box<dyn CheckFieldsPredicate>>, Vec<String>> {
+    let mut predicates: Vec<Box<dyn CheckFieldsPredicate>> = Vec::new();
+    let mut errors = Vec::new();
+
+    for (target_pred, arg) in map {
+        if target_pred
+            .rfind('.')
+            .and_then(|i| {
+                if i > 0 && i < target_pred.len() - 1 {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .and_then(|i| {
+                let mut target = target_pred.clone();
+                let pred = target.split_off(i + 1);
+                target.truncate(target.len() - 1);
+                match build_predicate(&pred, target, arg) {
+                    Ok(pred) => predicates.push(pred),
+                    Err(err) => errors.push(err),
+                }
+                Some(())
+            })
+            .is_none()
+        {
+            errors.push(format!("predicate not found in check_fields value '{}', format must be <target>.<predicate>", target_pred));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(predicates)
+    } else {
+        Err(errors)
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct CheckFieldsConfig {
+    #[serde(flatten, default)]
+    predicates: IndexMap<String, CheckFieldsPredicateArg>,
+}
+
+inventory::submit! {
+    ConditionDescription::new::<CheckFieldsConfig>("check_fields")
+}
+
+#[typetag::serde(name = "check_fields")]
+impl ConditionConfig for CheckFieldsConfig {
+    fn build(&self) -> crate::Result<Box<dyn Condition>> {
+        build_predicates(&self.predicates)
+            .map(|preds| -> Box<dyn Condition> { Box::new(CheckFields { predicates: preds }) })
+            .map_err(|errs| {
+                if errs.len() > 1 {
+                    let mut err_fmt = errs.join("\n");
+                    err_fmt.insert_str(0, "failed to parse predicates:\n");
+                    err_fmt
+                } else {
+                    errs[0].clone()
+                }
+                .into()
+            })
+    }
+}
+
+//------------------------------------------------------------------------------
+
+pub struct CheckFields {
+    predicates: Vec<Box<dyn CheckFieldsPredicate>>,
+}
+
+impl Condition for CheckFields {
+    fn check(&self, e: &Event) -> bool {
+        self.predicates.iter().find(|p| !p.check(e)).is_none()
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Event;
+
+    #[test]
+    fn check_predicate_errors() {
+        let cases = vec![
+            ("foo", "predicate not found in check_fields value 'foo', format must be <target>.<predicate>"),
+            (".nah", "predicate not found in check_fields value '.nah', format must be <target>.<predicate>"),
+            ("", "predicate not found in check_fields value '', format must be <target>.<predicate>"),
+            ("what.", "predicate not found in check_fields value 'what.', format must be <target>.<predicate>"),
+            ("foo.not_real", "predicate type 'not_real' not recognized"),
+        ];
+
+        let mut aggregated_preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
+        let mut exp_errs = Vec::new();
+        for (pred, exp) in cases {
+            aggregated_preds.insert(pred.into(), CheckFieldsPredicateArg::String("foo".into()));
+            exp_errs.push(exp);
+
+            let mut preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
+            preds.insert(pred.into(), CheckFieldsPredicateArg::String("foo".into()));
+
+            assert_eq!(
+                CheckFieldsConfig { predicates: preds }
+                    .build()
+                    .err()
+                    .unwrap()
+                    .to_string(),
+                exp.to_owned()
+            );
+        }
+
+        let mut exp_err = exp_errs.join("\n");
+        exp_err.insert_str(0, "failed to parse predicates:\n");
+
+        assert_eq!(
+            CheckFieldsConfig {
+                predicates: aggregated_preds
+            }
+            .build()
+            .err()
+            .unwrap()
+            .to_string(),
+            exp_err
+        );
+    }
+
+    #[test]
+    fn check_field_equals() {
+        let mut preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
+        preds.insert(
+            "message.equals".into(),
+            CheckFieldsPredicateArg::String("foo".into()),
+        );
+        preds.insert(
+            "other_thing.eq".into(),
+            CheckFieldsPredicateArg::String("bar".into()),
+        );
+
+        let cond = CheckFieldsConfig { predicates: preds }.build().unwrap();
+
+        let mut event = Event::from("foo");
+        assert_eq!(cond.check(&event), false);
+
+        event
+            .as_mut_log()
+            .insert_implicit("other_thing".into(), "bar".into());
+        assert_eq!(cond.check(&event), true);
+
+        event
+            .as_mut_log()
+            .insert_implicit("message".into(), "not foo".into());
+        assert_eq!(cond.check(&event), false);
+    }
+
+    #[test]
+    fn check_field_not_equals() {
+        let mut preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
+        preds.insert(
+            "message.not_equals".into(),
+            CheckFieldsPredicateArg::String("foo".into()),
+        );
+        preds.insert(
+            "other_thing.neq".into(),
+            CheckFieldsPredicateArg::String("bar".into()),
+        );
+
+        let cond = CheckFieldsConfig { predicates: preds }.build().unwrap();
+
+        let mut event = Event::from("not foo");
+        assert_eq!(cond.check(&event), false);
+
+        event
+            .as_mut_log()
+            .insert_implicit("other_thing".into(), "not bar".into());
+        assert_eq!(cond.check(&event), true);
+
+        event
+            .as_mut_log()
+            .insert_implicit("other_thing".into(), "bar".into());
+        assert_eq!(cond.check(&event), false);
+
+        event
+            .as_mut_log()
+            .insert_implicit("message".into(), "foo".into());
+        assert_eq!(cond.check(&event), false);
+    }
+
+    #[test]
+    fn check_field_exists() {
+        let mut preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
+        preds.insert("foo.exists".into(), CheckFieldsPredicateArg::Boolean(true));
+        preds.insert("bar.exists".into(), CheckFieldsPredicateArg::Boolean(false));
+
+        let cond = CheckFieldsConfig { predicates: preds }.build().unwrap();
+
+        let mut event = Event::from("ignored field");
+        assert_eq!(cond.check(&event), false);
+
+        event
+            .as_mut_log()
+            .insert_implicit("foo".into(), "not ignored".into());
+        assert_eq!(cond.check(&event), true);
+
+        event
+            .as_mut_log()
+            .insert_implicit("bar".into(), "also not ignored".into());
+        assert_eq!(cond.check(&event), false);
+    }
+}

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,0 +1,18 @@
+use crate::topology::config::component::ComponentDescription;
+use crate::Event;
+use inventory;
+
+pub mod check_fields;
+
+pub trait Condition: Send + Sync {
+    fn check(&self, e: &Event) -> bool; // TODO: Add method that provides fail context? -> Result<(), String>
+}
+
+#[typetag::serde(tag = "type")]
+pub trait ConditionConfig: std::fmt::Debug {
+    fn build(&self) -> crate::Result<Box<dyn Condition>>;
+}
+
+pub type ConditionDescription = ComponentDescription<Box<dyn ConditionConfig>>;
+
+inventory::collect!(ConditionDescription);

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use derive_is_enum_variant::is_enum_variant;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, PartialEq, Serialize, is_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, is_enum_variant)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Metric {
     Counter {
@@ -34,7 +34,7 @@ pub enum Metric {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum Direction {
     Plus,
     Minus,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate derivative;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub mod buffers;
+pub mod conditions;
 pub mod event;
 pub mod generate;
 pub mod list;
@@ -26,6 +27,7 @@ pub mod topology;
 pub mod trace;
 pub mod transforms;
 pub mod types;
+pub mod unit_test;
 
 pub use event::Event;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{generate, list, metrics, runtime, topology, trace};
+use vector::{generate, list, metrics, runtime, topology, trace, unit_test};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -80,6 +80,9 @@ struct RootOpts {
 enum SubCommand {
     /// Validate the target config, then exit.
     Validate(Validate),
+
+    /// Run Vector config unit tests, then exit. This command is experimental and therefore subject to change.
+    Test(unit_test::Opts),
 
     /// List available components, then exit.
     List(list::Opts),
@@ -196,6 +199,7 @@ fn main() {
         std::process::exit(match s {
             SubCommand::Validate(v) => validate(&v),
             SubCommand::List(l) => list::cmd(&l),
+            SubCommand::Test(t) => unit_test::cmd(&t),
             SubCommand::Generate(g) => generate::cmd(&g),
         })
     });

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -216,7 +216,7 @@ fn default_test_input_type() -> String {
 #[serde(deny_unknown_fields)]
 pub struct TestOutput {
     pub extract_from: String,
-    pub conditions: IndexMap<String, TestCondition>,
+    pub conditions: Vec<TestCondition>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -2,6 +2,7 @@ pub mod builder;
 pub mod config;
 mod fanout;
 mod task;
+pub mod unit_test;
 
 pub use self::config::Config;
 

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -1,0 +1,804 @@
+use crate::{
+    conditions::Condition,
+    event::Event,
+    topology::config::{TestCondition, TestDefinition, TestInputValue},
+    transforms::Transform,
+};
+use std::collections::HashMap;
+
+//------------------------------------------------------------------------------
+
+pub struct UnitTestCheck {
+    extract_from: String,
+    conditions: HashMap<String, Box<dyn Condition>>,
+}
+
+pub struct UnitTestTransform {
+    transform: Box<dyn Transform>,
+    next: Vec<String>,
+}
+
+pub struct UnitTest {
+    pub name: String,
+    input: (String, Event),
+    transforms: HashMap<String, UnitTestTransform>,
+    checks: Vec<UnitTestCheck>,
+}
+
+//------------------------------------------------------------------------------
+
+fn event_to_string(event: Event) -> String {
+    match event {
+        Event::Log(log) => serde_json::to_string(&log.unflatten()).unwrap_or_else(|_| "{}".into()),
+        Event::Metric(metric) => serde_json::to_string(&metric).unwrap_or_else(|_| "{}".into()),
+    }
+}
+
+fn walk(
+    node: &str,
+    inputs: Vec<Event>,
+    transforms: &mut HashMap<String, UnitTestTransform>,
+    aggregated_results: &mut HashMap<String, Vec<Event>>,
+) {
+    let mut results = Vec::new();
+    let mut targets = Vec::new();
+
+    if let Some(target) = transforms.get_mut(node) {
+        for input in inputs {
+            target.transform.transform_into(&mut results, input);
+        }
+        targets = target.next.clone();
+    }
+
+    for child in targets {
+        walk(&child, results.clone(), transforms, aggregated_results);
+    }
+    aggregated_results.insert(node.into(), results);
+}
+
+impl UnitTest {
+    pub fn run(&mut self) -> Vec<String> {
+        let mut errors = Vec::new();
+        let mut results = HashMap::new();
+
+        walk(
+            &self.input.0,
+            vec![self.input.1.clone()],
+            &mut self.transforms,
+            &mut results,
+        );
+
+        for check in &self.checks {
+            if let Some(results) = results.get(&check.extract_from) {
+                let mut failed_conditions = Vec::new();
+                for (name, cond) in &check.conditions {
+                    if results.iter().find(|e| cond.check(e)).is_none() {
+                        failed_conditions.push(name.to_owned());
+                    }
+                }
+                if !failed_conditions.is_empty() {
+                    let event_strings: Vec<String> =
+                        results.iter().map(|e| event_to_string(e.clone())).collect();
+                    errors.push(format!(
+                        "check transform '{}' failed conditions: [ {} ], payloads (encoded in JSON format):\n  {}",
+                        check.extract_from,
+                        failed_conditions.join(", "),
+                        event_strings.join("\n  "),
+                    ));
+                }
+            } else {
+                errors.push(format!(
+                    "check transform '{}' failed: received zero resulting events.",
+                    check.extract_from,
+                ));
+            }
+        }
+
+        errors
+    }
+}
+
+//------------------------------------------------------------------------------
+
+fn links_to_a_leaf(
+    target: &str,
+    leaves: &HashMap<String, ()>,
+    link_checked: &mut HashMap<String, bool>,
+    transform_outputs: &HashMap<String, HashMap<String, ()>>,
+) -> bool {
+    if let Some(check) = link_checked.get(target) {
+        return *check;
+    }
+    let has_linked_children = if let Some(outputs) = transform_outputs.get(target) {
+        outputs
+            .iter()
+            .filter(|(o, _)| links_to_a_leaf(o, leaves, link_checked, transform_outputs))
+            .count()
+            > 0
+    } else {
+        false
+    };
+    let linked = leaves.contains_key(target) || has_linked_children;
+    link_checked.insert(target.to_owned(), linked);
+    linked
+}
+
+/// Reduces a collection of transforms into a set that only contains those that
+/// link between our root (test input) and a set of leaves (test outputs).
+fn reduce_transforms(
+    root: &str,
+    leaves: &HashMap<String, ()>,
+    transform_outputs: &mut HashMap<String, HashMap<String, ()>>,
+) {
+    let mut link_checked: HashMap<String, bool> = HashMap::new();
+
+    if !links_to_a_leaf(root, leaves, &mut link_checked, transform_outputs) {
+        transform_outputs.clear();
+    }
+
+    transform_outputs.retain(|name, children| {
+        let linked = name == root || *link_checked.get(name).unwrap_or(&false);
+        if linked {
+            // Also remove all unlinked children.
+            children.retain(|child_name, _| {
+                name == root || *link_checked.get(child_name).unwrap_or(&false)
+            })
+        }
+        linked
+    });
+}
+
+fn build_unit_test(
+    definition: &TestDefinition,
+    config: &super::Config,
+) -> Result<UnitTest, Vec<String>> {
+    let mut errors = vec![];
+
+    // Build input event.
+    let input_event = match definition.input.type_str.as_ref() {
+        "raw" => match definition.input.value.as_ref() {
+            Some(v) => Event::from(v.clone()),
+            None => {
+                errors.push(format!("input type 'raw' requires the field 'value'"));
+                Event::from("")
+            }
+        },
+        "log" => {
+            if let Some(log_fields) = &definition.input.log_fields {
+                let mut event = Event::from("");
+                for (path, value) in log_fields {
+                    event.as_mut_log().insert_explicit(
+                        path.to_owned().into(),
+                        match value {
+                            TestInputValue::String(s) => s.as_bytes().into(),
+                            TestInputValue::Boolean(b) => (*b).into(),
+                            TestInputValue::Integer(i) => (*i).into(),
+                            TestInputValue::Float(f) => (*f).into(),
+                        },
+                    );
+                }
+                event
+            } else {
+                errors.push(format!("input type 'log' requires the field 'log_fields'"));
+                Event::from("")
+            }
+        }
+        "metric" => {
+            if let Some(metric) = &definition.input.metric {
+                Event::Metric(metric.clone())
+            } else {
+                errors.push(format!("input type 'log' requires the field 'log_fields'"));
+                Event::from("")
+            }
+        }
+        _ => {
+            errors.push(format!(
+                "unrecognized input type '{}', expected one of: 'raw', 'log' or 'metric'",
+                definition.input.type_str
+            ));
+            Event::from("")
+        }
+    };
+
+    // Maps transform names with their output targets (transforms that use it as
+    // an input).
+    let mut transform_outputs: HashMap<String, HashMap<String, ()>> = config
+        .transforms
+        .iter()
+        .map(|(k, _)| (k.clone(), HashMap::new()))
+        .collect();
+
+    config.transforms.iter().for_each(|(k, t)| {
+        t.inputs.iter().for_each(|i| {
+            if let Some(outputs) = transform_outputs.get_mut(i) {
+                outputs.insert(k.to_string(), ());
+            }
+        })
+    });
+
+    if !transform_outputs.contains_key(&definition.input.insert_at) {
+        errors.push(format!(
+            "unable to locate target transform '{}'",
+            definition.input.insert_at,
+        ));
+        return Err(errors);
+    }
+
+    let mut leaves: HashMap<String, ()> = HashMap::new();
+    definition.outputs.iter().for_each(|o| {
+        leaves.insert(o.extract_from.clone(), ());
+    });
+
+    // Reduce the configured transforms into just the ones connecting our test
+    // target with output targets.
+    reduce_transforms(&definition.input.insert_at, &leaves, &mut transform_outputs);
+
+    // Build reduced transforms.
+    let mut transforms: HashMap<String, UnitTestTransform> = HashMap::new();
+    for (name, transform_config) in &config.transforms {
+        if let Some(outputs) = transform_outputs.remove(name) {
+            match transform_config.inner.build() {
+                Ok(transform) => {
+                    transforms.insert(
+                        name.clone(),
+                        UnitTestTransform {
+                            transform: transform,
+                            next: outputs.into_iter().map(|(k, _)| k).collect(),
+                        },
+                    );
+                }
+                Err(err) => {
+                    errors.push(format!("failed to build transform '{}': {}", name, err));
+                }
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    definition.outputs.iter().for_each(|o| {
+        if !transforms.contains_key(&o.extract_from) {
+            errors.push(format!(
+                "unable to complete topology between target transform '{}' and output target '{}'",
+                definition.input.insert_at, o.extract_from
+            ));
+        }
+    });
+
+    // Build all output conditions.
+    let checks = definition.outputs.iter().map(|o| {
+        let mut conditions: HashMap<String, Box<dyn Condition>> = HashMap::new();
+        for (k, cond_conf) in &o.conditions {
+            match cond_conf {
+                TestCondition::Embedded(b) => {
+                    match b.build() {
+                        Ok(c) => {
+                            conditions.insert(k.clone(), c);
+                        },
+                        Err(e) => {
+                            errors.push(format!(
+                                "failed to create test condition '{}': {}",
+                                k, e,
+                            ));
+                        },
+                    }
+                },
+                TestCondition::String(_s) => {
+                    errors.push(format!("failed to create test condition '{}': condition references are not yet supported", k));
+                },
+            }
+        }
+        UnitTestCheck{
+            extract_from: o.extract_from.clone(),
+            conditions: conditions,
+        }
+    }).collect();
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(UnitTest {
+            name: definition.name.clone(),
+            input: (definition.input.insert_at.clone(), input_event),
+            transforms: transforms,
+            checks: checks,
+        })
+    }
+}
+
+pub fn build_unit_tests(config: &super::Config) -> Result<Vec<UnitTest>, Vec<String>> {
+    let mut tests = vec![];
+    let mut errors = vec![];
+
+    config
+        .tests
+        .iter()
+        .for_each(|test| match build_unit_test(test, config) {
+            Ok(t) => tests.push(t),
+            Err(errs) => {
+                let mut test_err = errs.join("\n");
+                // Indent all line breaks
+                test_err = test_err.replace("\n", "\n  ");
+                test_err.insert_str(0, &format!("Failed to build test '{}':\n  ", test.name));
+                errors.push(test_err);
+            }
+        });
+
+    if errors.is_empty() {
+        Ok(tests)
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::topology::config::Config;
+
+    #[test]
+    fn parse_no_input() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    my_string_field = "string value"
+
+[[tests]]
+  name = "broken test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [tests.outputs.conditions.always_false]
+      type = "check_fields"
+      "#,
+        )
+        .unwrap();
+
+        let errs = build_unit_tests(&config).err().unwrap();
+        assert_eq!(
+            errs,
+            vec![r#"Failed to build test 'broken test':
+  unable to locate target transform 'foo'"#
+                .to_owned(),]
+        );
+    }
+
+    #[test]
+    fn parse_broken_topology() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["something"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    foo_field = "string value"
+
+[transforms.baz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    baz_field = "string value"
+
+[transforms.quz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.quz.fields]
+    quz_field = "string value"
+
+[[tests]]
+  name = "broken test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [tests.outputs.conditions.always_false]
+      type = "check_fields"
+      "message.equals" = "not this"
+
+  [[tests.outputs]]
+    extract_from = "quz"
+    [tests.outputs.conditions.always_false]
+      type = "check_fields"
+      "message.equals" = "not this"
+
+[[tests]]
+  name = "broken test 2"
+
+  [tests.input]
+    insert_at = "nope"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "quz"
+    [tests.outputs.conditions.always_false]
+      type = "check_fields"
+      "message.equals" = "not this"
+      "#,
+        )
+        .unwrap();
+
+        let errs = build_unit_tests(&config).err().unwrap();
+        assert_eq!(
+            errs,
+            vec![
+                r#"Failed to build test 'broken test':
+  unable to complete topology between target transform 'foo' and output target 'baz'
+  unable to complete topology between target transform 'foo' and output target 'quz'"#
+                    .to_owned(),
+                r#"Failed to build test 'broken test 2':
+  unable to locate target transform 'nope'"#
+                    .to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_bad_input_event() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    my_string_field = "string value"
+
+[[tests]]
+  name = "broken test"
+
+  [tests.input]
+    insert_at = "foo"
+    type = "nah"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.always_false]
+      type = "check_fields"
+      "#,
+        )
+        .unwrap();
+
+        let errs = build_unit_tests(&config).err().unwrap();
+        assert_eq!(
+            errs,
+            vec![r#"Failed to build test 'broken test':
+  unrecognized input type 'nah', expected one of: 'raw', 'log' or 'metric'"#
+                .to_owned(),]
+        );
+    }
+
+    #[test]
+    fn test_success() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    new_field = "string value"
+
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    second_new_field = "also a string value"
+
+[transforms.baz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    third_new_field = "also also a string value"
+
+[[tests]]
+  name = "successful test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "message.equals" = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "message.equals" = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "third_new_field.equals" = "also also a string value"
+      "message.equals" = "nah this doesnt matter"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_log_input() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    new_field = "string value"
+
+[[tests]]
+  name = "successful test with log event"
+
+  [tests.input]
+    insert_at = "foo"
+    type = "log"
+    [tests.input.log_fields]
+      message = "this is the message"
+      int_val = 5
+      bool_val = true
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "message.equals" = "this is the message"
+      "bool_val.eq" = true
+      "int_val.eq" = 5
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_metric_input() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_tags"
+  [transforms.foo.tags]
+    new_tag = "new value added"
+
+[[tests]]
+  name = "successful test with metric event"
+
+  [tests.input]
+    insert_at = "foo"
+    type = "metric"
+    [tests.input.metric]
+      type = "counter"
+      name = "foometric"
+      val = 7
+      [tests.input.metric.tags]
+        tagfoo = "valfoo"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.check_new_tag]
+      type = "check_fields"
+      "tagfoo.equals" = "valfoo"
+      "new_tag.eq" = "new value added"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_success_over_gap() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    new_field = "string value"
+
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    second_new_field = "also a string value"
+
+[transforms.baz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    third_new_field = "also also a string value"
+
+[[tests]]
+  name = "successful test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "third_new_field.equals" = "also also a string value"
+      "message.equals" = "nah this doesnt matter"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_success_tree() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.ignored]
+  inputs = ["also_ignored"]
+  type = "add_fields"
+  [transforms.ignored.fields]
+    not_field = "string value"
+
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    new_field = "string value"
+
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    second_new_field = "also a string value"
+
+[transforms.baz]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    second_new_field = "also also a string value"
+
+[[tests]]
+  name = "successful test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "message.equals" = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also also a string value"
+      "message.equals" = "nah this doesnt matter"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_fails() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "remove_fields"
+  fields = ["timestamp"]
+
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    second_new_field = "also a string value"
+
+[transforms.baz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    third_new_field = "also also a string value"
+
+[[tests]]
+  name = "failing test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "message.equals" = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "message.equals" = "not this"
+    [tests.outputs.conditions.check_second_new_field]
+      type = "check_fields"
+      "second_new_field.equals" = "and not this"
+
+[[tests]]
+  name = "another failing test"
+
+  [tests.input]
+    insert_at = "foo"
+    value = "also this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "message.equals" = "also this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [tests.outputs.conditions.check_new_field]
+      type = "check_fields"
+      "second_new_field.equals" = "nope not this"
+      "third_new_field.equals" = "and not this"
+      "message.equals" = "also this doesnt matter"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_ne!(tests[0].run(), Vec::<String>::new());
+        assert_ne!(tests[1].run(), Vec::<String>::new());
+        // TODO: The json representations are randomly ordered so these checks
+        // don't always pass:
+        /*
+                assert_eq!(tests[0].run(), vec![
+        r#"check transform 'bar' failed conditions: [ check_second_new_field, check_new_field ], payloads (encoded in JSON format):
+          {"second_new_field":"also a string value","message":"nah this doesnt matter"}
+        "#.to_owned(),
+                ]);
+                assert_eq!(tests[1].run(), vec![
+        r#"check transform 'baz' failed conditions: [ check_new_field ], payloads (encoded in JSON format):
+          {"message":"also this doesnt matter","second_new_field":"also a string value","new_field":"string value"}
+        "#.to_owned(),
+                ]);
+                */
+    }
+}

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,0 +1,89 @@
+use crate::topology::{config::Config, unit_test::UnitTest};
+use colored::*;
+use std::{fs::File, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Opts {
+    /// Any number of Vector config files to test.
+    paths: Vec<PathBuf>,
+}
+
+fn build_tests(path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(error) => {
+            if let std::io::ErrorKind::NotFound = error.kind() {
+                return Err(vec![format!(
+                    "Config file not found in path '{}'",
+                    path.to_str().unwrap_or("")
+                )]);
+            } else {
+                return Err(vec![format!(
+                    "Could not open file '{}': {}",
+                    path.to_str().unwrap_or(""),
+                    error
+                )]);
+            }
+        }
+    };
+
+    let config = match Config::load(file) {
+        Err(load_errs) => {
+            return Err(load_errs);
+        }
+        Ok(c) => c,
+    };
+
+    crate::topology::unit_test::build_unit_tests(&config)
+}
+
+pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
+    let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
+
+    for (i, p) in opts.paths.iter().enumerate() {
+        let path_str = p.to_str().unwrap_or("");
+        if i > 0 {
+            println!("");
+        }
+        println!("Running {} tests", path_str);
+        match build_tests(p) {
+            Ok(mut tests) => {
+                let mut aggregated_test_errors = Vec::new();
+                tests.iter_mut().for_each(|t| {
+                    let test_errors = t.run();
+                    if !test_errors.is_empty() {
+                        println!("Test {}: {} ... {}", path_str, t.name, "failed".red());
+                        aggregated_test_errors.push((t.name.clone(), test_errors));
+                    } else {
+                        println!("Test {}: {} ... {}", path_str, t.name, "passed".green());
+                    }
+                });
+                if !aggregated_test_errors.is_empty() {
+                    failed_files.push((path_str.to_owned(), aggregated_test_errors));
+                }
+            }
+            Err(errs) => {
+                error!("Failed to execute {} tests:\n{}", path_str, errs.join("\n"));
+                return exitcode::CONFIG;
+            }
+        }
+    }
+
+    if !failed_files.is_empty() {
+        println!("\nfailures:");
+        for (path, failures) in failed_files {
+            println!("\n--- {} ---", path);
+            for (test_name, fails) in failures {
+                println!("\nTest '{}':", test_name);
+                for fail in fails {
+                    println!("{}", fail);
+                }
+            }
+        }
+        exitcode::CONFIG
+    } else {
+        exitcode::OK
+    }
+}

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -405,7 +405,7 @@ Options for custom headers.
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"Authorization","value":"${TOKEN_ENV_VAR}"},{"name":"X-Powered-By","value":"Vector"}]}
-  name={"*"}
+  name={"`<header-name>`"}
   nullable={false}
   path={"headers"}
   relevantWhen={null}
@@ -415,7 +415,7 @@ Options for custom headers.
   unit={null}
   >
 
-#### *
+#### `<header-name>`
 
 A custom header to be added to each outgoing Elasticsearch request.
 
@@ -547,7 +547,7 @@ Custom parameters to Elasticsearch query string.
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"X-Powered-By","value":"Vector"}]}
-  name={"*"}
+  name={"`<parameter-name>`"}
   nullable={false}
   path={"query"}
   relevantWhen={null}
@@ -557,7 +557,7 @@ Custom parameters to Elasticsearch query string.
   unit={null}
   >
 
-#### *
+#### `<parameter-name>`
 
 A custom parameter to be added to each Elasticsearch request.
 

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -92,8 +92,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   
   # OPTIONAL - Headers
   [sinks.my_sink_id.headers]
-    Authorization = "${TOKEN_ENV_VAR}" # example
-    X-Powered-By = "Vector" # example
+    Authorization = "${TOKEN_ENV_VAR}"
   
   # OPTIONAL - Tls
   [sinks.my_sink_id.tls]

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -260,6 +260,24 @@ More detail on the output schema is below.
 
 <Field
   enumValues={null}
+  examples={["my-value"]}
+  name={"*"}
+  path={null}
+  required={false}
+  type={"*"}
+  >
+
+### *
+
+Additional Journald fields are passed through as log fields.
+
+
+
+</Field>
+
+
+<Field
+  enumValues={null}
   examples={["my.host.com"]}
   name={"host"}
   path={null}
@@ -304,24 +322,6 @@ The value of the journald `MESSAGE` field.
 ### timestamp
 
 The value of the journald `_SOURCE_REALTIME_TIMESTAMP` field.
-
-
-</Field>
-
-
-<Field
-  enumValues={null}
-  examples={["my-value"]}
-  name={"*"}
-  path={null}
-  required={false}
-  type={"*"}
-  >
-
-### *
-
-Additional Journald fields are passed through as log fields.
-
 
 
 </Field>

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -1,0 +1,644 @@
+---
+title: Unit Tests
+description: Unit test configuration options
+---
+
+It's possible to define unit tests within a Vector configuration file that cover
+a network of transforms within the topology. The intention of these tests is to
+improve the maintainability of configs containing larger and more complex
+combinations of transforms.
+
+Executing tests within a config file can be done with the[`test`](#test) subcommand:
+
+```bash
+vector test /etc/vector/*.toml
+```
+
+## Configuration
+
+import Tabs from '@theme/Tabs';
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[
+    { label: 'Common', value: 'common', },
+    { label: 'Advanced', value: 'advanced', },
+  ]
+}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="common">
+
+import CodeHeader from '@site/src/components/CodeHeader';
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+[[.tests]]
+    # REQUIRED - General
+    name = "foo test" # example
+    
+    # REQUIRED - Outputs
+    [[.tests.outputs]]
+      # REQUIRED - General
+      extract_from = "bar" # example
+      
+      # REQUIRED - Conditions
+      [.tests.outputs.conditions]
+        [.tests.outputs.conditions.*]
+    
+    # REQUIRED - Input
+    [.tests.input]
+      # REQUIRED
+      type = "raw" # example, enum
+      insert_at = "foo" # example
+      
+      # OPTIONAL
+      value = "some message contents" # example, no default, relevant when type = "raw"
+```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+[[.tests]]
+    # REQUIRED - General
+    name = "foo test" # example
+    
+    # REQUIRED - Outputs
+    [[.tests.outputs]]
+      # REQUIRED - General
+      extract_from = "bar" # example
+      
+      # REQUIRED - Conditions
+      [.tests.outputs.conditions]
+        [.tests.outputs.conditions.*]
+    
+    # REQUIRED - Input
+    [.tests.input]
+      # REQUIRED - General
+      type = "raw" # example, enum
+      insert_at = "foo" # example
+      
+      # OPTIONAL - General
+      value = "some message contents" # example, no default, relevant when type = "raw"
+      
+      # OPTIONAL - Log fields
+      [.tests.input.log_fields]
+        message = "some message contents" # example
+        host = "myhost" # example
+      
+      # OPTIONAL - Metric
+      [.tests.input.metric]
+        # REQUIRED - General
+        type = "counter" # example, enum
+        name = "duration_total" # example
+        timestamp = "2019-11-01T21:15:47.443232Z" # example
+        val = 10.2 # example
+        
+        # OPTIONAL - General
+        direction = "plus" # example, no default, enum
+        sample_rate = 1 # example, no default
+        
+        # OPTIONAL - Tags
+        [.tests.input.metric.tags]
+          host = "foohost" # example
+          region = "us-east-1" # example
+```
+
+</TabItem>
+
+</Tabs>
+
+## Options
+
+import Fields from '@site/src/components/Fields';
+
+import Field from '@site/src/components/Field';
+
+<Fields filters={true}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"tests"}
+  nullable={false}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"[table]"}
+  unit={null}
+  >
+
+### tests
+
+A table that defines a unit test.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["foo test"]}
+  name={"name"}
+  nullable={false}
+  path={"tests"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### name
+
+A unique identifier for this test.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"input"}
+  nullable={false}
+  path={"tests"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+#### input
+
+A table that defines a unit test input event.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["foo"]}
+  name={"insert_at"}
+  nullable={false}
+  path={"tests.input"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### insert_at
+
+The name of a transform, the input event will be delivered to this transform inorder to begin the test.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"raw":"Creates a log event where the message contents are specified in the field 'value'.","log":"Creates a log event where log fields are specified in the table 'log_fields'.","metric":"Creates a metric event, where its type and fields are specified in the table 'metric'."}}
+  examples={["raw","log","metric"]}
+  name={"type"}
+  nullable={false}
+  path={"tests.input"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### type
+
+The event type.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["some message contents"]}
+  name={"value"}
+  nullable={true}
+  path={"tests.input"}
+  relevantWhen={{"type":"raw"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### value
+
+Specifies the log message field contents when the input type is 'raw'.
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"log_fields"}
+  nullable={true}
+  path={"tests.input"}
+  relevantWhen={{"type":"log"}}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+##### log_fields
+
+Specifies the log fields when the input type is 'log'.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"name":"message","value":"some message contents"},{"name":"host","value":"myhost"}]}
+  name={"*"}
+  nullable={false}
+  path={"tests.input.log_fields"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"*"}
+  unit={null}
+  >
+
+###### *
+
+A key/value pair representing a field to be added to the input event.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"metric"}
+  nullable={true}
+  path={"tests.input"}
+  relevantWhen={{"type":"metric"}}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+##### metric
+
+Specifies the metric type when the input type is 'metric'.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"counter":"A [counter metric type][docs.data-model#counters].","gauge":"A [gauge metric type][docs.data-model#gauges].","histogram":"A [histogram metric type][docs.data-model#histograms].","set":"A [set metric type][docs.data-model#sets]."}}
+  examples={["counter"]}
+  name={"type"}
+  nullable={false}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+###### type
+
+The metric type.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["duration_total"]}
+  name={"name"}
+  nullable={false}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+###### name
+
+The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"tags"}
+  nullable={true}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+###### tags
+
+Key/value pairs representing [metric tags][docs.data-model#tags].
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"name":"host","value":"foohost"},{"name":"region","value":"us-east-1"}]}
+  name={"*"}
+  nullable={false}
+  path={"tests.input.metric.tags"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+####### *
+
+Key/value pairs representing [metric tags][docs.data-model#tags].
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[10.2]}
+  name={"val"}
+  nullable={false}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"float"}
+  unit={null}
+  >
+
+###### val
+
+Amount to increment/decrement or gauge.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["2019-11-01T21:15:47.443232Z"]}
+  name={"timestamp"}
+  nullable={false}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+###### timestamp
+
+Time metric was created/ingested.
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[1]}
+  name={"sample_rate"}
+  nullable={true}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"float"}
+  unit={null}
+  >
+
+###### sample_rate
+
+The bucket/distribution the metric is a part of.
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={{"plus":"Increase the gauge","minus":"Decrease the gauge"}}
+  examples={["plus","minus"]}
+  name={"direction"}
+  nullable={true}
+  path={"tests.input.metric"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+###### direction
+
+The direction to increase or decrease the gauge value.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"outputs"}
+  nullable={false}
+  path={"tests"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"[table]"}
+  unit={null}
+  >
+
+#### outputs
+
+A table that defines a unit test expected output.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["bar"]}
+  name={"extract_from"}
+  nullable={false}
+  path={"tests.outputs"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### extract_from
+
+The name of a transform, at the end of the test events extracted from thistransform will be checked against a table of conditions.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"conditions"}
+  nullable={false}
+  path={"tests.outputs"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+##### conditions
+
+A table that defines a collection of conditions to check against the output of atransform. A test is considered to have passed when each condition has resolvedtrue for one or more events extracted from the target transform.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"key":"check message is a thing","value":{"type":"check_fields","message.equals":"a thing"}}]}
+  name={"*"}
+  nullable={false}
+  path={"tests.outputs.conditions"}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+###### *
+
+A key/value pair representing a condition to be checked on the output of atransform. Keys should be an identifier for the condition that gives context asto what it is checking for.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+</Fields>
+
+
+[docs.data-model#counters]: /docs/about/data-model#counters
+[docs.data-model#gauges]: /docs/about/data-model#gauges
+[docs.data-model#histograms]: /docs/about/data-model#histograms
+[docs.data-model#sets]: /docs/about/data-model#sets
+[docs.data-model#tags]: /docs/about/data-model#tags

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -8,7 +8,7 @@ a network of transforms within the topology. The intention of these tests is to
 improve the maintainability of configs containing larger and more complex
 combinations of transforms.
 
-Executing tests within a config file can be done with the[`test`](#test) subcommand:
+Executing tests within a config file can be done with the `test` subcommand:
 
 ```bash
 vector test /etc/vector/*.toml
@@ -36,27 +36,27 @@ import CodeHeader from '@site/src/components/CodeHeader';
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-[[.tests]]
+[tests]
+  # REQUIRED - General
+  name = "foo test" # example
+  
+  # REQUIRED - Outputs
+  [[tests.outputs]]
     # REQUIRED - General
-    name = "foo test" # example
+    extract_from = "bar" # example
     
-    # REQUIRED - Outputs
-    [[.tests.outputs]]
-      # REQUIRED - General
-      extract_from = "bar" # example
-      
-      # REQUIRED - Conditions
-      [.tests.outputs.conditions]
-        [.tests.outputs.conditions.*]
+    # REQUIRED - Conditions
+    [tests.outputs.conditions]
+      [tests.outputs.conditions.*]
+  
+  # REQUIRED - Input
+  [tests.input]
+    # REQUIRED
+    type = "raw" # example, enum
+    insert_at = "foo" # example
     
-    # REQUIRED - Input
-    [.tests.input]
-      # REQUIRED
-      type = "raw" # example, enum
-      insert_at = "foo" # example
-      
-      # OPTIONAL
-      value = "some message contents" # example, no default, relevant when type = "raw"
+    # OPTIONAL
+    value = "some message contents" # example, no default, relevant when type = "raw"
 ```
 
 </TabItem>
@@ -65,49 +65,49 @@ import CodeHeader from '@site/src/components/CodeHeader';
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-[[.tests]]
+[tests]
+  # REQUIRED - General
+  name = "foo test" # example
+  
+  # REQUIRED - Outputs
+  [[tests.outputs]]
     # REQUIRED - General
-    name = "foo test" # example
+    extract_from = "bar" # example
     
-    # REQUIRED - Outputs
-    [[.tests.outputs]]
-      # REQUIRED - General
-      extract_from = "bar" # example
-      
-      # REQUIRED - Conditions
-      [.tests.outputs.conditions]
-        [.tests.outputs.conditions.*]
+    # REQUIRED - Conditions
+    [tests.outputs.conditions]
+      [tests.outputs.conditions.*]
+  
+  # REQUIRED - Input
+  [tests.input]
+    # REQUIRED - General
+    type = "raw" # example, enum
+    insert_at = "foo" # example
     
-    # REQUIRED - Input
-    [.tests.input]
+    # OPTIONAL - General
+    value = "some message contents" # example, no default, relevant when type = "raw"
+    
+    # OPTIONAL - Log fields
+    [tests.input.log_fields]
+      message = "some message contents" # example
+      host = "myhost" # example
+    
+    # OPTIONAL - Metric
+    [tests.input.metric]
       # REQUIRED - General
-      type = "raw" # example, enum
-      insert_at = "foo" # example
+      type = "counter" # example, enum
+      name = "duration_total" # example
+      timestamp = "2019-11-01T21:15:47.443232Z" # example
+      val = 10.2 # example
       
       # OPTIONAL - General
-      value = "some message contents" # example, no default, relevant when type = "raw"
+      direction = "plus" # example, no default, enum
+      sample_rate = 1 # example, no default
       
-      # OPTIONAL - Log fields
-      [.tests.input.log_fields]
-        message = "some message contents" # example
-        host = "myhost" # example
-      
-      # OPTIONAL - Metric
-      [.tests.input.metric]
-        # REQUIRED - General
-        type = "counter" # example, enum
-        name = "duration_total" # example
-        timestamp = "2019-11-01T21:15:47.443232Z" # example
-        val = 10.2 # example
-        
-        # OPTIONAL - General
-        direction = "plus" # example, no default, enum
-        sample_rate = 1 # example, no default
-        
-        # OPTIONAL - Tags
-        [.tests.input.metric.tags]
-          host = "foohost" # example
-          region = "us-east-1" # example
+      # OPTIONAL - Tags
+      [tests.input.metric.tags]
+        host = "foohost" # example
+        region = "us-east-1" # example
 ```
 
 </TabItem>
@@ -127,32 +127,10 @@ import Field from '@site/src/components/Field';
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={[]}
-  name={"tests"}
-  nullable={false}
-  path={null}
-  relevantWhen={null}
-  required={true}
-  templateable={false}
-  type={"[table]"}
-  unit={null}
-  >
-
-### tests
-
-A table that defines a unit test.
-
-<Fields filters={false}>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
   examples={["foo test"]}
   name={"name"}
   nullable={false}
-  path={"tests"}
+  path={null}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -160,7 +138,7 @@ A table that defines a unit test.
   unit={null}
   >
 
-#### name
+### name
 
 A unique identifier for this test.
 
@@ -175,7 +153,7 @@ A unique identifier for this test.
   examples={[]}
   name={"input"}
   nullable={false}
-  path={"tests"}
+  path={null}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -183,7 +161,7 @@ A unique identifier for this test.
   unit={null}
   >
 
-#### input
+### input
 
 A table that defines a unit test input event.
 
@@ -197,7 +175,7 @@ A table that defines a unit test input event.
   examples={["foo"]}
   name={"insert_at"}
   nullable={false}
-  path={"tests.input"}
+  path={"input"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -205,7 +183,7 @@ A table that defines a unit test input event.
   unit={null}
   >
 
-##### insert_at
+#### insert_at
 
 The name of a transform, the input event will be delivered to this transform inorder to begin the test.
 
@@ -220,7 +198,7 @@ The name of a transform, the input event will be delivered to this transform ino
   examples={["raw","log","metric"]}
   name={"type"}
   nullable={false}
-  path={"tests.input"}
+  path={"input"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -228,7 +206,7 @@ The name of a transform, the input event will be delivered to this transform ino
   unit={null}
   >
 
-##### type
+#### type
 
 The event type.
 
@@ -243,7 +221,7 @@ The event type.
   examples={["some message contents"]}
   name={"value"}
   nullable={true}
-  path={"tests.input"}
+  path={"input"}
   relevantWhen={{"type":"raw"}}
   required={false}
   templateable={false}
@@ -251,7 +229,7 @@ The event type.
   unit={null}
   >
 
-##### value
+#### value
 
 Specifies the log message field contents when the input type is 'raw'.
 
@@ -266,7 +244,7 @@ Specifies the log message field contents when the input type is 'raw'.
   examples={[]}
   name={"log_fields"}
   nullable={true}
-  path={"tests.input"}
+  path={"input"}
   relevantWhen={{"type":"log"}}
   required={false}
   templateable={false}
@@ -274,7 +252,7 @@ Specifies the log message field contents when the input type is 'raw'.
   unit={null}
   >
 
-##### log_fields
+#### log_fields
 
 Specifies the log fields when the input type is 'log'.
 
@@ -286,9 +264,9 @@ Specifies the log fields when the input type is 'log'.
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"message","value":"some message contents"},{"name":"host","value":"myhost"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
-  path={"tests.input.log_fields"}
+  path={"input.log_fields"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -296,7 +274,7 @@ Specifies the log fields when the input type is 'log'.
   unit={null}
   >
 
-###### *
+##### `<field-name>`
 
 A key/value pair representing a field to be added to the input event.
 
@@ -316,7 +294,7 @@ A key/value pair representing a field to be added to the input event.
   examples={[]}
   name={"metric"}
   nullable={true}
-  path={"tests.input"}
+  path={"input"}
   relevantWhen={{"type":"metric"}}
   required={false}
   templateable={false}
@@ -324,7 +302,7 @@ A key/value pair representing a field to be added to the input event.
   unit={null}
   >
 
-##### metric
+#### metric
 
 Specifies the metric type when the input type is 'metric'.
 
@@ -338,7 +316,7 @@ Specifies the metric type when the input type is 'metric'.
   examples={["counter"]}
   name={"type"}
   nullable={false}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -346,7 +324,7 @@ Specifies the metric type when the input type is 'metric'.
   unit={null}
   >
 
-###### type
+##### type
 
 The metric type.
 
@@ -361,7 +339,7 @@ The metric type.
   examples={["duration_total"]}
   name={"name"}
   nullable={false}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -369,7 +347,7 @@ The metric type.
   unit={null}
   >
 
-###### name
+##### name
 
 The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`.
 
@@ -384,7 +362,7 @@ The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` 
   examples={[]}
   name={"tags"}
   nullable={true}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -392,7 +370,7 @@ The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` 
   unit={null}
   >
 
-###### tags
+##### tags
 
 Key/value pairs representing [metric tags][docs.data-model#tags].
 
@@ -404,9 +382,9 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"host","value":"foohost"},{"name":"region","value":"us-east-1"}]}
-  name={"*"}
+  name={"`<tag-name>`"}
   nullable={false}
-  path={"tests.input.metric.tags"}
+  path={"input.metric.tags"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -414,7 +392,7 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   unit={null}
   >
 
-####### *
+###### `<tag-name>`
 
 Key/value pairs representing [metric tags][docs.data-model#tags].
 
@@ -434,7 +412,7 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   examples={[10.2]}
   name={"val"}
   nullable={false}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -442,7 +420,7 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   unit={null}
   >
 
-###### val
+##### val
 
 Amount to increment/decrement or gauge.
 
@@ -457,7 +435,7 @@ Amount to increment/decrement or gauge.
   examples={["2019-11-01T21:15:47.443232Z"]}
   name={"timestamp"}
   nullable={false}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -465,7 +443,7 @@ Amount to increment/decrement or gauge.
   unit={null}
   >
 
-###### timestamp
+##### timestamp
 
 Time metric was created/ingested.
 
@@ -480,7 +458,7 @@ Time metric was created/ingested.
   examples={[1]}
   name={"sample_rate"}
   nullable={true}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -488,7 +466,7 @@ Time metric was created/ingested.
   unit={null}
   >
 
-###### sample_rate
+##### sample_rate
 
 The bucket/distribution the metric is a part of.
 
@@ -503,7 +481,7 @@ The bucket/distribution the metric is a part of.
   examples={["plus","minus"]}
   name={"direction"}
   nullable={true}
-  path={"tests.input.metric"}
+  path={"input.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -511,7 +489,7 @@ The bucket/distribution the metric is a part of.
   unit={null}
   >
 
-###### direction
+##### direction
 
 The direction to increase or decrease the gauge value.
 
@@ -536,7 +514,7 @@ The direction to increase or decrease the gauge value.
   examples={[]}
   name={"outputs"}
   nullable={false}
-  path={"tests"}
+  path={null}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -544,7 +522,7 @@ The direction to increase or decrease the gauge value.
   unit={null}
   >
 
-#### outputs
+### outputs
 
 A table that defines a unit test expected output.
 
@@ -558,7 +536,7 @@ A table that defines a unit test expected output.
   examples={["bar"]}
   name={"extract_from"}
   nullable={false}
-  path={"tests.outputs"}
+  path={"outputs"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -566,7 +544,7 @@ A table that defines a unit test expected output.
   unit={null}
   >
 
-##### extract_from
+#### extract_from
 
 The name of a transform, at the end of the test events extracted from thistransform will be checked against a table of conditions.
 
@@ -581,7 +559,7 @@ The name of a transform, at the end of the test events extracted from thistransf
   examples={[]}
   name={"conditions"}
   nullable={false}
-  path={"tests.outputs"}
+  path={"outputs"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -589,7 +567,7 @@ The name of a transform, at the end of the test events extracted from thistransf
   unit={null}
   >
 
-##### conditions
+#### conditions
 
 A table that defines a collection of conditions to check against the output of atransform. A test is considered to have passed when each condition has resolvedtrue for one or more events extracted from the target transform.
 
@@ -603,7 +581,7 @@ A table that defines a collection of conditions to check against the output of a
   examples={[{"key":"check message is a thing","value":{"type":"check_fields","message.equals":"a thing"}}]}
   name={"*"}
   nullable={false}
-  path={"tests.outputs.conditions"}
+  path={"outputs.conditions"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -611,15 +589,10 @@ A table that defines a collection of conditions to check against the output of a
   unit={null}
   >
 
-###### *
+##### *
 
 A key/value pair representing a condition to be checked on the output of atransform. Keys should be an identifier for the condition that gives context asto what it is checking for.
 
-
-</Field>
-
-
-</Fields>
 
 </Field>
 

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -36,7 +36,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-[tests]
+[[tests]]
   # REQUIRED - General
   name = "foo test" # example
   
@@ -46,8 +46,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
     extract_from = "bar" # example
     
     # REQUIRED - Conditions
-    [tests.outputs.conditions]
-      [tests.outputs.conditions.*]
+    [[tests.outputs.conditions]]
+      # REQUIRED
+      type = "check_fields" # example
+      
+      # OPTIONAL
+      message.eq = "this is the content to match against" # example
+      host.exists = true # example
+      method.neq = "POST" # example
   
   # REQUIRED - Input
   [tests.input]
@@ -65,7 +71,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-[tests]
+[[tests]]
   # REQUIRED - General
   name = "foo test" # example
   
@@ -75,8 +81,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
     extract_from = "bar" # example
     
     # REQUIRED - Conditions
-    [tests.outputs.conditions]
-      [tests.outputs.conditions.*]
+    [[tests.outputs.conditions]]
+      # REQUIRED
+      type = "check_fields" # example
+      
+      # OPTIONAL
+      message.eq = "this is the content to match against" # example
+      host.exists = true # example
+      method.neq = "POST" # example
   
   # REQUIRED - Input
   [tests.input]
@@ -185,7 +197,7 @@ A table that defines a unit test input event.
 
 #### insert_at
 
-The name of a transform, the input event will be delivered to this transform inorder to begin the test.
+The name of a transform, the input event will be delivered to this transform in order to begin the test.
 
 
 </Field>
@@ -546,7 +558,7 @@ A table that defines a unit test expected output.
 
 #### extract_from
 
-The name of a transform, at the end of the test events extracted from thistransform will be checked against a table of conditions.
+The name of a transform, at the end of the test events extracted from this transform will be checked against a table of conditions.
 
 
 </Field>
@@ -563,13 +575,13 @@ The name of a transform, at the end of the test events extracted from thistransf
   relevantWhen={null}
   required={true}
   templateable={false}
-  type={"table"}
+  type={"[table]"}
   unit={null}
   >
 
 #### conditions
 
-A table that defines a collection of conditions to check against the output of atransform. A test is considered to have passed when each condition has resolvedtrue for one or more events extracted from the target transform.
+A table that defines a collection of conditions to check against the output of a transform. A test is considered to have passed when each condition has resolved true for one or more events extracted from the target transform.
 
 <Fields filters={false}>
 
@@ -578,20 +590,89 @@ A table that defines a collection of conditions to check against the output of a
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={[{"key":"check message is a thing","value":{"type":"check_fields","message.equals":"a thing"}}]}
-  name={"*"}
+  examples={["check_fields"]}
+  name={"type"}
   nullable={false}
   path={"outputs.conditions"}
   relevantWhen={null}
   required={true}
   templateable={false}
-  type={"table"}
+  type={"string"}
   unit={null}
   >
 
-##### *
+##### type
 
-A key/value pair representing a condition to be checked on the output of atransform. Keys should be an identifier for the condition that gives context asto what it is checking for.
+The type of the condition to execute. Currently only the `check_fields` type is available.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"name":"message.eq","value":"this is the content to match against"}]}
+  name={"`<field_name>`.eq"}
+  nullable={true}
+  path={"outputs.conditions"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.eq
+
+Check whether a fields contents exactly matches the value specified.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"name":"method.neq","value":"POST"}]}
+  name={"`<field_name>`.neq"}
+  nullable={true}
+  path={"outputs.conditions"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.neq
+
+Check whether a fields contents does not match the value specified.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"name":"host.exists","value":true}]}
+  name={"`<field_name>`.exists"}
+  nullable={true}
+  path={"outputs.conditions"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+##### `<field_name>`.exists
+
+Check whether a field exists or does not exist, depending on the provided valuebeing `true` or `false` respectively.
 
 
 </Field>

--- a/website/docs/reference/testing.md.erb
+++ b/website/docs/reference/testing.md.erb
@@ -30,7 +30,7 @@ vector test /etc/vector/*.toml
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-<%= config_example(metadata.testing.to_h.values.sort, common: true) %>
+<%= config_example(metadata.testing.tests.options, path: "tests", common: true) %>
 ```
 
 </TabItem>
@@ -39,7 +39,7 @@ vector test /etc/vector/*.toml
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-<%= config_example(metadata.testing.to_h.values.sort, common: false) %>
+<%= config_example(metadata.testing.tests.options, path: "tests", common: false) %>
 ```
 
 </TabItem>
@@ -48,4 +48,4 @@ vector test /etc/vector/*.toml
 
 ## Options
 
-<%= options(metadata.testing.to_h.values.sort, heading_depth: 3) %>
+<%= options(metadata.testing.tests.options, heading_depth: 3) %>

--- a/website/docs/reference/testing.md.erb
+++ b/website/docs/reference/testing.md.erb
@@ -30,7 +30,7 @@ vector test /etc/vector/*.toml
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-<%= config_example(metadata.testing.tests.options, path: "tests", common: true) %>
+<%= config_example(metadata.testing.tests.options, path: "tests", array: true, common: true) %>
 ```
 
 </TabItem>
@@ -39,7 +39,7 @@ vector test /etc/vector/*.toml
 <CodeHeader fileName="vector.toml" />
 
 ```toml
-<%= config_example(metadata.testing.tests.options, path: "tests", common: false) %>
+<%= config_example(metadata.testing.tests.options, path: "tests", array: true, common: false) %>
 ```
 
 </TabItem>

--- a/website/docs/reference/testing.md.erb
+++ b/website/docs/reference/testing.md.erb
@@ -1,0 +1,51 @@
+---
+title: Unit Tests
+description: Unit test configuration options
+---
+
+It's possible to define unit tests within a Vector configuration file that cover
+a network of transforms within the topology. The intention of these tests is to
+improve the maintainability of configs containing larger and more complex
+combinations of transforms.
+
+Executing tests within a config file can be done with the `test` subcommand:
+
+```bash
+vector test /etc/vector/*.toml
+```
+
+## Configuration
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[
+    { label: 'Common', value: 'common', },
+    { label: 'Advanced', value: 'advanced', },
+  ]
+}>
+
+<TabItem value="common">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+<%= config_example(metadata.testing.to_h.values.sort, common: true) %>
+```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+<%= config_example(metadata.testing.to_h.values.sort, common: false) %>
+```
+
+</TabItem>
+
+</Tabs>
+
+## Options
+
+<%= options(metadata.testing.to_h.values.sort, heading_depth: 3) %>

--- a/website/docs/reference/transforms/add_fields.md
+++ b/website/docs/reference/transforms/add_fields.md
@@ -70,7 +70,7 @@ A table of key/value pairs representing the keys to be added to the event.
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"my_string_field","value":"string value"},{"name":"my_env_var_field","value":"${ENV_VAR}"},{"name":"my_int_field","value":1},{"name":"my_float_field","value":1.2},{"name":"my_bool_field","value":true},{"name":"my_timestamp_field","value":"1979-05-27 00:32:00 -0700"},{"name":"my_nested_fields","value":{"key1":"value1","key2":"value2"}},{"name":"my_list","value":["first","second","third"]}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"fields"}
   relevantWhen={null}
@@ -80,9 +80,9 @@ A table of key/value pairs representing the keys to be added to the event.
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
-A key/value pair representing the new log fields to be added. Accepts all [supported types][docs.configuration#value_types]. Use `.` for adding nested fields.
+The name of the field to add. Accepts all [supported types][docs.configuration#value_types]. Use `.` for adding nested fields.
 
 
 </Field>

--- a/website/docs/reference/transforms/add_tags.md
+++ b/website/docs/reference/transforms/add_tags.md
@@ -64,19 +64,19 @@ A table of key/value pairs representing the tags to be added to the metric.
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"my_tag","value":"my value"},{"name":"my_env_tag","value":"${ENV_VAR}"}]}
-  name={"*"}
+  name={"`<tag-name>`"}
   nullable={false}
   path={"tags"}
   relevantWhen={null}
   required={true}
   templateable={false}
-  type={"*"}
+  type={"string"}
   unit={null}
   >
 
-#### *
+#### `<tag-name>`
 
-A key/value pair representing the new tag to be added.
+The name of the tag to add. Due to the nature of metric tags, the value must be a string.
 
 
 </Field>

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -69,7 +69,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"name":"status","value":"int"},{"name":"duration","value":"float"},{"name":"success","value":"bool"},{"name":"timestamp","value":"timestamp|%s","comment":"unix"},{"name":"timestamp","value":"timestamp|%+","comment":"iso8601 (date and time)"},{"name":"timestamp","value":"timestamp|%F","comment":"iso8601 (date)"},{"name":"timestamp","value":"timestamp|%a %b %e %T %Y","comment":"custom strptime format"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"types"}
   relevantWhen={null}
@@ -79,7 +79,7 @@ Key/Value pairs representing mapped log field types.
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
 A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
 

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -143,7 +143,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"name":"status","value":"int"},{"name":"duration","value":"float"},{"name":"success","value":"bool"},{"name":"timestamp","value":"timestamp|%s","comment":"unix"},{"name":"timestamp","value":"timestamp|%+","comment":"iso8601 (date and time)"},{"name":"timestamp","value":"timestamp|%F","comment":"iso8601 (date)"},{"name":"timestamp","value":"timestamp|%a %b %e %T %Y","comment":"custom strptime format"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"types"}
   relevantWhen={null}
@@ -153,7 +153,7 @@ Key/Value pairs representing mapped log field types.
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
 A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
 

--- a/website/docs/reference/transforms/log_to_metric.md
+++ b/website/docs/reference/transforms/log_to_metric.md
@@ -231,7 +231,7 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   defaultValue={null}
   enumValues={null}
   examples={[{"name":"host","value":"${HOSTNAME}"},{"name":"region","value":"us-east-1"},{"name":"status","value":"{{status}}"}]}
-  name={"*"}
+  name={"`<tag-name>`"}
   nullable={false}
   path={"metrics.tags"}
   relevantWhen={null}
@@ -241,7 +241,7 @@ Key/value pairs representing [metric tags][docs.data-model#tags].
   unit={null}
   >
 
-##### *
+##### `<tag-name>`
 
 Key/value pairs representing [metric tags][docs.data-model#tags]. Environment variables and field interpolation is allowed.
 

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -143,7 +143,7 @@ Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-s
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"name":"status","value":"int"},{"name":"duration","value":"float"},{"name":"success","value":"bool"},{"name":"timestamp","value":"timestamp|%s","comment":"unix"},{"name":"timestamp","value":"timestamp|%+","comment":"iso8601 (date and time)"},{"name":"timestamp","value":"timestamp|%F","comment":"iso8601 (date)"},{"name":"timestamp","value":"timestamp|%a %b %e %T %Y","comment":"custom strptime format"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"types"}
   relevantWhen={null}
@@ -153,7 +153,7 @@ Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-s
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
 A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
 

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -167,7 +167,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"name":"status","value":"int"},{"name":"duration","value":"float"},{"name":"success","value":"bool"},{"name":"timestamp","value":"timestamp|%s","comment":"unix"},{"name":"timestamp","value":"timestamp|%+","comment":"iso8601 (date and time)"},{"name":"timestamp","value":"timestamp|%F","comment":"iso8601 (date)"},{"name":"timestamp","value":"timestamp|%a %b %e %T %Y","comment":"custom strptime format"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"types"}
   relevantWhen={null}
@@ -177,7 +177,7 @@ Key/Value pairs representing mapped log field types.
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
 A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
 

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -143,7 +143,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"name":"status","value":"int"},{"name":"duration","value":"float"},{"name":"success","value":"bool"},{"name":"timestamp","value":"timestamp|%s","comment":"unix"},{"name":"timestamp","value":"timestamp|%+","comment":"iso8601 (date and time)"},{"name":"timestamp","value":"timestamp|%F","comment":"iso8601 (date)"},{"name":"timestamp","value":"timestamp|%a %b %e %T %Y","comment":"custom strptime format"}]}
-  name={"*"}
+  name={"`<field-name>`"}
   nullable={false}
   path={"types"}
   relevantWhen={null}
@@ -153,7 +153,7 @@ Key/Value pairs representing mapped log field types.
   unit={null}
   >
 
-#### *
+#### `<field-name>`
 
 A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -105,7 +105,6 @@ module.exports = {
       label: 'Reference',
       items: [
         "reference",
-        "reference/global-options",
         {
           type: 'category',
           label: 'Sources',
@@ -214,6 +213,7 @@ module.exports = {
         },
         "reference",
         "reference/testing",
+        "reference/global-options",
       ],
     },
     {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -212,6 +212,8 @@ module.exports = {
             
           ],
         },
+        "reference",
+        "reference/testing",
       ],
     },
     {

--- a/website/sidebars.js.erb
+++ b/website/sidebars.js.erb
@@ -103,7 +103,6 @@ module.exports = {
       label: 'Reference',
       items: [
         <%= metadata.links.fetch_id("docs.reference").to_json %>,
-        <%= metadata.links.fetch_id("docs.reference.global-options").to_json %>,
         {
           type: 'category',
           label: 'Sources',
@@ -136,6 +135,7 @@ module.exports = {
         },
         <%= metadata.links.fetch_id("docs.reference").to_json %>,
         <%= metadata.links.fetch_id("docs.reference.testing").to_json %>,
+        <%= metadata.links.fetch_id("docs.reference.global-options").to_json %>,
       ],
     },
     {

--- a/website/sidebars.js.erb
+++ b/website/sidebars.js.erb
@@ -134,6 +134,8 @@ module.exports = {
             <% end %>
           ],
         },
+        <%= metadata.links.fetch_id("docs.reference").to_json %>,
+        <%= metadata.links.fetch_id("docs.reference.testing").to_json %>,
       ],
     },
     {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -724,19 +724,22 @@ section .sub-title {
   padding-left: var(--ifm-spacing-horizontal);
 }
 .section-list .section:hover > h3 > .hash-link,
-.section-list .section:hover > h4 > .hash-link {
+.section-list .section:hover > h4 > .hash-link,
+.section-list .section:hover > h5 > .hash-link,
+.section-list .section:hover > h6 > .hash-link {
   opacity: 1;
 }
-.section-list .section h3 .hash-link {
-  margin-left: calc((var(--ifm-spacing-horizontal) * -1) - 1.5rem) !important;
-  padding-right: 3rem;
-}
-.section-list .section h4 .hash-link {
-  margin-left: calc((var(--ifm-spacing-horizontal) * -2) - 1.5rem) !important;
-  padding-right: 4.25rem;
+.section-list .section h3 .hash-link,
+.section-list .section h4 .hash-link,
+.section-list .section h5 .hash-link,
+.section-list .section h6 .hash-link {
+  margin-left: calc((var(--ifm-spacing-horizontal) * -1.75) - var(--ifm-spacing-horizontal)) !important;
+  padding-right: 3em;
 }
 .section-list .section h3::before,
-.section-list .section h4::before {
+.section-list .section h4::before,
+.section-list .section h5::before,
+.section-list .section h6::before {
   content: "• ";
   float: left;
   display: block;
@@ -745,7 +748,9 @@ section .sub-title {
   text-align: center;
 }
 .section-list .section h3, 
-.section-list .section h4 {
+.section-list .section h4,
+.section-list .section h5,
+.section-list .section h6 {
   margin-bottom: 1em;
 }
 .section-list .section .info {


### PR DESCRIPTION
This PR expands the configuration schema to include tests and adds a new subcommand `test`, which executes the tests within a config. This PR also introduces a new `condition` component type which allows users to define arbitrary rules for testing events. Currently the condition type is limited to `check_fields`, but can later be expanded to enable a wide range of conditional expression types, and can also be used in a `filter` transform.

This PR shouldn't be merged until the documentation is ready but the implementation is ready to review.

This is an opportunity to discuss the future of the `condition` component but I also don't want to get too caught up in it for now. The unit test functionality is going to be documented as experimental, so we can afford to continue modifying conditions after this PR until we feel they're right.

Closes #232