### PR TITLE
docs(file source): Clairfy `start_at_beginning`

### DIFF
--- a/.meta/sources/file.toml
+++ b/.meta/sources/file.toml
@@ -91,8 +91,9 @@ common = true
 required = true
 default = false
 description = """\
-When `true` Vector will read from the beginning of new files, when \
-`false` Vector will only read new data added to the file.\
+For files with a stored checkpoint at startup, setting this option \
+to `true` will tell Vector to read from the beginning of the file instead \
+of the stored checkpoint. \
 """
 
 [sources.file.options.fingerprinting]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -106,8 +106,9 @@ dns_servers = ["0.0.0.0:53"]
   # * type: [string]
   include = ["/var/log/nginx/*.log"]
 
-  # When `true` Vector will read from the beginning of new files, when `false`
-  # Vector will only read new data added to the file.
+  # For files with a stored checkpoint at startup, setting this option to `true`
+  # will tell Vector to read from the beginning of the file instead of the stored
+  # checkpoint.
   #
   # * required
   # * default: false

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -483,7 +483,7 @@ Instead of balancing read capacity fairly across all watched files, prioritize d
 
 ### start_at_beginning
 
-When `true` Vector will read from the beginning of new files, when `false` Vector will only read new data added to the file. See [Read Position](#read-position) for more info.
+For files with a stored checkpoint at startup, setting this option to `true` will tell Vector to read from the beginning of the file instead of the stored checkpoint.  See [Read Position](#read-position) for more info.
 
 
 </Field>


### PR DESCRIPTION
Related to #1055.

This PR updates the docs for `start_at_beginning` to be clear on what it actually changes. @lukesteensen and I chatted and opted for not updating the code since this change is very nuanced. We most likely want to refactor part of the file source to reduce the places where we choose what to do with a file.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
