### PR TITLE
fix(operations): Fix build with `--no-default-features`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config_paths;
 pub mod dns;
 pub mod event;
 pub mod generate;
+#[cfg(feature = "rdkafka")]
 pub mod kafka;
 pub mod list;
 pub mod metrics;


### PR DESCRIPTION
This PR places `src/kafka.rs` module behind `#[cfg(feature = "rdkafka")]` in order to make it possible to build Vector without default features.