### PR TITLE
chore(operations): Support bug fixing releases

### DIFF
--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -64,11 +64,8 @@ else
     <<~EOF
     git add . -A
     git commit -sam 'chore: Prepare v#{release.version} release'
-    git push origin master
     git tag -a v#{release.version} -m "v#{release.version}"
-    git push origin v#{release.version}
     git branch v#{branch_name}
-    git push origin v#{branch_name}
     EOF
 
   commands.chomp!

--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -65,7 +65,7 @@ else
     git add . -A
     git commit -sam 'chore: Prepare v#{release.version} release'
     git tag -a v#{release.version} -m "v#{release.version}"
-    git branch v#{branch_name}
+    git branch v#{branch_name} 2>/dev/null || true
     EOF
 
   commands.chomp!

--- a/scripts/release-meta.rb
+++ b/scripts/release-meta.rb
@@ -116,7 +116,7 @@ def create_release_meta_file!(current_commits, new_version)
 end
 
 def get_commit_log(last_version)
-  range = "v#{last_version}...master"
+  range = "v#{last_version}..."
   `git log #{range} --no-merges --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
 end
 
@@ -159,6 +159,18 @@ def get_new_version(last_version, commits)
       else
         nil
       end
+    elsif commits.any? { |c| fix?(c) }
+      next_version = "#{last_version.major}.#{last_version.minor}.#{last_version.patch + 1}"
+
+      words = "It looks like this release contains commits with bug fixes. " +
+        "Would you like to use the recommended version #{next_version} for " +
+        "this release?"
+
+      if get(words, ["y", "n"]) == "y"
+        next_version
+      else
+        nil
+      end
     end
 
   version_string = next_version || get("What is the next version you are releasing? (current version is #{last_version})")
@@ -181,6 +193,10 @@ end
 
 def new_feature?(commit)
   !commit.fetch("message").match(/^feat/).nil?
+end
+
+def fix?(commit)
+  !commit.fetch("message").match(/^fix/).nil?
 end
 
 def parse_commit_line!(commit_line)


### PR DESCRIPTION
The flow for doing a new patch release is expected to be the following:

1. Backport all necessary fx from `master` to the branch corresponding to the minor version (for example `v0.7`). Pull requests (https://github.com/timberio/vector/pull/1586 is an example) can be used  to simplify reviewing and discussions, but these pull requests have to be merged using `git rebase` instead of `git merge --squash` in order to preserve the commit messages. As currently only squash merges are enabled in GitHub UI for Vector's repository, the simplest way to do it is to use the command line, for example:
    ```git
    MINOR_VERSION_BRNACH=v0.7
    PR_BRANCH=prepare-0-7-1
    git checkout $PR_BRANCH
    git rebase $MINOR_VERSION_BRANCH
    git checkout $MINOR_VERSION_BRANCH
    git merge $PR_BRANCH
    ```
2. Run `make release` in the branch corresponding to the minor version. It would produce `.meta/releases/X.Y.Z.toml`, generate the release notes, and create a commit with these changes. Additionally, the tag `vX.Y.Z` would be created and point to the head of the branch corresponding to the minor version.
3. Push release commit and tag to the repository, for example:
    ```sh
    git push v0.7
    git push v0.7.1
    ```
    Pushing is made manual instead of automatic in this PR because it allows to:
    * Review the changes to be pushed.
    * Run `make release` from Docker as `./scripts/docker-run.sh release make release`, avoiding the need to install the dependencies manually. Pushing from Docker doesn't work because the SSH keys are not present in the container.

After the tag is pushed, it would trigger the `release-*` jobs defined in the CI configuration and, as a result, produce and publish the release artifacts.