### PR TITLE
fix(operations): Do not require `systemd` as an RPM dependency

### DIFF
--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -17,8 +17,6 @@ Group: Applications/System
 Source: %{_source}
 URL: %{_url}
 
-Requires: systemd
-
 %description
 %{summary}
 


### PR DESCRIPTION
Previously `systemd` was required only as built-time dependency, but not a run-time dependency. #1583 added it to the list of run-time dependencies, however it turned out that it breaks installation of the package on Amazon Linux: https://circleci.com/gh/timberio/vector/79129?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

So this PR removes it from the list of dependencies, as Vector can start without it. The users who want to use `journald` source would already have it installed on their machines, so there is no need to explicitly require it.