### PR TITLE
chore(operations): Add support for running containers under Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := help
 _latest_version := $(shell scripts/version.sh true)
 _version := $(shell scripts/version.sh)
-export USE_DOCKER ?= true
+export USE_CONTAINER ?= docker
 
 
 help:

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -9,6 +9,8 @@
 
 set -eou pipefail
 
+DOCKER=${USE_CONTAINER:-docker}
+
 #
 # Requirements
 #
@@ -34,7 +36,7 @@ image="timberiodev/vector-$tag:latest"
 # Execute
 #
 
-docker build \
+$DOCKER build \
   -t $image \
   -f scripts/ci-docker-images/$tag/Dockerfile \
   .
@@ -56,7 +58,7 @@ for line in $(env | grep '^PASS_' | sed 's/^PASS_//'); do
 done
 unset IFS
 
-docker run \
+$DOCKER run \
   "${docker_flags[@]}" \
   -w "$PWD" \
   -v "$PWD":"$PWD" \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,27 +4,32 @@
 #
 # SUMMARY
 #
-#   A simple script that runs commands in a Docker environment based on the
-#   presence of the `USE_DOCKER` environment variable.
+#   A simple script that runs commands in a container environment based
+#   on the presence of the `USE_CONTAINER` environment variable.
 #
-#   This helps to reduce the friction running various `make` commands. For
-#   example, the `make generate` command requires Ruby and other dependencies
-#   to be installed. Routing this command through a Docker images removes this.
+#   This helps to reduce the friction running various `make`
+#   commands. For example, the `make generate` command requires Ruby and
+#   other dependencies to be installed. Routing this command through a
+#   container images removes this.
 
 set -eou pipefail
 
-if [ "$USE_DOCKER" == "true" ]; then
-  echo "Executing within Docker. To disable set USE_DOCKER to false"
-  echo ""
-  echo "  make ... USE_DOCKER=false"
-  echo ""
+case "$USE_CONTAINER" in
+  docker | podman)
+    echo "Executing within $USE_CONTAINER. To disable set USE_CONTAINER to none"
+    echo ""
+    echo "  make ... USE_CONTAINER=none"
+    echo ""
 
-  scripts/docker-run.sh "$@"
-else
-  echo "Executing locally. To use Docker set USE_DOCKER to true"
-  echo ""
-  echo "  make ... USE_DOCKER=true"
-  echo ""
+    scripts/docker-run.sh "$@"
+    ;;
 
-  ${@:2}
-fi
+  *)
+    echo "Executing locally. To use Docker set USE_CONTAINER to docker or podman"
+    echo ""
+    echo "  make ... USE_CONTAINER=docker"
+    echo "  make ... USE_CONTAINER=podman"
+    echo ""
+
+    ${@:2}
+esac


### PR DESCRIPTION
[Podman](https://github.com/containers/libpod) is a drop-in command line replacement for docker that adds the ability to run containers rootless with no daemon. For running things like `make generate` this may be a useful solution for some.

Signed-off-by: Bruce Guenter <bruce@timber.io>