### PR TITLE
docs(clickhouse sink): Set `min_version` to `1.1.54378`

### DIFF
--- a/.meta/sinks/clickhouse.toml
+++ b/.meta/sinks/clickhouse.toml
@@ -7,7 +7,7 @@ function_category = "transmit"
 healthcheck = true
 egress_method = "batching"
 input_types = ["log"]
-min_version = "0"
+min_version = "1.1.54378"
 requirements = {}
 write_to_description = "[Clickhouse][urls.clickhouse] via the [`HTTP` Interface][urls.clickhouse_http]"
 

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -4,7 +4,7 @@ component_title: "Clickhouse"
 description: "The Vector `clickhouse` sink batches `log` events to Clickhouse via the `HTTP` Interface."
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+clickhouse%22
-min_version: "0"
+min_version: "1.1.54378"
 operating_systems: ["Linux","MacOS","Windows"]
 sidebar_label: "clickhouse|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/clickhouse.rs
@@ -119,6 +119,17 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
 </TabItem>
 </Tabs>
+
+## Requirements
+
+import Alert from '@site/src/components/Alert';
+
+<Alert icon={false} type="danger" classNames="list--warnings">
+
+* Clickhouse version >= 1.1.54378 is required.
+
+
+</Alert>
 
 ## Options
 


### PR DESCRIPTION
Ref #1876.

1.1.54378 was released on 2018-04-16, Vector passes Docker tests with it.