### PR TITLE
docs: Fix name of `shiplift/unix-socket` feature

### DIFF
--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -186,7 +186,7 @@ executing `make build`:
 | `openssl/vendored` | Enables vendored [OpenSSL][urls.openssl]. If disabled, system SSL library is used instead. | <i className="feather icon-check"></i> |
 | `rdkafka` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
 | `rdkafka/cmake_build` | Can be used together with `rdkafka` feature to build `librdkafka` using `cmake` instead of default build script in case of build problems on non-standard system configurations. | |
-| `shiplift/unix` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |
+| `shiplift/unix-socket` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |
 
 
 [docs.configuration]: /docs/setup/configuration

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -122,4 +122,4 @@ executing `make build`:
 | `openssl/vendored` | Enables vendored [OpenSSL][urls.openssl]. If disabled, system SSL library is used instead. | <i className="feather icon-check"></i> |
 | `rdkafka` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
 | `rdkafka/cmake_build` | Can be used together with `rdkafka` feature to build `librdkafka` using `cmake` instead of default build script in case of build problems on non-standard system configurations. | |
-| `shiplift/unix` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |
+| `shiplift/unix-socket` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |


### PR DESCRIPTION
This PR fixes name of `shiplift/unix-socket` feature in installation docs.