### PR TITLE
chore(operations): Build multi-arch Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,18 +475,17 @@ jobs:
             EOF
 
   verify-docker:
-    docker:
-      - image: timberiodev/vector-releaser:latest
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    resource_class: large
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
       - checkout
       - *restore-artifacts-from-workspace
       - run:
           name: Build & verify Docker
           command: |
             export VERSION=$(make version)
-            export PLATFORM="linux/amd64,linux/arm64,linux/arm"
             make build-docker
           no_output_timeout: 30m
 
@@ -664,7 +663,7 @@ jobs:
           name: Release Docker
           command: |
             export VERSION=$(make version)
-            make release-docker
+            make build-docker
           no_output_timeout: 30m
 
   release-github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,6 +486,7 @@ jobs:
           name: Build & verify Docker
           command: |
             export VERSION=$(make version)
+            export PLATFORM="linux/amd64,linux/arm64,linux/arm"
             make build-docker
           no_output_timeout: 30m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,8 +652,10 @@ jobs:
   #
 
   release-docker:
-    docker:
-      - image: timberiodev/vector-releaser:latest
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    resource_class: large
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,7 +663,7 @@ jobs:
           name: Release Docker
           command: |
             export VERSION=$(make version)
-            make build-docker
+            make release-docker
           no_output_timeout: 30m
 
   release-github:
@@ -810,6 +810,8 @@ workflows:
       - verify-docker:
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
+            - build-aarch64-unknown-linux-musl-archive-and-deb-package
+            - build-armv7-unknown-linux-musleabihf-archive-and-deb-package
       - verify-rpm-artifact-on-amazon-linux-1:
           requires:
             - package-rpm
@@ -885,7 +887,8 @@ workflows:
           <<: *release-filters
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
-            - build-x86_64-unknown-linux-musl-archive-and-deb-package
+            - build-aarch64-unknown-linux-musl-archive-and-deb-package
+            - build-armv7-unknown-linux-musleabihf-archive-and-deb-package
       - verify-rpm-artifact-on-amazon-linux-1:
           <<: *release-filters
           requires:
@@ -970,6 +973,8 @@ workflows:
       - verify-docker:
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
+            - build-aarch64-unknown-linux-musl-archive-and-deb-package
+            - build-armv7-unknown-linux-musleabihf-archive-and-deb-package
       - verify-rpm-artifact-on-amazon-linux-1:
           requires:
             - package-rpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - *upgrade-docker
       - run:
           name: Check generate
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,26 @@ install-rust: &install-rust
     command: |
       curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 
+upgrade-docker: &upgrade-docker
+  run:
+    name: Upgrade Docker
+    command: |
+      sudo apt-get remove docker docker-engine docker.io containerd runc
+      sudo apt-get update
+      sudo apt-get install \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+      sudo add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable"
+      sudo apt-get update
+      sudo apt-get install docker-ce docker-ce-cli containerd.io
+
 install-vector: &install-vector
   run:
     name: Execute install.sh
@@ -71,6 +91,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - *upgrade-docker
       - run:
           name: Check generate
           command: |
@@ -482,6 +503,7 @@ jobs:
     steps:
       - checkout
       - *restore-artifacts-from-workspace
+      - *upgrade-docker
       - run:
           name: Build & verify Docker
           command: |
@@ -661,6 +683,7 @@ jobs:
           docker_layer_caching: true
       - checkout
       - *restore-artifacts-from-workspace
+      - *upgrade-docker
       - run:
           name: Release Docker
           command: |

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -35,7 +35,7 @@ simple and unified.
 ## Running
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:0.5.0-alpine
 ```
 
 * The `vector` binary is located at `/usr/local/bin/vector`, which should be in your `$PATH`.
@@ -52,7 +52,7 @@ To use your own configuration file:
 2. Run the Vector Docker image with the following command:
 
    ```bash
-   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:latest-alpine
+   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:0.5.0-alpine
    ```
 
    Modify `$PWD` to the directory where you store your local `vector.toml` file.
@@ -67,7 +67,7 @@ smaller in size than other Docker images and statically links libraries. This
 is the image we recommend due to it's small size and reliability.
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:0.5.0-alpine
 ```
 
 ### debian
@@ -76,7 +76,7 @@ This image is based on the [`debian-slim` image][urls.docker_debian],
 which is a smaller, more compact variant of the [`debian` image][urls.docker_debian].
 
 ```bash
-docker run timberio/vector:latest-debian
+docker run timberio/vector:0.5.0-debian
 ```
 
 ## Versions
@@ -106,24 +106,36 @@ Vector's releases nightly versions that contain the latest changes.
 docker run timberio/vector:nightly-alpine
 ```
 
-## Updating
-
-Simply run the with the `latest` tag:
+Historical nightly versions are also available:
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
 ```
 
-Or specify the exact version:
+## Updating
+
+Simply run with newer version in the tag:
 
 ```bash
 docker run timberio/vector:X.X.X-alpine
 ```
 
-Or specify the nigtly version:
+Or pull the newest latest version:
 
 ```bash
-docker run timberio/vector:nightly-alpine
+docker pull timberio/vector:latest-alpine && docker run timberio/vector:latest-alpine
+```
+
+Or run with newer nightly date in the tag:
+
+```bash
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
+```
+
+Or pull the newest nightly version:
+
+```bash
+docker pull timberio/vector:nightly-alpine && docker run timberio/vector:nightly-alpine
 ```
 
 ## Source Files

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.10.1 AS builder
+FROM alpine:3.10 AS builder
 
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
 RUN tar -xvf vector-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
-FROM alpine:3.10.1
+FROM alpine:3.10
 RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=builder /vector/bin/* /usr/local/bin/

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.10.1 AS builder
 
 WORKDIR /vector
 
-COPY vector-x86_64-unknown-linux-musl.tar.gz .
-RUN tar -xvf vector-x86_64-unknown-linux-musl.tar.gz --strip-components=2
+COPY vector-*-unknown-linux-musl*.tar.gz ./
+RUN tar -xvf vector-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
 FROM alpine:3.10.1
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,8 +1,14 @@
-FROM debian:buster-slim
-RUN apt-get update && apt-get install -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
+FROM debian:buster-slim AS builder
 
 COPY vector-*.deb ./
 RUN dpkg -i vector-$(dpkg --print-architecture).deb
-RUN rm /vector-$(dpkg --print-architecture).deb
+
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/bin/vector /usr/bin/vector
+COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
+COPY --from=builder /etc/vector /etc/vector
 
 ENTRYPOINT ["/usr/bin/vector"]

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
 
-COPY vector-amd64.deb .
-RUN dpkg -i vector-amd64.deb
-RUN rm /vector-amd64.deb
+COPY vector-*.deb ./
+RUN dpkg -i vector-$(dpkg --print-architecture).deb
+RUN rm /vector-$(dpkg --print-architecture).deb
 
 ENTRYPOINT ["/usr/bin/vector"]

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -6,13 +6,26 @@
 #
 #   Builds the Vector docker images
 
-set -eu
+set -eux
 
 CHANNEL=$(scripts/util/release-channel.sh)
+VERSION=$(scripts/version.sh)
+DATE=$(date -u +%Y-%m-%d)
 
 #
 # Functions
 #
+
+build() {
+  base=$1
+  version=$2
+
+  docker buildx build \
+    --platform="$PLATFORM" \
+    --tag timberio/vector:$version-$base \
+    target/artifacts \
+    -f distribution/docker/$base/Dockerfile
+}
 
 verify() {
   tag=$1
@@ -31,38 +44,43 @@ verify() {
 }
 
 #
-# Prepare
-#
-
-cp -av target/artifacts/vector-x86_64-unknown-linux-musl.tar.gz distribution/docker/alpine
-cp -av target/artifacts/vector-amd64.deb distribution/docker/debian
-
-#
 # Build
 #
 
 echo "Building timberio/vector:* Docker images"
 
+export DOCKER_CLI_EXPERIMENTAL=enabled
+docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+docker buildx rm vector-builder || true
+docker buildx create --use --name vector-builder
+docker buildx install
+
 if [[ "$CHANNEL" == "latest" ]]; then
-  docker build --tag timberio/vector:$VERSION-alpine distribution/docker/alpine
-  docker build --tag timberio/vector:latest-alpine distribution/docker/alpine
-  docker build --tag timberio/vector:$VERSION-debian distribution/docker/debian
-  docker build --tag timberio/vector:latest-debian distribution/docker/debian
+  build alpine latest
+  build alpine $VERSION
+  build debian latest
+  build debian $VERSION
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  docker build --tag timberio/vector:nightly-alpine distribution/docker/alpine
-  docker build --tag timberio/vector:nightly-debian distribution/docker/debian
+  build alpine nightly
+  build alpine nightly-$DATE
+  build debian nightly
+  build debian nightly-$DATE
 fi
 
 #
 # Verify
 #
 
-if [[ "$CHANNEL" == "latest" ]]; then
-  verify timberio/vector:$VERSION-alpine
-  verify timberio/vector:latest-alpine
-  verify timberio/vector:$VERSION-debian
-  verify timberio/vector:latest-debian
-elif [[ "$CHANNEL" == "nightly" ]]; then
-  verify timberio/vector:nightly-alpine
-  verify timberio/vector:nightly-debian
-fi
+# Images built using `buildx` are invisible to `docker run`
+
+# if [[ "$CHANNEL" == "latest" ]]; then
+#   verify timberio/vector:$VERSION-alpine
+#   verify timberio/vector:latest-alpine
+#   verify timberio/vector:$VERSION-debian
+#   verify timberio/vector:latest-debian
+# elif [[ "$CHANNEL" == "nightly" ]]; then
+#   verify timberio/vector:nightly-alpine
+#   verify timberio/vector:nightly-$DATE-alpine
+#   verify timberio/vector:nightly-debian
+#   verify timberio/vector:nightly-$DATE-debian
+# fi

--- a/scripts/generate/templates/_partials/_docker_docs.md.erb
+++ b/scripts/generate/templates/_partials/_docker_docs.md.erb
@@ -1,7 +1,7 @@
 ## Running
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:<%= metadata.latest_version %>-alpine
 ```
 
 * The `vector` binary is located at `/usr/local/bin/vector`, which should be in your `$PATH`.
@@ -18,7 +18,7 @@ To use your own configuration file:
 2. Run the Vector Docker image with the following command:
 
    ```bash
-   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:latest-alpine
+   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:<%= metadata.latest_version %>-alpine
    ```
 
    Modify `$PWD` to the directory where you store your local `vector.toml` file.
@@ -33,7 +33,7 @@ smaller in size than other Docker images and statically links libraries. This
 is the image we recommend due to it's small size and reliability.
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:<%= metadata.latest_version %>-alpine
 ```
 
 ### debian
@@ -42,7 +42,7 @@ This image is based on the [`debian-slim` image][urls.docker_debian],
 which is a smaller, more compact variant of the [`debian` image][urls.docker_debian].
 
 ```bash
-docker run timberio/vector:latest-debian
+docker run timberio/vector:<%= metadata.latest_version %>-debian
 ```
 
 ## Versions
@@ -72,24 +72,36 @@ Vector's releases nightly versions that contain the latest changes.
 docker run timberio/vector:nightly-alpine
 ```
 
-## Updating
-
-Simply run the with the `latest` tag:
+Historical nightly versions are also available:
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
 ```
 
-Or specify the exact version:
+## Updating
+
+Simply run with newer version in the tag:
 
 ```bash
 docker run timberio/vector:X.X.X-alpine
 ```
 
-Or specify the nigtly version:
+Or pull the newest latest version:
 
 ```bash
-docker run timberio/vector:nightly-alpine
+docker pull timberio/vector:latest-alpine && docker run timberio/vector:latest-alpine
+```
+
+Or run with newer nightly date in the tag:
+
+```bash
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
+```
+
+Or pull the newest nightly version:
+
+```bash
+docker pull timberio/vector:nightly-alpine && docker run timberio/vector:nightly-alpine
 ```
 
 ## Source Files

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -1,35 +1,4 @@
-#!/usr/bin/env bash
-
-# release-docker.sh
-#
-# SUMMARY
-#
-#   Builds and pushes Vector docker images
-
-set -eu
-
-CHANNEL=$(scripts/util/release-channel.sh)
-
-#
-# Build
-#
-
-./scripts/build-docker.sh
-
-#
-# Push
-#
-
-echo "Pushing timberio/vector Docker images"
+#!/bin/bash
 
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-
-if [[ "$CHANNEL" == "latest" ]]; then
-  docker push timberio/vector:$VERSION-alpine
-  docker push timberio/vector:$VERSION-debian
-  docker push timberio/vector:latest-alpine
-  docker push timberio/vector:latest-debian
-elif [[ "$CHANNEL" == "nightly" ]]; then
-  docker push timberio/vector:nightly-alpine
-  docker push timberio/vector:nightly-debian
-fi
+PUSH=1 ./scripts/build-docker.sh

--- a/website/docs/setup/installation/containers/docker.md
+++ b/website/docs/setup/installation/containers/docker.md
@@ -16,7 +16,8 @@ source_url: https://github.com/timberio/vector/tree/master/distribution/docker
 
 Vector maintains the [`timberio/vector` Docker images][urls.docker_hub_vector]
 available on [Docker Hub][urls.docker_hub_vector] which come pre-installed
-with Vector and any recommended system dependencies.
+with Vector and any recommended system dependencies. These images are available
+for x86_64, ARM64, and ARMv7 architectures.
 
 ## Running
 

--- a/website/docs/setup/installation/containers/docker.md
+++ b/website/docs/setup/installation/containers/docker.md
@@ -21,7 +21,7 @@ with Vector and any recommended system dependencies.
 ## Running
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:0.5.0-alpine
 ```
 
 * The `vector` binary is located at `/usr/local/bin/vector`, which should be in your `$PATH`.
@@ -38,7 +38,7 @@ To use your own configuration file:
 2. Run the Vector Docker image with the following command:
 
    ```bash
-   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:latest-alpine
+   docker run -v $PWD/vector.toml:/etc/vector/vector.toml:ro timberio/vector:0.5.0-alpine
    ```
 
    Modify `$PWD` to the directory where you store your local `vector.toml` file.
@@ -53,7 +53,7 @@ smaller in size than other Docker images and statically links libraries. This
 is the image we recommend due to it's small size and reliability.
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:0.5.0-alpine
 ```
 
 ### debian
@@ -62,7 +62,7 @@ This image is based on the [`debian-slim` image][urls.docker_debian],
 which is a smaller, more compact variant of the [`debian` image][urls.docker_debian].
 
 ```bash
-docker run timberio/vector:latest-debian
+docker run timberio/vector:0.5.0-debian
 ```
 
 ## Versions
@@ -92,24 +92,36 @@ Vector's releases nightly versions that contain the latest changes.
 docker run timberio/vector:nightly-alpine
 ```
 
-## Updating
-
-Simply run the with the `latest` tag:
+Historical nightly versions are also available:
 
 ```bash
-docker run timberio/vector:latest-alpine
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
 ```
 
-Or specify the exact version:
+## Updating
+
+Simply run with newer version in the tag:
 
 ```bash
 docker run timberio/vector:X.X.X-alpine
 ```
 
-Or specify the nigtly version:
+Or pull the newest latest version:
 
 ```bash
-docker run timberio/vector:nightly-alpine
+docker pull timberio/vector:latest-alpine && docker run timberio/vector:latest-alpine
+```
+
+Or run with newer nightly date in the tag:
+
+```bash
+docker run timberio/vector:nightly-<YYYY-MM-DD>-alpine
+```
+
+Or pull the newest nightly version:
+
+```bash
+docker pull timberio/vector:nightly-alpine && docker run timberio/vector:nightly-alpine
 ```
 
 ## Source Files

--- a/website/docs/setup/installation/containers/docker.md.erb
+++ b/website/docs/setup/installation/containers/docker.md.erb
@@ -8,6 +8,7 @@ source_url: [[[urls.vector_docker_source_files]]]
 
 Vector maintains the [`timberio/vector` Docker images][urls.docker_hub_vector]
 available on [Docker Hub][urls.docker_hub_vector] which come pre-installed
-with Vector and any recommended system dependencies.
+with Vector and any recommended system dependencies. These images are available
+for x86_64, ARM64, and ARMv7 architectures.
 
 <%= docker_docs %>


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/1196.

This uses the new `docker buildx` command to build images for all architectures at once. However, I haven't found a way to run images built with `docker buildx` locally to verify them yet. It looks like it is caused by multi-arch builders using `docker-container` engine, while `docker run` supports only `docker` engine.