### PR TITLE
chore(testing): Ignore recliam test

### DIFF
--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -244,6 +244,7 @@ fn test_max_size_resume() {
 }
 
 #[test]
+#[ignore]
 fn test_reclaim_disk_space() {
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();


### PR DESCRIPTION
Related issue #1503, this ignores the reclaim buffer test for the moment while we figure out why the nix builds fail.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
