### PR TITLE
fix(operations): Pass `CIRCLE_SHA1` environment variable to `release-github` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -727,6 +727,7 @@ jobs:
           name: Release Github
           command: |
             export PASS_VERSION=$(make version)
+            export PASS_CIRCLE_SHA1="$CIRCLE_SHA1"
             ./scripts/docker-run.sh releaser make release-github
 
   release-homebrew:


### PR DESCRIPTION
It is used by `scripts/release-github.rb` script, but is not passed inside the Docker container where this job is running.