### PR TITLE
chore(sinks): New `StreamingSink` trait and file sink spike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "async-trait"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
 name = "bytesize"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +370,7 @@ dependencies = [
 name = "codec"
 version = "0.1.0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "serde_json",
  "tokio-codec",
  "tracing",
@@ -836,7 +853,7 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5589ce096bbfc5465cc2f3f6de6605803d6b4ef741ad6d38172dc30bfeea5f95"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "smallvec 1.2.0",
 ]
 
@@ -890,7 +907,7 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 name = "file-source"
 version = "0.1.0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "crc",
  "flate2",
  "futures 0.1.29",
@@ -1193,7 +1210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "fnv",
  "futures 0.1.29",
  "http",
@@ -1236,7 +1253,7 @@ checksum = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 dependencies = [
  "base64 0.10.1",
  "bitflags",
- "bytes",
+ "bytes 0.4.12",
  "headers-core",
  "http",
  "mime 0.3.16",
@@ -1250,7 +1267,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "http",
 ]
 
@@ -1321,7 +1338,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "fnv",
  "itoa",
 ]
@@ -1332,7 +1349,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "http",
  "tokio-buf",
@@ -1369,7 +1386,7 @@ version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "futures-cpupool",
  "h2",
@@ -1382,7 +1399,7 @@ dependencies = [
  "net2",
  "rustc_version",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -1400,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52657b5cdb2a8067efd29a02e011b7cf656b473ec8a5c34e86645e85d763006"
 dependencies = [
  "antidote",
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "hyper",
  "lazy_static",
@@ -1417,7 +1434,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "hyper",
  "native-tls",
@@ -1433,7 +1450,7 @@ dependencies = [
  "futures 0.1.29",
  "hex",
  "hyper",
- "tokio",
+ "tokio 0.1.22",
  "tokio-io",
  "tokio-uds",
 ]
@@ -1496,7 +1513,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
 ]
 
 [[package]]
@@ -1603,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e2ac1496d5920d157d0eb5ab453b0af1e6622d5ffa8e7f9c60d435d13342da"
 dependencies = [
  "base64 0.10.1",
- "bytes",
+ "bytes 0.4.12",
  "chrono",
  "http",
  "serde",
@@ -2399,6 +2416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,7 +2551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "prost-derive",
 ]
 
@@ -2538,7 +2561,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "heck",
  "itertools",
  "log 0.4.8",
@@ -2569,7 +2592,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "prost",
 ]
 
@@ -2952,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
  "base64 0.10.1",
- "bytes",
+ "bytes 0.4.12",
  "cookie",
  "cookie_store",
  "encoding_rs",
@@ -2969,7 +2992,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.5.5",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
  "tokio-threadpool",
@@ -3007,7 +3030,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f470c278733d18760a5966a89227f4d9a06bb1d8260d676b011faa4d2aa82342"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "rusoto_core",
  "serde_urlencoded 0.5.5",
@@ -3021,7 +3044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "351e97aedcc659bd03168ff7fd3dbb270b6ee812c0c51c7953d2ef6f0a119aa9"
 dependencies = [
  "base64 0.10.1",
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "hex",
  "hmac",
@@ -3039,7 +3062,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-timer",
  "xml-rs",
 ]
@@ -3069,7 +3092,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef495217f457f6ad9a1d975fcbedc346b39708a6725118d58f704064e0252c81"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "rusoto_core",
  "serde",
@@ -3083,7 +3106,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88609598b24779b268f47c0d19780cf4865b0cbccd9f677bae75f7f7c5d4dcb"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "rusoto_core",
  "serde",
@@ -3097,7 +3120,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "691f665f2ae401d4fddaac8d6a33c3e7c388e93494242ea937ebdddf9961f7f6"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "rusoto_core",
  "serde",
@@ -3111,7 +3134,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c840fca030950caf0c9bea89eb35311aa5b01c0341fb0aaf28d347b5c416d7"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "rusoto_core",
  "xml-rs",
@@ -3123,7 +3146,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8cdff317625611de545e91b80a883a7d6fb1cf2d772f64abaf83c0925fa0ff"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "chrono",
  "futures 0.1.29",
  "rusoto_core",
@@ -3414,7 +3437,7 @@ checksum = "b78521d24224ac77e489f92efa0f02884e7fc2973f97b2e72c9bb3e4771e6f6b"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "flate2",
  "futures 0.1.29",
  "http",
@@ -3427,7 +3450,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "tokio",
+ "tokio 0.1.22",
  "tokio-codec",
  "tokio-io",
  "url 2.1.1",
@@ -3569,7 +3592,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
 ]
 
 [[package]]
@@ -3804,7 +3827,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "mio",
  "num_cpus 1.12.0",
@@ -3824,12 +3847,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "either",
  "futures 0.1.29",
 ]
@@ -3840,7 +3875,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "tokio-io",
 ]
@@ -3882,7 +3917,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "log 0.4.8",
 ]
@@ -3980,7 +4015,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
  "mio",
@@ -4034,7 +4069,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "log 0.4.8",
  "mio",
@@ -4049,7 +4084,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
  "libc",
@@ -4340,7 +4375,7 @@ dependencies = [
  "hotmic",
  "hyper",
  "serde_json",
- "tokio",
+ "tokio 0.1.22",
  "tracing",
  "tracing-core",
  "tracing-futures 0.2.1",
@@ -4406,7 +4441,7 @@ dependencies = [
  "log 0.4.8",
  "radix_trie",
  "rand 0.7.3",
- "tokio",
+ "tokio 0.1.22",
  "tokio-tcp",
  "tokio-udp",
  "trust-dns-proto",
@@ -4454,7 +4489,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec 0.6.13",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-tcp",
  "tokio-udp",
@@ -4468,7 +4503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e526ea9c9203633a7818e9d459ff29a3fca050281f6de24db07d873f9d95792e"
 dependencies = [
  "backtrace",
- "bytes",
+ "bytes 0.4.12",
  "chrono",
  "clap",
  "enum-as-inner",
@@ -4481,7 +4516,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
  "tokio-reactor",
@@ -4517,7 +4552,7 @@ checksum = "8a0c2bd5aeb7dcd2bb32e472c8872759308495e5eccc942e929a513cd8d36110"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "http",
  "httparse",
  "input_buffer",
@@ -4715,10 +4750,11 @@ name = "vector"
 version = "0.8.0"
 dependencies = [
  "approx",
+ "async-trait",
  "atty",
  "base64 0.10.1",
  "built",
- "bytes",
+ "bytes 0.4.12",
  "bytesize",
  "chrono",
  "codec",
@@ -4800,7 +4836,8 @@ dependencies = [
  "structopt",
  "syslog_loose",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
+ "tokio 0.2.11",
  "tokio-retry",
  "tokio-signal",
  "tokio-threadpool",
@@ -4893,7 +4930,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3921463c44f680d24f1273ea55efd985f31206a22a02dee207a2ec72684285ca"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures 0.1.29",
  "headers",
  "http",
@@ -4906,7 +4943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.6.1",
- "tokio",
+ "tokio 0.1.22",
  "tokio-io",
  "tokio-threadpool",
  "tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-threadpool = "0.1.16"
 tokio-tls = "0.2.1"
+tokio02 = { package = "tokio", version = "0.2", features = ["sync", "fs"] }
+async-trait = "0.1"
 
 # Tracing
 tracing = "0.1.9"

--- a/src/sinks/file2.rs
+++ b/src/sinks/file2.rs
@@ -1,0 +1,197 @@
+use crate::{
+    template::Template,
+    topology::config::{DataType, SinkConfig, SinkContext},
+    Event, Result,
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{Poll, Sink, StartSend};
+use futures03::channel::mpsc::{channel, Receiver, Sender};
+use futures03::compat::CompatSink;
+use futures03::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::{ffi, path};
+use tokio02::{fs::File, io::AsyncWriteExt};
+
+// === StreamingSink ===
+
+#[async_trait]
+pub trait StreamingSink: Send + Sync + 'static {
+    async fn run(&mut self, input: Receiver<Event>) -> Result<()>;
+
+    fn build_sink(self) -> super::RouterSink
+    where
+        Self: Sized + 'static,
+    {
+        let (tx, rx) = channel(64);
+
+        let sink = LazyStreamingSink {
+            sink: Some((rx, self)),
+            inner: CompatSink::new(tx),
+        };
+
+        Box::new(sink)
+    }
+}
+
+pub struct LazyStreamingSink<T> {
+    sink: Option<(Receiver<Event>, T)>,
+    inner: CompatSink<Sender<Event>, Event>,
+}
+
+impl<T: StreamingSink> Sink for LazyStreamingSink<T> {
+    type SinkItem = Event;
+    type SinkError = ();
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        if let Some((rx, mut sink)) = self.sink.take() {
+            tokio02::spawn(async move {
+                if let Err(error) = sink.run(rx).await {
+                    error!(message = "Unexpected sink failure.", %error);
+                }
+            });
+        }
+
+        self.inner.start_send(item).map_err(drop)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.poll_complete().map_err(drop)
+    }
+}
+
+// === File Sink Implementation ===
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct FileSinkConfig {
+    pub path: Template,
+    pub idle_timeout_secs: Option<u64>,
+    pub encoding: Encoding,
+}
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum Encoding {
+    Text,
+    Ndjson,
+}
+
+#[typetag::serde(name = "file2")]
+impl SinkConfig for FileSinkConfig {
+    fn build(&self, _cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+        let sink = FileSink {
+            path: self.path.clone(),
+            files: HashMap::new(),
+            encoding: self.encoding.clone(),
+        }
+        .build_sink();
+
+        Ok((sink, Box::new(futures::future::ok(()))))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "file2"
+    }
+}
+
+struct FileSink {
+    path: Template,
+    files: HashMap<Bytes, File>,
+    encoding: Encoding,
+}
+
+impl FileSink {
+    fn partition_event(&mut self, event: &Event) -> Option<Bytes> {
+        let bytes = match self.path.render(event) {
+            Ok(b) => b,
+            Err(missing_keys) => {
+                warn!(
+                    message = "Keys do not exist on the event. Dropping event.",
+                    ?missing_keys
+                );
+                return None;
+            }
+        };
+
+        Some(bytes)
+    }
+}
+
+#[async_trait]
+impl StreamingSink for FileSink {
+    async fn run(&mut self, mut input: Receiver<Event>) -> Result<()> {
+        while let Some(event) = input.next().await {
+            if let Some(path) = self.partition_event(&event) {
+                let mut file = if let Some(file) = self.files.get_mut(&path) {
+                    file
+                } else {
+                    let file = File::create(BytesPath::new(path.clone())).await.unwrap();
+                    self.files.insert(path.clone(), file);
+
+                    self.files.get_mut(&path).unwrap()
+                };
+
+                let log = event.into_log();
+
+                let mut buf = match self.encoding {
+                    Encoding::Ndjson => serde_json::to_vec(&log.unflatten())
+                        .expect("Unable to encode event as JSON."),
+                    Encoding::Text => log
+                        .get(&crate::event::log_schema().message_key())
+                        .map(|v| v.to_string_lossy().into_bytes())
+                        .unwrap_or_default(),
+                };
+
+                buf.push(b'\n');
+
+                let encoded_event: Vec<u8> = buf.into();
+
+                file.write_all(&encoded_event[..]).await.unwrap();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// === Fun little hack around bytse and OsStr ===
+
+#[derive(Debug, Clone)]
+struct BytesPath {
+    #[cfg(unix)]
+    path: Bytes,
+    #[cfg(windows)]
+    path: path::PathBuf,
+}
+
+impl BytesPath {
+    #[cfg(unix)]
+    fn new(path: Bytes) -> BytesPath {
+        BytesPath { path }
+    }
+    #[cfg(windows)]
+    fn new(path: Bytes) -> BytesPath {
+        let utf8_string = String::from_utf8_lossy(&path[..]);
+        let path = path::PathBuf::from(utf8_string.as_ref());
+        BytesPath { path }
+    }
+}
+
+impl AsRef<path::Path> for BytesPath {
+    #[cfg(unix)]
+    fn as_ref(&self) -> &path::Path {
+        use std::os::unix::ffi::OsStrExt;
+        let os_str = ffi::OsStr::from_bytes(&self.path);
+        &path::Path::new(os_str)
+    }
+    #[cfg(windows)]
+    fn as_ref(&self) -> &path::Path {
+        &self.path.as_ref()
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -12,6 +12,7 @@ pub mod console;
 pub mod datadog_metrics;
 pub mod elasticsearch;
 pub mod file;
+pub mod file2;
 pub mod gcp;
 pub mod http;
 pub mod humio_logs;


### PR DESCRIPTION
This is an initial spike of what a `StreamingSink` trait would look like with `tokio 0.2` and async/await. This is a proposal that could possibly get adopted for our file sink rewrite that is due since it is not compatible with our current runtime upgrade work.

Mainly opening this to get some feedback and thoughts, this tries to implement the previous logic in a very intuitive and easy to follow method.

cc @lukesteensen @MOZGIII 

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>

