### PR TITLE
chore(operations): Increase CI output timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
       - run:
           name: Build and test
           shell: bash
+          no_output_timeout: 30m
           command: |
             RUSTFLAGS=-Ctarget-feature=+crt-static
             PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
@@ -188,6 +189,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Test
+          no_output_timeout: 30m
           command: cargo test --all --features docker --jobs 4 -- --test-threads 4
       - store_test_results:
           path: ./test-results
@@ -207,6 +209,7 @@ jobs:
       - *install-rust
       - run:
           name: Build archive
+          no_output_timeout: 30m
           command: |
             export PATH="$HOME/.cargo/bin:$PATH"
             make build-archive
@@ -256,6 +259,7 @@ jobs:
       - run:
           name: Build archive
           shell: bash
+          no_output_timeout: 30m
           command: |
             export PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
             function zip() {
@@ -286,6 +290,7 @@ jobs:
       - checkout
       - run:
           name: Build archive and .deb package
+          no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
             PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"
@@ -306,6 +311,7 @@ jobs:
       - checkout
       - run:
           name: Build archive and .deb package
+          no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
             PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"
@@ -326,6 +332,7 @@ jobs:
       - checkout
       - run:
           name: Build archive and .deb package
+          no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
             PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Test
           no_output_timeout: 30m
-          command: cargo test --all --features docker --jobs 4 -- --test-threads 4
+          command: cargo test --all --features docker
       - store_test_results:
           path: ./test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Test
           no_output_timeout: 30m
-          command: cargo test --all --features docker
+          command: cargo test --all --features docker --jobs 4
       - store_test_results:
           path: ./test-results
 


### PR DESCRIPTION
It looks like CircleCI executors sometime work slower than usually, which results in broken build jobs for ARM ([example](https://app.circleci.com/jobs/github/timberio/vector/45191)). It is probably caused by CPU being used by other build jobs on the same physical machine, which explains why such failures are non-deterministic.

This PR increases max timeout that CircleCI would wait for output before failing the build from 10 minutes to 30 minutes.