### PR TITLE
docs: Use `sidebar_label` as subpage title if possible

### DIFF
--- a/scripts/generate/templates.rb
+++ b/scripts/generate/templates.rb
@@ -486,6 +486,12 @@ class Templates
         path = DOCS_BASE_PATH + f.gsub(DOCS_ROOT, '').split(".").first
         name = File.basename(f).split(".").first.gsub("-", " ").humanize
 
+        front_matter = FrontMatterParser::Parser.parse_file(f).front_matter
+        sidebar_label = front_matter.fetch("sidebar_label", "hidden")
+        if sidebar_label != "hidden"
+          name = sidebar_label
+        end
+
         "<Jump to=\"#{path}\">#{name}</Jump>"
       end.
       join("\n")

--- a/website/docs/setup/guides.md
+++ b/website/docs/setup/guides.md
@@ -14,9 +14,9 @@ hide_pagination: true
 
 import Jump from '@site/src/components/Jump';
 
-<Jump to="/docs/setup/guides/getting-started">Getting started</Jump>
+<Jump to="/docs/setup/guides/getting-started">Getting Started</Jump>
 <Jump to="/docs/setup/guides/troubleshooting">Troubleshooting</Jump>
-<Jump to="/docs/setup/guides/unit-testing">Unit testing</Jump>
+<Jump to="/docs/setup/guides/unit-testing">Unit Testing</Jump>
 
 
 

--- a/website/docs/setup/installation/manual.md
+++ b/website/docs/setup/installation/manual.md
@@ -18,8 +18,8 @@ installed through a supported [container platform][docs.containers] or
 
 import Jump from '@site/src/components/Jump';
 
-<Jump to="/docs/setup/installation/manual/from-archives">From archives</Jump>
-<Jump to="/docs/setup/installation/manual/from-source">From source</Jump>
+<Jump to="/docs/setup/installation/manual/from-archives">From Archives</Jump>
+<Jump to="/docs/setup/installation/manual/from-source">From Source</Jump>
 
 
 [docs.containers]: /docs/setup/installation/containers

--- a/website/docs/setup/installation/operating-systems.md
+++ b/website/docs/setup/installation/operating-systems.md
@@ -14,12 +14,12 @@ hide_pagination: true
 
 import Jump from '@site/src/components/Jump';
 
-<Jump to="/docs/setup/installation/operating-systems/amazon-linux">Amazon linux</Jump>
-<Jump to="/docs/setup/installation/operating-systems/centos">Centos</Jump>
+<Jump to="/docs/setup/installation/operating-systems/amazon-linux">Amazon Linux</Jump>
+<Jump to="/docs/setup/installation/operating-systems/centos">CentOS</Jump>
 <Jump to="/docs/setup/installation/operating-systems/debian">Debian</Jump>
-<Jump to="/docs/setup/installation/operating-systems/macos">Macos</Jump>
-<Jump to="/docs/setup/installation/operating-systems/raspberry-pi">Raspberry pi</Jump>
-<Jump to="/docs/setup/installation/operating-systems/rhel">Rhel</Jump>
+<Jump to="/docs/setup/installation/operating-systems/macos">MacOS</Jump>
+<Jump to="/docs/setup/installation/operating-systems/raspberry-pi">Raspberry Pi</Jump>
+<Jump to="/docs/setup/installation/operating-systems/rhel">RHEL</Jump>
 <Jump to="/docs/setup/installation/operating-systems/ubuntu">Ubuntu</Jump>
 <Jump to="/docs/setup/installation/operating-systems/windows">Windows</Jump>
 

--- a/website/docs/setup/installation/package-managers.md
+++ b/website/docs/setup/installation/package-managers.md
@@ -14,9 +14,9 @@ hide_pagination: true
 
 import Jump from '@site/src/components/Jump';
 
-<Jump to="/docs/setup/installation/package-managers/dpkg">Dpkg</Jump>
+<Jump to="/docs/setup/installation/package-managers/dpkg">DPKG</Jump>
 <Jump to="/docs/setup/installation/package-managers/homebrew">Homebrew</Jump>
-<Jump to="/docs/setup/installation/package-managers/rpm">Rpm</Jump>
+<Jump to="/docs/setup/installation/package-managers/rpm">RPM</Jump>
 
 
 


### PR DESCRIPTION
This makes capitalization of names of package managers same in different parts of the docs.

[Before](https://deploy-preview-1278--vector-project.netlify.com/docs/setup/installation/package-managers) | [After](https://deploy-preview-1283--vector-project.netlify.com/docs/setup/installation/package-managers)