### PR TITLE
fix(docker source): Always check containers for self

### DIFF
--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -191,6 +191,10 @@ struct DockerSource {
     ignore_container_id: Vec<ContainerId>,
     ///receives ContainerLogInfo comming from event stream futures
     main_recv: UnboundedReceiver<ContainerLogInfo>,
+    /// It may contain shortened container id.
+    hostname: Option<String>,
+    /// True if self needs to be excluded
+    exclude_self: bool,
 }
 
 impl DockerSource {
@@ -198,6 +202,19 @@ impl DockerSource {
         config: DockerConfig,
         out: Sender<Event>,
     ) -> crate::Result<impl Future<Item = (), Error = ()>> {
+        // Find out it's own container id, if it's inside a docker container.
+        // Since docker doesn't readily provide such information,
+        // various approches need to be made. As such the solution is not
+        // exact, but probable.
+        // This is to be used only if source is in state of catching everything.
+        // Or in other words, if includes are used then this is not necessary.
+        let exclude_self = config
+            .include_containers
+            .clone()
+            .unwrap_or_default()
+            .is_empty()
+            && config.include_labels.clone().unwrap_or_default().is_empty();
+
         // Only logs created at, or after this moment are logged.
         let core = DockerSourceCore::new(config)?;
 
@@ -225,6 +242,8 @@ impl DockerSource {
             containers: HashMap::new(),
             ignore_container_id: Vec::new(),
             main_recv,
+            hostname: env::var("HOSTNAME").ok(),
+            exclude_self,
         }
         .running_containers()
         .and_then(|source| source))
@@ -250,37 +269,6 @@ impl DockerSource {
                 .collect(),
         );
 
-        // Find out it's own container id, if it's inside a docker container.
-        // Since docker doesn't readily provide such information,
-        // various approches need to be made. As such the solution is not
-        // exact, but probable.
-        // This is to be used only if source is in state of catching everything.
-        // Or in other words, if includes are used then this is not necessary.
-        let exclude_self = self
-            .esb
-            .core
-            .config
-            .include_containers
-            .clone()
-            .unwrap_or_default()
-            .is_empty()
-            && self
-                .esb
-                .core
-                .config
-                .include_labels
-                .clone()
-                .unwrap_or_default()
-                .is_empty();
-
-        // HOSTNAME hint
-        // It may contain shortened container id.
-        let hostname = env::var("HOSTNAME").ok();
-
-        // IMAGE hint
-        // If image name starts with this.
-        let image = VECTOR_IMAGE_NAME;
-
         // Future
         self.esb
             .core
@@ -295,23 +283,8 @@ impl DockerSource {
                         names = field::debug(&container.names)
                     );
 
-                    if exclude_self {
-                        let hostname_hint = hostname
-                            .as_ref()
-                            .map(|maybe_short_id| container.id.starts_with(maybe_short_id))
-                            .unwrap_or(false);
-                        let image_hint = container.image.starts_with(image);
-                        if hostname_hint || image_hint {
-                            // This container is probably itself.
-                            // So ignore it.
-                            info!(
-                                message = "Detected self container",
-                                id = field::display(&container.id)
-                            );
-                            self.ignore_container_id
-                                .push(ContainerId::new(container.id));
-                            continue;
-                        }
+                    if !self.self_check(container.id.as_str(), container.image.as_str()) {
+                        continue;
                     }
 
                     // This check is necessary since shiplift doesn't have way to include
@@ -353,6 +326,27 @@ impl DockerSource {
                 self
             })
             .map_err(|error| error!(message="Listing currently running containers, failed",%error))
+    }
+
+    /// True if passed check
+    fn self_check<'a>(&self, id: &str, image: impl Into<Option<&'a str>>) -> bool {
+        if self.exclude_self {
+            let hostname_hint = self
+                .hostname
+                .as_ref()
+                .map(|maybe_short_id| id.starts_with(maybe_short_id))
+                .unwrap_or(false);
+            let image_hint = image
+                .into()
+                .map(|image| image.starts_with(VECTOR_IMAGE_NAME))
+                .unwrap_or(false);
+            if hostname_hint || image_hint {
+                // This container is probably itself.
+                info!(message = "Detected self container", id);
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -421,7 +415,16 @@ impl Future for DockerSource {
                                                         .map(|s| s.as_str()),
                                                 );
 
-                                            if !ignore_flag && include_name {
+                                            let self_check = self.self_check(
+                                                id.as_str(),
+                                                event
+                                                    .actor
+                                                    .attributes
+                                                    .get("image")
+                                                    .map(|s| s.as_str()),
+                                            );
+
+                                            if !ignore_flag && include_name && self_check {
                                                 // Included
                                                 self.containers
                                                     .insert(id.clone(), self.esb.start(id));

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -280,7 +280,7 @@ impl DockerSource {
                         names = field::debug(&container.names)
                     );
 
-                    if !self.self_check(container.id.as_str(), container.image.as_str()) {
+                    if !self.exclude_vector(container.id.as_str(), container.image.as_str()) {
                         continue;
                     }
 
@@ -323,8 +323,9 @@ impl DockerSource {
             .map_err(|error| error!(message="Listing currently running containers, failed",%error))
     }
 
-    /// True if passed check
-    fn self_check<'a>(&self, id: &str, image: impl Into<Option<&'a str>>) -> bool {
+    /// True if container with the given id and image must be excluded from logging,
+    /// because it's a vector instance, probably this one.
+    fn exclude_vector<'a>(&self, id: &str, image: impl Into<Option<&'a str>>) -> bool {
         if self.exclude_self {
             let hostname_hint = self
                 .hostname
@@ -405,7 +406,7 @@ impl Future for DockerSource {
                                                         .map(|s| s.as_str()),
                                                 );
 
-                                            let self_check = self.self_check(
+                                            let self_check = self.exclude_vector(
                                                 id.as_str(),
                                                 event
                                                     .actor


### PR DESCRIPTION
Fixes bug reported in [comment](https://github.com/timberio/vector/issues/984#issuecomment-573683760).

As mentioned in the following [comment](https://github.com/timberio/vector/issues/984#issuecomment-574225167), initial list of containers gotten from docker sometimes doesn't contain container of the vector requesting the list.  

This PR has a fix which checks all encountered containers if they are self/vector, and not only the ones from the initial list.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
