### PR TITLE
feat(clickhouse sink): Add timestamp_format field

### DIFF
--- a/.meta/sinks/clickhouse.toml
+++ b/.meta/sinks/clickhouse.toml
@@ -93,3 +93,12 @@ type = "string"
 common = true
 examples = ["mydatabase"]
 description = "The database that contains the stable that data will be inserted into."
+
+[sinks.clickhouse.options.timestamp_format]
+type = "string"
+common = true
+required = false
+description = "Optionally convert timestamps into a format that can be parsed as a Clickhouse DateTime. This loses precision as DateTimes are defined in seconds."
+
+[sinks.clickhouse.options.timestamp_format.enum]
+unix = "Format as a unix timestamp"

--- a/.meta/sinks/clickhouse.toml
+++ b/.meta/sinks/clickhouse.toml
@@ -94,11 +94,19 @@ common = true
 examples = ["mydatabase"]
 description = "The database that contains the stable that data will be inserted into."
 
-[sinks.clickhouse.options.timestamp_format]
+[sinks.clickhouse.options.encoding]
+type = "table"
+common = true
+required = false
+description = "Customize how events are encoded."
+
+[sinks.clickhouse.options.encoding.children.timestamp_format]
 type = "string"
 common = true
 required = false
-description = "Optionally convert timestamps into a format that can be parsed as a Clickhouse DateTime. This loses precision as DateTimes are defined in seconds."
+default = "rfc3339"
+description = "How to format event timestamps. Formats such as unix can be parsed as a Clickhouse DateTime, however, this loses precision as DateTimes are defined in seconds."
 
-[sinks.clickhouse.options.timestamp_format.enum]
-unix = "Format as a unix timestamp"
+[sinks.clickhouse.options.encoding.children.timestamp_format.enum]
+rfc3339 = "Format as an RFC3339 string"
+unix = "Format as a unix timestamp, can be parsed as a Clickhouse DateTime"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2841,15 +2841,6 @@ end
   healthcheck = true
   healthcheck = false
 
-  # Optionally convert timestamps into a format that can be parsed as a
-  # Clickhouse DateTime. This loses precision as DateTimes are defined in seconds.
-  #
-  # * optional
-  # * no default
-  # * type: string
-  # * must be: "unix" (if supplied)
-  timestamp_format = "unix"
-
   #
   # requests
   #
@@ -2952,6 +2943,22 @@ end
     # * enum: "block" or "drop_newest"
     when_full = "block"
     when_full = "drop_newest"
+
+  #
+  # Encoding
+  #
+
+  [sinks.clickhouse.encoding]
+    # How to format event timestamps. Formats such as unix can be parsed as a
+    # Clickhouse DateTime, however, this loses precision as DateTimes are defined
+    # in seconds.
+    #
+    # * optional
+    # * default: "rfc3339"
+    # * type: string
+    # * enum: "rfc3339" or "unix"
+    timestamp_format = "rfc3339"
+    timestamp_format = "unix"
 
   #
   # Request

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2841,6 +2841,15 @@ end
   healthcheck = true
   healthcheck = false
 
+  # Optionally convert timestamps into a format that can be parsed as a
+  # Clickhouse DateTime. This loses precision as DateTimes are defined in seconds.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  # * must be: "unix" (if supplied)
+  timestamp_format = "unix"
+
   #
   # requests
   #

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -52,6 +52,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # OPTIONAL - General
   database = "mydatabase" # example, no default
   healthcheck = true # default
+  timestamp_format = "unix" # no default, must be: "unix" (if supplied)
 
   # OPTIONAL - requests
   compression = "none" # default, enum
@@ -73,6 +74,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # OPTIONAL - General
   database = "mydatabase" # example, no default
   healthcheck = true # default
+  timestamp_format = "unix" # no default, must be: "unix" (if supplied)
 
   # OPTIONAL - requests
   compression = "none" # default, enum
@@ -727,6 +729,29 @@ The maximum time a request can take before being aborted. It is highly recommend
 ### table
 
 The table that data will be inserted into.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"unix":"Format as a unix timestamp"}}
+  examples={["unix"]}
+  groups={[]}
+  name={"timestamp_format"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### timestamp_format
+
+Optionally convert timestamps into a format that can be parsed as a Clickhouse DateTime. This loses precision as DateTimes are defined in seconds.
 
 
 </Field>

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -52,10 +52,13 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # OPTIONAL - General
   database = "mydatabase" # example, no default
   healthcheck = true # default
-  timestamp_format = "unix" # no default, must be: "unix" (if supplied)
 
   # OPTIONAL - requests
   compression = "none" # default, enum
+
+  # OPTIONAL - Encoding
+  [sinks.my_sink_id.encoding]
+    timestamp_format = "rfc3339" # default, enum
 ```
 
 </TabItem>
@@ -74,7 +77,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # OPTIONAL - General
   database = "mydatabase" # example, no default
   healthcheck = true # default
-  timestamp_format = "unix" # no default, must be: "unix" (if supplied)
 
   # OPTIONAL - requests
   compression = "none" # default, enum
@@ -99,6 +101,10 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
     # REQUIRED
     max_size = 104900000 # example, bytes, relevant when type = "disk"
+
+  # OPTIONAL - Encoding
+  [sinks.my_sink_id.encoding]
+    timestamp_format = "rfc3339" # default, enum
 
   # OPTIONAL - Request
   [sinks.my_sink_id.request]
@@ -479,6 +485,56 @@ The database that contains the stable that data will be inserted into.
 
 <Field
   common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  groups={[]}
+  name={"encoding"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### encoding
+
+Customize how events are encoded.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={"rfc3339"}
+  enumValues={{"rfc3339":"Format as an RFC3339 string","unix":"Format as a unix timestamp, can be parsed as a Clickhouse DateTime"}}
+  examples={["rfc3339","unix"]}
+  groups={[]}
+  name={"timestamp_format"}
+  path={"encoding"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### timestamp_format
+
+How to format event timestamps. Formats such as unix can be parsed as a Clickhouse DateTime, however, this loses precision as DateTimes are defined in seconds.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
+<Field
+  common={true}
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
@@ -729,29 +785,6 @@ The maximum time a request can take before being aborted. It is highly recommend
 ### table
 
 The table that data will be inserted into.
-
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={{"unix":"Format as a unix timestamp"}}
-  examples={["unix"]}
-  groups={[]}
-  name={"timestamp_format"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-### timestamp_format
-
-Optionally convert timestamps into a format that can be parsed as a Clickhouse DateTime. This loses precision as DateTimes are defined in seconds.
 
 
 </Field>


### PR DESCRIPTION
Allows users to specify a format for `timestamp` such that it can be parsed by Clickhouse as a `DateTime` data type.

By default we're not applying any formatting (sending as a string), this preserves backwards compatibility, it's also not an entirely unfavorable behavior since it has a higher precision. However, it's worth considering making `unix` formatting the default behavior here instead.

Closes #1443