### PR TITLE
fix(operations): Add all generated files to the release commit

### DIFF
--- a/scripts/release-commit.rb
+++ b/scripts/release-commit.rb
@@ -62,7 +62,7 @@ else
 
   commands =
     <<~EOF
-    git add . -A
+    git add #{ROOT_DIR} -A
     git commit -sam 'chore: Prepare v#{release.version} release'
     git tag -a v#{release.version} -m "v#{release.version}"
     git branch v#{branch_name} 2>/dev/null || true


### PR DESCRIPTION
A follow-up to https://github.com/timberio/vector/pull/1587. Running `make release` command didn't add the newly generated files in `.meta/releases` to the release commit automatically, which lead to incomplete releases. This PR fixes it.