### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Set some common grounds for the file styling rules.
See https://editorconfig.org.

So far only rust (`.rs`) rules are added, we can add more (i.e. `.sh`, `.md`) as we see fit.