### PR TITLE
feat(config): Clarify topology warnings

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -70,7 +70,7 @@ pub fn check(config: &super::Config) -> Result<Vec<String>, Vec<String>> {
                 .any(|(_, sink)| sink.inputs.contains(&name))
         {
             warnings.push(format!(
-                "{} {:?} has nothing consuming from it",
+                "{} {:?} has no consumers",
                 capitalize(input_type),
                 name
             ));

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -70,7 +70,7 @@ pub fn check(config: &super::Config) -> Result<Vec<String>, Vec<String>> {
                 .any(|(_, sink)| sink.inputs.contains(&name))
         {
             warnings.push(format!(
-                "{} {:?} has no outputs",
+                "{} {:?} has nothing consuming from it",
                 capitalize(input_type),
                 name
             ));

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -80,7 +80,7 @@ pub fn validate(config: &Config, exec: runtime::TaskExecutor) -> Option<Pieces> 
         }
         Ok((new_pieces, warnings)) => {
             for warning in warnings {
-                error!("Configuration warning: {}", warning);
+                warn!("Configuration warning: {}", warning);
             }
             Some(new_pieces)
         }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -371,8 +371,8 @@ fn warnings() {
     assert_eq!(
         warnings,
         vec![
-            "Transform \"sampler2\" has nothing consuming from it",
-            "Source \"in2\" has nothing consuming from it",
+            "Transform \"sampler2\" has no consumers",
+            "Source \"in2\" has no consumers",
         ]
     )
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -371,8 +371,8 @@ fn warnings() {
     assert_eq!(
         warnings,
         vec![
-            "Transform \"sampler2\" has no outputs",
-            "Source \"in2\" has no outputs",
+            "Transform \"sampler2\" has nothing consuming from it",
+            "Source \"in2\" has nothing consuming from it",
         ]
     )
 }


### PR DESCRIPTION
Prints topology warnings as... warnings. Also clarifies the message about zero outputs.

Closes https://github.com/timberio/vector/issues/414