### PR TITLE
chore(testing): Add behavior tests for `add_fields` and `remove_fields` transforms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,3 +12,8 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v0
       with:
         command: "check advisories"
+  test-behavior:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: "cd tests && make test-behavior"

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ test: ## Spins up Docker resources and runs _every_ test
 	@docker-compose up -d test-runtime-deps
 	@cargo test --all --features docker -- --test-threads 4
 
+test-behavior: ## Runs behavioral tests
+	@cargo run -- test tests/behavior/**/*.toml
+
 clean: ## Remove build artifacts
 	@cargo clean
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -415,6 +415,14 @@ services:
       working_dir: $PWD
       command: cargo test --all --no-default-features --features docker,default-musl --target x86_64-unknown-linux-musl -- --test-threads 4
 
+    test-behavior:
+      image: ubuntu:18.04
+      volumes:
+        - $PWD:$PWD
+      working_dir: $PWD
+      user: $USER
+      command: ["sh", "-c", "./target/x86_64-unknown-linux-musl/debug/vector test tests/behavior/**/*.toml"]
+
     # test dependencies
 
     # dummy service which runs all dependencies

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 RUN := $(shell realpath $(shell dirname $(firstword $(MAKEFILE_LIST)))/../scripts/docker-compose-run.sh)
 
 # run all tests, checks, and verifications
-all: check build-all package-all test-docker verify
+all: check build-all package-all test-docker test-behavior verify
 
 # default target, build the project in debug mode
 build: build-x86_64
@@ -25,6 +25,10 @@ bench: build
 # run tests which do not require additional services to be present
 test: build
 	$(RUN) test
+
+# run behaviorial tests
+test-behavior: build
+	$(RUN) test-behavior
 
 # run tests which use Docker
 test-docker: build

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -1,0 +1,86 @@
+[transforms.add_fields_nested]
+  inputs = []
+  type = "add_fields"
+  [transforms.add_fields_nested.fields]
+    "a.b" = 123
+    x.y = 456
+    "x.z" = 789
+[[tests]]
+  name = "add_fields_nested"
+  [tests.input]
+    insert_at = "add_fields_nested"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_fields_nested"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.b.equals" = 123
+      "x.y.equals" = 456
+      "x.z.equals" = 789
+
+[transforms.add_fields_scalar_then_nested_1]
+  inputs = []
+  type = "add_fields"
+  [transforms.add_fields_scalar_then_nested_1.fields]
+    a = "initial value"
+[transforms.add_fields_scalar_then_nested_2]
+  inputs = ["add_fields_scalar_then_nested_1"]
+  type = "add_fields"
+  [transforms.add_fields_scalar_then_nested_2.fields]
+    "a.b" = "new value"
+[[tests]]
+  name = "add_fields_scalar_then_nested"
+  [tests.input]
+    insert_at = "add_fields_scalar_then_nested_1"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_fields_scalar_then_nested_2"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.b.equals" = "new value"
+
+[transforms.add_fields_nested_then_scalar_1]
+  inputs = []
+  type = "add_fields"
+  [transforms.add_fields_nested_then_scalar_1.fields]
+    a.b = "initial value"
+[transforms.add_fields_nested_then_scalar_2]
+  inputs = ["add_fields_nested_then_scalar_1"]
+  type = "add_fields"
+  [transforms.add_fields_nested_then_scalar_2.fields]
+    a = "new value"
+[[tests]]
+  name = "add_fields_nested_then_scalar"
+  [tests.input]
+    insert_at = "add_fields_nested_then_scalar_1"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_fields_nested_then_scalar_2"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.equals" = "new value"
+
+[transforms.add_fields_scalar_then_scalar_1]
+  inputs = []
+  type = "add_fields"
+  [transforms.add_fields_scalar_then_scalar_1.fields]
+    a = "initial value"
+[transforms.add_fields_scalar_then_scalar_2]
+  inputs = ["add_fields_scalar_then_scalar_1"]
+  type = "add_fields"
+  [transforms.add_fields_scalar_then_scalar_2.fields]
+    a = "new value"
+[[tests]]
+  name = "add_fields_scalar_then_scalar"
+  [tests.input]
+    insert_at = "add_fields_scalar_then_scalar_1"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_fields_scalar_then_scalar_2"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.equals" = "new value"

--- a/tests/behavior/transforms/remove_fields.toml
+++ b/tests/behavior/transforms/remove_fields.toml
@@ -1,0 +1,37 @@
+[transforms.remove_fields_simple]
+  inputs = []
+  type = "remove_fields"
+  fields = ["a"]
+[[tests]]
+  name = "remove_fields_simple"
+  [tests.input]
+    insert_at = "remove_fields_simple"
+    type = "log"
+    [tests.input.log_fields]
+      a = 3
+      b = 4
+  [[tests.outputs]]
+    extract_from = "remove_fields_simple"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.exists" = false
+      "b.equals" = 4
+
+[transforms.remove_fields_nested]
+  inputs = []
+  type = "remove_fields"
+  fields = ["a.c"]
+[[tests]]
+  name = "remove_fields_nested"
+  [tests.input]
+    insert_at = "remove_fields_nested"
+    type = "log"
+    [tests.input.log_fields]
+      "a.b" = 3
+      "a.c" = 4
+  [[tests.outputs]]
+    extract_from = "remove_fields_nested"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "a.b.equals" = 3
+      "a.c.exists" = false


### PR DESCRIPTION
This PR adds behavior tests for `add_fields` transform using the config unit testing framework.

The goal is to codify the current behavior of our transforms related to nested fields to ensure that  either it doesn't change or the changes are properly communicated in the release notes. It can be considered a part of work on #704, related to https://github.com/timberio/vector/pull/1662#issuecomment-584250760.