### PR TITLE
fix(config): Partial `LogSchema`

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -762,7 +762,7 @@ mod test {
 
     #[test]
     fn partial_log_schema() {
-        let toml = r#"     
+        let toml = r#"
 message_key = "message"
 timestamp_key = "timestamp"
 "#;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -179,6 +179,7 @@ pub fn log_schema() -> &'static LogSchema {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Getters, Setters)]
+#[serde(default)]
 pub struct LogSchema {
     #[getset(get = "pub", set = "pub(crate)")]
     message_key: Atom,
@@ -666,7 +667,7 @@ impl<'a> Serialize for FieldsIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::{Atom, Event, Value};
+    use super::{Atom, Event, LogSchema, Value};
     use regex::Regex;
     use std::collections::HashSet;
 
@@ -757,5 +758,14 @@ mod test {
                 (&Atom::from("o9amkaRY"), &Value::from("pGsfG7Nr")),
             ]
         );
+    }
+
+    #[test]
+    fn partial_log_schema() {
+        let toml = r#"     
+message_key = "message"
+timestamp_key = "timestamp"
+"#;
+        let _ = toml::from_str::<LogSchema>(toml).unwrap();
     }
 }


### PR DESCRIPTION
As it stands, vector will fail to run with partial `LogSchema` configuration. Example:

```toml
[log_schema]
    message_key = "message"
    timestamp_key = "timestamp" 
```

would report "missing field `host_key`".

One of the consequences is that adding a new key like `kubernetes_key` would break all configurations that are configuring `log_schema`.

This PR adds `#[serde(default)]` to the `struct LogSchema` which enables partial configuration.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
