### PR TITLE
fix(cli): Test & validate subcommands without args target default path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
 use vector::{generate, list, metrics, runtime, topology, trace, unit_test};
+use lazy_static::lazy_static;
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -102,8 +103,9 @@ struct Validate {
     #[structopt(short, long)]
     deny_warnings: bool,
 
-    /// Any number of Vector config files to validate.
-    config_paths: Vec<PathBuf>,
+    /// Any number of Vector config files to validate. If none are specified the
+    /// default config path `/etc/vector/vector.toml` will be targeted.
+    paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -420,8 +422,18 @@ fn open_config(path: &Path) -> Option<File> {
     }
 }
 
+lazy_static! {
+    static ref DEFAULT_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
+}
+
 fn validate(opts: &Validate) -> exitcode::ExitCode {
-    for config_path in &opts.config_paths {
+    let paths = if opts.paths.len() > 0 {
+        &opts.paths
+    } else {
+        &DEFAULT_PATHS
+    };
+
+    for config_path in paths {
         let file = if let Some(file) = open_config(&config_path) {
             file
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate tracing;
 
 use futures::{future, Future, Stream};
+use lazy_static::lazy_static;
 use std::{
     cmp::{max, min},
     fs::File,
@@ -14,7 +15,6 @@ use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
 use vector::{generate, list, metrics, runtime, topology, trace, unit_test};
-use lazy_static::lazy_static;
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 extern crate tracing;
 
 use futures::{future, Future, Stream};
-use lazy_static::lazy_static;
 use std::{
     cmp::{max, min},
     fs::File,
@@ -14,7 +13,9 @@ use structopt::StructOpt;
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{generate, list, metrics, runtime, topology, trace, unit_test};
+use vector::{
+    generate, list, metrics, runtime, topology, trace, types::DEFAULT_CONFIG_PATHS, unit_test,
+};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -422,15 +423,11 @@ fn open_config(path: &Path) -> Option<File> {
     }
 }
 
-lazy_static! {
-    static ref DEFAULT_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
-}
-
 fn validate(opts: &Validate) -> exitcode::ExitCode {
     let paths = if opts.paths.len() > 0 {
         &opts.paths
     } else {
-        &DEFAULT_PATHS
+        &DEFAULT_CONFIG_PATHS
     };
 
     for config_path in paths {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,16 @@
 use crate::event::ValueKind;
 use chrono::{DateTime, Local, ParseError as ChronoParseError, TimeZone, Utc};
+use lazy_static::lazy_static;
 use snafu::{ResultExt, Snafu};
 use std::collections::{HashMap, HashSet};
 use std::num::{ParseFloatError, ParseIntError};
+use std::path::PathBuf;
 use std::str::FromStr;
 use string_cache::DefaultAtom as Atom;
+
+lazy_static! {
+    pub static ref DEFAULT_CONFIG_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
+}
 
 #[derive(Debug, Snafu)]
 pub enum ConversionError {

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,8 +1,8 @@
 use crate::topology::{config::Config, unit_test::UnitTest};
 use colored::*;
+use lazy_static::lazy_static;
 use std::{fs::File, path::PathBuf};
 use structopt::StructOpt;
-use lazy_static::lazy_static;
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -2,11 +2,13 @@ use crate::topology::{config::Config, unit_test::UnitTest};
 use colored::*;
 use std::{fs::File, path::PathBuf};
 use structopt::StructOpt;
+use lazy_static::lazy_static;
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
-    /// Any number of Vector config files to test.
+    /// Any number of Vector config files to test. If none are specified the
+    /// default config path `/etc/vector/vector.toml` will be targeted.
     paths: Vec<PathBuf>,
 }
 
@@ -39,10 +41,20 @@ fn build_tests(path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
     crate::topology::unit_test::build_unit_tests(&config)
 }
 
+lazy_static! {
+    static ref DEFAULT_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
+}
+
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
 
-    for (i, p) in opts.paths.iter().enumerate() {
+    let paths = if opts.paths.len() > 0 {
+        &opts.paths
+    } else {
+        &DEFAULT_PATHS
+    };
+
+    for (i, p) in paths.iter().enumerate() {
         let path_str = p.to_str().unwrap_or("");
         if i > 0 {
             println!("");

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,6 +1,8 @@
-use crate::topology::{config::Config, unit_test::UnitTest};
+use crate::{
+    topology::{config::Config, unit_test::UnitTest},
+    types::DEFAULT_CONFIG_PATHS,
+};
 use colored::*;
-use lazy_static::lazy_static;
 use std::{fs::File, path::PathBuf};
 use structopt::StructOpt;
 
@@ -41,17 +43,13 @@ fn build_tests(path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
     crate::topology::unit_test::build_unit_tests(&config)
 }
 
-lazy_static! {
-    static ref DEFAULT_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
-}
-
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
 
     let paths = if opts.paths.len() > 0 {
         &opts.paths
     } else {
-        &DEFAULT_PATHS
+        &DEFAULT_CONFIG_PATHS
     };
 
     for (i, p) in paths.iter().enumerate() {


### PR DESCRIPTION
This commit makes the test and validate subcommands target the default config path in the absense of path arguments.

Closes #1310

Signed-off-by: Ashley Jeffs <ash@jeffail.uk>