### PR TITLE
chore(http sink): Refactor internal http sink to use new `HttpS…

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -30,7 +30,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
                     "out",
                     &["in"],
                     sinks::http::HttpSinkConfig {
-                        uri: out_addr.to_string(),
+                        uri: out_addr.to_string().parse::<http::Uri>().unwrap().into(),
                         compression: Some(sinks::util::Compression::None),
                         ..Default::default()
                     },
@@ -81,7 +81,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
                     "out",
                     &["in"],
                     sinks::http::HttpSinkConfig {
-                        uri: out_addr.to_string(),
+                        uri: out_addr.to_string().parse::<http::Uri>().unwrap().into(),
                         ..Default::default()
                     },
                 );

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -102,6 +102,8 @@ impl NewRelicLogsConfig {
             request,
 
             tls: None,
+
+            ..Default::default()
         })
     }
 }

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -3,6 +3,7 @@ use crate::{
     sinks::util::{BatchBytesConfig, Compression, TowerRequestConfig},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
+use http::Uri;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -70,8 +71,8 @@ impl NewRelicLogsConfig {
         }
 
         let uri = match self.region.as_ref().unwrap_or(&NewRelicLogsRegion::Us) {
-            NewRelicLogsRegion::Us => "https://log-api.newrelic.com/log/v1",
-            NewRelicLogsRegion::Eu => "https://log-api.eu.newrelic.com/log/v1",
+            NewRelicLogsRegion::Us => Uri::from_static("https://log-api.newrelic.com/log/v1"),
+            NewRelicLogsRegion::Eu => Uri::from_static("https://log-api.eu.newrelic.com/log/v1"),
         };
 
         let batch = BatchBytesConfig {
@@ -90,7 +91,7 @@ impl NewRelicLogsConfig {
         };
 
         Ok(HttpSinkConfig {
-            uri: uri.to_owned(),
+            uri: uri.into(),
             method: Some(HttpMethod::Post),
             healthcheck_uri: None,
             auth: None,
@@ -142,7 +143,10 @@ mod tests {
         nr_config.license_key = Some("foo".to_owned());
         let http_config = nr_config.create_config().unwrap();
 
-        assert_eq!(http_config.uri, "https://log-api.newrelic.com/log/v1");
+        assert_eq!(
+            format!("{}", http_config.uri),
+            "https://log-api.newrelic.com/log/v1".to_string()
+        );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding, Encoding::Json);
         assert_eq!(
@@ -170,7 +174,10 @@ mod tests {
 
         let http_config = nr_config.create_config().unwrap();
 
-        assert_eq!(http_config.uri, "https://log-api.eu.newrelic.com/log/v1");
+        assert_eq!(
+            format!("{}", http_config.uri),
+            "https://log-api.eu.newrelic.com/log/v1".to_string()
+        );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding, Encoding::Json);
         assert_eq!(
@@ -204,7 +211,10 @@ mod tests {
 
         let http_config = nr_config.create_config().unwrap();
 
-        assert_eq!(http_config.uri, "https://log-api.eu.newrelic.com/log/v1");
+        assert_eq!(
+            format!("{}", http_config.uri),
+            "https://log-api.eu.newrelic.com/log/v1".to_string()
+        );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding, Encoding::Json);
         assert_eq!(
@@ -263,7 +273,10 @@ mod tests {
         let mut nr_config = NewRelicLogsConfig::default();
         nr_config.license_key = Some("foo".to_owned());
         let mut http_config = nr_config.create_config().unwrap();
-        http_config.uri = format!("http://{}/fake_nr", in_addr);
+        http_config.uri = format!("http://{}/fake_nr", in_addr)
+            .parse::<http::Uri>()
+            .unwrap()
+            .into();
 
         let mut rt = Runtime::new().unwrap();
 

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -101,6 +101,10 @@ where
         Self::build(inner, batch, min_size, min_size, max_linger)
     }
 
+    pub fn from_settings(inner: S, batch: B, settings: BatchSettings) -> Self {
+        Self::new_min(inner, batch, settings.size, settings.timeout.into())
+    }
+
     fn build(
         inner: S,
         batch: B,

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -6,6 +6,7 @@ pub mod rusoto;
 pub mod service;
 pub mod tcp;
 pub mod tls;
+pub mod uri;
 
 use crate::buffers::Acker;
 use futures::{
@@ -20,6 +21,7 @@ pub use buffer::metrics::{MetricBuffer, MetricEntry};
 pub use buffer::partition::{Partition, PartitionedBatchSink};
 pub use buffer::{Buffer, Compression, PartitionBuffer, PartitionInnerBuffer};
 pub use service::{ServiceBuilderExt, TowerRequestConfig, TowerRequestLayer, TowerRequestSettings};
+pub use uri::UriSerde;
 
 pub trait SinkExt<T>
 where

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -16,6 +16,9 @@ use tower::{
     Service, ServiceBuilder,
 };
 
+pub type TowerBatchedSink<T, L, B, S> =
+    BatchServiceSink<T, ConcurrencyLimit<RateLimit<Retry<FixedRetryPolicy<L>, Timeout<S>>>>, B>;
+
 pub trait ServiceBuilderExt<L> {
     fn map<R1, R2, F>(self, f: F) -> ServiceBuilder<Stack<MapLayer<R1, R2>, L>>
     where
@@ -119,7 +122,7 @@ impl TowerRequestSettings {
         retry_logic: L,
         service: S,
         acker: Acker,
-    ) -> BatchServiceSink<T, ConcurrencyLimit<RateLimit<Retry<FixedRetryPolicy<L>, Timeout<S>>>>, B>
+    ) -> TowerBatchedSink<T, L, B, S>
     // Would like to return `impl Sink + SinkExt<T>` here, but that
     // doesn't work with later calls to `batched_with_min` etc (via
     // `trait SinkExt` above), as it is missing a bound on the

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -1,0 +1,62 @@
+use http::Uri;
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt;
+
+/// A wrapper for `http::Uri` that implements the serde traits.
+#[derive(Default, Debug, Clone)]
+pub struct UriSerde(Uri);
+
+impl Serialize for UriSerde {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let uri = format!("{}", self.0);
+        serializer.serialize_str(&uri)
+    }
+}
+
+impl<'a> Deserialize<'a> for UriSerde {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_string(UriVisitor)
+    }
+}
+
+impl fmt::Display for UriSerde {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+struct UriVisitor;
+
+impl<'a> Visitor<'a> for UriVisitor {
+    type Value = UriSerde;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a string containing a HTTP")
+    }
+
+    fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let uri = s.parse::<Uri>().map_err(Error::custom)?;
+        Ok(UriSerde(uri))
+    }
+}
+
+impl From<UriSerde> for Uri {
+    fn from(t: UriSerde) -> Self {
+        t.0
+    }
+}
+
+impl From<Uri> for UriSerde {
+    fn from(t: Uri) -> Self {
+        Self(t)
+    }
+}

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -21,7 +21,7 @@ impl<'a> Deserialize<'a> for UriSerde {
     where
         D: Deserializer<'a>,
     {
-        deserializer.deserialize_string(UriVisitor)
+        deserializer.deserialize_str(UriVisitor)
     }
 }
 
@@ -37,10 +37,10 @@ impl<'a> Visitor<'a> for UriVisitor {
     type Value = UriSerde;
 
     fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "a string containing a HTTP")
+        write!(f, "a string containing a valid HTTP Uri")
     }
 
-    fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
     where
         E: Error,
     {


### PR DESCRIPTION
This refactors the internals to our `HttpService` to provide an easier to use `BatchedHttpSink` which takes some `HttpSink` implementation and some batch implementation and will implement sink that can be returned from a sink config. The `HttpSink` trait provides two methods one to encode events and one to build the overall http request. This is a common pattern among our http sinks and will make it easier to build them with less generics and less trait problems.

Sinks to convert:

- [x] `http`
- [ ] `splunk_hec`
- [ ] `elasticsearch`
- [ ] `datadog_metrics`
- [ ] `clickhouse`

Reference #1434.

## Motivation

The motivation for this change was mainly due to the unwieldiness of generics when it comes to multiple stacked sinks together. While it is nice to use `SinkExt` and a stack of 4-5 sink/service implementations and bundling them together with a builder pattern, it can start to get a bit crazy when adding some more generic things. I started to notice when making `HttpService` generic over the batch output type that it was getting difficult to align the types. This is something I've noticed with tower's layers that the more generics the worse the compiler gets at helping you. Since one of my goals here is to reduce complexity in buildings http based sinks I thought i'd be a good idea to let the user just implement a very easy trait and then tie all the composed sinks together in one inherent method on a very easy to use `BatchedHttpSink`. This should make it much easier to build these sinks and would reduce a lot of code around how we handle optional encoding etc.

cc @lukesteensen 