### PR TITLE
chore(operations): Use LLVM from an archive instead of Git

### DIFF
--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -1,10 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use Clang and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
-ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -36,29 +33,18 @@ ARG RUST_PREFIX=/opt/rust
 ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
-# Independent components are built in different stages, so that
-# change of individual arguments would rebuild only affected stages.
-
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
-
-ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang llvm lld
+FROM ubuntu:19.10 AS libs-builder
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
 RUN apt-get update && apt-get -y install curl xz-utils
+
+ARG LLVM_VERSION
+RUN curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/llvm/llvm-project/archive/llvmorg-$LLVM_VERSION.tar.gz | \
+  tar xzf -
+ENV LLVM_DIR $SRC_DIR/llvm-project-llvmorg-$LLVM_VERSION
 
 ARG MUSL_VERSION
 RUN curl --proto '=https' --tlsv1.2 -sSf \
@@ -73,7 +59,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils 
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
 
 ARG TARGET
 ARG LIBS_PREFIX
@@ -83,6 +69,7 @@ ARG LIBS_PREFIX
 # Because Clang toolchain is not fully bootstrapped yet (no standard library),
 # it is necessary to use GCC to compile it.
 ARG GNU_TARGET
+ARG CLANG_PREFIX
 RUN apt-get install -y gcc${GNU_TARGET:+-${GNU_TARGET}} g++${GNU_TARGET:+-${GNU_TARGET}}
 WORKDIR $LLVM_DIR/compiler-rt
 ENV CC=${GNU_TARGET:+${GNU_TARGET}-}gcc

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,5 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
-ARG RUST_VERSION=1.38.0
+ARG RUST_VERSION=1.39.0
 # We use Clang and libc++ from LLVM. The commit should match the one
 # used by Rust. For each Rust version it can be found here
 # https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
@@ -33,14 +33,13 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/opt/clang
+ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Independent components are built in different stages, so that
 # change of individual arguments would rebuild only affected stages.
 
-# LLVM source tree is shared by both clang and libs builder stages.
-FROM ubuntu:18.04 AS llvm-source
+FROM ubuntu:19.10 AS llvm-source
 RUN apt-get update && apt-get install -y git
 ENV SRC_DIR=/src
 WORKDIR $SRC_DIR
@@ -51,30 +50,11 @@ RUN git clone https://github.com/rust-lang/llvm-project.git && \
   rm -rf .git
 ENV LLVM_DIR=$SRC_DIR/llvm-project
 
-# Clang
-FROM llvm-source AS clang-builder
-RUN apt-get update && apt-get -y install build-essential ninja-build cmake python3-distutils
-ARG CLANG_PREFIX
-ARG LLVM_TARGET
-WORKDIR $LLVM_DIR
-RUN mkdir build && \
-  cd build && \
-  cmake \
-  -DLLVM_ENABLE_PROJECTS="clang;lld" \
-  -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGET" \
-  -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON \
-  -DCMAKE_BUILD_TYPE=release \
-  -DCMAKE_INSTALL_PREFIX=$CLANG_PREFIX \
-  -G Ninja \
-  ../llvm && \
-  cmake --build . --target install
-
 # Libs
 FROM llvm-source AS libs-builder
 
 ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y clang llvm lld
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -259,7 +239,9 @@ RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/g++
 RUN if [ -n "$GNU_TARGET" ]; then ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/$(echo $GNU_TARGET | sed 's/gnu/musl/g')-g++; fi
 RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
-RUN ln -s $CLANG_PREFIX/bin/ar $LIBS_PREFIX/bin/aarch64-linux-musl-ar
+RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
+RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/aarch64-linux-musl-ar
 
 # Use some headers provided by Clang because which are not present in musl.
 RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
@@ -272,7 +254,7 @@ RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/emmintrin.h $LIBS_PREFIX/include
 # `clang++ -o program program.cpp -lstdc++` would still link to libc++.
 RUN echo > dummy.c && \
   $LIBS_PREFIX/bin/cc -c dummy.c && \
-  $CLANG_PREFIX/bin/ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
+  $CLANG_PREFIX/bin/llvm-ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
   rm dummy.c dummy.o
 
 # The actual builder.
@@ -290,8 +272,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH="$RUST_PREFIX/bin:$PATH"
 
 ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y clang llvm lld
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -241,6 +241,7 @@ RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
 RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-strip $LIBS_PREFIX/bin/strip
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/aarch64-linux-musl-ar
 
 # Use some headers provided by Clang because which are not present in musl.

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -1,10 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use Clang and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
-ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -36,22 +33,8 @@ ARG RUST_PREFIX=/opt/rust
 ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
-# Independent components are built in different stages, so that
-# change of individual arguments would rebuild only affected stages.
-
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
+FROM ubuntu:19.10 AS libs-builder
 
 ARG CLANG_PREFIX
 RUN apt-get update && apt-get install -y clang llvm lld

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,10 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use libunwind and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
-ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -36,29 +33,18 @@ ARG RUST_PREFIX=/opt/rust
 ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
-# Independent components are built in different stages, so that
-# change of individual arguments would rebuild only affected stages.
-
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
-
-ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang llvm lld
+FROM ubuntu:19.10 AS libs-builder
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
 RUN apt-get update && apt-get -y install curl xz-utils
+
+ARG LLVM_VERSION
+RUN curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/llvm/llvm-project/archive/llvmorg-$LLVM_VERSION.tar.gz | \
+  tar xzf -
+ENV LLVM_DIR $SRC_DIR/llvm-project-llvmorg-$LLVM_VERSION
 
 ARG MUSL_VERSION
 RUN curl --proto '=https' --tlsv1.2 -sSf \
@@ -73,7 +59,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils 
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
 
 ARG TARGET
 ARG LIBS_PREFIX
@@ -83,6 +69,7 @@ ARG LIBS_PREFIX
 # Because Clang toolchain is not fully bootstrapped yet (no standard library),
 # it is necessary to use GCC to compile it.
 ARG GNU_TARGET
+ARG CLANG_PREFIX
 RUN apt-get install -y gcc${GNU_TARGET:+-${GNU_TARGET}} g++${GNU_TARGET:+-${GNU_TARGET}}
 WORKDIR $LLVM_DIR/compiler-rt
 ENV CC=${GNU_TARGET:+${GNU_TARGET}-}gcc

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -241,6 +241,7 @@ RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
 RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-strip $LIBS_PREFIX/bin/strip
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/arm-linux-musleabihf-ar
 
 # Use stdatomic.h header provided by Clang because it is not present in musl.

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,10 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use libunwind and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
-ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -36,22 +33,8 @@ ARG RUST_PREFIX=/opt/rust
 ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
-# Independent components are built in different stages, so that
-# change of individual arguments would rebuild only affected stages.
-
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
+FROM ubuntu:19.10 AS libs-builder
 
 ARG CLANG_PREFIX
 RUN apt-get update && apt-get install -y clang llvm lld

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,6 +1,6 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
-ARG RUST_VERSION=1.38.0
-# We use Clang and libc++ from LLVM. The commit should match the one
+ARG RUST_VERSION=1.39.0
+# We use libunwind and libc++ from LLVM. The commit should match the one
 # used by Rust. For each Rust version it can be found here
 # https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
 # submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
@@ -33,14 +33,13 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/opt/clang
+ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Independent components are built in different stages, so that
 # change of individual arguments would rebuild only affected stages.
 
-# LLVM source tree is shared by both clang and libs builder stages.
-FROM ubuntu:18.04 AS llvm-source
+FROM ubuntu:19.10 AS llvm-source
 RUN apt-get update && apt-get install -y git
 ENV SRC_DIR=/src
 WORKDIR $SRC_DIR
@@ -51,30 +50,11 @@ RUN git clone https://github.com/rust-lang/llvm-project.git && \
   rm -rf .git
 ENV LLVM_DIR=$SRC_DIR/llvm-project
 
-# Clang
-FROM llvm-source AS clang-builder
-RUN apt-get update && apt-get -y install build-essential ninja-build cmake python3-distutils
-ARG CLANG_PREFIX
-ARG LLVM_TARGET
-WORKDIR $LLVM_DIR
-RUN mkdir build && \
-  cd build && \
-  cmake \
-  -DLLVM_ENABLE_PROJECTS="clang;lld" \
-  -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGET" \
-  -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON \
-  -DCMAKE_BUILD_TYPE=release \
-  -DCMAKE_INSTALL_PREFIX=$CLANG_PREFIX \
-  -G Ninja \
-  ../llvm && \
-  cmake --build . --target install
-
 # Libs
 FROM llvm-source AS libs-builder
 
 ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y clang llvm lld
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -259,7 +239,9 @@ RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/g++
 RUN if [ -n "$GNU_TARGET" ]; then ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/$(echo $GNU_TARGET | sed 's/gnu/musl/g')-g++; fi
 RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
-RUN ln -s $CLANG_PREFIX/bin/ar $LIBS_PREFIX/bin/arm-linux-musleabihf-ar
+RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
+RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/arm-linux-musleabihf-ar
 
 # Use stdatomic.h header provided by Clang because it is not present in musl.
 RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
@@ -271,7 +253,7 @@ RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include
 # `clang++ -o program program.cpp -lstdc++` would still link to libc++.
 RUN echo > dummy.c && \
   $LIBS_PREFIX/bin/cc -c dummy.c && \
-  $CLANG_PREFIX/bin/ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
+  $CLANG_PREFIX/bin/llvm-ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
   rm dummy.c dummy.o
 
 # The actual builder.
@@ -289,8 +271,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH="$RUST_PREFIX/bin:$PATH"
 
 ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y clang llvm lld
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -1,10 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use Clang and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
-ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -39,27 +36,18 @@ ARG LIBS_PREFIX=/opt/libs
 # Independent components are built in different stages, so that
 # change of individual arguments would rebuild only affected stages.
 
-# LLVM source tree is shared by both clang and libs builder stages.
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
-
-ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y llvm clang lld
+FROM ubuntu:19.10 AS libs-builder
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
 RUN apt-get update && apt-get -y install curl xz-utils
+
+ARG LLVM_VERSION
+RUN curl --proto '=https' --tlsv1.2 -sSfL \
+  https://github.com/llvm/llvm-project/archive/llvmorg-$LLVM_VERSION.tar.gz | \
+  tar xzf -
+ENV LLVM_DIR $SRC_DIR/llvm-project-llvmorg-$LLVM_VERSION
 
 ARG MUSL_VERSION
 RUN curl --proto '=https' --tlsv1.2 -sSf \
@@ -74,9 +62,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils 
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
 
 ARG TARGET
+ARG CLANG_PREFIX
 ARG LIBS_PREFIX
 
 # Compile Clang runtime (https://compiler-rt.llvm.org).

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -1,9 +1,7 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
 ARG RUST_VERSION=1.39.0
-# We use Clang and libc++ from LLVM. The commit should match the one
-# used by Rust. For each Rust version it can be found here
-# https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
-# submodule "llvm-project". Example "71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5".
+# We use compiler-rt, libunwind, and libc++ from LLVM.
+ARG LLVM_VERSION=9.0.0
 ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
@@ -36,23 +34,8 @@ ARG RUST_PREFIX=/opt/rust
 ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
-# Independent components are built in different stages, so that
-# change of individual arguments would rebuild only affected stages.
-
-# LLVM source tree is shared by both clang and libs builder stages.
-FROM ubuntu:19.10 AS llvm-source
-RUN apt-get update && apt-get install -y git
-ENV SRC_DIR=/src
-WORKDIR $SRC_DIR
-ARG LLVM_GIT_COMMIT
-RUN git clone https://github.com/rust-lang/llvm-project.git && \
-  cd llvm-project && \
-  git checkout $LLVM_GIT_COMMIT && \
-  rm -rf .git
-ENV LLVM_DIR=$SRC_DIR/llvm-project
-
 # Libs
-FROM llvm-source AS libs-builder
+FROM ubuntu:19.10 AS libs-builder
 
 ARG CLANG_PREFIX
 RUN apt-get update && apt-get install -y llvm clang lld

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -241,6 +241,7 @@ RUN if [ -n "$GNU_TARGET" ]; then ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/b
 RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-strip $LIBS_PREFIX/bin/strip
 RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
 
 # Use some headers provided by Clang because they are not present in musl.

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,5 @@
 # A version like "1.38.0" or "nightly-2019-11-01".
-ARG RUST_VERSION=1.38.0
+ARG RUST_VERSION=1.39.0
 # We use Clang and libc++ from LLVM. The commit should match the one
 # used by Rust. For each Rust version it can be found here
 # https://github.com/rust-lang/rust/tree/master/src as the commit hash of the
@@ -33,14 +33,14 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/opt/clang
+ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Independent components are built in different stages, so that
 # change of individual arguments would rebuild only affected stages.
 
 # LLVM source tree is shared by both clang and libs builder stages.
-FROM ubuntu:18.04 AS llvm-source
+FROM ubuntu:19.10 AS llvm-source
 RUN apt-get update && apt-get install -y git
 ENV SRC_DIR=/src
 WORKDIR $SRC_DIR
@@ -51,30 +51,11 @@ RUN git clone https://github.com/rust-lang/llvm-project.git && \
   rm -rf .git
 ENV LLVM_DIR=$SRC_DIR/llvm-project
 
-# Clang
-FROM llvm-source AS clang-builder
-RUN apt-get update && apt-get -y install build-essential ninja-build cmake python3-distutils
-ARG CLANG_PREFIX
-ARG LLVM_TARGET
-WORKDIR $LLVM_DIR
-RUN mkdir build && \
-  cd build && \
-  cmake \
-  -DLLVM_ENABLE_PROJECTS="clang;lld" \
-  -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGET" \
-  -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON \
-  -DCMAKE_BUILD_TYPE=release \
-  -DCMAKE_INSTALL_PREFIX=$CLANG_PREFIX \
-  -G Ninja \
-  ../llvm && \
-  cmake --build . --target install
-
 # Libs
 FROM llvm-source AS libs-builder
 
 ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y llvm clang lld
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -259,7 +240,8 @@ RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/g++
 RUN if [ -n "$GNU_TARGET" ]; then ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/$(echo $GNU_TARGET | sed 's/gnu/musl/g')-g++; fi
 RUN ln -s $LIBS_PREFIX/bin/musl-c++ $LIBS_PREFIX/bin/musl-g++
 
-RUN ln -s $CLANG_PREFIX/bin/ar $LIBS_PREFIX/bin/aarch64-linux-musl-ar
+RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/ar
+RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
 
 # Use some headers provided by Clang because they are not present in musl.
 RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
@@ -275,7 +257,7 @@ RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/mm_malloc.h $LIBS_PREFIX/include
 # `clang++ -o program program.cpp -lstdc++` would still link to libc++.
 RUN echo > dummy.c && \
   $LIBS_PREFIX/bin/cc -c dummy.c && \
-  $CLANG_PREFIX/bin/ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
+  $CLANG_PREFIX/bin/llvm-ar cr $LIBS_PREFIX/lib/libstdc++.a dummy.o && \
   rm dummy.c dummy.o
 
 # The actual builder.
@@ -283,18 +265,15 @@ FROM ubuntu:19.10
 
 # Install Rust using rustup.
 RUN apt-get update && apt-get install -y curl
-ARG RUST_VERSION
 ARG TARGET
 ARG RUST_PREFIX
 ENV RUSTUP_HOME=$RUST_PREFIX
 ENV CARGO_HOME=$RUST_PREFIX
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain $RUST_VERSION --target $TARGET
+  sh -s -- -y --target $TARGET
 ENV PATH="$RUST_PREFIX/bin:$PATH"
 
-ARG CLANG_PREFIX
-COPY --from=clang-builder $CLANG_PREFIX $CLANG_PREFIX
-ENV PATH="$CLANG_PREFIX/bin:$PATH"
+RUN apt-get update && apt-get install -y llvm clang lld
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX


### PR DESCRIPTION
This speeds up building of the Docker images.

Ref #1320.