### PR TITLE
fix(testing): Run `x86_64-pc-windows-msvc` tests in release mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
             FEATURES="leveldb leveldb/leveldb-sys-3 rdkafka rdkafka/cmake_build openssl/vendored"
             rm rust-toolchain
-            cargo test --no-default-features --features "$FEATURES" -- --test-threads 4
+            cargo test --release --no-default-features --features "$FEATURES" -- --test-threads 1
 
   test-stable:
     resource_class: xlarge


### PR DESCRIPTION
Because it looks like the timeouts happen only in debug mode, but our target binary is compiled in release mode. So the main downside is longer test duration.