### PR TITLE
fix(operations): Reduce test concurrency to avoid CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: Test
           no_output_timeout: 30m
-          command: cargo test --all --features docker --jobs 4
+          command: cargo test --all --features docker --jobs 4 -- test-threads 1
       - store_test_results:
           path: ./test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: Test
           no_output_timeout: 30m
-          command: cargo test --all --features docker --jobs 4 -- test-threads 1
+          command: cargo test --all --features docker --jobs 4
       - store_test_results:
           path: ./test-results
 

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -38,7 +38,7 @@ fn sleep_ms(dur: u64) {
 }
 
 // The duration at which we let the runtime spawn its extra tasks.
-const RUNTIME_SLEEP_DURATION: u64 = 50;
+const RUNTIME_SLEEP_DURATION: u64 = 100;
 
 #[test]
 fn topology_source_and_sink() {


### PR DESCRIPTION
It looks like multiple test threads cause some sporadic `test-stable` failures. This PR sets number of test threads to 1.