### PR TITLE
chore(operations): Use bash from Docker containers as a shell in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,10 @@ jobs:
       - checkout
       - run:
           name: Check generate
+          shell: ./scripts/docker-run.sh checker bash
           environment:
             RUSTFLAGS: "-D warnings"
-          command: ./scripts/run-docker.sh checker make check-code
+          command: make check-code
 
   check-fmt:
     resource_class: large
@@ -56,9 +57,10 @@ jobs:
       - checkout
       - run:
           name: Check fmt
+          shell: ./scripts/docker-run.sh checker bash
           environment:
             RUSTFLAGS: "-D warnings"
-          command: ./scripts/run-docker.sh checker make check-fmt
+          command: make check-fmt
 
   check-generate:
     resource_class: large
@@ -68,7 +70,8 @@ jobs:
       - checkout
       - run:
           name: Check generate
-          command: ./scripts/run-docker.sh checker make check-generate
+          shell: ./scripts/docker-run.sh checker bash
+          command: make check-generate
 
   check-version:
     resource_class: large
@@ -78,7 +81,8 @@ jobs:
       - checkout
       - run:
           name: Check version
-          command: ./scripts/run-docker.sh checker make check-version
+          shell: ./scripts/docker-run.sh checker bash
+          command: make check-version
 
   test-x86_64-pc-windows-msvc:
     executor: win/vs2019

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -17,8 +17,12 @@ docker build \
   -f scripts/ci-docker-images/$tag/Dockerfile \
   scripts/ci-docker-images
 
+docker_flags="--privileged"
+if [ -t 1 ]; then # the script is running in a terminal
+  docker_flags="$docker_flags --interactive"
+fi
 docker run \
-  --privileged \
+  $docker_flags \
   $(env | xargs -n1 printf '-e "%s"\n') \
   -w "$PWD" \
   -v "$PWD":"$PWD" \


### PR DESCRIPTION
This PR renames script `scripts/run-docker.sh` to `scripts/docker-run.sh` and adds interactive mode to it.

It also uses `./scripts/docker-run.sh <ci-image-name> bash` as a shell for CircleCI `check-*` jobs, which results in cleaner `.circleci/config.yml`.