### PR TITLE
feat(cli): Improve cyclic deps error message

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -77,10 +77,12 @@ pub fn check(config: &super::Config) -> Result<Vec<String>, Vec<String>> {
         }
     }
 
-    if config.contains_cycle() {
-        errors.push("Configured topology contains a cycle".to_string());
-    } else if let Err(type_errors) = config.typecheck() {
+    if let Err(type_errors) = config.typecheck() {
         errors.extend(type_errors);
+    } else if config.contains_cycle() {
+        // I still think it's worth performing this for the listeners at the
+        // back.
+        errors.push("Configured topology contains a cycle".to_string());
     }
 
     if errors.is_empty() {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -79,10 +79,6 @@ pub fn check(config: &super::Config) -> Result<Vec<String>, Vec<String>> {
 
     if let Err(type_errors) = config.typecheck() {
         errors.extend(type_errors);
-    } else if config.contains_cycle() {
-        // I still think it's worth performing this for the listeners at the
-        // back.
-        errors.push("Configured topology contains a cycle".to_string());
     }
 
     if errors.is_empty() {

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -363,10 +363,6 @@ impl Config {
         Ok(())
     }
 
-    pub fn contains_cycle(&self) -> bool {
-        validation::contains_cycle(self)
-    }
-
     pub fn typecheck(&self) -> Result<(), Vec<String>> {
         validation::typecheck(self)
     }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -420,7 +420,10 @@ fn cycle() {
     )
     .unwrap_err();
 
-    assert_eq!(errors, vec!["Configured topology contains a cycle"])
+    assert_eq!(
+        errors,
+        vec!["Cyclic dependency detected in the chain [ four -> two -> three -> four ]"]
+    )
 }
 
 #[test]


### PR DESCRIPTION
This allows us to report to users the exact chain of components that
causes the cycle.

The message now looks like:

`ERROR vector: Topology error: Cyclic dependency detected in the chain [ baz -> foo -> bar -> baz ]`

Closes #321