### PR TITLE
chore(testing): Use `.iter()` instead of `.into_iter()` for arrays

### DIFF
--- a/src/sinks/gcp_pubsub.rs
+++ b/src/sinks/gcp_pubsub.rs
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn encode_valid1() {
-        let log = LogEvent::from_iter([("message", "hello world")].into_iter().map(|&s| s));
+        let log = LogEvent::from_iter([("message", "hello world")].iter().map(|&s| s));
         let body = make_body(encode_event(log.into()));
         let body = String::from_utf8_lossy(&body);
         assert_eq!(
@@ -274,8 +274,8 @@ mod tests {
 
     #[test]
     fn encode_valid2() {
-        let log1 = LogEvent::from_iter([("message", "hello world")].into_iter().map(|&s| s));
-        let log2 = LogEvent::from_iter([("message", "killroy was here")].into_iter().map(|&s| s));
+        let log1 = LogEvent::from_iter([("message", "hello world")].iter().map(|&s| s));
+        let log2 = LogEvent::from_iter([("message", "killroy was here")].iter().map(|&s| s));
         let mut event = encode_event(log1.into());
         event.extend(encode_event(log2.into()));
         let body = make_body(event);


### PR DESCRIPTION
`into_iter()` is expected for arrays is expected to be deprecated in upcoming versions of Rust, nightly already give a warning on using it instead of `iter()`.