### PR TITLE
fix(testing): Remove sleeps from topology tests

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,7 +29,7 @@ pub fn sink_failing_healthcheck() -> (Receiver<Event>, MockSinkConfig) {
 }
 
 pub fn source() -> (Sender<Event>, MockSourceConfig) {
-    let (tx, rx) = futures::sync::mpsc::channel(10);
+    let (tx, rx) = futures::sync::mpsc::channel(0);
     let source = MockSourceConfig::new(rx);
     (tx, source)
 }

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -33,13 +33,6 @@ fn into_message(event: Event) -> String {
     event.as_log().get(&MESSAGE).unwrap().to_string_lossy()
 }
 
-fn sleep_ms(dur: u64) {
-    std::thread::sleep(std::time::Duration::from_millis(dur));
-}
-
-// The duration at which we let the runtime spawn its extra tasks.
-const RUNTIME_SLEEP_DURATION: u64 = 50;
-
 #[test]
 fn topology_source_and_sink() {
     let mut rt = runtime();
@@ -54,8 +47,6 @@ fn topology_source_and_sink() {
 
     let event = Event::from("this");
     in1.send(event.clone()).wait().unwrap();
-
-    sleep_ms(RUNTIME_SLEEP_DURATION);
 
     rt.block_on(topology.stop()).unwrap();
 
@@ -116,8 +107,6 @@ fn topology_multiple_sinks() {
 
     in1.send(event.clone()).wait().unwrap();
 
-    sleep_ms(RUNTIME_SLEEP_DURATION);
-
     rt.block_on(topology.stop()).unwrap();
 
     let res1 = out1.collect().wait().unwrap();
@@ -147,8 +136,6 @@ fn topology_transform_chain() {
     let event = Event::from("this");
 
     in1.send(event.clone()).wait().unwrap();
-
-    sleep_ms(RUNTIME_SLEEP_DURATION);
 
     rt.block_on(topology.stop()).unwrap();
 
@@ -216,8 +203,6 @@ fn topology_remove_one_sink() {
     let event = Event::from("this");
 
     in1.send(event.clone()).wait().unwrap();
-
-    sleep_ms(RUNTIME_SLEEP_DURATION);
 
     rt.block_on(topology.stop()).unwrap();
 


### PR DESCRIPTION
We've been seeing some flakiness in these tests on master, so I took a stab at fixing them. These have passed a few thousand times in a row for me locally, so hopefully CI feels the same way.

Instead of relying on sleeps to ensure that our mock source has a chance to process messages, we make its input an unbuffered channel. This means that the `send` future in our test will not resolve until the source actually has possession of the input, as opposed to it sitting in the channel buffer. This should remove all need to worry about timing for these interactions.