### PR TITLE
feat(cli): Support multiple configuration files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "flate2",
  "futures 0.1.29",
  "futures 0.3.1",
+ "glob 0.2.11",
  "goauth",
  "grok",
  "headers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ lazy_static = "1.3.0"
 rlua = { git = "https://github.com/timberio/rlua" }
 num_cpus = "1.10.0"
 bytesize = "1.0.0"
+glob = "0.2.11"
 grok = "~1.0.1"
 nom = "5.0.0"
 uuid = { version = "0.7", features = ["serde", "v4"] }

--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@
   <img src="./website/static/img/readme_diagram.svg" alt="Vector">
 </p>
 
----
-
-<p align="center">
-  <strong>
-    New post! <a href="https://vector.dev/blog/prometheus-source">Prometheus Source</a>
-  </strong>
-</p>
-
----
 
 Vector is an [open-source][urls.vector_repo] utility for building observability
 pipelines. [Collect][docs.sources], [transform][docs.transforms], and

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,8 @@ fn main() {
             config_paths.push(path);
         }
     }
+    config_paths.sort();
+    config_paths.dedup();
 
     info!(
         message = "Loading configs.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate tracing;
 
 use futures::{future, Future, Stream};
+use glob::glob;
 use std::{
     cmp::{max, min},
     fs::File,
@@ -30,15 +31,11 @@ struct Opts {
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 struct RootOpts {
-    /// Read configuration from the specified file
-    #[structopt(
-        name = "config",
-        value_name = "FILE",
-        short,
-        long,
-        default_value = "/etc/vector/vector.toml"
-    )]
-    config_path: PathBuf,
+    /// Read configuration from one or more files. Wildcard paths are supported.
+    /// If zero files are specified the default config path
+    /// `/etc/vector/vector.toml` will be targeted.
+    #[structopt(name = "config", short, long)]
+    config_paths: Vec<PathBuf>,
 
     /// Exit on startup if any sinks fail healthchecks
     #[structopt(short, long)]
@@ -220,23 +217,33 @@ fn main() {
         }
     }
 
-    info!(
-        message = "Loading config.",
-        path = ?opts.config_path
-    );
-
-    let file = if let Some(file) = open_config(&opts.config_path) {
-        file
+    let mut config_paths = Vec::new();
+    for config_pattern in if !opts.config_paths.is_empty() {
+        opts.config_paths
     } else {
-        std::process::exit(exitcode::CONFIG);
-    };
+        DEFAULT_CONFIG_PATHS.to_vec()
+    } {
+        let matches: Vec<PathBuf> = glob(config_pattern.to_str().expect("no ability to glob"))
+            .expect("Failed to read glob pattern")
+            .filter_map(Result::ok)
+            .collect();
 
-    trace!(
-        message = "Parsing config.",
-        path = ?opts.config_path
+        if matches.is_empty() {
+            error!(message = "Config file not found in path.", path = ?config_pattern);
+            std::process::exit(exitcode::CONFIG);
+        }
+
+        for path in matches {
+            config_paths.push(path);
+        }
+    }
+
+    info!(
+        message = "Loading configs.",
+        path = ?config_paths
     );
 
-    let config = vector::topology::Config::load(file);
+    let config = read_configs(&config_paths);
     let config = handle_config_errors(config);
     let config = config.unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
@@ -323,18 +330,12 @@ fn main() {
 
             // Reload config
             info!(
-                message = "Reloading config.",
-                path = ?opts.config_path
+                message = "Reloading configs.",
+                path = ?config_paths
             );
-
-            let file = if let Some(file) = open_config(&opts.config_path) {
-                file
-            } else {
-                continue;
-            };
+            let config = read_configs(&config_paths);
 
             trace!("Parsing config");
-            let config = vector::topology::Config::load(file);
             let config = handle_config_errors(config);
             if let Some(config) = config {
                 let success =
@@ -412,6 +413,43 @@ fn handle_config_errors(config: Result<Config, Vec<String>>) -> Option<Config> {
             None
         }
         Ok(config) => Some(config),
+    }
+}
+
+fn read_configs(config_paths: &Vec<PathBuf>) -> Result<Config, Vec<String>> {
+    let mut config = vector::topology::Config::empty();
+    let mut errors = Vec::new();
+
+    config_paths.iter().for_each(|p| {
+        let file = if let Some(file) = open_config(&p) {
+            file
+        } else {
+            errors.push(format!("Config file not found in path: {:?}.", p));
+            return;
+        };
+
+        trace!(
+            message = "Parsing config.",
+            path = ?p
+        );
+
+        match Config::load(file) {
+            Ok(next_config) => match config.append(next_config) {
+                Err(next_errors) => {
+                    errors.extend(next_errors.iter().map(|e| format!("{:?}: {}", p, e)))
+                }
+                _ => (),
+            },
+            Err(next_errors) => {
+                errors.extend(next_errors.iter().map(|e| format!("{:?}: {}", p, e)))
+            }
+        };
+    });
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(config)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ fn main() {
     } else {
         DEFAULT_CONFIG_PATHS.to_vec()
     } {
-        let matches: Vec<PathBuf> = glob(config_pattern.to_str().expect("no ability to glob"))
+        let matches: Vec<PathBuf> = glob(config_pattern.to_str().expect("No ability to glob"))
             .expect("Failed to read glob pattern")
             .filter_map(Result::ok)
             .collect();
@@ -435,16 +435,9 @@ fn read_configs(config_paths: &Vec<PathBuf>) -> Result<Config, Vec<String>> {
             path = ?p
         );
 
-        match Config::load(file) {
-            Ok(next_config) => match config.append(next_config) {
-                Err(next_errors) => {
-                    errors.extend(next_errors.iter().map(|e| format!("{:?}: {}", p, e)))
-                }
-                _ => (),
-            },
-            Err(next_errors) => {
-                errors.extend(next_errors.iter().map(|e| format!("{:?}: {}", p, e)))
-            }
+        match Config::load(file).and_then(|n| config.append(n)) {
+            Err(errs) => errors.extend(errs.iter().map(|e| format!("{:?}: {}", p, e))),
+            _ => (),
         };
     });
 


### PR DESCRIPTION
This currently works by parsing each discrete file individually, and appending them to a root config. This has the advantage of being able to report the specific file that fails to parse or introduces a duplicate. However, it also means we need to manually determine how parsed config structs are to be merged.

Global fields may be specified multiple times, but if there is a collision then it is considered an error. This makes it possible to run configs together that also work individually.