### PR TITLE
fix(regex_parser transform): make truncation utf8-aware

### DIFF
--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -175,13 +175,15 @@ impl Transform for RegexParser {
     }
 }
 
+const ELLIPSIS: &str = "[...]";
+
 fn truncate_string_at(s: &str, maxlen: usize) -> Cow<str> {
     if s.len() >= maxlen {
-        let mut len = maxlen - "[...]".len();
+        let mut len = maxlen - ELLIPSIS.len();
         while !s.is_char_boundary(len) {
             len -= 1;
         }
-        format!("{}[...]", &s[..len]).into()
+        format!("{}{}", &s[..len], ELLIPSIS).into()
     } else {
         s.into()
     }

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -177,7 +177,11 @@ impl Transform for RegexParser {
 
 fn truncate_string_at(s: &str, maxlen: usize) -> Cow<str> {
     if s.len() >= maxlen {
-        format!("{}[...]", &s[..maxlen - 5]).into()
+        let mut len = maxlen - "[...]".len();
+        while !s.is_char_boundary(len) {
+            len -= 1;
+        }
+        format!("{}[...]", &s[..len]).into()
     } else {
         s.into()
     }
@@ -331,5 +335,11 @@ mod tests {
         assert_eq!(log[&"check".into()], ValueKind::Boolean(false));
         assert_eq!(log[&"status".into()], ValueKind::Integer(1234));
         assert_eq!(log[&"time".into()], ValueKind::Float(6789.01));
+    }
+
+    #[test]
+    fn regex_parser_truncate_utf8() {
+        let message = "hello 😁 this is test";
+        assert_eq!("hello [...]", super::truncate_string_at(&message, 13));
     }
 }


### PR DESCRIPTION
Closes #1349 

When a regex pattern fails to match, we log a warning message that contains the value of the field we tried to match against. To keep the logs tidy, we truncate that value to a reasonable length.

The bug was that our truncation function didn't take into account multi-byte UTF-8 characters. If the byte index at which we attempted to truncate was not at a Unicode character boundary (i.e. in the middle of a multi-byte character), the string slice operation would panic and cause Vector to shut down.