### PR TITLE
chore(operations): Rename make release target to release-prepare

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,9 @@ always run `make generate` before attempting to merge your commits.
 #### Changelog
 
 Developers do not need to maintain the [`Changelog`](/CHANGELOG.md). This is
-automatically generated via the `make release` command. This is made possible
-by the use of [conventional commit](#what-is-conventioonal-commits) titles.
+automatically generated via the `make release-prepare` command. This is made
+possible by the use of [conventional commit](#what-is-conventioonal-commits)
+titles.
 
 ### Building a sink
 

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ fmt: ## Format code
 	@scripts/check-style.sh --fix
 	@cargo fmt
 
-release: ## Release a new Vector version
+release-prepare: ## Prepare a new Vector release
 	@$(MAKE) release-meta
 	@$(MAKE) generate CHECK_URLS=false
 	@$(MAKE) release-commit
 
-release-push: ## Push new Vector version
+release-push: ## Push a prepared Vector release
 	@scripts/release-push.sh
 
 run: ## Starts Vector in development mode

--- a/scripts/release-push.sh
+++ b/scripts/release-push.sh
@@ -4,7 +4,7 @@
 #
 # SUMMARY
 #
-#   Pushes new versions produced by `make release` to the repository
+#   Pushes new versions produced by `make release-prepare` to the repository
 
 set -euo pipefail
 


### PR DESCRIPTION
This renames `make release` to `make release-prepare`.

@a-rodin I noticed `make release-push` creates the git tag, yet `make release` [still commits and tags the release](https://github.com/timberio/vector/blob/d6c85157af4cf189b8d0b29b26cf0468e32ce36c/scripts/release-commit.rb#L63-L69). Is this intentional?