### PR TITLE
feat(cli): Allow multiple unit test inputs

### DIFF
--- a/.meta/tests.toml
+++ b/.meta/tests.toml
@@ -11,13 +11,13 @@ common = true
 required = true
 description = "A unique identifier for this test."
 
-[tests.children.input]
-type = "table"
+[tests.children.inputs]
+type = "[table]"
 common = true
 required = true
 description = "A table that defines a unit test input event."
 
-[tests.children.input.children.insert_at]
+[tests.children.inputs.children.insert_at]
 type = "string"
 examples = ["foo"]
 common = true
@@ -27,32 +27,32 @@ The name of a transform, the input event will be delivered to this transform in 
 order to begin the test.\
 """
 
-[tests.children.input.children.type]
+[tests.children.inputs.children.type]
 type = "string"
 examples = ["raw", "log", "metric"]
 required = true
 common = true
 description = "The event type."
 
-[tests.children.input.children.type.enum]
+[tests.children.inputs.children.type.enum]
 raw = "Creates a log event where the message contents are specified in the field 'value'."
 log = "Creates a log event where log fields are specified in the table 'log_fields'."
 metric = "Creates a metric event, where its type and fields are specified in the table 'metric'."
 
-[tests.children.input.children.value]
+[tests.children.inputs.children.value]
 type = "string"
 examples = ["some message contents"]
 relevant_when = {type = "raw"}
 common = true
 description = "Specifies the log message field contents when the input type is 'raw'."
 
-[tests.children.input.children.log_fields]
+[tests.children.inputs.children.log_fields]
 type = "table"
 common = false
 relevant_when = {type = "log"}
 description = "Specifies the log fields when the input type is 'log'."
 
-[tests.children.input.children.log_fields.children."`[field-name]`"]
+[tests.children.inputs.children.log_fields.children."`[field-name]`"]
 type = "*"
 required = true
 examples = [
@@ -63,26 +63,26 @@ description = """\
 A key/value pair representing a field to be added to the input event.\
 """
 
-[tests.children.input.children.metric]
+[tests.children.inputs.children.metric]
 type = "table"
 common = false
 relevant_when = {type = "metric"}
 description = "Specifies the metric type when the input type is 'metric'."
 
-[tests.children.input.children.metric.children.type]
+[tests.children.inputs.children.metric.children.type]
 type = "string"
 required = true
 examples = ["counter"]
 common = true
 description = "The metric type."
 
-[tests.children.input.children.metric.children.type.enum]
+[tests.children.inputs.children.metric.children.type.enum]
 counter = "A [counter metric type][docs.data-model.metric#counter]."
 gauge = "A [gauge metric type][docs.data-model.metric#gauge]."
 histogram = "A [distribution metric type][docs.data-model.metric#distribution]."
 set = "A [set metric type][docs.data-model.metric#set]."
 
-[tests.children.input.children.metric.children.name]
+[tests.children.inputs.children.metric.children.name]
 type = "string"
 examples = ["duration_total"]
 required = true
@@ -92,12 +92,12 @@ The name of the metric. Defaults to `<field>_total` for `counter` and \
 `<field>` for `gauge`.\
 """
 
-[tests.children.input.children.metric.children.tags]
+[tests.children.inputs.children.metric.children.tags]
 type = "table"
 common = true
 description = "Key/value pairs representing [metric tags][docs.data-model.metric#tags]."
 
-[tests.children.input.children.metric.children.tags.children."`[tag-name]`"]
+[tests.children.inputs.children.metric.children.tags.children."`[tag-name]`"]
 type = "string"
 examples = [
   {host = "foohost"},
@@ -109,7 +109,7 @@ description = """\
 Key/value pairs representing [metric tags][docs.data-model.metric#tags].\
 """
 
-[tests.children.input.children.metric.children.val]
+[tests.children.inputs.children.metric.children.val]
 type = "float"
 examples = [10.2]
 required = true
@@ -117,7 +117,7 @@ description = """\
 Amount to increment/decrement or gauge.\
 """
 
-[tests.children.input.children.metric.children.timestamp]
+[tests.children.inputs.children.metric.children.timestamp]
 type = "string"
 examples = ["2019-11-01T21:15:47.443232Z"]
 required = true
@@ -125,20 +125,20 @@ description = """\
 Time metric was created/ingested.\
 """
 
-[tests.children.input.children.metric.children.sample_rate]
+[tests.children.inputs.children.metric.children.sample_rate]
 type = "float"
 examples = [1]
 description = """\
 The bucket/distribution the metric is a part of.\
 """
 
-[tests.children.input.children.metric.children.direction]
+[tests.children.inputs.children.metric.children.direction]
 type = "string"
 description = """\
 The direction to increase or decrease the gauge value.\
 """
 
-[tests.children.input.children.metric.children.direction.enum]
+[tests.children.inputs.children.metric.children.direction.enum]
 plus = "Increase the gauge"
 minus = "Decrease the gauge"
 

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -236,7 +236,9 @@ inventory::collect!(TransformDescription);
 #[serde(deny_unknown_fields)]
 pub struct TestDefinition {
     pub name: String,
-    pub input: TestInput,
+    pub input: Option<TestInput>,
+    #[serde(default)]
+    pub inputs: Vec<TestInput>,
     pub outputs: Vec<TestOutput>,
 }
 

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -715,9 +715,12 @@ mod tests {
       type = "check_fields"
       "new_field.equals" = "string value"
       "message.equals" = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo_two"
     [[tests.outputs.conditions]]
       type = "check_fields"
-      "new_field.equals" = "string value"
+      "new_field_two.equals" = "second string value"
       "message.equals" = "nah this also doesnt matter"
 
   [[tests.outputs]]
@@ -729,7 +732,7 @@ mod tests {
       "message.equals" = "nah this doesnt matter"
     [[tests.outputs.conditions]]
       type = "check_fields"
-      "new_field.equals" = "string value"
+      "new_field_two.equals" = "second string value"
       "second_new_field.equals" = "also a string value"
       "message.equals" = "nah this also doesnt matter"
 
@@ -743,7 +746,7 @@ mod tests {
       "message.equals" = "nah this doesnt matter"
     [[tests.outputs.conditions]]
       type = "check_fields"
-      "new_field.equals" = "string value"
+      "new_field_two.equals" = "second string value"
       "second_new_field.equals" = "also a string value"
       "third_new_field.equals" = "also also a string value"
       "message.equals" = "nah this also doesnt matter"

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -2,7 +2,7 @@ use crate::{
     conditions::Condition,
     event::{Event, Value},
     runtime::Runtime,
-    topology::config::{TestCondition, TestDefinition, TestInputValue, TransformContext},
+    topology::config::{TestCondition, TestDefinition, TestInput, TestInputValue, TransformContext},
     transforms::Transform,
 };
 use indexmap::IndexMap;
@@ -22,7 +22,7 @@ pub struct UnitTestTransform {
 
 pub struct UnitTest {
     pub name: String,
-    input: (String, Event),
+    inputs: Vec<(String, Event)>,
     transforms: IndexMap<String, UnitTestTransform>,
     checks: Vec<UnitTestCheck>,
 }
@@ -91,12 +91,14 @@ impl UnitTest {
         let mut inspections = Vec::new();
         let mut results = HashMap::new();
 
-        walk(
-            &self.input.0,
-            vec![self.input.1.clone()],
-            &mut self.transforms,
-            &mut results,
-        );
+        for input in &self.inputs {
+            walk(
+                &input.0,
+                vec![input.1.clone()],
+                &mut self.transforms,
+                &mut results,
+            );
+        }
 
         for check in &self.checks {
             if let Some((inputs, outputs)) = results.get(&check.extract_from) {
@@ -190,46 +192,40 @@ fn links_to_a_leaf(
 /// Reduces a collection of transforms into a set that only contains those that
 /// link between our root (test input) and a set of leaves (test outputs).
 fn reduce_transforms(
-    root: &str,
+    roots: &Vec<String>,
     leaves: &IndexMap<String, ()>,
     transform_outputs: &mut IndexMap<String, IndexMap<String, ()>>,
 ) {
     let mut link_checked: IndexMap<String, bool> = IndexMap::new();
 
-    if !links_to_a_leaf(root, leaves, &mut link_checked, transform_outputs) {
+    if roots
+        .iter()
+        .all(|r| !links_to_a_leaf(r, leaves, &mut link_checked, transform_outputs))
+    {
         transform_outputs.clear();
     }
 
     transform_outputs.retain(|name, children| {
-        let linked = name == root || *link_checked.get(name).unwrap_or(&false);
+        let linked = roots.contains(name) || *link_checked.get(name).unwrap_or(&false);
         if linked {
             // Also remove all unlinked children.
             children.retain(|child_name, _| {
-                name == root || *link_checked.get(child_name).unwrap_or(&false)
+                roots.contains(child_name) || *link_checked.get(child_name).unwrap_or(&false)
             })
         }
         linked
     });
 }
 
-fn build_unit_test(
-    definition: &TestDefinition,
-    config: &super::Config,
-) -> Result<UnitTest, Vec<String>> {
-    let rt = Runtime::single_threaded().unwrap();
-    let mut errors = vec![];
-
-    // Build input event.
-    let input_event = match definition.input.type_str.as_ref() {
-        "raw" => match definition.input.value.as_ref() {
-            Some(v) => Event::from(v.clone()),
-            None => {
-                errors.push("input type 'raw' requires the field 'value'".to_string());
-                Event::from("")
-            }
+fn build_input(input: &TestInput) -> Result<(String, Event), String> {
+    let target = input.insert_at.clone();
+    match input.type_str.as_ref() {
+        "raw" => match input.value.as_ref() {
+            Some(v) => Ok((target, Event::from(v.clone()))),
+            None => Err("input type 'raw' requires the field 'value'".to_string()),
         },
         "log" => {
-            if let Some(log_fields) = &definition.input.log_fields {
+            if let Some(log_fields) = &input.log_fields {
                 let mut event = Event::from("");
                 for (path, value) in log_fields {
                     let value: Value = match value {
@@ -240,26 +236,63 @@ fn build_unit_test(
                     };
                     event.as_mut_log().insert(path.to_owned(), value);
                 }
-                event
+                Ok((target, event))
             } else {
-                errors.push("input type 'log' requires the field 'log_fields'".to_string());
-                Event::from("")
+                Err("input type 'log' requires the field 'log_fields'".to_string())
             }
         }
         "metric" => {
-            if let Some(metric) = &definition.input.metric {
-                Event::Metric(metric.clone())
+            if let Some(metric) = &input.metric {
+                Ok((target, Event::Metric(metric.clone())))
             } else {
-                errors.push("input type 'log' requires the field 'log_fields'".to_string());
-                Event::from("")
+                Err("input type 'log' requires the field 'log_fields'".to_string())
             }
         }
-        _ => {
-            errors.push(format!(
-                "unrecognized input type '{}', expected one of: 'raw', 'log' or 'metric'",
-                definition.input.type_str
-            ));
-            Event::from("")
+        _ => Err(format!(
+            "unrecognized input type '{}', expected one of: 'raw', 'log' or 'metric'",
+            input.type_str
+        )),
+    }
+}
+
+fn build_inputs(definition: &TestDefinition) -> Result<Vec<(String, Event)>, Vec<String>> {
+    let mut inputs = Vec::new();
+    let mut errors = vec![];
+
+    if let Some(input_def) = &definition.input {
+        match build_input(input_def) {
+            Ok(input_event) => inputs.push(input_event),
+            Err(err) => errors.push(err),
+        }
+    } else if definition.inputs.is_empty() {
+        errors.push("must specify at least one input.".to_owned());
+    }
+    for input_def in &definition.inputs {
+        match build_input(input_def) {
+            Ok(input_event) => inputs.push(input_event),
+            Err(err) => errors.push(err),
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(inputs)
+    } else {
+        Err(errors)
+    }
+}
+
+fn build_unit_test(
+    definition: &TestDefinition,
+    config: &super::Config,
+) -> Result<UnitTest, Vec<String>> {
+    let rt = Runtime::single_threaded().unwrap();
+    let mut errors = vec![];
+
+    let inputs = match build_inputs(&definition) {
+        Ok(inputs) => inputs,
+        Err(mut errs) => {
+            errors.append(&mut errs);
+            Vec::new()
         }
     };
 
@@ -279,11 +312,15 @@ fn build_unit_test(
         })
     });
 
-    if !transform_outputs.contains_key(&definition.input.insert_at) {
-        errors.push(format!(
-            "unable to locate target transform '{}'",
-            definition.input.insert_at,
-        ));
+    for (input_target, _) in &inputs {
+        if !transform_outputs.contains_key(input_target) {
+            errors.push(format!(
+                "unable to locate target transform '{}'",
+                input_target
+            ));
+        }
+    }
+    if !errors.is_empty() {
         return Err(errors);
     }
 
@@ -294,7 +331,14 @@ fn build_unit_test(
 
     // Reduce the configured transforms into just the ones connecting our test
     // target with output targets.
-    reduce_transforms(&definition.input.insert_at, &leaves, &mut transform_outputs);
+    reduce_transforms(
+        &inputs
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect::<Vec<_>>(),
+        &leaves,
+        &mut transform_outputs,
+    );
 
     // Build reduced transforms.
     let mut transforms: IndexMap<String, UnitTestTransform> = IndexMap::new();
@@ -326,10 +370,17 @@ fn build_unit_test(
 
     definition.outputs.iter().for_each(|o| {
         if !transforms.contains_key(&o.extract_from) {
-            errors.push(format!(
-                "unable to complete topology between target transform '{}' and output target '{}'",
-                definition.input.insert_at, o.extract_from
-            ));
+            if inputs.len() == 1 {
+                errors.push(format!(
+                    "unable to complete topology between target transform '{}' and output target '{}'",
+                    inputs.first().map(|(i, _)| i).unwrap_or(&"".to_owned()), o.extract_from
+                ));
+            } else {
+                errors.push(format!(
+                    "unable to complete topology between target transforms {:?} and output target '{}'",
+                    inputs.iter().map(|(i, _)| i).collect::<Vec<_>>(), o.extract_from
+                ));
+            }
         }
     });
 
@@ -378,7 +429,7 @@ fn build_unit_test(
     } else {
         Ok(UnitTest {
             name: definition.name.clone(),
-            input: (definition.input.insert_at.clone(), input_event),
+            inputs,
             transforms,
             checks,
         })
@@ -450,6 +501,36 @@ mod tests {
     }
 
     #[test]
+    fn parse_no_test_input() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.bar]
+  inputs = ["foo"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    my_string_field = "string value"
+
+[[tests]]
+  name = "broken test"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "#,
+        )
+        .unwrap();
+
+        let errs = build_unit_tests(&config).err().unwrap();
+        assert_eq!(
+            errs,
+            vec![r#"Failed to build test 'broken test':
+  must specify at least one input."#
+                .to_owned(),]
+        );
+    }
+
+    #[test]
     fn parse_broken_topology() {
         let config: Config = toml::from_str(
             r#"
@@ -458,6 +539,12 @@ mod tests {
   type = "add_fields"
   [transforms.foo.fields]
     foo_field = "string value"
+
+[transforms.nah]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.nah.fields]
+    new_field = "string value"
 
 [transforms.baz]
   inputs = ["bar"]
@@ -502,6 +589,29 @@ mod tests {
     [[tests.outputs.conditions]]
       type = "check_fields"
       "message.equals" = "not this"
+
+[[tests]]
+  name = "broken test 3"
+
+  [[tests.inputs]]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.inputs]]
+    insert_at = "nah"
+    value = "nah this doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "message.equals" = "not this"
+
+  [[tests.outputs]]
+    extract_from = "quz"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "message.equals" = "not this"
       "#,
         )
         .unwrap();
@@ -516,6 +626,10 @@ mod tests {
                     .to_owned(),
                 r#"Failed to build test 'broken test 2':
   unable to locate target transform 'nope'"#
+                    .to_owned(),
+                r#"Failed to build test 'broken test 3':
+  unable to complete topology between target transforms ["foo", "nah"] and output target 'baz'
+  unable to complete topology between target transforms ["foo", "nah"] and output target 'quz'"#
                     .to_owned(),
             ]
         );
@@ -554,6 +668,91 @@ mod tests {
   unrecognized input type 'nah', expected one of: 'raw', 'log' or 'metric'"#
                 .to_owned(),]
         );
+    }
+
+    #[test]
+    fn test_success_multi_inputs() {
+        let config: Config = toml::from_str(
+            r#"
+[transforms.foo]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo.fields]
+    new_field = "string value"
+
+[transforms.foo_two]
+  inputs = ["ignored"]
+  type = "add_fields"
+  [transforms.foo_two.fields]
+    new_field_two = "second string value"
+
+[transforms.bar]
+  inputs = ["foo", "foo_two"]
+  type = "add_fields"
+  [transforms.bar.fields]
+    second_new_field = "also a string value"
+
+[transforms.baz]
+  inputs = ["bar"]
+  type = "add_fields"
+  [transforms.baz.fields]
+    third_new_field = "also also a string value"
+
+[[tests]]
+  name = "successful test"
+
+  [[tests.inputs]]
+    insert_at = "foo"
+    value = "nah this doesnt matter"
+
+  [[tests.inputs]]
+    insert_at = "foo_two"
+    value = "nah this also doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "foo"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "message.equals" = "nah this doesnt matter"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "message.equals" = "nah this also doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "bar"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "message.equals" = "nah this doesnt matter"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "message.equals" = "nah this also doesnt matter"
+
+  [[tests.outputs]]
+    extract_from = "baz"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "third_new_field.equals" = "also also a string value"
+      "message.equals" = "nah this doesnt matter"
+    [[tests.outputs.conditions]]
+      type = "check_fields"
+      "new_field.equals" = "string value"
+      "second_new_field.equals" = "also a string value"
+      "third_new_field.equals" = "also also a string value"
+      "message.equals" = "nah this also doesnt matter"
+      "#,
+        )
+        .unwrap();
+
+        let mut tests = build_unit_tests(&config).unwrap();
+        assert_eq!(tests[0].run().1, Vec::<String>::new());
     }
 
     #[test]

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -53,6 +53,37 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # REQUIRED - General
   name = "foo test" # example
 
+  # REQUIRED - Inputs
+  [[tests.inputs]]
+    # REQUIRED - General
+    type = "raw" # example, enum
+    insert_at = "foo" # example
+
+    # OPTIONAL - General
+    value = "some message contents" # example, no default, relevant when type = "raw"
+
+    # OPTIONAL - Log fields
+    [tests.inputs.log_fields]
+      message = "some message contents" # example
+      host = "myhost" # example
+
+    # OPTIONAL - Metric
+    [tests.inputs.metric]
+      # REQUIRED - General
+      type = "counter" # example, enum
+      name = "duration_total" # example
+      timestamp = "2019-11-01T21:15:47.443232Z" # example
+      val = 10.2 # example
+
+      # OPTIONAL - General
+      direction = "plus" # example, no default, enum
+      sample_rate = 1 # example, no default
+
+      # OPTIONAL - Tags
+      [tests.inputs.metric.tags]
+        host = "foohost" # example
+        region = "us-east-1" # example
+
   # REQUIRED - Outputs
   [[tests.outputs]]
     # REQUIRED - General
@@ -67,37 +98,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
       "message.eq" = "this is the content to match against"
       "host.exists" = true
       "method.neq" = "POST"
-
-  # REQUIRED - Input
-  [tests.input]
-    # REQUIRED - General
-    type = "raw" # example, enum
-    insert_at = "foo" # example
-
-    # OPTIONAL - General
-    value = "some message contents" # example, no default, relevant when type = "raw"
-
-    # OPTIONAL - Log fields
-    [tests.input.log_fields]
-      message = "some message contents" # example
-      host = "myhost" # example
-
-    # OPTIONAL - Metric
-    [tests.input.metric]
-      # REQUIRED - General
-      type = "counter" # example, enum
-      name = "duration_total" # example
-      timestamp = "2019-11-01T21:15:47.443232Z" # example
-      val = 10.2 # example
-
-      # OPTIONAL - General
-      direction = "plus" # example, no default, enum
-      sample_rate = 1 # example, no default
-
-      # OPTIONAL - Tags
-      [tests.input.metric.tags]
-        host = "foohost" # example
-        region = "us-east-1" # example
 ```
 
 </TabItem>
@@ -114,6 +114,37 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # REQUIRED - General
   name = "foo test" # example
 
+  # REQUIRED - Inputs
+  [[tests.inputs]]
+    # REQUIRED - General
+    type = "raw" # example, enum
+    insert_at = "foo" # example
+
+    # OPTIONAL - General
+    value = "some message contents" # example, no default, relevant when type = "raw"
+
+    # OPTIONAL - Log fields
+    [tests.inputs.log_fields]
+      message = "some message contents" # example
+      host = "myhost" # example
+
+    # OPTIONAL - Metric
+    [tests.inputs.metric]
+      # REQUIRED - General
+      type = "counter" # example, enum
+      name = "duration_total" # example
+      timestamp = "2019-11-01T21:15:47.443232Z" # example
+      val = 10.2 # example
+
+      # OPTIONAL - General
+      direction = "plus" # example, no default, enum
+      sample_rate = 1 # example, no default
+
+      # OPTIONAL - Tags
+      [tests.inputs.metric.tags]
+        host = "foohost" # example
+        region = "us-east-1" # example
+
   # REQUIRED - Outputs
   [[tests.outputs]]
     # REQUIRED - General
@@ -128,37 +159,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
       "message.eq" = "this is the content to match against"
       "host.exists" = true
       "method.neq" = "POST"
-
-  # REQUIRED - Input
-  [tests.input]
-    # REQUIRED - General
-    type = "raw" # example, enum
-    insert_at = "foo" # example
-
-    # OPTIONAL - General
-    value = "some message contents" # example, no default, relevant when type = "raw"
-
-    # OPTIONAL - Log fields
-    [tests.input.log_fields]
-      message = "some message contents" # example
-      host = "myhost" # example
-
-    # OPTIONAL - Metric
-    [tests.input.metric]
-      # REQUIRED - General
-      type = "counter" # example, enum
-      name = "duration_total" # example
-      timestamp = "2019-11-01T21:15:47.443232Z" # example
-      val = 10.2 # example
-
-      # OPTIONAL - General
-      direction = "plus" # example, no default, enum
-      sample_rate = 1 # example, no default
-
-      # OPTIONAL - Tags
-      [tests.input.metric.tags]
-        host = "foohost" # example
-        region = "us-east-1" # example
 ```
 
 </TabItem>
@@ -182,16 +182,16 @@ import Field from '@site/src/components/Field';
   enumValues={null}
   examples={[]}
   groups={[]}
-  name={"input"}
+  name={"inputs"}
   path={null}
   relevantWhen={null}
   required={true}
   templateable={false}
-  type={"table"}
+  type={"[table]"}
   unit={null}
   >
 
-### input
+### inputs
 
 A table that defines a unit test input event.
 
@@ -205,7 +205,7 @@ A table that defines a unit test input event.
   examples={["foo"]}
   groups={[]}
   name={"insert_at"}
-  path={"input"}
+  path={"inputs"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -228,7 +228,7 @@ The name of a transform, the input event will be delivered to this transform in 
   examples={[]}
   groups={[]}
   name={"log_fields"}
-  path={"input"}
+  path={"inputs"}
   relevantWhen={{"type":"log"}}
   required={false}
   templateable={false}
@@ -250,7 +250,7 @@ Specifies the log fields when the input type is 'log'.
   examples={[{"message":"some message contents"},{"host":"myhost"}]}
   groups={[]}
   name={"`[field-name]`"}
-  path={"input.log_fields"}
+  path={"inputs.log_fields"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -278,7 +278,7 @@ A key/value pair representing a field to be added to the input event.
   examples={[]}
   groups={[]}
   name={"metric"}
-  path={"input"}
+  path={"inputs"}
   relevantWhen={{"type":"metric"}}
   required={false}
   templateable={false}
@@ -300,7 +300,7 @@ Specifies the metric type when the input type is 'metric'.
   examples={["plus","minus"]}
   groups={[]}
   name={"direction"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -323,7 +323,7 @@ The direction to increase or decrease the gauge value.
   examples={["duration_total"]}
   groups={[]}
   name={"name"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -346,7 +346,7 @@ The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` 
   examples={[1]}
   groups={[]}
   name={"sample_rate"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -369,7 +369,7 @@ The bucket/distribution the metric is a part of.
   examples={[]}
   groups={[]}
   name={"tags"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={false}
   templateable={false}
@@ -391,7 +391,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags].
   examples={[{"host":"foohost"},{"region":"us-east-1"}]}
   groups={[]}
   name={"`[tag-name]`"}
-  path={"input.metric.tags"}
+  path={"inputs.metric.tags"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -419,7 +419,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags].
   examples={["2019-11-01T21:15:47.443232Z"]}
   groups={[]}
   name={"timestamp"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -442,7 +442,7 @@ Time metric was created/ingested.
   examples={["counter"]}
   groups={[]}
   name={"type"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -465,7 +465,7 @@ The metric type.
   examples={[10.2]}
   groups={[]}
   name={"val"}
-  path={"input.metric"}
+  path={"inputs.metric"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -493,7 +493,7 @@ Amount to increment/decrement or gauge.
   examples={["raw","log","metric"]}
   groups={[]}
   name={"type"}
-  path={"input"}
+  path={"inputs"}
   relevantWhen={null}
   required={true}
   templateable={false}
@@ -516,7 +516,7 @@ The event type.
   examples={["some message contents"]}
   groups={[]}
   name={"value"}
-  path={"input"}
+  path={"inputs"}
   relevantWhen={{"type":"raw"}}
   required={false}
   templateable={false}

--- a/website/docs/setup/guides/unit-testing.md
+++ b/website/docs/setup/guides/unit-testing.md
@@ -72,14 +72,14 @@ live with us indefinitely. We will do _anything_ to prevent that.
 ## Input
 
 First we shall write a single unit test at the bottom of our config called
-`check_simple_log`. Each test must define a single input event, which initiates
-the test by injecting that event into a transform of the topology:
+`check_simple_log`. Each test must define input events (usually just one), which
+initiates the test by injecting those events into a transform of the topology:
 
 ```toml
 [[tests]]
   name = "check_simple_log"
 
-  [tests.input]
+  [[tests.inputs]]
     insert_at = "foo"
     type = "raw"
     value = "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"
@@ -99,7 +99,7 @@ order to perform checks with this unit test we define an output to inspect:
 [[tests]]
   name = "check_simple_log"
 
-  [tests.input]
+  [[tests.inputs]]
     insert_at = "foo"
     type = "raw"
     value = "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"


### PR DESCRIPTION
This replaces the field `input` with an array `inputs`, allowing you to specify any number of input test events for your test. If an `input` is specified this test will still execute, making it backwards compatible with old tests.

~Note: there's a unit test that will fail, I need https://github.com/timberio/vector/pull/1814 in order for it to pass. I'll rebase once it's merged.~

Closes https://github.com/timberio/vector/issues/1819