### PR TITLE
chore(website): Allow partials in /.meta/*.toml files

### DIFF
--- a/.meta/.schema.json
+++ b/.meta/.schema.json
@@ -522,10 +522,6 @@
           "description": "A simple title for this transform, typically one word.",
           "minLength": 1,
           "max_lenfth": 50
-        },
-        "types_coercion": {
-          "type": "boolean",
-          "description": "If this transform offers a `type` table for field coercion."
         }
       }
     }

--- a/.meta/_partials/_types.toml
+++ b/.meta/_partials/_types.toml
@@ -10,8 +10,6 @@ examples = [
 {status = "int"},
 {duration = "float"},
 {success = "bool"},
-{timestamp = "timestamp|%s"},
-{timestamp = "timestamp|%+"},
 {timestamp = "timestamp|%F"},
 {timestamp = "timestamp|%a %b %e %T %Y"}
 ]

--- a/.meta/_partials/_types.toml
+++ b/.meta/_partials/_types.toml
@@ -1,0 +1,30 @@
+[<%= namespace %>.options.types]
+type = "table"
+common = <%= common %>
+description = "Key/Value pairs representing mapped log field types."
+
+[<%= namespace %>.options.types.options."`[field-name]`"]
+type = "string"
+common = <%= common %>
+examples = [
+{status = "int"},
+{duration = "float"},
+{success = "bool"},
+{timestamp = "timestamp|%s"},
+{timestamp = "timestamp|%+"},
+{timestamp = "timestamp|%F"},
+{timestamp = "timestamp|%a %b %e %T %Y"}
+]
+null = false
+description = """\
+A definition of log field type conversions. They key is the log field name and \
+the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are \
+supported for the `timestamp` type.\
+"""
+
+[<%= namespace %>.options.types.options."`[field-name]`".enum]
+bool = "Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean."
+float = "Coerce to a 64 bit float."
+int = "Coerce to a 64 bit integer."
+string = "Coerce to a string."
+timestamp = "Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."

--- a/.meta/transforms/coercer.toml
+++ b/.meta/transforms/coercer.toml
@@ -5,7 +5,6 @@ common = false
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.coercer.options.drop_unspecified]
 type = "bool"
@@ -17,6 +16,8 @@ Make sure both `message` and `timestamp` are specified in the `types` table \
 as their absense will cause the original message data to be dropped along \
 with other extraneous fields.\
 """
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
 
 [[transforms.coercer.output.log.examples]]
 label = "Generic"

--- a/.meta/transforms/grok_parser.toml
+++ b/.meta/transforms/grok_parser.toml
@@ -5,7 +5,6 @@ common = false
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.grok_parser.options.drop_field]
 type = "bool"
@@ -31,3 +30,5 @@ common = true
 examples = ["%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"]
 required = true
 description = "The [Grok pattern][urls.grok_patterns]"
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>

--- a/.meta/transforms/grok_parser.toml
+++ b/.meta/transforms/grok_parser.toml
@@ -31,4 +31,4 @@ examples = ["%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:messa
 required = true
 description = "The [Grok pattern][urls.grok_patterns]"
 
-<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
+<%= render("_partials/_types.toml", namespace: "transforms.grok_parser", common: true) %>

--- a/.meta/transforms/logfmt_parser.toml
+++ b/.meta/transforms/logfmt_parser.toml
@@ -22,4 +22,4 @@ default = true
 required = true
 description = "If the specified `field` should be dropped (removed) after parsing."
 
-<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
+<%= render("_partials/_types.toml", namespace: "transforms.logfmt_parser", common: true) %>

--- a/.meta/transforms/logfmt_parser.toml
+++ b/.meta/transforms/logfmt_parser.toml
@@ -7,7 +7,6 @@ common = true
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.logfmt_parser.options.field]
 type = "string"
@@ -22,3 +21,5 @@ common = true
 default = true
 required = true
 description = "If the specified `field` should be dropped (removed) after parsing."
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>

--- a/.meta/transforms/regex_parser.toml
+++ b/.meta/transforms/regex_parser.toml
@@ -35,4 +35,4 @@ description = """\
 The Regular Expression to apply. Do not include the leading or trailing `/`.\
 """
 
-<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
+<%= render("_partials/_types.toml", namespace: "transforms.regex_parser", common: true) %>

--- a/.meta/transforms/regex_parser.toml
+++ b/.meta/transforms/regex_parser.toml
@@ -7,7 +7,6 @@ common = true
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.regex_parser.options.drop_field]
 type = "bool"
@@ -35,3 +34,5 @@ required = true
 description = """\
 The Regular Expression to apply. Do not include the leading or trailing `/`.\
 """
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>

--- a/.meta/transforms/split.toml
+++ b/.meta/transforms/split.toml
@@ -41,4 +41,4 @@ default = true
 required = true
 description = "If `true` the `field` will be dropped after parsing."
 
-<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
+<%= render("_partials/_types.toml", namespace: "transforms.split", common: true) %>

--- a/.meta/transforms/split.toml
+++ b/.meta/transforms/split.toml
@@ -8,7 +8,6 @@ common = false
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.split.options.field]
 type = "string"
@@ -41,3 +40,5 @@ common = true
 default = true
 required = true
 description = "If `true` the `field` will be dropped after parsing."
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>

--- a/.meta/transforms/tokenizer.toml
+++ b/.meta/transforms/tokenizer.toml
@@ -8,7 +8,6 @@ common = true
 function_category = "parse"
 input_types = ["log"]
 output_types = ["log"]
-types_coercion = true
 
 [transforms.tokenizer.options.field]
 type = "string"
@@ -30,3 +29,5 @@ common = true
 default = true
 required = true
 description = "If `true` the `field` will be dropped after parsing."
+
+<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>

--- a/.meta/transforms/tokenizer.toml
+++ b/.meta/transforms/tokenizer.toml
@@ -30,4 +30,4 @@ default = true
 required = true
 description = "If `true` the `field` will be dropped after parsing."
 
-<%= render("_partials/_types.toml", namespace: "transforms.coercer", common: true) %>
+<%= render("_partials/_types.toml", namespace: "transforms.tokenizer", common: true) %>

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -853,8 +853,6 @@ dns_servers = ["0.0.0.0:53"]
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 
@@ -1023,8 +1021,6 @@ dns_servers = ["0.0.0.0:53"]
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 
@@ -1203,8 +1199,6 @@ dns_servers = ["0.0.0.0:53"]
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 
@@ -1351,8 +1345,6 @@ end
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 
@@ -1498,8 +1490,6 @@ end
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 
@@ -1560,8 +1550,6 @@ end
     status = "int"
     duration = "float"
     success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
     timestamp = "timestamp|%F"
     timestamp = "timestamp|%a %b %e %T %Y"
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -968,10 +968,6 @@ dns_servers = ["0.0.0.0:53"]
 
 # Accepts `log` events and allows you to parse a log field value with Grok.
 [transforms.grok_parser]
-  #
-  # General
-  #
-
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `grok_parser`.
   #
@@ -1006,27 +1002,6 @@ dns_servers = ["0.0.0.0:53"]
   # * required
   # * type: string
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
-
-  #
-  # Types
-  #
-
-  [transforms.grok_parser.types]
-    # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strptime` specifiers are supported for the
-    # `timestamp` type.
-    #
-    # * optional
-    # * no default
-    # * type: string
-    # * enum: "bool", "float", "int", "string", and "timestamp"
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to parse a log field value as JSON.
 [transforms.json_parser]
@@ -1154,10 +1129,6 @@ dns_servers = ["0.0.0.0:53"]
 
 # Accepts `log` events and allows you to extract data from a logfmt-formatted log field.
 [transforms.logfmt_parser]
-  #
-  # General
-  #
-
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `logfmt_parser`.
   #
@@ -1186,27 +1157,6 @@ dns_servers = ["0.0.0.0:53"]
   # * default: "message"
   # * type: string
   field = "message"
-
-  #
-  # Types
-  #
-
-  [transforms.logfmt_parser.types]
-    # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strptime` specifiers are supported for the
-    # `timestamp` type.
-    #
-    # * optional
-    # * no default
-    # * type: string
-    # * enum: "bool", "float", "int", "string", and "timestamp"
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to transform events with a full embedded Lua engine.
 [transforms.lua]
@@ -1296,10 +1246,6 @@ end
 
 # Accepts `log` events and allows you to parse a log field's value with a Regular Expression.
 [transforms.regex_parser]
-  #
-  # General
-  #
-
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `regex_parser`.
   #
@@ -1334,27 +1280,6 @@ end
   # * required
   # * type: string
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
-
-  #
-  # Types
-  #
-
-  [transforms.regex_parser.types]
-    # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strptime` specifiers are supported for the
-    # `timestamp` type.
-    #
-    # * optional
-    # * no default
-    # * type: string
-    # * enum: "bool", "float", "int", "string", and "timestamp"
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to remove one or more log fields.
 [transforms.remove_fields]
@@ -1435,10 +1360,6 @@ end
 
 # Accepts `log` events and allows you to split a field's value on a given separator and zip the tokens into ordered field names.
 [transforms.split]
-  #
-  # General
-  #
-
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `split`.
   #
@@ -1482,33 +1403,8 @@ end
   # * type: [string]
   separator = ","
 
-  #
-  # Types
-  #
-
-  [transforms.split.types]
-    # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strptime` specifiers are supported for the
-    # `timestamp` type.
-    #
-    # * optional
-    # * no default
-    # * type: string
-    # * enum: "bool", "float", "int", "string", and "timestamp"
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
-
 # Accepts `log` events and allows you to tokenize a field's value by splitting on white space, ignoring special wrapping characters, and zip the tokens into ordered field names.
 [transforms.tokenizer]
-  #
-  # General
-  #
-
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `tokenizer`.
   #
@@ -1543,27 +1439,6 @@ end
   # * required
   # * type: [string]
   field_names = ["timestamp", "level", "message"]
-
-  #
-  # Types
-  #
-
-  [transforms.tokenizer.types]
-    # A definition of log field type conversions. They key is the log field name
-    # and the value is the type. `strptime` specifiers are supported for the
-    # `timestamp` type.
-    #
-    # * optional
-    # * no default
-    # * type: string
-    # * enum: "bool", "float", "int", "string", and "timestamp"
-    status = "int"
-    duration = "float"
-    success = "bool"
-    timestamp = "timestamp|%s"
-    timestamp = "timestamp|%+"
-    timestamp = "timestamp|%F"
-    timestamp = "timestamp|%a %b %e %T %Y"
 
 
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -968,6 +968,10 @@ dns_servers = ["0.0.0.0:53"]
 
 # Accepts `log` events and allows you to parse a log field value with Grok.
 [transforms.grok_parser]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `grok_parser`.
   #
@@ -1002,6 +1006,27 @@ dns_servers = ["0.0.0.0:53"]
   # * required
   # * type: string
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
+
+  #
+  # Types
+  #
+
+  [transforms.grok_parser.types]
+    # A definition of log field type conversions. They key is the log field name
+    # and the value is the type. `strptime` specifiers are supported for the
+    # `timestamp` type.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * enum: "bool", "float", "int", "string", and "timestamp"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to parse a log field value as JSON.
 [transforms.json_parser]
@@ -1129,6 +1154,10 @@ dns_servers = ["0.0.0.0:53"]
 
 # Accepts `log` events and allows you to extract data from a logfmt-formatted log field.
 [transforms.logfmt_parser]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `logfmt_parser`.
   #
@@ -1157,6 +1186,27 @@ dns_servers = ["0.0.0.0:53"]
   # * default: "message"
   # * type: string
   field = "message"
+
+  #
+  # Types
+  #
+
+  [transforms.logfmt_parser.types]
+    # A definition of log field type conversions. They key is the log field name
+    # and the value is the type. `strptime` specifiers are supported for the
+    # `timestamp` type.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * enum: "bool", "float", "int", "string", and "timestamp"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to transform events with a full embedded Lua engine.
 [transforms.lua]
@@ -1246,6 +1296,10 @@ end
 
 # Accepts `log` events and allows you to parse a log field's value with a Regular Expression.
 [transforms.regex_parser]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `regex_parser`.
   #
@@ -1280,6 +1334,27 @@ end
   # * required
   # * type: string
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
+
+  #
+  # Types
+  #
+
+  [transforms.regex_parser.types]
+    # A definition of log field type conversions. They key is the log field name
+    # and the value is the type. `strptime` specifiers are supported for the
+    # `timestamp` type.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * enum: "bool", "float", "int", "string", and "timestamp"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 # Accepts `log` events and allows you to remove one or more log fields.
 [transforms.remove_fields]
@@ -1360,6 +1435,10 @@ end
 
 # Accepts `log` events and allows you to split a field's value on a given separator and zip the tokens into ordered field names.
 [transforms.split]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `split`.
   #
@@ -1403,8 +1482,33 @@ end
   # * type: [string]
   separator = ","
 
+  #
+  # Types
+  #
+
+  [transforms.split.types]
+    # A definition of log field type conversions. They key is the log field name
+    # and the value is the type. `strptime` specifiers are supported for the
+    # `timestamp` type.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * enum: "bool", "float", "int", "string", and "timestamp"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
+
 # Accepts `log` events and allows you to tokenize a field's value by splitting on white space, ignoring special wrapping characters, and zip the tokens into ordered field names.
 [transforms.tokenizer]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `tokenizer`.
   #
@@ -1439,6 +1543,27 @@ end
   # * required
   # * type: [string]
   field_names = ["timestamp", "level", "message"]
+
+  #
+  # Types
+  #
+
+  [transforms.tokenizer.types]
+    # A definition of log field type conversions. They key is the log field name
+    # and the value is the type. `strptime` specifiers are supported for the
+    # `timestamp` type.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * enum: "bool", "float", "int", "string", and "timestamp"
+    status = "int"
+    duration = "float"
+    success = "bool"
+    timestamp = "timestamp|%s"
+    timestamp = "timestamp|%+"
+    timestamp = "timestamp|%F"
+    timestamp = "timestamp|%a %b %e %T %Y"
 
 
 # ------------------------------------------------------------------------------

--- a/scripts/util/metadata.rb
+++ b/scripts/util/metadata.rb
@@ -17,6 +17,23 @@ require_relative "metadata/transform"
 # This represents the /.meta directory in object form. Sub-classes represent
 # each sub-component.
 class Metadata
+  module Template
+    extend self
+
+    def render(path, args = {})
+      context = binding
+
+      args.each do |key, value|
+        context.local_variable_set("#{key}", value)
+      end
+
+      full_path = path.start_with?("/") ? path : "#{META_ROOT}/#{path}"
+      body = File.read(full_path)
+      renderer = ERB.new(body, nil, '-')
+      renderer.result(context)
+    end
+  end
+
   class << self
     def load!(meta_dir, docs_root, pages_root)
       metadata = load_metadata!(meta_dir)
@@ -40,8 +57,9 @@ class Metadata
       def load_metadata!(meta_dir)
         metadata = {}
 
-        Dir.glob("#{meta_dir}/**/*.toml").each do |file|
-          hash = TomlRB.load_file(file)
+        Dir.glob("#{meta_dir}/**/[^_]*.toml").each do |file|
+          content = Template.render(file)
+          hash = TomlRB.parse(content)
           metadata.deep_merge!(hash)
         end
 
@@ -49,8 +67,8 @@ class Metadata
       end
 
       def read_json(path)
-        json_data = File.read(path)
-        JSON.parse(json_data)
+        body = File.read(path)
+        JSON.parse(body)
       end
 
       def validate_schema!(schema, metadata)

--- a/scripts/util/metadata.rb
+++ b/scripts/util/metadata.rb
@@ -1,3 +1,4 @@
+require "erb"
 require "json_schemer"
 require "ostruct"
 require "toml-rb"

--- a/scripts/util/metadata/transform.rb
+++ b/scripts/util/metadata/transform.rb
@@ -18,7 +18,6 @@ class Transform < Component
     @input_types = hash.fetch("input_types")
     @output = OpenStruct.new
     @output_types = hash.fetch("output_types")
-    types_coercion = hash["types_coercion"] == true
 
     # checks
 
@@ -44,46 +43,6 @@ class Transform < Component
 
     if output["metric"]
       @output.metric = Output.new(output["metric"])
-    end
-
-    # types
-
-    if types_coercion
-      wildcard_option =
-        {
-          "name" => "`[field-name]`",
-          "category" => "requests",
-          "enum" => {
-            "bool" => "Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.",
-            "float" => "Coerce to a 64 bit float.",
-            "int" => "Coerce to a 64 bit integer.",
-            "string" => "Coerce to a string.",
-            "timestamp" => "Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."
-          },
-          "examples" => [
-            {"status" => "int"},
-            {"duration" => "float"},
-            {"success" => "bool"},
-            {"timestamp" => "timestamp|%s"},
-            {"timestamp" => "timestamp|%+"},
-            {"timestamp" => "timestamp|%F"},
-            {"timestamp" => "timestamp|%a %b %e %T %Y"}
-          ],
-          "description" => "A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.",
-          "null" => false,
-          "simple" => true,
-          "type" => "string"
-        }
-
-      @options.types =
-        Option.new({
-          "name" => "types",
-          "common" => true,
-          "description" => "Key/Value pairs representing mapped log field types.",
-          "null" => true,
-          "options" => {"`[field-name]`" => wildcard_option},
-          "type" => "table"
-        })
     end
   end
 

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -47,6 +47,13 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # OPTIONAL - Types
   [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 </TabItem>
@@ -131,7 +138,7 @@ Key/Value pairs representing mapped log field types.
 
 
 <Field
-  common={false}
+  common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -50,8 +50,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -75,8 +73,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -141,7 +137,7 @@ Key/Value pairs representing mapped log field types.
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -26,17 +26,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED - General
+  # REQUIRED
   type = "grok_parser" # must be: "grok_parser"
   inputs = ["my-source-id"] # example
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}" # example
 
-  # OPTIONAL - General
+  # OPTIONAL
   drop_field = true # default
   field = "message" # default
-
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
 ```
 
 ## Options
@@ -114,54 +111,6 @@ The [Grok pattern][urls.grok_patterns]
 </Field>
 
 
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[]}
-  name={"types"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"table"}
-  unit={null}
-  >
-
-### types
-
-Key/Value pairs representing mapped log field types.
-
-<Fields filters={false}>
-
-
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
-  name={"`[field-name]`"}
-  path={"types"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-#### `[field-name]`
-
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
-
-
-</Field>
-
-
-</Fields>
-
-</Field>
-
-
 </Fields>
 
 ## How It Works
@@ -203,4 +152,3 @@ performance issues.
 [urls.grok_debugger]: http://grokdebug.herokuapp.com/
 [urls.grok_patterns]: https://github.com/daschl/grok/tree/master/patterns
 [urls.rust_grok_library]: https://github.com/daschl/grok
-[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -40,8 +40,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -146,7 +144,7 @@ Key/Value pairs representing mapped log field types.
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -26,14 +26,24 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "grok_parser" # must be: "grok_parser"
   inputs = ["my-source-id"] # example
   pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}" # example
 
-  # OPTIONAL
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 ## Options
@@ -111,6 +121,54 @@ The [Grok pattern][urls.grok_patterns]
 </Field>
 
 
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"types"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### types
+
+Key/Value pairs representing mapped log field types.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  name={"`[field-name]`"}
+  path={"types"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### `[field-name]`
+
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
 </Fields>
 
 ## How It Works
@@ -152,3 +210,4 @@ performance issues.
 [urls.grok_debugger]: http://grokdebug.herokuapp.com/
 [urls.grok_patterns]: https://github.com/daschl/grok/tree/master/patterns
 [urls.rust_grok_library]: https://github.com/daschl/grok
+[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/logfmt_parser.md
+++ b/website/docs/reference/transforms/logfmt_parser.md
@@ -26,16 +26,13 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED - General
+  # REQUIRED
   type = "logfmt_parser" # must be: "logfmt_parser"
   inputs = ["my-source-id"] # example
 
-  # OPTIONAL - General
+  # OPTIONAL
   drop_field = true # default
   field = "message" # default
-
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
 ```
 
 ## Options
@@ -91,54 +88,6 @@ The log field to parse.
 </Field>
 
 
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[]}
-  name={"types"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"table"}
-  unit={null}
-  >
-
-### types
-
-Key/Value pairs representing mapped log field types.
-
-<Fields filters={false}>
-
-
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
-  name={"`[field-name]`"}
-  path={"types"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-#### `[field-name]`
-
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
-
-
-</Field>
-
-
-</Fields>
-
-</Field>
-
-
 </Fields>
 
 ## How It Works
@@ -155,4 +104,3 @@ section.
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
-[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/logfmt_parser.md
+++ b/website/docs/reference/transforms/logfmt_parser.md
@@ -26,13 +26,23 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "logfmt_parser" # must be: "logfmt_parser"
   inputs = ["my-source-id"] # example
 
-  # OPTIONAL
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 ## Options
@@ -88,6 +98,54 @@ The log field to parse.
 </Field>
 
 
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"types"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### types
+
+Key/Value pairs representing mapped log field types.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  name={"`[field-name]`"}
+  path={"types"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### `[field-name]`
+
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
 </Fields>
 
 ## How It Works
@@ -104,3 +162,4 @@ section.
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
+[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/logfmt_parser.md
+++ b/website/docs/reference/transforms/logfmt_parser.md
@@ -39,8 +39,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -123,7 +121,7 @@ Key/Value pairs representing mapped log field types.
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -26,14 +26,24 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "regex_parser" # must be: "regex_parser"
   inputs = ["my-source-id"] # example
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$" # example
 
-  # OPTIONAL
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 ## Options
@@ -107,6 +117,54 @@ The log field to parse. See [Failed Parsing](#failed-parsing) for more info.
 
 The Regular Expression to apply. Do not include the leading or trailing `/`. See [Failed Parsing](#failed-parsing) and [Regex Debugger](#regex-debugger) for more info.
 
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"types"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### types
+
+Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-syntax) for more info.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  name={"`[field-name]`"}
+  path={"types"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### `[field-name]`
+
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
+
+
+</Field>
+
+
+</Fields>
 
 </Field>
 
@@ -209,7 +267,7 @@ You can name Regex captures with the `<name>` syntax. For example:
 ```
 
 Will capture `timestamp`, `level`, and `message`. All values are extracted as
-`string` values and must be coerced with the `types` table.
+`string` values and must be coerced with the [`types`](#types) table.
 
 More info can be found in the [Regex grouping and flags
 documentation][urls.regex_grouping_and_flags].
@@ -246,3 +304,4 @@ documentation][urls.regex_grouping_and_flags].
 [urls.regex_parsing_performance_test]: https://github.com/timberio/vector-test-harness/tree/master/cases/regex_parsing_performance
 [urls.regex_tester]: https://rustexp.lpil.uk/
 [urls.rust_regex_syntax]: https://docs.rs/regex/1.1.7/regex/#syntax
+[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -40,8 +40,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -146,7 +144,7 @@ Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-s
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -26,17 +26,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED - General
+  # REQUIRED
   type = "regex_parser" # must be: "regex_parser"
   inputs = ["my-source-id"] # example
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$" # example
 
-  # OPTIONAL - General
+  # OPTIONAL
   drop_field = true # default
   field = "message" # default
-
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
 ```
 
 ## Options
@@ -110,54 +107,6 @@ The log field to parse. See [Failed Parsing](#failed-parsing) for more info.
 
 The Regular Expression to apply. Do not include the leading or trailing `/`. See [Failed Parsing](#failed-parsing) and [Regex Debugger](#regex-debugger) for more info.
 
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[]}
-  name={"types"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"table"}
-  unit={null}
-  >
-
-### types
-
-Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-syntax) for more info.
-
-<Fields filters={false}>
-
-
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
-  name={"`[field-name]`"}
-  path={"types"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-#### `[field-name]`
-
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
-
-
-</Field>
-
-
-</Fields>
 
 </Field>
 
@@ -260,7 +209,7 @@ You can name Regex captures with the `<name>` syntax. For example:
 ```
 
 Will capture `timestamp`, `level`, and `message`. All values are extracted as
-`string` values and must be coerced with the [`types`](#types) table.
+`string` values and must be coerced with the `types` table.
 
 More info can be found in the [Regex grouping and flags
 documentation][urls.regex_grouping_and_flags].
@@ -297,4 +246,3 @@ documentation][urls.regex_grouping_and_flags].
 [urls.regex_parsing_performance_test]: https://github.com/timberio/vector-test-harness/tree/master/cases/regex_parsing_performance
 [urls.regex_tester]: https://rustexp.lpil.uk/
 [urls.rust_regex_syntax]: https://docs.rs/regex/1.1.7/regex/#syntax
-[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -26,15 +26,25 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "split" # must be: "split"
   inputs = ["my-source-id"] # example
   field_names = ["timestamp", "level", "message"] # example
 
-  # OPTIONAL
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
   separator = "whitespace" # default
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 ## Options
@@ -134,6 +144,54 @@ The separator to split the field on. If no separator is given, it will split on 
 </Field>
 
 
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"types"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### types
+
+Key/Value pairs representing mapped log field types.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  name={"`[field-name]`"}
+  path={"types"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### `[field-name]`
+
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
 </Fields>
 
 ## Output
@@ -191,3 +249,4 @@ section.
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
+[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -26,18 +26,15 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED - General
+  # REQUIRED
   type = "split" # must be: "split"
   inputs = ["my-source-id"] # example
   field_names = ["timestamp", "level", "message"] # example
 
-  # OPTIONAL - General
+  # OPTIONAL
   drop_field = true # default
   field = "message" # default
   separator = "whitespace" # default
-
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
 ```
 
 ## Options
@@ -137,54 +134,6 @@ The separator to split the field on. If no separator is given, it will split on 
 </Field>
 
 
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[]}
-  name={"types"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"table"}
-  unit={null}
-  >
-
-### types
-
-Key/Value pairs representing mapped log field types.
-
-<Fields filters={false}>
-
-
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
-  name={"`[field-name]`"}
-  path={"types"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-#### `[field-name]`
-
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
-
-
-</Field>
-
-
-</Fields>
-
-</Field>
-
-
 </Fields>
 
 ## Output
@@ -242,4 +191,3 @@ section.
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
-[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -41,8 +41,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -169,7 +167,7 @@ Key/Value pairs representing mapped log field types.
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -26,17 +26,14 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED - General
+  # REQUIRED
   type = "tokenizer" # must be: "tokenizer"
   inputs = ["my-source-id"] # example
   field_names = ["timestamp", "level", "message"] # example
 
-  # OPTIONAL - General
+  # OPTIONAL
   drop_field = true # default
   field = "message" # default
-
-  # OPTIONAL - Types
-  [transforms.my_transform_id.types]
 ```
 
 ## Options
@@ -114,54 +111,6 @@ The log field names assigned to the resulting tokens, in order.
 </Field>
 
 
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[]}
-  name={"types"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"table"}
-  unit={null}
-  >
-
-### types
-
-Key/Value pairs representing mapped log field types.
-
-<Fields filters={false}>
-
-
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
-  name={"`[field-name]`"}
-  path={"types"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-#### `[field-name]`
-
-A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
-
-
-</Field>
-
-
-</Fields>
-
-</Field>
-
-
 </Fields>
 
 ## Output
@@ -233,4 +182,3 @@ certain characters as special. These characters will be discarded:
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
-[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -40,8 +40,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     status = "int" # example
     duration = "float" # example
     success = "bool" # example
-    timestamp = "timestamp|%s" # example
-    timestamp = "timestamp|%+" # example
     timestamp = "timestamp|%F" # example
     timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
@@ -146,7 +144,7 @@ Key/Value pairs representing mapped log field types.
   common={true}
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
-  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -26,14 +26,24 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [transforms.my_transform_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "tokenizer" # must be: "tokenizer"
   inputs = ["my-source-id"] # example
   field_names = ["timestamp", "level", "message"] # example
 
-  # OPTIONAL
+  # OPTIONAL - General
   drop_field = true # default
   field = "message" # default
+
+  # OPTIONAL - Types
+  [transforms.my_transform_id.types]
+    status = "int" # example
+    duration = "float" # example
+    success = "bool" # example
+    timestamp = "timestamp|%s" # example
+    timestamp = "timestamp|%+" # example
+    timestamp = "timestamp|%F" # example
+    timestamp = "timestamp|%a %b %e %T %Y" # example
 ```
 
 ## Options
@@ -111,6 +121,54 @@ The log field names assigned to the resulting tokens, in order.
 </Field>
 
 
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  name={"types"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  >
+
+### types
+
+Key/Value pairs representing mapped log field types.
+
+<Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
+  examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%s"},{"timestamp":"timestamp|%+"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  name={"`[field-name]`"}
+  path={"types"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### `[field-name]`
+
+A definition of log field type conversions. They key is the log field name and the value is the type. [`strptime` specifiers][urls.strptime_specifiers] are supported for the `timestamp` type.
+
+
+</Field>
+
+
+</Fields>
+
+</Field>
+
+
 </Fields>
 
 ## Output
@@ -182,3 +240,4 @@ certain characters as special. These characters will be discarded:
 
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log]: /docs/about/data-model/log/
+[urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html


### PR DESCRIPTION
This introduces the usage of partials in our `/.meta/**/*.toml` files allowing us to compose configuration files versus magical attributes deep in our `script/generate` Ruby files. I started with the `types` table as an example and plan to follow up with more changes over time to complete this transition.

The has the following advantages:

1. We can begin to remove custom logic deep in our `scripts/generate` Ruby files, reducing our dependence on these classes.
2. Moving construction of all options into the `.meta` dir has the advantage of running through our new [`.meta/.schema.json` file](https://github.com/timberio/vector/blob/master/.meta/.schema.json). Currently, options defined during Ruby class instantiation skip this validation.
3. It removes a layer that documenters have to deal with, containing all documentation changes to the `.meta` dir.
4. It's explicit and obvious. There are no "magic" options. They are explicitly represented in the `.toml` file one way or another.

Finally, this is precursor to my documentation solution for https://github.com/timberio/vector/pull/1703.

@LucioFranco I know you enjoy our Ruby files, so I'm sorry for reducing our dependence on them.