### PR TITLE
fix(sampler transform): Make pass_list field optional

### DIFF
--- a/config/examples/docs_example.toml
+++ b/config/examples/docs_example.toml
@@ -18,7 +18,6 @@ data_dir = "/var/lib/vector"
   inputs       = ["apache_parser"]
   type         = "sampler"
   rate         = 50                            # only keep 50%
-  pass_list    = []
 
 # Send structured data to a short-term storage
 [sinks.es_cluster]

--- a/src/transforms/sampler.rs
+++ b/src/transforms/sampler.rs
@@ -13,6 +13,7 @@ use string_cache::DefaultAtom as Atom;
 #[serde(deny_unknown_fields)]
 pub struct SamplerConfig {
     pub rate: u64,
+    #[serde(default)]
     pub pass_list: Vec<String>,
 }
 

--- a/website/docs/setup/configuration.md
+++ b/website/docs/setup/configuration.md
@@ -48,7 +48,6 @@ data_dir = "/var/lib/vector"
   inputs       = ["apache_parser"]
   type         = "sampler"
   rate         = 50                            # only keep 50%
-  pass_list    = []
 
 # Send structured data to a short-term storage
 [sinks.es_cluster]


### PR DESCRIPTION
The field `pass_list` is documented as optional so this updates the transform to match that.