### PR TITLE
enhancement(splunk_hec sink)!: Add a new option for specifying indexed fields to `splunk_hec` sink

### DIFF
--- a/.meta/links.toml
+++ b/.meta/links.toml
@@ -131,6 +131,7 @@ rust_tier_1_platform = "https://forge.rust-lang.org/release/platform-support.htm
 rustup = "https://rustup.rs"
 splunk_hec = "http://dev.splunk.com/view/event-collector/SP-CAAAE6M"
 splunk_hec_event_endpoint = "https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fevent"
+splunk_hec_indexed_fields = "https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC"
 splunk_hec_protocol = "https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/HECRESTendpoints"
 splunk_hec_raw_endpoint = "https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fraw"
 splunk_hec_setup = "https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector"

--- a/.meta/sinks/splunk_hec.toml
+++ b/.meta/sinks/splunk_hec.toml
@@ -34,3 +34,10 @@ common = true
 examples = ["${TOKEN_ENV_VAR}", "A94A8FE5CCB19BA61C4C08"]
 required = true
 description = "Your Splunk HEC token."
+
+[sinks.splunk_hec.options.indexed_fields]
+type = "[string]"
+common = true
+examples = [["field1", "field2"]]
+required = false
+description = "Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields]. Applicable only to `json` encoding."

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -4233,7 +4233,7 @@ end
   healthcheck = true
   healthcheck = false
 
-  # Fields to be added to Splunk index.
+  # Fields to be added to Splunk index. Applicable only to `json` encoding.
   #
   # * optional
   # * no default

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -4233,6 +4233,13 @@ end
   healthcheck = true
   healthcheck = false
 
+  # Fields to be added to Splunk index.
+  #
+  # * optional
+  # * no default
+  # * type: [string]
+  indexed_fields = ["field1", "field2"]
+
   #
   # requests
   #

--- a/src/event/unflatten.rs
+++ b/src/event/unflatten.rs
@@ -46,6 +46,7 @@ impl From<HashMap<Atom, Value>> for Unflatten {
 /// This produces one path down the tree for each key that has
 /// previously been flattened. The goal here is that the return value
 /// of this function will be merged into the overall tree.
+/// h
 fn unflatten(k: Atom, v: MapValue) -> MapValue {
     // Maps are delimited via `.`.
     let mut s = k.rsplit('.').peekable();

--- a/src/event/unflatten.rs
+++ b/src/event/unflatten.rs
@@ -46,7 +46,6 @@ impl From<HashMap<Atom, Value>> for Unflatten {
 /// This produces one path down the tree for each key that has
 /// previously been flattened. The goal here is that the return value
 /// of this function will be merged into the overall tree.
-/// h
 fn unflatten(k: Atom, v: MapValue) -> MapValue {
     // Maps are delimited via `.`.
     let mut s = k.rsplit('.').peekable();

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -385,7 +385,7 @@ Your Splunk HEC host. See [Setup](#setup) for more info.
 
 ### indexed_fields
 
-Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields].
+Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields]. Applicable only to `json` encoding.
 
 
 </Field>

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -44,10 +44,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [sinks.my_sink_id]
+  # REQUIRED
   type = "splunk_hec" # must be: "splunk_hec"
   inputs = ["my-source-id"] # example
   host = "my-splunk-host.com" # example
   token = "${TOKEN_ENV_VAR}" # example
+
+  # OPTIONAL
+  indexed_fields = ["field1", "field2"] # example, no default
 ```
 
 </TabItem>
@@ -65,6 +69,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # OPTIONAL - General
   healthcheck = true # default
+  indexed_fields = ["field1", "field2"] # example, no default
 
   # OPTIONAL - requests
   encoding = "ndjson" # example, no default, enum
@@ -359,6 +364,28 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 ### host
 
 Your Splunk HEC host. See [Setup](#setup) for more info.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[["field1","field2"]]}
+  name={"indexed_fields"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"[string]"}
+  unit={null}
+  >
+
+### indexed_fields
+
+Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields].
 
 
 </Field>
@@ -813,4 +840,5 @@ should supply to the [`host`](#host) and [`token`](#token) options.
 [docs.guarantees]: /docs/about/guarantees/
 [urls.new_splunk_hec_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+splunk_hec
 [urls.splunk_hec]: http://dev.splunk.com/view/event-collector/SP-CAAAE6M
+[urls.splunk_hec_indexed_fields]: https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC
 [urls.splunk_hec_setup]: https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/1534.

The option is added only to `json` encoding, as `text` encoding was not using `fields` previously.

I decided to not implement dropping the indexed fields from `events` mentioned in #1534 for now as I'm worried about unexpected results for existing users. It can be easily changed.