### PR TITLE
fix(operations): Don't put *.erb files to configs directory

### DIFF
--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -106,6 +106,8 @@ cp -av $target_dir/release/vector $archive_dir/bin
 
 # Copy the entire config dir to /config
 cp -rv config $archive_dir/config
+# Remove templates sources
+find $archive_dir/config -type f -name '*.erb' -delete
 
 # Copy /etc usefule files
 mkdir -p $archive_dir/etc/systemd

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -107,7 +107,7 @@ cp -av $target_dir/release/vector $archive_dir/bin
 # Copy the entire config dir to /config
 cp -rv config $archive_dir/config
 # Remove templates sources
-find $archive_dir/config -type f -name '*.erb' -delete
+rm $archive_dir/config/*.erb
 
 # Copy /etc usefule files
 mkdir -p $archive_dir/etc/systemd


### PR DESCRIPTION
Currently our release archives contain template file `config/vector.spec.toml.erb`. This PR prevents it from being bundled.