### PR TITLE
enhancement(observability): Enable `rdkafka` logs by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() {
             format!("codec={}", level),
             format!("file_source={}", level),
             format!("tower_limit=trace"),
+            format!("rdkafka={}", level),
         ]
         .join(",")
         .to_string()


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/1752, closes #1903.

This turns on reporting of all errors happening inside `librdkafka` by default. However, currently these errors are not linked to a a particular sink or source. Ideally we also want to have the related sink or source in the report, but I think it is better to have a separate issue  for this because it might require modification of `rdkafka` to use `tracing` instead of `log`.