### PR TITLE
feat(config): Default to `check_fields` condition

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -4,6 +4,8 @@ use inventory;
 
 pub mod check_fields;
 
+pub use check_fields::CheckFieldsConfig;
+
 pub trait Condition: Send + Sync {
     fn check(&self, e: &Event) -> bool;
 

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -286,8 +286,9 @@ pub struct TestOutput {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum TestCondition {
-    String(String),
     Embedded(Box<dyn conditions::ConditionConfig>),
+    NoTypeEmbedded(conditions::CheckFieldsConfig),
+    String(String),
 }
 
 // Helper methods for programming construction during tests

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::Condition,
+    conditions::{Condition, ConditionConfig},
     event::{Event, Value},
     runtime::Runtime,
     topology::config::{
@@ -437,6 +437,17 @@ fn build_unit_test(
             {
                 match cond_conf {
                     TestCondition::Embedded(b) => match b.build() {
+                        Ok(c) => {
+                            conditions.push(c);
+                        }
+                        Err(e) => {
+                            errors.push(format!(
+                                "failed to create test condition '{}': {}",
+                                index, e,
+                            ));
+                        }
+                    },
+                    TestCondition::NoTypeEmbedded(n) => match n.build() {
                         Ok(c) => {
                             conditions.push(c);
                         }

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -14,7 +14,6 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.b.equals" = 123
       "x.y.equals" = 456
       "x.z.equals" = 789
@@ -38,7 +37,6 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_nested_2"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.b.equals" = "new value"
 
 [transforms.add_fields_nested_then_scalar_1]
@@ -60,7 +58,6 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested_then_scalar_2"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.equals" = "new value"
 
 [transforms.add_fields_scalar_then_scalar_1]
@@ -82,7 +79,6 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_scalar_2"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.equals" = "new value"
 
 [transforms.add_fields_templated_1]
@@ -104,7 +100,6 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_2"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "b.equals" = "a was: initial value"
 
 [transforms.add_fields_templated_nested_1]
@@ -126,5 +121,4 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_nested_2"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "b.c.equals" = "a.b was: initial value"

--- a/tests/behavior/transforms/ansi_stripper.toml
+++ b/tests/behavior/transforms/ansi_stripper.toml
@@ -11,7 +11,6 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "message.equals" = "hello123"
 
 [transforms.ansi_stripper_nested]
@@ -28,5 +27,4 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.b.equals" = "hello123"

--- a/tests/behavior/transforms/coercer.toml
+++ b/tests/behavior/transforms/coercer.toml
@@ -23,7 +23,6 @@
   [[tests.outputs]]
     extract_from = "coercer_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "integer_field.equals" = 123
       "boolean_field.equals" = true
       "float_field.equals" = 3.1415926535
@@ -46,5 +45,4 @@
   [[tests.outputs]]
     extract_from = "coercer_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.field.equals" = 1234

--- a/tests/behavior/transforms/concat.toml
+++ b/tests/behavior/transforms/concat.toml
@@ -15,7 +15,6 @@
   [[tests.outputs]]
     extract_from = "concat_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "concatenated.equals" = "on wo re"
 
 [transforms.concat_nested]
@@ -35,5 +34,4 @@
   [[tests.outputs]]
     extract_from = "concat_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.concatenated.field.equals" = "ababab cdcdcd efe"

--- a/tests/behavior/transforms/grok_parser.toml
+++ b/tests/behavior/transforms/grok_parser.toml
@@ -11,7 +11,6 @@
   [[tests.outputs]]
     extract_from = "grok_parser_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "timestamp.equals" = "12/Dec/2015:18:32:56 +0100"
       "message.equals" = "hello"
 
@@ -28,6 +27,5 @@
   [[tests.outputs]]
     extract_from = "grok_parser_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.timestamp.equals" = "12/Dec/2015:18:32:56 +0100"
       "doubly.nested.message.equals" = "hello"

--- a/tests/behavior/transforms/json_parser.toml
+++ b/tests/behavior/transforms/json_parser.toml
@@ -10,7 +10,6 @@
   [[tests.outputs]]
     extract_from = "json_parser_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.equals" = 3
       "b.c.equals" = 4
 
@@ -27,7 +26,6 @@
   [[tests.outputs]]
     extract_from = "json_parser_target_field"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "target_field.a.equals" = 3
       "target_field.b.c.equals" = 4
 
@@ -43,6 +41,5 @@
   [[tests.outputs]]
     extract_from = "json_parser_null_value"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.equals" = 3
       "b.equals" = "<null>"

--- a/tests/behavior/transforms/logfmt_parser.toml
+++ b/tests/behavior/transforms/logfmt_parser.toml
@@ -15,7 +15,6 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "code.equals" = 1234
       "flag.equals" = true
       "number.equals" = 42.3
@@ -38,7 +37,6 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.code.equals" = 1234
       "nested.flag.equals" = true
       "nested.number.equals" = 42.3

--- a/tests/behavior/transforms/merge.toml
+++ b/tests/behavior/transforms/merge.toml
@@ -17,7 +17,6 @@
   [[tests.outputs]]
     extract_from = "merge"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "message.equals" = "hello world"
       "_partial.exists" = false
 
@@ -41,7 +40,6 @@
   [[tests.outputs]]
     extract_from = "merge_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.message.equals" = "hello world"
       "_partial.exists" = false
 
@@ -66,6 +64,5 @@
   [[tests.outputs]]
     extract_from = "merge_nested_marker"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.message.equals" = "hello world"
       "nested.is_partial.exists" = false

--- a/tests/behavior/transforms/regex_parser.toml
+++ b/tests/behavior/transforms/regex_parser.toml
@@ -11,7 +11,6 @@
   [[tests.outputs]]
     extract_from = "regex_parser_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "timestamp.equals" = "2020-01-01T12:34:56Z"
       "level.equals" = "INFO"
       "message.equals" = "hello"

--- a/tests/behavior/transforms/remove_fields.toml
+++ b/tests/behavior/transforms/remove_fields.toml
@@ -13,7 +13,6 @@
   [[tests.outputs]]
     extract_from = "remove_fields_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.exists" = false
       "b.equals" = 4
 
@@ -32,6 +31,5 @@
   [[tests.outputs]]
     extract_from = "remove_fields_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "a.b.equals" = 3
       "a.c.exists" = false

--- a/tests/behavior/transforms/rename_fields.toml
+++ b/tests/behavior/transforms/rename_fields.toml
@@ -21,7 +21,6 @@
   [[tests.outputs]]
     extract_from = "rename_fields_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       # Plain
       "a.exists" = false
       "renamed_a.equals" = "a"

--- a/tests/behavior/transforms/split.toml
+++ b/tests/behavior/transforms/split.toml
@@ -11,7 +11,6 @@
   [[tests.outputs]]
     extract_from = "split_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "timestamp.equals" = "2020-01-01T12:34:56Z"
       "level.equals" = "INFO"
       "message.equals" = "\"hello,"
@@ -30,7 +29,6 @@
   [[tests.outputs]]
     extract_from = "split_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.timestamp.equals" = "2020-01-01T12:34:56Z"
       "nested.level.equals" = "INFO"
       "doubly.nested.message.equals" = "hello"

--- a/tests/behavior/transforms/swimlanes.toml
+++ b/tests/behavior/transforms/swimlanes.toml
@@ -2,10 +2,8 @@
   inputs = ["ignored"]
   type = "swimlanes"
   [transforms.foo.lanes.first]
-    type = "check_fields"
     "message.eq" = "test swimlane 1"
   [transforms.foo.lanes.second]
-    type = "check_fields"
     "message.eq" = "test swimlane 2"
 
 [transforms.bar]
@@ -25,13 +23,11 @@
   [[tests.outputs]]
     extract_from = "foo.first"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "message.equals" = "test swimlane 1"
 
   [[tests.outputs]]
     extract_from = "bar"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "message.equals" = "test swimlane 1"
       "new_field.equals" = "new field added"
 
@@ -46,5 +42,4 @@
   [[tests.outputs]]
     extract_from = "foo.second"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "message.equals" = "test swimlane 2"

--- a/tests/behavior/transforms/tokenizer.toml
+++ b/tests/behavior/transforms/tokenizer.toml
@@ -11,7 +11,6 @@
   [[tests.outputs]]
     extract_from = "tokenizer_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "timestamp.equals" = "2020-01-01T12:34:56Z"
       "level.equals" = "INFO"
       "message.equals" = "hello, world"
@@ -30,7 +29,6 @@
   [[tests.outputs]]
     extract_from = "tokenizer_nested"
     [[tests.outputs.conditions]]
-      type = "check_fields"
       "nested.timestamp.equals" = "2020-01-01T12:34:56Z"
       "nested.level.equals" = "INFO"
       "nested.message.equals" = "hello"


### PR DESCRIPTION
Allows you, for both unit test output conditions and swimlanes, to remove the `type = "check_fields"` line as it's now a default condition.

You _can_ still specify the `type` field without problems, which allows us to add more condition options in the future (coming soon!)

Closes #1840