### PR TITLE
chore(log data model): Add Event::extend, change param to slice

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -133,15 +133,20 @@ impl std::ops::Index<&Atom> for LogEvent {
     }
 }
 
+impl<K: Into<Atom>, V: Into<Value>> Extend<(K, V)> for LogEvent {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        for (k, v) in iter {
+            self.insert(k.into(), v.into());
+        }
+    }
+}
+
 // Allow converting any kind of appropriate key/value iterator directly into a LogEvent.
 impl<K: Into<Atom>, V: Into<Value>> FromIterator<(K, V)> for LogEvent {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        Self {
-            fields: iter
-                .into_iter()
-                .map(|(key, value)| (key.into(), value.into()))
-                .collect(),
-        }
+        let mut log_event = Event::new_empty_log().into_log();
+        log_event.extend(iter);
+        log_event
     }
 }
 
@@ -522,14 +527,7 @@ impl<'a> Iterator for FieldsIter<'a> {
     type Item = (&'a Atom, &'a Value);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let (key, value) = match self.inner.next() {
-                Some(next) => next,
-                None => return None,
-            };
-
-            return Some((key, &value));
-        }
+        self.inner.next()
     }
 }
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -180,13 +180,11 @@ pub fn validate_host(host: &str) -> crate::Result<()> {
     }
 }
 
-fn event_to_json(event: LogEvent, indexed_fields: &Vec<Atom>, timestamp: i64) -> JsonValue {
-    let mut fields = Event::new_empty_log().into_log();
-    for field in indexed_fields.iter() {
-        if let Some(value) = event.get(field) {
-            fields.insert(field, value.clone());
-        }
-    }
+fn event_to_json(event: LogEvent, indexed_fields: &[Atom], timestamp: i64) -> JsonValue {
+    let fields = indexed_fields
+        .iter()
+        .filter_map(|field| event.get(field).map(|value| (field, value.clone())))
+        .collect::<LogEvent>();
 
     json!({
         "fields": fields.unflatten(),
@@ -198,7 +196,7 @@ fn event_to_json(event: LogEvent, indexed_fields: &Vec<Atom>, timestamp: i64) ->
 fn encode_event(
     host_field: &Atom,
     event: Event,
-    indexed_fields: &Vec<Atom>,
+    indexed_fields: &[Atom],
     encoding: &Encoding,
 ) -> Option<Vec<u8>> {
     let mut event = event.into_log();


### PR DESCRIPTION
This is a minor refactor of `LogEvent` iterator traits. Usually `FromIterator` is implemented in terms of `Extend`, so I've done that which allowed simplifying in a few places. Additionally, `FieldsIter` has an `Iterator` implementation with a loop that would never loop (if `None` `return None`, if `Some` return (k, v))-- so I reduced that to a `.map` call.


