### PR TITLE
feat(cli): Add `log-format` cli option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,10 +220,9 @@ fn main() {
 
     let (metrics_controller, metrics_sink) = metrics::build();
 
-    let json = match &opts.log_format {
-        Some(LogFormat::Text) => false,
-        Some(LogFormat::Json) => true,
-        None => false,
+    let json = match &opts.log_format.unwrap_or(LogFormat::Text) {
+        LogFormat::Text => false,
+        LogFormat::Json => true,
     };
 
     trace::init(

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ struct RootOpts {
     #[structopt(short, long, parse(from_occurrences))]
     quiet: u8,
 
+    /// Set the logging format. Options are "text" or "json". Defaults to "text".
+    #[structopt(long)]
+    log_format: Option<LogFormat>,
+
     /// Control when ANSI terminal formatting is used.
     ///
     /// By default `vector` will try and detect if `stdout` is a terminal, if it is
@@ -115,6 +119,12 @@ enum Color {
     Never,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
 impl std::str::FromStr for Color {
     type Err = String;
 
@@ -125,6 +135,21 @@ impl std::str::FromStr for Color {
             "never" => Ok(Color::Never),
             s => Err(format!(
                 "{} is not a valid option, expected `auto`, `always` or `never`",
+                s
+            )),
+        }
+    }
+}
+
+impl std::str::FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(LogFormat::Text),
+            "json" => Ok(LogFormat::Json),
+            s => Err(format!(
+                "{} is not a valid option, expected `text` or `json`",
                 s
             )),
         }
@@ -195,8 +220,15 @@ fn main() {
 
     let (metrics_controller, metrics_sink) = metrics::build();
 
+    let json = match &opts.log_format {
+        Some(LogFormat::Text) => false,
+        Some(LogFormat::Json) => true,
+        None => false,
+    };
+
     trace::init(
         color,
+        json,
         levels.as_str(),
         opts.metrics_addr.map(|_| metrics_sink),
     );

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -11,17 +11,32 @@ use tracing_subscriber::{layer::SubscriberExt, FmtSubscriber};
 pub use tracing_futures::Instrument;
 pub use tracing_tower::{InstrumentableService, InstrumentedService};
 
-pub fn init(color: bool, levels: &str, metrics: Option<metrics::Sink>) {
-    let subscriber = FmtSubscriber::builder()
-        .with_ansi(color)
-        .with_env_filter(levels)
-        .finish()
-        .with(Limit::default());
+pub fn init(color: bool, json: bool, levels: &str, metrics: Option<metrics::Sink>) {
+    let dispatch = if json {
+        let subscriber = FmtSubscriber::builder()
+            .with_ansi(color)
+            .with_env_filter(levels)
+            .json()
+            .finish()
+            .with(Limit::default());
 
-    let dispatch = if let Some(sink) = metrics {
-        Dispatch::new(MetricsSubscriber::new(subscriber, sink))
+        if let Some(sink) = metrics {
+            Dispatch::new(MetricsSubscriber::new(subscriber, sink))
+        } else {
+            Dispatch::new(subscriber)
+        }
     } else {
-        Dispatch::new(subscriber)
+        let subscriber = FmtSubscriber::builder()
+            .with_ansi(color)
+            .with_env_filter(levels)
+            .finish()
+            .with(Limit::default());
+
+        if let Some(sink) = metrics {
+            Dispatch::new(MetricsSubscriber::new(subscriber, sink))
+        } else {
+            Dispatch::new(subscriber)
+        }
     };
 
     let _ = LogTracer::init();

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -14,7 +14,6 @@ pub use tracing_tower::{InstrumentableService, InstrumentedService};
 pub fn init(color: bool, json: bool, levels: &str, metrics: Option<metrics::Sink>) {
     let dispatch = if json {
         let subscriber = FmtSubscriber::builder()
-            .with_ansi(color)
             .with_env_filter(levels)
             .json()
             .finish()


### PR DESCRIPTION
Example json output:

```json
{"timestamp":"Feb 20 11:28:15.096","level":"INFO","target":"vector","fields":{"message":"Log level \"info\" is enabled."}}
{"timestamp":"Feb 20 11:28:15.096","level":"INFO","target":"vector","fields":{"message":"Loading configs.","path":"[\"/etc/vector/vector.toml\"]"}}
{"timestamp":"Feb 20 11:28:15.108","level":"INFO","target":"vector","fields":{"message":"Vector is starting.","version":"0.8.0","git_version":"v0.7.0-168-g841a8f8","released":"Wed, 19 Feb 2020 20:17:41 +0000","arch":"x86_64"}}
{"timestamp":"Feb 20 11:28:15.114","level":"INFO","target":"vector::topology","fields":{"message":"Running healthchecks."}}
{"timestamp":"Feb 20 11:28:15.114","level":"INFO","target":"vector::topology","fields":{"message":"Starting source \"stdin\""}}
{"timestamp":"Feb 20 11:28:15.114","level":"INFO","target":"vector::topology","fields":{"message":"Starting sink \"loki\""}}
{"timestamp":"Feb 20 11:28:15.115","level":"INFO","span":{"name":"source","type":"stdin"},"target":"vector::sources::stdin","fields":{"message":"Capturing STDIN"}}
{"timestamp":"Feb 20 11:28:15.120","level":"ERROR","target":"vector::topology::builder","fields":{"message":"Healthcheck: Failed Reason: error trying to connect: Connection refused (os error 111)"}}
^C{"timestamp":"Feb 20 11:28:17.057","level":"INFO","target":"vector","fields":{"message":"Shutting down."}}
```

Closes #1709

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
