### PR TITLE
chore(elasticsearch sink)!: Nest the AWS endpoint/region options under `aws`

### DIFF
--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -303,7 +303,9 @@ mod integration_tests {
 
         let config = ElasticSearchConfig {
             auth: Some(ElasticSearchAuth::Aws),
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4571".into()),
+            aws: Some(RegionOrEndpoint::with_endpoint(
+                "http://localhost:4571".into(),
+            )),
             index: Some(stream.clone()),
             ..Default::default()
         };

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -464,7 +464,7 @@ mod tests {
     fn host_is_not_required_for_aws() {
         let result = parse_config(
             r#"
-            region = "us-east-1"
+            aws.region = "us-east-1"
 
             [auth]
             strategy = "aws"

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -484,7 +484,7 @@ mod tests {
     fn region_is_not_required_for_default() {
         let common = parse_config(r#"host = "https://example.com""#).unwrap();
 
-        assert_eq!(None, common.region);
+        assert_eq!(None, common.aws_region);
     }
 
     #[test]
@@ -601,7 +601,9 @@ mod integration_tests {
     fn insert_events_on_aws() {
         run_insert_tests(ElasticSearchConfig {
             auth: Some(ElasticSearchAuth::Aws),
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4571".into()),
+            aws: Some(RegionOrEndpoint::with_endpoint(
+                "http://localhost:4571".into(),
+            )),
             ..config()
         });
     }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -605,7 +605,7 @@ fn parses_sink_full_es_aws() {
         [sinks.out]
         type = "elasticsearch"
         inputs = ["in"]
-        region = "us-east-1"
+        aws.region = "us-east-1"
 
         [sinks.out.auth]
         strategy = "aws"


### PR DESCRIPTION
References #1608 

This has no documentation changes, as they are hard coded into the generate script. Some thought will need to be given to how to rework that to allow for the nesting.