### PR TITLE
status(cloudwatch_logs sink): Advance to `prod-ready` status

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,12 +2,13 @@
 titleOnly: true
 
 types:
-  - chore               # An internal change that should not be communicated to Vector users.
-  - docs                # A change relating to Vector's documentation.
-  - enhancement         # Anything that enhances it's subject.
-  - feat                # An entirely new feature, such as a new platform, source, transform, or sink.
-  - fix                 # A bug fix.
-  - perf                # A change that enhancements performance.
+  - chore               # An internal change this is not observable by users.
+  - docs                # Any user observable documentation change.
+  - enhancement         # Any user observable enhancement to an existing feature.
+  - feat                # Any user observable new feature, such as a new platform, source, transform, or sink.
+  - fix                 # Any user observable bug fix.
+  - perf                # Any user observable performance improvment.
+  - status              # A status change to a Vector component.
 
 scopes:
 

--- a/.github/semantic.yml.erb
+++ b/.github/semantic.yml.erb
@@ -2,12 +2,13 @@
 titleOnly: true
 
 types:
-  - chore               # An internal change that should not be communicated to Vector users.
-  - docs                # A change relating to Vector's documentation.
-  - enhancement         # Anything that enhances it's subject.
-  - feat                # An entirely new feature, such as a new platform, source, transform, or sink.
-  - fix                 # A bug fix.
-  - perf                # A change that enhancements performance.
+  - chore               # An internal change this is not observable by users.
+  - docs                # Any user observable documentation change.
+  - enhancement         # Any user observable enhancement to an existing feature.
+  - feat                # Any user observable new feature, such as a new platform, source, transform, or sink.
+  - fix                 # Any user observable bug fix.
+  - perf                # Any user observable performance improvment.
+  - status              # A status change to a Vector component.
 
 scopes:
 

--- a/.meta/sinks/aws_cloudwatch_logs.toml
+++ b/.meta/sinks/aws_cloudwatch_logs.toml
@@ -1,6 +1,6 @@
 [sinks.aws_cloudwatch_logs]
 title = "AWS Cloudwatch Logs"
-beta = true
+beta = false
 common = true
 delivery_guarantee = "at_least_once"
 egress_method = "batching"

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -8,7 +8,7 @@ min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
 sidebar_label: "aws_cloudwatch_logs|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/aws_cloudwatch_logs/
-status: "beta"
+status: "prod-ready"
 title: "AWS Cloudwatch Logs Sink"
 unsupported_operating_systems: []
 ---

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -17007,7 +17007,7 @@ module.exports = {
   },
   "sinks": {
     "aws_cloudwatch_logs": {
-      "beta": true,
+      "beta": false,
       "delivery_guarantee": "at_least_once",
       "description": "Batches log events to [Amazon Web Service's CloudWatch Logs service][urls.aws_cw_logs] via the [`PutLogEvents` API endpoint](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html).",
       "event_types": [
@@ -17024,7 +17024,7 @@ module.exports = {
       "service_providers": [
         "AWS"
       ],
-      "status": "beta",
+      "status": "prod-ready",
       "type": "sink",
       "unsupported_operating_systems": [
 


### PR DESCRIPTION
Advance the `cloudwatch_logs` sink to the [`prod-ready` status](https://vector.dev/docs/about/guarantees/#prod-ready). I'd like for this to live as an individual commit so that we can communicate status changes in release notes.