### PR TITLE
docs: Add support for option groups and versions 

### DIFF
--- a/.meta/.schema.json
+++ b/.meta/.schema.json
@@ -244,6 +244,13 @@
             "transmit"
           ]
         },
+        "groups": {
+          "type": "array",
+          "description": "The overaching group that this configuration belongs to. This is an advanced option that should be used for large groups of mutually exclusive options. For example, a set of options specifically for v1 and another set for v2.",
+          "items": {
+            "type": "string"
+          }
+        },
         "healthcheck": {
           "type": "boolean",
           "description": "If the sink implements a healthcheck."
@@ -255,6 +262,10 @@
             "type": "string",
             "enum": ["log", "metric"]
           }
+        },
+        "min_version": {
+          "type": "string",
+          "description": "The minimum version supported for the system this component interfaces with."
         },
         "options": {
           "$ref": "#/definitions/fields",

--- a/.meta/.schema.json
+++ b/.meta/.schema.json
@@ -99,6 +99,13 @@
           "type": "array",
           "description": "An array of example values used for documentation purposes."
         },
+        "groups": {
+          "type": "array",
+          "description": "The overaching group that this configuration belongs to. This is an advanced option that should be used for large groups of mutually exclusive options. For example, a set of options specifically for v1 and another set for v2.",
+          "items": {
+            "type": "string"
+          }
+        },
         "partition_key": {
           "type": "boolean",
           "description": "If this option can be used to partition data. For example, the `path` option in the `aws_s3` sink."
@@ -243,13 +250,6 @@
             "test",
             "transmit"
           ]
-        },
-        "groups": {
-          "type": "array",
-          "description": "The overaching group that this configuration belongs to. This is an advanced option that should be used for large groups of mutually exclusive options. For example, a set of options specifically for v1 and another set for v2.",
-          "items": {
-            "type": "string"
-          }
         },
         "healthcheck": {
           "type": "boolean",

--- a/.meta/_partials/_batch_options.toml
+++ b/.meta/_partials/_batch_options.toml
@@ -1,6 +1,8 @@
+<%- groups ||= [] -%>
 [<%= namespace %>.batch]
 type = "table"
 common = <%= common %>
+groups = <%= groups.to_json %>
 description = "Configures the sink batching behavior."
 
 <%- if max_events -%>

--- a/.meta/_partials/_buffer_options.toml
+++ b/.meta/_partials/_buffer_options.toml
@@ -1,5 +1,7 @@
+<%- groups ||= [] -%>
 [<%= namespace %>.buffer]
 type = "table"
+groups = <%= groups.to_json %>
 description = "Configures the sink specific buffer behavior."
 
 [<%= namespace %>.buffer.children.max_events]

--- a/.meta/_partials/_request_options.toml
+++ b/.meta/_partials/_request_options.toml
@@ -1,6 +1,8 @@
+<%- groups ||= [] -%>
 [<%= namespace %>.request]
 type = "table"
 common = <%= common %>
+groups = <%= groups.to_json %>
 description = "Configures the sink request behavior."
 
 [<%= namespace %>.request.children.in_flight_limit]

--- a/.meta/sinks/influxdb_metrics.toml
+++ b/.meta/sinks/influxdb_metrics.toml
@@ -2,7 +2,7 @@
 title = "InfluxDB Metrics"
 beta = true
 common = false
-delivery_guarantee = "best_effort"
+delivery_guarantee = "at_least_once"
 egress_method = "batching"
 function_category = "transmit"
 healthcheck = true
@@ -31,13 +31,17 @@ write_to_description = "[InfluxDB][urls.influxdb] using [v1][urls.influxdb_http_
 type = "string"
 common = true
 examples = ["https://us-west-2-1.aws.cloud2.influxdata.com", "http://localhost:8086/"]
+groups = ["v1", "v2"]
+prioritize = true
 required = true
 description = "InfluxDB endpoint to send metrics to."
 
 [sinks.influxdb_metrics.options.org]
 type = "string"
+category = "auth"
 common = true
 examples = ["Organization", "33f2cff0a28e5b63"]
+groups = ["v2"]
 required = true
 description = "Specifies the destination organization for writes into InfluxDB 2."
 
@@ -45,13 +49,16 @@ description = "Specifies the destination organization for writes into InfluxDB 2
 type = "string"
 common = true
 examples = ["vector-bucket", "4d2225e4d3d49f75"]
+groups = ["v2"]
 required = true
 description = "The destination bucket for writes into InfluxDB 2."
 
 [sinks.influxdb_metrics.options.token]
 type = "string"
+categpry = "auth"
 common = true
 examples = ["${INFLUXDB_TOKEN_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
+groups = ["v2"]
 required = true
 description = "[Authentication token][urls.influxdb_authentication_token] for InfluxDB 2."
 
@@ -59,34 +66,43 @@ description = "[Authentication token][urls.influxdb_authentication_token] for In
 type = "string"
 common = true
 examples = ["vector-database", "iot-store"]
+groups = ["v1"]
 required = true
 description = "Sets the target database for the write into InfluxDB 1."
 
 [sinks.influxdb_metrics.options.consistency]
 type = "string"
+category = "persistence"
 common = true
 examples = ["any", "one", "quorum", "all"]
+groups = ["v1"]
 required = false
 description = "Sets the write consistency for the point for InfluxDB 1."
 
 [sinks.influxdb_metrics.options.retention_policy_name]
 type = "string"
+category = "persistence"
 common = true
 examples = ["autogen", "one_day_only"]
+groups = ["v1"]
 required = false
 description = "Sets the target retention policy for the write into InfluxDB 1."
 
 [sinks.influxdb_metrics.options.username]
 type = "string"
+category = "auth"
 common = true
 examples = ["todd", "vector-source"]
+groups = ["v1"]
 required = false
 description = "Sets the username for authentication if you’ve enabled authentication for the write into InfluxDB 1."
 
 [sinks.influxdb_metrics.options.password]
 type = "string"
+category = "auth"
 common = true
 examples = ["${INFLUXDB_PASSWORD_ENV_VAR}", "influxdb4ever"]
+groups = ["v1"]
 required = false
 description = "Sets the password for authentication if you’ve enabled authentication for the write into InfluxDB 1."
 
@@ -94,5 +110,7 @@ description = "Sets the password for authentication if you’ve enabled authenti
 type = "string"
 common = true
 examples = ["service"]
+groups = ["v1", "v2"]
+prioritize = true
 required = true
 description = "A prefix that will be added to all metric names."

--- a/.meta/sinks/influxdb_metrics.toml
+++ b/.meta/sinks/influxdb_metrics.toml
@@ -10,14 +10,28 @@ input_types = ["metric"]
 service_providers = ["InfluxData"]
 write_to_description = "[InfluxDB][urls.influxdb] using [v1][urls.influxdb_http_api_v1] or [v2][urls.influxdb_http_api_v2] HTTP API"
 
-<%= render("_partials/_component_options.toml", type: "sink", name: "influxdb_metrics") %>
+<%= render(
+  "_partials/_component_options.toml",
+  groups: ["v1", "v2"],
+  name: "influxdb_metrics",
+  type: "sink"
+) %>
 
-<%= render("_partials/_batch_options.toml", namespace: "sinks.influxdb_metrics.options", common: false, max_events: 20, max_size: nil, timeout_secs: 1) %>
+<%= render(
+  "_partials/_batch_options.toml",
+  common: false,
+  groups: ["v1", "v2"],
+  max_events: 20,
+  max_size: nil,
+  namespace: "sinks.influxdb_metrics.options",
+  timeout_secs: 1
+) %>
 
 <%= render(
   "_partials/_request_options.toml",
   namespace: "sinks.influxdb_metrics.options",
   common: false,
+  groups: ["v1", "v2"],
   in_flight_limit: 5,
   rate_limit_duration_secs: 1,
   rate_limit_num: 5,
@@ -55,7 +69,7 @@ description = "The destination bucket for writes into InfluxDB 2."
 
 [sinks.influxdb_metrics.options.token]
 type = "string"
-categpry = "auth"
+category = "auth"
 common = true
 examples = ["${INFLUXDB_TOKEN_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 groups = ["v2"]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -4554,6 +4554,18 @@ end
   # * type: string
   namespace = "service"
 
+  # Enables/disables the sink healthcheck upon start.
+  #
+  # * optional
+  # * default: true
+  # * type: bool
+  healthcheck = true
+  healthcheck = false
+
+  #
+  # auth
+  #
+
   # Specifies the destination organization for writes into InfluxDB 2.
   #
   # * required
@@ -4568,6 +4580,28 @@ end
   token = "${INFLUXDB_TOKEN_ENV_VAR}"
   token = "ef8d5de700e7989468166c40fc8a0ccd"
 
+  # Sets the password for authentication if you’ve enabled authentication for the
+  # write into InfluxDB 1.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
+  password = "influxdb4ever"
+
+  # Sets the username for authentication if you’ve enabled authentication for the
+  # write into InfluxDB 1.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  username = "todd"
+  username = "vector-source"
+
+  #
+  # persistence
+  #
+
   # Sets the write consistency for the point for InfluxDB 1.
   #
   # * optional
@@ -4578,23 +4612,6 @@ end
   consistency = "quorum"
   consistency = "all"
 
-  # Enables/disables the sink healthcheck upon start.
-  #
-  # * optional
-  # * default: true
-  # * type: bool
-  healthcheck = true
-  healthcheck = false
-
-  # Sets the password for authentication if you’ve enabled authentication for the
-  # write into InfluxDB 1.
-  #
-  # * optional
-  # * no default
-  # * type: string
-  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
-  password = "influxdb4ever"
-
   # Sets the target retention policy for the write into InfluxDB 1.
   #
   # * optional
@@ -4602,15 +4619,6 @@ end
   # * type: string
   retention_policy_name = "autogen"
   retention_policy_name = "one_day_only"
-
-  # Sets the username for authentication if you’ve enabled authentication for the
-  # write into InfluxDB 1.
-  #
-  # * optional
-  # * no default
-  # * type: string
-  username = "todd"
-  username = "vector-source"
 
   #
   # Batch

--- a/scripts/generate/templates.rb
+++ b/scripts/generate/templates.rb
@@ -93,13 +93,9 @@ class Templates
     render("#{partials_path}/_components_table.md", binding).strip
   end
 
-  def config_example(options, array: false, common: false, path: nil, titles: true)
+  def config_example(options, array: false, path: nil, titles: true)
     if !options.is_a?(Array)
       raise ArgumentError.new("Options must be an Array")
-    end
-
-    if common
-      options = options.select(&:common?)
     end
 
     options = options.sort_by(&:config_file_sort_token)

--- a/scripts/generate/templates/_partials/_component_config_example.md.erb
+++ b/scripts/generate/templates/_partials/_component_config_example.md.erb
@@ -1,35 +1,26 @@
-<%- if component.advanced_relevant? -%>
+<%- keys = component.sorted_option_group_keys -%>
+<%- if keys.length > 1 -%>
 <Tabs
   block={true}
-  defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  defaultValue="<%= keys.first.parameterize %>"
+  values={<%= keys.collect { |k| {label: k, value: k.parameterize} }.to_json %>}>
 
-<TabItem value="common">
 <%- end -%>
+<%- keys.each do |key| -%>
+<%- if keys.length > 1 -%>
+<TabItem value="<%= key.parameterize %>">
 
+<%- end -%>
 <CodeHeader fileName="vector.toml" learnMoreUrl="<%= metadata.links.fetch("docs.configuration") %>"/ >
 
 ```toml
-<%= config_example(component.options_list, path: "#{component.type.pluralize}.my_#{component.type}_id", common: true) %>
+<%= config_example(component.option_example_groups.fetch(key), path: "#{component.type.pluralize}.my_#{component.type}_id") %>
 ```
-
-<%- if component.advanced_relevant? -%>
-</TabItem>
-<TabItem value="advanced">
-
-<CodeHeader fileName="vector.toml" learnMoreUrl="<%= metadata.links.fetch("docs.configuration") %>" />
-
-```toml
-<%= config_example(component.options_list, path: "#{component.type.pluralize}.my_#{component.type}_id") %>
-```
+<%- if keys.length > 1 -%>
 
 </TabItem>
 <%- end -%>
-
-<% if component.advanced_relevant? -%>
+<%- end -%>
+<%- if keys.length > 1 -%>
 </Tabs>
 <%- end -%>

--- a/scripts/generate/templates/_partials/_config_example.toml.erb
+++ b/scripts/generate/templates/_partials/_config_example.toml.erb
@@ -5,9 +5,9 @@
   <%- end -%>
   <%- options.each do |option| -%>
     <%- if option.array_of_objects? -%>
-<%= config_example(option.children_list, array: true, path: [path, option.name].compact.join("."), common: common).indent(2) %>
+<%= config_example(option.children_list, array: true, path: [path, option.name].compact.join(".")).indent(2) %>
     <%- elsif option.object? -%>
-<%= config_example(option.children_list, path: [path, option.name].compact.join("."), common: common).indent(2) %>
+<%= config_example(option.children_list, path: [path, option.name].compact.join(".")).indent(2) %>
     <%- elsif option.wildcard? -%>
       <%- option.examples.each do |e| -%>
   <%= e.to_toml %> # example

--- a/scripts/generate/templates/_partials/_fields.md.erb
+++ b/scripts/generate/templates/_partials/_fields.md.erb
@@ -8,6 +8,7 @@
   defaultValue={<%= field.default.to_json %>}
   enumValues={<%= field.enum.to_json %>}
   examples={<%= field.examples.to_json %>}
+  groups={<%= field.groups.to_json %>}
   name={<%= field.name.to_json %>}
   path={<%= path.to_json %>}
   relevantWhen={<%= field.relevant_when.to_json %>}

--- a/scripts/util/metadata/component.rb
+++ b/scripts/util/metadata/component.rb
@@ -105,7 +105,7 @@ class Component
     @option_example_groups ||=
       begin
         groups = {}
-        
+
         if option_groups.any?
           option_groups.each do |group|
             groups[group] = options_list.select do |option|

--- a/scripts/util/metadata/component.rb
+++ b/scripts/util/metadata/component.rb
@@ -97,6 +97,41 @@ class Component
     @options_list ||= options.to_h.values.sort
   end
 
+  def option_groups
+    @option_groups ||= options_list.collect(&:groups).flatten.uniq.sort
+  end
+
+  def option_example_groups
+    @option_example_groups ||=
+      begin
+        groups = {}
+        
+        if option_groups.any?
+          option_groups.each do |group|
+            groups[group] = options_list.select do |option|
+              option.group?(group) && option.common?
+            end
+          end
+
+          if advanced_relevant?
+            option_groups.each do |group|
+              groups["#{group} (advanced)"] = options_list.select do |option|
+                option.group?(group)
+              end
+            end
+          end
+        else
+          groups["Common"] = options_list.select(&:common?)
+
+          if advanced_relevant?
+            groups["Advanced"] = options_list
+          end
+        end
+
+        groups
+      end
+  end
+
   def partition_options
     options_list.select(&:partition_key?)
   end
@@ -107,6 +142,16 @@ class Component
 
   def sink?
     type == "sink"
+  end
+
+  def sorted_option_group_keys
+    option_example_groups.keys.sort_by do |key|
+      if key.downcase.include?("advanced")
+        1
+      else
+        -1
+      end
+    end
   end
 
   def source?

--- a/scripts/util/metadata/component.rb
+++ b/scripts/util/metadata/component.rb
@@ -147,11 +147,11 @@ class Component
   def sorted_option_group_keys
     option_example_groups.keys.sort_by do |key|
       if key.downcase.include?("advanced")
-        1
-      else
         -1
+      else
+        1
       end
-    end
+    end.reverse
   end
 
   def source?

--- a/scripts/util/metadata/field.rb
+++ b/scripts/util/metadata/field.rb
@@ -13,6 +13,7 @@ class Field
     :display,
     :enum,
     :examples,
+    :groups,
     :partition_key,
     :prioritize,
     :relevant_when,
@@ -29,6 +30,7 @@ class Field
     @display = hash["display"]
     @enum = hash["enum"]
     @examples = hash["examples"] || []
+    @groups = hash["groups"] || []
     @name = hash.fetch("name")
     @partition_key = hash["partition_key"] == true
     @prioritize = hash["prioritize"] == true
@@ -39,6 +41,8 @@ class Field
     @unit = hash["unit"]
 
     @category = hash["category"] || ((@children.to_h.values.empty? || inline?) ? "General" : @name.humanize)
+
+    if !@
 
     if @required == true && !@defualt.nil?
       raise ArgumentError.new("#{self.class.name}#required must be false if there is a default for field #{@name}")

--- a/scripts/util/metadata/field.rb
+++ b/scripts/util/metadata/field.rb
@@ -42,8 +42,6 @@ class Field
 
     @category = hash["category"] || ((@children.to_h.values.empty? || inline?) ? "General" : @name.humanize)
 
-    if !@
-
     if @required == true && !@defualt.nil?
       raise ArgumentError.new("#{self.class.name}#required must be false if there is a default for field #{@name}")
     end
@@ -171,6 +169,12 @@ class Field
     sections.select do |section|
       section.referenced_options.include?(name) ||
         section.referenced_options.any? { |o| o.end_with?(name) }
+    end
+  end
+
+  def group?(group_name)
+    groups.any? do |group|
+      group.downcase == group_name.downcase
     end
   end
 

--- a/website/docs/about/data-model/log.md
+++ b/website/docs/about/data-model/log.md
@@ -95,6 +95,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -117,6 +118,7 @@ Represents the originating host of the log. This is automatically set within sel
   defaultValue={null}
   enumValues={null}
   examples={["<13>Feb 13 20:07:26 74794bfb6795 root[8539]: i am foobar"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -140,6 +142,7 @@ Represents the log message. Change this field name via the [global `message_key`
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}
@@ -163,6 +166,7 @@ A normalized [Rust DateTime struct][urls.rust_date_time] in UTC. Change this fie
   defaultValue={null}
   enumValues={null}
   examples={[{"my-key":"my-value"},{"parent":{"child":"child-value"}}]}
+  groups={[]}
   name={"`[custom-key]`"}
   path={null}
   relevantWhen={null}

--- a/website/docs/about/data-model/metric.md
+++ b/website/docs/about/data-model/metric.md
@@ -175,6 +175,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={{"absolute":"The value is an absolute, stand-alone value. It can be used individually.","incremental":"The value is incremental and is used to form a holistic value by merging with other incremental values. Individually it does not tell the whole story."}}
   examples={["absolute","incremental"]}
+  groups={[]}
   name={"kind"}
   path={null}
   relevantWhen={null}
@@ -198,6 +199,7 @@ The metric value kind. This determines how the value is merged downstream if met
   defaultValue={null}
   enumValues={null}
   examples={["login.count","response_time"]}
+  groups={[]}
   name={"name"}
   path={null}
   relevantWhen={null}
@@ -220,6 +222,7 @@ The metric name.
   defaultValue={null}
   enumValues={null}
   examples={[{"host":"my.host.com"}]}
+  groups={[]}
   name={"tags"}
   path={null}
   relevantWhen={null}
@@ -242,6 +245,7 @@ Tags that add additional metadata or context to the metric. These are simple key
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}
@@ -264,6 +268,7 @@ The metric timestamp, representing when the metric was created/ingested within V
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"type"}
   path={null}
   relevantWhen={null}
@@ -285,6 +290,7 @@ A metric must be one of 6 types.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"aggregated_histogram"}
   path={"type"}
   relevantWhen={null}
@@ -306,6 +312,7 @@ Also called a "timer". A [`aggregated_histogram`](#aggregated_histogram) samples
   defaultValue={null}
   enumValues={null}
   examples={[[1,2,5,10,25]]}
+  groups={[]}
   name={"buckets"}
   path={"type.aggregated_histogram"}
   relevantWhen={null}
@@ -328,6 +335,7 @@ The buckets contained within this histogram.
   defaultValue={null}
   enumValues={null}
   examples={[54]}
+  groups={[]}
   name={"count"}
   path={"type.aggregated_histogram"}
   relevantWhen={null}
@@ -350,6 +358,7 @@ The total number of values contained within the histogram.
   defaultValue={null}
   enumValues={null}
   examples={[[1,5,25,2,5]]}
+  groups={[]}
   name={"counts"}
   path={"type.aggregated_histogram"}
   relevantWhen={null}
@@ -372,6 +381,7 @@ The number of values contained within each bucket.
   defaultValue={null}
   enumValues={null}
   examples={[524.0]}
+  groups={[]}
   name={"sum"}
   path={"type.aggregated_histogram"}
   relevantWhen={null}
@@ -399,6 +409,7 @@ The sum of all values contained within the histogram.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"aggregated_summary"}
   path={"type"}
   relevantWhen={null}
@@ -421,6 +432,7 @@ Similar to a histogram, a summary samples observations (usually things like requ
   defaultValue={null}
   enumValues={null}
   examples={[54]}
+  groups={[]}
   name={"count"}
   path={"type.aggregated_summary"}
   relevantWhen={null}
@@ -443,6 +455,7 @@ The total number of values contained within the summary.
   defaultValue={null}
   enumValues={null}
   examples={[[0.1,0.5,0.75,1.0]]}
+  groups={[]}
   name={"quantiles"}
   path={"type.aggregated_summary"}
   relevantWhen={null}
@@ -465,6 +478,7 @@ The quantiles contained within the summary, where where 0 ≤ quantile ≤ 1.
   defaultValue={null}
   enumValues={null}
   examples={[524.0]}
+  groups={[]}
   name={"sum"}
   path={"type.aggregated_summary"}
   relevantWhen={null}
@@ -487,6 +501,7 @@ The sum of all values contained within the summary.
   defaultValue={null}
   enumValues={null}
   examples={[[2.1,4.68,23.02,120.1]]}
+  groups={[]}
   name={"values"}
   path={"type.aggregated_summary"}
   relevantWhen={null}
@@ -514,6 +529,7 @@ The values contained within the summary that align with the [`quantiles`](#quant
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"counter"}
   path={"type"}
   relevantWhen={null}
@@ -535,6 +551,7 @@ A single value that can _only_ be incremented or reset to zero value, it cannot 
   defaultValue={null}
   enumValues={null}
   examples={[2.6,5.0]}
+  groups={[]}
   name={"value"}
   path={"type.counter"}
   relevantWhen={null}
@@ -562,6 +579,7 @@ The value to increment the counter by. Can only be positive.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"distribution"}
   path={"type"}
   relevantWhen={null}
@@ -583,6 +601,7 @@ A distribution represents a distribution of sampled values.
   defaultValue={null}
   enumValues={null}
   examples={[[12,43,25]]}
+  groups={[]}
   name={"sample_rates"}
   path={"type.distribution"}
   relevantWhen={null}
@@ -605,6 +624,7 @@ The rate at which each individual value was sampled.
   defaultValue={null}
   enumValues={null}
   examples={[[12.0,43.3,25.2]]}
+  groups={[]}
   name={"values"}
   path={"type.distribution"}
   relevantWhen={null}
@@ -632,6 +652,7 @@ The list of values contained within the distribution.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"gauge"}
   path={"type"}
   relevantWhen={null}
@@ -653,6 +674,7 @@ A gauge represents a point-in-time value that can increase and decrease. Vector'
   defaultValue={null}
   enumValues={null}
   examples={[554222.0]}
+  groups={[]}
   name={"value"}
   path={"type.gauge"}
   relevantWhen={null}
@@ -680,6 +702,7 @@ A specific point-in-time value for the gauge.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"set"}
   path={"type"}
   relevantWhen={null}
@@ -701,6 +724,7 @@ A set represents a count of unique values, AKA the cardinality.
   defaultValue={null}
   enumValues={null}
   examples={[["unique item 1","unique item 2"]]}
+  groups={[]}
   name={"values"}
   path={"type.set"}
   relevantWhen={null}

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -35,6 +35,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -57,6 +58,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}
@@ -79,6 +81,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={"unix:///var/run/docker.sock"}
   enumValues={null}
   examples={["unix://path/to/socket","tcp://host:2375/path"]}
+  groups={[]}
   name={"DOCKER_HOST"}
   path={null}
   relevantWhen={null}
@@ -101,6 +104,7 @@ The docker host to connect to.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"DOCKER_VERIFY_TLS"}
   path={null}
   relevantWhen={null}
@@ -123,6 +127,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/credentials.json"]}
+  groups={[]}
   name={"GOOGLE_APPLICATION_CREDENTIALS"}
   path={null}
   relevantWhen={null}
@@ -145,6 +150,7 @@ The [GCP api key][urls.gcp_authentication_api_key] used for authentication.
   defaultValue={null}
   enumValues={null}
   examples={["debug"]}
+  groups={[]}
   name={"LOG"}
   path={null}
   relevantWhen={null}
@@ -167,6 +173,7 @@ Sets Vector's log level. See the [log section in the monitoring guide][docs.moni
   defaultValue={null}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"RUST_BACKTRACE"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/global-options.md
+++ b/website/docs/reference/global-options.md
@@ -47,6 +47,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["/var/lib/vector"]}
+  groups={[]}
   name={"data_dir"}
   path={null}
   relevantWhen={null}
@@ -69,6 +70,7 @@ The directory used for persisting Vector state, such as on-disk buffers, file ch
   defaultValue={null}
   enumValues={null}
   examples={[["0.0.0.0:53"]]}
+  groups={[]}
   name={"dns_servers"}
   path={null}
   relevantWhen={null}
@@ -91,6 +93,7 @@ The list of DNS servers Vector will use to resolve DNS requests. When set Vector
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"log_schema"}
   path={null}
   relevantWhen={null}
@@ -113,6 +116,7 @@ The default log schema that all Vector components operate on. See the [log data 
   defaultValue={"host"}
   enumValues={null}
   examples={["host","@host","instance","machine"]}
+  groups={[]}
   name={"host_key"}
   path={"log_schema"}
   relevantWhen={null}
@@ -135,6 +139,7 @@ The key used to hold the log host. See the [log data model page][docs.data-model
   defaultValue={"message"}
   enumValues={null}
   examples={["message","@message","msg"]}
+  groups={[]}
   name={"message_key"}
   path={"log_schema"}
   relevantWhen={null}
@@ -157,6 +162,7 @@ The key used to hold the log message. See the [log data model page][docs.data-mo
   defaultValue={"timestamp"}
   enumValues={null}
   examples={["timestamp","@timestamp","datetime"]}
+  groups={[]}
   name={"timestamp_key"}
   path={"log_schema"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -63,7 +59,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -111,7 +107,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -123,6 +123,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["arn:aws:iam::123456789098:role/my_role"]}
+  groups={[]}
   name={"assume_role"}
   path={null}
   relevantWhen={null}
@@ -145,6 +146,7 @@ The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authe
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -166,6 +168,7 @@ Configures the sink batching behavior.
   defaultValue={1049000}
   enumValues={null}
   examples={[1049000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -188,6 +191,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -215,6 +219,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -236,6 +241,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -258,6 +264,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -280,6 +287,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -302,6 +310,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -329,6 +338,7 @@ The behavior when the buffer becomes full.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"create_missing_group"}
   path={null}
   relevantWhen={null}
@@ -351,6 +361,7 @@ Dynamically create a [log group][urls.aws_cw_logs_group_name] if it does not alr
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"create_missing_stream"}
   path={null}
   relevantWhen={null}
@@ -373,6 +384,7 @@ Dynamically create a [log stream][urls.aws_cw_logs_stream_name] if it does not a
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -395,6 +407,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.0:5000/path/to/service"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={{"region":""}}
@@ -417,6 +430,7 @@ Custom endpoint for use with AWS-compatible services. Providing a value for this
   defaultValue={null}
   enumValues={null}
   examples={["{{ file }}","ec2/{{ instance_id }}","group-name"]}
+  groups={[]}
   name={"group_name"}
   path={null}
   relevantWhen={null}
@@ -439,6 +453,7 @@ The [group name][urls.aws_cw_logs_group_name] of the target CloudWatch Logs stre
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -461,6 +476,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={{"host":""}}
@@ -483,6 +499,7 @@ The [AWS region][urls.aws_regions] of the target service. If [`endpoint`](#endpo
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -504,6 +521,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -526,6 +544,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -548,6 +567,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -570,6 +590,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -592,6 +613,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -614,6 +636,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -636,6 +659,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -663,6 +687,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["{{ instance_id }}","%Y-%m-%d","stream-name"]}
+  groups={[]}
   name={"stream_name"}
   path={null}
   relevantWhen={null}
@@ -692,6 +717,7 @@ The [stream name][urls.aws_cw_logs_stream_name] of the target CloudWatch Logs st
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -714,6 +740,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -57,7 +53,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -79,7 +75,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -91,6 +91,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["arn:aws:iam::123456789098:role/my_role"]}
+  groups={[]}
   name={"assume_role"}
   path={null}
   relevantWhen={null}
@@ -113,6 +114,7 @@ The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authe
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -134,6 +136,7 @@ Configures the sink batching behavior.
   defaultValue={20}
   enumValues={null}
   examples={[20]}
+  groups={[]}
   name={"max_events"}
   path={"batch"}
   relevantWhen={null}
@@ -156,6 +159,7 @@ The maximum size of a batch, in events, before it is flushed.
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -183,6 +187,7 @@ The maximum age of a batch before it is flushed.
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.0:5000/path/to/service"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={{"region":""}}
@@ -205,6 +210,7 @@ Custom endpoint for use with AWS-compatible services. Providing a value for this
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -227,6 +233,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["service"]}
+  groups={[]}
   name={"namespace"}
   path={null}
   relevantWhen={null}
@@ -249,6 +256,7 @@ A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/clo
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={{"host":""}}
@@ -278,6 +286,7 @@ The [AWS region][urls.aws_regions] of the target service. If [`endpoint`](#endpo
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -300,6 +309,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -60,7 +56,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -105,7 +101,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -117,6 +117,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["arn:aws:iam::123456789098:role/my_role"]}
+  groups={[]}
   name={"assume_role"}
   path={null}
   relevantWhen={null}
@@ -139,6 +140,7 @@ The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authe
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -160,6 +162,7 @@ Configures the sink batching behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"batch"}
   relevantWhen={null}
@@ -182,6 +185,7 @@ The maximum size of a batch, in events, before it is flushed. See [Buffers & Bat
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -209,6 +213,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -230,6 +235,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -252,6 +258,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer. See [Buff
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -274,6 +281,7 @@ The maximum size of the buffer on the disk.
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -296,6 +304,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -323,6 +332,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -345,6 +355,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.0:5000/path/to/service"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={{"region":""}}
@@ -367,6 +378,7 @@ Custom endpoint for use with AWS-compatible services. Providing a value for this
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -389,6 +401,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={{"host":""}}
@@ -411,6 +424,7 @@ The [AWS region][urls.aws_regions] of the target service. If [`endpoint`](#endpo
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -432,6 +446,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -454,6 +469,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -476,6 +492,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -498,6 +515,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -520,6 +538,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -542,6 +561,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -564,6 +584,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -591,6 +612,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["my-stream"]}
+  groups={[]}
   name={"stream_name"}
   path={null}
   relevantWhen={null}
@@ -620,6 +642,7 @@ The [stream name][urls.aws_cw_logs_stream_name] of the target Kinesis Firehose d
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -642,6 +665,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -117,6 +117,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["arn:aws:iam::123456789098:role/my_role"]}
+  groups={[]}
   name={"assume_role"}
   path={null}
   relevantWhen={null}
@@ -139,6 +140,7 @@ The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authe
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -160,6 +162,7 @@ Configures the sink batching behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"batch"}
   relevantWhen={null}
@@ -182,6 +185,7 @@ The maximum size of a batch, in events, before it is flushed. See [Buffers & Bat
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -209,6 +213,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -230,6 +235,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -252,6 +258,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer. See [Buff
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -274,6 +281,7 @@ The maximum size of the buffer on the disk.
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -296,6 +304,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -323,6 +332,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -345,6 +355,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.0:5000/path/to/service"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={{"region":""}}
@@ -367,6 +378,7 @@ Custom endpoint for use with AWS-compatible services. Providing a value for this
   defaultValue={null}
   enumValues={null}
   examples={["user_id"]}
+  groups={[]}
   name={"partition_key_field"}
   path={null}
   relevantWhen={null}
@@ -389,6 +401,7 @@ The log field used as the Kinesis record's partition key value. See [Partitionin
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={{"host":""}}
@@ -411,6 +424,7 @@ The [AWS region][urls.aws_regions] of the target service. If [`endpoint`](#endpo
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -432,6 +446,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -454,6 +469,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -476,6 +492,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -498,6 +515,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -520,6 +538,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -542,6 +561,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -564,6 +584,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -591,6 +612,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["my-stream"]}
+  groups={[]}
   name={"stream_name"}
   path={null}
   relevantWhen={null}
@@ -620,6 +642,7 @@ The [stream name][urls.aws_cw_logs_stream_name] of the target Kinesis Logs strea
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -642,6 +665,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -60,7 +56,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -105,7 +101,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -72,7 +68,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -136,7 +132,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -148,6 +148,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={{"private":"Owner gets FULL_CONTROL. No one else has access rights (default).","public-read":"Owner gets FULL_CONTROL. The AllUsers group gets READ access.","public-read-write":"Owner gets FULL_CONTROL. The AllUsers group gets READ and WRITE access. Granting this on a bucket is generally not recommended.","aws-exec-read":"Owner gets FULL_CONTROL. Amazon EC2 gets READ access to GET an Amazon Machine Image (AMI) bundle from Amazon S3.","authenticated-read":"Owner gets FULL_CONTROL. The AuthenticatedUsers group gets READ access.","log-delivery-write":"The LogDelivery group gets WRITE and READ_ACP permissions on the bucket. For more information about logs, see [Amazon S3 Server Access Logging](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html)."}}
   examples={["private","public-read","public-read-write","aws-exec-read","authenticated-read","log-delivery-write"]}
+  groups={[]}
   name={"acl"}
   path={null}
   relevantWhen={null}
@@ -170,6 +171,7 @@ Canned ACL to apply to the created objects. For more information, see [Canned AC
   defaultValue={null}
   enumValues={null}
   examples={["arn:aws:iam::123456789098:role/my_role"]}
+  groups={[]}
   name={"assume_role"}
   path={null}
   relevantWhen={null}
@@ -192,6 +194,7 @@ The ARN of an [IAM role][urls.aws_iam_role] to assume at startup. See [AWS Authe
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -213,6 +216,7 @@ Configures the sink batching behavior.
   defaultValue={10490000}
   enumValues={null}
   examples={[10490000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -235,6 +239,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={300}
   enumValues={null}
   examples={[300]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -262,6 +267,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={["my-bucket"]}
+  groups={[]}
   name={"bucket"}
   path={null}
   relevantWhen={null}
@@ -284,6 +290,7 @@ The S3 bucket name. Do not include a leading `s3://` or a trailing `/`.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -305,6 +312,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -327,6 +335,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -349,6 +358,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -371,6 +381,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -398,6 +409,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"gzip":"GZIP compression","none":"No compression"}}
   examples={["gzip","none"]}
+  groups={[]}
   name={"compression"}
   path={null}
   relevantWhen={null}
@@ -420,6 +432,7 @@ The compression mechanism to use.
   defaultValue={null}
   enumValues={{"ndjson":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["ndjson","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -442,6 +455,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.0:5000/path/to/service"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={{"region":""}}
@@ -464,6 +478,7 @@ Custom endpoint for use with AWS-compatible services. Providing a value for this
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"filename_append_uuid"}
   path={null}
   relevantWhen={null}
@@ -486,6 +501,7 @@ Whether or not to append a UUID v4 token to the end of the file. This ensures th
   defaultValue={"log"}
   enumValues={null}
   examples={["log"]}
+  groups={[]}
   name={"filename_extension"}
   path={null}
   relevantWhen={null}
@@ -508,6 +524,7 @@ The extension to use in the object name.
   defaultValue={"%s"}
   enumValues={null}
   examples={["%s"]}
+  groups={[]}
   name={"filename_time_format"}
   path={null}
   relevantWhen={null}
@@ -530,6 +547,7 @@ The format of the resulting object file name. [`strftime` specifiers][urls.strpt
   defaultValue={null}
   enumValues={null}
   examples={["79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be","person@email.com","http://acs.amazonaws.com/groups/global/AllUsers"]}
+  groups={[]}
   name={"grant_full_control"}
   path={null}
   relevantWhen={null}
@@ -552,6 +570,7 @@ Gives the named [grantee][urls.aws_s3_grantee] READ, READ_ACP, and WRITE_ACP per
   defaultValue={null}
   enumValues={null}
   examples={["79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be","person@email.com","http://acs.amazonaws.com/groups/global/AllUsers"]}
+  groups={[]}
   name={"grant_read"}
   path={null}
   relevantWhen={null}
@@ -574,6 +593,7 @@ Allows the named [grantee][urls.aws_s3_grantee] to read the created objects and 
   defaultValue={null}
   enumValues={null}
   examples={["79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be","person@email.com","http://acs.amazonaws.com/groups/global/AllUsers"]}
+  groups={[]}
   name={"grant_read_acp"}
   path={null}
   relevantWhen={null}
@@ -596,6 +616,7 @@ Allows the named [grantee][urls.aws_s3_grantee] to read the created objects' ACL
   defaultValue={null}
   enumValues={null}
   examples={["79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be","person@email.com","http://acs.amazonaws.com/groups/global/AllUsers"]}
+  groups={[]}
   name={"grant_write_acp"}
   path={null}
   relevantWhen={null}
@@ -618,6 +639,7 @@ Allows the named [grantee][urls.aws_s3_grantee] to write the created objects' AC
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -640,6 +662,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={"date=%F/"}
   enumValues={null}
   examples={["date=%F/","date=%F/hour=%H/","year=%Y/month=%m/day=%d/","application_id={{ application_id }}/date=%F/"]}
+  groups={[]}
   name={"key_prefix"}
   path={null}
   relevantWhen={null}
@@ -662,6 +685,7 @@ A prefix to apply to all object key names. This should be used to partition your
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={{"host":""}}
@@ -684,6 +708,7 @@ The [AWS region][urls.aws_regions] of the target service. If [`endpoint`](#endpo
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -705,6 +730,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -727,6 +753,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -749,6 +776,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -771,6 +799,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -793,6 +822,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -815,6 +845,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -837,6 +868,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -864,6 +896,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={{"AES256":"256-bit Advanced Encryption Standard","aws:kms":"AWS managed key encryption"}}
   examples={["AES256","aws:kms"]}
+  groups={[]}
   name={"server_side_encryption"}
   path={null}
   relevantWhen={null}
@@ -886,6 +919,7 @@ The server-side encryption algorithm used when storing these objects. See [Serve
   defaultValue={null}
   enumValues={null}
   examples={["abcd1234"]}
+  groups={[]}
   name={"ssekms_key_id"}
   path={null}
   relevantWhen={null}
@@ -908,6 +942,7 @@ If [`server_side_encryption`](#server_side_encryption) has the value `"aws.kms"`
   defaultValue={null}
   enumValues={{"STANDARD":"The default storage class. If you don't specify the storage class when you upload an object, Amazon S3 assigns the STANDARD storage class.","REDUCED_REDUNDANCY":"Designed for noncritical, reproducible data that can be stored with less redundancy than the STANDARD storage class. AWS recommends that you not use this storage class. The STANDARD storage class is more cost effective. ","INTELLIGENT_TIERING":"Stores objects in two access tiers: one tier that is optimized for frequent access and another lower-cost tier that is optimized for infrequently accessed data.","STANDARD_IA":"Amazon S3 stores the object data redundantly across multiple geographically separated Availability Zones (similar to the STANDARD storage class).","ONEZONE_IA":"Amazon S3 stores the object data in only one Availability Zone.","GLACIER":"Use for archives where portions of the data might need to be retrieved in minutes.","DEEP_ARCHIVE":"Use for archiving data that rarely needs to be accessed."}}
   examples={["STANDARD","REDUCED_REDUNDANCY","INTELLIGENT_TIERING","STANDARD_IA","ONEZONE_IA","GLACIER","DEEP_ARCHIVE"]}
+  groups={[]}
   name={"storage_class"}
   path={null}
   relevantWhen={null}
@@ -930,6 +965,7 @@ The storage class for the created objects. See [the S3 Storage Classes](https://
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tags"}
   path={null}
   relevantWhen={null}
@@ -951,6 +987,7 @@ The tag-set for the object.
   defaultValue={null}
   enumValues={null}
   examples={[{"Tag1":"Value1"}]}
+  groups={[]}
   name={"`[tag-name]`"}
   path={"tags"}
   relevantWhen={null}
@@ -985,6 +1022,7 @@ A custom tag to be added to the created objects.
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -1007,6 +1045,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/blackhole.md
+++ b/website/docs/reference/sinks/blackhole.md
@@ -52,6 +52,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -74,6 +75,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={[1000]}
+  groups={[]}
   name={"print_amount"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -132,6 +132,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"auth"}
   path={null}
   relevantWhen={null}
@@ -153,6 +154,7 @@ Options for the authentication strategy.
   defaultValue={null}
   enumValues={{"basic":"The [basic authentication strategy][urls.basic_auth]."}}
   examples={["basic"]}
+  groups={[]}
   name={"strategy"}
   path={"auth"}
   relevantWhen={null}
@@ -175,6 +177,7 @@ The authentication strategy to use.
   defaultValue={null}
   enumValues={null}
   examples={["${PASSWORD_ENV_VAR}","password"]}
+  groups={[]}
   name={"password"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -197,6 +200,7 @@ The basic authentication password.
   defaultValue={null}
   enumValues={null}
   examples={["${USERNAME_ENV_VAR}","username"]}
+  groups={[]}
   name={"user"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -224,6 +228,7 @@ The basic authentication user name.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -245,6 +250,7 @@ Configures the sink batching behavior.
   defaultValue={1049000}
   enumValues={null}
   examples={[1049000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -267,6 +273,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -294,6 +301,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -315,6 +323,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -337,6 +346,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -359,6 +369,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -381,6 +392,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -408,6 +420,7 @@ The behavior when the buffer becomes full.
   defaultValue={"none"}
   enumValues={{"none":"The payload will not be compressed.","gzip":"The payload will be compressed in [Gzip][urls.gzip] format before being sent."}}
   examples={["none","gzip"]}
+  groups={[]}
   name={"compression"}
   path={null}
   relevantWhen={null}
@@ -430,6 +443,7 @@ The compression strategy used to compress the encoded event data before outputti
   defaultValue={null}
   enumValues={null}
   examples={["mydatabase"]}
+  groups={[]}
   name={"database"}
   path={null}
   relevantWhen={null}
@@ -452,6 +466,7 @@ The database that contains the stable that data will be inserted into.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -474,6 +489,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://localhost:8123"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -496,6 +512,7 @@ The host url of the [Clickhouse][urls.clickhouse] server.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -517,6 +534,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -539,6 +557,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -561,6 +580,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -583,6 +603,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -605,6 +626,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -627,6 +649,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -649,6 +672,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -676,6 +700,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["mytable"]}
+  groups={[]}
   name={"table"}
   path={null}
   relevantWhen={null}
@@ -698,6 +723,7 @@ The table that data will be inserted into.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -719,6 +745,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -741,6 +768,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -763,6 +791,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -785,6 +814,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -807,6 +837,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -829,6 +860,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -61,7 +57,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -120,7 +116,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/console.md
+++ b/website/docs/reference/sinks/console.md
@@ -55,6 +55,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON.","text":"Each event is encoded into text via the `message` key."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -77,6 +78,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -99,6 +101,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={"stdout"}
   enumValues={{"stdout":"Output will be written to [STDOUT][urls.stdout]","stderr":"Output will be written to [STDERR][urls.stderr]"}}
   examples={["stdout","stderr"]}
+  groups={[]}
   name={"target"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -101,6 +101,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["${DATADOG_API_KEY_ENV_VAR}","ef8d5de700e7989468166c40fc8a0ccd"]}
+  groups={[]}
   name={"api_key"}
   path={null}
   relevantWhen={null}
@@ -123,6 +124,7 @@ Datadog [API key](https://docs.datadoghq.com/api/?lang=bash#authentication)
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -144,6 +146,7 @@ Configures the sink batching behavior.
   defaultValue={20}
   enumValues={null}
   examples={[20]}
+  groups={[]}
   name={"max_events"}
   path={"batch"}
   relevantWhen={null}
@@ -166,6 +169,7 @@ The maximum size of a batch, in events, before it is flushed.
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -193,6 +197,7 @@ The maximum age of a batch before it is flushed.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -215,6 +220,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={"https://api.datadoghq.com"}
   enumValues={null}
   examples={["https://api.datadoghq.com","https://api.datadoghq.eu"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -237,6 +243,7 @@ Datadog endpoint to send metrics to.
   defaultValue={null}
   enumValues={null}
   examples={["service"]}
+  groups={[]}
   name={"namespace"}
   path={null}
   relevantWhen={null}
@@ -259,6 +266,7 @@ A prefix that will be added to all metric names.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -280,6 +288,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -302,6 +311,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -324,6 +334,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -346,6 +357,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -368,6 +380,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -390,6 +403,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -412,6 +426,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -58,7 +54,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -89,7 +85,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -58,7 +54,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -123,7 +119,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -135,6 +135,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"auth"}
   path={null}
   relevantWhen={null}
@@ -156,6 +157,7 @@ Options for the authentication strategy.
   defaultValue={null}
   enumValues={{"aws":"Authentication strategy used for [AWS' hosted Elasticsearch service][urls.aws_elasticsearch].","basic":"The [basic authentication strategy][urls.basic_auth]."}}
   examples={["aws","basic"]}
+  groups={[]}
   name={"strategy"}
   path={"auth"}
   relevantWhen={null}
@@ -178,6 +180,7 @@ The authentication strategy to use.
   defaultValue={null}
   enumValues={null}
   examples={["${PASSWORD_ENV_VAR}","password"]}
+  groups={[]}
   name={"password"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -200,6 +203,7 @@ The basic authentication password.
   defaultValue={null}
   enumValues={null}
   examples={["${USERNAME_ENV_VAR}","username"]}
+  groups={[]}
   name={"user"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -227,6 +231,7 @@ The basic authentication user name.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -248,6 +253,7 @@ Configures the sink batching behavior.
   defaultValue={10490000}
   enumValues={null}
   examples={[10490000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -270,6 +276,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -297,6 +304,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -318,6 +326,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -340,6 +349,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -362,6 +372,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -384,6 +395,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -411,6 +423,7 @@ The behavior when the buffer becomes full.
   defaultValue={"_doc"}
   enumValues={null}
   examples={["_doc"]}
+  groups={[]}
   name={"doc_type"}
   path={null}
   relevantWhen={null}
@@ -433,6 +446,7 @@ The [`doc_type`](#doc_type) for your index data. This is only relevant for Elast
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"headers"}
   path={null}
   relevantWhen={null}
@@ -454,6 +468,7 @@ Options for custom headers.
   defaultValue={null}
   enumValues={null}
   examples={[{"Authorization":"${TOKEN_ENV_VAR}"},{"X-Powered-By":"Vector"}]}
+  groups={[]}
   name={"`[header-name]`"}
   path={"headers"}
   relevantWhen={null}
@@ -481,6 +496,7 @@ A custom header to be added to each outgoing Elasticsearch request.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -503,6 +519,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://10.24.32.122:9000"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -525,6 +542,7 @@ The host of your Elasticsearch cluster. This should be the full URL as shown in 
   defaultValue={"vector-%F"}
   enumValues={null}
   examples={["application-{{ application_id }}-%Y-%m-%d","vector-%Y-%m-%d"]}
+  groups={[]}
   name={"index"}
   path={null}
   relevantWhen={null}
@@ -547,6 +565,7 @@ Index name to write events to. See [Template Syntax](#template-syntax) for more 
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"query"}
   path={null}
   relevantWhen={null}
@@ -568,6 +587,7 @@ Custom parameters to Elasticsearch query string.
   defaultValue={null}
   enumValues={null}
   examples={[{"X-Powered-By":"Vector"}]}
+  groups={[]}
   name={"`[parameter-name]`"}
   path={"query"}
   relevantWhen={null}
@@ -595,6 +615,7 @@ A custom parameter to be added to each Elasticsearch request.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -616,6 +637,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -638,6 +660,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -660,6 +683,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -682,6 +706,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -704,6 +729,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -726,6 +752,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -748,6 +775,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -775,6 +803,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -796,6 +825,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -818,6 +848,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -840,6 +871,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -862,6 +894,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -884,6 +917,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -906,6 +940,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}
@@ -940,6 +975,7 @@ If `true` (the default), Vector will validate the configured remote host name ag
   defaultValue={null}
   enumValues={null}
   examples={["AKIAIOSFODNN7EXAMPLE"]}
+  groups={[]}
   name={"AWS_ACCESS_KEY_ID"}
   path={null}
   relevantWhen={null}
@@ -962,6 +998,7 @@ Used for AWS authentication when communicating with AWS services. See relevant [
   defaultValue={null}
   enumValues={null}
   examples={["wJalrXUtnFEMI/K7MDENG/FD2F4GJ"]}
+  groups={[]}
   name={"AWS_SECRET_ACCESS_KEY"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/file.md
+++ b/website/docs/reference/sinks/file.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -59,7 +55,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -77,7 +73,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/file.md
+++ b/website/docs/reference/sinks/file.md
@@ -89,6 +89,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={{"ndjson":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["ndjson","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -111,6 +112,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -133,6 +135,7 @@ Enables/disables the sink healthcheck upon start.
   defaultValue={"30"}
   enumValues={null}
   examples={["30"]}
+  groups={[]}
   name={"idle_timeout_secs"}
   path={null}
   relevantWhen={null}
@@ -156,6 +159,7 @@ The amount of time a file can be idle  and stay open. After not receiving any ev
   defaultValue={null}
   enumValues={null}
   examples={["vector-%Y-%m-%d.log","application-{{ application_id }}-%Y-%m-%d.log"]}
+  groups={[]}
   name={"path"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -120,6 +120,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["${GCP_API_KEY_ENV_VAR}","ef8d5de700e7989468166c40fc8a0ccd"]}
+  groups={[]}
   name={"api_key"}
   path={null}
   relevantWhen={null}
@@ -142,6 +143,7 @@ A Google Cloud API key used to authenticate access the pubsub project and topic.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -163,6 +165,7 @@ Configures the sink batching behavior.
   defaultValue={10485760}
   enumValues={null}
   examples={[10485760]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -185,6 +188,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -212,6 +216,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -233,6 +238,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -255,6 +261,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -277,6 +284,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -299,6 +307,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -326,6 +335,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/credentials.json"]}
+  groups={[]}
   name={"credentials_path"}
   path={null}
   relevantWhen={null}
@@ -348,6 +358,7 @@ The filename for a Google Cloud service account credentials JSON file used to au
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -370,6 +381,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["vector-123456"]}
+  groups={[]}
   name={"project"}
   path={null}
   relevantWhen={null}
@@ -392,6 +404,7 @@ The project name to which to publish logs.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -413,6 +426,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -435,6 +449,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -457,6 +472,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={100}
   enumValues={null}
   examples={[100]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -479,6 +495,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -501,6 +518,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -523,6 +541,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -545,6 +564,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -572,6 +592,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -593,6 +614,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -615,6 +637,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -637,6 +660,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -659,6 +683,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -681,6 +706,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -703,6 +729,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}
@@ -730,6 +757,7 @@ If `true` (the default), Vector will validate the configured remote host name ag
   defaultValue={null}
   enumValues={null}
   examples={["this-is-a-topic"]}
+  groups={[]}
   name={"topic"}
   path={null}
   relevantWhen={null}
@@ -759,6 +787,7 @@ The topic within the project to which to publish logs.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/credentials.json"]}
+  groups={[]}
   name={"GOOGLE_APPLICATION_CREDENTIALS"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -57,7 +53,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -108,7 +104,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/gcp_stackdriver_logging.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logging.md
@@ -132,6 +132,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -153,6 +154,7 @@ Configures the sink batching behavior.
   defaultValue={5242880}
   enumValues={null}
   examples={[5242880]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -175,6 +177,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -202,6 +205,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={["012345-6789AB-CDEF01"]}
+  groups={[]}
   name={"billing_account_id"}
   path={null}
   relevantWhen={null}
@@ -226,6 +230,7 @@ Exactly one of [`billing_account_id`](#billing_account_id), [`folder_id`](#folde
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -247,6 +252,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -269,6 +275,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -291,6 +298,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -313,6 +321,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -340,6 +349,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/credentials.json"]}
+  groups={[]}
   name={"credentials_path"}
   path={null}
   relevantWhen={null}
@@ -362,6 +372,7 @@ The filename for a Google Cloud service account credentials JSON file used to au
   defaultValue={null}
   enumValues={null}
   examples={["My Folder"]}
+  groups={[]}
   name={"folder_id"}
   path={null}
   relevantWhen={null}
@@ -387,6 +398,7 @@ Exactly one of [`billing_account_id`](#billing_account_id), [`folder_id`](#folde
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -409,6 +421,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["vector-logs"]}
+  groups={[]}
   name={"log_id"}
   path={null}
   relevantWhen={null}
@@ -431,6 +444,7 @@ The log ID to which to publish logs. This is a name you create to identify this 
   defaultValue={null}
   enumValues={null}
   examples={["622418129737"]}
+  groups={[]}
   name={"organization_id"}
   path={null}
   relevantWhen={null}
@@ -455,6 +469,7 @@ Exactly one of [`billing_account_id`](#billing_account_id), [`folder_id`](#folde
   defaultValue={null}
   enumValues={null}
   examples={["vector-123456"]}
+  groups={[]}
   name={"project_id"}
   path={null}
   relevantWhen={null}
@@ -479,6 +494,7 @@ Exactly one of [`billing_account_id`](#billing_account_id), [`folder_id`](#folde
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -500,6 +516,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -522,6 +539,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -544,6 +562,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={1000}
   enumValues={null}
   examples={[1000]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -566,6 +585,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -588,6 +608,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -610,6 +631,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -632,6 +654,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -659,6 +682,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"resource"}
   path={null}
   relevantWhen={null}
@@ -680,6 +704,7 @@ Options for describing the logging resource.
   defaultValue={null}
   enumValues={null}
   examples={["global","gce_instance"]}
+  groups={[]}
   name={"type"}
   path={"resource"}
   relevantWhen={null}
@@ -704,6 +729,7 @@ See the [Google Cloud Platform monitored resource documentation][urls.gcp_resour
   defaultValue={null}
   enumValues={null}
   examples={[{"projectId":"vector-123456"},{"zone":"Twilight"}]}
+  groups={[]}
   name={"`[label]`"}
   path={"resource"}
   relevantWhen={null}
@@ -733,6 +759,7 @@ For example, Compute Engine VM instances use the labels `projectId`, `instanceId
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -754,6 +781,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -776,6 +804,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -798,6 +827,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -820,6 +850,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -842,6 +873,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -864,6 +896,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}
@@ -898,6 +931,7 @@ If `true` (the default), Vector will validate the configured remote host name ag
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/credentials.json"]}
+  groups={[]}
   name={"GOOGLE_APPLICATION_CREDENTIALS"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/gcp_stackdriver_logging.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logging.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -58,7 +54,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -120,7 +116,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -77,7 +73,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -143,7 +139,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -155,6 +155,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"auth"}
   path={null}
   relevantWhen={null}
@@ -176,6 +177,7 @@ Options for the authentication strategy.
   defaultValue={null}
   enumValues={{"basic":"The [basic authentication strategy][urls.basic_auth]."}}
   examples={["basic"]}
+  groups={[]}
   name={"strategy"}
   path={"auth"}
   relevantWhen={null}
@@ -198,6 +200,7 @@ The authentication strategy to use.
   defaultValue={null}
   enumValues={null}
   examples={["${PASSWORD_ENV_VAR}","password"]}
+  groups={[]}
   name={"password"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -220,6 +223,7 @@ The basic authentication password.
   defaultValue={null}
   enumValues={null}
   examples={["${USERNAME_ENV_VAR}","username"]}
+  groups={[]}
   name={"user"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -247,6 +251,7 @@ The basic authentication user name.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -268,6 +273,7 @@ Configures the sink batching behavior.
   defaultValue={1049000}
   enumValues={null}
   examples={[1049000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -290,6 +296,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -317,6 +324,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -338,6 +346,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -360,6 +369,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -382,6 +392,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -404,6 +415,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -431,6 +443,7 @@ The behavior when the buffer becomes full.
   defaultValue={"none"}
   enumValues={{"none":"The payload will not be compressed.","gzip":"The payload will be compressed in [Gzip][urls.gzip] format before being sent."}}
   examples={["none","gzip"]}
+  groups={[]}
   name={"compression"}
   path={null}
   relevantWhen={null}
@@ -453,6 +466,7 @@ The compression strategy used to compress the encoded event data before outputti
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","ndjson":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["json","ndjson","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -475,6 +489,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"headers"}
   path={null}
   relevantWhen={null}
@@ -496,6 +511,7 @@ Options for custom headers. See [Authentication](#authentication) for more info.
   defaultValue={null}
   enumValues={null}
   examples={[{"Authorization":"${TOKEN_ENV_VAR}"},{"X-Powered-By":"Vector"}]}
+  groups={[]}
   name={"`[header-key]`"}
   path={"headers"}
   relevantWhen={null}
@@ -523,6 +539,7 @@ A custom header to be added to each outgoing HTTP request.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -545,6 +562,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["https://10.22.212.22:9000/_health"]}
+  groups={[]}
   name={"healthcheck_uri"}
   path={null}
   relevantWhen={null}
@@ -567,6 +585,7 @@ A URI that Vector can request in order to determine the service health. See [Hea
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -588,6 +607,7 @@ Configures the sink request behavior.
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -610,6 +630,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -632,6 +653,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={1000}
   enumValues={null}
   examples={[1000]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -654,6 +676,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -676,6 +699,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -698,6 +722,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -720,6 +745,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -747,6 +773,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -768,6 +795,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -790,6 +818,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -812,6 +841,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -834,6 +864,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -856,6 +887,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -878,6 +910,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}
@@ -905,6 +938,7 @@ If `true` (the default), Vector will validate the configured remote host name ag
   defaultValue={null}
   enumValues={null}
   examples={["https://10.22.212.22:9000/endpoint"]}
+  groups={[]}
   name={"uri"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/humio_logs.md
+++ b/website/docs/reference/sinks/humio_logs.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -56,7 +52,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -96,7 +92,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/humio_logs.md
+++ b/website/docs/reference/sinks/humio_logs.md
@@ -108,6 +108,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -129,6 +130,7 @@ Configures the sink batching behavior.
   defaultValue={1049000}
   enumValues={null}
   examples={[1049000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -151,6 +153,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -178,6 +181,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -199,6 +203,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -221,6 +226,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -243,6 +249,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -265,6 +272,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -292,6 +300,7 @@ The behavior when the buffer becomes full.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -314,6 +323,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://myhumiohost.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -336,6 +346,7 @@ The optional host to send Humio logs to.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -357,6 +368,7 @@ Configures the sink request behavior.
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -379,6 +391,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -401,6 +414,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -423,6 +437,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -445,6 +460,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -467,6 +483,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -489,6 +506,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -516,6 +534,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["${TOKEN_ENV_VAR}","A94A8FE5CCB19BA61C4C08"]}
+  groups={[]}
   name={"token"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/influxdb_metrics.md
+++ b/website/docs/reference/sinks/influxdb_metrics.md
@@ -1,5 +1,5 @@
 ---
-delivery_guarantee: "best_effort"
+delivery_guarantee: "at_least_once"
 description: "The Vector `influxdb_metrics` sink batches `metric` events to InfluxDB using v1 or v2 HTTP API."
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+influxdb_metrics%22
@@ -27,16 +27,12 @@ import Tabs from '@theme/Tabs';
 
 <Tabs
   block={true}
-  defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  defaultValue="v1"
+  values={[{"label":"v1","value":"v1"},{"label":"v2","value":"v2"},{"label":"v1 (advanced)","value":"v1-advanced"},{"label":"v2 (advanced)","value":"v2-advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
-<TabItem value="common">
+<TabItem value="v1">
 
 import CodeHeader from '@site/src/components/CodeHeader';
 
@@ -44,47 +40,56 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 ```toml
 [sinks.my_sink_id]
-  # REQUIRED
-  type = "influxdb_metrics" # must be: "influxdb_metrics"
-  inputs = ["my-source-id"] # example
-  bucket = "vector-bucket" # example
+  # REQUIRED - General
   database = "vector-database" # example
   endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
   namespace = "service" # example
-  org = "Organization" # example
-  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
 
-  # OPTIONAL
-  consistency = "any" # example, no default
-  healthcheck = true # default
+  # OPTIONAL - auth
   password = "${INFLUXDB_PASSWORD_ENV_VAR}" # example, no default
-  retention_policy_name = "autogen" # example, no default
   username = "todd" # example, no default
+
+  # OPTIONAL - persistence
+  consistency = "any" # example, no default
+  retention_policy_name = "autogen" # example, no default
 ```
 
 </TabItem>
-<TabItem value="advanced">
+<TabItem value="v2">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
   # REQUIRED - General
-  type = "influxdb_metrics" # must be: "influxdb_metrics"
-  inputs = ["my-source-id"] # example
   bucket = "vector-bucket" # example
+  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
+  namespace = "service" # example
+
+  # REQUIRED - auth
+  org = "Organization" # example
+  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
+```
+
+</TabItem>
+<TabItem value="v1-advanced">
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sinks.my_sink_id]
+  # REQUIRED - General
   database = "vector-database" # example
   endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
   namespace = "service" # example
-  org = "Organization" # example
-  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
 
-  # OPTIONAL - General
-  consistency = "any" # example, no default
-  healthcheck = true # default
+  # OPTIONAL - auth
   password = "${INFLUXDB_PASSWORD_ENV_VAR}" # example, no default
-  retention_policy_name = "autogen" # example, no default
   username = "todd" # example, no default
+
+  # OPTIONAL - persistence
+  consistency = "any" # example, no default
+  retention_policy_name = "autogen" # example, no default
 
   # OPTIONAL - Batch
   [sinks.my_sink_id.batch]
@@ -103,7 +108,38 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
+<TabItem value="v2-advanced">
 
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sinks.my_sink_id]
+  # REQUIRED - General
+  bucket = "vector-bucket" # example
+  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
+  namespace = "service" # example
+
+  # REQUIRED - auth
+  org = "Organization" # example
+  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
+
+  # OPTIONAL - Batch
+  [sinks.my_sink_id.batch]
+    max_events = 20 # default, events
+    timeout_secs = 1 # default, seconds
+
+  # OPTIONAL - Request
+  [sinks.my_sink_id.request]
+    in_flight_limit = 5 # default, requests
+    rate_limit_duration_secs = 1 # default, seconds
+    rate_limit_num = 5 # default
+    retry_attempts = -1 # default
+    retry_initial_backoff_secs = 1 # default, seconds
+    retry_max_duration_secs = 10 # default, seconds
+    timeout_secs = 60 # default, seconds
+```
+
+</TabItem>
 </Tabs>
 
 ## Options
@@ -233,28 +269,6 @@ Sets the write consistency for the point for InfluxDB 1.
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={["vector-database","iot-store"]}
-  name={"database"}
-  path={null}
-  relevantWhen={null}
-  required={true}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-### database
-
-Sets the target database for the write into InfluxDB 1.
-
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
   examples={["https://us-west-2-1.aws.cloud2.influxdata.com","http://localhost:8086/"]}
   name={"endpoint"}
   path={null}
@@ -268,6 +282,28 @@ Sets the target database for the write into InfluxDB 1.
 ### endpoint
 
 InfluxDB endpoint to send metrics to.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["vector-database","iot-store"]}
+  name={"database"}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### database
+
+Sets the target database for the write into InfluxDB 1.
 
 
 </Field>
@@ -610,32 +646,6 @@ Sets the username for authentication if you’ve enabled authentication for the 
 </Fields>
 
 ## How It Works
-
-### Configuration example
-
-#### InfluxDB v1
-```toml
-[sinks.my_sink_id]
-  type = "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud1.influxdata.com"
-  database = "vector-database"
-  consistency = "one"
-  retention_policy_name = "one_day_only"
-  username = "vector-source"
-  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
-```
-
-#### InfluxDB v2
-```toml
-[sinks.my_sink_id]
-  type = "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com"
-  org = "my-org"
-  bucket = "my-bucket"
-  token = "${INFLUXDB_TOKEN_ENV_VAR}"
-```
 
 ### Environment Variables
 

--- a/website/docs/reference/sinks/influxdb_metrics.md
+++ b/website/docs/reference/sinks/influxdb_metrics.md
@@ -27,14 +27,31 @@ import Tabs from '@theme/Tabs';
 
 <Tabs
   block={true}
-  defaultValue="v1"
-  values={[{"label":"v1","value":"v1"},{"label":"v2","value":"v2"},{"label":"v1 (advanced)","value":"v1-advanced"},{"label":"v2 (advanced)","value":"v2-advanced"}]}>
+  defaultValue="v2"
+  values={[{"label":"v2","value":"v2"},{"label":"v1","value":"v1"},{"label":"v2 (advanced)","value":"v2-advanced"},{"label":"v1 (advanced)","value":"v1-advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
-<TabItem value="v1">
+<TabItem value="v2">
 
 import CodeHeader from '@site/src/components/CodeHeader';
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sinks.my_sink_id]
+  # REQUIRED - General
+  bucket = "vector-bucket" # example
+  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
+  namespace = "service" # example
+
+  # REQUIRED - auth
+  org = "Organization" # example
+  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
+```
+
+</TabItem>
+<TabItem value="v1">
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
@@ -55,7 +72,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-<TabItem value="v2">
+<TabItem value="v2-advanced">
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
@@ -69,6 +86,21 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # REQUIRED - auth
   org = "Organization" # example
   token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
+
+  # OPTIONAL - Batch
+  [sinks.my_sink_id.batch]
+    max_events = 20 # default, events
+    timeout_secs = 1 # default, seconds
+
+  # OPTIONAL - Request
+  [sinks.my_sink_id.request]
+    in_flight_limit = 5 # default, requests
+    rate_limit_duration_secs = 1 # default, seconds
+    rate_limit_num = 5 # default
+    retry_attempts = -1 # default
+    retry_initial_backoff_secs = 1 # default, seconds
+    retry_max_duration_secs = 10 # default, seconds
+    timeout_secs = 60 # default, seconds
 ```
 
 </TabItem>
@@ -108,38 +140,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-<TabItem value="v2-advanced">
-
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
-
-```toml
-[sinks.my_sink_id]
-  # REQUIRED - General
-  bucket = "vector-bucket" # example
-  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com" # example
-  namespace = "service" # example
-
-  # REQUIRED - auth
-  org = "Organization" # example
-  token = "${INFLUXDB_TOKEN_ENV_VAR}" # example
-
-  # OPTIONAL - Batch
-  [sinks.my_sink_id.batch]
-    max_events = 20 # default, events
-    timeout_secs = 1 # default, seconds
-
-  # OPTIONAL - Request
-  [sinks.my_sink_id.request]
-    in_flight_limit = 5 # default, requests
-    rate_limit_duration_secs = 1 # default, seconds
-    rate_limit_num = 5 # default
-    retry_attempts = -1 # default
-    retry_initial_backoff_secs = 1 # default, seconds
-    retry_max_duration_secs = 10 # default, seconds
-    timeout_secs = 60 # default, seconds
-```
-
-</TabItem>
 </Tabs>
 
 ## Options
@@ -156,6 +156,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={["v1","v2"]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -177,6 +178,7 @@ Configures the sink batching behavior.
   defaultValue={20}
   enumValues={null}
   examples={[20]}
+  groups={[]}
   name={"max_events"}
   path={"batch"}
   relevantWhen={null}
@@ -199,6 +201,7 @@ The maximum size of a batch, in events, before it is flushed.
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -225,7 +228,31 @@ The maximum age of a batch before it is flushed.
   common={true}
   defaultValue={null}
   enumValues={null}
+  examples={["https://us-west-2-1.aws.cloud2.influxdata.com","http://localhost:8086/"]}
+  groups={["v1","v2"]}
+  name={"endpoint"}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### endpoint
+
+InfluxDB endpoint to send metrics to.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
   examples={["vector-bucket","4d2225e4d3d49f75"]}
+  groups={["v2"]}
   name={"bucket"}
   path={null}
   relevantWhen={null}
@@ -248,6 +275,7 @@ The destination bucket for writes into InfluxDB 2.
   defaultValue={null}
   enumValues={null}
   examples={["any","one","quorum","all"]}
+  groups={["v1"]}
   name={"consistency"}
   path={null}
   relevantWhen={null}
@@ -269,29 +297,8 @@ Sets the write consistency for the point for InfluxDB 1.
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={["https://us-west-2-1.aws.cloud2.influxdata.com","http://localhost:8086/"]}
-  name={"endpoint"}
-  path={null}
-  relevantWhen={null}
-  required={true}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-### endpoint
-
-InfluxDB endpoint to send metrics to.
-
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
   examples={["vector-database","iot-store"]}
+  groups={["v1"]}
   name={"database"}
   path={null}
   relevantWhen={null}
@@ -314,6 +321,7 @@ Sets the target database for the write into InfluxDB 1.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -336,6 +344,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["service"]}
+  groups={["v1","v2"]}
   name={"namespace"}
   path={null}
   relevantWhen={null}
@@ -358,6 +367,7 @@ A prefix that will be added to all metric names.
   defaultValue={null}
   enumValues={null}
   examples={["Organization","33f2cff0a28e5b63"]}
+  groups={["v2"]}
   name={"org"}
   path={null}
   relevantWhen={null}
@@ -380,6 +390,7 @@ Specifies the destination organization for writes into InfluxDB 2.
   defaultValue={null}
   enumValues={null}
   examples={["${INFLUXDB_PASSWORD_ENV_VAR}","influxdb4ever"]}
+  groups={["v1"]}
   name={"password"}
   path={null}
   relevantWhen={null}
@@ -402,6 +413,7 @@ Sets the password for authentication if you’ve enabled authentication for the 
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={["v1","v2"]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -423,6 +435,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -445,6 +458,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -467,6 +481,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -489,6 +504,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -511,6 +527,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -533,6 +550,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -555,6 +573,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -582,6 +601,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["autogen","one_day_only"]}
+  groups={["v1"]}
   name={"retention_policy_name"}
   path={null}
   relevantWhen={null}
@@ -604,6 +624,7 @@ Sets the target retention policy for the write into InfluxDB 1.
   defaultValue={null}
   enumValues={null}
   examples={["${INFLUXDB_TOKEN_ENV_VAR}","ef8d5de700e7989468166c40fc8a0ccd"]}
+  groups={["v2"]}
   name={"token"}
   path={null}
   relevantWhen={null}
@@ -626,6 +647,7 @@ Sets the target retention policy for the write into InfluxDB 1.
   defaultValue={null}
   enumValues={null}
   examples={["todd","vector-source"]}
+  groups={["v1"]}
   name={"username"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/influxdb_metrics.md.erb
+++ b/website/docs/reference/sinks/influxdb_metrics.md.erb
@@ -4,7 +4,65 @@
 
 ## Configuration
 
-<%= component_config_example(component) %>
+<Tabs
+  block={true}
+  defaultValue="default"
+  values={[
+    { label: 'Default Schema', value: 'default', },
+    { label: 'Custom Fields', value: 'custom', },
+    { label: 'Nested Fields', value: 'nested', },
+  ]
+}>
+<TabItem value="v2">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+[sinks.my_sink_id]
+  # REQUIRED
+  type = "influxdb_metrics" # must be: "influxdb_metrics"
+  namespace = "service"
+  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com"
+  org = "my-org"
+  bucket = "my-bucket"
+  token = "${INFLUXDB_TOKEN_ENV_VAR}"
+
+  # OPTIONAL
+  healthcheck = true # default
+```
+
+</TabItem>
+<TabItem value="v1">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+[sinks.my_sink_id]
+  # REQUIRED
+  type = "influxdb_metrics"
+  namespace = "service"
+  endpoint = "https://us-west-2-1.aws.cloud1.influxdata.com"
+  database = "vector-database"
+
+  # OPTIONAL
+  consistency = "one"
+  healthcheck = true # default
+  retention_policy_name = "one_day_only"
+  username = "vector-source"
+  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
+```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" />
+
+```toml
+<%= config_example(component.options_list, path: "#{component.type.pluralize}.my_#{component.type}_id") %>
+```
+
+</TabItem>
+</Tabs>
 
 <%- if !component.requirements.nil? -%>
 ## Requirements

--- a/website/docs/reference/sinks/influxdb_metrics.md.erb
+++ b/website/docs/reference/sinks/influxdb_metrics.md.erb
@@ -4,65 +4,7 @@
 
 ## Configuration
 
-<Tabs
-  block={true}
-  defaultValue="default"
-  values={[
-    { label: 'Default Schema', value: 'default', },
-    { label: 'Custom Fields', value: 'custom', },
-    { label: 'Nested Fields', value: 'nested', },
-  ]
-}>
-<TabItem value="v2">
-
-<CodeHeader fileName="vector.toml" />
-
-```toml
-[sinks.my_sink_id]
-  # REQUIRED
-  type = "influxdb_metrics" # must be: "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com"
-  org = "my-org"
-  bucket = "my-bucket"
-  token = "${INFLUXDB_TOKEN_ENV_VAR}"
-
-  # OPTIONAL
-  healthcheck = true # default
-```
-
-</TabItem>
-<TabItem value="v1">
-
-<CodeHeader fileName="vector.toml" />
-
-```toml
-[sinks.my_sink_id]
-  # REQUIRED
-  type = "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud1.influxdata.com"
-  database = "vector-database"
-
-  # OPTIONAL
-  consistency = "one"
-  healthcheck = true # default
-  retention_policy_name = "one_day_only"
-  username = "vector-source"
-  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
-```
-
-</TabItem>
-<TabItem value="advanced">
-
-<CodeHeader fileName="vector.toml" />
-
-```toml
-<%= config_example(component.options_list, path: "#{component.type.pluralize}.my_#{component.type}_id") %>
-```
-
-</TabItem>
-</Tabs>
+<%= component_config_example(component) %>
 
 <%- if !component.requirements.nil? -%>
 ## Requirements
@@ -91,32 +33,6 @@
 
 <%- end -%>
 ## How It Works [[sort]]
-
-### Configuration example
-
-#### InfluxDB v1
-```toml
-[sinks.my_sink_id]
-  type = "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud1.influxdata.com"
-  database = "vector-database"
-  consistency = "one"
-  retention_policy_name = "one_day_only"
-  username = "vector-source"
-  password = "${INFLUXDB_PASSWORD_ENV_VAR}"
-```
-
-#### InfluxDB v2
-```toml
-[sinks.my_sink_id]
-  type = "influxdb_metrics"
-  namespace = "service"
-  endpoint = "https://us-west-2-1.aws.cloud2.influxdata.com"
-  org = "my-org"
-  bucket = "my-bucket"
-  token = "${INFLUXDB_TOKEN_ENV_VAR}"
-```
 
 ### Metric Types
 

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -61,7 +57,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -105,7 +101,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -117,6 +117,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["10.14.22.123:9092,10.14.23.332:9092"]}
+  groups={[]}
   name={"bootstrap_servers"}
   path={null}
   relevantWhen={null}
@@ -139,6 +140,7 @@ A comma delimited list of host and port pairs that the Kafka client should conta
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -160,6 +162,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -182,6 +185,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -204,6 +208,7 @@ The maximum size of the buffer on the disk.
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -226,6 +231,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -253,6 +259,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","text":"Each event is encoded into text via the [`message`](#message) key and the payload is new line delimited."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -275,6 +282,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -297,6 +305,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["user_id"]}
+  groups={[]}
   name={"key_field"}
   path={null}
   relevantWhen={null}
@@ -319,6 +328,7 @@ The log field name to use for the topic key. If unspecified, the key will be ran
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"librdkafka_options"}
   path={null}
   relevantWhen={null}
@@ -341,6 +351,7 @@ Advanced producer options. See [`librdkafka` documentation][urls.lib_rdkafka_con
   defaultValue={null}
   enumValues={null}
   examples={[{"client.id":"${ENV_VAR}"},{"socket.send.buffer.bytes":"100"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"librdkafka_options"}
   relevantWhen={null}
@@ -369,6 +380,7 @@ The options and their values. Accepts `string` values.
   defaultValue={300000}
   enumValues={null}
   examples={[150000,450000]}
+  groups={[]}
   name={"message_timeout_ms"}
   path={null}
   relevantWhen={null}
@@ -391,6 +403,7 @@ Local message timeout.
   defaultValue={60000}
   enumValues={null}
   examples={[30000,90000]}
+  groups={[]}
   name={"socket_timeout_ms"}
   path={null}
   relevantWhen={null}
@@ -413,6 +426,7 @@ Default timeout for network requests.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -434,6 +448,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"enabled"}
   path={"tls"}
   relevantWhen={null}
@@ -456,6 +471,7 @@ Enable TLS during connections to the remote.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -478,6 +494,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -500,6 +517,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -522,6 +540,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -549,6 +568,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={null}
   enumValues={null}
   examples={["topic-1234"]}
+  groups={[]}
   name={"topic"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/logdna.md
+++ b/website/docs/reference/sinks/logdna.md
@@ -114,6 +114,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["${LOGDNA_API_KEY_ENV_VAR}","ef8d5de700e7989468166c40fc8a0ccd"]}
+  groups={[]}
   name={"api_key"}
   path={null}
   relevantWhen={null}
@@ -136,6 +137,7 @@ The Ingestion API key.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -157,6 +159,7 @@ Configures the sink batching behavior.
   defaultValue={10490000}
   enumValues={null}
   examples={[10490000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -179,6 +182,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -206,6 +210,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -227,6 +232,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -249,6 +255,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -271,6 +278,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -293,6 +301,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -320,6 +329,7 @@ The behavior when the buffer becomes full.
   defaultValue={"vector"}
   enumValues={null}
   examples={["vector","myapp"]}
+  groups={[]}
   name={"default_app"}
   path={null}
   relevantWhen={null}
@@ -342,6 +352,7 @@ The default app that will be set for events that do not contain a `file` or `app
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -364,6 +375,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://127.0.0.1","http://example.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -386,6 +398,7 @@ An optional host that will override the default one.
   defaultValue={null}
   enumValues={null}
   examples={["my-local-machine"]}
+  groups={[]}
   name={"hostname"}
   path={null}
   relevantWhen={null}
@@ -408,6 +421,7 @@ The hostname that will be attached to each batch of events.
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0"]}
+  groups={[]}
   name={"ip"}
   path={null}
   relevantWhen={null}
@@ -430,6 +444,7 @@ The IP address that will be attached to each batch of events.
   defaultValue={null}
   enumValues={null}
   examples={["my-mac-address"]}
+  groups={[]}
   name={"mac"}
   path={null}
   relevantWhen={null}
@@ -452,6 +467,7 @@ The mac address that will be attached to each batch of events.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -473,6 +489,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -495,6 +512,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -517,6 +535,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -539,6 +558,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -561,6 +581,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -583,6 +604,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -605,6 +627,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -632,6 +655,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[["tag1","tag2"]]}
+  groups={[]}
   name={"tags"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/logdna.md
+++ b/website/docs/reference/sinks/logdna.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -57,7 +53,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -102,7 +98,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -137,6 +137,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"auth"}
   path={null}
   relevantWhen={null}
@@ -158,6 +159,7 @@ Options for the authentication strategy.
   defaultValue={null}
   enumValues={{"basic":"The [basic authentication strategy][urls.basic_auth]."}}
   examples={["basic"]}
+  groups={[]}
   name={"strategy"}
   path={"auth"}
   relevantWhen={null}
@@ -180,6 +182,7 @@ The authentication strategy to use.
   defaultValue={null}
   enumValues={null}
   examples={["${PASSWORD_ENV_VAR}","password"]}
+  groups={[]}
   name={"password"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -202,6 +205,7 @@ The basic authentication password.If using GrafanaLab's hosted Loki then this mu
   defaultValue={null}
   enumValues={null}
   examples={["${USERNAME_ENV_VAR}","username"]}
+  groups={[]}
   name={"user"}
   path={"auth"}
   relevantWhen={{"strategy":"basic"}}
@@ -229,6 +233,7 @@ The basic authentication user name.If using GrafanaLab's hosted Loki then this m
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -250,6 +255,7 @@ Configures the sink batching behavior.
   defaultValue={10490000}
   enumValues={null}
   examples={[10490000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -272,6 +278,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -299,6 +306,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -320,6 +328,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -342,6 +351,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -364,6 +374,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -386,6 +397,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -413,6 +425,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON","text":"Each event is encoded into text via the `message` key."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -435,6 +448,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={null}
   enumValues={null}
   examples={["http://localhost:3100","http://127.0.0.1:8080"]}
+  groups={[]}
   name={"endpoint"}
   path={null}
   relevantWhen={null}
@@ -457,6 +471,7 @@ The endpoint used to ship logs to.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -479,6 +494,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={[{"label":"value"}]}
+  groups={[]}
   name={"labels"}
   path={null}
   relevantWhen={null}
@@ -500,6 +516,7 @@ A set of labels that will be attached to each batch of events. These valuesare a
   defaultValue={null}
   enumValues={null}
   examples={[{"key":"value"},{"key":"{{ event_field }}"}]}
+  groups={[]}
   name={"`[label-name`"}
   path={"labels"}
   relevantWhen={null}
@@ -527,6 +544,7 @@ A key-value pair for labels.
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"remove_label_fields"}
   path={null}
   relevantWhen={null}
@@ -549,6 +567,7 @@ If this is set to `true` then when labels are collected from events those fields
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"remove_timestamp"}
   path={null}
   relevantWhen={null}
@@ -571,6 +590,7 @@ If this is set to `true` then the timestamp will be removed from the event. This
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -592,6 +612,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -614,6 +635,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -636,6 +658,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -658,6 +681,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -680,6 +704,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -702,6 +727,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -724,6 +750,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -751,6 +778,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["some_tenant_id"]}
+  groups={[]}
   name={"tenant_id"}
   path={null}
   relevantWhen={null}
@@ -775,6 +803,7 @@ You can read more about tenant id's [here][urls.loki_multi_tenancy]
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -796,6 +825,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -818,6 +848,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -840,6 +871,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -862,6 +894,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -884,6 +917,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -906,6 +940,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -62,7 +58,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -125,7 +121,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/new_relic_logs.md
+++ b/website/docs/reference/sinks/new_relic_logs.md
@@ -111,6 +111,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -132,6 +133,7 @@ Configures the sink batching behavior.
   defaultValue={524000}
   enumValues={null}
   examples={[524000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -154,6 +156,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -181,6 +184,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -202,6 +206,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -224,6 +229,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -246,6 +252,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -268,6 +275,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -295,6 +303,7 @@ The behavior when the buffer becomes full.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -317,6 +326,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["xxxx","${INSERT_KEY_ENV_VAR}"]}
+  groups={[]}
   name={"insert_key"}
   path={null}
   relevantWhen={null}
@@ -339,6 +349,7 @@ Your New Relic insert key (if applicable).
   defaultValue={null}
   enumValues={null}
   examples={["xxxx","${LICENSE_KEY_ENV_VAR}"]}
+  groups={[]}
   name={"license_key"}
   path={null}
   relevantWhen={null}
@@ -361,6 +372,7 @@ Your New Relic license key (if applicable).
   defaultValue={"us"}
   enumValues={{"us":"The US region","eu":"The EU region"}}
   examples={["us","eu"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={null}
@@ -383,6 +395,7 @@ The API region to send logs to.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -404,6 +417,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -426,6 +440,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -448,6 +463,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={100}
   enumValues={null}
   examples={[100]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -470,6 +486,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -492,6 +509,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -514,6 +532,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -536,6 +555,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/new_relic_logs.md
+++ b/website/docs/reference/sinks/new_relic_logs.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -58,7 +54,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -99,7 +95,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/prometheus.md
+++ b/website/docs/reference/sinks/prometheus.md
@@ -55,6 +55,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0:9598"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}
@@ -77,6 +78,7 @@ The address to expose for scraping. See [Exposing & Scraping](#exposing--scrapin
   defaultValue={[0.005,0.01,0.025,0.05,0.1,0.25,0.5,1.0,2.5,5.0,10.0]}
   enumValues={null}
   examples={[[0.005,0.01,0.025,0.05,0.1,0.25,0.5,1.0,2.5,5.0,10.0]]}
+  groups={[]}
   name={"buckets"}
   path={null}
   relevantWhen={null}
@@ -99,6 +101,7 @@ Default buckets to use for aggregating [distribution][docs.data-model.metric#dis
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"flush_period_secs"}
   path={null}
   relevantWhen={null}
@@ -121,6 +124,7 @@ Time interval between [set][docs.data-model.metric#set] values are reset.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -143,6 +147,7 @@ Enables/disables the sink healthcheck upon start.
   defaultValue={null}
   enumValues={null}
   examples={["service"]}
+  groups={[]}
   name={"namespace"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/sematext.md
+++ b/website/docs/reference/sinks/sematext.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -56,7 +52,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -97,7 +93,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 

--- a/website/docs/reference/sinks/sematext.md
+++ b/website/docs/reference/sinks/sematext.md
@@ -110,6 +110,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -131,6 +132,7 @@ Configures the sink batching behavior.
   defaultValue={10490000}
   enumValues={null}
   examples={[10490000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -153,6 +155,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -180,6 +183,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -201,6 +205,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -223,6 +228,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -245,6 +251,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -267,6 +274,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -294,6 +302,7 @@ The behavior when the buffer becomes full.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -316,6 +325,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://127.0.0.1","http://example.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -338,6 +348,7 @@ The host that will be used to send logs to. This option is required if [`region`
   defaultValue={null}
   enumValues={null}
   examples={["na","eu"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={null}
@@ -360,6 +371,7 @@ The region destination to send logs to. This option is required if [`host`](#hos
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -381,6 +393,7 @@ Configures the sink request behavior.
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -403,6 +416,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -425,6 +439,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={5}
   enumValues={null}
   examples={[5]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -447,6 +462,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -469,6 +485,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -491,6 +508,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -513,6 +531,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -540,6 +559,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={["${SEMATEXT_TOKEN_ENV_VAR}","some-sematext-token"]}
+  groups={[]}
   name={"token"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -61,7 +57,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -100,7 +96,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -112,6 +112,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["92.12.333.224:5000"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={{"mode":"tcp"}}
@@ -134,6 +135,7 @@ The address to connect to. The address _must_ include a port.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -155,6 +157,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -177,6 +180,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -199,6 +203,7 @@ The maximum size of the buffer on the disk.
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -221,6 +226,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -248,6 +254,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON.","text":"Each event is encoded into text via the `message` key."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -270,6 +277,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -292,6 +300,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={{"tcp":"TCP Socket.","unix":"Unix Domain Socket."}}
   examples={["tcp","unix"]}
+  groups={[]}
   name={"mode"}
   path={null}
   relevantWhen={null}
@@ -314,6 +323,7 @@ The type of socket to use.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/socket"]}
+  groups={[]}
   name={"path"}
   path={null}
   relevantWhen={{"mode":"unix"}}
@@ -336,6 +346,7 @@ The unix socket path. This should be the absolute path.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -357,6 +368,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"enabled"}
   path={"tls"}
   relevantWhen={null}
@@ -379,6 +391,7 @@ Enable TLS during connections to the remote.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -401,6 +414,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -423,6 +437,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -445,6 +460,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -467,6 +483,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -489,6 +506,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -61,7 +57,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -114,7 +110,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -126,6 +126,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"batch"}
   path={null}
   relevantWhen={null}
@@ -147,6 +148,7 @@ Configures the sink batching behavior.
   defaultValue={1049000}
   enumValues={null}
   examples={[1049000]}
+  groups={[]}
   name={"max_size"}
   path={"batch"}
   relevantWhen={null}
@@ -169,6 +171,7 @@ The maximum size of a batch, in bytes, before it is flushed. See [Buffers & Batc
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"timeout_secs"}
   path={"batch"}
   relevantWhen={null}
@@ -196,6 +199,7 @@ The maximum age of a batch before it is flushed. See [Buffers & Batches](#buffer
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -217,6 +221,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -239,6 +244,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -261,6 +267,7 @@ The maximum size of the buffer on the disk. See [Buffers & Batches](#buffers--ba
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -283,6 +290,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -310,6 +318,7 @@ The behavior when the buffer becomes full.
   defaultValue={null}
   enumValues={{"json":"Each event is encoded into JSON and the payload is new line delimited.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
   examples={["json","text"]}
+  groups={[]}
   name={"encoding"}
   path={null}
   relevantWhen={null}
@@ -332,6 +341,7 @@ The encoding format used to serialize the events before outputting.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -354,6 +364,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
   defaultValue={null}
   enumValues={null}
   examples={["http://my-splunk-host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -376,6 +387,7 @@ Your Splunk HEC host. See [Setup](#setup) for more info.
   defaultValue={null}
   enumValues={null}
   examples={[["field1","field2"]]}
+  groups={[]}
   name={"indexed_fields"}
   path={null}
   relevantWhen={{"encoding":"json"}}
@@ -398,6 +410,7 @@ Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields].
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"request"}
   path={null}
   relevantWhen={null}
@@ -419,6 +432,7 @@ Configures the sink request behavior.
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"in_flight_limit"}
   path={"request"}
   relevantWhen={null}
@@ -441,6 +455,7 @@ The maximum number of in-flight requests allowed at any given time. See [Rate Li
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"rate_limit_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -463,6 +478,7 @@ The time window, in seconds, used for the [`rate_limit_num`](#rate_limit_num) op
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"rate_limit_num"}
   path={"request"}
   relevantWhen={null}
@@ -485,6 +501,7 @@ The maximum number of requests allowed within the [`rate_limit_duration_secs`](#
   defaultValue={-1}
   enumValues={null}
   examples={[-1]}
+  groups={[]}
   name={"retry_attempts"}
   path={"request"}
   relevantWhen={null}
@@ -507,6 +524,7 @@ The maximum number of retries to make for failed requests. See [Retry Policy](#r
   defaultValue={1}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"retry_initial_backoff_secs"}
   path={"request"}
   relevantWhen={null}
@@ -529,6 +547,7 @@ The amount of time to wait before attempting the first retry for a failed reques
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"retry_max_duration_secs"}
   path={"request"}
   relevantWhen={null}
@@ -551,6 +570,7 @@ The maximum amount of time, in seconds, to wait between retries.
   defaultValue={60}
   enumValues={null}
   examples={[60]}
+  groups={[]}
   name={"timeout_secs"}
   path={"request"}
   relevantWhen={null}
@@ -578,6 +598,7 @@ The maximum time a request can take before being aborted. It is highly recommend
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tls"}
   path={null}
   relevantWhen={null}
@@ -599,6 +620,7 @@ Configures the TLS options for connections from this sink.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
   name={"ca_path"}
   path={"tls"}
   relevantWhen={null}
@@ -621,6 +643,7 @@ Absolute path to an additional CA certificate file, in DER or PEM format (X.509)
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.crt"]}
+  groups={[]}
   name={"crt_path"}
   path={"tls"}
   relevantWhen={null}
@@ -643,6 +666,7 @@ Absolute path to a certificate file used to identify this connection, in DER or 
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
+  groups={[]}
   name={"key_pass"}
   path={"tls"}
   relevantWhen={null}
@@ -665,6 +689,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/host_certificate.key"]}
+  groups={[]}
   name={"key_path"}
   path={"tls"}
   relevantWhen={null}
@@ -687,6 +712,7 @@ Absolute path to a certificate key file used to identify this connection, in DER
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_certificate"}
   path={"tls"}
   relevantWhen={null}
@@ -709,6 +735,7 @@ If `true` (the default), Vector will validate the TLS certificate of the remote 
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"verify_hostname"}
   path={"tls"}
   relevantWhen={null}
@@ -736,6 +763,7 @@ If `true` (the default), Vector will validate the configured remote host name ag
   defaultValue={null}
   enumValues={null}
   examples={["${TOKEN_ENV_VAR}","A94A8FE5CCB19BA61C4C08"]}
+  groups={[]}
   name={"token"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/statsd.md
+++ b/website/docs/reference/sinks/statsd.md
@@ -53,6 +53,7 @@ import Field from '@site/src/components/Field';
   defaultValue={"127.0.0.1:8125"}
   enumValues={null}
   examples={["127.0.0.1:8125"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}
@@ -75,6 +76,7 @@ The UDP socket address to send stats to.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}
@@ -97,6 +99,7 @@ Enables/disables the sink healthcheck upon start.
   defaultValue={null}
   enumValues={null}
   examples={["service"]}
+  groups={[]}
   name={"namespace"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -92,6 +92,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["92.12.333.224:5000"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}
@@ -114,6 +115,7 @@ The downstream Vector address to connect to. The address _must_ include a port.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"buffer"}
   path={null}
   relevantWhen={null}
@@ -135,6 +137,7 @@ Configures the sink specific buffer behavior.
   defaultValue={500}
   enumValues={null}
   examples={[500]}
+  groups={[]}
   name={"max_events"}
   path={"buffer"}
   relevantWhen={{"type":"memory"}}
@@ -157,6 +160,7 @@ The maximum number of [events][docs.data-model] allowed in the buffer.
   defaultValue={null}
   enumValues={null}
   examples={[104900000]}
+  groups={[]}
   name={"max_size"}
   path={"buffer"}
   relevantWhen={{"type":"disk"}}
@@ -179,6 +183,7 @@ The maximum size of the buffer on the disk.
   defaultValue={"memory"}
   enumValues={{"memory":"Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully.","disk":"Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."}}
   examples={["memory","disk"]}
+  groups={[]}
   name={"type"}
   path={"buffer"}
   relevantWhen={null}
@@ -201,6 +206,7 @@ The buffer's type and storage mechanism.
   defaultValue={"block"}
   enumValues={{"block":"Applies back pressure when the buffer is full. This prevents data loss, but will cause data to pile up on the edge.","drop_newest":"Drops new data as it's received. This data is lost. This should be used when performance is the highest priority."}}
   examples={["block","drop_newest"]}
+  groups={[]}
   name={"when_full"}
   path={"buffer"}
   relevantWhen={null}
@@ -228,6 +234,7 @@ The behavior when the buffer becomes full.
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"healthcheck"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -56,7 +52,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sinks.my_sink_id]
@@ -80,7 +76,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -56,7 +52,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -72,7 +68,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options
@@ -259,10 +254,10 @@ For example:
   "container_id": "9b6247364a03",
   "container_name": "evil_ptolemy",
   "image": "ubuntu:latest",
-  "com.example.vendor": "Timber Inc.",
   "message": "Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100",
   "stream": "stdout",
-  "timestamp": "2019-11-01T21:15:47+00:00"
+  "timestamp": "2019-11-01T21:15:47+00:00",
+  "com.example.vendor": "Timber Inc."
 }
 ```
 More detail on the output schema is below.
@@ -362,28 +357,6 @@ The image name that the container is based on.
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={[{"com.example.vendor":"Timber Inc."},{"com.example.name":"Vector"},{"com.example.build-date":"2029-04-12T23:20:50.52Z"}]}
-  name={"`[label-key]`"}
-  path={null}
-  relevantWhen={null}
-  required={true}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-### `[label-key]`
-
-[Docker object labels][urls.docker_object_labels]. Each label is inserted with it's exact key/value pair.
-
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
   name={"message"}
   path={null}
@@ -441,6 +414,28 @@ The [standard stream][urls.standard_streams] that the log was collected from.
 ### timestamp
 
 The UTC timestamp extracted from the Docker log event.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"com.example.vendor":"Timber Inc."},{"com.example.name":"Vector"},{"com.example.build-date":"2029-04-12T23:20:50.52Z"}]}
+  name={"`[label-key]`"}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### `[label-key]`
+
+[Docker object labels][urls.docker_object_labels]. Each label is inserted with it's exact key/value pair.
 
 
 </Field>

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -84,6 +84,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"auto_partial_merge"}
   path={null}
   relevantWhen={null}
@@ -106,6 +107,7 @@ Setting this to `false` will disable the automatic merging of partial events. Se
   defaultValue={null}
   enumValues={null}
   examples={[["serene_","serene_leakey","ad08cc418cf9"]]}
+  groups={[]}
   name={"include_containers"}
   path={null}
   relevantWhen={null}
@@ -129,6 +131,7 @@ container ID or name. If not provided, all containers will be included.
   defaultValue={null}
   enumValues={null}
   examples={[["httpd","redis"]]}
+  groups={[]}
   name={"include_images"}
   path={null}
   relevantWhen={null}
@@ -151,6 +154,7 @@ A list of image names to match against. If not provided, all images will be incl
   defaultValue={null}
   enumValues={null}
   examples={[["com.example.vendor=Timber Inc.","com.example.name=Vector"]]}
+  groups={[]}
   name={"include_labels"}
   path={null}
   relevantWhen={null}
@@ -173,6 +177,7 @@ A list of container object labels to match against when filtering running contai
   defaultValue={"_partial"}
   enumValues={null}
   examples={["_partial"]}
+  groups={[]}
   name={"partial_event_marker_field"}
   path={null}
   relevantWhen={null}
@@ -202,6 +207,7 @@ The field name to be added to events that are detected to contain an incomplete 
   defaultValue={"unix:///var/run/docker.sock"}
   enumValues={null}
   examples={["unix://path/to/socket","tcp://host:2375/path"]}
+  groups={[]}
   name={"DOCKER_HOST"}
   path={null}
   relevantWhen={null}
@@ -224,6 +230,7 @@ The docker host to connect to. See [Connecting to the Docker daemon](#connecting
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"DOCKER_VERIFY_TLS"}
   path={null}
   relevantWhen={null}
@@ -254,10 +261,10 @@ For example:
   "container_id": "9b6247364a03",
   "container_name": "evil_ptolemy",
   "image": "ubuntu:latest",
+  "com.example.vendor": "Timber Inc.",
   "message": "Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100",
   "stream": "stdout",
-  "timestamp": "2019-11-01T21:15:47+00:00",
-  "com.example.vendor": "Timber Inc."
+  "timestamp": "2019-11-01T21:15:47+00:00"
 }
 ```
 More detail on the output schema is below.
@@ -270,6 +277,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"container_created_at"}
   path={null}
   relevantWhen={null}
@@ -292,6 +300,7 @@ A UTC timestamp representing when the container was created.
   defaultValue={null}
   enumValues={null}
   examples={["9b6247364a03","715ebfcee040"]}
+  groups={[]}
   name={"container_id"}
   path={null}
   relevantWhen={null}
@@ -314,6 +323,7 @@ The Docker container ID that the log was collected from.
   defaultValue={null}
   enumValues={null}
   examples={["evil_ptolemy","nostalgic_stallman"]}
+  groups={[]}
   name={"container_name"}
   path={null}
   relevantWhen={null}
@@ -336,6 +346,7 @@ The Docker container name that the log was collected from.
   defaultValue={null}
   enumValues={null}
   examples={["ubuntu:latest","busybox","timberio/vector:latest-alpine"]}
+  groups={[]}
   name={"image"}
   path={null}
   relevantWhen={null}
@@ -357,7 +368,31 @@ The image name that the container is based on.
   common={true}
   defaultValue={null}
   enumValues={null}
+  examples={[{"com.example.vendor":"Timber Inc."},{"com.example.name":"Vector"},{"com.example.build-date":"2029-04-12T23:20:50.52Z"}]}
+  groups={[]}
+  name={"`[label-key]`"}
+  path={null}
+  relevantWhen={null}
+  required={true}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### `[label-key]`
+
+[Docker object labels][urls.docker_object_labels]. Each label is inserted with it's exact key/value pair.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -380,6 +415,7 @@ The raw log message, unaltered.
   defaultValue={null}
   enumValues={{"stdout":"The STDOUT stream","stderr":"The STDERR stream"}}
   examples={["stdout","stderr"]}
+  groups={[]}
   name={"stream"}
   path={null}
   relevantWhen={null}
@@ -402,6 +438,7 @@ The [standard stream][urls.standard_streams] that the log was collected from.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}
@@ -414,28 +451,6 @@ The [standard stream][urls.standard_streams] that the log was collected from.
 ### timestamp
 
 The UTC timestamp extracted from the Docker log event.
-
-
-</Field>
-
-
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[{"com.example.vendor":"Timber Inc."},{"com.example.name":"Vector"},{"com.example.build-date":"2029-04-12T23:20:50.52Z"}]}
-  name={"`[label-key]`"}
-  path={null}
-  relevantWhen={null}
-  required={true}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  >
-
-### `[label-key]`
-
-[Docker object labels][urls.docker_object_labels]. Each label is inserted with it's exact key/value pair.
 
 
 </Field>

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -112,6 +112,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["/var/lib/vector"]}
+  groups={[]}
   name={"data_dir"}
   path={null}
   relevantWhen={null}
@@ -134,6 +135,7 @@ The directory used to persist file checkpoint positions. By default, the [global
   defaultValue={null}
   enumValues={null}
   examples={[["/var/log/nginx/*.[0-9]*.log"]]}
+  groups={[]}
   name={"exclude"}
   path={null}
   relevantWhen={null}
@@ -156,6 +158,7 @@ Array of file patterns to exclude. [Globbing](#globbing) is supported.*Takes pre
   defaultValue={"file"}
   enumValues={null}
   examples={["file"]}
+  groups={[]}
   name={"file_key"}
   path={null}
   relevantWhen={null}
@@ -178,6 +181,7 @@ The key name added to each event with the full path of the file. See [Context](#
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"fingerprinting"}
   path={null}
   relevantWhen={null}
@@ -199,6 +203,7 @@ Configuration for how the file source should identify files.
   defaultValue={"checksum"}
   enumValues={{"checksum":"Read [`fingerprint_bytes`](#fingerprint_bytes) bytes from the head of the file to uniquely identify files via a checksum.","device_and_inode":"Uses the [device and inode][urls.inode] to unique identify files."}}
   examples={["checksum","device_and_inode"]}
+  groups={[]}
   name={"strategy"}
   path={"fingerprinting"}
   relevantWhen={null}
@@ -221,6 +226,7 @@ The strategy used to uniquely identify files. This is important for [checkpointi
   defaultValue={256}
   enumValues={null}
   examples={[256]}
+  groups={[]}
   name={"fingerprint_bytes"}
   path={"fingerprinting"}
   relevantWhen={{"strategy":"checksum"}}
@@ -243,6 +249,7 @@ The number of bytes read off the head of the file to generate a unique fingerpri
   defaultValue={0}
   enumValues={null}
   examples={[0]}
+  groups={[]}
   name={"ignored_header_bytes"}
   path={"fingerprinting"}
   relevantWhen={{"strategy":"checksum"}}
@@ -270,6 +277,7 @@ The number of bytes to skip ahead (or ignore) when generating a unique fingerpri
   defaultValue={1000}
   enumValues={null}
   examples={[1000]}
+  groups={[]}
   name={"glob_minimum_cooldown"}
   path={null}
   relevantWhen={null}
@@ -292,6 +300,7 @@ Delay between file discovery calls. This controls the interval at which Vector s
   defaultValue={"host"}
   enumValues={null}
   examples={["host"]}
+  groups={[]}
   name={"host_key"}
   path={null}
   relevantWhen={null}
@@ -314,6 +323,7 @@ The key name added to each event representing the current host. This can also be
   defaultValue={null}
   enumValues={null}
   examples={[86400]}
+  groups={[]}
   name={"ignore_older"}
   path={null}
   relevantWhen={null}
@@ -336,6 +346,7 @@ Ignore files with a data modification date that does not exceed this age.
   defaultValue={null}
   enumValues={null}
   examples={[["/var/log/nginx/*.log"]]}
+  groups={[]}
   name={"include"}
   path={null}
   relevantWhen={null}
@@ -358,6 +369,7 @@ Array of file patterns to include. [Globbing](#globbing) is supported. See [File
   defaultValue={102400}
   enumValues={null}
   examples={[102400]}
+  groups={[]}
   name={"max_line_bytes"}
   path={null}
   relevantWhen={null}
@@ -380,6 +392,7 @@ The maximum number of a bytes a line can contain before being discarded. This pr
   defaultValue={2048}
   enumValues={null}
   examples={[2048]}
+  groups={[]}
   name={"max_read_bytes"}
   path={null}
   relevantWhen={null}
@@ -402,6 +415,7 @@ An approximate limit on the amount of data read from a single file at a given ti
   defaultValue={null}
   enumValues={null}
   examples={["^(INFO|ERROR)"]}
+  groups={[]}
   name={"message_start_indicator"}
   path={null}
   relevantWhen={null}
@@ -424,6 +438,7 @@ When present, Vector will aggregate multiple lines into a single event, using th
   defaultValue={1000}
   enumValues={null}
   examples={[1000]}
+  groups={[]}
   name={"multi_line_timeout"}
   path={null}
   relevantWhen={null}
@@ -446,6 +461,7 @@ When [`message_start_indicator`](#message_start_indicator) is present, this sets
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"oldest_first"}
   path={null}
   relevantWhen={null}
@@ -468,6 +484,7 @@ Instead of balancing read capacity fairly across all watched files, prioritize d
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"start_at_beginning"}
   path={null}
   relevantWhen={null}
@@ -510,6 +527,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["/var/log/nginx.log"]}
+  groups={[]}
   name={"file"}
   path={null}
   relevantWhen={null}
@@ -532,6 +550,7 @@ The _full_ path of the file tha the log originated from. This can be renamed via
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -554,6 +573,7 @@ The current hostname, equivalent to the `gethostname` command. This can be renam
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -576,6 +596,7 @@ The raw log message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -64,7 +60,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -100,7 +96,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -94,6 +94,7 @@ import Field from '@site/src/components/Field';
   defaultValue={16}
   enumValues={null}
   examples={[16]}
+  groups={[]}
   name={"batch_size"}
   path={null}
   relevantWhen={null}
@@ -116,6 +117,7 @@ The systemd journal is read in batches, and a checkpoint is set at the end of ea
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"current_boot_only"}
   path={null}
   relevantWhen={null}
@@ -138,6 +140,7 @@ Include only entries from the current boot.
   defaultValue={null}
   enumValues={null}
   examples={["/var/lib/vector"]}
+  groups={[]}
   name={"data_dir"}
   path={null}
   relevantWhen={null}
@@ -160,6 +163,7 @@ The directory used to persist the journal checkpoint position. By default, the g
   defaultValue={"journalctl"}
   enumValues={null}
   examples={["/usr/local/bin/journalctl"]}
+  groups={[]}
   name={"journalctl_path"}
   path={null}
   relevantWhen={null}
@@ -182,6 +186,7 @@ The full path of the [`journalctl`](#journalctl) executable. If not set, Vector 
   defaultValue={[]}
   enumValues={null}
   examples={[["ntpd","sysinit.target"]]}
+  groups={[]}
   name={"units"}
   path={null}
   relevantWhen={null}
@@ -274,6 +279,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={[{"_SYSTEMD_UNIT":"ntpd.service"},{"_BOOT_ID":"124c781146e841ae8d9b4590df8b9231"}]}
+  groups={[]}
   name={"`[record-key]`"}
   path={null}
   relevantWhen={null}
@@ -297,6 +303,7 @@ Additional Journald fields are passed through as log fields.
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -319,6 +326,7 @@ The value of the journald `_HOSTNAME` field.
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -341,6 +349,7 @@ The value of the journald `MESSAGE` field.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -55,7 +51,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -71,7 +67,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Requirements

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -57,7 +53,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -81,7 +77,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -93,6 +93,7 @@ import Field from '@site/src/components/Field';
   defaultValue={"largest"}
   enumValues={null}
   examples={["smallest","earliest","beginning","largest","latest","end","error"]}
+  groups={[]}
   name={"auto_offset_reset"}
   path={null}
   relevantWhen={null}
@@ -115,6 +116,7 @@ If offsets for consumer group do not exist, set them using this strategy. [librd
   defaultValue={null}
   enumValues={null}
   examples={["10.14.22.123:9092,10.14.23.332:9092"]}
+  groups={[]}
   name={"bootstrap_servers"}
   path={null}
   relevantWhen={null}
@@ -137,6 +139,7 @@ A comma-separated list of host and port pairs that are the addresses of the Kafk
   defaultValue={100}
   enumValues={null}
   examples={[50,100]}
+  groups={[]}
   name={"fetch_wait_max_ms"}
   path={null}
   relevantWhen={null}
@@ -160,6 +163,7 @@ Maximum time the broker may wait to fill the response.
   defaultValue={null}
   enumValues={null}
   examples={["consumer-group-name"]}
+  groups={[]}
   name={"group_id"}
   path={null}
   relevantWhen={null}
@@ -183,6 +187,7 @@ The consumer group name to be used to consume events from Kafka.
   defaultValue={null}
   enumValues={null}
   examples={["user_id"]}
+  groups={[]}
   name={"key_field"}
   path={null}
   relevantWhen={null}
@@ -205,6 +210,7 @@ The log field name to use for the topic key. If unspecified, the key would not b
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"librdkafka_options"}
   path={null}
   relevantWhen={null}
@@ -227,6 +233,7 @@ Advanced consumer options. See [`librdkafka` documentation][urls.lib_rdkafka_con
   defaultValue={null}
   enumValues={null}
   examples={[{"client.id":"${ENV_VAR}"},{"fetch.error.backoff.ms":"1000"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"librdkafka_options"}
   relevantWhen={null}
@@ -255,6 +262,7 @@ The options and their values. Accepts `string` values.
   defaultValue={10000}
   enumValues={null}
   examples={[5000,10000]}
+  groups={[]}
   name={"session_timeout_ms"}
   path={null}
   relevantWhen={null}
@@ -278,6 +286,7 @@ The Kafka session timeout in milliseconds.
   defaultValue={60000}
   enumValues={null}
   examples={[30000,60000]}
+  groups={[]}
   name={"socket_timeout_ms"}
   path={null}
   relevantWhen={null}
@@ -301,6 +310,7 @@ Default timeout for network requests.
   defaultValue={null}
   enumValues={null}
   examples={[["^(prefix1|prefix2)-.+","topic-1","topic-2"]]}
+  groups={[]}
   name={"topics"}
   path={null}
   relevantWhen={null}
@@ -342,6 +352,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -365,6 +376,7 @@ The raw event message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/logplex.md
+++ b/website/docs/reference/sources/logplex.md
@@ -47,6 +47,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0:8088"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/prometheus.md
+++ b/website/docs/reference/sources/prometheus.md
@@ -49,6 +49,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["http://localhost:9090"]]}
+  groups={[]}
   name={"hosts"}
   path={null}
   relevantWhen={null}
@@ -71,6 +72,7 @@ Host addresses to scrape metrics from.
   defaultValue={null}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"scrape_interval_secs"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -60,7 +56,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -79,7 +75,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -91,6 +91,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0:9000","systemd","systemd#3"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={{"mode":["tcp","udp"]}}
@@ -114,6 +115,7 @@ The address to listen for connections on, or `systemd#N` to use the Nth socket p
   defaultValue={"host"}
   enumValues={null}
   examples={["host"]}
+  groups={[]}
   name={"host_key"}
   path={null}
   relevantWhen={null}
@@ -136,6 +138,7 @@ The key name added to each event representing the current host. This can also be
   defaultValue={102400}
   enumValues={null}
   examples={[102400]}
+  groups={[]}
   name={"max_length"}
   path={null}
   relevantWhen={null}
@@ -158,6 +161,7 @@ The maximum bytes size of incoming messages before they are discarded.
   defaultValue={null}
   enumValues={{"tcp":"TCP Socket.","udp":"UDP Socket.","unix":"Unix Domain Socket."}}
   examples={["tcp","udp","unix"]}
+  groups={[]}
   name={"mode"}
   path={null}
   relevantWhen={null}
@@ -180,6 +184,7 @@ The type of socket to use.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/socket"]}
+  groups={[]}
   name={"path"}
   path={null}
   relevantWhen={{"mode":"unix"}}
@@ -202,6 +207,7 @@ The unix socket path. *This should be absolute path*.
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"shutdown_timeout_secs"}
   path={null}
   relevantWhen={{"mode":"tcp"}}
@@ -253,6 +259,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -276,6 +283,7 @@ The upstream hostname.
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -299,6 +307,7 @@ The raw message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/splunk_hec.md
+++ b/website/docs/reference/sources/splunk_hec.md
@@ -51,6 +51,7 @@ import Field from '@site/src/components/Field';
   defaultValue={"0.0.0.0:8088"}
   enumValues={null}
   examples={["0.0.0.0:8088"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}
@@ -73,6 +74,7 @@ The address to accept connections on.
   defaultValue={null}
   enumValues={null}
   examples={["A94A8FE5CCB19BA61C4C08"]}
+  groups={[]}
   name={"token"}
   path={null}
   relevantWhen={null}
@@ -125,6 +127,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -147,6 +150,7 @@ The raw log message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"splunk_channel"}
   path={null}
   relevantWhen={null}
@@ -169,6 +173,7 @@ The Splunk channel, value of the `X-Splunk-Request-Channel` header.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/statsd.md
+++ b/website/docs/reference/sources/statsd.md
@@ -47,6 +47,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["127.0.0.1:8126"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/stdin.md
+++ b/website/docs/reference/sources/stdin.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -54,7 +50,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -69,7 +65,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/stdin.md
+++ b/website/docs/reference/sources/stdin.md
@@ -81,6 +81,7 @@ import Field from '@site/src/components/Field';
   defaultValue={"host"}
   enumValues={null}
   examples={["host"]}
+  groups={[]}
   name={"host_key"}
   path={null}
   relevantWhen={null}
@@ -103,6 +104,7 @@ The key name added to each event representing the current host. This can also be
   defaultValue={102400}
   enumValues={null}
   examples={[102400]}
+  groups={[]}
   name={"max_length"}
   path={null}
   relevantWhen={null}
@@ -154,6 +156,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -177,6 +180,7 @@ The local hostname.
   defaultValue={null}
   enumValues={null}
   examples={["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -200,6 +204,7 @@ The raw message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -89,6 +89,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0:9000","systemd","systemd#2"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={{"mode":["tcp","udp"]}}
@@ -111,6 +112,7 @@ The TCP or UDP address to listen for connections on, or "systemd#N" to use the N
   defaultValue={"host"}
   enumValues={null}
   examples={["host"]}
+  groups={[]}
   name={"host_key"}
   path={null}
   relevantWhen={null}
@@ -133,6 +135,7 @@ The key name added to each event representing the current host. This can also be
   defaultValue={102400}
   enumValues={null}
   examples={[102400]}
+  groups={[]}
   name={"max_length"}
   path={null}
   relevantWhen={null}
@@ -155,6 +158,7 @@ The maximum bytes size of incoming messages before they are discarded.
   defaultValue={null}
   enumValues={{"tcp":"Read incoming Syslog data over the TCP protocol.","udp":"Read incoming Syslog data over the UDP protocol.","unix":"Read uncoming Syslog data through a Unix socker."}}
   examples={["tcp","udp","unix"]}
+  groups={[]}
   name={"mode"}
   path={null}
   relevantWhen={null}
@@ -177,6 +181,7 @@ The input mode.
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/socket"]}
+  groups={[]}
   name={"path"}
   path={null}
   relevantWhen={{"mode":"unix"}}
@@ -225,6 +230,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["app-name"]}
+  groups={[]}
   name={"appname"}
   path={null}
   relevantWhen={null}
@@ -247,6 +253,7 @@ The appname extracted from the Syslog formatted line. If a appname is not found,
   defaultValue={null}
   enumValues={null}
   examples={["1"]}
+  groups={[]}
   name={"facility"}
   path={null}
   relevantWhen={null}
@@ -269,6 +276,7 @@ The facility extracted from the Syslog line. If a facility is not found, then th
   defaultValue={null}
   enumValues={null}
   examples={["my.host.com"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -291,6 +299,7 @@ The hostname extracted from the  Syslog line. If a hostname is not found, then V
   defaultValue={null}
   enumValues={null}
   examples={["<13>Feb 13 20:07:26 74794bfb6795 root[8539]: i am foobar"]}
+  groups={[]}
   name={"message"}
   path={null}
   relevantWhen={null}
@@ -314,6 +323,7 @@ The raw message, unaltered.
   defaultValue={null}
   enumValues={null}
   examples={["ID47"]}
+  groups={[]}
   name={"msgid"}
   path={null}
   relevantWhen={null}
@@ -336,6 +346,7 @@ The msgid extracted from the Syslog line. If a msgid is not found, then the key 
   defaultValue={null}
   enumValues={null}
   examples={[8710]}
+  groups={[]}
   name={"procid"}
   path={null}
   relevantWhen={null}
@@ -358,6 +369,7 @@ The procid extracted from the Syslog line. If a procid is not found, then the ke
   defaultValue={null}
   enumValues={null}
   examples={["notice"]}
+  groups={[]}
   name={"severity"}
   path={null}
   relevantWhen={null}
@@ -380,6 +392,7 @@ The severity extracted from the Syslog line. If a severity is not found, then th
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47+00:00"]}
+  groups={[]}
   name={"timestamp"}
   path={null}
   relevantWhen={null}
@@ -402,6 +415,7 @@ The timestamp extracted from the incoming line. If a timestamp is not found, the
   defaultValue={null}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"version"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -28,11 +28,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -59,7 +55,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [sources.my_source_id]
@@ -77,7 +73,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -51,6 +51,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["0.0.0.0:9000","systemd","systemd#1"]}
+  groups={[]}
   name={"address"}
   path={null}
   relevantWhen={null}
@@ -74,6 +75,7 @@ The TCP address to listen for connections on, or `systemd#N to use the Nth socke
   defaultValue={30}
   enumValues={null}
   examples={[30]}
+  groups={[]}
   name={"shutdown_timeout_secs"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -70,12 +70,34 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # REQUIRED - Input
   [tests.input]
-    # REQUIRED
+    # REQUIRED - General
     type = "raw" # example, enum
     insert_at = "foo" # example
 
-    # OPTIONAL
+    # OPTIONAL - General
     value = "some message contents" # example, no default, relevant when type = "raw"
+
+    # OPTIONAL - Log fields
+    [tests.input.log_fields]
+      message = "some message contents" # example
+      host = "myhost" # example
+
+    # OPTIONAL - Metric
+    [tests.input.metric]
+      # REQUIRED - General
+      type = "counter" # example, enum
+      name = "duration_total" # example
+      timestamp = "2019-11-01T21:15:47.443232Z" # example
+      val = 10.2 # example
+
+      # OPTIONAL - General
+      direction = "plus" # example, no default, enum
+      sample_rate = 1 # example, no default
+
+      # OPTIONAL - Tags
+      [tests.input.metric.tags]
+        host = "foohost" # example
+        region = "us-east-1" # example
 ```
 
 </TabItem>

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -181,6 +181,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"input"}
   path={null}
   relevantWhen={null}
@@ -202,6 +203,7 @@ A table that defines a unit test input event.
   defaultValue={null}
   enumValues={null}
   examples={["foo"]}
+  groups={[]}
   name={"insert_at"}
   path={"input"}
   relevantWhen={null}
@@ -224,6 +226,7 @@ The name of a transform, the input event will be delivered to this transform in 
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"log_fields"}
   path={"input"}
   relevantWhen={{"type":"log"}}
@@ -245,6 +248,7 @@ Specifies the log fields when the input type is 'log'.
   defaultValue={null}
   enumValues={null}
   examples={[{"message":"some message contents"},{"host":"myhost"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"input.log_fields"}
   relevantWhen={null}
@@ -272,6 +276,7 @@ A key/value pair representing a field to be added to the input event.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"metric"}
   path={"input"}
   relevantWhen={{"type":"metric"}}
@@ -293,6 +298,7 @@ Specifies the metric type when the input type is 'metric'.
   defaultValue={null}
   enumValues={{"plus":"Increase the gauge","minus":"Decrease the gauge"}}
   examples={["plus","minus"]}
+  groups={[]}
   name={"direction"}
   path={"input.metric"}
   relevantWhen={null}
@@ -315,6 +321,7 @@ The direction to increase or decrease the gauge value.
   defaultValue={null}
   enumValues={null}
   examples={["duration_total"]}
+  groups={[]}
   name={"name"}
   path={"input.metric"}
   relevantWhen={null}
@@ -337,6 +344,7 @@ The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` 
   defaultValue={null}
   enumValues={null}
   examples={[1]}
+  groups={[]}
   name={"sample_rate"}
   path={"input.metric"}
   relevantWhen={null}
@@ -359,6 +367,7 @@ The bucket/distribution the metric is a part of.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tags"}
   path={"input.metric"}
   relevantWhen={null}
@@ -380,6 +389,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags].
   defaultValue={null}
   enumValues={null}
   examples={[{"host":"foohost"},{"region":"us-east-1"}]}
+  groups={[]}
   name={"`[tag-name]`"}
   path={"input.metric.tags"}
   relevantWhen={null}
@@ -407,6 +417,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags].
   defaultValue={null}
   enumValues={null}
   examples={["2019-11-01T21:15:47.443232Z"]}
+  groups={[]}
   name={"timestamp"}
   path={"input.metric"}
   relevantWhen={null}
@@ -429,6 +440,7 @@ Time metric was created/ingested.
   defaultValue={null}
   enumValues={{"counter":"A [counter metric type][docs.data-model.metric#counter].","gauge":"A [gauge metric type][docs.data-model.metric#gauge].","histogram":"A [distribution metric type][docs.data-model.metric#distribution].","set":"A [set metric type][docs.data-model.metric#set]."}}
   examples={["counter"]}
+  groups={[]}
   name={"type"}
   path={"input.metric"}
   relevantWhen={null}
@@ -451,6 +463,7 @@ The metric type.
   defaultValue={null}
   enumValues={null}
   examples={[10.2]}
+  groups={[]}
   name={"val"}
   path={"input.metric"}
   relevantWhen={null}
@@ -478,6 +491,7 @@ Amount to increment/decrement or gauge.
   defaultValue={null}
   enumValues={{"raw":"Creates a log event where the message contents are specified in the field 'value'.","log":"Creates a log event where log fields are specified in the table 'log_fields'.","metric":"Creates a metric event, where its type and fields are specified in the table 'metric'."}}
   examples={["raw","log","metric"]}
+  groups={[]}
   name={"type"}
   path={"input"}
   relevantWhen={null}
@@ -500,6 +514,7 @@ The event type.
   defaultValue={null}
   enumValues={null}
   examples={["some message contents"]}
+  groups={[]}
   name={"value"}
   path={"input"}
   relevantWhen={{"type":"raw"}}
@@ -527,6 +542,7 @@ Specifies the log message field contents when the input type is 'raw'.
   defaultValue={null}
   enumValues={null}
   examples={["foo test"]}
+  groups={[]}
   name={"name"}
   path={null}
   relevantWhen={null}
@@ -549,6 +565,7 @@ A unique identifier for this test.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"outputs"}
   path={null}
   relevantWhen={null}
@@ -570,6 +587,7 @@ A table that defines a unit test expected output.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"conditions"}
   path={"outputs"}
   relevantWhen={null}
@@ -591,6 +609,7 @@ A table that defines a collection of conditions to check against the output of a
   defaultValue={null}
   enumValues={null}
   examples={[{"message.eq":"this is the content to match against"}]}
+  groups={[]}
   name={"`<field_name>`.eq"}
   path={"outputs.conditions"}
   relevantWhen={null}
@@ -613,6 +632,7 @@ Check whether a fields contents exactly matches the value specified.
   defaultValue={null}
   enumValues={null}
   examples={[{"host.exists":true}]}
+  groups={[]}
   name={"`<field_name>`.exists"}
   path={"outputs.conditions"}
   relevantWhen={null}
@@ -635,6 +655,7 @@ Check whether a field exists or does not exist, depending on the provided valueb
   defaultValue={null}
   enumValues={null}
   examples={[{"method.neq":"POST"}]}
+  groups={[]}
   name={"`<field_name>`.neq"}
   path={"outputs.conditions"}
   relevantWhen={null}
@@ -657,6 +678,7 @@ Check whether a fields contents does not match the value specified.
   defaultValue={null}
   enumValues={null}
   examples={["check_fields"]}
+  groups={[]}
   name={"type"}
   path={"outputs.conditions"}
   relevantWhen={null}
@@ -684,6 +706,7 @@ The type of the condition to execute. Currently only the `check_fields` type is 
   defaultValue={null}
   enumValues={null}
   examples={["foo"]}
+  groups={[]}
   name={"extract_from"}
   path={"outputs"}
   relevantWhen={null}

--- a/website/docs/reference/tests.md.erb
+++ b/website/docs/reference/tests.md.erb
@@ -35,7 +35,7 @@ vector test /etc/vector/*.toml
   type = "regex_parser"
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
 
-<%= config_example(metadata.tests.children_list, path: "tests", array: true, common: true) %>
+<%= config_example(metadata.tests.children_list.select(&:common?), path: "tests", array: true) %>
 ```
 
 </TabItem>
@@ -48,7 +48,7 @@ vector test /etc/vector/*.toml
   type = "regex_parser"
   regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
 
-<%= config_example(metadata.tests.children_list, path: "tests", array: true, common: false) %>
+<%= config_example(metadata.tests.children_list, path: "tests", array: true) %>
 ```
 
 </TabItem>

--- a/website/docs/reference/transforms/add_fields.md
+++ b/website/docs/reference/transforms/add_fields.md
@@ -56,6 +56,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"fields"}
   path={null}
   relevantWhen={null}
@@ -77,6 +78,7 @@ A table of key/value pairs representing the keys to be added to the event.
   defaultValue={null}
   enumValues={null}
   examples={[{"string_field":"string value"},{"env_var_field":"${ENV_VAR}"},{"int_field":1},{"float_field":1.2},{"bool_field":true},{"timestamp_field":"1979-05-27 00:32:00 -0700"},{"parent":{"child":"child_value"}},{"list_field":["first","second","third"]}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"fields"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/add_tags.md
+++ b/website/docs/reference/transforms/add_tags.md
@@ -50,6 +50,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tags"}
   path={null}
   relevantWhen={null}
@@ -71,6 +72,7 @@ A table of key/value pairs representing the tags to be added to the metric.
   defaultValue={null}
   enumValues={null}
   examples={[{"static_tag":"my value"},{"env_tag":"${ENV_VAR}"}]}
+  groups={[]}
   name={"`[tag-name]`"}
   path={"tags"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/ansi_stripper.md
+++ b/website/docs/reference/transforms/ansi_stripper.md
@@ -48,6 +48,7 @@ import Field from '@site/src/components/Field';
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/aws_ec2_metadata.md
+++ b/website/docs/reference/transforms/aws_ec2_metadata.md
@@ -51,6 +51,7 @@ import Field from '@site/src/components/Field';
   defaultValue={["instance-id","local-hostname","local-ipv4","public-hostname","public-ipv4","ami-id","availability-zone","vpc-id","subnet-id","region"]}
   enumValues={null}
   examples={[["instance-id","local-hostname","local-ipv4","public-hostname","public-ipv4","ami-id","availability-zone","vpc-id","subnet-id","region"]]}
+  groups={[]}
   name={"fields"}
   path={null}
   relevantWhen={null}
@@ -73,6 +74,7 @@ A list of fields to include in each event.
   defaultValue={"http://169.254.169.254"}
   enumValues={null}
   examples={["http://169.254.169.254"]}
+  groups={[]}
   name={"host"}
   path={null}
   relevantWhen={null}
@@ -95,6 +97,7 @@ Override the default EC2 Metadata host.
   defaultValue={""}
   enumValues={null}
   examples={[""]}
+  groups={[]}
   name={"namespace"}
   path={null}
   relevantWhen={null}
@@ -117,6 +120,7 @@ Prepend a namespace to each field's key.
   defaultValue={10}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"refresh_interval_secs"}
   path={null}
   relevantWhen={null}
@@ -166,6 +170,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={["ami-00068cd7555f543d5"]}
+  groups={[]}
   name={"ami-id"}
   path={null}
   relevantWhen={null}
@@ -188,6 +193,7 @@ The `ami-id` that the current EC2 instance is using.
   defaultValue={null}
   enumValues={null}
   examples={["54.234.246.107"]}
+  groups={[]}
   name={"availability-zone"}
   path={null}
   relevantWhen={null}
@@ -210,6 +216,7 @@ The `availability-zone` that the current EC2 instance is running in.
   defaultValue={null}
   enumValues={null}
   examples={["i-096fba6d03d36d262"]}
+  groups={[]}
   name={"instance-id"}
   path={null}
   relevantWhen={null}
@@ -232,6 +239,7 @@ The `instance-id` of the current EC2 instance.
   defaultValue={null}
   enumValues={null}
   examples={["ip-172-31-93-227.ec2.internal"]}
+  groups={[]}
   name={"local-hostname"}
   path={null}
   relevantWhen={null}
@@ -254,6 +262,7 @@ The `local-hostname` of the current EC2 instance.
   defaultValue={null}
   enumValues={null}
   examples={["172.31.93.227"]}
+  groups={[]}
   name={"local-ipv4"}
   path={null}
   relevantWhen={null}
@@ -276,6 +285,7 @@ The `local-ipv4` of the current EC2 instance.
   defaultValue={null}
   enumValues={null}
   examples={["ec2-54-234-246-107.compute-1.amazonaws.com"]}
+  groups={[]}
   name={"public-hostname"}
   path={null}
   relevantWhen={null}
@@ -298,6 +308,7 @@ The `public-hostname` of the current EC2 instance.
   defaultValue={null}
   enumValues={null}
   examples={["54.234.246.107"]}
+  groups={[]}
   name={"public-ipv4"}
   path={null}
   relevantWhen={null}
@@ -320,6 +331,7 @@ The `public-ipv4` of the current EC2 instance.
   defaultValue={null}
   enumValues={null}
   examples={["us-east-1"]}
+  groups={[]}
   name={"region"}
   path={null}
   relevantWhen={null}
@@ -342,6 +354,7 @@ The [`region`](#region) that the current EC2 instance is running in.
   defaultValue={null}
   enumValues={null}
   examples={["some_iam_role"]}
+  groups={[]}
   name={"role-name"}
   path={null}
   relevantWhen={null}
@@ -364,6 +377,7 @@ The `role-name` that the current EC2 instance is using.
   defaultValue={null}
   enumValues={null}
   examples={["subnet-9d6713b9"]}
+  groups={[]}
   name={"subnet-id"}
   path={null}
   relevantWhen={null}
@@ -386,6 +400,7 @@ The `subnet-id` of the current EC2 instance's default network interface.
   defaultValue={null}
   enumValues={null}
   examples={["vpc-a51da4dc"]}
+  groups={[]}
   name={"vpc-id"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -25,11 +25,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -57,7 +53,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [transforms.my_transform_id]
@@ -78,7 +74,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -90,6 +90,7 @@ import Field from '@site/src/components/Field';
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"drop_unspecified"}
   path={null}
   relevantWhen={null}
@@ -112,6 +113,7 @@ Set to `true` to drop all fields that are not specified in the [`types`](#types)
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -133,6 +135,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/concat.md
+++ b/website/docs/reference/transforms/concat.md
@@ -50,6 +50,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["first[..3]","second[-5..]","third[3..6]"]]}
+  groups={[]}
   name={"items"}
   path={null}
   relevantWhen={null}
@@ -72,6 +73,7 @@ A list of substring definitons in the format of source_field[start..end]. For bo
   defaultValue={" "}
   enumValues={null}
   examples={[" ",",","_","+"]}
+  groups={[]}
   name={"joiner"}
   path={null}
   relevantWhen={null}
@@ -94,6 +96,7 @@ The string that is used to join all items.
   defaultValue={null}
   enumValues={null}
   examples={["dest_field_name"]}
+  groups={[]}
   name={"target"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/field_filter.md
+++ b/website/docs/reference/transforms/field_filter.md
@@ -46,6 +46,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["file"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -68,6 +69,7 @@ The target log field to compare against the [`value`](#value).
   defaultValue={null}
   enumValues={null}
   examples={["/var/log/nginx.log"]}
+  groups={[]}
   name={"value"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/geoip.md
+++ b/website/docs/reference/transforms/geoip.md
@@ -50,6 +50,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={["/path/to/GeoLite2-City.mmdb"]}
+  groups={[]}
   name={"database"}
   path={null}
   relevantWhen={null}
@@ -73,6 +74,7 @@ Path to the MaxMind GeoIP2 or GeoLite2 binary city database file (`GeoLite2-City
   defaultValue={null}
   enumValues={null}
   examples={["ip_address","x-forwarded-for"]}
+  groups={[]}
   name={"source"}
   path={null}
   relevantWhen={null}
@@ -95,6 +97,7 @@ The field name that contains the IP address. This field should contain a valid I
   defaultValue={"geoip"}
   enumValues={null}
   examples={["geoip"]}
+  groups={[]}
   name={"target"}
   path={null}
   relevantWhen={null}
@@ -142,6 +145,7 @@ More detail on the output schema is below.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"geoip"}
   path={null}
   relevantWhen={null}
@@ -163,6 +167,7 @@ The root field containing all geolocation data as sub-fields.
   defaultValue={null}
   enumValues={null}
   examples={["New York","Brooklyn","Chicago"]}
+  groups={[]}
   name={"city_name"}
   path={"geoip"}
   relevantWhen={null}
@@ -185,6 +190,7 @@ The city name associated with the IP address.
   defaultValue={null}
   enumValues={{"AF":"Africa","AN":"Antarctica","AS":"Asia","EU":"Europe","NA":"North America","OC":"Oceania","SA":"South America"}}
   examples={["AF","AN","AS","EU","NA","OC","SA"]}
+  groups={[]}
   name={"continent_code"}
   path={"geoip"}
   relevantWhen={null}
@@ -207,6 +213,7 @@ The continent code associated with the IP address.
   defaultValue={null}
   enumValues={null}
   examples={["US","US-PR","FR","FR-BL","GB","A1","A2"]}
+  groups={[]}
   name={"country_code"}
   path={"geoip"}
   relevantWhen={null}
@@ -229,6 +236,7 @@ The [ISO 3166-2 country codes][urls.iso3166-2] associated with the IP address.
   defaultValue={null}
   enumValues={null}
   examples={["51.75"]}
+  groups={[]}
   name={"latitude"}
   path={"geoip"}
   relevantWhen={null}
@@ -251,6 +259,7 @@ The latitude associated with the IP address.
   defaultValue={null}
   enumValues={null}
   examples={["-1.25"]}
+  groups={[]}
   name={"longitude"}
   path={"geoip"}
   relevantWhen={null}
@@ -273,6 +282,7 @@ The longitude associated with the IP address.
   defaultValue={null}
   enumValues={null}
   examples={["07094","10010","OX1"]}
+  groups={[]}
   name={"postal_code"}
   path={"geoip"}
   relevantWhen={null}
@@ -295,6 +305,7 @@ The postal code associated with the IP address.
   defaultValue={null}
   enumValues={null}
   examples={["America/New_York","Asia/Atyrau","Europe/London"]}
+  groups={[]}
   name={"timezone"}
   path={"geoip"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -58,6 +58,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -80,6 +81,7 @@ If `true` will drop the specified [`field`](#field) after parsing.
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -102,6 +104,7 @@ The log field to execute the [`pattern`](#pattern) against. Must be a `string` v
   defaultValue={null}
   enumValues={null}
   examples={["%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"]}
+  groups={[]}
   name={"pattern"}
   path={null}
   relevantWhen={null}
@@ -124,6 +127,7 @@ The [Grok pattern][urls.grok_patterns]
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -145,6 +149,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/json_parser.md
+++ b/website/docs/reference/transforms/json_parser.md
@@ -25,11 +25,7 @@ import Tabs from '@theme/Tabs';
 <Tabs
   block={true}
   defaultValue="common"
-  values={[
-    { label: 'Common', value: 'common', },
-    { label: 'Advanced', value: 'advanced', },
-  ]
-}>
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
 
 import TabItem from '@theme/TabItem';
 
@@ -54,7 +50,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 </TabItem>
 <TabItem value="advanced">
 
-<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/" />
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
 
 ```toml
 [transforms.my_transform_id]
@@ -71,7 +67,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Options

--- a/website/docs/reference/transforms/json_parser.md
+++ b/website/docs/reference/transforms/json_parser.md
@@ -83,6 +83,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -105,6 +106,7 @@ If the specified [`field`](#field) should be dropped (removed) after parsing.
   defaultValue={null}
   enumValues={null}
   examples={[true]}
+  groups={[]}
   name={"drop_invalid"}
   path={null}
   relevantWhen={null}
@@ -127,6 +129,7 @@ If `true` events with invalid JSON will be dropped, otherwise the event will be 
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -149,6 +152,7 @@ The log field to decode as JSON. Must be a `string` value type. See [Invalid JSO
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"overwrite_target"}
   path={null}
   relevantWhen={null}
@@ -171,6 +175,7 @@ If [`target_field`](#target_field) is set and the log contains a field of the sa
   defaultValue={null}
   enumValues={null}
   examples={["target"]}
+  groups={[]}
   name={"target_field"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/log_to_metric.md
+++ b/website/docs/reference/transforms/log_to_metric.md
@@ -51,6 +51,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"metrics"}
   path={null}
   relevantWhen={null}
@@ -72,6 +73,7 @@ A table of key/value pairs representing the keys to be added to the event.
   defaultValue={null}
   enumValues={null}
   examples={["duration"]}
+  groups={[]}
   name={"field"}
   path={"metrics"}
   relevantWhen={null}
@@ -94,6 +96,7 @@ The log field to use as the metric. See [Null Fields](#null-fields) for more inf
   defaultValue={false}
   enumValues={null}
   examples={[false,true]}
+  groups={[]}
   name={"increment_by_value"}
   path={"metrics"}
   relevantWhen={{"type":"counter"}}
@@ -116,6 +119,7 @@ If `true` the metric will be incremented by the [`field`](#field) value. If `fal
   defaultValue={null}
   enumValues={null}
   examples={["duration_total"]}
+  groups={[]}
   name={"name"}
   path={"metrics"}
   relevantWhen={null}
@@ -138,6 +142,7 @@ The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` 
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"tags"}
   path={"metrics"}
   relevantWhen={null}
@@ -159,6 +164,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags].
   defaultValue={null}
   enumValues={null}
   examples={[{"host":"${HOSTNAME}"},{"region":"us-east-1"},{"status":"{{status}}"}]}
+  groups={[]}
   name={"`[tag-name]`"}
   path={"metrics.tags"}
   relevantWhen={null}
@@ -186,6 +192,7 @@ Key/value pairs representing [metric tags][docs.data-model.metric#tags]. Environ
   defaultValue={null}
   enumValues={{"counter":"A [counter metric type][docs.data-model.metric#counter].","gauge":"A [gauge metric type][docs.data-model.metric#gauge].","histogram":"A [distribution metric type][docs.data-model.metric#distribution].","set":"A [set metric type][docs.data-model.metric#set]."}}
   examples={["counter","gauge","histogram","set"]}
+  groups={[]}
   name={"type"}
   path={"metrics"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/logfmt_parser.md
+++ b/website/docs/reference/transforms/logfmt_parser.md
@@ -57,6 +57,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -79,6 +80,7 @@ If the specified [`field`](#field) should be dropped (removed) after parsing.
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -101,6 +103,7 @@ The log field to parse.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -122,6 +125,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/lua.md
+++ b/website/docs/reference/transforms/lua.md
@@ -59,6 +59,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["/etc/vector/lua"]]}
+  groups={[]}
   name={"search_dirs"}
   path={null}
   relevantWhen={null}
@@ -81,6 +82,7 @@ A list of directories search when loading a Lua file via the `require` function.
   defaultValue={null}
   enumValues={null}
   examples={["require(\"script\") # a `script.lua` file must be in your [`search_dirs`](#search_dirs)\n\nif event[\"host\"] == nil then\n  local f = io.popen (\"/bin/hostname\")\n  local hostname = f:read(\"*a\") or \"\"\n  f:close()\n  hostname = string.gsub(hostname, \"\\n$\", \"\")\n  event[\"host\"] = hostname\nend"]}
+  groups={[]}
   name={"source"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/merge.md
+++ b/website/docs/reference/transforms/merge.md
@@ -50,6 +50,7 @@ import Field from '@site/src/components/Field';
   defaultValue={["message"]}
   enumValues={null}
   examples={[["message"]]}
+  groups={[]}
   name={"merge_fields"}
   path={null}
   relevantWhen={null}
@@ -72,6 +73,7 @@ Fields to merge. The values of these fields will be merged into the first partia
   defaultValue={"_partial"}
   enumValues={null}
   examples={["_partial"]}
+  groups={[]}
   name={"partial_event_marker_field"}
   path={null}
   relevantWhen={null}
@@ -94,6 +96,7 @@ The field that indicates that the event is partial. A consequent stream of parti
   defaultValue={[]}
   enumValues={null}
   examples={[[]]}
+  groups={[]}
   name={"stream_discriminant_fields"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -58,6 +58,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -80,6 +81,7 @@ If the specified [`field`](#field) should be dropped (removed) after parsing.
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -102,6 +104,7 @@ The log field to parse. See [Failed Parsing](#failed-parsing) for more info.
   defaultValue={null}
   enumValues={null}
   examples={["^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"]}
+  groups={[]}
   name={"regex"}
   path={null}
   relevantWhen={null}
@@ -124,6 +127,7 @@ The Regular Expression to apply. Do not include the leading or trailing `/`. See
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -145,6 +149,7 @@ Key/Value pairs representing mapped log field types. See [Regex Syntax](#regex-s
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/remove_fields.md
+++ b/website/docs/reference/transforms/remove_fields.md
@@ -45,6 +45,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["field1","field2"]]}
+  groups={[]}
   name={"fields"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/remove_tags.md
+++ b/website/docs/reference/transforms/remove_tags.md
@@ -45,6 +45,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["tag1","tag2"]]}
+  groups={[]}
   name={"tags"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/sampler.md
+++ b/website/docs/reference/transforms/sampler.md
@@ -49,6 +49,7 @@ import Field from '@site/src/components/Field';
   defaultValue={null}
   enumValues={null}
   examples={[["[error]","field2"]]}
+  groups={[]}
   name={"pass_list"}
   path={null}
   relevantWhen={null}
@@ -71,6 +72,7 @@ A list of regular expression patterns to exclude events from sampling. If an eve
   defaultValue={null}
   enumValues={null}
   examples={[10]}
+  groups={[]}
   name={"rate"}
   path={null}
   relevantWhen={null}

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -59,6 +59,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -81,6 +82,7 @@ If `true` the [`field`](#field) will be dropped after parsing.
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -103,6 +105,7 @@ The field to apply the split on.
   defaultValue={null}
   enumValues={null}
   examples={[["timestamp","level","message"]]}
+  groups={[]}
   name={"field_names"}
   path={null}
   relevantWhen={null}
@@ -125,6 +128,7 @@ The field names assigned to the resulting tokens, in order.
   defaultValue={"whitespace"}
   enumValues={null}
   examples={[","]}
+  groups={[]}
   name={"separator"}
   path={null}
   relevantWhen={null}
@@ -147,6 +151,7 @@ The separator to split the field on. If no separator is given, it will split on 
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -168,6 +173,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -58,6 +58,7 @@ import Field from '@site/src/components/Field';
   defaultValue={true}
   enumValues={null}
   examples={[true,false]}
+  groups={[]}
   name={"drop_field"}
   path={null}
   relevantWhen={null}
@@ -80,6 +81,7 @@ If `true` the [`field`](#field) will be dropped after parsing.
   defaultValue={"message"}
   enumValues={null}
   examples={["message"]}
+  groups={[]}
   name={"field"}
   path={null}
   relevantWhen={null}
@@ -102,6 +104,7 @@ The log field to tokenize.
   defaultValue={null}
   enumValues={null}
   examples={[["timestamp","level","message"]]}
+  groups={[]}
   name={"field_names"}
   path={null}
   relevantWhen={null}
@@ -124,6 +127,7 @@ The log field names assigned to the resulting tokens, in order.
   defaultValue={null}
   enumValues={null}
   examples={[]}
+  groups={[]}
   name={"types"}
   path={null}
   relevantWhen={null}
@@ -145,6 +149,7 @@ Key/Value pairs representing mapped log field types.
   defaultValue={null}
   enumValues={{"bool":"Coerces `\"true\"`/`/\"false\"`, `\"1\"`/`\"0\"`, and `\"t\"`/`\"f\"` values into boolean.","float":"Coerce to a 64 bit float.","int":"Coerce to a 64 bit integer.","string":"Coerce to a string.","timestamp":"Coerces to a Vector timestamp. [`strptime` specificiers][urls.strptime_specifiers] must be used to parse the string."}}
   examples={[{"status":"int"},{"duration":"float"},{"success":"bool"},{"timestamp":"timestamp|%F"},{"timestamp":"timestamp|%a %b %e %T %Y"}]}
+  groups={[]}
   name={"`[field-name]`"}
   path={"types"}
   relevantWhen={null}

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -17371,7 +17371,7 @@ module.exports = {
     },
     "influxdb_metrics": {
       "beta": true,
-      "delivery_guarantee": "best_effort",
+      "delivery_guarantee": "at_least_once",
       "description": "Batches metric events to [InfluxDB][urls.influxdb] using [v1][urls.influxdb_http_api_v1] or [v2][urls.influxdb_http_api_v2] HTTP API.",
       "event_types": [
         "metric"

--- a/website/src/components/CheckboxList/index.js
+++ b/website/src/components/CheckboxList/index.js
@@ -30,7 +30,7 @@ function CheckboxList({humanize, icon, values, currentState, setState}) {
                 setState(newValues);
               }}
               checked={currentState.has(value)} />
-            {icon ? <i className={`feather icon-${icon}`}></i> : ''} {label}
+            {label && <>{icon ? <i className={`feather icon-${icon}`}></i> : ''} {label}</>}
           </label>
         );
       })}

--- a/website/src/components/Field/index.js
+++ b/website/src/components/Field/index.js
@@ -153,7 +153,7 @@ function Field({children, common, defaultValue, enumValues, examples, groups, na
   return (
     <div className={classnames('field', 'section', (required ? 'field-required' : ''), (collapse ? 'field-collapsed' : ''))} required={required}>
       <div className="badges">
-        {groups.map((group, idx) => <span key={idx} className="badge badge--secondary">{group}</span>)}
+        {groups && groups.map((group, idx) => <span key={idx} className="badge badge--secondary">{group}</span>)}
         {templateable && <span className="badge badge--primary" title="This option is dynamic and accepts the Vector template syntax">templateable</span>}
         <span className="badge badge--secondary">{type}{unit && <> ({unit})</>}</span>
         {enumValues && Object.keys(enumValues).length > 0 && <span className="badge badge--secondary" title="This option is an enumation and only allows specific values">enum</span>}

--- a/website/src/components/Field/index.js
+++ b/website/src/components/Field/index.js
@@ -85,6 +85,17 @@ function Examples({name, path, values}) {
   );
 }
 
+function Groups({values}) {
+  let elements = [];
+
+  values.forEach(function (value) {
+    elements.push(<code key={value}>{value}</code>);
+    elements.push(" ");
+  })
+
+  return elements;
+}
+
 function RelevantWhen({value}) {
   let relKey = Object.keys(value)[0];
   let relValue = Object.values(value)[0];
@@ -100,10 +111,10 @@ function RelevantWhen({value}) {
   );
 }
 
-function FieldFooter({defaultValue, enumValues, examples, name, path, relevantWhen, unit}) {
+function FieldFooter({defaultValue, enumValues, examples, groups, name, path, relevantWhen, unit}) {
   const [showExamples, setShowExamples] = useState(false);
 
-  if (defaultValue || enumValues || (examples && examples.length > 0)) {
+  if (defaultValue || enumValues || (examples && examples.length > 0) || (groups && groups.length > 0)) {
     return (
       <div className="info">
         {defaultValue !== undefined ?
@@ -130,7 +141,7 @@ function FieldFooter({defaultValue, enumValues, examples, name, path, relevantWh
   }
 }
 
-function Field({children, common, defaultValue, enumValues, examples, name, path, relevantWhen, templateable, type, unit, required}) {
+function Field({children, common, defaultValue, enumValues, examples, groups, name, path, relevantWhen, templateable, type, unit, required}) {
   const [collapse, setCollapse] = useState(false);
 
   let filteredChildren = children;
@@ -142,18 +153,26 @@ function Field({children, common, defaultValue, enumValues, examples, name, path
   return (
     <div className={classnames('field', 'section', (required ? 'field-required' : ''), (collapse ? 'field-collapsed' : ''))} required={required}>
       <div className="badges">
-        {common && <span className="badge badge--primary" title="This is a popular that we recommend for getting started">common</span>}
+        {groups.map((group, idx) => <span key={idx} className="badge badge--secondary">{group}</span>)}
         {templateable && <span className="badge badge--primary" title="This option is dynamic and accepts the Vector template syntax">templateable</span>}
-        <span className="badge badge--secondary">{type}</span>
+        <span className="badge badge--secondary">{type}{unit && <> ({unit})</>}</span>
         {enumValues && Object.keys(enumValues).length > 0 && <span className="badge badge--secondary" title="This option is an enumation and only allows specific values">enum</span>}
-        {unit && <span className="badge badge--secondary">{unit}</span>}
+        {common && <span className="badge badge--primary" title="This is a popular that we recommend for getting started">common</span>}
         {required ?
           <span className="badge badge--danger">required</span> :
           <span className="badge badge--secondary">optional</span>}
       </div>
       {filteredChildren}
-      {!collapse &&
-        <FieldFooter defaultValue={defaultValue} enumValues={enumValues} examples={examples} name={name} path={path} relevantWhen={relevantWhen} unit={unit} />}
+      {!collapse && type != "table" &&
+        <FieldFooter
+          defaultValue={defaultValue}
+          enumValues={enumValues}
+          examples={examples}
+          groups={groups}
+          name={name}
+          path={path}
+          relevantWhen={relevantWhen}
+          unit={unit} />}
     </div>
   );
 }

--- a/website/src/components/Fields/index.js
+++ b/website/src/components/Fields/index.js
@@ -1,9 +1,14 @@
 import React, {useState} from 'react';
 
+import CheckboxList from '@site/src/components/CheckboxList';
+
+import _ from 'lodash';
+
 import './styles.css';
 
 function Fields({children, filters}) {
   const [onlyCommon, setOnlyCommon] = useState(false);
+  const [onlyGroups, setOnlyGroups] = useState(new Set());
   const [onlyRequired, setOnlyRequired] = useState(false);
   const [searchTerm, setSearchTerm] = useState(null);
 
@@ -14,11 +19,16 @@ function Fields({children, filters}) {
   }
 
   let commonRelevant = childrenArray.some(child => child.props.common);
+  let groups = _(childrenArray).flatMap(child => child.props.groups).uniq().value();
   let requiredRelevant = childrenArray.some(child => child.props.required);
   let filteredChildren = childrenArray;
 
   if (onlyCommon) {
     filteredChildren = filteredChildren.filter(child => child.props.common);
+  }
+
+  if (onlyGroups.size > 0) {
+    filteredChildren = filteredChildren.filter(child => Array.from(onlyGroups).every(group => child.props.groups.includes(group)));
   }
 
   if (onlyRequired) {
@@ -43,6 +53,10 @@ function Fields({children, filters}) {
               placeholder="🔍 Search..." />
           </div>
           <div className="checkboxes">
+            <CheckboxList
+              values={groups}
+              currentState={onlyGroups}
+              setState={setOnlyGroups} />
             {commonRelevant && (
               <label title="Only show popular/common results">
               <input

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -49,12 +49,12 @@ function Statuses({deliveryGuarantee, minVersion, operatingSystems, status, unsu
   let operatingSystemsEls = [];
 
   (operatingSystems || []).forEach(operatingSystem => {
-    operatingSystemsEls.push(<span className="text--primary">{operatingSystem}</span>);
+    operatingSystemsEls.push(<span key={operatingSystem} className="text--primary">{operatingSystem}</span>);
     operatingSystemsEls.push(<>, </>);
   });
 
   (unsupportedOperatingSystems || []).forEach(operatingSystem => {
-    operatingSystemsEls.push(<del className="text--warning">{operatingSystem}</del>);
+    operatingSystemsEls.push(<del key={operatingSystem} className="text--warning">{operatingSystem}</del>);
     operatingSystemsEls.push(<>, </>);
   });
 

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -42,7 +42,7 @@ function Headings({headings, isChild}) {
   );
 }
 
-function Statuses({status, deliveryGuarantee, operatingSystems, unsupportedOperatingSystems}) {
+function Statuses({deliveryGuarantee, minVersion, operatingSystems, status, unsupportedOperatingSystems}) {
   if (!status && !deliveryGuarantee && !operatingSystems && !unsupportedOperatingSystems)
     return null;
 
@@ -87,6 +87,10 @@ function Statuses({status, deliveryGuarantee, operatingSystems, unsupportedOpera
             <i className="feather icon-shield"></i> at-least-once
           </Link>
         </div>}
+      {minVersion &&
+        <div>
+          <i className="feather icon-key"></i> >= {minVersion}
+        </div>}
       {operatingSystemsEls.length > 0 &&
         <div>
           <Link to="/docs/setup/installation/operating-systems/" title={`This component works on the ${operatingSystems.join(", ")} operating systems.`}>
@@ -121,6 +125,7 @@ function DocItem(props) {
       hide_title: hideTitle,
       hide_table_of_contents: hideTableOfContents,
       issues_url: issuesUrl,
+      min_version: minVersion,
       operating_systems: operatingSystems,
       posts_path: postsPath,
       source_url: sourceUrl,
@@ -187,7 +192,12 @@ function DocItem(props) {
             {DocContent.rightToc && (
               <div className="col col--3">
                 <div className="table-of-contents">
-                  <Statuses status={status} deliveryGuarantee={deliveryGuarantee} operatingSystems={operatingSystems} unsupportedOperatingSystems={unsupportedOperatingSystems} />
+                  <Statuses
+                    deliveryGuarantee={deliveryGuarantee}
+                    minVersion={minVersion}
+                    operatingSystems={operatingSystems}
+                    status={status}
+                    unsupportedOperatingSystems={unsupportedOperatingSystems} />
                   {DocContent.rightToc.length > 0 &&
                     <div className="section">
                       <div className="title">Contents</div>


### PR DESCRIPTION
The new `influxdb_metrics` sink is unique in that it supports a group of options for v1 and v2 of influxdb. This change supports a new `groups` parameter for options in the `.meta` directory. This value controls how options are grouped and displayed to users. In other words, users will be presented with a `v1` and `v2` tab for configuration examples of this component.