### PR TITLE
fix(socket sink): Improve DNS resolution

### DIFF
--- a/.meta/sinks/socket.toml
+++ b/.meta/sinks/socket.toml
@@ -25,4 +25,4 @@ type = "string"
 common = true
 examples = ["92.12.333.224:5000"]
 required = true
-description = "The address to bind to."
+description = "The address to bind to, this must include some <host>:<port> pair."

--- a/.meta/sinks/vector.toml
+++ b/.meta/sinks/vector.toml
@@ -14,4 +14,4 @@ type = "string"
 common = true
 examples = ["92.12.333.224:5000"]
 required = true
-description = "The downstream Vector address."
+description = "The downstream Vector address, this must include <host>:<port>."

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -4128,7 +4128,7 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The address to bind to.
+  # The address to bind to, this must include some <host>:<port> pair.
   #
   # * required
   # * type: string
@@ -4574,7 +4574,7 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The downstream Vector address.
+  # The downstream Vector address, this must include <host>:<port>.
   #
   # * required
   # * type: string

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -88,10 +88,9 @@ impl TcpSource for VectorSource {
 mod test {
     use super::VectorConfig;
     use crate::{
-        buffers::Acker,
-        sinks::vector::vector,
+        sinks::vector::VectorSinkConfig,
         test_util::{next_addr, wait_for_tcp, CollectCurrent},
-        topology::config::{GlobalOptions, SourceConfig},
+        topology::config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig},
         Event,
     };
     use futures::{stream, sync::mpsc, Future, Sink};
@@ -108,7 +107,13 @@ mod test {
         rt.spawn(server);
         wait_for_tcp(addr);
 
-        let sink = vector("NONE".into(), addr, Acker::Null);
+        let cx = SinkContext::new_test(rt.executor());
+        let (sink, _) = VectorSinkConfig {
+            address: format!("{}", addr),
+        }
+        .build(cx)
+        .unwrap();
+
         let events = vec![
             Event::from("test"),
             Event::from("events"),

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -109,7 +109,7 @@ mod test {
 
         let cx = SinkContext::new_test(rt.executor());
         let (sink, _) = VectorSinkConfig {
-            address: format!("{}", addr),
+            address: format!("localhost:{}", addr.port()),
         }
         .build(cx)
         .unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -351,15 +351,25 @@ fn reconnect() {
 #[test]
 fn healthcheck() {
     let addr = next_addr();
+    let rt = vector::test_util::runtime();
+    let resolver = vector::dns::Resolver::new(Vec::new(), rt.executor()).unwrap();
 
     let _listener = TcpListener::bind(&addr).unwrap();
 
-    let healthcheck = vector::sinks::util::tcp::tcp_healthcheck(addr);
+    let healthcheck = vector::sinks::util::tcp::tcp_healthcheck(
+        addr.ip().to_string(),
+        addr.port(),
+        resolver.clone(),
+    );
 
     assert!(healthcheck.wait().is_ok());
 
     let bad_addr = next_addr();
-    let bad_healthcheck = vector::sinks::util::tcp::tcp_healthcheck(bad_addr);
+    let bad_healthcheck = vector::sinks::util::tcp::tcp_healthcheck(
+        bad_addr.ip().to_string(),
+        bad_addr.port(),
+        resolver,
+    );
 
     assert!(bad_healthcheck.wait().is_err());
 }

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -116,7 +116,7 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The address to bind to.
+The address to bind to, this must include some <host>:<port> pair.
 
 
 </Field>

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -101,7 +101,7 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The downstream Vector address.
+The downstream Vector address, this must include <host>:<port>.
 
 
 </Field>


### PR DESCRIPTION
This PR fixes the issues observed in #1574 and also refactors our TCP sink to handle DNS resolution internally instead of during the build phase. Since the `vector` sink also uses this implementation it has also been fixed.

### Original Issue

The issue was originally noted in #1574 and it showed that the `vector` sink would panic if set using a host name that was not an `IPv4` or `IPv6` address. The panic turned out to be produced from [`this line`] of code from `trust-dns`. This line attempts to find the current executor in thread local storage and spawn the tcp future onto that executor. Since, in our build phase we do not currently provide access to this executor in thread local storage the `spawn` here would fail and panic (which is normal behavior if you just call `tokio::spawn`). The problem here is that the build phase is never run inside the tokio runtime or with the tokio thread locals set.

Initially, this was tested to prove to not be an issue and our tests were not catching this error because we almost exclusively setup our tests with addresses that are `IPv4`s. This means this was never caught in any of our TCP nor vector tests.

[`this line`]: https://github.com/bluejekyll/trust-dns/blob/aaffb89ddaec4c4999823e3614b4bb2acba72004/crates/resolver/src/name_server/connection_provider.rs#L162

### Discovery of the Second issue

While I was thinking about this issue and how we could resolve this in the future I noticed that our TCP sink did not actually implement DNS correctly. In fact, the TCP sink would only run DNS at the beginning during build time instead of repeatedly doing it on each TCP connect. Because of this the DNS resolver never had access to the tokio executor and neither would it allow the sink to dynamically update the DNS address.


### Fixes

With both problems stated, this PR fixes both issues in one swoop by removing all custom DNS lookups during build phase and pushing the resolution to happen while the sink is running. The downsides to this is that if there is a DNS error it will take a bit longer for it to resolve. There are also no breaking changes for the user but this is mainly a bug fix and improvement to the TCP and vector sinks.

### Questions

Now this brings up a couple points related to some original issues I opened a long time ago #170 and #300. The original DNS issue would have been a non issue if we would have represented the entire application as a future. In this case since we are a future that is getting run on the tokio runtime our thread locals are always set. This is an easy footgun to hit because there are many implicit dependencies that are not described at compile time. But instead these dependencies will cause a panic at runtime and affect our users. So does this mean that we should think about possibly resolving #300? 

Fixes #1574

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>