### PR TITLE
docs: Fix socket address documentation

### DIFF
--- a/.meta/sinks/socket.toml
+++ b/.meta/sinks/socket.toml
@@ -25,4 +25,4 @@ type = "string"
 common = true
 examples = ["92.12.333.224:5000"]
 required = true
-description = "The address to connect to, this must include some <host>:<port> pair."
+description = "The address to connect to. The address _must_ include a port."

--- a/.meta/sinks/vector.toml
+++ b/.meta/sinks/vector.toml
@@ -14,4 +14,6 @@ type = "string"
 common = true
 examples = ["92.12.333.224:5000"]
 required = true
-description = "The downstream Vector address to connect to, this must include <host>:<port>."
+description = """\
+The downstream Vector address to connect to. The address _must_ include a port.\
+"""

--- a/.meta/sources/socket.toml
+++ b/.meta/sources/socket.toml
@@ -26,8 +26,10 @@ examples = ["0.0.0.0:9000", "systemd", "systemd#3"]
 null = false
 relevant_when = {mode = ["tcp", "udp"]}
 required = true
-description = """The address to listen for connections on, \
-or "systemd#N" to use the Nth socket passed by systemd socket activation.\
+description = """\
+The address to listen for connections on, or `systemd#N` to use the Nth socket \
+passed by systemd socket activation. If an address is used it _must_ include \
+a port.
 """
 
 [sources.socket.options.path]

--- a/.meta/sources/vector.toml
+++ b/.meta/sources/vector.toml
@@ -14,8 +14,10 @@ type = "string"
 common = true
 examples = ["0.0.0.0:9000", "systemd", "systemd#1"]
 required = true
-description = """The TCP address to listen for connections on, \
-or "systemd#N" to use the Nth socket passed by systemd socket activation.\
+description = """\
+The TCP address to listen for connections on, or `systemd#N to use the Nth \
+socket passed by systemd socket activation. If an address is used it _must_ \
+include a port.
 """
 
 [sources.vector.options.shutdown_timeout_secs]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -423,8 +423,9 @@ dns_servers = ["0.0.0.0:53"]
   # * must be: "socket"
   type = "socket"
 
-  # The address to listen for connections on, or "systemd#N" to use the Nth
-  # socket passed by systemd socket activation.
+  # The address to listen for connections on, or `systemd#N` to use the Nth
+  # socket passed by systemd socket activation. If an address is used it _must_
+  # include a port.
   #
   # * required
   # * type: string
@@ -625,8 +626,9 @@ dns_servers = ["0.0.0.0:53"]
   # * must be: "vector"
   type = "vector"
 
-  # The TCP address to listen for connections on, or "systemd#N" to use the Nth
-  # socket passed by systemd socket activation.
+  # The TCP address to listen for connections on, or `systemd#N to use the Nth
+  # socket passed by systemd socket activation. If an address is used it _must_
+  # include a port.
   #
   # * required
   # * type: string
@@ -4128,7 +4130,7 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The address to connect to, this must include some <host>:<port> pair.
+  # The address to connect to. The address _must_ include a port.
   #
   # * required
   # * type: string
@@ -4574,7 +4576,8 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The downstream Vector address to connect to, this must include <host>:<port>.
+  # The downstream Vector address to connect to. The address _must_ include a
+  # port.
   #
   # * required
   # * type: string

--- a/scripts/generate/templates/_partials/_options.md.erb
+++ b/scripts/generate/templates/_partials/_options.md.erb
@@ -19,7 +19,7 @@
 
 <%= "#" * heading_depth %> <%= option.name %>
 
-<%= option.description.html_escape %>[[references:<%= option.name %>]]
+<%= option.description %>[[references:<%= option.name %>]]
 
 <%- if option.options_list.any? -%>
 <%= options(option.options_list, filters: false, heading_depth: heading_depth + 1, level: level + 1, path: full_path) %>

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -90,7 +90,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 ### LOG
 
-Sets Vector&#39;s log level. See the [log section in the monitoring guide][docs.monitoring#level] for more information on the available levels.
+Sets Vector's log level. See the [log section in the monitoring guide][docs.monitoring#level] for more information on the available levels.
 
 
 </Field>

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -288,7 +288,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -622,7 +622,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -256,7 +256,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -524,7 +524,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -261,7 +261,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -354,7 +354,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 
 ### partition_key_field
 
-The log field used as the Kinesis record&#39;s partition key value. See [Partitioning](#partitioning) for more info.
+The log field used as the Kinesis record's partition key value. See [Partitioning](#partitioning) for more info.
 
 
 </Field>
@@ -551,7 +551,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -296,7 +296,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -389,7 +389,7 @@ The encoding format used to serialize the events before outputting.
 
 ### endpoint
 
-The [endpoint][urls.aws_s3_endpoints] of the target S3 bucket. Either &quot;endpoint&quot; or &quot;region&quot; must be specified.
+The [endpoint][urls.aws_s3_endpoints] of the target S3 bucket. Either "endpoint" or "region" must be specified.
 
 
 </Field>
@@ -499,7 +499,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 
 ### key_prefix
 
-A prefix to apply to all object key names. This should be used to partition your objects, and it&#39;s important to end this value with a `/` if you want this to be the root S3 &quot;folder&quot;. See [Object Naming](#object-naming), [Partitioning](#partitioning), and [Template Syntax](#template-syntax) for more info.
+A prefix to apply to all object key names. This should be used to partition your objects, and it's important to end this value with a `/` if you want this to be the root S3 "folder". See [Object Naming](#object-naming), [Partitioning](#partitioning), and [Template Syntax](#template-syntax) for more info.
 
 
 </Field>
@@ -521,7 +521,7 @@ A prefix to apply to all object key names. This should be used to partition your
 
 ### region
 
-The [AWS region][urls.aws_s3_regions] of the target S3 bucket. Either &quot;region&quot; or &quot;endpoint&quot; must be specified.
+The [AWS region][urls.aws_s3_regions] of the target S3 bucket. Either "region" or "endpoint" must be specified.
 
 
 </Field>
@@ -696,7 +696,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -368,7 +368,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -658,7 +658,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>
@@ -838,7 +838,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -427,7 +427,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream.
 
 
 </Field>

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -376,7 +376,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -425,7 +425,7 @@ The behavior when the buffer becomes full.
 
 ### doc_type
 
-The [`doc_type`](#doc_type) for your index data. This is only relevant for Elasticsearch &lt;= 6.X. If you are using &gt;= 7.0 you do not need to set this option since Elasticsearch has removed it.
+The [`doc_type`](#doc_type) for your index data. This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to set this option since Elasticsearch has removed it.
 
 
 </Field>
@@ -517,7 +517,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 
 ### host
 
-The host of your Elasticsearch cluster. This should be the full URL as shown in the example. This is required if the [`provider`](#provider) is not `&quot;aws&quot;`
+The host of your Elasticsearch cluster. This should be the full URL as shown in the example. This is required if the [`provider`](#provider) is not `"aws"`
 
 
 </Field>
@@ -806,7 +806,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>
@@ -964,7 +964,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -286,7 +286,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -554,7 +554,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>
@@ -712,7 +712,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -367,7 +367,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -683,7 +683,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>
@@ -841,7 +841,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -203,7 +203,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>

--- a/website/docs/reference/sinks/new_relic_logs.md
+++ b/website/docs/reference/sinks/new_relic_logs.md
@@ -258,7 +258,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -548,7 +548,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -116,7 +116,7 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The address to connect to, this must include some &lt;host&gt;:&lt;port&gt; pair.
+The address to connect to. The address _must_ include a port.
 
 
 </Field>
@@ -203,7 +203,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -471,7 +471,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -270,7 +270,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>
@@ -560,7 +560,7 @@ The maximum amount of time to wait between retries.
 
 #### timeout_secs
 
-The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service&#39;s internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
+The maximum time a request can take before being aborted. It is highly recommended that you do not lower value below the service's internal timeout, as this could create orphaned requests, pile on retries, and result in deuplicate data downstream. See [Buffers & Batches](#buffers--batches) for more info.
 
 
 </Field>
@@ -718,7 +718,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
 
 #### verify_hostname
 
-If `true` (the default), Vector will validate the configured remote host name against the remote host&#39;s TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -101,7 +101,7 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The downstream Vector address to connect to, this must include &lt;host&gt;:&lt;port&gt;.
+The downstream Vector address to connect to. The address _must_ include a port.
 
 
 </Field>
@@ -188,7 +188,7 @@ The maximum size of the buffer on the disk.
 
 #### type
 
-The buffer&#39;s type / location. `disk` buffers are persistent and will be retained between restarts.
+The buffer's type / location. `disk` buffers are persistent and will be retained between restarts.
 
 
 </Field>

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -108,7 +108,7 @@ A list of image names to match against. If not provided, all images will be incl
 
 ### include_labels
 
-A list of container object labels to match against when filtering running containers. This should follow the described label&#39;s synatx in [docker object labels docs][urls.docker_object_labels].
+A list of container object labels to match against when filtering running containers. This should follow the described label's synatx in [docker object labels docs][urls.docker_object_labels].
 
 
 </Field>

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -187,7 +187,7 @@ The full path of the [`journalctl`](#journalctl) executable. If not set, Vector 
 
 ### units
 
-The list of units names to monitor. If empty or not present, all units are accepted. Unit names lacking a `&quot;.&quot;` will have `&quot;.service&quot;` appended to make them a valid service unit name.
+The list of units names to monitor. If empty or not present, all units are accepted. Unit names lacking a `"."` will have `".service"` appended to make them a valid service unit name.
 
 
 </Field>

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -124,7 +124,7 @@ If offsets for consumer group do not exist, set them using this strategy. [librd
 
 ### bootstrap_servers
 
-A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a &quot;bootstrap&quot; Kafka cluster that a Kafka client connects to initially to bootstrap itself.
+A comma-separated list of host and port pairs that are the addresses of the Kafka brokers in a "bootstrap" Kafka cluster that a Kafka client connects to initially to bootstrap itself.
 
 
 </Field>

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -107,7 +107,8 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The address to listen for connections on, or &quot;systemd#N&quot; to use the Nth socket passed by systemd socket activation.
+The address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd socket activation. If an address is used it _must_ include a port.
+
 
 
 </Field>

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -105,7 +105,7 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The TCP or UDP address to listen for connections on, or &quot;systemd#N&quot; to use the Nth socket passed by systemd socket activation.
+The TCP or UDP address to listen for connections on, or "systemd#N" to use the Nth socket passed by systemd socket activation.
 
 
 </Field>

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -62,7 +62,8 @@ import Field from '@site/src/components/Field';
 
 ### address
 
-The TCP address to listen for connections on, or &quot;systemd#N&quot; to use the Nth socket passed by systemd socket activation.
+The TCP address to listen for connections on, or `systemd#N to use the Nth socket passed by systemd socket activation. If an address is used it _must_ include a port.
+
 
 
 </Field>

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -213,7 +213,7 @@ The name of a transform, the input event will be delivered to this transform in 
 
 #### log_fields
 
-Specifies the log fields when the input type is &#39;log&#39;.
+Specifies the log fields when the input type is 'log'.
 
 <Fields filters={false}>
 
@@ -261,7 +261,7 @@ A key/value pair representing a field to be added to the input event.
 
 #### metric
 
-Specifies the metric type when the input type is &#39;metric&#39;.
+Specifies the metric type when the input type is 'metric'.
 
 <Fields filters={false}>
 
@@ -304,7 +304,7 @@ The direction to increase or decrease the gauge value.
 
 ##### name
 
-The name of the metric. Defaults to `&lt;field&gt;_total` for `counter` and `&lt;field&gt;` for `gauge`.
+The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`.
 
 
 </Field>
@@ -489,7 +489,7 @@ The event type.
 
 #### value
 
-Specifies the log message field contents when the input type is &#39;raw&#39;.
+Specifies the log message field contents when the input type is 'raw'.
 
 
 </Field>

--- a/website/docs/reference/transforms/aws_ec2_metadata.md
+++ b/website/docs/reference/transforms/aws_ec2_metadata.md
@@ -106,7 +106,7 @@ Override the default EC2 Metadata host.
 
 ### namespace
 
-Prepend a namespace to each field&#39;s key.
+Prepend a namespace to each field's key.
 
 
 </Field>

--- a/website/docs/reference/transforms/log_to_metric.md
+++ b/website/docs/reference/transforms/log_to_metric.md
@@ -127,7 +127,7 @@ If `true` the metric will be incremented by the [`field`](#field) value. If `fal
 
 #### name
 
-The name of the metric. Defaults to `&lt;field&gt;_total` for `counter` and `&lt;field&gt;` for `gauge`.
+The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`.
 
 
 </Field>

--- a/website/docs/reference/transforms/sampler.md
+++ b/website/docs/reference/transforms/sampler.md
@@ -60,7 +60,7 @@ import Field from '@site/src/components/Field';
 
 ### pass_list
 
-A list of regular expression patterns to exclude events from sampling. If an event&#39;s `&quot;message&quot;` key matches _any_ of these patterns it will _not_ be sampled.
+A list of regular expression patterns to exclude events from sampling. If an event's `"message"` key matches _any_ of these patterns it will _not_ be sampled.
 
 
 </Field>


### PR DESCRIPTION
This fixes a couple of issues introduced in #1585 

1. The `socket` source was not updated.
2. The use of HTML tags broke website builds. Escaping the characters is not correct because they are [used literally in code blocks](https://share.getcloudapp.com/jkunBg9q).