### PR TITLE
fix(operations): Upgrade Docker on the step in which it is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,26 +8,6 @@ install-rust: &install-rust
     command: |
       curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 
-upgrade-docker: &upgrade-docker
-  run:
-    name: Upgrade Docker
-    command: |
-      sudo apt-get remove docker docker-engine docker.io containerd runc
-      sudo apt-get update
-      sudo apt-get install \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        software-properties-common
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-      sudo add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       $(lsb_release -cs) \
-       stable"
-      sudo apt-get update
-      sudo apt-get install docker-ce docker-ce-cli containerd.io
-
 install-vector: &install-vector
   run:
     name: Execute install.sh
@@ -509,10 +489,10 @@ jobs:
     steps:
       - checkout
       - *restore-artifacts-from-workspace
-      - *upgrade-docker
       - run:
           name: Build & verify Docker
           command: |
+            ./scripts/upgrade-docker.sh
             export VERSION=$(make version)
             make build-docker
           no_output_timeout: 30m
@@ -687,10 +667,10 @@ jobs:
     steps:
       - checkout
       - *restore-artifacts-from-workspace
-      - *upgrade-docker
       - run:
           name: Release Docker
           command: |
+            ./scripts/upgrade-docker.sh
             export VERSION=$(make version)
             make release-docker
           no_output_timeout: 30m

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /scripts/generate* @binarylogic
 /scripts/package-* @a-rodin
 /scripts/release-* @a-rodin
+/scripts/upgrade-* @a-rodin
 
 /src/buffers/ @a-rodin
 

--- a/scripts/upgrade-docker.sh
+++ b/scripts/upgrade-docker.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -exu
+
+sudo apt-get remove -y docker docker-engine docker.io containerd runc
+sudo apt-get update
+sudo apt-get install \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg-agent \
+  software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+ "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+ $(lsb_release -cs) \
+ stable"
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io


### PR DESCRIPTION
Sometimes the new `verify-docker` job fails in CircleCI ([example](https://app.circleci.com/jobs/github/timberio/vector/47471)).

It might be caused by issues related to persisting of the workspace after upgrading Docker, so this PR attempts to avoid this issue by merging the upgrade of Docker with building of the images into a single CircleCI step.