### PR TITLE
fix(operations): Add AWS API key for Windows tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,12 @@ jobs:
           name: Build and test
           shell: bash
           no_output_timeout: 30m
+          environment:
+            RUSTFLAGS: -Ctarget-feature=+crt-static
+            RUST_BACKTRACE: full
+            AWS_ACCESS_KEY_ID: fake-aws-key
+            AWS_SECRET_ACCESS_KEY: fake-aws-key
           command: |
-            RUSTFLAGS=-Ctarget-feature=+crt-static
             PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
             rm rust-toolchain
             cargo test --release --no-default-features --features default-msvc -- --test-threads 1


### PR DESCRIPTION
Ref #1527.

This PR adds the same AWS keys to the environment as the ones used in `test-stable` for `test-x86_64-pc-windows-msvc` test job.