### PR TITLE
chore(security): add cargo-deny check for advisories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: ci
+on:
+  push:
+    branches:
+    - master
+  pull_request: {}
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: EmbarkStudios/cargo-deny-action@v0
+      with:
+        command: "check advisories"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0002", # tracked in #1639
+    "RUSTSEC-2020-0001", # dev dependency only
+    "RUSTSEC-2019-0031", # spin is unmaintained
+]


### PR DESCRIPTION
We can expand this later on, but this gives us a simple check for new security advisories against any of our dependencies.

The check should currently fail until we merge #1638, so I'll rebase after that.