### PR TITLE
docs(docker source): Refer to docker API

### DIFF
--- a/.meta/.schema.json
+++ b/.meta/.schema.json
@@ -298,6 +298,10 @@
           "description": "A link to the target service's limits, if applicable.",
           "minLength": 1
         },
+        "service_name": {
+          "type": "string",
+          "description": "The name of the underlying service that this component integrates with."
+        },
         "service_providers": {
           "type": "array",
           "description": "A list of providers that offer this service.",
@@ -404,6 +408,10 @@
         "requirements": {
           "$ref": "#/definitions/requirements",
           "description": "Component requirements"
+        },
+        "service_name": {
+          "type": "string",
+          "description": "The name of the underlying service that this component integrates with."
         },
         "through_description": {
           "type": "string",

--- a/.meta/sources/docker.toml
+++ b/.meta/sources/docker.toml
@@ -13,6 +13,7 @@ must be enabled for this source to work. See the \
 [Docker Integration Strategy section](#docker-integration-strategy) \
 for more info.
 """
+service_name = "Docker API"
 through_description = "the [Docker engine daemon][urls.docker_daemon]"
 
 <%= render("_partials/_component_options.toml", type: "source", name: "docker") %>

--- a/scripts/generate/templates/_partials/_component_header.md.erb
+++ b/scripts/generate/templates/_partials/_component_header.md.erb
@@ -13,6 +13,7 @@ operating_systems: <%= component.operating_systems.to_json %>
 <%- if component.posts.any? -%>
 posts_path: /blog/tags/<%= "#{component.type}: #{component.name}".slugify %>
 <%- end -%>
+service_name: <%= component.service_name.to_json %>
 sidebar_label: <%= "#{component.name}|#{component.event_types.to_json}".to_json %>
 source_url: <%= metadata.links.fetch("urls.#{component.id}_source") %>
 status: <%= component.status.to_json %>

--- a/scripts/util/metadata/component.rb
+++ b/scripts/util/metadata/component.rb
@@ -21,6 +21,7 @@ class Component
     :options,
     :posts,
     :requirements,
+    :service_name,
     :service_providers,
     :title,
     :type,
@@ -35,6 +36,7 @@ class Component
     @name = hash.fetch("name")
     @posts = hash.fetch("posts")
     @requirements = Requirements.new(hash["requirements"] || {})
+    @service_name = hash["service_name"] || hash.fetch("title")
     @service_providers = hash["service_providers"] || []
     @title = hash.fetch("title")
     @type ||= self.class.name.downcase
@@ -44,7 +46,7 @@ class Component
     # Requirements
 
     if @min_version && @min_version != "0" && (!@requirements.additional || !@requirements.additional.include?(@min_version))
-      @requirements.additional = "* #{title} version >= #{@min_version} is required.\n#{@requirements.additional}"
+      @requirements.additional = "* #{@service_name} version >= #{@min_version} is required.\n#{@requirements.additional}"
     end
 
     # Operating Systems

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_cloudwatch_logs%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "AWS Cloudwatch Logs"
 sidebar_label: "aws_cloudwatch_logs|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/aws_cloudwatch_logs/
 status: "prod-ready"

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_cloudwatch_metrics%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "AWS Cloudwatch Metrics"
 sidebar_label: "aws_cloudwatch_metrics|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_cloudwatch_metrics.rs
 status: "beta"

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_kinesis_firehose%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "AWS Kinesis Firehose"
 sidebar_label: "aws_kinesis_firehose|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_kinesis_firehose.rs
 status: "beta"

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_kinesis_streams%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "AWS Kinesis Data Streams"
 sidebar_label: "aws_kinesis_streams|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_kinesis_streams.rs
 status: "beta"

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+aws_s3%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "AWS S3"
 sidebar_label: "aws_s3|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/aws_s3.rs
 status: "beta"

--- a/website/docs/reference/sinks/blackhole.md
+++ b/website/docs/reference/sinks/blackhole.md
@@ -6,6 +6,7 @@ event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+blackhole%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Blackhole"
 sidebar_label: "blackhole|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/blackhole.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+clickhouse%22
 min_version: "1.1.54378"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Clickhouse"
 sidebar_label: "clickhouse|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/clickhouse.rs
 status: "beta"

--- a/website/docs/reference/sinks/console.md
+++ b/website/docs/reference/sinks/console.md
@@ -6,6 +6,7 @@ event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+console%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Console"
 sidebar_label: "console|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/console.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+datadog_metrics%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Datadog Metrics"
 sidebar_label: "datadog_metrics|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/datadog_metrics.rs
 status: "beta"

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+elasticsearch%22
 min_version: "0"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Elasticsearch"
 sidebar_label: "elasticsearch|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/elasticsearch.rs
 status: "beta"

--- a/website/docs/reference/sinks/file.md
+++ b/website/docs/reference/sinks/file.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+file%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "File"
 sidebar_label: "file|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/file/
 status: "prod-ready"

--- a/website/docs/reference/sinks/gcp_cloud_storage.md
+++ b/website/docs/reference/sinks/gcp_cloud_storage.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+gcp_cloud_storage%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "GCP Cloud Storage (GCS)"
 sidebar_label: "gcp_cloud_storage|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/gcp_cloud_storage.rs
 status: "beta"

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+gcp_pubsub%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "GCP PubSub"
 sidebar_label: "gcp_pubsub|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/gcp/pubsub.rs
 status: "beta"

--- a/website/docs/reference/sinks/gcp_stackdriver_logging.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logging.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+gcp_stackdriver_logging%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "GCP Stackdriver Logging"
 sidebar_label: "gcp_stackdriver_logging|[\"log\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sinks/gcp/stackdriver_logging.rs
 status: "beta"

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+http%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "HTTP"
 sidebar_label: "http|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/http.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/humio_logs.md
+++ b/website/docs/reference/sinks/humio_logs.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+humio_logs%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Humio Logs"
 sidebar_label: "humio_logs|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/humio_logs.rs
 status: "beta"

--- a/website/docs/reference/sinks/influxdb_metrics.md
+++ b/website/docs/reference/sinks/influxdb_metrics.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+influxdb_metrics%22
 min_version: "0"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "InfluxDB Metrics"
 sidebar_label: "influxdb_metrics|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/influxdb_metrics.rs
 status: "beta"

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+kafka%22
 min_version: "0.8"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Kafka"
 sidebar_label: "kafka|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/kafka.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/logdna.md
+++ b/website/docs/reference/sinks/logdna.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+logdna%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "LogDNA"
 sidebar_label: "logdna|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/logdna.rs
 status: "beta"

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+loki%22
 min_version: "0"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "loki"
 sidebar_label: "loki|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/loki.rs
 status: "beta"

--- a/website/docs/reference/sinks/new_relic_logs.md
+++ b/website/docs/reference/sinks/new_relic_logs.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+new_relic_logs%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "New Relic Logs"
 sidebar_label: "new_relic_logs|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/new_relic_logs.rs
 status: "beta"

--- a/website/docs/reference/sinks/prometheus.md
+++ b/website/docs/reference/sinks/prometheus.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+prometheus%22
 min_version: "1.0"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Prometheus"
 sidebar_label: "prometheus|[\"metric\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sources/prometheus/
 status: "beta"

--- a/website/docs/reference/sinks/sematext.md
+++ b/website/docs/reference/sinks/sematext.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+sematext%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Sematext"
 sidebar_label: "sematext|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/sematext.rs
 status: "beta"

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+socket%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Socket"
 sidebar_label: "socket|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/socket.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+splunk_hec%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Splunk HEC"
 sidebar_label: "splunk_hec|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/splunk_hec.rs
 status: "prod-ready"

--- a/website/docs/reference/sinks/statsd.md
+++ b/website/docs/reference/sinks/statsd.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+statsd%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Statsd"
 sidebar_label: "statsd|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/statsd.rs
 status: "beta"

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22sink%3A+vector%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Vector"
 sidebar_label: "vector|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sinks/vector.rs
 status: "beta"

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+docker%22
 min_version: "1.24"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Docker API"
 sidebar_label: "docker|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/docker.rs
 status: "beta"

--- a/website/docs/reference/sources/docker.md
+++ b/website/docs/reference/sources/docker.md
@@ -78,7 +78,7 @@ import Alert from '@site/src/components/Alert';
 
 <Alert icon={false} type="danger" classNames="list--warnings">
 
-* Docker version >= 1.24 is required.
+* Docker API version >= 1.24 is required.
 * The [`json-file`][urls.docker_logging_driver_json_file] (default) or [`journald`][urls.docker_logging_driver_journald] Docker logging driver must be enabled for this source to work. See the [Docker Integration Strategy section](#docker-integration-strategy) for more info.
 
 

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+file%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "File"
 sidebar_label: "file|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/file.rs
 status: "prod-ready"

--- a/website/docs/reference/sources/journald.md
+++ b/website/docs/reference/sources/journald.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+journald%22
 min_version: null
 operating_systems: ["Linux"]
+service_name: "Journald"
 sidebar_label: "journald|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/journald.rs
 status: "beta"

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+kafka%22
 min_version: "0.8"
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Kafka"
 sidebar_label: "kafka|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/kafka.rs
 status: "beta"

--- a/website/docs/reference/sources/logplex.md
+++ b/website/docs/reference/sources/logplex.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+logplex%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Heroku Logplex"
 sidebar_label: "logplex|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/logplex.rs
 status: "beta"

--- a/website/docs/reference/sources/prometheus.md
+++ b/website/docs/reference/sources/prometheus.md
@@ -7,6 +7,7 @@ issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+lab
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
 posts_path: /blog/tags/source-prometheus
+service_name: "Prometheus"
 sidebar_label: "prometheus|[\"metric\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sources/prometheus/
 status: "beta"

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+socket%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Socket"
 sidebar_label: "socket|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/socket
 status: "prod-ready"

--- a/website/docs/reference/sources/splunk_hec.md
+++ b/website/docs/reference/sources/splunk_hec.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+splunk_hec%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Splunk HEC"
 sidebar_label: "splunk_hec|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/splunk_hec.rs
 status: "beta"

--- a/website/docs/reference/sources/statsd.md
+++ b/website/docs/reference/sources/statsd.md
@@ -6,6 +6,7 @@ event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+statsd%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Statsd"
 sidebar_label: "statsd|[\"metric\"]"
 source_url: https://github.com/timberio/vector/blob/master/src/sources/statsd/
 status: "beta"

--- a/website/docs/reference/sources/stdin.md
+++ b/website/docs/reference/sources/stdin.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+stdin%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "STDIN"
 sidebar_label: "stdin|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/stdin.rs
 status: "prod-ready"

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -6,6 +6,7 @@ event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+syslog%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Syslog"
 sidebar_label: "syslog|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/syslog.rs
 status: "prod-ready"

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -6,6 +6,7 @@ event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22source%3A+vector%22
 min_version: null
 operating_systems: ["Linux","MacOS","Windows"]
+service_name: "Vector"
 sidebar_label: "vector|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/sources/vector.rs
 status: "beta"

--- a/website/docs/reference/transforms/add_fields.md
+++ b/website/docs/reference/transforms/add_fields.md
@@ -4,6 +4,7 @@ description: "The Vector `add_fields` transform accepts and outputs `log` events
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_fields%22
 min_version: null
+service_name: "Add Fields"
 sidebar_label: "add_fields|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/add_fields.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/add_tags.md
+++ b/website/docs/reference/transforms/add_tags.md
@@ -4,6 +4,7 @@ description: "The Vector `add_tags` transform accepts and outputs `metric` event
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+add_tags%22
 min_version: null
+service_name: "Add Tags"
 sidebar_label: "add_tags|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/add_tags.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/ansi_stripper.md
+++ b/website/docs/reference/transforms/ansi_stripper.md
@@ -4,6 +4,7 @@ description: "The Vector `ansi_stripper` transform accepts and outputs `log` eve
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+ansi_stripper%22
 min_version: null
+service_name: "ANSI Stripper"
 sidebar_label: "ansi_stripper|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/ansi_stripper.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/aws_ec2_metadata.md
+++ b/website/docs/reference/transforms/aws_ec2_metadata.md
@@ -4,6 +4,7 @@ description: "The Vector `aws_ec2_metadata` transform accepts and outputs `log` 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+aws_ec2_metadata%22
 min_version: null
+service_name: "AWS EC2 Metadata"
 sidebar_label: "aws_ec2_metadata|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/aws_ec2_metadata.rs
 status: "beta"

--- a/website/docs/reference/transforms/coercer.md
+++ b/website/docs/reference/transforms/coercer.md
@@ -4,6 +4,7 @@ description: "The Vector `coercer` transform accepts and outputs `log` events al
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+coercer%22
 min_version: null
+service_name: "Coercer"
 sidebar_label: "coercer|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/coercer.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/concat.md
+++ b/website/docs/reference/transforms/concat.md
@@ -4,6 +4,7 @@ description: "The Vector `concat` transform accepts and outputs `log` events all
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+concat%22
 min_version: null
+service_name: "Concat"
 sidebar_label: "concat|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/concat.rs
 status: "beta"

--- a/website/docs/reference/transforms/field_filter.md
+++ b/website/docs/reference/transforms/field_filter.md
@@ -4,6 +4,7 @@ description: "The Vector `field_filter` transform accepts and outputs `log` even
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+field_filter%22
 min_version: null
+service_name: "Field Filter"
 sidebar_label: "field_filter|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/field_filter.rs
 status: "beta"

--- a/website/docs/reference/transforms/geoip.md
+++ b/website/docs/reference/transforms/geoip.md
@@ -4,6 +4,7 @@ description: "The Vector [`geoip`](#geoip) transform accepts and outputs `log` e
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+geoip%22
 min_version: null
+service_name: "GeoIP"
 sidebar_label: "geoip|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/geoip.rs
 status: "beta"

--- a/website/docs/reference/transforms/grok_parser.md
+++ b/website/docs/reference/transforms/grok_parser.md
@@ -4,6 +4,7 @@ description: "The Vector `grok_parser` transform accepts and outputs `log` event
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+grok_parser%22
 min_version: null
+service_name: "Grok Parser"
 sidebar_label: "grok_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/grok_parser.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/json_parser.md
+++ b/website/docs/reference/transforms/json_parser.md
@@ -4,6 +4,7 @@ description: "The Vector `json_parser` transform accepts and outputs `log` event
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+json_parser%22
 min_version: null
+service_name: "JSON Parser"
 sidebar_label: "json_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/json_parser.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/log_to_metric.md
+++ b/website/docs/reference/transforms/log_to_metric.md
@@ -4,6 +4,7 @@ description: "The Vector `log_to_metric` transform accepts `log` events but outp
 event_types: ["log","metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+log_to_metric%22
 min_version: null
+service_name: "Log to Metric"
 sidebar_label: "log_to_metric|[\"log\",\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/log_to_metric.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/logfmt_parser.md
+++ b/website/docs/reference/transforms/logfmt_parser.md
@@ -4,6 +4,7 @@ description: "The Vector `logfmt_parser` transform accepts and outputs `log` eve
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+logfmt_parser%22
 min_version: null
+service_name: "Logfmt Parser"
 sidebar_label: "logfmt_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/logfmt_parser.rs
 status: "beta"

--- a/website/docs/reference/transforms/lua.md
+++ b/website/docs/reference/transforms/lua.md
@@ -4,6 +4,7 @@ description: "The Vector `lua` transform accepts and outputs `log` events allowi
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+lua%22
 min_version: null
+service_name: "LUA"
 sidebar_label: "lua|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/lua.rs
 status: "beta"

--- a/website/docs/reference/transforms/merge.md
+++ b/website/docs/reference/transforms/merge.md
@@ -4,6 +4,7 @@ description: "The Vector [`merge`](#merge) transform accepts and outputs `log` e
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+merge%22
 min_version: null
+service_name: "Merge"
 sidebar_label: "merge|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/merge.rs
 status: "beta"

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -4,6 +4,7 @@ description: "The Vector `regex_parser` transform accepts and outputs `log` even
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+regex_parser%22
 min_version: null
+service_name: "Regex Parser"
 sidebar_label: "regex_parser|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/regex_parser.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/remove_fields.md
+++ b/website/docs/reference/transforms/remove_fields.md
@@ -4,6 +4,7 @@ description: "The Vector `remove_fields` transform accepts and outputs `log` eve
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+remove_fields%22
 min_version: null
+service_name: "Remove Fields"
 sidebar_label: "remove_fields|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/remove_fields.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/remove_tags.md
+++ b/website/docs/reference/transforms/remove_tags.md
@@ -4,6 +4,7 @@ description: "The Vector `remove_tags` transform accepts and outputs `metric` ev
 event_types: ["metric"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+remove_tags%22
 min_version: null
+service_name: "Remove Tags"
 sidebar_label: "remove_tags|[\"metric\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/remove_tags.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/sampler.md
+++ b/website/docs/reference/transforms/sampler.md
@@ -4,6 +4,7 @@ description: "The Vector `sampler` transform accepts and outputs `log` events al
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+sampler%22
 min_version: null
+service_name: "Sampler"
 sidebar_label: "sampler|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/sampler.rs
 status: "beta"

--- a/website/docs/reference/transforms/split.md
+++ b/website/docs/reference/transforms/split.md
@@ -4,6 +4,7 @@ description: "The Vector `split` transform accepts and outputs `log` events allo
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+split%22
 min_version: null
+service_name: "Split"
 sidebar_label: "split|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/split.rs
 status: "prod-ready"

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -4,6 +4,7 @@ description: "The Vector `tokenizer` transform accepts and outputs `log` events 
 event_types: ["log"]
 issues_url: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22transform%3A+tokenizer%22
 min_version: null
+service_name: "Tokenizer"
 sidebar_label: "tokenizer|[\"log\"]"
 source_url: https://github.com/timberio/vector/tree/master/src/transforms/tokenizer.rs
 status: "prod-ready"

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -42,7 +42,7 @@ function Headings({headings, isChild}) {
   );
 }
 
-function Statuses({componentTitle, deliveryGuarantee, minVersion, operatingSystems, status, unsupportedOperatingSystems}) {
+function Statuses({deliveryGuarantee, minVersion, operatingSystems, serviceName, status, unsupportedOperatingSystems}) {
   if (!status && !deliveryGuarantee && !operatingSystems && !unsupportedOperatingSystems)
     return null;
 
@@ -89,7 +89,7 @@ function Statuses({componentTitle, deliveryGuarantee, minVersion, operatingSyste
         </div>}
       {minVersion &&
         <div className="text--primary">
-          <i className="feather icon-box"></i> {minVersion == "0" ? <>All {componentTitle} versions</> : <>{componentTitle} >= {minVersion}</>}
+          <i className="feather icon-box"></i> {minVersion == "0" ? <>All {serviceName} versions</> : <>{serviceName} >= {minVersion}</>}
         </div>}
       {operatingSystemsEls.length > 0 &&
         <div>
@@ -194,10 +194,10 @@ function DocItem(props) {
               <div className="col col--3">
                 <div className="table-of-contents">
                   <Statuses
-                    componentTitle={componentTitle}
                     deliveryGuarantee={deliveryGuarantee}
                     minVersion={minVersion}
                     operatingSystems={operatingSystems}
+                    serviceName={serviceName}
                     status={status}
                     unsupportedOperatingSystems={unsupportedOperatingSystems} />
                   {DocContent.rightToc.length > 0 &&

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -129,6 +129,7 @@ function DocItem(props) {
       min_version: minVersion,
       operating_systems: operatingSystems,
       posts_path: postsPath,
+      service_name: serviceName,
       source_url: sourceUrl,
       status,
       unsupported_operating_systems: unsupportedOperatingSystems,


### PR DESCRIPTION
Supercedes https://github.com/timberio/vector/pull/1882 since it was out of sync with master and it was easier to just create a new branch.