### PR TITLE
chore(operations): Add aliases for latest major and minor versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,7 +773,6 @@ jobs:
       - run:
           name: Release S3
           command: |
-            export VERSION=$(make version)
             echo "Releasing $VERSION..."
             make release-s3
 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -43,13 +43,17 @@ docker buildx create --use --name vector-builder
 docker buildx install
 
 if [[ "$CHANNEL" == "latest" ]]; then
-  build alpine latest
-  build alpine $VERSION
-  build debian latest
-  build debian $VERSION
+  version_exact=$VERSION
+  version_minor_x=$(echo $VERSION | sed 's/\.[0-9]*$/.X/g')
+  version_major_x=$(echo $VERSION | sed 's/\.[0-9]*\.[0-9]*$/.X/g')
+
+  for i in $version_exact $version_minor_x $version_major_x latest; do
+    build alpine $i
+    build debin $i
+  done
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  build alpine nightly
-  build alpine nightly-$DATE
-  build debian nightly
-  build debian nightly-$DATE
+  for i in nightly-$DATE nightly; do
+    build alpine $i
+    build debian $i
+  done
 fi

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -49,7 +49,7 @@ if [[ "$CHANNEL" == "latest" ]]; then
 
   for i in $version_exact $version_minor_x $version_major_x latest; do
     build alpine $i
-    build debin $i
+    build debian $i
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
   for i in nightly-$DATE nightly; do

--- a/scripts/util/version.rb
+++ b/scripts/util/version.rb
@@ -25,8 +25,16 @@ class Version < Gem::Version
     segments[0]
   end
 
+  def major_x
+    "#{segments[0]}.X"
+  end
+
   def minor
     segments[1]
+  end
+
+  def minor_x
+    "#{segments[0]}.#{segments[1]}.X"
   end
 
   def patch

--- a/website/docs/setup/installation/manual/from-archives.md
+++ b/website/docs/setup/installation/manual/from-archives.md
@@ -56,7 +56,7 @@ import TabItem from '@theme/TabItem';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.0/vector-x86_64-unknown-linux-musl.tar.gz | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.X/vector-x86_64-unknown-linux-musl.tar.gz | \
       tar xzf - -C vector --strip-components=2
     ```
 
@@ -112,7 +112,7 @@ import TabItem from '@theme/TabItem';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.0/vector-aarch64-unknown-linux-musl.tar.gz | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.X/vector-aarch64-unknown-linux-musl.tar.gz | \
       tar xzf - -C vector --strip-components=2
     ```
 
@@ -168,7 +168,7 @@ import TabItem from '@theme/TabItem';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.0/vector-armv7-unknown-linux-musleabihf.tar.gz | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.X/vector-armv7-unknown-linux-musleabihf.tar.gz | \
       tar xzf - -C vector --strip-components=2
     ```
 
@@ -224,7 +224,7 @@ import TabItem from '@theme/TabItem';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.0/vector-x86_64-apple-darwin.tar.gz | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.6.X/vector-x86_64-apple-darwin.tar.gz | \
       tar xzf - -C vector --strip-components=2
     ```
 
@@ -279,7 +279,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bat
-    powershell Invoke-WebRequest https://packages.timber.io/vector/0.6.0/vector-x86_64-pc-windows-msvc.zip -OutFile vector-x86_64-pc-windows-msvc.zip
+    powershell Invoke-WebRequest https://packages.timber.io/vector/0.6.X/vector-x86_64-pc-windows-msvc.zip -OutFile vector-x86_64-pc-windows-msvc.zip
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/manual/from-archives.md.erb
+++ b/website/docs/setup/installation/manual/from-archives.md.erb
@@ -48,7 +48,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bat
-    powershell Invoke-WebRequest <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version}/#{download.file_name}") %> -OutFile <%= download.file_name %>
+    powershell Invoke-WebRequest <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version.minor_x}/#{download.file_name}") %> -OutFile <%= download.file_name %>
     ```
 
     </TabItem>
@@ -94,7 +94,7 @@ import TabItem from '@theme/TabItem';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version}/#{download.file_name}") %> | \
+      curl -sSfL --proto '=https' --tlsv1.2 <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version.minor_x}/#{download.file_name}") %> | \
       tar xzf - -C vector --strip-components=2
     ```
 

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -67,7 +67,7 @@ import Tabs from '@theme/Tabs';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.6.0 | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.6.X | \
       tar xzf - -C vector --strip-components=1
     ```
 
@@ -230,7 +230,7 @@ Building steps:
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.6.0 | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.6.X | \
       tar xzf - -C vector --strip-components=1
     ```
 

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -55,7 +55,7 @@ import Tabs from '@theme/Tabs';
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version %> | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version.minor_x %> | \
       tar xzf - -C vector --strip-components=1
     ```
 
@@ -158,7 +158,7 @@ Building steps:
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version %> | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version.minor_x %> | \
       tar xzf - -C vector --strip-components=1
     ```
 

--- a/website/docs/setup/installation/package-managers/dpkg.md
+++ b/website/docs/setup/installation/package-managers/dpkg.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.0/vector-amd64.deb 
+    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.X/vector-amd64.deb 
     ```
 
     </TabItem>
@@ -86,7 +86,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.0/vector-arm64.deb 
+    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.X/vector-arm64.deb 
     ```
 
     </TabItem>
@@ -129,7 +129,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.0/vector-armhf.deb 
+    curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/0.6.X/vector-armhf.deb 
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/package-managers/dpkg.md.erb
+++ b/website/docs/setup/installation/package-managers/dpkg.md.erb
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -O <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version}/#{download.file_name}") %> 
+    curl --proto '=https' --tlsv1.2 -O <%= metadata.links.fetch("urls.vector_downloads.#{metadata.latest_version.minor_x}/#{download.file_name}") %> 
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/package-managers/msi.md
+++ b/website/docs/setup/installation/package-managers/msi.md
@@ -42,7 +42,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bat
-    powershell Invoke-WebRequest https://packages.timber.io/vector/0.6.0/vector-x64.msi -OutFile vector-x64.msi
+    powershell Invoke-WebRequest https://packages.timber.io/vector/0.6.X/vector-x64.msi -OutFile vector-x64.msi
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/package-managers/msi.md.erb
+++ b/website/docs/setup/installation/package-managers/msi.md.erb
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bat
-    powershell Invoke-WebRequest [[[urls.vector_downloads.<%= metadata.latest_version %>/<%= download.file_name %>]]] -OutFile <%= download.file_name %>
+    powershell Invoke-WebRequest [[[urls.vector_downloads.<%= metadata.latest_version.minor_x %>/<%= download.file_name %>]]] -OutFile <%= download.file_name %>
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/package-managers/rpm.md
+++ b/website/docs/setup/installation/package-managers/rpm.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl -O https://packages.timber.io/vector/0.6.0/vector-x86_64.rpm
+    curl -O https://packages.timber.io/vector/0.6.X/vector-x86_64.rpm
     ```
 
     </TabItem>
@@ -88,7 +88,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl -O https://packages.timber.io/vector/0.6.0/vector-aarch64.rpm
+    curl -O https://packages.timber.io/vector/0.6.X/vector-aarch64.rpm
     ```
 
     </TabItem>
@@ -133,7 +133,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl -O https://packages.timber.io/vector/0.6.0/vector-armv7hl.rpm
+    curl -O https://packages.timber.io/vector/0.6.X/vector-armv7hl.rpm
     ```
 
     </TabItem>

--- a/website/docs/setup/installation/package-managers/rpm.md.erb
+++ b/website/docs/setup/installation/package-managers/rpm.md.erb
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="latest">
 
     ```bash
-    curl -O [[[urls.vector_downloads.<%= metadata.latest_version %>/<%= download.file_name %>]]]
+    curl -O [[[urls.vector_downloads.<%= metadata.latest_version.minor_x %>/<%= download.file_name %>]]]
     ```
 
     </TabItem>


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/1255.

Note about the docs: the tabs titles still display exact versions, but the installation commands use `0.6.X`:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/1885277/71105020-e1e33e80-21cd-11ea-8ffc-b85e4c3a6423.png">
