### PR TITLE
docs: Add operating system as a compenent attribute and filter

### DIFF
--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -2,6 +2,7 @@
 beta = true
 common = true
 delivery_guarantee = "best_effort"
+except_operating_systems = ["windows"]
 function_category = "collect"
 guides = []
 output_types = ["log"]

--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -2,9 +2,9 @@
 beta = true
 common = true
 delivery_guarantee = "best_effort"
-except_operating_systems = ["windows"]
 function_category = "collect"
 guides = []
+only_operating_systems = ["linux"]
 output_types = ["log"]
 resources = []
 through_description = "log records from journald"

--- a/scripts/generate/templates/_partials/_component_header.md.erb
+++ b/scripts/generate/templates/_partials/_component_header.md.erb
@@ -2,10 +2,12 @@
 <% if component.respond_to?(:delivery_guarantee) %>delivery_guarantee: <%= component.delivery_guarantee.to_json %><% end %>
 event_types: <%= component.event_types.to_json %>
 issues_url: <%= metadata.links.fetch("urls.#{component.id}_issues") %>
+operating_systems: <%= component.operating_systems.to_json %>
 sidebar_label: <%= "#{component.name}|#{component.event_types.to_json}".to_json %>
 source_url: <%= metadata.links.fetch("urls.#{component.id}_source") %>
 status: <%= component.status.to_json %>
-title: <%= "#{component.name} #{component.type}".to_json %> 
+title: <%= "#{component.name} #{component.type}".to_json %>
+unsupported_operating_systems: <%= component.unsupported_operating_systems.to_json %>
 ---
 
 The `<%= component.name %>` <%= component.type %> <%= component_description(component).continuize %>

--- a/scripts/setup.rb
+++ b/scripts/setup.rb
@@ -33,18 +33,18 @@ include Printer
 # Constants
 #
 
-HOST = "https://vector.dev"
-DOCS_BASE_PATH = "/docs"
+HOST = "https://vector.dev".freeze
+DOCS_BASE_PATH = "/docs".freeze
 
-ROOT_DIR = Pathname.new("#{Dir.pwd}/..").cleanpath.to_s
-WEBSITE_ROOT = File.join(ROOT_DIR, "website")
-ASSETS_ROOT = File.join(ROOT_DIR, "website", "static")
-BLOG_HOST = "#{HOST}/blog"
-DOCS_ROOT = File.join(ROOT_DIR, "website", "docs")
-DOCS_HOST = "#{HOST}#{DOCS_BASE_PATH}"
-META_ROOT = File.join(ROOT_DIR, ".meta")
-PAGES_ROOT = File.join(ROOT_DIR, "website", "src", "pages")
-POSTS_ROOT = File.join(ROOT_DIR, "website", "blog")
-REFERENCE_ROOT = File.join(ROOT_DIR, "website", "docs", "reference")
-RELEASE_META_DIR = "#{ROOT_DIR}/.meta/releases"
-PARTIALS_DIR = File.join(ROOT_DIR, "scripts", "generate", "templates", "_partials")
+ROOT_DIR = Pathname.new("#{Dir.pwd}/..").cleanpath.to_s.freeze
+WEBSITE_ROOT = File.join(ROOT_DIR, "website").freeze
+ASSETS_ROOT = File.join(ROOT_DIR, "website", "static").freeze
+BLOG_HOST = "#{HOST}/blog".freeze
+DOCS_ROOT = File.join(ROOT_DIR, "website", "docs").freeze
+DOCS_HOST = "#{HOST}#{DOCS_BASE_PATH}".freeze
+META_ROOT = File.join(ROOT_DIR, ".meta").freeze
+PAGES_ROOT = File.join(ROOT_DIR, "website", "src", "pages").freeze
+POSTS_ROOT = File.join(ROOT_DIR, "website", "blog").freeze
+REFERENCE_ROOT = File.join(ROOT_DIR, "website", "docs", "reference").freeze
+RELEASE_META_DIR = "#{ROOT_DIR}/.meta/releases".freeze
+PARTIALS_DIR = File.join(ROOT_DIR, "scripts", "generate", "templates", "_partials").freeze

--- a/scripts/util/metadata/commit.rb
+++ b/scripts/util/metadata/commit.rb
@@ -5,8 +5,8 @@ require "active_support/core_ext/string/filters"
 require_relative "commit_scope"
 
 class Commit
-  TYPES = ["chore", "docs", "enhancement", "feat", "fix", "perf"]
-  TYPES_THAT_REQUIRE_SCOPES = ["enhancement", "feat", "fix"]
+  TYPES = ["chore", "docs", "enhancement", "feat", "fix", "perf"].freeze
+  TYPES_THAT_REQUIRE_SCOPES = ["enhancement", "feat", "fix"].freeze
 
   attr_reader :author,
     :breaking_change,

--- a/scripts/util/metadata/component.rb
+++ b/scripts/util/metadata/component.rb
@@ -3,8 +3,9 @@
 require_relative "option"
 
 class Component
-  DELIVERY_GUARANTEES = ["at_least_once", "best_effort"]
-  EVENT_TYPES = ["log", "metric"]
+  DELIVERY_GUARANTEES = ["at_least_once", "best_effort"].freeze
+  EVENT_TYPES = ["log", "metric"].freeze
+  OPERATING_SYSTEMS = ["linux", "macos", "windows"].freeze
 
   include Comparable
 
@@ -13,9 +14,11 @@ class Component
     :function_category,
     :id,
     :name,
+    :operating_systems,
     :options,
     :resources,
-    :type
+    :type,
+    :unsupported_operating_systems
 
   def initialize(hash)
     @beta = hash["beta"] == true
@@ -25,6 +28,20 @@ class Component
     @type ||= self.class.name.downcase
     @id = "#{@name}_#{@type}"
     @options = OpenStruct.new()
+
+    # Operating Systems
+
+    if hash["only_operating_systems"]
+      @operating_systems = hash["only_operating_systems"]
+    elsif hash["except_operating_systems"]
+      @operating_systems = OPERATING_SYSTEMS - hash["except_operating_systems"]
+    else
+      @operating_systems = OPERATING_SYSTEMS
+    end
+
+    @unsupported_operating_systems = OPERATING_SYSTEMS - @operating_systems
+
+    # Options
 
     (hash["options"] || {}).each do |option_name, option_hash|
       option = Option.new(
@@ -133,9 +150,11 @@ class Component
       function_category: (respond_to?(:function_category, true) ? function_category : nil),
       id: id,
       name: name,
+      operating_systems: operating_systems,
       service_provider: (respond_to?(:service_provider, true) ? service_provider : nil),
       status: status,
-      type: type
+      type: type,
+      unsupported_operating_systems: unsupported_operating_systems
     }
   end
 

--- a/scripts/util/metadata/field.rb
+++ b/scripts/util/metadata/field.rb
@@ -3,7 +3,7 @@
 class Field
   include Comparable
 
-  TYPES = ["*", "bool", "double", "int", "map", "string", "struct", "timestamp"]
+  TYPES = ["*", "bool", "double", "int", "map", "string", "struct", "timestamp"].freeze
 
   class << self
     def build_struct(hash)

--- a/scripts/util/metadata/links.rb
+++ b/scripts/util/metadata/links.rb
@@ -25,12 +25,12 @@ require 'net/http'
 # implement dynamic readers that can be found in the `#fetch_dynamic_url`
 # method.
 class Links
-  CATEGORIES = ["assets", "docs", "pages", "urls"]
-  VECTOR_ROOT = "https://github.com/timberio/vector"
-  VECTOR_COMMIT_ROOT = "#{VECTOR_ROOT}/commit"
-  VECTOR_ISSUES_ROOT = "#{VECTOR_ROOT}/issues"
-  VECTOR_PRS_ROOT = "#{VECTOR_ROOT}/pull"
-  TEST_HARNESS_ROOT = "https://github.com/timberio/vector-test-harness"
+  CATEGORIES = ["assets", "docs", "pages", "urls"].freeze
+  VECTOR_ROOT = "https://github.com/timberio/vector".freeze
+  VECTOR_COMMIT_ROOT = "#{VECTOR_ROOT}/commit".freeze
+  VECTOR_ISSUES_ROOT = "#{VECTOR_ROOT}/issues".freeze
+  VECTOR_PRS_ROOT = "#{VECTOR_ROOT}/pull".freeze
+  TEST_HARNESS_ROOT = "https://github.com/timberio/vector-test-harness".freeze
 
   attr_reader :values
 

--- a/scripts/util/metadata/option.rb
+++ b/scripts/util/metadata/option.rb
@@ -3,7 +3,7 @@
 class Option
   include Comparable
 
-  TYPES = ["*", "bool", "float", "[float]", "int", "string", "[string]", "table", "[table]"]
+  TYPES = ["*", "bool", "float", "[float]", "int", "string", "[string]", "table", "[table]"].freeze
 
   attr_reader :name,
     :category,

--- a/scripts/util/metadata/sink.rb
+++ b/scripts/util/metadata/sink.rb
@@ -3,7 +3,7 @@
 require_relative "component"
 
 class Sink < Component
-  EGRESS_METHODS = ["batching", "exposing", "streaming"]
+  EGRESS_METHODS = ["batching", "exposing", "streaming"].freeze
 
   attr_reader :buffer,
     :delivery_guarantee,

--- a/website/docs/about/guarantees.md
+++ b/website/docs/about/guarantees.md
@@ -55,9 +55,12 @@ import Jump from '@site/src/components/Jump';
 ### Best-Effort
 
 A `best-effort` delivery guarantee means that Vector will make a best effort to
-deliver each event, but cannot guarantee delivery. While rare, this means it is
-possible for the occasional event to not be lost. See the ["Do I need at least
-once delivery?"](#do-i-need-at-least-once-delivery) FAQ.
+deliver each event, but cannot _guarantee_ delivery. This is usually due to 
+limitations of the underlying protocol; outside the sccope of Vector. It's
+important to note that while data is possible, it is usually rare and Vector
+does everything within it's control to ensure data is not lost. For more info,
+see the ["Do I need at least once delivery?"](#do-i-need-at-least-once-delivery)
+FAQ.
 
 </div>
 </div>

--- a/website/docs/about/guarantees.md.erb
+++ b/website/docs/about/guarantees.md.erb
@@ -49,9 +49,12 @@ Each [sink][docs.sinks] will include documentation for its buffer options.
 ### Best-Effort
 
 A `best-effort` delivery guarantee means that Vector will make a best effort to
-deliver each event, but cannot guarantee delivery. While rare, this means it is
-possible for the occasional event to not be lost. See the ["Do I need at least
-once delivery?"](#do-i-need-at-least-once-delivery) FAQ.
+deliver each event, but cannot _guarantee_ delivery. This is usually due to 
+limitations of the underlying protocol; outside the sccope of Vector. It's
+important to note that while data is possible, it is usually rare and Vector
+does everything within it's control to ensure data is not lost. For more info,
+see the ["Do I need at least once delivery?"](#do-i-need-at-least-once-delivery)
+FAQ.
 
 </div>
 </div>

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_cloudwatch_logs%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "aws_cloudwatch_logs|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/aws_cloudwatch_logs/mod.rs
 status: "beta"
-title: "aws_cloudwatch_logs sink" 
+title: "aws_cloudwatch_logs sink"
+unsupported_operating_systems: []
 ---
 
 The `aws_cloudwatch_logs` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to [AWS CloudWatch Logs][urls.aws_cw_logs] via the [`PutLogEvents` API endpoint](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html).

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_cloudwatch_metrics%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "aws_cloudwatch_metrics|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_cloudwatch_metrics.rs
 status: "beta"
-title: "aws_cloudwatch_metrics sink" 
+title: "aws_cloudwatch_metrics sink"
+unsupported_operating_systems: []
 ---
 
 The `aws_cloudwatch_metrics` sink [streams](#streaming) [`metric`][docs.data-model#metric] events to [AWS CloudWatch Metrics][urls.aws_cw_metrics] via the [`PutMetricData` API endpoint](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html).

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_kinesis_streams%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "aws_kinesis_streams|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_kinesis_streams.rs
 status: "beta"
-title: "aws_kinesis_streams sink" 
+title: "aws_kinesis_streams sink"
+unsupported_operating_systems: []
 ---
 
 The `aws_kinesis_streams` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to [AWS Kinesis Data Stream][urls.aws_kinesis_data_streams] via the [`PutRecords` API endpoint](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html).

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_s3%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "aws_s3|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_s3.rs
 status: "beta"
-title: "aws_s3 sink" 
+title: "aws_s3 sink"
+unsupported_operating_systems: []
 ---
 
 The `aws_s3` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to [AWS S3][urls.aws_s3] via the [`PutObject` API endpoint](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html).

--- a/website/docs/reference/sinks/blackhole.md
+++ b/website/docs/reference/sinks/blackhole.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+blackhole%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "blackhole|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/blackhole.rs
 status: "prod-ready"
-title: "blackhole sink" 
+title: "blackhole sink"
+unsupported_operating_systems: []
 ---
 
 The `blackhole` sink [streams](#streaming) [`log`][docs.data-model#log] and [`metric`][docs.data-model#metric] events to a blackhole that simply discards data, designed for testing and benchmarking purposes.

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+clickhouse%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "clickhouse|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/clickhouse.rs
 status: "beta"
-title: "clickhouse sink" 
+title: "clickhouse sink"
+unsupported_operating_systems: []
 ---
 
 The `clickhouse` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to [Clickhouse][urls.clickhouse] via the [`HTTP` Interface][urls.clickhouse_http].

--- a/website/docs/reference/sinks/console.md
+++ b/website/docs/reference/sinks/console.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+console%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "console|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/console.rs
 status: "prod-ready"
-title: "console sink" 
+title: "console sink"
+unsupported_operating_systems: []
 ---
 
 The `console` sink [streams](#streaming) [`log`][docs.data-model#log] and [`metric`][docs.data-model#metric] events to [standard output streams][urls.standard_streams], such as `STDOUT` and `STDERR`.

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+datadog_metrics%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "datadog_metrics|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/datadog_metrics.rs
 status: "beta"
-title: "datadog_metrics sink" 
+title: "datadog_metrics sink"
+unsupported_operating_systems: []
 ---
 
 The `datadog_metrics` sink [batches](#buffers-and-batches) [`metric`][docs.data-model#metric] events to [Datadog][urls.datadog] metrics service using [HTTP API](https://docs.datadoghq.com/api/?lang=bash#metrics).

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+elasticsearch%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "elasticsearch|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/elasticsearch.rs
 status: "beta"
-title: "elasticsearch sink" 
+title: "elasticsearch sink"
+unsupported_operating_systems: []
 ---
 
 The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to [Elasticsearch][urls.elasticsearch] via the [`_bulk` API endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).

--- a/website/docs/reference/sinks/file.md
+++ b/website/docs/reference/sinks/file.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+file%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "file|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/file/mod.rs
 status: "prod-ready"
-title: "file sink" 
+title: "file sink"
+unsupported_operating_systems: []
 ---
 
 The `file` sink [streams](#streaming) [`log`][docs.data-model#log] events to a file.

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+http%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "http|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/http.rs
 status: "prod-ready"
-title: "http sink" 
+title: "http sink"
+unsupported_operating_systems: []
 ---
 
 The `http` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to a generic HTTP endpoint.

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+kafka%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "kafka|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/kafka.rs
 status: "prod-ready"
-title: "kafka sink" 
+title: "kafka sink"
+unsupported_operating_systems: []
 ---
 
 The `kafka` sink [streams](#streaming) [`log`][docs.data-model#log] events to [Apache Kafka][urls.kafka] via the [Kafka protocol][urls.kafka_protocol].

--- a/website/docs/reference/sinks/prometheus.md
+++ b/website/docs/reference/sinks/prometheus.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+prometheus%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "prometheus|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/prometheus.rs
 status: "beta"
-title: "prometheus sink" 
+title: "prometheus sink"
+unsupported_operating_systems: []
 ---
 
 The `prometheus` sink [exposes](#exposing-and-scraping) [`metric`][docs.data-model#metric] events to [Prometheus][urls.prometheus] metrics service.

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+splunk_hec%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "splunk_hec|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/splunk_hec.rs
 status: "prod-ready"
-title: "splunk_hec sink" 
+title: "splunk_hec sink"
+unsupported_operating_systems: []
 ---
 
 The `splunk_hec` sink [batches](#buffers-and-batches) [`log`][docs.data-model#log] events to a [Splunk HTTP Event Collector][urls.splunk_hec].

--- a/website/docs/reference/sinks/statsd.md
+++ b/website/docs/reference/sinks/statsd.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+statsd%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "statsd|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/statsd.rs
 status: "beta"
-title: "statsd sink" 
+title: "statsd sink"
+unsupported_operating_systems: []
 ---
 
 The `statsd` sink [streams](#streaming) [`metric`][docs.data-model#metric] events to [StatsD][urls.statsd] metrics service.

--- a/website/docs/reference/sinks/tcp.md
+++ b/website/docs/reference/sinks/tcp.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+tcp%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "tcp|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/tcp.rs
 status: "prod-ready"
-title: "tcp sink" 
+title: "tcp sink"
+unsupported_operating_systems: []
 ---
 
 The `tcp` sink [streams](#streaming) [`log`][docs.data-model#log] events to a TCP connection.

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+vector%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "vector|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/vector.rs
 status: "prod-ready"
-title: "vector sink" 
+title: "vector sink"
+unsupported_operating_systems: []
 ---
 
 The `vector` sink [streams](#streaming) [`log`][docs.data-model#log] events to another downstream [`vector` source][docs.sources.vector].

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+docker%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "docker|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/docker.rs
 status: "beta"
-title: "docker source" 
+title: "docker source"
+unsupported_operating_systems: []
 ---
 
 The `docker` source ingests data through the docker engine daemon and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+file%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "file|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/file.rs
 status: "prod-ready"
-title: "file source" 
+title: "file source"
+unsupported_operating_systems: []
 ---
 
 The[`file`](#file) source ingests data through one or more local files and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -2,12 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+journald%22
-operating_systems: ["linux","macos"]
+operating_systems: ["linux"]
 sidebar_label: "journald|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/journald.rs
 status: "beta"
 title: "journald source"
-unsupported_operating_systems: ["windows"]
+unsupported_operating_systems: ["macos","windows"]
 ---
 
 The `journald` source ingests data through log records from journald and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+journald%22
+operating_systems: ["linux","macos"]
 sidebar_label: "journald|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/journald.rs
 status: "beta"
-title: "journald source" 
+title: "journald source"
+unsupported_operating_systems: ["windows"]
 ---
 
 The `journald` source ingests data through log records from journald and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+kafka%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "kafka|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/kafka.rs
 status: "beta"
-title: "kafka source" 
+title: "kafka source"
+unsupported_operating_systems: []
 ---
 
 The `kafka` source ingests data through Kafka 0.9 or later and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/statsd.md
+++ b/website/docs/reference/sources/statsd.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+statsd%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "statsd|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/statsd/mod.rs
 status: "beta"
-title: "statsd source" 
+title: "statsd source"
+unsupported_operating_systems: []
 ---
 
 The `statsd` source ingests data through the StatsD UDP protocol and outputs [`metric`][docs.data-model#metric] events.

--- a/website/docs/reference/sources/stdin.md
+++ b/website/docs/reference/sources/stdin.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "at_least_once"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+stdin%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "stdin|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/stdin.rs
 status: "prod-ready"
-title: "stdin source" 
+title: "stdin source"
+unsupported_operating_systems: []
 ---
 
 The `stdin` source ingests data through standard input (STDIN) and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+syslog%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "syslog|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/syslog.rs
 status: "prod-ready"
-title: "syslog source" 
+title: "syslog source"
+unsupported_operating_systems: []
 ---
 
 The `syslog` source ingests data through the Syslog 5424 protocol and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/tcp.md
+++ b/website/docs/reference/sources/tcp.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+tcp%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "tcp|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/tcp.rs
 status: "prod-ready"
-title: "tcp source" 
+title: "tcp source"
+unsupported_operating_systems: []
 ---
 
 The `tcp` source ingests data through the TCP protocol and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/udp.md
+++ b/website/docs/reference/sources/udp.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+udp%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "udp|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/udp.rs
 status: "prod-ready"
-title: "udp source" 
+title: "udp source"
+unsupported_operating_systems: []
 ---
 
 The `udp` source ingests data through the UDP protocol and outputs [`log`][docs.data-model#log] events.

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -2,10 +2,12 @@
 delivery_guarantee: "best_effort"
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+vector%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "vector|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/vector.rs
 status: "beta"
-title: "vector source" 
+title: "vector source"
+unsupported_operating_systems: []
 ---
 
 The `vector` source ingests data through another upstream [`vector` sink][docs.sinks.vector] and outputs [`log`][docs.data-model#log] and [`metric`][docs.data-model#metric] events.

--- a/website/docs/reference/transforms/add_fields.md
+++ b/website/docs/reference/transforms/add_fields.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_fields%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "add_fields|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/add_fields.rs
 status: "prod-ready"
-title: "add_fields transform" 
+title: "add_fields transform"
+unsupported_operating_systems: []
 ---
 
 The `add_fields` transform accepts [`log`][docs.data-model#log] events and allows you to add one or more log fields.

--- a/website/docs/reference/transforms/add_tags.md
+++ b/website/docs/reference/transforms/add_tags.md
@@ -2,10 +2,12 @@
 
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_tags%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "add_tags|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/add_tags.rs
 status: "prod-ready"
-title: "add_tags transform" 
+title: "add_tags transform"
+unsupported_operating_systems: []
 ---
 
 The `add_tags` transform accepts [`metric`][docs.data-model#metric] events and allows you to add one or more metric tags.

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+coercer%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "coercer|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/coercer.rs
 status: "prod-ready"
-title: "coercer transform" 
+title: "coercer transform"
+unsupported_operating_systems: []
 ---
 
 The `coercer` transform accepts [`log`][docs.data-model#log] events and allows you to coerce log fields into fixed types.

--- a/website/docs/reference/transforms/field_filter.md
+++ b/website/docs/reference/transforms/field_filter.md
@@ -2,10 +2,12 @@
 
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+field_filter%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "field_filter|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/field_filter.rs
 status: "beta"
-title: "field_filter transform" 
+title: "field_filter transform"
+unsupported_operating_systems: []
 ---
 
 The `field_filter` transform accepts [`log`][docs.data-model#log] and [`metric`][docs.data-model#metric] events and allows you to filter events by a log field's value.

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+grok_parser%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "grok_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/grok_parser.rs
 status: "prod-ready"
-title: "grok_parser transform" 
+title: "grok_parser transform"
+unsupported_operating_systems: []
 ---
 
 The `grok_parser` transform accepts [`log`][docs.data-model#log] events and allows you to parse a log field value with [Grok][urls.grok].

--- a/website/docs/reference/transforms/json_parser.md
+++ b/website/docs/reference/transforms/json_parser.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+json_parser%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "json_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/json_parser.rs
 status: "prod-ready"
-title: "json_parser transform" 
+title: "json_parser transform"
+unsupported_operating_systems: []
 ---
 
 The `json_parser` transform accepts [`log`][docs.data-model#log] events and allows you to parse a log field value as JSON.

--- a/website/docs/reference/transforms/log_to_metric.md
+++ b/website/docs/reference/transforms/log_to_metric.md
@@ -2,10 +2,12 @@
 
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+log_to_metric%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "log_to_metric|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/log_to_metric.rs
 status: "prod-ready"
-title: "log_to_metric transform" 
+title: "log_to_metric transform"
+unsupported_operating_systems: []
 ---
 
 The `log_to_metric` transform accepts [`log`][docs.data-model#log] events and allows you to convert logs into one or more metrics.

--- a/website/docs/reference/transforms/lua.md
+++ b/website/docs/reference/transforms/lua.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+lua%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "lua|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/lua.rs
 status: "beta"
-title: "lua transform" 
+title: "lua transform"
+unsupported_operating_systems: []
 ---
 
 The `lua` transform accepts [`log`][docs.data-model#log] events and allows you to transform events with a full embedded [Lua][urls.lua] engine.

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+regex_parser%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "regex_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/regex_parser.rs
 status: "prod-ready"
-title: "regex_parser transform" 
+title: "regex_parser transform"
+unsupported_operating_systems: []
 ---
 
 The `regex_parser` transform accepts [`log`][docs.data-model#log] events and allows you to parse a log field's value with a [Regular Expression][urls.regex].

--- a/website/docs/reference/transforms/remove_fields.md
+++ b/website/docs/reference/transforms/remove_fields.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+remove_fields%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "remove_fields|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/remove_fields.rs
 status: "prod-ready"
-title: "remove_fields transform" 
+title: "remove_fields transform"
+unsupported_operating_systems: []
 ---
 
 The `remove_fields` transform accepts [`log`][docs.data-model#log] events and allows you to remove one or more log fields.

--- a/website/docs/reference/transforms/remove_tags.md
+++ b/website/docs/reference/transforms/remove_tags.md
@@ -2,10 +2,12 @@
 
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+remove_tags%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "remove_tags|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/remove_tags.rs
 status: "prod-ready"
-title: "remove_tags transform" 
+title: "remove_tags transform"
+unsupported_operating_systems: []
 ---
 
 The `remove_tags` transform accepts [`metric`][docs.data-model#metric] events and allows you to remove one or more metric tags.

--- a/website/docs/reference/transforms/sampler.md
+++ b/website/docs/reference/transforms/sampler.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+sampler%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "sampler|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/sampler.rs
 status: "beta"
-title: "sampler transform" 
+title: "sampler transform"
+unsupported_operating_systems: []
 ---
 
 The `sampler` transform accepts [`log`][docs.data-model#log] events and allows you to sample events with a configurable rate.

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+split%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "split|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/split.rs
 status: "prod-ready"
-title: "split transform" 
+title: "split transform"
+unsupported_operating_systems: []
 ---
 
 The `split` transform accepts [`log`][docs.data-model#log] events and allows you to split a field's value on a given separator and zip the tokens into ordered field names.

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -2,10 +2,12 @@
 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+tokenizer%22
+operating_systems: ["linux","macos","windows"]
 sidebar_label: "tokenizer|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/tokenizer.rs
 status: "prod-ready"
-title: "tokenizer transform" 
+title: "tokenizer transform"
+unsupported_operating_systems: []
 ---
 
 The `tokenizer` transform accepts [`log`][docs.data-model#log] events and allows you to tokenize a field's value by splitting on white space, ignoring special wrapping characters, and zip the tokens into ordered field names.

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -561,13 +561,13 @@ module.exports = {
       "id": "journald_source",
       "name": "journald",
       "operating_systems": [
-        "linux",
-        "macos"
+        "linux"
       ],
       "service_provider": null,
       "status": "beta",
       "type": "source",
       "unsupported_operating_systems": [
+        "macos",
         "windows"
       ]
     },

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -157,9 +157,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "aws_cloudwatch_logs_sink",
       "name": "aws_cloudwatch_logs",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "AWS",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "aws_cloudwatch_metrics": {
       "beta": true,
@@ -170,9 +178,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "aws_cloudwatch_metrics_sink",
       "name": "aws_cloudwatch_metrics",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "AWS",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "aws_kinesis_streams": {
       "beta": true,
@@ -183,9 +199,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "aws_kinesis_streams_sink",
       "name": "aws_kinesis_streams",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "AWS",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "aws_s3": {
       "beta": true,
@@ -196,9 +220,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "aws_s3_sink",
       "name": "aws_s3",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "AWS",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "blackhole": {
       "beta": false,
@@ -210,9 +242,17 @@ module.exports = {
       "function_category": "test",
       "id": "blackhole_sink",
       "name": "blackhole",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "clickhouse": {
       "beta": true,
@@ -223,9 +263,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "clickhouse_sink",
       "name": "clickhouse",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "console": {
       "beta": false,
@@ -237,9 +285,17 @@ module.exports = {
       "function_category": "test",
       "id": "console_sink",
       "name": "console",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "datadog_metrics": {
       "beta": true,
@@ -250,9 +306,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "datadog_metrics_sink",
       "name": "datadog_metrics",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "Datadog",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "elasticsearch": {
       "beta": true,
@@ -263,9 +327,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "elasticsearch_sink",
       "name": "elasticsearch",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "Elastic",
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "file": {
       "beta": false,
@@ -276,9 +348,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "file_sink",
       "name": "file",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "http": {
       "beta": false,
@@ -289,9 +369,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "http_sink",
       "name": "http",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "kafka": {
       "beta": false,
@@ -302,9 +390,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "kafka_sink",
       "name": "kafka",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "Confluent",
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "prometheus": {
       "beta": true,
@@ -315,9 +411,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "prometheus_sink",
       "name": "prometheus",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "splunk_hec": {
       "beta": false,
@@ -328,9 +432,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "splunk_hec_sink",
       "name": "splunk_hec",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": "Splunk",
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "statsd": {
       "beta": true,
@@ -341,9 +453,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "statsd_sink",
       "name": "statsd",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "tcp": {
       "beta": false,
@@ -354,9 +474,17 @@ module.exports = {
       "function_category": "transmit",
       "id": "tcp_sink",
       "name": "tcp",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "vector": {
       "beta": false,
@@ -367,9 +495,17 @@ module.exports = {
       "function_category": "proxy",
       "id": "vector_sink",
       "name": "vector",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "sink"
+      "type": "sink",
+      "unsupported_operating_systems": [
+
+      ]
     }
   },
   "sources": {
@@ -382,9 +518,17 @@ module.exports = {
       "function_category": "collect",
       "id": "docker_source",
       "name": "docker",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "file": {
       "beta": false,
@@ -395,9 +539,17 @@ module.exports = {
       "function_category": "collect",
       "id": "file_source",
       "name": "file",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "journald": {
       "beta": true,
@@ -408,9 +560,16 @@ module.exports = {
       "function_category": "collect",
       "id": "journald_source",
       "name": "journald",
+      "operating_systems": [
+        "linux",
+        "macos"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+        "windows"
+      ]
     },
     "kafka": {
       "beta": true,
@@ -421,9 +580,17 @@ module.exports = {
       "function_category": "collect",
       "id": "kafka_source",
       "name": "kafka",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "statsd": {
       "beta": true,
@@ -434,9 +601,17 @@ module.exports = {
       "function_category": "receive",
       "id": "statsd_source",
       "name": "statsd",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "stdin": {
       "beta": false,
@@ -447,9 +622,17 @@ module.exports = {
       "function_category": "receive",
       "id": "stdin_source",
       "name": "stdin",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "syslog": {
       "beta": false,
@@ -460,9 +643,17 @@ module.exports = {
       "function_category": "receive",
       "id": "syslog_source",
       "name": "syslog",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "tcp": {
       "beta": false,
@@ -473,9 +664,17 @@ module.exports = {
       "function_category": "receive",
       "id": "tcp_source",
       "name": "tcp",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "udp": {
       "beta": false,
@@ -486,9 +685,17 @@ module.exports = {
       "function_category": "receive",
       "id": "udp_source",
       "name": "udp",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "vector": {
       "beta": true,
@@ -500,9 +707,17 @@ module.exports = {
       "function_category": "proxy",
       "id": "vector_source",
       "name": "vector",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "source"
+      "type": "source",
+      "unsupported_operating_systems": [
+
+      ]
     }
   },
   "transforms": {
@@ -515,9 +730,17 @@ module.exports = {
       "function_category": "shape",
       "id": "add_fields_transform",
       "name": "add_fields",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "add_tags": {
       "beta": false,
@@ -528,9 +751,17 @@ module.exports = {
       "function_category": "shape",
       "id": "add_tags_transform",
       "name": "add_tags",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "coercer": {
       "beta": false,
@@ -541,9 +772,17 @@ module.exports = {
       "function_category": "parse",
       "id": "coercer_transform",
       "name": "coercer",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "field_filter": {
       "beta": true,
@@ -555,9 +794,17 @@ module.exports = {
       "function_category": "filter",
       "id": "field_filter_transform",
       "name": "field_filter",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "grok_parser": {
       "beta": false,
@@ -568,9 +815,17 @@ module.exports = {
       "function_category": "parse",
       "id": "grok_parser_transform",
       "name": "grok_parser",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "json_parser": {
       "beta": false,
@@ -581,9 +836,17 @@ module.exports = {
       "function_category": "parse",
       "id": "json_parser_transform",
       "name": "json_parser",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "log_to_metric": {
       "beta": false,
@@ -595,9 +858,17 @@ module.exports = {
       "function_category": "convert",
       "id": "log_to_metric_transform",
       "name": "log_to_metric",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "lua": {
       "beta": true,
@@ -608,9 +879,17 @@ module.exports = {
       "function_category": "program",
       "id": "lua_transform",
       "name": "lua",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "regex_parser": {
       "beta": false,
@@ -621,9 +900,17 @@ module.exports = {
       "function_category": "parse",
       "id": "regex_parser_transform",
       "name": "regex_parser",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "remove_fields": {
       "beta": false,
@@ -634,9 +921,17 @@ module.exports = {
       "function_category": "shape",
       "id": "remove_fields_transform",
       "name": "remove_fields",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "remove_tags": {
       "beta": false,
@@ -647,9 +942,17 @@ module.exports = {
       "function_category": "shape",
       "id": "remove_tags_transform",
       "name": "remove_tags",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "sampler": {
       "beta": true,
@@ -660,9 +963,17 @@ module.exports = {
       "function_category": "filter",
       "id": "sampler_transform",
       "name": "sampler",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "beta",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "split": {
       "beta": false,
@@ -673,9 +984,17 @@ module.exports = {
       "function_category": "parse",
       "id": "split_transform",
       "name": "split",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     },
     "tokenizer": {
       "beta": false,
@@ -686,9 +1005,17 @@ module.exports = {
       "function_category": "parse",
       "id": "tokenizer_transform",
       "name": "tokenizer",
+      "operating_systems": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "service_provider": null,
       "status": "prod-ready",
-      "type": "transform"
+      "type": "transform",
+      "unsupported_operating_systems": [
+
+      ]
     }
   }
 };

--- a/website/package.json
+++ b/website/package.json
@@ -19,11 +19,13 @@
     "docusaurus": "^2.0.0-alpha.36",
     "humanize-string": "^2.1.0",
     "prismjs": "^1.17.1",
+    "qs": "^6.9.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-inlinesvg": "^1.1.7",
     "react-select": "^3.0.8",
-    "svg.js": "^2.6.2"
+    "svg.js": "^2.6.2",
+    "underscore": "^1.9.1"
   },
   "browserslist": {
     "production": [

--- a/website/package.json
+++ b/website/package.json
@@ -24,8 +24,7 @@
     "react-dom": "^16.8.4",
     "react-inlinesvg": "^1.1.7",
     "react-select": "^3.0.8",
-    "svg.js": "^2.6.2",
-    "underscore": "^1.9.1"
+    "svg.js": "^2.6.2"
   },
   "browserslist": {
     "production": [

--- a/website/src/components/VectorComponents/index.js
+++ b/website/src/components/VectorComponents/index.js
@@ -5,7 +5,8 @@ import Link from '@docusaurus/Link';
 
 import classnames from 'classnames';
 import humanizeString from 'humanize-string';
-import queryString from 'query-string';
+import intersection from 'underscore';
+import qs from 'qs';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import './styles.css';
@@ -24,17 +25,17 @@ function Component({delivery_guarantee, description, event_types, name, status, 
       </div>
       <div className="vector-component--badges">
         {event_types.includes("log") ?
-          <span className="badge badge--secondary" title="This component works with log event types"><i className="feather icon-database"></i> log</span> :
+          <span className="badge badge--primary" title="This component works with log event types"><i className="feather icon-database"></i></span> :
           ''}
         {event_types.includes("metric") ?
-          <span className="badge badge--secondary" title="This component works with metric event types"><i className="feather icon-bar-chart"></i> metric</span> :
+          <span className="badge badge--primary" title="This component works with metric event types"><i className="feather icon-bar-chart"></i></span> :
           ''}
         {status == "beta" ?
-          <span className="badge badge--warning" title="This component is in beta and is not recommended for production environments"><i className="feather icon-alert-triangle"></i> beta</span> :
-          <span className="badge badge--primary" title="This component has passed reliability standards that make it production ready"><i className="feather icon-award"></i> prod-ready</span>}
+          <span className="badge badge--warning" title="This component is in beta and is not recommended for production environments"><i className="feather icon-alert-triangle"></i></span> :
+          <span className="badge badge--primary" title="This component has passed reliability standards that make it production ready"><i className="feather icon-award"></i></span>}
         {delivery_guarantee == "best_effort" ?
-          <span className="badge badge--warning" title="This component makes a best-effort delivery guarantee, and in rare cases can lose data"><i className="feather icon-shield-off"></i> best-effort</span> :
-          <span className="badge badge--primary" title="This component offers an at-least-once delivery guarantee"><i className="feather icon-shield"></i> at-least-once</span>}
+          <span className="badge badge--warning" title="This component makes a best-effort delivery guarantee, and in rare cases can lose data"><i className="feather icon-shield-off"></i></span> :
+          <span className="badge badge--primary" title="This component offers an at-least-once delivery guarantee"><i className="feather icon-shield"></i></span>}
       </div>
     </Link>
   );
@@ -124,7 +125,7 @@ function FilterList({label, icon, values, currentState, setState}) {
                 setState(newValues);
               }}
               checked={currentState.has(value)} />
-            {label} {icon ? <i className={`feather icon-${icon}`}></i> : ''}
+            {icon ? <i className={`feather icon-${icon}`}></i> : ''} {label}
           </label>
         );
       })}
@@ -141,7 +142,7 @@ function VectorComponents(props) {
   const {metadata: {sources, transforms, sinks}} = siteConfig.customFields;
   const titles = props.titles || props.titles == undefined;
   const filterColumn = props.filterColumn == true;
-  const queryObj = props.location ? queryString.parse(props.location.search) : {};
+  const queryObj = props.location ? qs.parse(props.location.search, {ignoreQueryPrefix: true}) : {};
 
   let components = [];
   if (props.sources || props.sources == undefined) components = components.concat(Object.values(sources));
@@ -157,6 +158,7 @@ function VectorComponents(props) {
   const [onlyFunctions, setOnlyFunctions] = useState(new Set(queryObj['functions']));
   const [onlyLog, setOnlyLog] = useState(queryObj['log'] == 'true');
   const [onlyMetric, setOnlyMetric] = useState(queryObj['metric'] == 'true');
+  const [onlyOperatingSystems, setOnlyOperatingSystems] = useState(new Set(queryObj['operating-systems']));
   const [onlyProductionReady, setOnlyProductionReady] = useState(queryObj['prod-ready'] == 'true');
   const [onlyProviders, setOnlyProviders] = useState(new Set(queryObj['providers']));
   const [searchTerm, setSearchTerm] = useState(null);
@@ -188,6 +190,10 @@ function VectorComponents(props) {
     components = components.filter(component => component.event_types.includes("metric"));
   }
 
+  if (onlyOperatingSystems.size > 0) {
+    components = components.filter(component => Array.from(onlyOperatingSystems).filter(x => component.operating_systems.includes(x)).length > 0);
+  }
+
   if (onlyProductionReady) {
     components = components.filter(component => component.status == "prod-ready");
   }
@@ -199,6 +205,11 @@ function VectorComponents(props) {
   //
   // Filter options
   //
+
+  const operatingSystemsArr =
+    components.flatMap(component => component.operating_systems).
+    sort((a, b) => (a > b) ? 1 : -1);
+  const operatingSystems = new Set(operatingSystemsArr);
 
   const serviceProvidersArr =
     components.filter(component => component.service_provider).
@@ -237,14 +248,14 @@ function VectorComponents(props) {
                 type="checkbox"
                 onChange={(event) => setOnlyLog(event.currentTarget.checked)}
                 checked={onlyLog} />
-              Log <i className="feather icon-database"></i>
+              <i className="feather icon-database"></i> Log
             </label>
             <label title="Show only components that work with metric event types.">
               <input
                 type="checkbox"
                 onChange={(event) => setOnlyMetric(event.currentTarget.checked)}
                 checked={onlyMetric} />
-              Metric <i className="feather icon-bar-chart"></i>
+              <i className="feather icon-bar-chart"></i> Metric
             </label>
           </span>
           <span className="vector-components--filters--section">
@@ -258,16 +269,22 @@ function VectorComponents(props) {
                 type="checkbox"
                 onChange={(event) => setOnlyAtLeastOnce(event.currentTarget.checked)}
                 checked={onlyAtLeastOnce} />
-              At-least-once <i className="feather icon-shield"></i>
+              <i className="feather icon-shield"></i> At-least-once
             </label>
             <label title="Show only production ready components.">
               <input
                 type="checkbox"
                 onChange={(event) => setOnlyProductionReady(event.currentTarget.checked)}
                 checked={onlyProductionReady} />
-              Prod-ready <i className="feather icon-award"></i>
+              <i className="feather icon-award"></i> Prod-ready
             </label>
           </span>
+          <FilterList
+            label="Operating Systems"
+            icon="cpu"
+            values={operatingSystems}
+            currentState={onlyOperatingSystems}
+            setState={setOnlyOperatingSystems} />
           <FilterList
             label="Providers"
             icon="cloud"
@@ -276,6 +293,7 @@ function VectorComponents(props) {
             setState={setOnlyProviders} />
           <FilterList
             label="Functions"
+            icon="code"
             values={functionCategories}
             currentState={onlyFunctions}
             setState={setOnlyFunctions} />

--- a/website/src/components/VectorComponents/index.js
+++ b/website/src/components/VectorComponents/index.js
@@ -4,8 +4,8 @@ import Jump from '@site/src/components/Jump';
 import Link from '@docusaurus/Link';
 
 import classnames from 'classnames';
+import flatten from 'lodash/flatten';
 import humanizeString from 'humanize-string';
-import intersection from 'underscore';
 import qs from 'qs';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -206,9 +206,9 @@ function VectorComponents(props) {
   // Filter options
   //
 
-  const operatingSystemsArr =
-    components.flatMap(component => component.operating_systems).
-    sort((a, b) => (a > b) ? 1 : -1);
+  let operatingSystemsArr = components.map(component => component.operating_systems);
+  console.log(flatten(operatingSystemsArr))
+  operatingSystemsArr = flatten(operatingSystemsArr).sort((a, b) => (a > b) ? 1 : -1);
   const operatingSystems = new Set(operatingSystemsArr);
 
   const serviceProvidersArr =

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -72,7 +72,7 @@ const features = [
     icon: 'code',
     description: (
       <>
-        An <Link to="/docs/reference/transforms/lua">embedded LUA engine</Link> makes it easy to program powerful transforms. Handle complex use cases without limitations.
+        <Link to="/components?functions[]=program">Programmable transforms</Link> give you the full power of a programmable runtime. Handle complex use cases with ease!
       </>
     ),
   },

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -40,13 +40,27 @@ function Headings({headings, isChild}) {
   );
 }
 
-function Statuses({status, deliveryGuarantee}) {
-  if (!status && !deliveryGuarantee)
+function Statuses({status, deliveryGuarantee, operatingSystems, unsupportedOperatingSystems}) {
+  if (!status && !deliveryGuarantee && !operatingSystems && !unsupportedOperatingSystems)
     return null;
+
+  let operatingSystemsEls = [];
+
+  operatingSystems.forEach(operatingSystem => {
+    operatingSystemsEls.push(<span className="text--primary">{operatingSystem}</span>);
+    operatingSystemsEls.push(<>, </>);
+  });
+
+  unsupportedOperatingSystems.forEach(operatingSystem => {
+    operatingSystemsEls.push(<del className="text--warning">{operatingSystem}</del>);
+    operatingSystemsEls.push(<>, </>);
+  });
+
+  operatingSystemsEls.pop();
 
   return (
     <div className="section">
-      <div className="title">Status</div>
+      <div className="title">Support</div>
       {status == "beta" &&
         <div>
           <Link to="/docs/about/guarantees#beta" className="text--warning" title="This component is in beta and is not recommended for production environments. Click to learn more.">
@@ -71,6 +85,12 @@ function Statuses({status, deliveryGuarantee}) {
             <i className="feather icon-shield"></i> at-least-once
           </Link>
         </div>}
+      {operatingSystems && 
+        <div>
+          <Link to="/docs/setup/installation/operating-systems" title={`This component works on the ${operatingSystems.join(", ")} operating systems.`}>
+            <i className="feather icon-cpu"></i> {operatingSystemsEls}
+          </Link>
+        </div>}
     </div>
   );
 }
@@ -80,7 +100,7 @@ function DocItem(props) {
   const {url: siteUrl} = siteConfig;
   const {metadata, content: DocContent} = props;
   const {
-    delivery_guarantee,
+    delivery_guarantee: deliveryGuarantee,
     description,
     editUrl,
     event_types: eventTypes,
@@ -89,10 +109,12 @@ function DocItem(props) {
     keywords,
     lastUpdatedAt,
     lastUpdatedBy,
+    operating_systems: operatingSystems,
     permalink,
     source_url: sourceUrl,
     status,
     title,
+    unsupported_operating_systems: unsupportedOperatingSystems,
   } = metadata;
 
   const metaImageUrl = siteUrl + useBaseUrl(metaImage);
@@ -144,7 +166,7 @@ function DocItem(props) {
             {DocContent.rightToc && (
               <div className="col col--3">
                 <div className={styles.tableOfContents}>
-                  <Statuses status={status} deliveryGuarantee={delivery_guarantee} />
+                  <Statuses status={status} deliveryGuarantee={deliveryGuarantee} operatingSystems={operatingSystems} unsupportedOperatingSystems={unsupportedOperatingSystems} />
                   {DocContent.rightToc.length > 0 &&
                     <div className="section">
                       <div className="title">Contents</div>

--- a/website/static/img/configuration.svg
+++ b/website/static/img/configuration.svg
@@ -82,12 +82,12 @@
                     <tspan x="223.624609" y="438" fill="#000000"></tspan>
                     <tspan x="67" y="464" fill="#000000"></tspan>
                     <tspan x="67" y="490" fill="#0092A8">[sinks.es_cluster]</tspan>
-                    <tspan x="67" y="516" fill="#0092A8">  inputs = ['nginx_error_parser']</tspan>
+                    <tspan x="67" y="516" fill="#0092A8">  inputs = ['nginx_transaction_sampler']</tspan>
                     <tspan x="67" y="542" fill="#0092A8">  type   = 'elasticsearch'</tspan>
                     <tspan x="67" y="568" fill="#0092A8">  host   = '123.123.123.123:5000'</tspan>
                     <tspan x="67" y="594" fill="#0092A8"></tspan>
                     <tspan x="67" y="620" fill="#0092A8">[sinks.s3_archive]</tspan>
-                    <tspan x="67" y="646" fill="#0092A8">  inputs = ['nginx_transaction_sampler']</tspan>
+                    <tspan x="67" y="646" fill="#0092A8">  inputs = ['nginx_error_parser']</tspan>
                     <tspan x="67" y="672" fill="#0092A8">  type   = 's3'</tspan>
                     <tspan x="67" y="698" fill="#0092A8">  region = 'us-east-1'</tspan>
                     <tspan x="67" y="724" fill="#0092A8">  bucket = 'log-archives'</tspan>

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10441,11 +10441,6 @@ unbzip2-stream@^1.0.9:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
-
 unherit@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8584,7 +8584,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.4.0:
+qs@^6.4.0, qs@^6.9.1:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
   integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
@@ -10440,6 +10440,11 @@ unbzip2-stream@^1.0.9:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 unherit@^1.0.4:
   version "1.1.2"


### PR DESCRIPTION
This exposes the supported operating systems for each component:

1. A filter on the components page: https://share.getcloudapp.com/Apuy5vxm
2. A line in the "support" section for each component's page: https://share.getcloudapp.com/xQuvyRz5

By default all components support all operating systems, you can specify exact support via the `only_operating_systems` attribute in the respective `.toml` file:

```toml
only_operating_systems = ["linux", "max", "windows"]
```

Or by excluding a specific operating system via the `except_operating_systems` attribute:

```toml
except_operating_systems = ["windows"]
```