### PR TITLE
fix(website): Fix `Raspbian` id capitalization

### DIFF
--- a/.meta/installation.toml
+++ b/.meta/installation.toml
@@ -30,7 +30,7 @@ package_manager = "Homebrew"
 os = "Linux"
 
 [[installation.operating_systems]]
-id = "Raspbian"
+id = "raspbian"
 name = "Raspbian"
 package_manager = "DPKG"
 os = "Linux"

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -159,7 +159,7 @@ module.exports = {
         "package_manager": "Homebrew"
       },
       {
-        "id": "Raspbian",
+        "id": "raspbian",
         "name": "Raspbian",
         "os": "Linux",
         "package_manager": "DPKG"


### PR DESCRIPTION
This fixes the link in the bottom of the main documentation page.