### PR TITLE
fix(operations): Use Bundler 2.0.x for the checker and releaser images

### DIFF
--- a/scripts/ci-docker-images/checker/Dockerfile
+++ b/scripts/ci-docker-images/checker/Dockerfile
@@ -13,7 +13,7 @@ RUN rustup component add rustfmt
 
 # Install Ruby dependencies
 ENV LC_ALL C.UTF-8
-RUN gem install bundler
+RUN gem install bundler -v '~> 2.0.0'
 COPY checker/Gemfile Gemfile
 RUN bundle install
 RUN rm Gemfile

--- a/scripts/ci-docker-images/releaser/Dockerfile
+++ b/scripts/ci-docker-images/releaser/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get remove docker docker-engine docker.io
 RUN apt-get update && apt-get install -y docker.io
 
 # Install gems to reduce setup time
-RUN gem install bundler
+RUN gem install bundler -v '~> 2.0.0'
 COPY checker/Gemfile Gemfile
 RUN bundle install
 RUN rm Gemfile


### PR DESCRIPTION
Release of Bunder 2.1 broke our `checker` and `releaser` Docker images, which used Bundler 2.0.

This PR forces installation of Bundler 2.0.x instead of the latest 2.1.x. The possible reason of the failures is the fact that 2.1 turned off all deprecated features by default (see [the release notes](https://github.com/bundler/bundler/releases/tag/v2.1.0)).

Going further, I think we need to migrate our Docker images to Bundler 2.1, which is represented by issue https://github.com/timberio/vector/issues/1393.