### PR TITLE
chore(testing): Add feature `disable-resolv-conf` to allow testing on NixOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,8 @@ influxdb-integration-tests = []
 kubernetes = ["kubernetes-integration-tests"]
 kubernetes-integration-tests = []
 
+disable-resolv-conf = []
+
 [[bench]]
 name = "bench"
 harness = false

--- a/distribution/nix/default.nix.erb
+++ b/distribution/nix/default.nix.erb
@@ -25,6 +25,7 @@ rustPlatform.buildRustPackage rec {
       sha256 = "<%= ENV["GITHUB_SHA256"] %>";
     }<% else %><%= Dir.getwd %><% end %>;
 
+  legacyCargoFetcher = true;
   cargoSha256 = "<%=
     # The only offical way to calculate `cargoSha256` is to set it arbitrarily,
     # run the build, and then extract the correct checksum from the error
@@ -55,7 +56,7 @@ rustPlatform.buildRustPackage rec {
   PROTOC_INCLUDE="${protobuf}/include";
 
   cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
-  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features}";
+  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features},disable-resolv-conf -- --test-threads 1";
 
   meta = with stdenv.lib; {
     description = "A high-performance logs, metrics, and events router";

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -66,7 +66,11 @@ impl Resolver {
 
             (config, opts)
         } else {
-            system_conf::read_system_conf().context(ReadSystemConf)?
+            #[cfg(feature = "disable-resolv-conf")]
+            let res = (Default::default(), Default::default());
+            #[cfg(not(feature = "disable-resolv-conf"))]
+            let res = system_conf::read_system_conf().context(ReadSystemConf)?;
+            res
         };
 
         let (inner, bg_task) = AsyncResolver::new(config, opt);


### PR DESCRIPTION
This might resolve https://github.com/timberio/vector/issues/1803.

It is a result of a discussion with @LucioFranco we had today about ways to prevent `trust-dns-resolver` to access `/etc/resolv.conf`.

This is WIP because I haven't tested it yet on an actual NixOS machine. Note that tests on NixOS running in Docker would not be enough because Docker mounts `/etc/resolv.conf` from the host machine, so it is always present there.