### PR TITLE
docs: Document adding the Vector user to a group which can use `journalctl`

### DIFF
--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -11,8 +11,7 @@ through_description = "log records from journald"
 requirements = """\
 1. The `journald` source requires the presence of the `journalctl` binary. \
 This ensures that this source works across all platforms. Please see the \
-["Communicating with systemd journal"](#communication-with-systemd-journal) \
-section for more info.
+["Communication strategy"](#communication-strategy) section for more info.
 2. If you run Vector from a non-root user, you need to add that user to the \
 `systemd-journal` group. Please see the ["User permissions"](#user-permissions) \
 section for more info.\

--- a/.meta/sources/journald.toml
+++ b/.meta/sources/journald.toml
@@ -9,9 +9,13 @@ output_types = ["log"]
 resources = []
 through_description = "log records from journald"
 requirements = """\
-The `journald` source requires the presence of the `journalctl` binary. This \
-ensures that this source works across all platforms. For more information, \
-please see [issue 1473][urls.issue_1473].\
+1. The `journald` source requires the presence of the `journalctl` binary. \
+This ensures that this source works across all platforms. Please see the \
+["Communicating with systemd journal"](#communication-with-systemd-journal) \
+section for more info.
+2. If you run Vector from a non-root user, you need to add that user to the \
+`systemd-journal` group. Please see the ["User permissions"](#user-permissions) \
+section for more info.\
 """
 
 [sources.journald.options.current_boot_only]

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -379,6 +379,17 @@ will be replaced before being evaluated.
 You can learn more in the [Environment Variables][docs.configuration#environment-variables]
 section.
 
+## Special notes
+
+If you run Vector from a non-root user, you need to add that user to the
+`systemd-journal` group.
+
+For example, if the user is named `vector`, it can be done by running
+
+```sh
+usermod -aG systemd-journal vector
+```
+
 
 [docs.configuration#data-directory]: /docs/setup/configuration/#data-directory
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -80,7 +80,8 @@ import Alert from '@site/src/components/Alert';
 
 <Alert type="danger" fill={true} icon={false}>
 
-The `journald` source requires the presence of the [`journalctl`](#journalctl) binary. This ensures that this source works across all platforms. For more information, please see [issue 1473][urls.issue_1473].
+1. The `journald` source requires the presence of the [`journalctl`](#journalctl) binary. This ensures that this source works across all platforms. Please see the ["Communication strategy"](#communication-strategy) section for more info.
+2. If you run Vector from a non-root user, you need to add that user to the `systemd-journal` group. Please see the ["User permissions"](#user-permissions) section for more info.
 
 </Alert>
 
@@ -175,7 +176,7 @@ The directory used to persist the journal checkpoint position. By default, the g
 
 ### journalctl_path
 
-The full path of the [`journalctl`](#journalctl) executable. If not set, Vector will search the path for [`journalctl`](#journalctl). See [Communication with systemd journal](#communication-with-systemd-journal) for more info.
+The full path of the [`journalctl`](#journalctl) executable. If not set, Vector will search the path for [`journalctl`](#journalctl). See [Communication strategy](#communication-strategy) for more info.
 
 
 </Field>
@@ -360,7 +361,7 @@ specified via the [global [`data_dir`](#data_dir) option][docs.configuration#dat
 but can be overridden via the [`data_dir`](#data_dir) option in the `journald` source
 directly.
 
-### Communication with systemd journal
+### Communication strategy
 
 To ensure the `journald` source works across all platforms, Vector interacts
 with the Systemd journal via the [`journalctl`](#journalctl) command. This is accomplished by
@@ -379,7 +380,7 @@ will be replaced before being evaluated.
 You can learn more in the [Environment Variables][docs.configuration#environment-variables]
 section.
 
-## Special notes
+### User permissions
 
 If you run Vector from a non-root user, you need to add that user to the
 `systemd-journal` group.

--- a/website/docs/reference/sources/journald.md.erb
+++ b/website/docs/reference/sources/journald.md.erb
@@ -54,4 +54,15 @@ specify the exact location via the `journalctl_path` option. For more
 information on this communication strategy please see
 [issue #1473][urls.issue_1473].
 
+## User permissions
+
+If you run Vector from a non-root user, you need to add that user to the
+`systemd-journal` group.
+
+For example, if the user is named `vector`, it can be done by running
+
+```sh
+usermod -aG systemd-journal vector
+```
+
 <%= component_sections(component) %>

--- a/website/docs/reference/sources/journald.md.erb
+++ b/website/docs/reference/sources/journald.md.erb
@@ -44,7 +44,7 @@ specified via the [global `data_dir` option][docs.configuration#data-directory]
 but can be overridden via the `data_dir` option in the `journald` source
 directly.
 
-### Communication with systemd journal
+### Communication strategy
 
 To ensure the `journald` source works across all platforms, Vector interacts
 with the Systemd journal via the `journalctl` command. This is accomplished by
@@ -54,7 +54,7 @@ specify the exact location via the `journalctl_path` option. For more
 information on this communication strategy please see
 [issue #1473][urls.issue_1473].
 
-## User permissions
+### User permissions
 
 If you run Vector from a non-root user, you need to add that user to the
 `systemd-journal` group.


### PR DESCRIPTION
See the note from https://github.com/timberio/vector/pull/1583#issue-366419329.