### PR TITLE
chore(topology): Allow transforms to implement `Stream`

### DIFF
--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -25,6 +25,8 @@ pub mod split;
 pub mod swimlanes;
 pub mod tokenizer;
 
+use futures::{sync::mpsc::Receiver, Stream};
+
 pub trait Transform: Send {
     fn transform(&mut self, event: Event) -> Option<Event>;
 
@@ -32,6 +34,25 @@ pub trait Transform: Send {
         if let Some(transformed) = self.transform(event) {
             output.push(transformed);
         }
+    }
+
+    fn transform_stream(
+        self,
+        input_rx: Receiver<Event>,
+    ) -> Box<dyn Stream<Item = Event, Error = ()> + Send>
+    where
+        Self: Sized + 'static,
+    {
+        let mut me = self;
+        Box::new(
+            input_rx
+                .map(move |event| {
+                    let mut output = Vec::with_capacity(1);
+                    me.transform_into(&mut output, event);
+                    futures::stream::iter_ok(output.into_iter())
+                })
+                .flatten(),
+        )
     }
 }
 


### PR DESCRIPTION
This adds a new `Transform::transform_stream` which allows consumers to
return their own type erased `Stream`. This should allow all various
types of advanced transforms, while still supporting simpler transforms
with a simpler API.

Closes #1598

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>