### PR TITLE
chore(testing): Add field order test at src/event/discriminant.rs

### DIFF
--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -159,6 +159,24 @@ mod tests {
     }
 
     #[test]
+    fn field_order() {
+        let mut event_1 = new_log_event();
+        event_1.insert("a", "a");
+        event_1.insert("b", "b");
+        let mut event_2 = new_log_event();
+        event_2.insert("b", "b");
+        event_2.insert("a", "a");
+
+        let discriminant_fields = vec![Atom::from("a"), Atom::from("b")];
+
+        let discriminant_1 = Discriminant::from_log_event(&event_1, &discriminant_fields);
+        let discriminant_2 = Discriminant::from_log_event(&event_2, &discriminant_fields);
+
+        assert_eq!(discriminant_1, discriminant_2);
+        assert_eq!(hash(discriminant_1), hash(discriminant_2));
+    }
+
+    #[test]
     fn with_hash_map() {
         let mut map: HashMap<Discriminant, usize> = HashMap::new();
 


### PR DESCRIPTION
Adds a test to ensure the root event field order are properly compared.

Relevant to #1662, see https://github.com/timberio/vector/pull/1662#discussion_r380309848