### PR TITLE
enhancement(observability): enable more logging by default

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -308,7 +308,7 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
             let (tx, rx) = oneshot::channel();
             self.token_rx = Some(rx);
 
-            debug!(message = "Sending events.", events = %events.len());
+            info!(message = "Sending events.", events = %events.len());
             request::CloudwatchFuture::new(
                 self.client.clone(),
                 self.stream_name.clone(),

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -124,7 +124,7 @@ impl Future for CloudwatchFuture {
                 State::CreateGroup(fut) => {
                     try_ready!(fut.poll().map_err(CloudwatchError::CreateGroup));
 
-                    info!("group created.");
+                    info!(message = "group created.", name = %self.client.group_name);
 
                     // This does not abide by `create_missing_stream` since a group
                     // never has any streams and thus we need to create one if a group
@@ -135,7 +135,7 @@ impl Future for CloudwatchFuture {
                 State::CreateStream(fut) => {
                     try_ready!(fut.poll().map_err(CloudwatchError::CreateStream));
 
-                    info!("stream created.");
+                    info!(message = "stream created.", name = %self.client.stream_name);
 
                     self.state = State::DescribeStream(self.client.describe_stream());
                 }

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -102,7 +102,7 @@ impl Future for CloudwatchFuture {
                         .into_iter()
                         .next()
                     {
-                        trace!(message = "stream found", stream = ?stream.log_stream_name);
+                        debug!(message = "stream found", stream = ?stream.log_stream_name);
 
                         let events = self
                             .events
@@ -111,10 +111,10 @@ impl Future for CloudwatchFuture {
 
                         let token = stream.upload_sequence_token;
 
-                        trace!(message = "putting logs.", ?token);
+                        info!(message = "putting logs.", ?token);
                         self.state = State::Put(self.client.put_logs(token, events));
                     } else if self.create_missing_stream {
-                        debug!("provided stream does not exist; creating a new one.");
+                        info!("provided stream does not exist; creating a new one.");
                         self.state = State::CreateStream(self.client.create_log_stream());
                     } else {
                         return Err(CloudwatchError::NoStreamsFound);
@@ -124,7 +124,7 @@ impl Future for CloudwatchFuture {
                 State::CreateGroup(fut) => {
                     try_ready!(fut.poll().map_err(CloudwatchError::CreateGroup));
 
-                    trace!("group created.");
+                    info!("group created.");
 
                     // This does not abide by `create_missing_stream` since a group
                     // never has any streams and thus we need to create one if a group
@@ -135,7 +135,7 @@ impl Future for CloudwatchFuture {
                 State::CreateStream(fut) => {
                     try_ready!(fut.poll().map_err(CloudwatchError::CreateStream));
 
-                    trace!("stream created.");
+                    info!("stream created.");
 
                     self.state = State::DescribeStream(self.client.describe_stream());
                 }
@@ -145,7 +145,7 @@ impl Future for CloudwatchFuture {
 
                     let next_token = res.next_sequence_token;
 
-                    trace!(message = "putting logs was successful.", ?next_token);
+                    info!(message = "putting logs was successful.", ?next_token);
 
                     self.token_tx
                         .take()

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -65,7 +65,7 @@ impl SourceConfig for LogplexConfig {
 
         let routes = svc.or(ping);
 
-        info!(message = "building logplex server", addr = ?self.address);
+        info!(message = "building logplex server", addr = %self.address);
         let (_, server) = warp::serve(routes).bind_with_graceful_shutdown(self.address, tripwire);
 
         Ok(Box::new(server))

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -65,6 +65,7 @@ impl SourceConfig for LogplexConfig {
 
         let routes = svc.or(ping);
 
+        info!(message = "building logplex server", addr = ?self.address);
         let (_, server) = warp::serve(routes).bind_with_graceful_shutdown(self.address, tripwire);
 
         Ok(Box::new(server))


### PR DESCRIPTION
This just upgrades a few log statements so that they show up by default. All of these statements should be sufficiently low volume as not to be annoying, but often enough that an operator can see what's happening.

This was prompted by running the cloudwatch sink myself and noticing that it's completely silent during operation, which makes me nervous.