### PR TITLE
feat(platforms): Initial Helm chart for daemonset installation

### DIFF
--- a/distribution/helm/vector/.helmignore
+++ b/distribution/helm/vector/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/distribution/helm/vector/Chart.yaml
+++ b/distribution/helm/vector/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: A Helm chart to collect Kubernetes logs with vector
+icon: https://vector.dev/press/vector-icon.svg
+name: vector
+version: 0.0.1
+appVersion: 0.7.2
+home: https://vector.dev/
+sources:
+- https://vector.dev/docs/
+maintainers:
+- name: sciyoshi
+  email: samuel@cormier-iijima.com

--- a/distribution/helm/vector/README.md
+++ b/distribution/helm/vector/README.md
@@ -1,0 +1,59 @@
+# Vector
+
+[Vector](https://vector.dev) is used to ship Kubernetes and host logs to multiple outputs.
+
+## Prerequisites
+
+- Kubernetes 1.10+
+
+## Note
+
+By default this chart only ships a single output to container logs.
+
+## Installing the Chart
+
+To install the chart with the release name `vector`:
+
+```bash
+$ helm install --name vector stable/vector
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the vector chart and their default values.
+
+| Parameter                       | Description                                                                            | Default           |
+| ------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| `image.repository`              | Docker image repo                                                                      | `timberio/vector` |
+| `image.tag`                     | Docker image tag                                                                       | `latest-alpine`   |
+| `image.pullPolicy`              | Docker image pull policy                                                               | `IfNotPresent`    |
+| `image.pullSecrets`             | Specify image pull secrets                                                             | `nil`             |
+| `config`                        | A string to use as the `vector.toml` configuration file                                | see [values.yaml] |
+| `data.hostPath`                 | Path on the host to mount to `/var/lib/vector` in the container.                       | `/var/lib/vector` |
+| `command`                       | Custom command (Docker Entrypoint)                                                     | `[]`              |
+| `args`                          | Custom args (Docker Cmd)                                                               | `[]`              |
+| `extraVars`                     | A list of additional environment variables                                             | `[]`              |
+| `extraVolumes`                  | Add additional volumes                                                                 | `[]`              |
+| `extraVolumeMounts`             | Add additional mounts                                                                  | `[]`              |
+| `extraSecrets`                  | Add additional secrets                                                                 | `{}`              |
+| `extraInitContainers`           | Add additional initContainers                                                          | `[]`              |
+| `resources`                     |                                                                                        | `{}`              |
+| `priorityClassName`             | priorityClassName                                                                      | `nil`             |
+| `nodeSelector`                  |                                                                                        | `{}`              |
+| `annotations`                   |                                                                                        | `{}`              |
+| `tolerations`                   |                                                                                        | `[]`              |
+| `affinity`                      |                                                                                        | `{}`              |
+| `rbac.create`                   | Specifies whether RBAC resources should be created                                     | `true`            |
+| `serviceAccount.create`         | Specifies whether a ServiceAccount should be created                                   | `true`            |
+| `serviceAccount.name`           | the name of the ServiceAccount to use                                                  | `""`              |
+| `podSecurityPolicy.enabled`     | Should the PodSecurityPolicy be created. Depends on `rbac.create` being set to `true`. | `false`           |
+| `podSecurityPolicy.annotations` | Annotations to be added to the created PodSecurityPolicy:                              | `""`              |
+| `privileged`                    | Specifies wheter to run as privileged                                                  | `false`           |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name vector -f values.yaml stable/vector
+```

--- a/distribution/helm/vector/templates/NOTES.txt
+++ b/distribution/helm/vector/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that Vector has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "vector.name" . }},release={{ .Release.Name }}"

--- a/distribution/helm/vector/templates/_helpers.tpl
+++ b/distribution/helm/vector/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "vector.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/distribution/helm/vector/templates/clusterrole.yaml
+++ b/distribution/helm/vector/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/distribution/helm/vector/templates/clusterrolebinding.yaml
+++ b/distribution/helm/vector/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "vector.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/distribution/helm/vector/templates/daemonset.yaml
+++ b/distribution/helm/vector/templates/daemonset.yaml
@@ -13,8 +13,6 @@ spec:
       app.kubernetes.io/name: {{ template "vector.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   minReadySeconds: 10
-  updateStrategy:
-    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/distribution/helm/vector/templates/daemonset.yaml
+++ b/distribution/helm/vector/templates/daemonset.yaml
@@ -15,8 +15,6 @@ spec:
   minReadySeconds: 10
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/distribution/helm/vector/templates/daemonset.yaml
+++ b/distribution/helm/vector/templates/daemonset.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "vector.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/secret: {{ toYaml (.Values.config | sha256sum) }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $sec := .Values.image.pullSecrets }}
+        - name: {{ $sec | quote }}
+      {{- end }}
+    {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+{{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 6 }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.command }}
+        command:
+{{ toYaml .Values.command | indent 8 }}
+{{- end }}
+        args:
+{{- if .Values.args }}
+{{ toYaml .Values.args | indent 8 }}
+{{- else }}
+{{- end }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{{- if .Values.extraVars }}
+{{ toYaml .Values.extraVars | indent 8 }}
+{{- end }}
+        securityContext:
+          runAsUser: 0
+{{- if .Values.privileged }}
+          privileged: true
+{{- end }}
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: vector-config
+          mountPath: /etc/vector/vector.toml
+          readOnly: true
+          subPath: vector.toml
+        - name: data
+          mountPath: /var/lib/vector
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: vector-config
+        secret:
+          secretName: {{ template "vector.fullname" . }}
+      - name: data
+        hostPath:
+          path: {{ .Values.data.hostPath }}
+          type: DirectoryOrCreate
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "vector.serviceAccountName" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/distribution/helm/vector/templates/podsecuritypolicy.yaml
+++ b/distribution/helm/vector/templates/podsecuritypolicy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "vector.fullname" . }}
+  annotations:
+{{- if .Values.podSecurityPolicy.annotations }}
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+    - pathPrefix: /var/log
+      readOnly: true
+    - pathPrefix: /var/lib/docker/containers
+      readOnly: true
+    - pathPrefix: {{ .Values.data.hostPath }}
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - configMap
+    - secret
+    - hostPath
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: MustRunAs
+    ranges:
+      - min: 0
+        max: 0
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  hostPorts:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+{{- end -}}
+{{- end -}}

--- a/distribution/helm/vector/templates/role.yaml
+++ b/distribution/helm/vector/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "vector.fullname" . }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector/templates/rolebinding.yaml
+++ b/distribution/helm/vector/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "vector.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector/templates/secret.yaml
+++ b/distribution/helm/vector/templates/secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  vector.toml: {{ toYaml (.Values.config | b64enc) }}
+  {{- if .Values.extraSecrets }}
+  {{- range $key, $value := .Values.extraSecrets }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end -}}
+
+  {{ end }}

--- a/distribution/helm/vector/templates/serviceaccount.yaml
+++ b/distribution/helm/vector/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "vector.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "vector.name" . }}
+    helm.sh/chart: {{ template "vector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -1,0 +1,105 @@
+image:
+  repository: timberio/vector
+  tag: latest-alpine
+  pullPolicy: IfNotPresent
+
+config: |-
+  data_dir = "/var/lib/vector"
+
+  [sources.kubernetes]
+    type = "kubernetes"
+
+  [sinks.console]
+    type = "console"
+    inputs = ["kubernetes"]
+
+# Path on the host to mount to /var/lib/vector in the container.
+data:
+  hostPath: /var/lib/vector
+
+# pass custom command. This is equivalent of Entrypoint in docker
+command: []
+
+# pass custom args. This is equivalent of Cmd in docker
+args: []
+
+# A list of additional environment variables
+extraVars: []
+  # - name: TEST1
+  #   value: TEST2
+  # - name: TEST3
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: configmap
+  #       key: config.key
+
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes: []
+  # - hostPath:
+  #     path: /var/log
+  #   name: varlog
+extraVolumeMounts: []
+  # - name: varlog
+  #   mountPath: /host/var/log
+  #   readOnly: true
+extraSecrets: {}
+  # secret: "TEST1"
+
+extraInitContainers: []
+  # - name: echo
+  #   image: busybox
+  #   imagePullPolicy: Always
+  #   args:
+  #     - echo
+  #     - hello
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+priorityClassName: ""
+
+nodeSelector: {}
+
+annotations: {}
+
+tolerations: []
+  # - operator: Exists
+
+affinity: {}
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+## Specify if a Pod Security Policy for vector must be created
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+##
+podSecurityPolicy:
+  enabled: False
+  annotations: {}
+    ## Specify pod annotations
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    ##
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+
+privileged: false


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

This is a first pass at implementing a Helm chart for running Vector as a Daemonset in a Kubernetes cluster. I see that there's already a sample in [config/kubernetes/vector-daemonset.yaml](https://github.com/timberio/vector/blob/master/config/kubernetes/vector-daemonset.yaml) but this PR is based off of the [Filebeat helm chart](https://github.com/helm/charts/tree/master/stable/filebeat) (the one in the stable Helm chart repo, not [the one that Elastic provides](https://github.com/elastic/helm-charts)). In particular, it stores the Vector config as a Secret rather than a ConfigMap.

NB the chart is not fully tested at this point. It's mainly for our own purposes at the moment, but I'm sharing it here in case anyone else finds it useful or would like to use it as a starting point.

Fixes #1397.