### PR TITLE
chore: Upgrade to `tracing-subscriber 0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4055f329d81a5948a02fb203bc51ab3579541cdca746631b0a3a8a7204d9ec96"
+checksum = "25dc36e47794112347ccb9ae8a05b5ec4fab45f01545e4929323cdb1a543a8f4"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio-tls = "0.2.1"
 # Tracing
 tracing = "0.1.9"
 tracing-futures = { version = "0.2", features = ["futures-01"]}
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-subscriber = "0.2"
 tracing-log = "0.1.0"
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", rev = "65547d8809fcc726b8187db85b23c42e32ef5dce" }
 

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tracing-core = "0.1"
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-subscriber = "0.2"
 ansi_term = "0.11"
 
 [dev-dependencies]

--- a/lib/tracing-metrics/Cargo.toml
+++ b/lib/tracing-metrics/Cargo.toml
@@ -14,5 +14,5 @@ serde_json = "1.0"
 futures = "0.1.25"
 tokio = "0.1.21"
 hyper = "0.12.18"
-tracing-futures = { version = "0.2", features = ["futures-01"]}
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-futures = { version = "0.2", features = ["futures-01"] }
+tracing-subscriber = "0.2"


### PR DESCRIPTION
This release just went out, so thought we should upgrade to it so we can get off an `alpha` release.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>