### PR TITLE
fix(windows platform): Correct lints and tests

### DIFF
--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -19,7 +19,10 @@ mod test {
     use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use std::fs;
     use std::io::Write;
+    #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
+    #[cfg(windows)]
+    use std::os::windows::fs::MetadataExt;
     use std::str;
     // Welcome.
     //
@@ -193,9 +196,10 @@ mod test {
     // time, recording the total number of reads/writes. The SUT reads should be
     // bounded below by the model reads, bounded above by the writes.
     fn experiment(actions: Vec<FWAction>) {
-        let dir = tempfile::TempDir::new().unwrap();
+        let dir = tempfile::TempDir::new().expect("could not create tempdir");
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");
+        let mut rotation_count = 0;
         let mut fw = FileWatcher::new(path.clone(), 0, None).expect("must be able to create");
 
         let mut writes = 0;
@@ -220,8 +224,14 @@ mod test {
                         .write(true)
                         .truncate(true)
                         .open(&path)
-                        .unwrap();
-                    assert_eq!(fp.metadata().unwrap().size(), 0);
+                        .expect("could not truncate");
+                    #[cfg(unix)]
+                    assert_eq!(fp.metadata().expect("could not get metadata").size(), 0);
+                    #[cfg(windows)]
+                    assert_eq!(
+                        fp.metadata().expect("could not get metadata").file_size(),
+                        0
+                    );
                     assert!(path.exists());
                 }
                 FWAction::Pause(ps) => delay(ps),
@@ -235,13 +245,9 @@ mod test {
                 }
                 FWAction::RotateFile => {
                     let mut new_path = path.clone();
-                    new_path.set_extension("log.1");
-                    match fs::rename(&path, &new_path) {
-                        Ok(_) => {}
-                        Err(_) => {
-                            assert!(false);
-                        }
-                    }
+                    new_path.set_extension(format!("log.{}", rotation_count));
+                    rotation_count += 1;
+                    fs::rename(&path, &new_path).expect("could not rename");
                     fp = fs::File::create(&path).expect("could not create");
                     fwfiles.insert(0, FWFile::new());
                     read_index += 1;
@@ -282,9 +288,10 @@ mod test {
     // model and SUT should agree exactly. To that end, we confirm that every
     // read from SUT exactly matches the reads from the model.
     fn experiment_no_truncations(actions: Vec<FWAction>) {
-        let dir = tempfile::TempDir::new().unwrap();
+        let dir = tempfile::TempDir::new().expect("could not create tempdir");
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");
+        let mut rotation_count = 0;
         let mut fw = FileWatcher::new(path.clone(), 0, None).expect("must be able to create");
 
         let mut fwfiles: Vec<FWFile> = vec![];
@@ -309,13 +316,9 @@ mod test {
                 }
                 FWAction::RotateFile => {
                     let mut new_path = path.clone();
-                    new_path.set_extension("log.1");
-                    match fs::rename(&path, &new_path) {
-                        Ok(_) => {}
-                        Err(_) => {
-                            assert!(false);
-                        }
-                    }
+                    new_path.set_extension(format!("log.{}", rotation_count));
+                    rotation_count += 1;
+                    fs::rename(&path, &new_path).expect("could not rename");
                     fp = fs::File::create(&path).expect("could not create");
                     fwfiles.insert(0, FWFile::new());
                     read_index += 1;
@@ -334,7 +337,8 @@ mod test {
                                 continue;
                             }
                             Ok(sz) => {
-                                let exp = fwfiles[read_index].read_line().unwrap();
+                                let exp =
+                                    fwfiles[read_index].read_line().expect("could not readline");
                                 assert_eq!(exp.into_bytes(), buf);
                                 assert_eq!(sz, buf.len() + 1);
                                 buf.clear();

--- a/lib/file-source/src/metadata_ext.rs
+++ b/lib/file-source/src/metadata_ext.rs
@@ -84,9 +84,11 @@ impl PortableFileExt for File {
         let info = self.get_file_info()?;
         Ok(info.dwVolumeSerialNumber.into())
     }
+    // This is not exactly inode, but it's close. See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
     fn portable_ino(&self) -> std::io::Result<u64> {
         let info = self.get_file_info()?;
-        Ok(info.nNumberOfLinks.into())
+        // https://github.com/rust-lang/rust/blob/30ddb5a8c1e85916da0acdc665d6a16535a12dd6/src/libstd/sys/windows/fs.rs#L347
+        Ok((info.nFileIndexLow as u64) | ((info.nFileIndexHigh as u64) << 32))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[macro_use]
 extern crate tracing;
 
@@ -290,7 +292,7 @@ fn main() {
     }
 
     let result = topology::start_validated(config, pieces, &mut rt, opts.require_healthy);
-    let (mut topology, mut graceful_crash) = result.unwrap_or_else(|| {
+    let (topology, mut graceful_crash) = result.unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
     });
 
@@ -301,6 +303,7 @@ fn main() {
 
     #[cfg(unix)]
     {
+        let mut topology = topology;
         let sigint = Signal::new(SIGINT).flatten_stream();
         let sigterm = Signal::new(SIGTERM).flatten_stream();
         let sigquit = Signal::new(SIGQUIT).flatten_stream();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 #[macro_use]
 extern crate tracing;
 

--- a/src/sinks/file/file.rs
+++ b/src/sinks/file/file.rs
@@ -3,7 +3,9 @@ use crate::event::{self, Event};
 use bytes::{Bytes, BytesMut};
 use codec::BytesDelimitedCodec;
 use futures::{future, try_ready, Async, AsyncSink, Future, Poll, Sink, StartSend};
-use std::{ffi, fmt, io, path};
+#[cfg(unix)]
+use std::ffi;
+use std::{fmt, io, path};
 use tokio::{
     codec::Encoder,
     fs::{self, file},

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -631,7 +631,7 @@ mod tests {
 
         sleep(); // The writes must be observed before rotating
 
-        fs::rename(&path, archive_path).unwrap();
+        fs::rename(&path, archive_path).expect("could not rename");
         let mut file = File::create(&path).unwrap();
 
         sleep(); // The rotation must be observed before writing again
@@ -959,7 +959,7 @@ mod tests {
             assert_eq!(lines, vec!["first line"]);
         }
         // Perform 'file rotation' to archive old lines.
-        fs::rename(&path, &path_for_old_file).unwrap();
+        fs::rename(&path, &path_for_old_file).expect("could not rename");
         // Restart the server and make sure it does not re-read the old file
         // even though it has a new name.
         {

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -112,13 +112,17 @@ mod test {
     use crate::test_util::{block_on, collect_n, next_addr, send_lines, wait_for_tcp};
     use crate::topology::config::{GlobalOptions, SourceConfig};
     use futures::sync::mpsc;
-    use futures::{Future, Sink, Stream};
+    use futures::Stream;
+    #[cfg(unix)]
+    use futures::{Future, Sink};
+    #[cfg(unix)]
+    use std::path::PathBuf;
     use std::{
         net::{SocketAddr, UdpSocket},
-        path::PathBuf,
         thread,
         time::Duration,
     };
+    #[cfg(unix)]
     use tokio::codec::{FramedWrite, LinesCodec};
     #[cfg(unix)]
     use tokio_uds::UnixStream;

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -1,10 +1,11 @@
 use crate::Error;
+#[cfg(unix)]
 use notify::{raw_watcher, Op, RawEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use std::{path::PathBuf, time::Duration};
+#[cfg(unix)]
 use std::{
-    path::PathBuf,
     sync::mpsc::{channel, Receiver},
     thread,
-    time::Duration,
 };
 
 /// Per notify own documentation, it's advised to have delay of more than 30 sec,
@@ -16,6 +17,7 @@ use std::{
 /// so we can use smaller, more responsive delay.
 pub const CONFIG_WATCH_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
+#[cfg(unix)]
 const RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Triggers SIGHUP when file on config_path changes.
@@ -78,7 +80,7 @@ fn raise_sighup() {
         error!(message = "Unable to reload configuration file. Restart Vector to reload it.", cause = ?error)
     });
 }
-
+#[cfg(unix)]
 fn create_watcher(
     config_paths: &Vec<PathBuf>,
 ) -> Result<(RecommendedWatcher, Receiver<RawEvent>), Error> {
@@ -91,6 +93,7 @@ fn create_watcher(
     Ok((watcher, receiver))
 }
 
+#[cfg(unix)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,7 +105,6 @@ mod tests {
     use tokio::timer::Delay;
     use tokio_signal::unix::{Signal, SIGHUP};
 
-    #[cfg(unix)]
     #[test]
     fn file_update() {
         crate::test_util::trace_init();

--- a/src/types.rs
+++ b/src/types.rs
@@ -258,7 +258,7 @@ pub fn parse_timestamp(s: &str) -> Result<DateTime<Utc>, Error> {
 mod tests {
     use super::parse_bool;
     #[cfg(unix)]
-    use super::parse_time_stamp;
+    use super::parse_timestamp;
     #[cfg(unix)]
     use super::{Conversion, Error};
     #[cfg(unix)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -256,16 +256,25 @@ pub fn parse_timestamp(s: &str) -> Result<DateTime<Utc>, Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_bool, parse_timestamp, Conversion, Error};
+    use super::parse_bool;
+    #[cfg(unix)]
+    use super::parse_time_stamp;
+    #[cfg(unix)]
+    use super::{Conversion, Error};
+    #[cfg(unix)]
     use crate::event::Value;
+    #[cfg(unix)]
     use chrono::prelude::*;
 
+    #[cfg(unix)]
     const TIMEZONE: &str = "Australia/Brisbane";
 
+    #[cfg(unix)]
     fn dateref() -> DateTime<Utc> {
         Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(981173106, 0))
     }
 
+    #[cfg(unix)]
     fn convert(fmt: &str, value: &str) -> Result<Value, Error> {
         std::env::set_var("TZ", TIMEZONE);
         fmt.parse::<Conversion>()

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -1,10 +1,12 @@
 use approx::assert_relative_eq;
+#[cfg(unix)]
 use futures::{Future, Sink, Stream};
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
 use sinks::socket::SocketSinkConfig;
 use sinks::util::Encoding;
 use std::{collections::HashMap, thread, time::Duration};
+#[cfg(unix)]
 use tokio::codec::{FramedWrite, LinesCodec};
 #[cfg(unix)]
 use tokio_uds::UnixStream;


### PR DESCRIPTION
As reported in #1412 , Windows builds/tests have lints and errors.

This PR fixes all lints and tweaks a few tests to make it viable for Windows to pass.

* Mark any `unix` only imports in `#[cfg(unix)]`.
* Windows errors if you try to rename a file into a path that already exists. So we now use a simple file rolling procedure in those tests.
* Improves `unwrap` errors into `expect` errors to give some context to failing tests.