### PR TITLE
enhancement(config): Option to reload config on file change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 
 [[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1443,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "input_buffer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1623,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "leveldb"
@@ -1869,6 +1914,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log 0.4.8",
+ "mio",
+ "slab",
+]
+
+[[package]]
 name = "mio-named-pipes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2060,24 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -4589,6 +4664,7 @@ dependencies = [
  "maxminddb",
  "native-tls",
  "nom 5.1.0",
+ "notify",
  "num_cpus 1.12.0",
  "openssl",
  "openssl-probe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 
 [[package]]
+name = "nix"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4663,6 +4676,7 @@ dependencies = [
  "matches",
  "maxminddb",
  "native-tls",
+ "nix",
  "nom 5.1.0",
  "notify",
  "num_cpus 1.12.0",
@@ -4741,6 +4755,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ notify = "4.0.14"
 
 [target.'cfg(unix)'.dependencies]
 atty = "0.2"
+nix = "0.16.1"
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ colored = "1.9"
 warp = "0.1.20"
 evmap = { version = "7", features = ["bytes"] }
 logfmt = "0.0.2"
+notify = "4.0.14"
 
 [target.'cfg(unix)'.dependencies]
 atty = "0.2"

--- a/config/kubernetes/vector-daemonset.yaml
+++ b/config/kubernetes/vector-daemonset.yaml
@@ -19,7 +19,6 @@ data:
 
     # Set global options
     data_dir = "/var/tmp/vector"
-    reload_config = true
 
     # Ingest logs from Kubernetes
     [sources.kubernetes]
@@ -72,6 +71,7 @@ spec:
       - name: vector
         image: timberio/vector:latest-alpine
         imagePullPolicy: Always
+        args: ["-w"]
         volumeMounts:
         - name: var-log
           mountPath: /var/log/

--- a/config/kubernetes/vector-daemonset.yaml
+++ b/config/kubernetes/vector-daemonset.yaml
@@ -19,6 +19,7 @@ data:
 
     # Set global options
     data_dir = "/var/tmp/vector"
+    reload_config = true
 
     # Ingest logs from Kubernetes
     [sources.kubernetes]

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ struct RootOpts {
     /// Options: `auto`, `always` or `never`
     #[structopt(long)]
     color: Option<Color>,
+
+    /// Watch for changes in configuration file, and update accordingly.
+    #[structopt(short, long)]
+    watch_config: bool,
 }
 
 #[derive(StructOpt, Debug)]
@@ -250,20 +254,6 @@ fn main() {
     let config = config.unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
     });
-
-    // Start listening for config changes immediately.
-    //
-    // There is a chance of config file changing since we read
-    // it with vector::topology::Config::load until the end of
-    // vector::topology::config::watcher::config_watcher function.
-    // This should be extremly rare, and because the solution is
-    // somewhat complex, intrusive, this will be fine for now.
-    let _ = vector::topology::config::watcher::config_watcher(
-        &config,
-        opts.config_path.clone(),
-        vector::topology::config::watcher::CONFIG_WATCH_DELAY,
-    )
-    .map_err(|error| error!(?error));
 
     let mut rt = {
         let threads = opts.threads.unwrap_or(max(1, num_cpus::get()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,15 +252,18 @@ fn main() {
     });
 
     // Start listening for config changes immediately.
+    //
     // There is a chance of config file changing since we read
-    // it unitl the end of this function. This should be extremly
-    // rare, the solution is somewhat complex, intrusive, so
-    // this will be fine for now.
-    vector::topology::config::watcher::config_watcher(
+    // it with vector::topology::Config::load until the end of
+    // vector::topology::config::watcher::config_watcher function.
+    // This should be extremly rare, and because the solution is
+    // somewhat complex, intrusive, this will be fine for now.
+    let _ = vector::topology::config::watcher::config_watcher(
         &config,
         opts.config_path.clone(),
         vector::topology::config::watcher::CONFIG_WATCH_DELAY,
-    );
+    )
+    .map_err(|error| error!(?error));
 
     let mut rt = {
         let threads = opts.threads.unwrap_or(max(1, num_cpus::get()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,17 @@ fn main() {
         std::process::exit(exitcode::CONFIG);
     });
 
+    // Start listening for config changes immediately.
+    // There is a chance of config file changing since we read
+    // it unitl the end of this function. This should be extremly
+    // rare, the solution is somewhat complex, intrusive, so
+    // this will be fine for now.
+    vector::topology::config::watcher::config_watcher(
+        &config,
+        opts.config_path.clone(),
+        vector::topology::config::watcher::CONFIG_WATCH_DELAY,
+    );
+
     let mut rt = {
         let threads = opts.threads.unwrap_or(max(1, num_cpus::get()));
         let num_threads = min(4, threads);

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ struct RootOpts {
     #[structopt(long)]
     color: Option<Color>,
 
-    /// Watch for changes in configuration file, and update accordingly.
+    /// Watch for changes in configuration file, and reload accordingly.
     #[structopt(short, long)]
     watch_config: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,18 @@ fn main() {
     config_paths.sort();
     config_paths.dedup();
 
+    if opts.watch_config {
+        // Start listening for config changes immediately.
+        vector::topology::config::watcher::config_watcher(
+            config_paths.clone(),
+            vector::topology::config::watcher::CONFIG_WATCH_DELAY,
+        )
+        .unwrap_or_else(|error| {
+            error!(message = "Unable to start config watcher.", %error);
+            std::process::exit(exitcode::CONFIG);
+        });
+    }
+
     info!(
         message = "Loading configs.",
         path = ?config_paths

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -40,8 +40,6 @@ pub struct GlobalOptions {
     pub data_dir: Option<PathBuf>,
     #[serde(default)]
     pub dns_servers: Vec<String>,
-    #[serde(default)]
-    pub reload_config: bool,
 }
 
 pub fn default_data_dir() -> Option<PathBuf> {
@@ -262,7 +260,6 @@ impl Config {
             global: GlobalOptions {
                 data_dir: None,
                 dns_servers: Vec::new(),
-                reload_config: false,
             },
             sources: IndexMap::new(),
             sinks: IndexMap::new(),

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -17,6 +17,7 @@ use std::{collections::HashMap, path::PathBuf};
 pub mod component;
 mod validation;
 mod vars;
+pub mod watcher;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -39,6 +40,8 @@ pub struct GlobalOptions {
     pub data_dir: Option<PathBuf>,
     #[serde(default)]
     pub dns_servers: Vec<String>,
+    #[serde(default)]
+    pub reload_config: bool,
 }
 
 pub fn default_data_dir() -> Option<PathBuf> {
@@ -259,6 +262,7 @@ impl Config {
             global: GlobalOptions {
                 data_dir: None,
                 dns_servers: Vec::new(),
+                reload_config: false,
             },
             sources: IndexMap::new(),
             sinks: IndexMap::new(),

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -113,6 +113,7 @@ mod tests {
     use tokio::timer::Delay;
     use tokio_signal::unix::{Signal, SIGHUP};
 
+    #[cfg(unix)]
     #[test]
     fn file_update() {
         crate::test_util::trace_init();
@@ -123,7 +124,7 @@ mod tests {
         let mut config = Config::empty();
         config.global.reload_config = true;
 
-        config_watcher(&config, file_path, delay);
+        let _ = config_watcher(&config, file_path, delay).unwrap();
 
         file.write_all(&[0]).unwrap();
         std::mem::drop(file);

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -19,6 +19,8 @@ const RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// On unix triggers SIGHUP when file on config_path changes.
 /// Accumulates file changes until no change for given duration has occured.
+/// Guarantes capture of all file changes from the end of this function until 
+/// main thread stops.
 /// 
 /// Doesn't do anything on Windows.
 pub fn config_watcher(

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -9,18 +9,21 @@ use std::{
 };
 
 
-// Per notify own documentation, it's advised to have delay of more than 30 sec,
-// so to avoid receiving repetitions of previous events on macOS.
-// Larger delays hurt responsivity, but that's fine as this is primarily designed
-// for cloud usage which isn't exactly super responsive.
-pub const CONFIG_WATCH_DELAY: std::time::Duration = std::time::Duration::from_secs(31);
+/// Per notify own documentation, it's advised to have delay of more than 30 sec,
+/// so to avoid receiving repetitions of previous events on macOS. 
+/// 
+/// But, config and topology reload logic can handle:
+///  - Invalid config, caused either by user or by data race.
+///  - Frequent changes, caused by user/editor modifying/saving file in small chunks. 
+/// so we can use smaller, more responsive delay.
+pub const CONFIG_WATCH_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
 const RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// On unix triggers SIGHUP when file on config_path changes.
 /// Accumulates file changes until no change for given duration has occured.
-/// Guarantes capture of all file changes from the end of this function until 
-/// main thread stops.
+/// Has best effort guarante of detecting all file changes from the end of 
+/// this function until the main thread stops.
 /// 
 /// Doesn't do anything on Windows.
 pub fn config_watcher(

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -1,0 +1,131 @@
+use super::Config;
+use futures::{stream, sync::mpsc, Async, Stream};
+use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::{channel, Receiver},
+    thread,
+    time::Duration,
+};
+
+// Per notify own documentation, it's advised to have delay of more than 30 sec,
+// so to avoid receiving repetitions of previous events on macOS.
+// Larger delays hurt responsivity, but that's fine as this is primarily designed
+// for cloud usage which isn't exactly super responsive.
+pub const CONFIG_WATCH_DELAY: std::time::Duration = std::time::Duration::from_secs(31);
+
+const RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Returns when config should be reloaded.
+/// Never errors, and never ends.
+pub fn config_watcher(
+    config: &Config,
+    config_path: PathBuf,
+    delay: Duration,
+) -> impl Stream<Item = (), Error = ()> {
+    // Each sender has one slot, and 0 shared slots.
+    let (mut out_sender, out_receiver) = mpsc::channel(0);
+
+    if config.global.reload_config {
+        // Create watcher now so not to miss any changes happening between
+        // returning from this function and thread started.
+        let mut watcher = create_watcher(&config_path, delay);
+
+        thread::spawn(move || {
+            loop {
+                if let Some((_, receiver)) = watcher.take() {
+                    info!("Watching configuration file");
+                    while let Ok(msg) = receiver.recv() {
+                        match msg {
+                            DebouncedEvent::Write(_)
+                            | DebouncedEvent::Create(_)
+                            | DebouncedEvent::Remove(_) => {
+                                info!("Configuration file changed");
+                                // If Ok, good, if Err, then there is already a message
+                                // in the channel so this one is not required.
+                                let _ = out_sender.try_send(());
+                            }
+                            event => debug!(message = "Ignoring event", ?event),
+                        }
+                    }
+                    error!("Stoped watching configuration file");
+                }
+
+                thread::sleep(RETRY_TIMEOUT);
+
+                watcher = create_watcher(&config_path, delay);
+            }
+        });
+    }
+
+    let mut change_stream = out_receiver.fuse();
+    stream::poll_fn(move || {
+        change_stream.poll().map(|asyn| match asyn {
+            // Fulfills neverending promise
+            Async::Ready(None) => Async::NotReady,
+            asyn => asyn,
+        })
+    })
+}
+
+fn create_watcher(
+    config_path: &Path,
+    delay: Duration,
+) -> Option<(RecommendedWatcher, Receiver<DebouncedEvent>)> {
+    info!("Creating configuration file watcher");
+    let (sender, receiver) = channel();
+    match watcher(sender, delay) {
+        Ok(mut watcher) => match watcher.watch(&config_path, RecursiveMode::NonRecursive) {
+            Ok(_) => {
+                return Some((watcher, receiver));
+            }
+            Err(error) => error!(message = "Failed to watch configuration file", ?error),
+        },
+        Err(error) => error!(message = "Failed to create file watcher", ?error),
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use super::*;
+    use crate::test_util::{runtime, temp_file};
+    use futures::future;
+    use futures::{Future, Stream};
+    use std::time::{Duration, Instant};
+    use std::{fs::File, io::Write};
+    use tokio::timer::Delay;
+
+    #[test]
+    fn file_update() {
+        crate::test_util::trace_init();
+        let delay = Duration::from_secs(1);
+        let file_path = temp_file();
+        let mut file = File::create(&file_path).unwrap();
+
+        let mut config = Config::empty();
+        config.global.reload_config = true;
+
+        let mut watcher = config_watcher(&config, file_path, delay);
+
+        file.write_all(&[0]).unwrap();
+        // Windows won't emit Write event while File handle is present.
+        std::mem::drop(file);
+
+        let mut rt = runtime();
+
+        let result = rt
+            .block_on(
+                future::poll_fn(move || watcher.poll())
+                    .select2(Delay::new(Instant::now() + delay * 5)),
+            )
+            .ok()
+            .unwrap();
+
+        match result {
+            future::Either::A(_) => (), //OK
+            future::Either::B(_) => panic!("Test timed out"),
+        }
+    }
+}

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -67,7 +67,7 @@ pub fn config_watcher(config_paths: Vec<PathBuf>, delay: Duration) -> Result<(),
 
 #[cfg(windows)]
 /// Errors on Windows.
-pub fn config_watcher(config_paths: Vec<PathBuf>, delay: Duration) -> Result<(), Error> {
+pub fn config_watcher(_config_paths: Vec<PathBuf>, _delay: Duration) -> Result<(), Error> {
     Err("Reloading config on Windows isn't currently supported. Related issue https://github.com/timberio/vector/issues/938 .".into())
 }
 

--- a/website/docs/administration/process-management.md
+++ b/website/docs/administration/process-management.md
@@ -103,7 +103,7 @@ test
 | `-t, --threads` | Limits the number of internal threads Vector can spawn. See the [Limiting Resources][docs.roles.agent#limiting-resources] in the [Agent role][docs.roles.agent] documentation. |
 | `-v, --verbose` | Drops the log level to `debug`. |
 | `-vv` | Drops the log level to `trace`, the lowest level possible. |
-| `-w, --watch-config` | Vector will watch for changes in [configuration file][docs.configuration], and reload accordingly. |
+| `-w, --watch-config` | Vector will watch for changes in [configuration file][docs.configuration], and reload accordingly. (Mac/Linux only) |
 
 ### Daemonizing
 

--- a/website/docs/administration/process-management.md
+++ b/website/docs/administration/process-management.md
@@ -103,6 +103,7 @@ test
 | `-t, --threads` | Limits the number of internal threads Vector can spawn. See the [Limiting Resources][docs.roles.agent#limiting-resources] in the [Agent role][docs.roles.agent] documentation. |
 | `-v, --verbose` | Drops the log level to `debug`. |
 | `-vv` | Drops the log level to `trace`, the lowest level possible. |
+| `-w, --watch-config` | Vector will watch for changes in [configuration file][docs.configuration], and reload accordingly. |
 
 ### Daemonizing
 

--- a/website/docs/administration/process-management.md
+++ b/website/docs/administration/process-management.md
@@ -191,7 +191,7 @@ are:
 ## Reloading
 
 Vector can be reloaded, on the fly, to recognize any configuration changes by
-sending the Vector process a `SIGHUP` signal:
+sending the Vector process a `SIGHUP` signal.
 
 <Tabs
   block={true}
@@ -245,6 +245,13 @@ ps -ax vector | grep vector
 
 </TabItem>
 </Tabs>
+
+### Automatic Reload On Changes
+
+You can automatically reload Vector's configuration file when it changes via
+the `-w` or `--watch-config` flag upon [starting](#starting). This is
+particularly helpful in scenarios where configuration is managed for you, such
+as Kubernetes.
 
 ### Configuration Errors
 


### PR DESCRIPTION
Closes #938

Watcher now raises SIGHUP on Unix, and does nothing on Windows.

Instead of `reload_config` option in `toml`, we are accepting optional flag `-w` as cli argument. 

### Questions

- [x]  Should `reload_config` flag be passed while starting Vector, instead of it being in configuration file? (Yes)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->