### PR TITLE
feat(cli): Clarify generate error messages with type info

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -2,6 +2,7 @@ use crate::topology::config::{
     component::ExampleError, GlobalOptions, SinkDescription, SourceDescription,
     TransformDescription,
 };
+use colored::*;
 use indexmap::IndexMap;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -92,7 +93,10 @@ fn generate_example(expression: &str) -> Result<String, Vec<String>> {
                 Ok(example) => example,
                 Err(err) => {
                     if err != ExampleError::MissingExample {
-                        errs.push(format!("{}", err));
+                        errs.push(format!(
+                            "failed to generate source '{}': {}",
+                            source_type, err
+                        ));
                     }
                     Value::Table(BTreeMap::new())
                 }
@@ -131,7 +135,10 @@ fn generate_example(expression: &str) -> Result<String, Vec<String>> {
                 Ok(example) => example,
                 Err(err) => {
                     if err != ExampleError::MissingExample {
-                        errs.push(format!("{}", err));
+                        errs.push(format!(
+                            "failed to generate transform '{}': {}",
+                            transform_type, err
+                        ));
                     }
                     Value::Table(BTreeMap::new())
                 }
@@ -163,7 +170,7 @@ fn generate_example(expression: &str) -> Result<String, Vec<String>> {
                 Ok(example) => example,
                 Err(err) => {
                     if err != ExampleError::MissingExample {
-                        errs.push(format!("{}", err));
+                        errs.push(format!("failed to generate sink '{}': {}", sink_type, err));
                     }
                     Value::Table(BTreeMap::new())
                 }
@@ -255,7 +262,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             exitcode::OK
         }
         Err(errs) => {
-            errs.iter().for_each(|e| eprintln!("Generate error: {}", e));
+            errs.iter().for_each(|e| eprintln!("{}", e.red()));
             exitcode::SOFTWARE
         }
     }

--- a/src/topology/config/component.rs
+++ b/src/topology/config/component.rs
@@ -8,7 +8,7 @@ use toml::Value;
 pub enum ExampleError {
     #[snafu(display("unable to create an example for this component"))]
     MissingExample,
-    #[snafu(display("component type '{}' does not exist", type_str))]
+    #[snafu(display("type '{}' does not exist", type_str))]
     DoesNotExist { type_str: String },
 }
 


### PR DESCRIPTION
Before:

```
vector generate 'stdin|console'
Generate error: component type 'console' does not exist
```

After:

```
vector generate 'stdin|console'
failed to generate transform 'console': type 'console' does not exist
```

It's also printed in red now.