### PR TITLE
chore: Remove unneeded remove clones

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -99,7 +99,7 @@ impl FileServer {
         existing_files.sort_by_key(|(path, _file_id)| {
             fs::metadata(&path)
                 .and_then(|m| m.created())
-                .unwrap_or(time::SystemTime::now())
+                .unwrap_or_else(|_| time::SystemTime::now())
         });
 
         for (path, file_id) in existing_files {

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -65,14 +65,12 @@ impl FileWatcher {
             } else {
                 (Box::new(io::BufReader::new(MultiGzDecoder::new(reader))), 0)
             }
+        } else if too_old {
+            let pos = reader.seek(io::SeekFrom::End(0)).unwrap();
+            (Box::new(reader), pos)
         } else {
-            if too_old {
-                let pos = reader.seek(io::SeekFrom::End(0)).unwrap();
-                (Box::new(reader), pos)
-            } else {
-                let pos = reader.seek(io::SeekFrom::Start(file_position)).unwrap();
-                (Box::new(reader), pos)
-            }
+            let pos = reader.seek(io::SeekFrom::Start(file_position)).unwrap();
+            (Box::new(reader), pos)
         };
 
         Ok(FileWatcher {

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -15,8 +15,8 @@ use tracing_core::{
 };
 use tracing_subscriber::layer::{Context, Layer};
 
-const RATE_LIMIT_FIELD: &'static str = "rate_limit_secs";
-const MESSAGE_FIELD: &'static str = "message";
+const RATE_LIMIT_FIELD: &str = "rate_limit_secs";
+const MESSAGE_FIELD: &str = "message";
 const DEFAULT_LIMIT: u64 = 5;
 
 #[derive(Debug, Default)]
@@ -112,7 +112,7 @@ where
                 // check if the event exists within the map, if it does
                 // that means we are currently rate limiting it.
                 if let Some(state) = events.get(&id) {
-                    let start = state.start.unwrap_or_else(|| Instant::now());
+                    let start = state.start.unwrap_or_else(Instant::now);
 
                     if start.elapsed().as_secs() < state.limit {
                         if state.count.load(Ordering::Acquire) == 1 {

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -118,7 +118,7 @@ impl Metric {
                 },
             ) => {
                 if buckets == buckets2 && counts.len() == counts2.len() {
-                    for (i, c) in counts2.into_iter().enumerate() {
+                    for (i, c) in counts2.iter().enumerate() {
                         counts[i] += c;
                     }
                     *count += count2;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -69,7 +69,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         .map(|s| {
             s.split(',')
                 .map(|s| s.trim())
-                .filter(|s| s.len() > 0)
+                .filter(|s| !s.is_empty())
                 .collect()
         })
         .collect();
@@ -104,7 +104,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             sources.insert(name, example);
         }
 
-        if sources.len() > 0 {
+        if !sources.is_empty() {
             config.sources = Some(sources);
         }
     }
@@ -149,7 +149,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             );
         }
 
-        if transforms.len() > 0 {
+        if !transforms.is_empty() {
             config.transforms = Some(transforms);
         }
     }
@@ -179,13 +179,13 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
                         .last()
                         .map(|s| vec![s.to_owned()])
                         .or_else(|| {
-                            if source_names.len() > 0 {
+                            if !source_names.is_empty() {
                                 Some(source_names.clone())
                             } else {
                                 None
                             }
                         })
-                        .unwrap_or(vec!["TODO".to_owned()]),
+                        .unwrap_or_else(|| vec!["TODO".to_owned()]),
                     buffer: crate::buffers::BufferConfig::default(),
                     healthcheck: true,
                     inner: example,
@@ -193,12 +193,12 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             );
         }
 
-        if sinks.len() > 0 {
+        if !sinks.is_empty() {
             config.sinks = Some(sinks);
         }
     }
 
-    if errs.len() > 0 {
+    if !errs.is_empty() {
         errs.iter().for_each(|e| eprintln!("Generate error: {}", e));
         return exitcode::CONFIG;
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -64,9 +64,9 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         }
         Format::Json => {
             let list = EncodedList {
-                sources: sources,
-                transforms: transforms,
-                sinks: sinks,
+                sources,
+                transforms,
+                sinks,
             };
             println!("{}", serde_json::to_string(&list).unwrap());
         }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -350,10 +350,7 @@ fn partition(
         }
     };
 
-    let key = CloudwatchKey {
-        stream,
-        group: group.clone(),
-    };
+    let key = CloudwatchKey { stream, group };
 
     Some(PartitionInnerBuffer::new(event, key))
 }
@@ -380,7 +377,7 @@ fn healthcheck(config: CloudwatchLogsSinkConfig) -> crate::Result<super::Healthc
 
     let group_name = String::from_utf8_lossy(&config.group_name.get_ref()[..]).into_owned();
 
-    let client = create_client(config.region.clone().try_into()?)?;
+    let client = create_client(config.region.try_into()?)?;
 
     let request = DescribeLogGroupsRequest {
         limit: Some(1),

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -212,9 +212,9 @@ impl Service<Request> for S3Sink {
         self.client
             .put_object(PutObjectRequest {
                 body: Some(request.body.into()),
-                bucket: request.bucket.into(),
-                key: request.key.into(),
-                content_encoding: request.content_encoding.into(),
+                bucket: request.bucket,
+                key: request.key,
+                content_encoding: request.content_encoding,
                 ..Default::default()
             })
             .instrument(info_span!("request"))
@@ -257,8 +257,8 @@ fn build_request(
     );
 
     Request {
-        body: inner.into(),
-        bucket: bucket.clone(),
+        body: inner,
+        bucket,
         key,
         content_encoding: if gzip { Some("gzip".to_string()) } else { None },
     }

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -219,7 +219,7 @@ fn encode_namespace(namespace: &str, name: &str) -> String {
     }
 }
 
-fn stats(values: &Vec<f64>, counts: &Vec<u32>) -> Option<DatadogStats> {
+fn stats(values: &[f64], counts: &[u32]) -> Option<DatadogStats> {
     if values.len() != counts.len() {
         return None;
     }
@@ -351,7 +351,7 @@ fn encode_events(events: Vec<Metric>, interval: i64, namespace: &str) -> Datadog
                         r#type: DatadogMetricType::Gauge,
                         interval: None,
                         points: vec![DatadogPoint(ts, values.len() as f64)],
-                        tags: tags.clone(),
+                        tags,
                     }]),
                     _ => None,
                 },
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn test_dense_stats() {
         // https://github.com/DataDog/dd-agent/blob/master/tests/core/test_histogram.py
-        let values = (0..20).into_iter().map(f64::from).collect();
+        let values = (0..20).into_iter().map(f64::from).collect::<Vec<_>>();
         let counts = vec![1; 20];
 
         assert_eq!(
@@ -513,8 +513,8 @@ mod tests {
 
     #[test]
     fn test_sparse_stats() {
-        let values = (1..5).into_iter().map(f64::from).collect();
-        let counts = (1..5).into_iter().collect();
+        let values = (1..5).into_iter().map(f64::from).collect::<Vec<_>>();
+        let counts = (1..5).into_iter().collect::<Vec<_>>();
 
         assert_eq!(
             stats(&values, &counts),

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -178,7 +178,7 @@ fn http(
             request
         });
 
-    let encoding = config.encoding.clone();
+    let encoding = config.encoding;
     let sink = request
         .batch_sink(HttpRetryLogic, http_service, cx.acker())
         .batched_with_min(Buffer::new(gzip), &batch)

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -163,7 +163,7 @@ impl PrometheusSink {
             f(counter);
         } else {
             let namespace = &self.config.namespace;
-            let opts = prometheus::Opts::new(name.clone(), name.clone()).namespace(namespace);
+            let opts = prometheus::Opts::new(name, name).namespace(namespace);
             let keys: Vec<_> = labels.keys().copied().collect();
             let counter = prometheus::CounterVec::new(opts, &keys[..]).unwrap();
             if let Err(e) = self.registry.register(Box::new(counter.clone())) {
@@ -184,7 +184,7 @@ impl PrometheusSink {
             f(gauge);
         } else {
             let namespace = &self.config.namespace;
-            let opts = prometheus::Opts::new(name.clone(), name.clone()).namespace(namespace);
+            let opts = prometheus::Opts::new(name, name).namespace(namespace);
             let keys: Vec<_> = labels.keys().copied().collect();
             let gauge = prometheus::GaugeVec::new(opts, &keys[..]).unwrap();
             if let Err(e) = self.registry.register(Box::new(gauge.clone())) {
@@ -206,7 +206,7 @@ impl PrometheusSink {
         } else {
             let buckets = self.config.buckets.clone();
             let namespace = &self.config.namespace;
-            let opts = prometheus::HistogramOpts::new(name.clone(), name.clone())
+            let opts = prometheus::HistogramOpts::new(name, name)
                 .buckets(buckets)
                 .namespace(namespace);
             let keys: Vec<_> = labels.keys().copied().collect();
@@ -230,7 +230,7 @@ impl PrometheusSink {
             f(set);
         } else {
             let namespace = &self.config.namespace;
-            let opts = prometheus::Opts::new(name.clone(), name.clone()).namespace(namespace);
+            let opts = prometheus::Opts::new(name, name).namespace(namespace);
             let keys: Vec<_> = labels.keys().copied().collect();
             let counter = prometheus::IntGaugeVec::new(opts, &keys[..]).unwrap();
             if let Err(e) = self.registry.register(Box::new(counter.clone())) {
@@ -240,7 +240,7 @@ impl PrometheusSink {
             // Send counter to flusher
             if let Some(ch) = self.flush_channel.as_mut() {
                 let c = counter.with_label_values(&keys[..]);
-                if let Err(e) = ch.send(c.clone()) {
+                if let Err(e) = ch.send(c) {
                     error!("Error sending Prometheus gauge to flusher: {}", e);
                 }
             }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -123,7 +123,7 @@ impl Batch for MetricBuffer {
                     // and emit the difference between previous and current as a Counter
                     let delta = MetricEntry(Metric {
                         name: item.name.to_string(),
-                        timestamp: item.timestamp.clone(),
+                        timestamp: item.timestamp,
                         tags: item.tags.clone(),
                         kind: MetricKind::Incremental,
                         value: MetricValue::Counter {
@@ -158,7 +158,7 @@ impl Batch for MetricBuffer {
                         // Otherwise we start from zero value
                         Metric {
                             name: item.name.to_string(),
-                            timestamp: item.timestamp.clone(),
+                            timestamp: item.timestamp,
                             tags: item.tags.clone(),
                             kind: MetricKind::Absolute,
                             value: MetricValue::Gauge { value: 0.0 },

--- a/src/sources/kubernetes/mod.rs
+++ b/src/sources/kubernetes/mod.rs
@@ -28,7 +28,7 @@ use string_cache::DefaultAtom as Atom;
 // LogPath = `containerName/Instance#.log`
 
 /// Location in which by Kubernetes CRI, container runtimes are to store logs.
-const LOG_DIRECTORY: &'static str = r"/var/log/pods/";
+const LOG_DIRECTORY: &str = r"/var/log/pods/";
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -185,10 +185,10 @@ pub fn unix(
                 let host_key = host_key.clone();
 
                 let span = info_span!("connection");
-                let path = if let Some(addr) = peer_addr.clone() {
+                let path = if let Some(addr) = peer_addr {
                     if let Some(path) = addr.as_pathname().map(|e| e.to_owned()) {
                         span.record("peer_path", &field::debug(&path));
-                        Some(path.clone())
+                        Some(path)
                     } else {
                         None
                     }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -78,7 +78,7 @@ pub fn check(config: &super::Config) -> Result<Vec<String>, Vec<String>> {
     }
 
     if config.contains_cycle() {
-        errors.push(format!("Configured topology contains a cycle"));
+        errors.push("Configured topology contains a cycle".to_string());
     } else if let Err(type_errors) = config.typecheck() {
         errors.extend(type_errors);
     }

--- a/src/topology/config/component.rs
+++ b/src/topology/config/component.rs
@@ -34,7 +34,7 @@ where
         B: Serialize + Deserialize<'de>,
     {
         ComponentDescription {
-            type_str: type_str,
+            type_str,
             example_value: || {
                 toml::from_str::<B>("")
                     .ok()
@@ -52,7 +52,7 @@ where
         B: Default + Serialize + Deserialize<'de>,
     {
         ComponentDescription {
-            type_str: type_str,
+            type_str,
             example_value: || Value::try_from(B::default()).ok(),
             component_type: PhantomData,
         }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -405,11 +405,11 @@ impl RunningTopology {
         }
     }
 
-    fn setup_outputs(&mut self, name: &String, new_pieces: &mut builder::Pieces) {
+    fn setup_outputs(&mut self, name: &str, new_pieces: &mut builder::Pieces) {
         let output = new_pieces.outputs.remove(name).unwrap();
 
         for (sink_name, sink) in &self.config.sinks {
-            if sink.inputs.contains(name) {
+            if sink.inputs.iter().any(|i| i == name) {
                 output
                     .unbounded_send(fanout::ControlMessage::Add(
                         sink_name.clone(),
@@ -419,7 +419,7 @@ impl RunningTopology {
             }
         }
         for (transform_name, transform) in &self.config.transforms {
-            if transform.inputs.contains(name) {
+            if transform.inputs.iter().any(|i| i == name) {
                 output
                     .unbounded_send(fanout::ControlMessage::Add(
                         transform_name.clone(),

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -161,7 +161,7 @@ fn build_unit_test(
         "raw" => match definition.input.value.as_ref() {
             Some(v) => Event::from(v.clone()),
             None => {
-                errors.push(format!("input type 'raw' requires the field 'value'"));
+                errors.push("input type 'raw' requires the field 'value'".to_string());
                 Event::from("")
             }
         },
@@ -181,7 +181,7 @@ fn build_unit_test(
                 }
                 event
             } else {
-                errors.push(format!("input type 'log' requires the field 'log_fields'"));
+                errors.push("input type 'log' requires the field 'log_fields'".to_string());
                 Event::from("")
             }
         }
@@ -189,7 +189,7 @@ fn build_unit_test(
             if let Some(metric) = &definition.input.metric {
                 Event::Metric(metric.clone())
             } else {
-                errors.push(format!("input type 'log' requires the field 'log_fields'"));
+                errors.push("input type 'log' requires the field 'log_fields'".to_string());
                 Event::from("")
             }
         }
@@ -244,7 +244,7 @@ fn build_unit_test(
                     transforms.insert(
                         name.clone(),
                         UnitTestTransform {
-                            transform: transform,
+                            transform,
                             next: outputs.into_iter().map(|(k, _)| k).collect(),
                         },
                     );
@@ -294,7 +294,7 @@ fn build_unit_test(
         }
         UnitTestCheck{
             extract_from: o.extract_from.clone(),
-            conditions: conditions,
+            conditions,
         }
     }).collect();
 
@@ -304,8 +304,8 @@ fn build_unit_test(
         Ok(UnitTest {
             name: definition.name.clone(),
             input: (definition.input.insert_at.clone(), input_event),
-            transforms: transforms,
-            checks: checks,
+            transforms,
+            checks,
         })
     }
 }

--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -57,9 +57,9 @@ impl TransformConfig for GeoipConfig {
 impl Geoip {
     pub fn new(dbreader: maxminddb::Reader<Vec<u8>>, source: Atom, target: String) -> Self {
         Geoip {
-            dbreader: dbreader,
-            source: source,
-            target: target,
+            dbreader,
+            source,
+            target,
         }
     }
 }
@@ -87,7 +87,7 @@ impl Transform for Geoip {
                     if let Some(continent_code) = continent_code {
                         event.as_mut_log().insert_explicit(
                             Atom::from(format!("{}.continent_code", target_field)),
-                            ValueKind::from(continent_code.to_string()),
+                            ValueKind::from(continent_code),
                         );
                     }
 
@@ -95,7 +95,7 @@ impl Transform for Geoip {
                     if let Some(iso_code) = iso_code {
                         event.as_mut_log().insert_explicit(
                             Atom::from(format!("{}.country_code", target_field)),
-                            ValueKind::from(iso_code.to_string()),
+                            ValueKind::from(iso_code),
                         );
                     }
 
@@ -103,7 +103,7 @@ impl Transform for Geoip {
                     if let Some(time_zone) = time_zone {
                         event.as_mut_log().insert_explicit(
                             Atom::from(format!("{}.timezone", target_field)),
-                            ValueKind::from(time_zone.to_string()),
+                            ValueKind::from(time_zone),
                         );
                     }
 
@@ -127,7 +127,7 @@ impl Transform for Geoip {
                     if let Some(postal_code) = postal_code {
                         event.as_mut_log().insert_explicit(
                             Atom::from(format!("{}.postal_code", target_field)),
-                            ValueKind::from(postal_code.to_string()),
+                            ValueKind::from(postal_code),
                         );
                     }
                 }

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -46,7 +46,7 @@ fn build_tests(path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
 
-    let paths = if opts.paths.len() > 0 {
+    let paths = if !opts.paths.is_empty() {
         &opts.paths
     } else {
         &DEFAULT_CONFIG_PATHS
@@ -55,7 +55,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     for (i, p) in paths.iter().enumerate() {
         let path_str = p.to_str().unwrap_or("");
         if i > 0 {
-            println!("");
+            println!();
         }
         println!("Running {} tests", path_str);
         match build_tests(p) {


### PR DESCRIPTION
When through to try and familiarize myself with the code, cleaned up a few things along the way.

- Removed unnecessary clones where I could find them
- In a few spots used closures to prevent `_or` param from being strictly evaluated
- simplified an if-else clause
- len() > 0 == !is_empty()
- &String -> &str (so the function can take both owned Strings and slices)
- redundant `into()` calls

Random question: I had some trouble building where I got a rustup error like `some components unavailable for download for channel 1.39.0: 'lldb-preview', 'miri'`. I don't get this error on `cargo build` in any other project. Am I not building the project correctly?