### PR TITLE
docs: Fix handling of locally-installed bundles

### DIFF
--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -137,7 +137,7 @@ end
 erb_paths =
   Dir.glob("#{ROOT_DIR}/**/*.erb", File::FNM_DOTMATCH).
   to_a.
-  filter { |path| !File.basename(path).start_with?("_") }
+  filter { |path| !File.basename(path).start_with?("_") && !path.include?("/bundle/") }
 
 #
 # Create missing .md files

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -137,7 +137,7 @@ end
 erb_paths =
   Dir.glob("#{ROOT_DIR}/**/*.erb", File::FNM_DOTMATCH).
   to_a.
-  filter { |path| !File.basename(path).start_with?("_") && !path.include?("/bundle/") }
+  filter { |path| !path.start_with?("#{ROOT_DIR}/scripts") }
 
 #
 # Create missing .md files


### PR DESCRIPTION
The docs generation script `scripts/generate.rb` recurses into all directories to find `.erb` files to transform. However, on some systems, the `bundle install` command in the `Makefile` will install the required gems into a `vendor` directory within the Vector source tree. This results in `scripts/generate.rb` attempting to generate docs in the gems, leading to errors.

Further, the source tree no longer stores any `.erb` files in the `scripts` directory, so just skip all of it.