### PR TITLE
chore(networking)!: Move all TLS support over to openssl

### DIFF
--- a/.meta/_partials/_tls_acceptor_options.toml
+++ b/.meta/_partials/_tls_acceptor_options.toml
@@ -14,14 +14,13 @@ Require TLS for incoming connections. \
 If this is set, an identity certificate is also required.\
 """
 
-# This is not yet supported
-#[<%= namespace %>.tls.children.ca_path]
-#type = "string"
-#examples = ["/path/to/certificate_authority.crt"]
-#description = """\
-#Absolute path to an additional CA certificate file, in DER or PEM format \
-#(X.509).\
-#"""
+[<%= namespace %>.tls.children.ca_path]
+type = "string"
+examples = ["/path/to/certificate_authority.crt"]
+description = """\
+Absolute path to an additional CA certificate file, in DER or PEM format \
+(X.509).\
+"""
 
 [<%= namespace %>.tls.children.crt_path]
 type = "string"
@@ -55,19 +54,11 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless \
 `key_path` is set.\
 """
 
-# These are not yet supported
-#[<%= namespace %>.tls.children.verify_certificate]
-#type = "bool"
-#default = true
-#description = """\
-#If `true` (the default), Vector will validate the TLS certificate of the \
-#connecting host.\
-#"""
-
-#[<%= namespace %>.tls.children.verify_hostname]
-#type = "bool"
-#default = true
-#description = """\
-#If `true` (the default), Vector will validate the configured connecting host
-#name against the remote host's TLS certificate.\
-#"""
+[<%= namespace %>.tls.children.verify_certificate]
+type = "bool"
+default = true
+description = """\
+If `true` (the default), Vector will require a TLS certificate from the connecting host \
+and terminate the connection if it is not valid. \
+If `false`, Vector will ignore the presence of a client certificate.\
+"""

--- a/.meta/_partials/_tls_acceptor_options.toml
+++ b/.meta/_partials/_tls_acceptor_options.toml
@@ -56,9 +56,9 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless \
 
 [<%= namespace %>.tls.children.verify_certificate]
 type = "bool"
-default = true
+default = false
 description = """\
-If `true` (the default), Vector will require a TLS certificate from the connecting host \
+If `true`, Vector will require a TLS certificate from the connecting host \
 and terminate the connection if it is not valid. \
-If `false`, Vector will ignore the presence of a client certificate.\
+If `false` (the default), Vector will ignore the presence of a client certificate.\
 """

--- a/.meta/_partials/_tls_connector_options.toml
+++ b/.meta/_partials/_tls_connector_options.toml
@@ -44,7 +44,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless \
 `key_path` is set.\
 """
 
-<%- if can_verify -%>
+<%- if can_verify_certificate -%>
 [<%= namespace %>.tls.children.verify_certificate]
 type = "bool"
 default = true
@@ -53,7 +53,9 @@ If `true` (the default), Vector will validate the TLS certificate of the \
 remote host. Do NOT set this to `false` unless you understand the risks of not \
 verifying the remote certificate.\
 """
+<%- end -%>
 
+<%- if can_verify_hostname -%>
 [<%= namespace %>.tls.children.verify_hostname]
 type = "bool"
 default = true

--- a/.meta/sinks/clickhouse.toml
+++ b/.meta/sinks/clickhouse.toml
@@ -86,7 +86,7 @@ examples = ["mytable"]
 required = true
 description = "The table that data will be inserted into."
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.clickhouse.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.clickhouse.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: false) %>
 
 [sinks.clickhouse.options.database]
 type = "string"

--- a/.meta/sinks/elasticsearch.toml
+++ b/.meta/sinks/elasticsearch.toml
@@ -109,7 +109,7 @@ examples = [{"X-Powered-By" = "Vector"}]
 required = true
 description = "A custom parameter to be added to each Elasticsearch request."
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.elasticsearch.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.elasticsearch.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: false) %>
 
 [[sinks.elasticsearch.output.examples]]
 label = "Generic"

--- a/.meta/sinks/gcp_cloud_storage.toml
+++ b/.meta/sinks/gcp_cloud_storage.toml
@@ -137,4 +137,4 @@ description = "The compression mechanism to use."
 gzip = "GZIP compression"
 none = "No compression"
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_cloud_storage.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_cloud_storage.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: true) %>

--- a/.meta/sinks/gcp_pubsub.toml
+++ b/.meta/sinks/gcp_pubsub.toml
@@ -47,7 +47,7 @@ required = true
 examples = ["vector-123456"]
 description = "The project name to which to publish logs."
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_pubsub.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_pubsub.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: true) %>
 
 [sinks.gcp_pubsub.options.topic]
 type = "string"

--- a/.meta/sinks/gcp_stackdriver_logging.toml
+++ b/.meta/sinks/gcp_stackdriver_logging.toml
@@ -121,4 +121,4 @@ For example, Compute Engine VM instances use the labels `projectId`, \
 `instanceId`, and `zone`.\
 """
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_stackdriver_logging.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.gcp_stackdriver_logging.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: false) %>

--- a/.meta/sinks/http.toml
+++ b/.meta/sinks/http.toml
@@ -103,7 +103,7 @@ type = "string"
 examples = ["https://10.22.212.22:9000/_health"]
 description = "A URI that Vector can request in order to determine the service health."
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.http.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.http.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: false) %>
 
 [sinks.http.options.uri]
 type = "string"

--- a/.meta/sinks/kafka.toml
+++ b/.meta/sinks/kafka.toml
@@ -51,7 +51,7 @@ randomly generated. If the field does not exist on the log, a blank value \
 will be used.\
 """
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.kafka.options", can_enable: true, can_verify: false) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.kafka.options", can_enable: true, can_verify_certificate: false, can_verify_hostname: false) %>
 
 [sinks.kafka.options.topic]
 type = "string"

--- a/.meta/sinks/loki.toml
+++ b/.meta/sinks/loki.toml
@@ -30,7 +30,7 @@ write_to_description = "[Loki][urls.loki]"
   timeout_secs: 60
 ) %>
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.loki.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.loki.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: true) %>
 
 [sinks.loki.options.endpoint]
 type = "string"

--- a/.meta/sinks/socket.toml
+++ b/.meta/sinks/socket.toml
@@ -54,5 +54,5 @@ relevant_when = {mode = "unix"}
 description = """The unix socket path. This should be the absolute path.\
 """
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.socket.options", can_enable: true, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.socket.options", can_enable: true, can_verify_certificate: true, can_verify_hostname: true) %>
 

--- a/.meta/sinks/splunk_hec.toml
+++ b/.meta/sinks/splunk_hec.toml
@@ -65,4 +65,4 @@ relevant_when = {encoding = "json"}
 required = false
 description = "Fields to be [added to Splunk index][urls.splunk_hec_indexed_fields]."
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.splunk_hec.options", can_enable: false, can_verify: true) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sinks.splunk_hec.options", can_enable: false, can_verify_certificate: true, can_verify_hostname: false) %>

--- a/.meta/sources/kafka.toml
+++ b/.meta/sources/kafka.toml
@@ -22,7 +22,7 @@ Kafka brokers in a \"bootstrap\" Kafka cluster that a Kafka client connects \
 to initially to bootstrap itself.\
 """
 
-<%= render("_partials/_tls_connector_options.toml", namespace: "sources.kafka.options", can_enable: true, can_verify: false) %>
+<%= render("_partials/_tls_connector_options.toml", namespace: "sources.kafka.options", can_enable: true, can_verify_certificate: false, can_verify_hostname: false) %>
 
 [sources.kafka.options.topics]
 type = "[string]"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4661,7 +4661,6 @@ dependencies = [
  "http",
  "hyper",
  "hyper-openssl",
- "hyper-tls",
  "indexmap",
  "inventory",
  "jemallocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,17 +3988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.29",
- "native-tls",
- "tokio-io",
-]
-
-[[package]]
 name = "tokio-udp"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,10 +4718,10 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-codec",
+ "tokio-openssl",
  "tokio-retry",
  "tokio-signal",
  "tokio-threadpool",
- "tokio-tls",
  "tokio-uds",
  "tokio01-test",
  "toml 0.4.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,6 @@ bytes = { version = "0.4.10", features = ["serde"] }
 stream-cancel = "0.4.3"
 hyper = "0.12.35"
 hyper-openssl = "0.7"
-hyper-tls = "0.3.2"
 native-tls = "0.2.3"
 openssl = "0.10.26"
 openssl-probe = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,9 +214,10 @@ sources = [
   "sources-statsd",
   "sources-stdin",
   "sources-syslog",
+  "sources-tls",
   "sources-vector",
 ]
-sources-tls = []
+sources-tls = ["sources-http", "sources-logplex", "sources-splunk_hec"]
 sources-docker = ["shiplift"]
 sources-file = ["bytesize"]
 sources-journald = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ tracing-limit = { path = "lib/tracing-limit" }
 futures01 = { package = "futures", version = "0.1.25" }
 futures = { version = "0.3", default-features = false, features = ["compat"] }
 tokio = { version = "0.1.22", features = ["io", "uds", "tcp", "rt-full", "experimental-tracing"], default-features = false }
+tokio-codec = "0.1.0"
+tokio-openssl = "0.3.0"
 tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-threadpool = "0.1.16"
-tokio-tls = "0.2.1"
-tokio-codec = "0.1.0"
 
 # Tracing
 tracing = "0.1.9"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -426,15 +426,15 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 # Ingests data through log records from journald and outputs `log` events.
 [sources.journald]
@@ -701,15 +701,15 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 # Ingests data through the Prometheus text exposition format and outputs `metric` events.
 [sources.prometheus]
@@ -855,15 +855,15 @@ dns_servers = ["0.0.0.0:53"]
     # * relevant when mode = "tcp"
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 # Ingests data through the Splunk HTTP Event Collector protocol and outputs `log` events.
 [sources.splunk_hec]
@@ -944,15 +944,15 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 # Ingests data through the StatsD UDP protocol and outputs `metric` events.
 [sources.statsd]
@@ -1114,15 +1114,15 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 # Ingests data through another upstream `vector` sink and outputs `log` and `metric` events.
 [sources.vector]
@@ -1204,15 +1204,15 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     key_path = "/path/to/host_certificate.key"
 
-    # If `true` (the default), Vector will require a TLS certificate from the
-    # connecting host and terminate the connection if it is not valid. If `false`,
-    # Vector will ignore the presence of a client certificate.
+    # If `true`, Vector will require a TLS certificate from the connecting host and
+    # terminate the connection if it is not valid. If `false` (the default), Vector
+    # will ignore the presence of a client certificate.
     #
     # * optional
-    # * default: true
+    # * default: false
     # * type: bool
-    verify_certificate = true
     verify_certificate = false
+    verify_certificate = true
 
 
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -383,6 +383,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.http.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -417,6 +425,16 @@ dns_servers = ["0.0.0.0:53"]
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 # Ingests data through log records from journald and outputs `log` events.
 [sources.journald]
@@ -640,6 +658,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.logplex.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -674,6 +700,16 @@ dns_servers = ["0.0.0.0:53"]
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 # Ingests data through the Prometheus text exposition format and outputs `metric` events.
 [sources.prometheus]
@@ -772,6 +808,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.socket.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -810,6 +854,16 @@ dns_servers = ["0.0.0.0:53"]
     # * type: string
     # * relevant when mode = "tcp"
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 # Ingests data through the Splunk HTTP Event Collector protocol and outputs `log` events.
 [sources.splunk_hec]
@@ -847,6 +901,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.splunk_hec.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -881,6 +943,16 @@ dns_servers = ["0.0.0.0:53"]
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 # Ingests data through the StatsD UDP protocol and outputs `metric` events.
 [sources.statsd]
@@ -999,6 +1071,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.syslog.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -1033,6 +1113,16 @@ dns_servers = ["0.0.0.0:53"]
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 # Ingests data through another upstream `vector` sink and outputs `log` and `metric` events.
 [sources.vector]
@@ -1071,6 +1161,14 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [sources.vector.tls]
+    # Absolute path to an additional CA certificate file, in DER or PEM format
+    # (X.509).
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_path = "/path/to/certificate_authority.crt"
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
     # `key_path` must also be set. This is required if `enabled` is set to `true`.
@@ -1105,6 +1203,16 @@ dns_servers = ["0.0.0.0:53"]
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # If `true` (the default), Vector will require a TLS certificate from the
+    # connecting host and terminate the connection if it is not valid. If `false`,
+    # Vector will ignore the presence of a client certificate.
+    #
+    # * optional
+    # * default: true
+    # * type: bool
+    verify_certificate = true
+    verify_certificate = false
 
 
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -3442,16 +3442,6 @@ end
     verify_certificate = true
     verify_certificate = false
 
-    # If `true` (the default), Vector will validate the configured remote host name
-    # against the remote host's TLS certificate. Do NOT set this to `false` unless
-    # you understand the risks of not verifying the remote hostname.
-    #
-    # * optional
-    # * default: true
-    # * type: bool
-    verify_hostname = true
-    verify_hostname = false
-
 # Streams `log` and `metric` events to standard output streams, such as `STDOUT` and `STDERR`.
 [sinks.console]
   #
@@ -3915,16 +3905,6 @@ end
     # * type: bool
     verify_certificate = true
     verify_certificate = false
-
-    # If `true` (the default), Vector will validate the configured remote host name
-    # against the remote host's TLS certificate. Do NOT set this to `false` unless
-    # you understand the risks of not verifying the remote hostname.
-    #
-    # * optional
-    # * default: true
-    # * type: bool
-    verify_hostname = true
-    verify_hostname = false
 
 # Streams `log` events to a file.
 [sinks.file]
@@ -4838,16 +4818,6 @@ end
     verify_certificate = true
     verify_certificate = false
 
-    # If `true` (the default), Vector will validate the configured remote host name
-    # against the remote host's TLS certificate. Do NOT set this to `false` unless
-    # you understand the risks of not verifying the remote hostname.
-    #
-    # * optional
-    # * default: true
-    # * type: bool
-    verify_hostname = true
-    verify_hostname = false
-
 # Batches `log` events to a generic HTTP endpoint.
 [sinks.http]
   #
@@ -5127,16 +5097,6 @@ end
     # * type: bool
     verify_certificate = true
     verify_certificate = false
-
-    # If `true` (the default), Vector will validate the configured remote host name
-    # against the remote host's TLS certificate. Do NOT set this to `false` unless
-    # you understand the risks of not verifying the remote hostname.
-    #
-    # * optional
-    # * default: true
-    # * type: bool
-    verify_hostname = true
-    verify_hostname = false
 
 # Batches `log` events to Humio via the HEC API.
 [sinks.humio_logs]
@@ -7001,16 +6961,6 @@ end
     # * type: bool
     verify_certificate = true
     verify_certificate = false
-
-    # If `true` (the default), Vector will validate the configured remote host name
-    # against the remote host's TLS certificate. Do NOT set this to `false` unless
-    # you understand the risks of not verifying the remote hostname.
-    #
-    # * optional
-    # * default: true
-    # * type: bool
-    verify_hostname = true
-    verify_hostname = false
 
 # Streams `metric` events to StatsD metrics service.
 [sinks.statsd]

--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use futures01::{Future, Poll};
 use http::{uri::InvalidUri, Method, StatusCode, Uri};
 use hyper;
-use hyper_tls::HttpsConnector;
+use hyper_openssl::HttpsConnector;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};

--- a/src/sinks/influxdb_metrics.rs
+++ b/src/sinks/influxdb_metrics.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use futures01::{Future, Poll};
 use http::{Method, StatusCode, Uri};
 use hyper;
-use hyper_tls::HttpsConnector;
+use hyper_openssl::HttpsConnector;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -18,7 +18,7 @@ use tokio::{
     net::tcp::{ConnectFuture, TcpStream},
     timer::Delay,
 };
-use tokio_openssl::{ConnectAsync as SslConnectAsync, SslConnectorExt, SslStream};
+use tokio_openssl::{ConnectAsync as SslConnectAsync, ConnectConfigurationExt, SslStream};
 use tokio_retry::strategy::ExponentialBackoff;
 use tracing::field;
 

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -2,7 +2,7 @@ use crate::{topology::config::GlobalOptions, Event};
 use futures01::{sync::mpsc, Future, Sink, Stream};
 use http::Uri;
 use hyper;
-use hyper_tls::HttpsConnector;
+use hyper_openssl::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::time::{Duration, Instant};

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -212,7 +212,6 @@ mod test {
             options: TlsOptions {
                 crt_path: Some("tests/data/localhost.crt".into()),
                 key_path: Some("tests/data/localhost.key".into()),
-                verify_certificate: Some(false),
                 ..Default::default()
             },
         });

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -212,6 +212,7 @@ mod test {
             options: TlsOptions {
                 crt_path: Some("tests/data/localhost.crt".into()),
                 key_path: Some("tests/data/localhost.key".into()),
+                verify_certificate: Some(false),
                 ..Default::default()
             },
         });

--- a/src/transforms/kubernetes/watch_client.rs
+++ b/src/transforms/kubernetes/watch_client.rs
@@ -2,7 +2,7 @@ use crate::{dns::Resolver, sinks::util::http::https_client, tls::TlsSettings};
 use futures01::{future::Future, stream::Stream};
 use http::{header, status::StatusCode, uri, Request, Uri};
 use hyper::{client::HttpConnector, Body, Chunk};
-use hyper_tls::HttpsConnector;
+use hyper_openssl::HttpsConnector;
 use k8s_openapi::{
     api::core::v1::{Pod, WatchPodForAllNamespacesResponse},
     apimachinery::pkg::apis::meta::v1::WatchEvent,

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -123,7 +123,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
     verify_certificate = true # default
-    verify_hostname = true # default
 ```
 
 </TabItem>
@@ -922,29 +921,6 @@ Absolute path to a certificate key file used to identify this connection, in DER
 #### verify_certificate
 
 If `true` (the default), Vector will validate the TLS certificate of the remote host. Do NOT set this to `false` unless you understand the risks of not verifying the remote certificate.
-
-
-</Field>
-
-
-<Field
-  common={false}
-  defaultValue={true}
-  enumValues={null}
-  examples={[true,false]}
-  groups={[]}
-  name={"verify_hostname"}
-  path={"tls"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"bool"}
-  unit={null}
-  >
-
-#### verify_hostname
-
-If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -118,7 +118,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
     verify_certificate = true # default
-    verify_hostname = true # default
 ```
 
 </TabItem>
@@ -933,29 +932,6 @@ Absolute path to a certificate key file used to identify this connection, in DER
 #### verify_certificate
 
 If `true` (the default), Vector will validate the TLS certificate of the remote host. Do NOT set this to `false` unless you understand the risks of not verifying the remote certificate.
-
-
-</Field>
-
-
-<Field
-  common={false}
-  defaultValue={true}
-  enumValues={null}
-  examples={[true,false]}
-  groups={[]}
-  name={"verify_hostname"}
-  path={"tls"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"bool"}
-  unit={null}
-  >
-
-#### verify_hostname
-
-If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/gcp_stackdriver_logging.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logging.md
@@ -115,7 +115,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
     verify_certificate = true # default
-    verify_hostname = true # default
 ```
 
 </TabItem>
@@ -889,29 +888,6 @@ Absolute path to a certificate key file used to identify this connection, in DER
 #### verify_certificate
 
 If `true` (the default), Vector will validate the TLS certificate of the remote host. Do NOT set this to `false` unless you understand the risks of not verifying the remote certificate.
-
-
-</Field>
-
-
-<Field
-  common={false}
-  defaultValue={true}
-  enumValues={null}
-  examples={[true,false]}
-  groups={[]}
-  name={"verify_hostname"}
-  path={"tls"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"bool"}
-  unit={null}
-  >
-
-#### verify_hostname
-
-If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -138,7 +138,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
     verify_certificate = true # default
-    verify_hostname = true # default
 ```
 
 </TabItem>
@@ -903,29 +902,6 @@ Absolute path to a certificate key file used to identify this connection, in DER
 #### verify_certificate
 
 If `true` (the default), Vector will validate the TLS certificate of the remote host. Do NOT set this to `false` unless you understand the risks of not verifying the remote certificate.
-
-
-</Field>
-
-
-<Field
-  common={false}
-  defaultValue={true}
-  enumValues={null}
-  examples={[true,false]}
-  groups={[]}
-  name={"verify_hostname"}
-  path={"tls"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"bool"}
-  unit={null}
-  >
-
-#### verify_hostname
-
-If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -109,7 +109,6 @@ import CodeHeader from '@site/src/components/CodeHeader';
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
     verify_certificate = true # default
-    verify_hostname = true # default
 ```
 
 </TabItem>
@@ -728,29 +727,6 @@ Absolute path to a certificate key file used to identify this connection, in DER
 #### verify_certificate
 
 If `true` (the default), Vector will validate the TLS certificate of the remote host. Do NOT set this to `false` unless you understand the risks of not verifying the remote certificate.
-
-
-</Field>
-
-
-<Field
-  common={false}
-  defaultValue={true}
-  enumValues={null}
-  examples={[true,false]}
-  groups={[]}
-  name={"verify_hostname"}
-  path={"tls"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"bool"}
-  unit={null}
-  >
-
-#### verify_hostname
-
-If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
 
 
 </Field>

--- a/website/docs/reference/sources/http.md
+++ b/website/docs/reference/sources/http.md
@@ -26,6 +26,17 @@ The Vector `http` source ingests data through the HTTP protocol and [outputs `lo
 
 ## Configuration
 
+import Tabs from '@theme/Tabs';
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="common">
+
 import CodeHeader from '@site/src/components/CodeHeader';
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
@@ -40,6 +51,34 @@ import CodeHeader from '@site/src/components/CodeHeader';
   encoding = "text" # default, enum
   headers = ["User-Agent", "X-My-Custom-Header"] # example, no default
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sources.my_source_id]
+  # REQUIRED - General
+  type = "http" # must be: "http"
+  address = "0.0.0.0:80" # example
+
+  # OPTIONAL - General
+  encoding = "text" # default, enum
+  headers = ["User-Agent", "X-My-Custom-Header"] # example, no default
+
+  # OPTIONAL - Tls
+  [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
+    crt_path = "/path/to/host_certificate.crt" # example, no default
+    enabled = false # default
+    key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
+    key_path = "/path/to/host_certificate.key" # example, no default
+    verify_certificate = true # default
+```
+
+</TabItem>
+</Tabs>
 
 ## Options
 
@@ -142,6 +181,29 @@ Configures the TLS options for connections from this source.
 
 
 <Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
+
+
+<Field
   common={true}
   defaultValue={null}
   enumValues={null}
@@ -228,6 +290,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/http.md
+++ b/website/docs/reference/sources/http.md
@@ -74,7 +74,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -297,9 +297,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -312,7 +312,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/logplex.md
+++ b/website/docs/reference/sources/logplex.md
@@ -26,6 +26,17 @@ The Vector `logplex` source ingests data through the [Heroku Logplex HTTP Drain 
 
 ## Configuration
 
+import Tabs from '@theme/Tabs';
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="common">
+
 import CodeHeader from '@site/src/components/CodeHeader';
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
@@ -35,6 +46,30 @@ import CodeHeader from '@site/src/components/CodeHeader';
   type = "logplex" # must be: "logplex"
   address = "0.0.0.0:8088" # example
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sources.my_source_id]
+  # REQUIRED - General
+  type = "logplex" # must be: "logplex"
+  address = "0.0.0.0:8088" # example
+
+  # OPTIONAL - Tls
+  [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
+    crt_path = "/path/to/host_certificate.crt" # example, no default
+    enabled = false # default
+    key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
+    key_path = "/path/to/host_certificate.key" # example, no default
+    verify_certificate = true # default
+```
+
+</TabItem>
+</Tabs>
 
 ## Options
 
@@ -88,6 +123,29 @@ The address to accept connections on. The address _must_ include a port.
 Configures the TLS options for connections from this source.
 
 <Fields filters={false}>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
 
 
 <Field
@@ -177,6 +235,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/logplex.md
+++ b/website/docs/reference/sources/logplex.md
@@ -65,7 +65,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -242,9 +242,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -257,7 +257,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -78,10 +78,12 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # OPTIONAL - Tls
   [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
     crt_path = "/path/to/host_certificate.crt" # example, no default, relevant when mode = "tcp"
     enabled = false # default, relevant when mode = "tcp"
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default, relevant when mode = "tcp"
     key_path = "/path/to/host_certificate.key" # example, no default, relevant when mode = "tcp"
+    verify_certificate = true # default
 ```
 
 </TabItem>
@@ -258,6 +260,29 @@ Configures the TLS options for connections from this source.
 
 
 <Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
+
+
+<Field
   common={true}
   defaultValue={null}
   enumValues={null}
@@ -344,6 +369,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -83,7 +83,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default, relevant when mode = "tcp"
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default, relevant when mode = "tcp"
     key_path = "/path/to/host_certificate.key" # example, no default, relevant when mode = "tcp"
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -376,9 +376,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -391,7 +391,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/splunk_hec.md
+++ b/website/docs/reference/sources/splunk_hec.md
@@ -26,6 +26,17 @@ The Vector `splunk_hec` source ingests data through the [Splunk HTTP Event Colle
 
 ## Configuration
 
+import Tabs from '@theme/Tabs';
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="common">
+
 import CodeHeader from '@site/src/components/CodeHeader';
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
@@ -39,6 +50,33 @@ import CodeHeader from '@site/src/components/CodeHeader';
   address = "0.0.0.0:8088" # default
   token = "A94A8FE5CCB19BA61C4C08" # example, no default
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sources.my_source_id]
+  # REQUIRED - General
+  type = "splunk_hec" # must be: "splunk_hec"
+
+  # OPTIONAL - General
+  address = "0.0.0.0:8088" # default
+  token = "A94A8FE5CCB19BA61C4C08" # example, no default
+
+  # OPTIONAL - Tls
+  [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
+    crt_path = "/path/to/host_certificate.crt" # example, no default
+    enabled = false # default
+    key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
+    key_path = "/path/to/host_certificate.key" # example, no default
+    verify_certificate = true # default
+```
+
+</TabItem>
+</Tabs>
 
 ## Options
 
@@ -92,6 +130,29 @@ The address to accept connections on.
 Configures the TLS options for connections from this source.
 
 <Fields filters={false}>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
 
 
 <Field
@@ -181,6 +242,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/splunk_hec.md
+++ b/website/docs/reference/sources/splunk_hec.md
@@ -72,7 +72,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -249,9 +249,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -264,7 +264,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -76,10 +76,12 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # OPTIONAL - Tls
   [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
     crt_path = "/path/to/host_certificate.crt" # example, no default
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
+    verify_certificate = true # default
 ```
 
 </TabItem>
@@ -233,6 +235,29 @@ Configures the TLS options for connections from this source.
 
 
 <Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
+
+
+<Field
   common={true}
   defaultValue={null}
   enumValues={null}
@@ -319,6 +344,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -81,7 +81,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -351,9 +351,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -366,7 +366,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -26,6 +26,17 @@ The Vector `vector` source ingests data through another upstream [`vector` sink]
 
 ## Configuration
 
+import Tabs from '@theme/Tabs';
+
+<Tabs
+  block={true}
+  defaultValue="common"
+  values={[{"label":"Common","value":"common"},{"label":"Advanced","value":"advanced"}]}>
+
+import TabItem from '@theme/TabItem';
+
+<TabItem value="common">
+
 import CodeHeader from '@site/src/components/CodeHeader';
 
 <CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
@@ -39,6 +50,33 @@ import CodeHeader from '@site/src/components/CodeHeader';
   # OPTIONAL
   shutdown_timeout_secs = 30 # default, seconds
 ```
+
+</TabItem>
+<TabItem value="advanced">
+
+<CodeHeader fileName="vector.toml" learnMoreUrl="/docs/setup/configuration/"/ >
+
+```toml
+[sources.my_source_id]
+  # REQUIRED - General
+  type = "vector" # must be: "vector"
+  address = "0.0.0.0:9000" # example
+
+  # OPTIONAL - General
+  shutdown_timeout_secs = 30 # default, seconds
+
+  # OPTIONAL - Tls
+  [sources.my_source_id.tls]
+    ca_path = "/path/to/certificate_authority.crt" # example, no default
+    crt_path = "/path/to/host_certificate.crt" # example, no default
+    enabled = false # default
+    key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
+    key_path = "/path/to/host_certificate.key" # example, no default
+    verify_certificate = true # default
+```
+
+</TabItem>
+</Tabs>
 
 ## Options
 
@@ -116,6 +154,29 @@ The timeout before a connection is forcefully closed during shutdown.
 Configures the TLS options for connections from this source.
 
 <Fields filters={false}>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["/path/to/certificate_authority.crt"]}
+  groups={[]}
+  name={"ca_path"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_path
+
+Absolute path to an additional CA certificate file, in DER or PEM format (X.509).
+
+
+</Field>
 
 
 <Field
@@ -205,6 +266,29 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless [`k
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or PEM format (PKCS#8).
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={true}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"verify_certificate"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  >
+
+#### verify_certificate
+
+If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
 
 
 </Field>

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -72,7 +72,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
     enabled = false # default
     key_pass = "${KEY_PASS_ENV_VAR}" # example, no default
     key_path = "/path/to/host_certificate.key" # example, no default
-    verify_certificate = true # default
+    verify_certificate = false # default
 ```
 
 </TabItem>
@@ -273,9 +273,9 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 <Field
   common={false}
-  defaultValue={true}
+  defaultValue={false}
   enumValues={null}
-  examples={[true,false]}
+  examples={[false,true]}
   groups={[]}
   name={"verify_certificate"}
   path={"tls"}
@@ -288,7 +288,7 @@ Absolute path to a certificate key file used to identify this server, in DER or 
 
 #### verify_certificate
 
-If `true` (the default), Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false`, Vector will ignore the presence of a client certificate.
+If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if it is not valid. If `false` (the default), Vector will ignore the presence of a client certificate.
 
 
 </Field>


### PR DESCRIPTION
This is incomplete, as several error paths remain incomplete.

There is one possible user-visible configuration change. At this point, the `verify_hostname` setting is non-functional due to a difference (at least in my understanding) of how `openssl` handles verification as compared to `native_tls`. I am still investigating and may need to port some code over to accommodate the differences.

Closes #1402 
Closes #1929 
