### PR TITLE
fix(kubernetes source): Use checksum fingerprinting

### DIFF
--- a/src/sources/kubernetes/file_source_builder.rs
+++ b/src/sources/kubernetes/file_source_builder.rs
@@ -49,8 +49,8 @@ impl<'a> FileSourceBuilder<'a> {
         // oldest_first false, having all pods equaly serviced is of greater importance
         //                     than having time order guarantee.
 
-        // CRI standard ensures unique naming.
-        self.file_config.fingerprinting = FingerprintingConfig::DevInode;
+        // CRI standard ensures unique naming, but Docker log rotation tends to re-use inodes,
+        // so we keep the default checksum fingerprinting strategy.
 
         // Have a subdirectory for this source to avoid collision of naming its file source.
         self.file_config.data_dir = Some(globals.resolve_and_make_data_subdir(None, kube_name)?);


### PR DESCRIPTION
Whenever an inode is reused from an old log file after rotating, Vector will keep the offset and not
process logs. This PR changes the source to use the default fingerprinting strategy instead.

Fixes #1910.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
