### PR TITLE
enhancement(lua transform)!: respect Lua types when converting back to events

### DIFF
--- a/website/docs/reference/transforms/lua.md
+++ b/website/docs/reference/transforms/lua.md
@@ -237,6 +237,14 @@ paths that will searched when using the [Lua `require`
 function][urls.lua_require].
 
 
+
+### Types
+
+Event fields can be set to scalar values (booleans, numbers, or strings),
+and the resulting event will keep the correct types. If an event field is
+set to an invalid value, a message will be logged and the field will be dropped.
+
+
 [docs.configuration#environment-variables]: /docs/setup/configuration/#environment-variables
 [docs.data-model.log#schema]: /docs/about/data-model/log/#schema
 [docs.data-model.log]: /docs/about/data-model/log/

--- a/website/docs/reference/transforms/lua.md.erb
+++ b/website/docs/reference/transforms/lua.md.erb
@@ -98,6 +98,12 @@ variable representing the event:
 Note, a Lua `table` is an associative array. You can read more about
 [Lua types][urls.lua_types] in the [Lua docs][urls.lua_docs].
 
+### Types
+
+Event fields can be set to scalar values (booleans, numbers, or strings),
+and the resulting event will keep the correct types. If an event field is
+set to an invalid value, a message will be logged and the field will be dropped.
+
 ### Nested Fields
 
 As described in the [Data Model document][docs.data_model], Vector flatten


### PR DESCRIPTION
When using the Lua transform with a function like this:

```lua
event["number"] = 42
```

the resulting event has the value converted back to a string:

```
{ ..., "number": "42", ... }
```

This PR changes the transform to preserve types, and also adds support for setting fields to boolean values, saving the need for further processing to restore the types. It also slightly changes the behavior to drop fields when set to invalid types, rather than erroring out the function. I'm not sure what impact this will have when it comes to https://github.com/timberio/vector/issues/704, however.

Fixes #857.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
