### PR TITLE
chore(operations): Add notices for OpenSSL to the license for binary distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ assets = [
   ["config/examples/*", "/etc/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/etc/systemd/system/vector.service", "644"]
 ]
-license-file = "target/debian-license.txt"
+license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ assets = [
   ["config/examples/*", "/etc/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/etc/systemd/system/vector.service", "644"]
 ]
+license-file = "target/debian-license.txt"
 extended-description-file = "target/debian-extended-description.txt"
 
 [workspace]

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+
+
+   ADDITIONAL NOTICES FOR DISTRIBUTIONS IN OBJECT FORM
+
+   1. This product includes software developed by the OpenSSL Project for
+      use in the OpenSSL Toolkit (http://www.openssl.org/).
+
+   2. This product includes cryptographic software written by Eric Young
+      (eay@cryptsoft.com).
+
+   ADDITIONAL NOTICES FOR DISTRIBUTIONS IN OBJECT FORM FOR WINDOWS
+
+   1. This product includes software written by Tim Hudson
+      (tjh@cryptsoft.com).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,7 @@
 
 
+   Copyright (c) 2019 Vector Authors <vector@timber.io>
+
    ADDITIONAL NOTICES FOR DISTRIBUTIONS IN OBJECT FORM
 
    1. This product includes software developed by the OpenSSL Project for

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -105,7 +105,8 @@ else
   suffix=""
 fi
 cp -av README.md $archive_dir/README.md$suffix
-cp -av LICENSE $archive_dir/LICENSE$suffix
+# Create the license file for binary distributions (LICENSE + NOTICE)
+cat LICENSE NOTICE > $archive_dir/LICENSE$suffix
 
 # Copy the vector binary to /bin
 mkdir -p $archive_dir/bin

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -36,6 +36,9 @@ cmark-gfm $project_root/README.md --to commonmark | # expand link aliases
   cmark-gfm --to plaintext | # convert to plain text
   fmt -uw 80 > $project_root/target/debian-extended-description.txt
 
+# Create the license file for binary distributions (LICENSE + NOTICE)
+cat LICENSE NOTICE > $project_root/target/debian-license.txt
+
 # Build the deb
 #
 #   --target


### PR DESCRIPTION
Closes #1348.

The name `NOTICE` is recommended by the Apache software foundation: http://www.apache.org/dev/licensing-howto.html.

I'm also thinking about including copyright information

```
Copyright (c) 2019 Vector Authors <vector@timber.io>
```

to the `NOTICE` file, as the `LICENSE` file is a standard Apache license file and doesn't contain any copyright information.