### PR TITLE
chore(website): Remove Google Analytics

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -125,9 +125,6 @@ module.exports = {
       },
       copyright: `Copyright © ${new Date().getFullYear()} Timber, Inc.`,
     },
-    googleAnalytics: {
-      trackingID: 'UA-79173230-9',
-    },
     algolia: {
       apiKey: '2356c5cb76b57b43624c6450b0a031cc',
       indexName: 'timberio_vector',


### PR DESCRIPTION
This was added as part of the basic Docusaurus setup, but I am very much against tracking users.