### PR TITLE
docs: Remove duplicated string from the installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@
   <img src="./website/static/img/readme_diagram.svg" alt="Vector">
 </p>
 
----
-
-<p align="center">
-  <strong>
-    New post! <a href="https://vector.dev/blog/unit-testing-vector-config-files">Unit Testing Your Vector Config Files</a>
-  </strong>
-</p>
-
----
 
 Vector is a [high-performance][pages.index#performance] observability data router. It
 makes [collecting][docs.sources], [transforming][docs.transforms], and

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -40,9 +40,7 @@ import Tabs from '@theme/Tabs';
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
     ```
 
-2. Install C++ toolchain
-
-    Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
+2.  Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
     on your system.
 
 3.  Create the `vector` directory

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -30,9 +30,7 @@ import Tabs from '@theme/Tabs';
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
     ```
 
-2. Install C++ toolchain
-
-    Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
+2.  Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
     on your system.
 
 3.  Create the `vector` directory


### PR DESCRIPTION
Removes some duplication from the item about installation of C and C++ toolchains.