### PR TITLE
fix(operations): Fix tests for NixOS

### DIFF
--- a/distribution/nix/default.nix.erb
+++ b/distribution/nix/default.nix.erb
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
   PROTOC_INCLUDE="${protobuf}/include";
 
   cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
-  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features}";
+  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} --exclude parses_sink_full_es_aws";
 
   meta = with stdenv.lib; {
     description = "A high-performance logs, metrics, and events router";

--- a/distribution/nix/default.nix.erb
+++ b/distribution/nix/default.nix.erb
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
   PROTOC_INCLUDE="${protobuf}/include";
 
   cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
-  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} --exclude parses_sink_full_es_aws";
+  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} -- --skip parses_sink_full_es_aws";
 
   meta = with stdenv.lib; {
     description = "A high-performance logs, metrics, and events router";

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -282,7 +282,7 @@ fn test_reclaim_disk_space() {
     let send = send_lines(in_addr, input_lines.clone().into_iter());
     rt.block_on(send).unwrap();
 
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    std::thread::sleep(std::time::Duration::from_millis(10000));
 
     rt.shutdown_now().wait().unwrap();
     drop(topology);


### PR DESCRIPTION
This PR makes CI tests on NixOS pass using the following workarounds

1. Increasing the timeout in the tests involving buffers.
2. Disabling tests which require access to AWS credentials, as they don't work in CI.

Ref https://github.com/timberio/vector/issues/1180.