### PR TITLE
fix(operations): Make sorting of blog posts stable

### DIFF
--- a/scripts/util/metadata.rb
+++ b/scripts/util/metadata.rb
@@ -68,7 +68,7 @@ class Metadata
     @posts ||=
       Dir.glob("#{POSTS_ROOT}/**/*.md").collect do |path|
         Post.new(path)
-      end.sort
+      end.sort_by { |post| [ post.date, post.id ] }
 
     # releases
 


### PR DESCRIPTION
This PR makes sorting order of blog posts stable in case if there are multiple posts with the same date, so the content of README becomes a deterministic function of the content.