### PR TITLE
fix(operations): Put `etc` directory only to Linux archives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,6 @@ jobs:
             export RUSTFLAGS=-Ctarget-feature=+crt-static
             export FEATURES="default-msvc"
             export ARCHIVE_TYPE="zip"
-            export OS_FAMILY="windows"
             export STRIP="false"
             export RUST_LTO=""
             export TARGET="x86_64-pc-windows-msvc"

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -128,10 +128,10 @@ _old_dir=$(pwd)
 cd $target_dir
 if [ "$ARCHIVE_TYPE" == "tar.gz" ]; then
   tar czvf vector-$TARGET.$ARCHIVE_TYPE ./$archive_dir_name
-elif [ "$ARCHIVE_TYPE" == "zip" ] && [ "$OS_FAMILY" == "windows" ]; then
+elif [ "$ARCHIVE_TYPE" == "zip" ] && [[ $TARGET == *windows* ]]; then
   powershell '$progressPreference = "silentlyContinue"; Compress-Archive -DestinationPath vector-'$TARGET'.'$ARCHIVE_TYPE' -Path "./'$archive_dir_name'/*"'
 else
-  echo "Unsupported combination of ARCHIVE_TYPE and OS_FAMILY"
+  echo "Unsupported combination of ARCHIVE_TYPE and TARGET"
   exit 1
 fi
 cd $_old_dir

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -94,7 +94,7 @@ fi
 
 # Build the archive directory
 rm -rf $archive_dir
-mkdir -p $archive_dira
+mkdir -p $archive_dir
 
 # Copy root level files
 

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -14,14 +14,12 @@
 #   $STRIP - whether or not to strip the binary
 #   $TARGET - a target triple. ex: x86_64-apple-darwin
 #   $ARCHIVE_TYPE - archive type, either "tar.gz" or "zip"
-#   $OS_FAMILY - OS family, either "posix" or "windows"
 
 NATIVE_BUILD=${NATIVE_BUILD:-}
 RUST_LTO=${RUST_LTO:-}
 STRIP=${STRIP:-}
 FEATURES=${FEATURES:-}
 ARCHIVE_TYPE=${ARCHIVE_TYPE:-tar.gz}
-OS_FAMILY=${OS_FAMILY:-posix}
 
 if [ -z "$FEATURES" ]; then
     FEATURES="default"
@@ -96,10 +94,11 @@ fi
 
 # Build the archive directory
 rm -rf $archive_dir
-mkdir -p $archive_dir
+mkdir -p $archive_dira
 
 # Copy root level files
-if [ "$OS_FAMILY" == "windows" ]; then
+
+if [[ $TARGET == *windows* ]]; then
   suffix=".txt"
 else
   suffix=""
@@ -116,11 +115,13 @@ cp -rv config $archive_dir/config
 # Remove templates sources
 rm $archive_dir/config/*.erb
 
-# Copy /etc usefule files
-mkdir -p $archive_dir/etc/systemd
-cp -av distribution/systemd/vector.service $archive_dir/etc/systemd
-mkdir -p $archive_dir/etc/init.d
-cp -av distribution/init.d/vector $archive_dir/etc/init.d
+if [[ $TARGET == *linux* ]]; then
+  # Copy /etc useful files
+  mkdir -p $archive_dir/etc/systemd
+  cp -av distribution/systemd/vector.service $archive_dir/etc/systemd
+  mkdir -p $archive_dir/etc/init.d
+  cp -av distribution/init.d/vector $archive_dir/etc/init.d
+fi
 
 # Build the release archive
 _old_dir=$(pwd)


### PR DESCRIPTION
Putting `/etc` directory with init scripts to the archives is relevant only for Linux. This PR modifies the `build-archive.sh` script to not do it for other operating systems.