### PR TITLE
chore(operations): Fix `check-generate` check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,47 +37,48 @@ jobs:
   #
 
   check-code:
-    resource_class: xlarge
-    docker:
-      - image: timberiodev/vector-checker:latest
+    resource_class: large
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
-          name: Check code
+          name: Check generate
           environment:
             RUSTFLAGS: "-D warnings"
-          command: make check-code
+          command: ./scripts/run-docker.sh checker make check-code
 
   check-fmt:
-    docker:
-      - image: timberiodev/vector-checker:latest
+    resource_class: large
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
           name: Check fmt
           environment:
             RUSTFLAGS: "-D warnings"
-          command: |
-            rustup component add rustfmt
-            make check-fmt
+          command: ./scripts/run-docker.sh checker make check-fmt
 
   check-generate:
-    docker:
-      - image: timberiodev/vector-checker:latest
+    resource_class: large
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
           name: Check generate
-          command: make check-generate
+          command: ./scripts/run-docker.sh checker make check-generate
 
   check-version:
-    docker:
-      - image: timberiodev/vector-checker:latest
+    resource_class: large
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
           name: Check version
-          command: make check-version
+          command: ./scripts/run-docker.sh checker make check-version
 
   test-x86_64-pc-windows-msvc:
     executor: win/vs2019

--- a/scripts/check-generate.sh
+++ b/scripts/check-generate.sh
@@ -29,7 +29,7 @@ if [[ -n "$changes" ]]; then
   echo ''
   echo 'This usually means that auto-generated sections were updated. '
   echo 'Instead, you should update the files in the /.meta dir and then run '
-  ecgo '`make generate`. See the ./DOCUMENTING.md guide for more info.'
+  echo '`make generate`. See the ./DOCUMENTING.md guide for more info.'
   exit 1
 else
   echo 'Nice! No generation changes detected.'

--- a/scripts/ci-docker-images/checker/Dockerfile
+++ b/scripts/ci-docker-images/checker/Dockerfile
@@ -1,20 +1,17 @@
-FROM ubuntu:18.04
+FROM ruby:2.6
 
 RUN apt-get update && \
   apt-get install -y \
   build-essential \
   curl \
-  git \
-  libssl-dev \
-  pkg-config \
-  ruby-full \
-  zlib1g-dev
+  git
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.39.0
 ENV PATH="$PATH:/root/.cargo/bin"
 RUN rustup component add rustfmt
 
-# We need ruby to check for documentation changes :)
+# Install Ruby dependencies
 ENV LC_ALL C.UTF-8
 RUN gem install bundler
 COPY checker/Gemfile Gemfile

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# run-docker.sh
+#
+# SUMMARY
+#
+#   Builds given CI Docker image and runs a command inside of a container
+#   based on this image.
+
+set -eou pipefail
+
+tag="$1"
+image="timberiodev/vector-$tag:latest"
+
+docker build \
+  -t $image \
+  -f scripts/ci-docker-images/$tag/Dockerfile \
+  scripts/ci-docker-images
+
+docker run \
+  --privileged \
+  $(env | xargs -n1 printf '-e "%s"\n') \
+  -w "$PWD" \
+  -v "$PWD":"$PWD" \
+  -t $image \
+  "${@:2}"

--- a/scripts/util/core_ext/object.rb
+++ b/scripts/util/core_ext/object.rb
@@ -1,7 +1,7 @@
 class Object
   def deep_to_h
     if is_a?(OpenStruct)
-      to_h.deep_to_h
+      to_h.sort.to_h.deep_to_h
     elsif is_a?(Hash)
       new_h = {}
       each do |k, v|
@@ -11,7 +11,7 @@ class Object
     elsif is_a?(Array)
       map(&:deep_to_h)
     elsif respond_to?(:to_h)
-      to_h
+      to_h.sort.to_h
     else
       self
     end

--- a/scripts/util/metadata/post.rb
+++ b/scripts/util/metadata/post.rb
@@ -15,7 +15,7 @@ class Post
     path_parts = path.split("-", 3)
 
     @date = Date.parse("#{path_parts.fetch(0)}-#{path_parts.fetch(1)}-#{path_parts.fetch(2)}")
-    @path = path
+    @path = Pathname.new(path).relative_path_from(ROOT_DIR).to_s
 
     front_matter = FrontMatterParser::Parser.parse_file(path).front_matter
 

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -2,84 +2,84 @@ module.exports = {
   "installation": {
     "containers": [
       {
-        "name": "Docker",
-        "id": "docker"
+        "id": "docker",
+        "name": "Docker"
       }
     ],
     "downloads": [
       {
-        "name": "Linux (x86_64 w/ MUSL)",
         "file_name": "vector-x86_64-unknown-linux-musl.tar.gz",
         "latest": true,
+        "name": "Linux (x86_64 w/ MUSL)",
         "nightly": true
       },
       {
-        "name": "Linux (ARM64 w/ MUSL)",
         "file_name": "vector-aarch64-unknown-linux-musl.tar.gz",
         "latest": false,
+        "name": "Linux (ARM64 w/ MUSL)",
         "nightly": true
       },
       {
-        "name": "MacOS (64-bit OSX)",
         "file_name": "vector-x86_64-apple-darwin.tar.gz",
         "latest": true,
+        "name": "MacOS (64-bit OSX)",
         "nightly": true
       },
       {
-        "name": "Deb",
         "file_name": "vector-amd64.deb",
         "latest": true,
+        "name": "Deb",
         "nightly": true
       },
       {
-        "name": "RPM",
         "file_name": "vector-x86_64.rpm",
         "latest": true,
+        "name": "RPM",
         "nightly": true
       }
     ],
     "operating_systems": [
       {
-        "name": "Amazon Linux",
-        "id": "amazon-linux"
+        "id": "amazon-linux",
+        "name": "Amazon Linux"
       },
       {
-        "name": "CentOS",
-        "id": "centos"
+        "id": "centos",
+        "name": "CentOS"
       },
       {
-        "name": "Debian",
-        "id": "debian"
+        "id": "debian",
+        "name": "Debian"
       },
       {
-        "name": "MacOS",
-        "id": "macos"
+        "id": "macos",
+        "name": "MacOS"
       },
       {
-        "name": "Raspberry Pi",
-        "id": "raspberry-pi"
+        "id": "raspberry-pi",
+        "name": "Raspberry Pi"
       },
       {
-        "name": "RHEL",
-        "id": "rhel"
+        "id": "rhel",
+        "name": "RHEL"
       },
       {
-        "name": "Ubuntu",
-        "id": "ubuntu"
+        "id": "ubuntu",
+        "name": "Ubuntu"
       }
     ],
     "package_managers": [
       {
-        "name": "DPKG",
-        "id": "dpkg"
+        "id": "dpkg",
+        "name": "DPKG"
       },
       {
-        "name": "Homebrew",
-        "id": "homebrew"
+        "id": "homebrew",
+        "name": "Homebrew"
       },
       {
-        "name": "RPM",
-        "id": "rpm"
+        "id": "rpm",
+        "name": "RPM"
       }
     ]
   },
@@ -112,414 +112,30 @@ module.exports = {
       "title": "Introducing Vector"
     }
   ],
-  "sources": {
-    "tcp": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "receive",
-      "id": "tcp_source",
-      "name": "tcp",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "source"
-    },
-    "stdin": {
-      "beta": false,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "receive",
-      "id": "stdin_source",
-      "name": "stdin",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "source"
-    },
-    "vector": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log",
-        "metric"
-      ],
-      "function_category": "proxy",
-      "id": "vector_source",
-      "name": "vector",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    },
-    "udp": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "receive",
-      "id": "udp_source",
-      "name": "udp",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "source"
-    },
-    "statsd": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "receive",
-      "id": "statsd_source",
-      "name": "statsd",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    },
-    "kafka": {
-      "beta": true,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "collect",
-      "id": "kafka_source",
-      "name": "kafka",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    },
-    "syslog": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "receive",
-      "id": "syslog_source",
-      "name": "syslog",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "source"
-    },
-    "file": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "collect",
-      "id": "file_source",
-      "name": "file",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "source"
-    },
-    "docker": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "collect",
-      "id": "docker_source",
-      "name": "docker",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    },
-    "journald": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "collect",
-      "id": "journald_source",
-      "name": "journald",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    }
-  },
-  "transforms": {
-    "coercer": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "coercer_transform",
-      "name": "coercer",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "add_fields": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "shape",
-      "id": "add_fields_transform",
-      "name": "add_fields",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "remove_fields": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "shape",
-      "id": "remove_fields_transform",
-      "name": "remove_fields",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "tokenizer": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "tokenizer_transform",
-      "name": "tokenizer",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "json_parser": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "json_parser_transform",
-      "name": "json_parser",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "sampler": {
-      "beta": true,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "filter",
-      "id": "sampler_transform",
-      "name": "sampler",
-      "service_provider": null,
-      "status": "beta",
-      "type": "transform"
-    },
-    "regex_parser": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "regex_parser_transform",
-      "name": "regex_parser",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "add_tags": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "shape",
-      "id": "add_tags_transform",
-      "name": "add_tags",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "split": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "split_transform",
-      "name": "split",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "lua": {
-      "beta": true,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "program",
-      "id": "lua_transform",
-      "name": "lua",
-      "service_provider": null,
-      "status": "beta",
-      "type": "transform"
-    },
-    "remove_tags": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "shape",
-      "id": "remove_tags_transform",
-      "name": "remove_tags",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "log_to_metric": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log",
-        "metric"
-      ],
-      "function_category": "convert",
-      "id": "log_to_metric_transform",
-      "name": "log_to_metric",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "grok_parser": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "parse",
-      "id": "grok_parser_transform",
-      "name": "grok_parser",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "field_filter": {
-      "beta": true,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log",
-        "metric"
-      ],
-      "function_category": "filter",
-      "id": "field_filter_transform",
-      "name": "field_filter",
-      "service_provider": null,
-      "status": "beta",
-      "type": "transform"
-    }
-  },
   "sinks": {
-    "tcp": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "tcp_sink",
-      "name": "tcp",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "vector": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "proxy",
-      "id": "vector_sink",
-      "name": "vector",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "statsd": {
+    "aws_cloudwatch_logs": {
       "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "transmit",
-      "id": "statsd_sink",
-      "name": "statsd",
-      "service_provider": null,
-      "status": "beta",
-      "type": "sink"
-    },
-    "prometheus": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "transmit",
-      "id": "prometheus_sink",
-      "name": "prometheus",
-      "service_provider": null,
-      "status": "beta",
-      "type": "sink"
-    },
-    "splunk_hec": {
-      "beta": false,
       "delivery_guarantee": "at_least_once",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "splunk_hec_sink",
-      "name": "splunk_hec",
-      "service_provider": "Splunk",
-      "status": "prod-ready",
+      "id": "aws_cloudwatch_logs_sink",
+      "name": "aws_cloudwatch_logs",
+      "service_provider": "AWS",
+      "status": "beta",
       "type": "sink"
     },
-    "kafka": {
-      "beta": false,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "kafka_sink",
-      "name": "kafka",
-      "service_provider": "Confluent",
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "datadog_metrics": {
+    "aws_cloudwatch_metrics": {
       "beta": true,
-      "delivery_guarantee": "best_effort",
+      "delivery_guarantee": "at_least_once",
       "event_types": [
         "metric"
       ],
       "function_category": "transmit",
-      "id": "datadog_metrics_sink",
-      "name": "datadog_metrics",
-      "service_provider": "Datadog",
+      "id": "aws_cloudwatch_metrics_sink",
+      "name": "aws_cloudwatch_metrics",
+      "service_provider": "AWS",
       "status": "beta",
       "type": "sink"
     },
@@ -533,19 +149,6 @@ module.exports = {
       "id": "aws_kinesis_streams_sink",
       "name": "aws_kinesis_streams",
       "service_provider": "AWS",
-      "status": "beta",
-      "type": "sink"
-    },
-    "elasticsearch": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "elasticsearch_sink",
-      "name": "elasticsearch",
-      "service_provider": "Elastic",
       "status": "beta",
       "type": "sink"
     },
@@ -572,32 +175,6 @@ module.exports = {
       "function_category": "test",
       "id": "blackhole_sink",
       "name": "blackhole",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "aws_cloudwatch_metrics": {
-      "beta": true,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "transmit",
-      "id": "aws_cloudwatch_metrics_sink",
-      "name": "aws_cloudwatch_metrics",
-      "service_provider": "AWS",
-      "status": "beta",
-      "type": "sink"
-    },
-    "file": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "file_sink",
-      "name": "file",
       "service_provider": null,
       "status": "prod-ready",
       "type": "sink"
@@ -629,17 +206,43 @@ module.exports = {
       "status": "prod-ready",
       "type": "sink"
     },
-    "aws_cloudwatch_logs": {
+    "datadog_metrics": {
       "beta": true,
-      "delivery_guarantee": "at_least_once",
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "transmit",
+      "id": "datadog_metrics_sink",
+      "name": "datadog_metrics",
+      "service_provider": "Datadog",
+      "status": "beta",
+      "type": "sink"
+    },
+    "elasticsearch": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "aws_cloudwatch_logs_sink",
-      "name": "aws_cloudwatch_logs",
-      "service_provider": "AWS",
+      "id": "elasticsearch_sink",
+      "name": "elasticsearch",
+      "service_provider": "Elastic",
       "status": "beta",
+      "type": "sink"
+    },
+    "file": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "file_sink",
+      "name": "file",
+      "service_provider": null,
+      "status": "prod-ready",
       "type": "sink"
     },
     "http": {
@@ -654,6 +257,403 @@ module.exports = {
       "service_provider": null,
       "status": "prod-ready",
       "type": "sink"
+    },
+    "kafka": {
+      "beta": false,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "kafka_sink",
+      "name": "kafka",
+      "service_provider": "Confluent",
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "prometheus": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "transmit",
+      "id": "prometheus_sink",
+      "name": "prometheus",
+      "service_provider": null,
+      "status": "beta",
+      "type": "sink"
+    },
+    "splunk_hec": {
+      "beta": false,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "splunk_hec_sink",
+      "name": "splunk_hec",
+      "service_provider": "Splunk",
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "statsd": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "transmit",
+      "id": "statsd_sink",
+      "name": "statsd",
+      "service_provider": null,
+      "status": "beta",
+      "type": "sink"
+    },
+    "tcp": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "tcp_sink",
+      "name": "tcp",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "vector": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "proxy",
+      "id": "vector_sink",
+      "name": "vector",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "sink"
+    }
+  },
+  "sources": {
+    "docker": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "collect",
+      "id": "docker_source",
+      "name": "docker",
+      "service_provider": null,
+      "status": "beta",
+      "type": "source"
+    },
+    "file": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "collect",
+      "id": "file_source",
+      "name": "file",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "source"
+    },
+    "journald": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "collect",
+      "id": "journald_source",
+      "name": "journald",
+      "service_provider": null,
+      "status": "beta",
+      "type": "source"
+    },
+    "kafka": {
+      "beta": true,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "collect",
+      "id": "kafka_source",
+      "name": "kafka",
+      "service_provider": null,
+      "status": "beta",
+      "type": "source"
+    },
+    "statsd": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "receive",
+      "id": "statsd_source",
+      "name": "statsd",
+      "service_provider": null,
+      "status": "beta",
+      "type": "source"
+    },
+    "stdin": {
+      "beta": false,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "receive",
+      "id": "stdin_source",
+      "name": "stdin",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "source"
+    },
+    "syslog": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "receive",
+      "id": "syslog_source",
+      "name": "syslog",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "source"
+    },
+    "tcp": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "receive",
+      "id": "tcp_source",
+      "name": "tcp",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "source"
+    },
+    "udp": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "receive",
+      "id": "udp_source",
+      "name": "udp",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "source"
+    },
+    "vector": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log",
+        "metric"
+      ],
+      "function_category": "proxy",
+      "id": "vector_source",
+      "name": "vector",
+      "service_provider": null,
+      "status": "beta",
+      "type": "source"
+    }
+  },
+  "transforms": {
+    "add_fields": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "shape",
+      "id": "add_fields_transform",
+      "name": "add_fields",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "add_tags": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "shape",
+      "id": "add_tags_transform",
+      "name": "add_tags",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "coercer": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "coercer_transform",
+      "name": "coercer",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "field_filter": {
+      "beta": true,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log",
+        "metric"
+      ],
+      "function_category": "filter",
+      "id": "field_filter_transform",
+      "name": "field_filter",
+      "service_provider": null,
+      "status": "beta",
+      "type": "transform"
+    },
+    "grok_parser": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "grok_parser_transform",
+      "name": "grok_parser",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "json_parser": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "json_parser_transform",
+      "name": "json_parser",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "log_to_metric": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log",
+        "metric"
+      ],
+      "function_category": "convert",
+      "id": "log_to_metric_transform",
+      "name": "log_to_metric",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "lua": {
+      "beta": true,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "program",
+      "id": "lua_transform",
+      "name": "lua",
+      "service_provider": null,
+      "status": "beta",
+      "type": "transform"
+    },
+    "regex_parser": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "regex_parser_transform",
+      "name": "regex_parser",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "remove_fields": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "shape",
+      "id": "remove_fields_transform",
+      "name": "remove_fields",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "remove_tags": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "shape",
+      "id": "remove_tags_transform",
+      "name": "remove_tags",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "sampler": {
+      "beta": true,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "filter",
+      "id": "sampler_transform",
+      "name": "sampler",
+      "service_provider": null,
+      "status": "beta",
+      "type": "transform"
+    },
+    "split": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "split_transform",
+      "name": "split",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "tokenizer": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "tokenizer_transform",
+      "name": "tokenizer",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
     }
   }
 };

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -87,7 +87,7 @@ module.exports = {
     "author": "Luke",
     "date": "2019-06-28",
     "id": "introducing-vector",
-    "path": "/Users/benjohnson/Code/timber/vector/website/blog/2019-06-28-introducing-vector.md",
+    "path": "website/blog/2019-06-28-introducing-vector.md",
     "permalink": "https://vector.dev/blog/introducing-vector",
     "tags": [
       "announcement"
@@ -104,7 +104,7 @@ module.exports = {
       "author": "Luke",
       "date": "2019-06-28",
       "id": "introducing-vector",
-      "path": "/Users/benjohnson/Code/timber/vector/website/blog/2019-06-28-introducing-vector.md",
+      "path": "website/blog/2019-06-28-introducing-vector.md",
       "permalink": "https://vector.dev/blog/introducing-vector",
       "tags": [
         "announcement"
@@ -113,15 +113,15 @@ module.exports = {
     }
   ],
   "sources": {
-    "udp": {
+    "tcp": {
       "beta": false,
       "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
       "function_category": "receive",
-      "id": "udp_source",
-      "name": "udp",
+      "id": "tcp_source",
+      "name": "tcp",
       "service_provider": null,
       "status": "prod-ready",
       "type": "source"
@@ -139,19 +139,6 @@ module.exports = {
       "status": "prod-ready",
       "type": "source"
     },
-    "docker": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "collect",
-      "id": "docker_source",
-      "name": "docker",
-      "service_provider": null,
-      "status": "beta",
-      "type": "source"
-    },
     "vector": {
       "beta": true,
       "delivery_guarantee": "best_effort",
@@ -164,6 +151,19 @@ module.exports = {
       "name": "vector",
       "service_provider": null,
       "status": "beta",
+      "type": "source"
+    },
+    "udp": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "receive",
+      "id": "udp_source",
+      "name": "udp",
+      "service_provider": null,
+      "status": "prod-ready",
       "type": "source"
     },
     "statsd": {
@@ -192,17 +192,17 @@ module.exports = {
       "status": "beta",
       "type": "source"
     },
-    "journald": {
-      "beta": true,
+    "syslog": {
+      "beta": false,
       "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
-      "function_category": "collect",
-      "id": "journald_source",
-      "name": "journald",
+      "function_category": "receive",
+      "id": "syslog_source",
+      "name": "syslog",
       "service_provider": null,
-      "status": "beta",
+      "status": "prod-ready",
       "type": "source"
     },
     "file": {
@@ -218,57 +218,82 @@ module.exports = {
       "status": "prod-ready",
       "type": "source"
     },
-    "syslog": {
-      "beta": false,
+    "docker": {
+      "beta": true,
       "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
-      "function_category": "receive",
-      "id": "syslog_source",
-      "name": "syslog",
+      "function_category": "collect",
+      "id": "docker_source",
+      "name": "docker",
       "service_provider": null,
-      "status": "prod-ready",
+      "status": "beta",
       "type": "source"
     },
-    "tcp": {
-      "beta": false,
+    "journald": {
+      "beta": true,
       "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
-      "function_category": "receive",
-      "id": "tcp_source",
-      "name": "tcp",
+      "function_category": "collect",
+      "id": "journald_source",
+      "name": "journald",
       "service_provider": null,
-      "status": "prod-ready",
+      "status": "beta",
       "type": "source"
     }
   },
   "transforms": {
-    "log_to_metric": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log",
-        "metric"
-      ],
-      "function_category": "convert",
-      "id": "log_to_metric_transform",
-      "name": "log_to_metric",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "split": {
+    "coercer": {
       "beta": false,
       "delivery_guarantee": null,
       "event_types": [
         "log"
       ],
       "function_category": "parse",
-      "id": "split_transform",
-      "name": "split",
+      "id": "coercer_transform",
+      "name": "coercer",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "add_fields": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "shape",
+      "id": "add_fields_transform",
+      "name": "add_fields",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "remove_fields": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "shape",
+      "id": "remove_fields_transform",
+      "name": "remove_fields",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "tokenizer": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log"
+      ],
+      "function_category": "parse",
+      "id": "tokenizer_transform",
+      "name": "tokenizer",
       "service_provider": null,
       "status": "prod-ready",
       "type": "transform"
@@ -286,31 +311,17 @@ module.exports = {
       "status": "prod-ready",
       "type": "transform"
     },
-    "field_filter": {
+    "sampler": {
       "beta": true,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log",
-        "metric"
-      ],
-      "function_category": "filter",
-      "id": "field_filter_transform",
-      "name": "field_filter",
-      "service_provider": null,
-      "status": "beta",
-      "type": "transform"
-    },
-    "remove_fields": {
-      "beta": false,
       "delivery_guarantee": null,
       "event_types": [
         "log"
       ],
-      "function_category": "shape",
-      "id": "remove_fields_transform",
-      "name": "remove_fields",
+      "function_category": "filter",
+      "id": "sampler_transform",
+      "name": "sampler",
       "service_provider": null,
-      "status": "prod-ready",
+      "status": "beta",
       "type": "transform"
     },
     "regex_parser": {
@@ -339,28 +350,15 @@ module.exports = {
       "status": "prod-ready",
       "type": "transform"
     },
-    "coercer": {
+    "split": {
       "beta": false,
       "delivery_guarantee": null,
       "event_types": [
         "log"
       ],
       "function_category": "parse",
-      "id": "coercer_transform",
-      "name": "coercer",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    },
-    "add_fields": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "shape",
-      "id": "add_fields_transform",
-      "name": "add_fields",
+      "id": "split_transform",
+      "name": "split",
       "service_provider": null,
       "status": "prod-ready",
       "type": "transform"
@@ -378,15 +376,29 @@ module.exports = {
       "status": "beta",
       "type": "transform"
     },
-    "tokenizer": {
+    "remove_tags": {
       "beta": false,
       "delivery_guarantee": null,
       "event_types": [
-        "log"
+        "metric"
       ],
-      "function_category": "parse",
-      "id": "tokenizer_transform",
-      "name": "tokenizer",
+      "function_category": "shape",
+      "id": "remove_tags_transform",
+      "name": "remove_tags",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "transform"
+    },
+    "log_to_metric": {
+      "beta": false,
+      "delivery_guarantee": null,
+      "event_types": [
+        "log",
+        "metric"
+      ],
+      "function_category": "convert",
+      "id": "log_to_metric_transform",
+      "name": "log_to_metric",
       "service_provider": null,
       "status": "prod-ready",
       "type": "transform"
@@ -404,72 +416,33 @@ module.exports = {
       "status": "prod-ready",
       "type": "transform"
     },
-    "sampler": {
+    "field_filter": {
       "beta": true,
       "delivery_guarantee": null,
-      "event_types": [
-        "log"
-      ],
-      "function_category": "filter",
-      "id": "sampler_transform",
-      "name": "sampler",
-      "service_provider": null,
-      "status": "beta",
-      "type": "transform"
-    },
-    "remove_tags": {
-      "beta": false,
-      "delivery_guarantee": null,
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "shape",
-      "id": "remove_tags_transform",
-      "name": "remove_tags",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "transform"
-    }
-  },
-  "sinks": {
-    "datadog_metrics": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "transmit",
-      "id": "datadog_metrics_sink",
-      "name": "datadog_metrics",
-      "service_provider": "Datadog",
-      "status": "beta",
-      "type": "sink"
-    },
-    "blackhole": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
       "event_types": [
         "log",
         "metric"
       ],
-      "function_category": "test",
-      "id": "blackhole_sink",
-      "name": "blackhole",
+      "function_category": "filter",
+      "id": "field_filter_transform",
+      "name": "field_filter",
       "service_provider": null,
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "aws_s3": {
-      "beta": true,
-      "delivery_guarantee": "at_least_once",
+      "status": "beta",
+      "type": "transform"
+    }
+  },
+  "sinks": {
+    "tcp": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "aws_s3_sink",
-      "name": "aws_s3",
-      "service_provider": "AWS",
-      "status": "beta",
+      "id": "tcp_sink",
+      "name": "tcp",
+      "service_provider": null,
+      "status": "prod-ready",
       "type": "sink"
     },
     "vector": {
@@ -498,15 +471,67 @@ module.exports = {
       "status": "beta",
       "type": "sink"
     },
-    "aws_cloudwatch_logs": {
+    "prometheus": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "transmit",
+      "id": "prometheus_sink",
+      "name": "prometheus",
+      "service_provider": null,
+      "status": "beta",
+      "type": "sink"
+    },
+    "splunk_hec": {
+      "beta": false,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "splunk_hec_sink",
+      "name": "splunk_hec",
+      "service_provider": "Splunk",
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "kafka": {
+      "beta": false,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "kafka_sink",
+      "name": "kafka",
+      "service_provider": "Confluent",
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "datadog_metrics": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "metric"
+      ],
+      "function_category": "transmit",
+      "id": "datadog_metrics_sink",
+      "name": "datadog_metrics",
+      "service_provider": "Datadog",
+      "status": "beta",
+      "type": "sink"
+    },
+    "aws_kinesis_streams": {
       "beta": true,
       "delivery_guarantee": "at_least_once",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "aws_cloudwatch_logs_sink",
-      "name": "aws_cloudwatch_logs",
+      "id": "aws_kinesis_streams_sink",
+      "name": "aws_kinesis_streams",
       "service_provider": "AWS",
       "status": "beta",
       "type": "sink"
@@ -524,33 +549,20 @@ module.exports = {
       "status": "beta",
       "type": "sink"
     },
-    "kafka": {
-      "beta": false,
+    "aws_s3": {
+      "beta": true,
       "delivery_guarantee": "at_least_once",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "kafka_sink",
-      "name": "kafka",
-      "service_provider": "Confluent",
-      "status": "prod-ready",
+      "id": "aws_s3_sink",
+      "name": "aws_s3",
+      "service_provider": "AWS",
+      "status": "beta",
       "type": "sink"
     },
-    "splunk_hec": {
-      "beta": false,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "splunk_hec_sink",
-      "name": "splunk_hec",
-      "service_provider": "Splunk",
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "console": {
+    "blackhole": {
       "beta": false,
       "delivery_guarantee": "best_effort",
       "event_types": [
@@ -558,47 +570,8 @@ module.exports = {
         "metric"
       ],
       "function_category": "test",
-      "id": "console_sink",
-      "name": "console",
-      "service_provider": null,
-      "status": "prod-ready",
-      "type": "sink"
-    },
-    "aws_kinesis_streams": {
-      "beta": true,
-      "delivery_guarantee": "at_least_once",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "aws_kinesis_streams_sink",
-      "name": "aws_kinesis_streams",
-      "service_provider": "AWS",
-      "status": "beta",
-      "type": "sink"
-    },
-    "clickhouse": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "clickhouse_sink",
-      "name": "clickhouse",
-      "service_provider": null,
-      "status": "beta",
-      "type": "sink"
-    },
-    "file": {
-      "beta": false,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "log"
-      ],
-      "function_category": "transmit",
-      "id": "file_sink",
-      "name": "file",
+      "id": "blackhole_sink",
+      "name": "blackhole",
       "service_provider": null,
       "status": "prod-ready",
       "type": "sink"
@@ -616,17 +589,57 @@ module.exports = {
       "status": "beta",
       "type": "sink"
     },
-    "tcp": {
+    "file": {
       "beta": false,
       "delivery_guarantee": "best_effort",
       "event_types": [
         "log"
       ],
       "function_category": "transmit",
-      "id": "tcp_sink",
-      "name": "tcp",
+      "id": "file_sink",
+      "name": "file",
       "service_provider": null,
       "status": "prod-ready",
+      "type": "sink"
+    },
+    "clickhouse": {
+      "beta": true,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "clickhouse_sink",
+      "name": "clickhouse",
+      "service_provider": null,
+      "status": "beta",
+      "type": "sink"
+    },
+    "console": {
+      "beta": false,
+      "delivery_guarantee": "best_effort",
+      "event_types": [
+        "log",
+        "metric"
+      ],
+      "function_category": "test",
+      "id": "console_sink",
+      "name": "console",
+      "service_provider": null,
+      "status": "prod-ready",
+      "type": "sink"
+    },
+    "aws_cloudwatch_logs": {
+      "beta": true,
+      "delivery_guarantee": "at_least_once",
+      "event_types": [
+        "log"
+      ],
+      "function_category": "transmit",
+      "id": "aws_cloudwatch_logs_sink",
+      "name": "aws_cloudwatch_logs",
+      "service_provider": "AWS",
+      "status": "beta",
       "type": "sink"
     },
     "http": {
@@ -640,19 +653,6 @@ module.exports = {
       "name": "http",
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
-    },
-    "prometheus": {
-      "beta": true,
-      "delivery_guarantee": "best_effort",
-      "event_types": [
-        "metric"
-      ],
-      "function_category": "transmit",
-      "id": "prometheus_sink",
-      "name": "prometheus",
-      "service_provider": null,
-      "status": "beta",
       "type": "sink"
     }
   }

--- a/website/metadata.js.erb
+++ b/website/metadata.js.erb
@@ -1,1 +1,1 @@
-module.exports = <%= JSON.pretty_generate(metadata.to_h) %>;
+module.exports = <%= JSON.pretty_generate(metadata.deep_to_h) %>;


### PR DESCRIPTION
This PR

1. Uses Ruby 2.6 for `check-generate`. The docker images for this are built in CI.
2. Makes generation of `website/metadata.json` deterministic by sorting keys of all hashes. Otherwise, `make generate` produces different output on different machines.