### PR TITLE
fix(cli): Relax the requirements for `no_outputs_from` unit test targets

### DIFF
--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -218,7 +218,10 @@ fn reduce_transforms(
 
     if roots
         .iter()
-        .all(|r| !links_to_a_leaf(r, leaves, &mut link_checked, transform_outputs))
+        .map(|r| links_to_a_leaf(r, leaves, &mut link_checked, transform_outputs))
+        .collect::<Vec<_>>() // Ensure we map each element.
+        .iter()
+        .all(|b| !b)
     {
         transform_outputs.clear();
     }
@@ -416,22 +419,6 @@ fn build_unit_test(
                 errors.push(format!(
                     "unable to complete topology between target transforms {:?} and output target '{}'",
                     targets, o.extract_from
-                ));
-            }
-        }
-    });
-    definition.no_outputs_from.iter().for_each(|o| {
-        if !transforms.contains_key(o) {
-            let targets = inputs.iter().map(|(i, _)| i).flatten().collect::<Vec<_>>();
-            if targets.len() == 1 {
-                errors.push(format!(
-                    "unable to complete topology between target transform '{}' and no_outputs_from target '{}'",
-                    targets.first().unwrap(), o,
-                ));
-            } else {
-                errors.push(format!(
-                    "unable to complete topology between target transforms {:?} and no_outputs_from target '{}'",
-                    targets, o,
                 ));
             }
         }

--- a/tests/behavior/transforms/swimlanes.toml
+++ b/tests/behavior/transforms/swimlanes.toml
@@ -16,8 +16,9 @@
 
 [[tests]]
   name = "swimlanes test 1"
+  no_outputs_from = [ "foo.second" ]
 
-  [tests.input]
+  [[tests.inputs]]
     insert_at = "foo"
     value = "test swimlane 1"
 
@@ -36,8 +37,9 @@
 
 [[tests]]
   name = "swimlanes test 2"
+  no_outputs_from = [ "foo.first", "bar" ]
 
-  [tests.input]
+  [[tests.inputs]]
     insert_at = "foo"
     value = "test swimlane 2"
 


### PR DESCRIPTION
When verifying unit tests Vector checks that input targets are actually connected to output targets in the topology. However, for targets within `no_outputs_from` this check seems heavy handed as it's nice to explicitly confirm it in a test even if components aren't necessarily directly connected.

Also fixes an issue with validating the tested topology when using `no_outputs_from` that was blocking it from being used with `swimlanes`.