### PR TITLE
chore(networking): Add custom dns for `vector` and `tcp` sinks

### DIFF
--- a/src/sinks/tcp.rs
+++ b/src/sinks/tcp.rs
@@ -13,7 +13,7 @@ use futures::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::{
     codec::{BytesCodec, FramedWrite},
@@ -34,6 +34,10 @@ enum BuildError {
     TlsIdentityError { source: native_tls::Error },
     #[snafu(display("Could not export identity to DER: {}", source))]
     DerExportError { source: openssl::error::ErrorStack },
+    #[snafu(display("Missing host in address field"))]
+    MissingHost,
+    #[snafu(display("Missing port in address field"))]
+    MissingPort,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -76,14 +80,22 @@ inventory::submit! {
 #[typetag::serde(name = "tcp")]
 impl SinkConfig for TcpSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let addr = self
-            .address
-            .to_socket_addrs()
-            .context(super::SocketAddressError)?
+        let uri = self.address.parse::<http::Uri>()?;
+
+        let ip_addr = cx
+            .resolver()
+            .lookup_ip(uri.host().ok_or(BuildError::MissingHost)?)
+            // This is fine to do here because this is just receiving on a channel
+            // and does not require access to the reactor/timer.
+            .wait()
+            .context(super::DNSError)?
             .next()
             .ok_or(Box::new(super::BuildError::DNSFailure {
                 address: self.address.clone(),
             }))?;
+
+        let port = uri.port_part().ok_or(BuildError::MissingPort)?.as_u16();
+        let addr = SocketAddr::new(ip_addr, port);
 
         let tls = match self.tls {
             Some(ref tls) => {

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -11,7 +11,7 @@ use futures::{future, Future, Sink};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -26,6 +26,14 @@ impl VectorSinkConfig {
     }
 }
 
+#[derive(Debug, Snafu)]
+enum BuildError {
+    #[snafu(display("Missing host in address field"))]
+    MissingHost,
+    #[snafu(display("Missing port in address field"))]
+    MissingPort,
+}
+
 inventory::submit! {
     SinkDescription::new_without_default::<VectorSinkConfig>("vector")
 }
@@ -33,14 +41,22 @@ inventory::submit! {
 #[typetag::serde(name = "vector")]
 impl SinkConfig for VectorSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let addr = self
-            .address
-            .to_socket_addrs()
-            .context(super::SocketAddressError)?
+        let uri = self.address.parse::<http::Uri>()?;
+
+        let ip_addr = cx
+            .resolver()
+            .lookup_ip(uri.host().ok_or(BuildError::MissingHost)?)
+            // This is fine to do here because this is just receiving on a channel
+            // and does not require access to the reactor/timer.
+            .wait()
+            .context(super::DNSError)?
             .next()
             .ok_or(Box::new(super::BuildError::DNSFailure {
                 address: self.address.clone(),
             }))?;
+
+        let port = uri.port_part().ok_or(BuildError::MissingPort)?.as_u16();
+        let addr = SocketAddr::new(ip_addr, port);
 
         let sink = vector(self.address.clone(), addr, cx.acker());
         let healthcheck = super::tcp::tcp_healthcheck(addr);


### PR DESCRIPTION
Related to #1307 