### PR TITLE
fix(buffers): Don't ack with zero items

### DIFF
--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -187,9 +187,11 @@ impl<S: Sink> Sink for DropWhenFull<S> {
 
 #[cfg(test)]
 mod test {
-    use super::DropWhenFull;
+    use super::{Acker, DropWhenFull};
     use crate::test_util::block_on;
-    use futures::{future, sync::mpsc, Async, AsyncSink, Sink, Stream};
+    use futures::{future, sync::mpsc, task::AtomicTask, Async, AsyncSink, Sink, Stream};
+    use std::sync::{atomic::AtomicUsize, Arc};
+    use tokio01_test::task::MockTask;
 
     #[test]
     fn drop_when_full() {
@@ -211,5 +213,22 @@ mod test {
             future::ok(())
         }))
         .unwrap();
+    }
+
+    #[test]
+    fn ack_with_none() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let task = Arc::new(AtomicTask::new());
+        let acker = Acker::Disk(counter, task.clone());
+
+        let mut mock = MockTask::new();
+
+        mock.enter(|| task.register());
+
+        assert!(!mock.is_notified());
+        acker.ack(0);
+        assert!(!mock.is_notified());
+        acker.ack(1);
+        assert!(mock.is_notified());
     }
 }

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -138,11 +138,14 @@ impl Acker {
     // This is primary used by the on-disk buffer to know which events are okay to
     // delete from disk.
     pub fn ack(&self, num: usize) {
-        match self {
-            Acker::Null => {}
-            Acker::Disk(counter, notifier) => {
-                counter.fetch_add(num, Ordering::Relaxed);
-                notifier.notify();
+        // Only ack items if the amount to ack is larger than zero.
+        if num > 0 {
+            match self {
+                Acker::Null => {}
+                Acker::Disk(counter, notifier) => {
+                    counter.fetch_add(num, Ordering::Relaxed);
+                    notifier.notify();
+                }
             }
         }
     }


### PR DESCRIPTION
This change allows the `Acker::ack` api to be more user friendly
by allowing users to ack zero items without forwarding that ack to
the inner buffer type.

Allowing the `Acker::ack` api to be more user friendly fixes a bug
when using the `StreamAck` sink combinator that would cause CPU usage
of vector to rise to unreasonable levels even when the sink is idle
(no events being processed). The root cause of this issue can be broken
up into two main problems. 1) `StreamAck<T>` would call `Acker::ack`
anytime the inner `Sink` type `T` would return `Ok(Async::Ready)` when
calling its `Sink::poll_complete`. This would cause `Acker::ack` to be
called with `0` pending items to ack. 2) When the buffer type was `Disk`
it would increase the counter by the ack amount and would notify the
writer task via `AtomicTask::notify` even if there were no items to ack.

The high CPU usage is related to #2 because of how we setup buffering
with our topology. We currently allow our buffers to create a writer and
reader end. The reader end implements `Stream` which we then pair with
the actual sink via `Stream::forward`. The reader and writer task for
the disk buffer use a shared `AtomicTask` that gets notified in two
places, 1) `Acker::ack` and 2) `Reader::deleted_acks`. The `AtomicTask`
also gets registered within the `Stream::poll` implementation of
reader. This means that the paired `reader.forward(sink)` future that is
done within `topology::builder` would cause this `AtomicTask` to be
registered with the overall sink task. Thus anytime we notified
the `AtomicTask` we would poll all the way into the inner sink via
`StreamAck` and `buffers::disk::Reader`.

As I mentioned above we were repeatedly calling `Acker::ack` which would
call `AtomicTask::notify` even if there were no events to notify. This
would cause the entire `Sink` task to be queued to be polled again. Which
then would cause us to, again, ack with zero items. This basically
caused a busy loop where we were doing no actual work but were not able
to break out of the loop (its not really a loop but the tokio executor
would basically keep attempting to poll our task).

Another thing to notice is that we would then call
`leveldb::Database::get` on each `poll` call to `disk::Reader` which we
have wrapped with a `tokio_threadpool::blocking` call. Again, this call
will force tokio to spawn a new thread and migrate the task queue. This
would happen even if we knew for a fact that we would get nothing back
and would therefore waste many empty disk/cpu cycles.

In conclusion, this fix changes the `Acker::ack` api to accept `0`
pending acks with no side effects. I choose to change the `Acker::ack`
implementation rather than the naive `StreamAck` implementation to
prevent future misuse of the api.

### CPU Usage

This shows vector running with zero events being fed through it with the config below:

```toml
data_dir = "/tmp/vector"

[sources.tcp_in]
  type = "tcp"
  address = "127.0.0.1:8080"

[sinks.tcp_out]
  type = "tcp"
  inputs = ["tcp_in"]
  address = "localhost:8081"
  encoding = "json"

[sinks.tcp_out.buffer]
  type = "disk"
  max_size = 104900
  when_full = "block"
```

#### Before

![image](https://user-images.githubusercontent.com/5758045/71601397-4339d480-2b21-11ea-87b7-3deb5e1012c5.png)


#### After

![image](https://user-images.githubusercontent.com/5758045/71601357-1daccb00-2b21-11ea-9253-538cbf6ae221.png)



Closes #1179

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
