### PR TITLE
docs: Document `endpoint` parameter for `aws_s3` sink

### DIFF
--- a/.meta/links.toml
+++ b/.meta/links.toml
@@ -31,6 +31,7 @@ aws_kinesis_streams_service_limits = "https://docs.aws.amazon.com/streams/latest
 aws_kinesis_firehose_service_limits = "https://docs.aws.amazon.com/firehose/latest/dev/limits.html"
 aws_kinesis_split_shards = "https://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding-split.html"
 aws_s3 = "https://aws.amazon.com/s3/"
+aws_s3_endpoints = "https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_endpoint"
 aws_s3_regions = "https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
 aws_s3_service_limits = "https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html"
 basic_auth = "https://en.wikipedia.org/wiki/Basic_access_authentication"

--- a/.meta/sinks/aws_s3.toml
+++ b/.meta/sinks/aws_s3.toml
@@ -80,5 +80,12 @@ description = "A prefix to apply to all object key names. This should be used to
 type = "string"
 common = true
 examples = ["us-east-1"]
-null = false
-description = "The [AWS region][urls.aws_s3_regions] of the target S3 bucket."
+null = true
+description = "The [AWS region][urls.aws_s3_regions] of the target S3 bucket. Either \"region\" or \"endpoint\" must be specified."
+
+[sinks.aws_s3.options.endpoint]
+type = "string"
+common = false
+examples = ["https://s3.us-east-1.amazonaws.com"]
+null = true
+description = "The [endpoint][urls.aws_s3_endpoints] of the target S3 bucket. Either \"endpoint\" or \"region\" must be specified."

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2008,11 +2008,13 @@ end
   compression = "gzip"
   compression = "none"
 
-  # The AWS region of the target S3 bucket.
+  # The endpoint of the target S3 bucket. Either "endpoint" or "region" must be
+  # specified.
   #
-  # * required
+  # * optional
+  # * no default
   # * type: string
-  region = "us-east-1"
+  endpoint = "https://my-bucket.us-east-1.amazonaws.com"
 
   # Enables/disables the sink healthcheck upon start.
   #
@@ -2021,6 +2023,14 @@ end
   # * type: bool
   healthcheck = true
   healthcheck = false
+
+  # The AWS region of the target S3 bucket. Either "region" or "endpoint" must be
+  # specified.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  region = "us-east-1"
 
   #
   # requests

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2014,7 +2014,7 @@ end
   # * optional
   # * no default
   # * type: string
-  endpoint = "https://my-bucket.us-east-1.amazonaws.com"
+  endpoint = "https://s3.us-east-1.amazonaws.com"
 
   # Enables/disables the sink healthcheck upon start.
   #

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -77,7 +77,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   encoding = "ndjson" # example, enum
 
   # OPTIONAL - General
-  endpoint = "https://my-bucket.us-east-1.amazonaws.com" # example, no default
+  endpoint = "https://s3.us-east-1.amazonaws.com" # example, no default
   healthcheck = true # default
   region = "us-east-1" # example, no default
 
@@ -358,7 +358,7 @@ The encoding format used to serialize the events before outputting.
   common={false}
   defaultValue={null}
   enumValues={null}
-  examples={["https://my-bucket.us-east-1.amazonaws.com"]}
+  examples={["https://s3.us-east-1.amazonaws.com"]}
   name={"endpoint"}
   nullable={true}
   path={null}

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -49,10 +49,12 @@ import CodeHeader from '@site/src/components/CodeHeader';
   inputs = ["my-source-id"] # example
   bucket = "my-bucket" # example
   compression = "gzip" # example, enum
-  region = "us-east-1" # example
 
   # REQUIRED - requests
   encoding = "ndjson" # example, enum
+
+  # OPTIONAL - General
+  region = "us-east-1" # example, no default
 
   # OPTIONAL - Object Names
   key_prefix = "date=%F/" # default
@@ -70,13 +72,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
   inputs = ["my-source-id"] # example
   bucket = "my-bucket" # example
   compression = "gzip" # example, enum
-  region = "us-east-1" # example
 
   # REQUIRED - requests
   encoding = "ndjson" # example, enum
 
   # OPTIONAL - General
+  endpoint = "https://my-bucket.us-east-1.amazonaws.com" # example, no default
   healthcheck = true # default
+  region = "us-east-1" # example, no default
 
   # OPTIONAL - Batching
   batch_size = 10490000 # default, bytes
@@ -353,6 +356,29 @@ The encoding format used to serialize the events before outputting.
 
 <Field
   common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["https://my-bucket.us-east-1.amazonaws.com"]}
+  name={"endpoint"}
+  nullable={true}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### endpoint
+
+The [endpoint][urls.aws_s3_endpoints] of the target S3 bucket. Either "endpoint" or "region" must be specified.
+
+
+</Field>
+
+
+<Field
+  common={false}
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
@@ -472,10 +498,10 @@ A prefix to apply to all object key names. This should be used to partition your
   enumValues={null}
   examples={["us-east-1"]}
   name={"region"}
-  nullable={false}
+  nullable={true}
   path={null}
   relevantWhen={null}
-  required={true}
+  required={false}
   templateable={false}
   type={"string"}
   unit={null}
@@ -483,7 +509,7 @@ A prefix to apply to all object key names. This should be used to partition your
 
 ### region
 
-The [AWS region][urls.aws_s3_regions] of the target S3 bucket.
+The [AWS region][urls.aws_s3_regions] of the target S3 bucket. Either "region" or "endpoint" must be specified.
 
 
 </Field>
@@ -788,6 +814,7 @@ You can read more about the complete syntax in the
 [docs.data-model.log]: /docs/about/data-model/log/
 [docs.guarantees]: /docs/about/guarantees/
 [urls.aws_s3]: https://aws.amazon.com/s3/
+[urls.aws_s3_endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_endpoint
 [urls.aws_s3_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 [urls.new_aws_s3_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_s3
 [urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html


### PR DESCRIPTION
The `aws_s3` sink supports [either `region` or `endpoint`](https://github.com/timberio/vector/blob/0a11a36f41143f0c7f39096dc7ad19698d70231d/src/sinks/aws_s3.rs#L42) to specify the location of the target bucket. However, Vector's docs mention only the `region` option.

This PR adds the `endpoint` parameter to the documentation.