### PR TITLE
fix(operations): Fix `release-github` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -698,17 +698,15 @@ jobs:
           no_output_timeout: 30m
 
   release-github:
-    docker:
-      - image: timberiodev/vector-releaser:latest
+    <<: *docker-machine
     steps:
       - checkout
       - *restore-artifacts-from-workspace
       - run:
           name: Release Github
           command: |
-            export VERSION=$(make version)
-            echo "Releasing $VERSION..."
-            make release-github
+            export PASS_VERSION=$(make version)
+            ./scripts/docker-run.sh releaser make release-github
 
   release-homebrew:
     docker:

--- a/scripts/ci-docker-images/releaser/Dockerfile
+++ b/scripts/ci-docker-images/releaser/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:18.04
+FROM ruby:2.6
 
 # Install the git repository to ensure we get the latest version.
 # This is important for determining the current Vector version number.
 RUN apt-get update && \
   apt-get install -y software-properties-common
-
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24
 RUN add-apt-repository -y ppa:git-core/ppa
 
 RUN apt-get update && \


### PR DESCRIPTION
This uses the same `./scripts/docker-run.sh` approach as the `check-fmt` and other similar jobs.