### PR TITLE
feat(networking): Add proper non retry messages

### DIFF
--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -3,7 +3,7 @@ use crate::{
     event::Event,
     sinks::util::{
         http::{https_client, Auth, HttpRetryLogic, HttpService, Response},
-        retries::RetryLogic,
+        retries::{RetryAction, RetryLogic},
         tls::{TlsOptions, TlsSettings},
         BatchBytesConfig, Buffer, Compression, SinkExt, TowerRequestConfig,
     },
@@ -16,7 +16,6 @@ use hyper::{Body, Request};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
-use std::borrow::Cow;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
@@ -179,7 +178,7 @@ impl RetryLogic for ClickhouseRetryLogic {
         self.inner.is_retriable_error(error)
     }
 
-    fn should_retry_response(&self, response: &Self::Response) -> Option<Cow<str>> {
+    fn should_retry_response(&self, response: &Self::Response) -> RetryAction {
         match response.status() {
             StatusCode::INTERNAL_SERVER_ERROR => {
                 let body = response.body();
@@ -190,9 +189,9 @@ impl RetryLogic for ClickhouseRetryLogic {
                 //
                 // Reference: https://github.com/timberio/vector/pull/693#issuecomment-517332654
                 if body.starts_with(b"Code: 117") || body.starts_with(b"Code: 53") {
-                    None
+                    RetryAction::DontRetry("incorrect data".into())
                 } else {
-                    Some(String::from_utf8_lossy(body).to_string().into())
+                    RetryAction::Retry(String::from_utf8_lossy(body).to_string().into())
                 }
             }
             _ => self.inner.should_retry_response(response),

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -188,8 +188,11 @@ impl RetryLogic for ClickhouseRetryLogic {
                 // retry those errors.
                 //
                 // Reference: https://github.com/timberio/vector/pull/693#issuecomment-517332654
-                if body.starts_with(b"Code: 117") || body.starts_with(b"Code: 53") {
+                // Error code definitions: https://github.com/ClickHouse/ClickHouse/blob/master/dbms/src/Common/ErrorCodes.cpp
+                if body.starts_with(b"Code: 117") {
                     RetryAction::DontRetry("incorrect data".into())
+                } else if body.starts_with(b"Code: 53") {
+                    RetryAction::DontRetry("type mismatch".into())
                 } else {
                     RetryAction::Retry(String::from_utf8_lossy(body).to_string().into())
                 }

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -325,7 +325,9 @@ mod test {
         assert!(logic
             .should_retry_response(&response_400)
             .is_not_retryable());
-        assert!(logic.should_retry_response(&response_501).is_retryable());
+        assert!(logic
+            .should_retry_response(&response_501)
+            .is_not_retryable());
     }
 
     #[test]

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -1,5 +1,5 @@
 use super::{
-    retries::RetryLogic,
+    retries::{RetryAction, RetryLogic},
     service::{TowerBatchedSink, TowerRequestSettings},
     tls::{TlsConnectorExt, TlsSettings},
     Batch, BatchSettings, BatchSink,
@@ -13,7 +13,6 @@ use http::{Request, StatusCode};
 use hyper::client::HttpConnector;
 use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::executor::DefaultExecutor;
 use tower::Service;
@@ -269,16 +268,18 @@ impl RetryLogic for HttpRetryLogic {
         error.is_connect() || error.is_closed()
     }
 
-    fn should_retry_response(&self, response: &Self::Response) -> Option<Cow<str>> {
+    fn should_retry_response(&self, response: &Self::Response) -> RetryAction {
         let status = response.status();
 
         match status {
-            StatusCode::TOO_MANY_REQUESTS => Some("Too many requests".into()),
-            StatusCode::NOT_IMPLEMENTED => None,
-            _ if status.is_server_error() => {
-                Some(format!("{}: {}", status, String::from_utf8_lossy(response.body())).into())
+            StatusCode::TOO_MANY_REQUESTS => RetryAction::Retry("Too many requests".into()),
+            StatusCode::NOT_IMPLEMENTED => {
+                RetryAction::DontRetry("endpoint not implemented".into())
             }
-            _ => None,
+            _ if status.is_server_error() => RetryAction::Retry(
+                format!("{}: {}", status, String::from_utf8_lossy(response.body())).into(),
+            ),
+            _ => RetryAction::DontRetry(format!("response status: {}", status)),
         }
     }
 }
@@ -319,10 +320,10 @@ mod test {
         let response_400 = Response::builder().status(400).body(Bytes::new()).unwrap();
         let response_501 = Response::builder().status(501).body(Bytes::new()).unwrap();
 
-        assert!(logic.should_retry_response(&response_429).is_some());
-        assert!(logic.should_retry_response(&response_500).is_some());
-        assert!(logic.should_retry_response(&response_400).is_none());
-        assert!(logic.should_retry_response(&response_501).is_none());
+        assert!(logic.should_retry_response(&response_429).is_retryable());
+        assert!(logic.should_retry_response(&response_500).is_retryable());
+        assert!(logic.should_retry_response(&response_400).is_retryable());
+        assert!(logic.should_retry_response(&response_501).is_retryable());
     }
 
     #[test]

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -279,6 +279,7 @@ impl RetryLogic for HttpRetryLogic {
             _ if status.is_server_error() => RetryAction::Retry(
                 format!("{}: {}", status, String::from_utf8_lossy(response.body())).into(),
             ),
+            _ if status.is_success() => RetryAction::Successful,
             _ => RetryAction::DontRetry(format!("response status: {}", status)),
         }
     }

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -322,7 +322,9 @@ mod test {
 
         assert!(logic.should_retry_response(&response_429).is_retryable());
         assert!(logic.should_retry_response(&response_500).is_retryable());
-        assert!(logic.should_retry_response(&response_400).is_retryable());
+        assert!(logic
+            .should_retry_response(&response_400)
+            .is_not_retryable());
         assert!(logic.should_retry_response(&response_501).is_retryable());
     }
 

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -1,12 +1,16 @@
 use crate::Error;
 use futures::{try_ready, Async, Future, Poll};
 use std::{
-    borrow::Cow,
     cmp,
     time::{Duration, Instant},
 };
 use tokio::timer::Delay;
 use tower::{retry::Policy, timeout::error::Elapsed};
+
+pub enum RetryAction {
+    Retry(String),
+    DontRetry(String),
+}
 
 pub trait RetryLogic: Clone {
     type Error: std::error::Error + Send + Sync + 'static;
@@ -14,8 +18,8 @@ pub trait RetryLogic: Clone {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool;
 
-    fn should_retry_response(&self, _response: &Self::Response) -> Option<Cow<str>> {
-        None
+    fn should_retry_response(&self, _response: &Self::Response) -> RetryAction {
+        RetryAction::DontRetry("unknown".into())
     }
 }
 
@@ -90,12 +94,15 @@ where
                     return None;
                 }
 
-                if let Some(ref reason) = self.logic.should_retry_response(response) {
-                    warn!(message = "retrying after response.", %reason);
-                    Some(self.build_retry())
-                } else {
-                    warn!("request is not retryable; dropping the request.");
-                    None
+                match self.logic.should_retry_response(response) {
+                    RetryAction::Retry(reason) => {
+                        warn!(message = "retrying after response.", %reason);
+                        Some(self.build_retry())
+                    }
+                    RetryAction::DontRetry(reason) => {
+                        warn!(message = "request is not retryable; dropping the request.", %reason);
+                        None
+                    }
                 }
             }
             Err(error) => {
@@ -138,6 +145,24 @@ impl<L: RetryLogic> Future for RetryPolicyFuture<L> {
             .poll()
             .map_err(|error| panic!("timer error: {}; this is a bug!", error)));
         Ok(Async::Ready(self.policy.clone()))
+    }
+}
+
+impl RetryAction {
+    pub fn is_retryable(&self) -> bool {
+        if let RetryAction::Retry(_) = &self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_not_retryable(&self) -> bool {
+        if let RetryAction::DontRetry(_) = &self {
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -23,6 +23,7 @@ pub trait RetryLogic: Clone {
     fn is_retriable_error(&self, error: &Self::Error) -> bool;
 
     fn should_retry_response(&self, _response: &Self::Response) -> RetryAction {
+        // Treat the default as the request is successful
         RetryAction::Successful
     }
 }


### PR DESCRIPTION
Follow up to #1706 this adds a `RetryAction` enum to allow sinks to specify why they are _not_ retrying a request.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
