### PR TITLE
chore(operations): Allow passing features to `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ bench: ## Run internal benchmarks
 	@cargo bench --all
 
 build: ## Build the project
-	@cargo build
+	@cargo build --no-default-features --features="$${FEATURES:-default}"
 
 check: check-code check-fmt check-generate check-examples
 


### PR DESCRIPTION
This makes it consistent with the way our build is [documented](https://vector.dev/docs/setup/installation/manual/from-source#feature-flags).