### PR TITLE
chore(log data model): Deprecate `LogEvent::into_value` in favor of `LogEvent::remove`

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -98,10 +98,6 @@ impl LogEvent {
         self.fields.contains_key(key)
     }
 
-    pub fn into_value(mut self, key: &Atom) -> Option<ValueKind> {
-        self.fields.remove(key).map(|v| v.value)
-    }
-
     pub fn insert_explicit<K, V>(&mut self, key: K, value: V)
     where
         K: Into<Atom>,
@@ -536,7 +532,7 @@ impl From<Event> for Vec<u8> {
     fn from(event: Event) -> Vec<u8> {
         event
             .into_log()
-            .into_value(&MESSAGE)
+            .remove(&MESSAGE)
             .unwrap()
             .as_bytes()
             .to_vec()

--- a/src/transforms/ansi_stripper.rs
+++ b/src/transforms/ansi_stripper.rs
@@ -97,7 +97,7 @@ mod tests {
                 let event = transform.transform(event).unwrap();
 
                 assert_eq!(
-                    event.into_log().into_value(&MESSAGE).unwrap(),
+                    event.into_log().remove(&MESSAGE).unwrap(),
                     ValueKind::from("foo bar")
                 );
             )+


### PR DESCRIPTION
Closes #1507.