### PR TITLE
fix(splunk_hec sink): Fix encoding docs

### DIFF
--- a/.meta/sinks/splunk_hec.toml
+++ b/.meta/sinks/splunk_hec.toml
@@ -39,7 +39,7 @@ The encoding format used to serialize the events before outputting.\
 """
 
 [sinks.splunk_hec.options.encoding.enum]
-ndjson = "Each event is encoded into JSON and the payload is new line delimited."
+json = "Each event is encoded into JSON and the payload is new line delimited."
 text = "Each event is encoded into text via the `message` key and the payload is new line delimited."
 
 [sinks.splunk_hec.options.host]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -5433,8 +5433,8 @@ end
   #
   # * required
   # * type: string
-  # * enum: "ndjson" or "text"
-  encoding = "ndjson"
+  # * enum: "json" or "text"
+  encoding = "json"
   encoding = "text"
 
   #

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -51,7 +51,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   token = "${TOKEN_ENV_VAR}" # example
 
   # REQUIRED - requests
-  encoding = "ndjson" # example, enum
+  encoding = "json" # example, enum
 
   # OPTIONAL - General
   healthcheck = true # default
@@ -72,7 +72,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   token = "${TOKEN_ENV_VAR}" # example
 
   # REQUIRED - requests
-  encoding = "ndjson" # example, enum
+  encoding = "json" # example, enum
 
   # OPTIONAL - General
   healthcheck = true # default
@@ -313,8 +313,8 @@ The behavior when the buffer becomes full.
 <Field
   common={true}
   defaultValue={null}
-  enumValues={{"ndjson":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
-  examples={["ndjson","text"]}
+  enumValues={{"json":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
+  examples={["json","text"]}
   name={"encoding"}
   path={null}
   relevantWhen={null}


### PR DESCRIPTION
It looks like our docs mention `ndjson` as being the config option but within the code we actually refer to it as `json`. This is because the user doesn't have to worry about the encoding format since we follow splunk's hec format. We also don't actually send the data as ndjson but as json anyways.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
