### PR TITLE
fix(json_parser transform): only drop source field if JSON parse succeeds (#1861)

### DIFF
--- a/.meta/transforms/json_parser.toml
+++ b/.meta/transforms/json_parser.toml
@@ -14,7 +14,10 @@ type = "bool"
 common = true
 default = true
 required = true
-description = "If the specified `field` should be dropped (removed) after parsing."
+description = """\
+If the specified `field` should be dropped (removed) after parsing. If \
+parsing fails, the field will not be removed, irrespective of this setting.\
+"""
 
 [transforms.json_parser.options.drop_invalid]
 type = "bool"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1118,7 +1118,8 @@ dns_servers = ["0.0.0.0:53"]
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # If the specified `field` should be dropped (removed) after parsing.
+  # If the specified `field` should be dropped (removed) after parsing. If
+  # parsing fails, the field will not be removed, irrespective of this setting.
   #
   # * required
   # * default: true

--- a/website/docs/reference/transforms/json_parser.md
+++ b/website/docs/reference/transforms/json_parser.md
@@ -95,7 +95,7 @@ import Field from '@site/src/components/Field';
 
 ### drop_field
 
-If the specified [`field`](#field) should be dropped (removed) after parsing.
+If the specified [`field`](#field) should be dropped (removed) after parsing. If parsing fails, the field will not be removed, irrespective of this setting.
 
 
 </Field>


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

Fixes #1861.