### PR TITLE
chore(operations): Add `release-push` target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ release: ## Release a new Vector version
 	@$(MAKE) generate CHECK_URLS=false
 	@$(MAKE) release-commit
 
+release-push: ## Push new Vector version
+	@scripts/release-push.sh
+
 run: ## Starts Vector in development mode
 	@cargo run
 

--- a/scripts/release-push.sh
+++ b/scripts/release-push.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# release-push.rb
+#
+# SUMMARY
+#
+#   Pushes new versions produced by `make release` to the repository
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+version=$(./scripts/version.sh | sed 's/-nightly$//')
+version_minor=$(echo $version | grep -o '^[0-9]*\.[0-9]*')
+current_branch_name=$(git branch | awk '{ print $2 }')
+
+echo "Preparing the branch and the tag..."
+set -x
+git checkout -b v$version_minor 2>/dev/null || git checkout v$version_minor
+git merge --ff $current_branch_name
+git tag v$version
+set +x
+
+echo "Pushing the branch and the tag..."
+set -x
+git push origin v$version_minor
+git push origin v$version
+set +x


### PR DESCRIPTION
This PR adds new Makefile target `push-release`.

Together with #1587 it splits single `make release` into two separate steps. The first one, `make release`, only generates a release commit, which is supposed to be pushed to `prepare-*` branch and tested in CI. On the other hand, `make release-push` actually tags the release and pushes it to the corresponding branch.