### PR TITLE
docs: Add assume_rule to AWS Authentication section

### DIFF
--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -3,10 +3,11 @@
 
 Vector checks for AWS credentials in the following order:
 
+<% if component.options.assume_role %>1. The [`assume_role` option](#assume_role), if provided.<% end %>
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -3,7 +3,6 @@
 
 Vector checks for AWS credentials in the following order:
 
-<% if component.options.assume_role %>1. The [`assume_role` option](#assume_role), if provided.<% end %>
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -132,7 +132,7 @@ import Field from '@site/src/components/Field';
 
 ### assume_role
 
-The ARN of an [IAM role][urls.aws_iam_role] to assume at startup.
+The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authentication](#aws-authentication) for more info.
 
 
 </Field>
@@ -776,10 +776,11 @@ X-Amz-Target: Logs_20140328.PutLogEvents
 
 Vector checks for AWS credentials in the following order:
 
+1. The [`assume_role` option](#assume_role), if provided.
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -132,7 +132,7 @@ import Field from '@site/src/components/Field';
 
 ### assume_role
 
-The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authentication](#aws-authentication) for more info.
+The ARN of an [IAM role][urls.aws_iam_role] to assume at startup.
 
 
 </Field>
@@ -776,7 +776,6 @@ X-Amz-Target: Logs_20140328.PutLogEvents
 
 Vector checks for AWS credentials in the following order:
 
-1. The [`assume_role` option](#assume_role), if provided.
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -228,10 +228,11 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -228,7 +228,6 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -647,10 +647,11 @@ For example:
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -647,7 +647,6 @@ For example:
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -674,10 +674,11 @@ For example:
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -674,7 +674,6 @@ For example:
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -764,10 +764,11 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -764,7 +764,6 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -1057,10 +1057,11 @@ Content-Length: <byte_size>
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -1057,7 +1057,6 @@ Content-Length: <byte_size>
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -565,10 +565,11 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
+
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
-3. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
-4. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
+1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
+1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)
+1. The [IAM instance profile][urls.iam_instance_profile]. (will only work if running on an EC2 instance with an instance profile/role)
 
 If credentials are not found the [healtcheck](#healthchecks) will fail and an
 error will be [logged][docs.monitoring#logs].

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -565,7 +565,6 @@ Used for AWS authentication when communicating with AWS services. See relevant [
 
 Vector checks for AWS credentials in the following order:
 
-
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 1. The [`credential_process` command][urls.aws_credential_process] in the AWS config file. (usually located at `~/.aws/config`)
 1. The [AWS credentials file][urls.aws_credentials_file]. (usually located at `~/.aws/credentials`)

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -17810,6 +17810,7 @@ module.exports = {
       "avatar": "https://github.com/a-rodin.png",
       "github": "https://github.com/a-rodin",
       "id": "alex",
+      "keybase": "https://keybase.io/arodin",
       "name": "Alexander"
     },
     {
@@ -17822,19 +17823,25 @@ module.exports = {
       "avatar": "https://github.com/hoverbear.png",
       "github": "https://github.com/hoverbear",
       "id": "ana",
-      "name": "Ana"
+      "keybase": "https://keybase.io/hoverbear",
+      "name": "Ana",
+      "twitter": "https://twitter.com/a_hoverbear"
     },
     {
       "avatar": "https://github.com/Jeffail.png",
       "github": "https://github.com/Jeffail",
       "id": "ashley",
-      "name": "Ashley"
+      "keybase": "https://keybase.io/jeffail",
+      "name": "Ashley",
+      "twitter": "https://twitter.com/jeffail"
     },
     {
       "avatar": "https://github.com/binarylogic.png",
       "github": "https://github.com/binarylogic",
       "id": "ben",
-      "name": "Ben"
+      "keybase": "https://keybase.io/binarylogic",
+      "name": "Ben",
+      "twitter": "https://twitter.com/binarylogic"
     },
     {
       "avatar": "https://github.com/bruceg.png",
@@ -17852,13 +17859,17 @@ module.exports = {
       "avatar": "https://github.com/LucioFranco.png",
       "github": "https://github.com/LucioFranco",
       "id": "lucio",
-      "name": "Lucio"
+      "keybase": "https://keybase.io/luciofranco",
+      "name": "Lucio",
+      "twitter": "https://twitter.com/lucio_d_franco"
     },
     {
       "avatar": "https://github.com/lukesteensen.png",
       "github": "https://github.com/lukesteensen",
       "id": "luke",
-      "name": "Luke"
+      "keybase": "https://keybase.io/lukesteensen",
+      "name": "Luke",
+      "twitter": "https://twitter.com/lukesteensen"
     }
   ],
   "transforms": {


### PR DESCRIPTION
This mentions the `assume_role` option in the "AWS Authentication" section. I want to make sure what I typed here is accurate.