### PR TITLE
feat(cli): Test sub command improvements

### DIFF
--- a/.meta/tests.toml
+++ b/.meta/tests.toml
@@ -161,11 +161,14 @@ transform will be checked against a table of conditions.\
 [tests.children.outputs.children.conditions]
 type = "[table]"
 common = true
-required = true
+required = false
 description = """\
 A table that defines a collection of conditions to check against the output of a \
 transform. A test is considered to have passed when each condition has resolved \
 true for one or more events extracted from the target transform.\
+\
+An expected output without conditions instead prints the input and output of a \
+target without checking its values.\
 """
 
 [tests.children.outputs.children.conditions.children.type]

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use string_cache::DefaultAtom as Atom;
 
 use crate::{
@@ -15,6 +16,17 @@ pub enum CheckFieldsPredicateArg {
     Integer(i64),
     Float(f64),
     Boolean(bool),
+}
+
+impl fmt::Display for CheckFieldsPredicateArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CheckFieldsPredicateArg::String(s) => write!(f, "'{}'", s),
+            CheckFieldsPredicateArg::Integer(i) => write!(f, "{}", i),
+            CheckFieldsPredicateArg::Float(fl) => write!(f, "{}", fl),
+            CheckFieldsPredicateArg::Boolean(b) => write!(f, "{}", b),
+        }
+    }
 }
 
 pub trait CheckFieldsPredicate: std::fmt::Debug + Send + Sync {
@@ -166,8 +178,8 @@ fn build_predicate(
 
 fn build_predicates(
     map: &IndexMap<String, CheckFieldsPredicateArg>,
-) -> Result<Vec<Box<dyn CheckFieldsPredicate>>, Vec<String>> {
-    let mut predicates: Vec<Box<dyn CheckFieldsPredicate>> = Vec::new();
+) -> Result<IndexMap<String, Box<dyn CheckFieldsPredicate>>, Vec<String>> {
+    let mut predicates: IndexMap<String, Box<dyn CheckFieldsPredicate>> = IndexMap::new();
     let mut errors = Vec::new();
 
     for (target_pred, arg) in map {
@@ -185,7 +197,9 @@ fn build_predicates(
                 let pred = target.split_off(i + 1);
                 target.truncate(target.len() - 1);
                 match build_predicate(&pred, target, arg) {
-                    Ok(pred) => predicates.push(pred),
+                    Ok(pred) => {
+                        predicates.insert(format!("{}: {}", target_pred, arg), pred);
+                    }
                     Err(err) => errors.push(err),
                 }
                 Some(())
@@ -236,12 +250,29 @@ impl ConditionConfig for CheckFieldsConfig {
 //------------------------------------------------------------------------------
 
 pub struct CheckFields {
-    predicates: Vec<Box<dyn CheckFieldsPredicate>>,
+    predicates: IndexMap<String, Box<dyn CheckFieldsPredicate>>,
 }
 
 impl Condition for CheckFields {
     fn check(&self, e: &Event) -> bool {
-        self.predicates.iter().find(|p| !p.check(e)).is_none()
+        self.predicates.iter().find(|(_, p)| !p.check(e)).is_none()
+    }
+
+    fn check_with_context(&self, e: &Event) -> Result<(), String> {
+        let failed_preds = self
+            .predicates
+            .iter()
+            .filter(|(_, p)| !p.check(e))
+            .map(|(n, _)| n.to_owned())
+            .collect::<Vec<_>>();
+        if failed_preds.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "predicates failed: [ {} ]",
+                failed_preds.join(", ")
+            ))
+        }
     }
 }
 
@@ -310,14 +341,30 @@ mod test {
 
         let cond = CheckFieldsConfig { predicates: preds }.build().unwrap();
 
-        let mut event = Event::from("foo");
+        let mut event = Event::from("neither");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ message.equals: 'foo', other_thing.eq: 'bar' ]".to_owned())
+        );
+
+        event.as_mut_log().insert("message", "foo");
+        assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ other_thing.eq: 'bar' ]".to_owned())
+        );
 
         event.as_mut_log().insert("other_thing", "bar");
         assert_eq!(cond.check(&event), true);
+        assert_eq!(cond.check_with_context(&event), Ok(()));
 
         event.as_mut_log().insert("message", "not foo");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ message.equals: 'foo' ]".to_owned())
+        );
     }
 
     #[test]
@@ -336,15 +383,31 @@ mod test {
 
         let mut event = Event::from("not foo");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ other_thing.neq: 'bar' ]".to_owned())
+        );
 
         event.as_mut_log().insert("other_thing", "not bar");
         assert_eq!(cond.check(&event), true);
+        assert_eq!(cond.check_with_context(&event), Ok(()));
 
         event.as_mut_log().insert("other_thing", "bar");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ other_thing.neq: 'bar' ]".to_owned())
+        );
 
         event.as_mut_log().insert("message", "foo");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err(
+                "predicates failed: [ message.not_equals: 'foo', other_thing.neq: 'bar' ]"
+                    .to_owned()
+            )
+        );
     }
 
     #[test]
@@ -357,11 +420,20 @@ mod test {
 
         let mut event = Event::from("ignored field");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ foo.exists: true ]".to_owned())
+        );
 
         event.as_mut_log().insert("foo", "not ignored");
         assert_eq!(cond.check(&event), true);
+        assert_eq!(cond.check_with_context(&event), Ok(()));
 
         event.as_mut_log().insert("bar", "also not ignored");
         assert_eq!(cond.check(&event), false);
+        assert_eq!(
+            cond.check_with_context(&event),
+            Err("predicates failed: [ bar.exists: false ]".to_owned())
+        );
     }
 }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -7,8 +7,8 @@ pub mod check_fields;
 pub trait Condition: Send + Sync {
     fn check(&self, e: &Event) -> bool;
 
-    // Provides context for a failure. This is potentially mildly expensive if
-    // it involves string building and so should be avoided in hot paths.
+    /// Provides context for a failure. This is potentially mildly expensive if
+    /// it involves string building and so should be avoided in hot paths.
     fn check_with_context(&self, e: &Event) -> Result<(), String> {
         if self.check(e) {
             Ok(())

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -5,7 +5,17 @@ use inventory;
 pub mod check_fields;
 
 pub trait Condition: Send + Sync {
-    fn check(&self, e: &Event) -> bool; // TODO: Add method that provides fail context? -> Result<(), String>
+    fn check(&self, e: &Event) -> bool;
+
+    // Provides context for a failure. This is potentially mildly expensive if
+    // it involves string building and so should be avoided in hot paths.
+    fn check_with_context(&self, e: &Event) -> Result<(), String> {
+        if self.check(e) {
+            Ok(())
+        } else {
+            Err("condition failed".into())
+        }
+    }
 }
 
 #[typetag::serde(tag = "type")]

--- a/src/config_paths.rs
+++ b/src/config_paths.rs
@@ -1,0 +1,37 @@
+use glob::glob;
+use lazy_static::lazy_static;
+use std::path::PathBuf;
+
+lazy_static! {
+    pub static ref DEFAULT_CONFIG_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
+}
+
+/// Expand a list of paths (potentially containing glob patterns) into real
+/// config paths, replacing it with the default paths when empty.
+pub fn expand(config_paths: Vec<PathBuf>) -> Option<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for config_pattern in if !config_paths.is_empty() {
+        config_paths
+    } else {
+        DEFAULT_CONFIG_PATHS.to_vec()
+    } {
+        let matches: Vec<PathBuf> = match glob(config_pattern.to_str().expect("No ability to glob"))
+        {
+            Ok(glob_paths) => glob_paths.filter_map(Result::ok).collect(),
+            Err(err) => {
+                error!(message = "Failed to read glob pattern.", path = ?config_pattern, error = ?err);
+                return None;
+            }
+        };
+
+        if matches.is_empty() {
+            error!(message = "Config file not found in path.", path = ?config_pattern);
+            std::process::exit(exitcode::CONFIG);
+        }
+
+        for path in matches {
+            paths.push(path);
+        }
+    }
+    Some(paths)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 pub mod buffers;
 pub mod conditions;
+pub mod config_paths;
 pub mod dns;
 pub mod event;
 pub mod generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ enum SubCommand {
     List(list::Opts),
 
     /// Run Vector config unit tests, then exit. This command is experimental and therefore subject to change.
+    /// For guidance on how to write unit tests check out: https://vector.dev/docs/setup/guides/unit-testing/
     Test(unit_test::Opts),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 extern crate tracing;
 
 use futures::{future, Future, Stream};
-use glob::glob;
 use std::{
     cmp::{max, min},
     fs::File,
@@ -14,9 +13,7 @@ use structopt::{clap::AppSettings, StructOpt};
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use tracing_futures::Instrument;
-use vector::{
-    generate, list, metrics, runtime, topology, trace, types::DEFAULT_CONFIG_PATHS, unit_test,
-};
+use vector::{config_paths, generate, list, metrics, runtime, topology, trace, unit_test};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -222,26 +219,9 @@ fn main() {
         }
     }
 
-    let mut config_paths = Vec::new();
-    for config_pattern in if !opts.config_paths.is_empty() {
-        opts.config_paths
-    } else {
-        DEFAULT_CONFIG_PATHS.to_vec()
-    } {
-        let matches: Vec<PathBuf> = glob(config_pattern.to_str().expect("No ability to glob"))
-            .expect("Failed to read glob pattern")
-            .filter_map(Result::ok)
-            .collect();
-
-        if matches.is_empty() {
-            error!(message = "Config file not found in path.", path = ?config_pattern);
-            std::process::exit(exitcode::CONFIG);
-        }
-
-        for path in matches {
-            config_paths.push(path);
-        }
-    }
+    let mut config_paths = config_paths::expand(opts.config_paths.clone()).unwrap_or_else(|| {
+        std::process::exit(exitcode::CONFIG);
+    });
     config_paths.sort();
     config_paths.dedup();
 
@@ -481,11 +461,9 @@ fn open_config(path: &Path) -> Option<File> {
 }
 
 fn validate(opts: &Validate) -> exitcode::ExitCode {
-    let paths = if opts.paths.len() > 0 {
-        &opts.paths
-    } else {
-        &DEFAULT_CONFIG_PATHS
-    };
+    let paths = config_paths::expand(opts.paths.clone()).unwrap_or_else(|| {
+        std::process::exit(exitcode::CONFIG);
+    });
 
     for config_path in paths {
         let file = if let Some(file) = open_config(&config_path) {

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -243,7 +243,7 @@ fn default_test_input_type() -> String {
 #[serde(deny_unknown_fields)]
 pub struct TestOutput {
     pub extract_from: String,
-    pub conditions: Vec<TestCondition>,
+    pub conditions: Option<Vec<TestCondition>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -50,14 +50,10 @@ fn events_to_string(name: &str, events: &Vec<Event>) -> String {
                 .join("\n    ")
         )
     } else {
-        format!(
-            "  {}: {}",
-            name,
-            events
-                .first()
-                .map(|e| event_to_string(e))
-                .unwrap_or("".to_string())
-        )
+        events
+            .first()
+            .map(|e| format!("  {}: {}", name, event_to_string(e)))
+            .unwrap_or(format!("  no {}", name))
     }
 }
 
@@ -106,7 +102,7 @@ impl UnitTest {
             if let Some((inputs, outputs)) = results.get(&check.extract_from) {
                 if check.conditions.is_empty() {
                     inspections.push(format!(
-                        "check transform '{}' payloads (JSON encoded):\n{}\n{}",
+                        "check transform '{}' payloads (events encoded as JSON):\n{}\n{}",
                         check.extract_from,
                         events_to_string("input", inputs),
                         events_to_string("output", outputs),
@@ -135,7 +131,7 @@ impl UnitTest {
                     .collect::<Vec<_>>();
                 if !failed_conditions.is_empty() {
                     errors.push(format!(
-                        "check transform '{}' failed conditions:\n  {}\npayloads (JSON encoded):\n{}\n{}",
+                        "check transform '{}' failed conditions:\n  {}\npayloads (events encoded as JSON):\n{}\n{}",
                         check.extract_from,
                         failed_conditions.join("\n  "),
                         events_to_string("input", inputs),

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -5,6 +5,7 @@ use crate::{
     topology::config::{TestCondition, TestDefinition, TestInputValue},
     transforms::Transform,
 };
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 //------------------------------------------------------------------------------
@@ -22,30 +23,55 @@ pub struct UnitTestTransform {
 pub struct UnitTest {
     pub name: String,
     input: (String, Event),
-    transforms: HashMap<String, UnitTestTransform>,
+    transforms: IndexMap<String, UnitTestTransform>,
     checks: Vec<UnitTestCheck>,
 }
 
 //------------------------------------------------------------------------------
 
-fn event_to_string(event: Event) -> String {
+fn event_to_string(event: &Event) -> String {
     match event {
-        Event::Log(log) => serde_json::to_string(&log.unflatten()).unwrap_or_else(|_| "{}".into()),
+        Event::Log(log) => {
+            serde_json::to_string(&log.clone().unflatten()).unwrap_or_else(|_| "{}".into())
+        }
         Event::Metric(metric) => serde_json::to_string(&metric).unwrap_or_else(|_| "{}".into()),
+    }
+}
+
+fn events_to_string(name: &str, events: &Vec<Event>) -> String {
+    if events.len() > 1 {
+        format!(
+            "  {}s:\n    {}",
+            name,
+            events
+                .iter()
+                .map(|e| event_to_string(e))
+                .collect::<Vec<_>>()
+                .join("\n    ")
+        )
+    } else {
+        format!(
+            "  {}: {}",
+            name,
+            events
+                .first()
+                .map(|e| event_to_string(e))
+                .unwrap_or("".to_string())
+        )
     }
 }
 
 fn walk(
     node: &str,
-    inputs: Vec<Event>,
-    transforms: &mut HashMap<String, UnitTestTransform>,
-    aggregated_results: &mut HashMap<String, Vec<Event>>,
+    mut inputs: Vec<Event>,
+    transforms: &mut IndexMap<String, UnitTestTransform>,
+    aggregated_results: &mut HashMap<String, (Vec<Event>, Vec<Event>)>,
 ) {
     let mut results = Vec::new();
     let mut targets = Vec::new();
 
     if let Some(target) = transforms.get_mut(node) {
-        for input in inputs {
+        for input in inputs.clone() {
             target.transform.transform_into(&mut results, input);
         }
         targets = target.next.clone();
@@ -54,7 +80,12 @@ fn walk(
     for child in targets {
         walk(&child, results.clone(), transforms, aggregated_results);
     }
-    aggregated_results.insert(node.into(), results);
+
+    if let Some((mut e_inputs, mut e_results)) = aggregated_results.remove(node) {
+        inputs.append(&mut e_inputs);
+        results.append(&mut e_results);
+    }
+    aggregated_results.insert(node.into(), (inputs, results));
 }
 
 impl UnitTest {
@@ -70,21 +101,34 @@ impl UnitTest {
         );
 
         for check in &self.checks {
-            if let Some(results) = results.get(&check.extract_from) {
-                let mut failed_conditions = Vec::new();
-                for (index, cond) in check.conditions.iter().enumerate() {
-                    if results.iter().find(|e| cond.check(e)).is_none() {
-                        failed_conditions.push(index);
-                    }
-                }
+            if let Some((inputs, outputs)) = results.get(&check.extract_from) {
+                let failed_conditions = check
+                    .conditions
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(i, cond)| {
+                        outputs
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(j, e)| {
+                                cond.check_with_context(e).err().map(|err| {
+                                    if outputs.len() > 1 {
+                                        format!("condition[{}], payload[{}]: {}", i, j, err)
+                                    } else {
+                                        format!("condition[{}]: {}", i, err)
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
                 if !failed_conditions.is_empty() {
-                    let event_strings: Vec<String> =
-                        results.iter().map(|e| event_to_string(e.clone())).collect();
                     errors.push(format!(
-                        "check transform '{}' failed conditions: [ {} ], payloads (encoded in JSON format):\n  {}",
+                        "check transform '{}' failed conditions:\n  {}\npayloads (JSON encoded):\n{}\n{}",
                         check.extract_from,
-                        failed_conditions.iter().map(|i| format!("{}", i)).collect::<Vec<String>>().join(", "),
-                        event_strings.join("\n  "),
+                        failed_conditions.join("\n  "),
+                        events_to_string("input", inputs),
+                        events_to_string("output", outputs),
                     ));
                 }
             } else {
@@ -103,9 +147,9 @@ impl UnitTest {
 
 fn links_to_a_leaf(
     target: &str,
-    leaves: &HashMap<String, ()>,
-    link_checked: &mut HashMap<String, bool>,
-    transform_outputs: &HashMap<String, HashMap<String, ()>>,
+    leaves: &IndexMap<String, ()>,
+    link_checked: &mut IndexMap<String, bool>,
+    transform_outputs: &IndexMap<String, IndexMap<String, ()>>,
 ) -> bool {
     if let Some(check) = link_checked.get(target) {
         return *check;
@@ -128,10 +172,10 @@ fn links_to_a_leaf(
 /// link between our root (test input) and a set of leaves (test outputs).
 fn reduce_transforms(
     root: &str,
-    leaves: &HashMap<String, ()>,
-    transform_outputs: &mut HashMap<String, HashMap<String, ()>>,
+    leaves: &IndexMap<String, ()>,
+    transform_outputs: &mut IndexMap<String, IndexMap<String, ()>>,
 ) {
-    let mut link_checked: HashMap<String, bool> = HashMap::new();
+    let mut link_checked: IndexMap<String, bool> = IndexMap::new();
 
     if !links_to_a_leaf(root, leaves, &mut link_checked, transform_outputs) {
         transform_outputs.clear();
@@ -202,10 +246,10 @@ fn build_unit_test(
 
     // Maps transform names with their output targets (transforms that use it as
     // an input).
-    let mut transform_outputs: HashMap<String, HashMap<String, ()>> = config
+    let mut transform_outputs: IndexMap<String, IndexMap<String, ()>> = config
         .transforms
         .iter()
-        .map(|(k, _)| (k.clone(), HashMap::new()))
+        .map(|(k, _)| (k.clone(), IndexMap::new()))
         .collect();
 
     config.transforms.iter().for_each(|(k, t)| {
@@ -224,7 +268,7 @@ fn build_unit_test(
         return Err(errors);
     }
 
-    let mut leaves: HashMap<String, ()> = HashMap::new();
+    let mut leaves: IndexMap<String, ()> = IndexMap::new();
     definition.outputs.iter().for_each(|o| {
         leaves.insert(o.extract_from.clone(), ());
     });
@@ -234,7 +278,7 @@ fn build_unit_test(
     reduce_transforms(&definition.input.insert_at, &leaves, &mut transform_outputs);
 
     // Build reduced transforms.
-    let mut transforms: HashMap<String, UnitTestTransform> = HashMap::new();
+    let mut transforms: IndexMap<String, UnitTestTransform> = IndexMap::new();
     for (name, transform_config) in &config.transforms {
         if let Some(outputs) = transform_outputs.remove(name) {
             match transform_config.inner.build(rt.executor()) {
@@ -796,16 +840,23 @@ mod tests {
         // TODO: The json representations are randomly ordered so these checks
         // don't always pass:
         /*
-                assert_eq!(tests[0].run(), vec![
-        r#"check transform 'bar' failed conditions: [ check_second_new_field, check_new_field ], payloads (encoded in JSON format):
-          {"second_new_field":"also a string value","message":"nah this doesnt matter"}
-        "#.to_owned(),
-                ]);
-                assert_eq!(tests[1].run(), vec![
-        r#"check transform 'baz' failed conditions: [ check_new_field ], payloads (encoded in JSON format):
-          {"message":"also this doesnt matter","second_new_field":"also a string value","new_field":"string value"}
-        "#.to_owned(),
-                ]);
+                assert_eq!(
+                    tests[0].run(),
+                    vec![r#"check transform 'bar' failed conditions:
+          condition[0]: predicates failed: [ message.equals: 'not this' ]
+          condition[1]: predicates failed: [ second_new_field.equals: 'and not this' ]
+        payloads (JSON encoded):
+          input: {"message":"nah this doesnt matter"}
+          output: {"message":"nah this doesnt matter","second_new_field":"also a string value"}"#.to_owned(),
+                    ]);
+                assert_eq!(
+                    tests[1].run(),
+                    vec![r#"check transform 'baz' failed conditions:
+          condition[0]: predicates failed: [ second_new_field.equals: 'nope not this', third_new_field.equals: 'and not this' ]
+        payloads (JSON encoded):
+          input: {"second_new_field":"also a string value","message":"also this doesnt matter"}
+          output: {"third_new_field":"also also a string value","second_new_field":"also a string value","message":"also this doesnt matter"}"#.to_owned(),
+                    ]);
                 */
     }
 }

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,6 +1,6 @@
 use crate::{
+    config_paths,
     topology::{config::Config, unit_test::UnitTest},
-    types::DEFAULT_CONFIG_PATHS,
 };
 use colored::*;
 use std::{fs::File, path::PathBuf};
@@ -47,11 +47,9 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
     let mut inspected_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
 
-    let paths = if !opts.paths.is_empty() {
-        &opts.paths
-    } else {
-        &DEFAULT_CONFIG_PATHS
-    };
+    let paths = config_paths::expand(opts.paths.clone()).unwrap_or_else(|| {
+        std::process::exit(exitcode::CONFIG);
+    });
 
     for (i, p) in paths.iter().enumerate() {
         let path_str = p.to_str().unwrap_or("");

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -81,6 +81,9 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
                 if !aggregated_test_errors.is_empty() {
                     failed_files.push((path_str.to_owned(), aggregated_test_errors));
                 }
+                if tests.is_empty() {
+                    println!("{}", "no tests found".yellow());
+                }
             }
             Err(errs) => {
                 error!("Failed to execute {} tests:\n{}", path_str, errs.join("\n"));

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -45,6 +45,7 @@ fn build_tests(path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
 
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     let mut failed_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
+    let mut inspected_files: Vec<(String, Vec<(String, Vec<String>)>)> = Vec::new();
 
     let paths = if !opts.paths.is_empty() {
         &opts.paths
@@ -61,15 +62,22 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         match build_tests(p) {
             Ok(mut tests) => {
                 let mut aggregated_test_errors = Vec::new();
+                let mut aggregated_test_inspections = Vec::new();
                 tests.iter_mut().for_each(|t| {
-                    let test_errors = t.run();
+                    let (test_inspections, test_errors) = t.run();
+                    if !test_inspections.is_empty() {
+                        aggregated_test_inspections.push((t.name.clone(), test_inspections));
+                    }
                     if !test_errors.is_empty() {
-                        println!("Test {}: {} ... {}", path_str, t.name, "failed".red());
+                        println!("test {}: {} ... {}", path_str, t.name, "failed".red());
                         aggregated_test_errors.push((t.name.clone(), test_errors));
                     } else {
-                        println!("Test {}: {} ... {}", path_str, t.name, "passed".green());
+                        println!("test {}: {} ... {}", path_str, t.name, "passed".green());
                     }
                 });
+                if !aggregated_test_inspections.is_empty() {
+                    inspected_files.push((path_str.to_owned(), aggregated_test_inspections));
+                }
                 if !aggregated_test_errors.is_empty() {
                     failed_files.push((path_str.to_owned(), aggregated_test_errors));
                 }
@@ -81,12 +89,25 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         }
     }
 
+    if !inspected_files.is_empty() {
+        println!("\ninspections:");
+        for (path, inspections) in inspected_files {
+            println!("\n--- {} ---", path);
+            for (test_name, inspection) in inspections {
+                println!("\ntest '{}':\n", test_name);
+                for inspect in inspection {
+                    println!("{}\n", inspect);
+                }
+            }
+        }
+    }
+
     if !failed_files.is_empty() {
         println!("\nfailures:");
         for (path, failures) in failed_files {
             println!("\n--- {} ---", path);
             for (test_name, fails) in failures {
-                println!("\nTest '{}':\n", test_name);
+                println!("\ntest '{}':\n", test_name);
                 for fail in fails {
                     println!("{}\n", fail);
                 }

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -86,9 +86,9 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         for (path, failures) in failed_files {
             println!("\n--- {} ---", path);
             for (test_name, fails) in failures {
-                println!("\nTest '{}':", test_name);
+                println!("\nTest '{}':\n", test_name);
                 for fail in fails {
-                    println!("{}", fail);
+                    println!("{}\n", fail);
                 }
             }
         }

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -58,7 +58,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     # REQUIRED - General
     extract_from = "foo" # example
 
-    # REQUIRED - Conditions
+    # OPTIONAL - Conditions
     [[tests.outputs.conditions]]
       # REQUIRED
       type = "check_fields" # example
@@ -97,7 +97,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     # REQUIRED - General
     extract_from = "foo" # example
 
-    # REQUIRED - Conditions
+    # OPTIONAL - Conditions
     [[tests.outputs.conditions]]
       # REQUIRED
       type = "check_fields" # example
@@ -551,7 +551,7 @@ A table that defines a unit test expected output.
   name={"conditions"}
   path={"outputs"}
   relevantWhen={null}
-  required={true}
+  required={false}
   templateable={false}
   type={"[table]"}
   unit={null}
@@ -559,7 +559,7 @@ A table that defines a unit test expected output.
 
 #### conditions
 
-A table that defines a collection of conditions to check against the output of a transform. A test is considered to have passed when each condition has resolved true for one or more events extracted from the target transform.
+A table that defines a collection of conditions to check against the output of a transform. A test is considered to have passed when each condition has resolved true for one or more events extracted from the target transform.An expected output without conditions instead prints the input and output of a target without checking its values.
 
 <Fields filters={false}>
 


### PR DESCRIPTION
This adds a few quality of life improvements to the `test` subcommand:

## Improved failure messages. 

You now see (in addition to before):
- The condition that failed (by index)
- The output that failed it, shown when there's > 1 output events (by index)
- The specific predicate(s) that failed for each condition (and their arguments)
- The input events that caused the test to fail

```
failures:

--- ./configs/test.toml ---

test 'foo':

check transform 'foo' failed conditions:
  condition[0]: predicates failed: [ message.eq: 'foo', other_field.exists: true ]
payloads (JSON encoded):
  input: {"hello":"world"}
  output: {"foo_field":"foo value","hello":"world"}
```

## Ability to Inspect

You can now also configure test outputs with no conditions, and instead of running conditions Vector will print what went in and what came out:

Config:

```toml
[[tests]]
  name = "foo"

  [tests.input]
    insert_at = "thing"
    type = "raw"
    value = '{"hello":"world"}'

  [[tests.outputs]]
    extract_from = "thing"
```

Output:

```
inspections:

--- ./configs/test.toml ---

test 'foo':

check transform 'thing' payloads (JSON encoded):
  input: {"message":"{\"hello\":\"world\"}","timestamp":"2020-02-07T15:46:34.771387075Z"}
  output: {"hello":"world","timestamp":"2020-02-07T15:46:34.771387075Z"}
```

This can be used exclusively or in conjunction with actual tests, which might help dig into the specific cause of a problem.

Closes https://github.com/timberio/vector/issues/1300