### PR TITLE
chore(operations): Add "default-{musl,msvc}" features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,8 @@ jobs:
           command: |
             RUSTFLAGS=-Ctarget-feature=+crt-static
             PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
-            FEATURES="leveldb leveldb/leveldb-sys-3 rdkafka rdkafka/cmake_build openssl/vendored"
             rm rust-toolchain
-            cargo test --release --no-default-features --features "$FEATURES" -- --test-threads 1
+            cargo test --release --no-default-features --features default-msvc -- --test-threads 1
 
   test-stable:
     resource_class: xlarge
@@ -262,7 +261,7 @@ jobs:
             export -f zip
 
             export RUSTFLAGS=-Ctarget-feature=+crt-static
-            export FEATURES="leveldb leveldb/leveldb-sys-3 rdkafka rdkafka/cmake_build openssl/vendored"
+            export FEATURES="default-msvc"
             export ARCHIVE_TYPE="zip"
             export STRIP="false"
             export RUST_LTO=""
@@ -284,7 +283,7 @@ jobs:
           no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
-            PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"
+            PASS_FEATURES: "default-musl"
           command: |
             ./scripts/docker-run.sh builder-x86_64-unknown-linux-musl make build-archive package-deb
       - persist_to_workspace:
@@ -302,7 +301,7 @@ jobs:
           no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
-            PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"
+            PASS_FEATURES: "default-musl"
           command: |
             ./scripts/docker-run.sh builder-aarch64-unknown-linux-musl make build-archive package-deb
       - persist_to_workspace:
@@ -320,7 +319,7 @@ jobs:
           no_output_timeout: 30m
           environment:
             PASS_RUST_LTO: "lto"
-            PASS_FEATURES: "jemallocator rdkafka rdkafka/cmake_build leveldb leveldb/leveldb-sys-3 shiplift/unix-socket openssl/vendored"
+            PASS_FEATURES: "default-musl"
           command: |
             ./scripts/docker-run.sh builder-armv7-unknown-linux-musleabihf make build-archive package-deb
       - persist_to_workspace:

--- a/.meta/links.toml
+++ b/.meta/links.toml
@@ -150,3 +150,4 @@ vector_systemd_file = "https://github.com/timberio/vector/blob/master/distributi
 vector_version_branches = "https://github.com/timberio/vector/branches/all?query=v"
 vote_feature = "https://github.com/timberio/vector/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3A%22Type%3A+New+Feature%22"
 website = "https://vector.dev"
+zlib = "https://www.zlib.net"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "codec"
 version = "0.1.0"
 dependencies = [
@@ -1240,6 +1248,7 @@ source = "git+https://github.com/timberio/leveldb#64265815bcf1b69f30e6cb35bf687f
 dependencies = [
  "db-key 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "leveldb-sys 3.0.0 (git+https://github.com/timberio/leveldb-sys?branch=v3.0.0)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1249,6 +1258,16 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "leveldb-sys"
+version = "3.0.0"
+source = "git+https://github.com/timberio/leveldb-sys?branch=v3.0.0#0f226b0cce86aff28f255ef89082916e4fdda4c7"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2187,6 +2206,7 @@ name = "rdkafka-sys"
 version = "1.2.1"
 source = "git+https://github.com/timberio/rust-rdkafka#f6519c99988f5de81026552725f9e693b39503f7"
 dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3755,6 +3775,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leveldb 0.8.4 (git+https://github.com/timberio/leveldb)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4000,6 +4021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "433e7ac7d511768127ed85b0c4947f47a254131e37864b2dc13f52aa32cd37e5"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
@@ -4105,6 +4127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum leveldb 0.8.4 (git+https://github.com/timberio/leveldb)" = "<none>"
 "checksum leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71f46429bb70612c3e939aaeed27ffd31a24a773d21728a1a426e4089d6778d2"
+"checksum leveldb-sys 3.0.0 (git+https://github.com/timberio/leveldb-sys?branch=v3.0.0)" = "<none>"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ criterion = "0.2.5"
 reqwest = "0.9.5"
 tempfile = "3.0.6"
 libc = "0.2.43"
+libz-sys = "1.0"
 walkdir = "2.2.7"
 elastic_responses = "0.20"
 matches = "0.1.8"
@@ -159,7 +160,32 @@ trust-dns = "0.17.0"
 trust-dns-proto = "0.8.0"
 
 [features]
-default = ["rdkafka", "leveldb", "leveldb/leveldb-sys-2", "shiplift/unix-socket", "jemallocator", "openssl/vendored"]
+# Default features for *-unknown-linux-gnu and *-apple-darwin
+default = ["vendored", "unix", "leveldb-plain", "rdkafka-plain"]
+# Default features for *-unknown-linux-musl
+default-musl = ["vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
+# Default features for *-pc-windows-msvc
+default-msvc = ["vendored", "leveldb-cmake", "rdkafka-cmake"]
+
+# Enables features that work only on systems providing `cfg(unix)
+unix = ["jemallocator", "shiplift/unix-socket"]
+# Forces vendoring of OpenSSL and ZLib dependencies
+vendored = ["openssl/vendored", "libz-sys/static"]
+# This feature is less portable, but doesn't require `cmake` as build dependency
+rdkafka-plain = ["rdkafka"]
+# Enables `rdkafka` dependency.
+# This feature is more portable, but requires `cmake` as build dependency. Use it if `rdkafka-plain` doesn't work.
+# The `sasl` feature has to be added because of the limitations of `librdkafka` build scripts for `cmake`.
+rdkafka-cmake = ["rdkafka", "rdkafka/cmake_build"]
+# This feature is less portable, but doesn't require `cmake` as build dependency
+leveldb-plain = ["leveldb", "leveldb/leveldb-sys-2"]
+# This feature is more portable, but requires `cmake` as build dependency. Use it if `leveldb-plain` doesn't work.
+leveldb-cmake = ["leveldb", "leveldb/leveldb-sys-3"]
+
+# Identifies that the build is a nightly build
+nightly = []
+
+# Testing-related features
 docker = [
   "cloudwatch-logs-integration-tests",
   "cloudwatch-metrics-integration-tests",
@@ -180,7 +206,6 @@ kinesis-integration-tests = []
 s3-integration-tests = []
 splunk-integration-tests = []
 docker-integration-tests = []
-nightly = []
 
 [[bench]]
 name = "bench"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ build: ## Build the project
 check: check-code check-fmt check-generate check-examples
 
 check-code: ## Checks code for compilation errors
-	@cargo check --all --all-features --all-targets
+	@cargo check --all --all-targets
+	@cargo check --all --all-targets --no-default-features --features default-musl
+	@cargo check --all --all-targets --no-default-features --features default-msvc
 
 check-fmt: ## Checks code formatting correctness
 	@cargo fmt -- --check

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,8 @@ build: ## Build the project
 
 check: check-code check-fmt check-generate check-examples
 
-check-code: ## Checks code for compilation errors
+check-code: ## Checks code for compilation errors (only default features)
 	@cargo check --all --all-targets
-	@cargo check --all --all-targets --no-default-features --features default-musl
-	@cargo check --all --all-targets --no-default-features --features default-msvc
 
 check-fmt: ## Checks code formatting correctness
 	@cargo fmt -- --check

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -190,9 +190,9 @@ are specified, then the `default` one is used.
 
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
-| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` as build dependency. | |
-| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` as build dependency. | |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. Requires `perl` as a build dependency, which is usually pre-installed on these platforms. | <i className="feather icon-check"></i> |
+| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` and `perl` as build dependencies. | |
+| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` and `perl` as build dependencies. | |
 
 Alternatively, for finer control, it is possible to use specific features from the list below:
 

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -185,16 +185,25 @@ executing `make build`:
 [FEATURES="<flag1>,<flag2>,..."] make build
 ```
 
+There are three meta-features which can be used when compiling for the corresponding targets. If no features
+are specified, then the `default` one is used.
+
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `jemallocator` | Enables vendored [jemalloc][urls.jemalloc] instead of default memory allocator, which improves [performance][docs.performance]. | <i className="feather icon-check"></i> |
-| `leveldb` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb/leveldb-sys-2` | Can be used together with `leveldb` feature to use LevelDB from [`leveldb-sys` 2.x][urls.leveldb-sys-2] crate, which doesn't require `cmake` as build dependency, but supports less platforms. | <i className="feather icon-check"></i> |
-| `leveldb/leveldb-sys-3` | Can be used together with `leveldb` feature to use LevelDB from development version of [`leveldb-sys` 3.x][urls.leveldb-sys-3] crate, which requires `cmake` as build dependency, but supports more platforms. | |
-| `openssl/vendored` | Enables vendored [OpenSSL][urls.openssl]. If disabled, system SSL library is used instead. | <i className="feather icon-check"></i> |
-| `rdkafka` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka/cmake_build` | Can be used together with `rdkafka` feature to build `librdkafka` using `cmake` instead of default build script in case of build problems on non-standard system configurations. | |
-| `shiplift/unix-socket` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
+| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` as build dependency. | |
+| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` as build dependency. | |
+
+Alternatively, for finer control, it is possible to use specific features from the list below:
+
+| Feature | Description | Included in `default` feature |
+| :------ | :---------- | :----------------- |
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of default memory allocator. | <i className="feather icon-check"></i> |
+| `vendored` | Forces using of vendored [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of versions installed in the system. | <i className="feather icon-check"></i>|
+| `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `leveldb-plain`. | |
+| `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `rdkafka-plain`. | |
 
 
 [docs.configuration]: /docs/setup/configuration
@@ -204,14 +213,12 @@ executing `make build`:
 [docs.global-options#data_dir]: /docs/reference/global-options#data_dir
 [docs.glossary#buffer]: /docs/meta/glossary#buffer
 [docs.package_managers]: /docs/setup/installation/package-managers
-[docs.performance]: /docs/about/performance
 [docs.sources.docker]: /docs/reference/sources/docker
 [docs.sources.kafka]: /docs/reference/sources/kafka
 [urls.jemalloc]: https://github.com/jemalloc/jemalloc
-[urls.leveldb-sys-2]: https://crates.io/crates/leveldb-sys
-[urls.leveldb-sys-3]: https://github.com/timberio/leveldb-sys/tree/v3.0.0
 [urls.leveldb]: https://github.com/google/leveldb
 [urls.lib_rdkafka]: https://github.com/edenhill/librdkafka
 [urls.musl_builder_docker_image]: https://github.com/timberio/vector/blob/master/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
 [urls.openssl]: https://www.openssl.org/
 [urls.rust]: https://www.rust-lang.org/
+[urls.zlib]: https://www.zlib.net

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -190,7 +190,7 @@ are specified, then the `default` one is used.
 
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. Requires `perl` as a build dependency, which is usually pre-installed on these platforms. | <i className="feather icon-check"></i> |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
 | `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` and `perl` as build dependencies. | |
 | `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` and `perl` as build dependencies. | |
 

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -198,12 +198,12 @@ Alternatively, for finer control, it is possible to use specific features from t
 
 | Feature | Description | Included in `default` feature |
 | :------ | :---------- | :----------------- |
-| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of default memory allocator. | <i className="feather icon-check"></i> |
-| `vendored` | Forces using of vendored [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of versions installed in the system. | <i className="feather icon-check"></i>|
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
+| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. | <i className="feather icon-check"></i>|
 | `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `leveldb-plain`. | |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
 | `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `rdkafka-plain`. | |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |
 
 
 [docs.configuration]: /docs/setup/configuration

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -198,12 +198,12 @@ Alternatively, for finer control, it is possible to use specific features from t
 
 | Feature | Description | Included in `default` feature |
 | :------ | :---------- | :----------------- |
-| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
-| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. | <i className="feather icon-check"></i>|
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely support for Unix domain sockets in [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
+| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. Requires `perl` as a build dependency. | <i className="feather icon-check"></i>|
 | `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as a build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
 | `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as a build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |
 
 
 [docs.configuration]: /docs/setup/configuration

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -118,7 +118,7 @@ are specified, then the `default` one is used.
 
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. Requires `perl` as a build dependency, which is usually pre-installed on these platforms. | <i className="feather icon-check"></i> |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
 | `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` and `perl` as build dependencies. | |
 | `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` and `perl` as build dependencies. | |
 

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -127,8 +127,8 @@ Alternatively, for finer control, it is possible to use specific features from t
 | Feature | Description | Included in `default` feature |
 | :------ | :---------- | :----------------- |
 | `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
-| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. | <i className="feather icon-check"></i>|
+| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. Requires `perl` as a build dependency. | <i className="feather icon-check"></i>|
 | `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as a build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
 | `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as a build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -126,9 +126,9 @@ Alternatively, for finer control, it is possible to use specific features from t
 
 | Feature | Description | Included in `default` feature |
 | :------ | :---------- | :----------------- |
-| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of default memory allocator. | <i className="feather icon-check"></i> |
-| `vendored` | Forces using of vendored [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of versions installed in the system. | <i className="feather icon-check"></i>|
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
+| `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. | <i className="feather icon-check"></i>|
 | `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `leveldb-plain`. | |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `leveldb-plain`. | |
 | `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `rdkafka-plain`. | |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it in case of compilation issues with `rdkafka-plain`. | |

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -113,13 +113,22 @@ executing `make build`:
 [FEATURES="<flag1>,<flag2>,..."] make build
 ```
 
+There are three meta-features which can be used when compiling for the corresponding targets. If no features
+are specified, then the `default` one is used.
+
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `jemallocator` | Enables vendored [jemalloc][urls.jemalloc] instead of default memory allocator, which improves [performance][docs.performance]. | <i className="feather icon-check"></i> |
-| `leveldb` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
-| `leveldb/leveldb-sys-2` | Can be used together with `leveldb` feature to use LevelDB from [`leveldb-sys` 2.x][urls.leveldb-sys-2] crate, which doesn't require `cmake` as build dependency, but supports less platforms. | <i className="feather icon-check"></i> |
-| `leveldb/leveldb-sys-3` | Can be used together with `leveldb` feature to use LevelDB from development version of [`leveldb-sys` 3.x][urls.leveldb-sys-3] crate, which requires `cmake` as build dependency, but supports more platforms. | |
-| `openssl/vendored` | Enables vendored [OpenSSL][urls.openssl]. If disabled, system SSL library is used instead. | <i className="feather icon-check"></i> |
-| `rdkafka` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
-| `rdkafka/cmake_build` | Can be used together with `rdkafka` feature to build `librdkafka` using `cmake` instead of default build script in case of build problems on non-standard system configurations. | |
-| `shiplift/unix-socket` | Enables support for Unix domain sockets in [`docker`][docs.sources.docker] source. | <i className="feather icon-check"></i> |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
+| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` as build dependency. | |
+| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` as build dependency. | |
+
+Alternatively, for finer control, it is possible to use specific features from the list below:
+
+| Feature | Description | Included in `default` feature |
+| :------ | :---------- | :----------------- |
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of default memory allocator. | <i className="feather icon-check"></i> |
+| `vendored` | Forces using of vendored [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of versions installed in the system. | <i className="feather icon-check"></i>|
+| `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
+| `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `leveldb-plain`. | |
+| `rdkafka-plain` | Enables vendored [librdkafka][urls.lib_rdkafka] dependency, which is required for [`kafka` source][docs.sources.kafka] and [`kafka` sink][docs.sources.kafka]. | <i className="feather icon-check"></i> |
+| `rdkafka-cmake` | The same as `rdkafka-plain`, but is more portable. Requires `cmake` as build dependency. Use it if there are compilation issues with `rdkafka-plain`. | |

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -126,7 +126,7 @@ Alternatively, for finer control, it is possible to use specific features from t
 
 | Feature | Description | Included in `default` feature |
 | :------ | :---------- | :----------------- |
-| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely Unix domain sockets for [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
+| `unix` | Enables features that require `cfg(unix)` to be present on the platform, namely support for Unix domain sockets in [docker][docs.sources.docker] source and [jemalloc][urls.jemalloc] instead of the default memory allocator. | <i className="feather icon-check"></i> |
 | `vendored` | Forces vendoring of [OpenSSL][urls.openssl] and [ZLib][urls.zlib] dependencies instead of using their versions installed in the system. Requires `perl` as a build dependency. | <i className="feather icon-check"></i>|
 | `leveldb-plain` | Enables support for [disk buffers][docs.glossary#buffer] using vendored [LevelDB][urls.leveldb]. | <i className="feather icon-check"></i> |
 | `leveldb-cmake` | The same as `leveldb-plain`, but is more portable. Requires `cmake` as a build dependency. Use it in case of compilation issues with `leveldb-plain`. | |

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -118,9 +118,9 @@ are specified, then the `default` one is used.
 
 | Feature | Description | Enabled by default |
 | :------ | :---------- | :----------------- |
-| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. | <i className="feather icon-check"></i> |
-| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` as build dependency. | |
-| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` as build dependency. | |
+| `default` | Default set of features for `*-unknown-linux-gnu` and `*-apple-darwin` targets. Requires `perl` as a build dependency, which is usually pre-installed on these platforms. | <i className="feather icon-check"></i> |
+| `default-musl` | Default set of features for `*-unknown-linux-musl` targets. Requires `cmake` and `perl` as build dependencies. | |
+| `default-msvc` | Default set of features for `*-pc-windows-msvc` targets. Requires `cmake` and `perl` as build dependencies. | |
 
 Alternatively, for finer control, it is possible to use specific features from the list below:
 


### PR DESCRIPTION
This PR reorganizes features and adds `default-musl` and `default-msvc` features which facilitate building on `*-unknown-linux-musl` and `*-pc-windows-msvc` platforms.

Some other wrapper features are also added, see the documentation.