### PR TITLE
chore(testing): Discriminant nested events semantics

### DIFF
--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -159,6 +159,24 @@ mod tests {
     }
 
     #[test]
+    fn field_order() {
+        let mut event_1 = new_log_event();
+        event_1.insert("a", "a");
+        event_1.insert("b", "b");
+        let mut event_2 = new_log_event();
+        event_2.insert("b", "b");
+        event_2.insert("a", "a");
+
+        let discriminant_fields = vec![Atom::from("a"), Atom::from("b")];
+
+        let discriminant_1 = Discriminant::from_log_event(&event_1, &discriminant_fields);
+        let discriminant_2 = Discriminant::from_log_event(&event_2, &discriminant_fields);
+
+        assert_eq!(discriminant_1, discriminant_2);
+        assert_eq!(hash(discriminant_1), hash(discriminant_2));
+    }
+
+    #[test]
     fn with_hash_map() {
         let mut map: HashMap<Discriminant, usize> = HashMap::new();
 

--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -195,10 +195,26 @@ mod tests {
     }
 
     #[test]
-    fn map_values_matter() {
+    fn map_values_matter_1() {
         let mut event_1 = new_log_event();
-        event_1.insert("nested.a", "a");
+        event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
         let event_2 = new_log_event(); // empty event
+
+        let discriminant_fields = vec![Atom::from("nested")];
+
+        let discriminant_1 = Discriminant::from_log_event(&event_1, &discriminant_fields);
+        let discriminant_2 = Discriminant::from_log_event(&event_2, &discriminant_fields);
+
+        assert_ne!(discriminant_1, discriminant_2);
+        assert_ne!(hash(discriminant_1), hash(discriminant_2));
+    }
+
+    #[test]
+    fn map_values_matter_2() {
+        let mut event_1 = new_log_event();
+        event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
+        let mut event_2 = new_log_event();
+        event_2.insert("nested", "x"); // `nested` is a `Value::String`
 
         let discriminant_fields = vec![Atom::from("nested")];
 

--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -177,6 +177,39 @@ mod tests {
     }
 
     #[test]
+    fn map_values_key_order() {
+        let mut event_1 = new_log_event();
+        event_1.insert("nested.a", "a");
+        event_1.insert("nested.b", "b");
+        let mut event_2 = new_log_event();
+        event_2.insert("nested.b", "b");
+        event_2.insert("nested.a", "a");
+
+        let discriminant_fields = vec![Atom::from("nested")];
+
+        let discriminant_1 = Discriminant::from_log_event(&event_1, &discriminant_fields);
+        let discriminant_2 = Discriminant::from_log_event(&event_2, &discriminant_fields);
+
+        assert_eq!(discriminant_1, discriminant_2);
+        assert_eq!(hash(discriminant_1), hash(discriminant_2));
+    }
+
+    #[test]
+    fn map_values_matter() {
+        let mut event_1 = new_log_event();
+        event_1.insert("nested.a", "a");
+        let event_2 = new_log_event(); // empty event
+
+        let discriminant_fields = vec![Atom::from("nested")];
+
+        let discriminant_1 = Discriminant::from_log_event(&event_1, &discriminant_fields);
+        let discriminant_2 = Discriminant::from_log_event(&event_2, &discriminant_fields);
+
+        assert_ne!(discriminant_1, discriminant_2);
+        assert_ne!(hash(discriminant_1), hash(discriminant_2));
+    }
+
+    #[test]
     fn with_hash_map() {
         let mut map: HashMap<Discriminant, usize> = HashMap::new();
 


### PR DESCRIPTION
Test cases for nested events support at discriminant.

Relevant to #1662, see https://github.com/timberio/vector/pull/1662#discussion_r380306776
Closes #1806.
 
I list the commit messages to better explain the purpose and logic.

#### Add two new tests for discriminant: map_values_key_order and map_values_matter

These are designed to help with ensuring the nested fields are properly
supported.
The design is as follows:
- The `map_values_key_order` test checks that the discriminant for two
  values with different key order still produce the same discriminant;
  this will pass without nested fields support (i.e. on current master),
  but not because it correctly distinguishes the streams - but because the
  map values are not considered for comparison at all. For the purpose of
  the discriminant, events are the same because no fields contributed to
  the calculation. The invariant is still checked and passes. But to ensure
  the actual correctness, the second test - `map_values_matter` - is
  added.
- The `map_values_matter` test checks that nested fields do actually
  contribute to the discriminant calculation.

#### Add another case for the `map_values_matter` test

This ensures the Map values are not confused with other variants, and also
validates another edge case that has to be properly supported for proper
nested field implementation - that `Value::Map` values are not ignored.

- rename `map_values_matter` to `map_values_matter_1`
- add `map_values_matter_2`