### PR TITLE
fix(lua transform): Explicitly call GC in `lua` transform

### DIFF
--- a/src/transforms/lua.rs
+++ b/src/transforms/lua.rs
@@ -80,16 +80,17 @@ impl Lua {
     }
 
     fn process(&self, event: Event) -> Result<Option<Event>, rlua::Error> {
-        self.lua.context(|ctx| {
+        let result = self.lua.context(|ctx| {
             let globals = ctx.globals();
 
             globals.set("event", event)?;
 
             let func = ctx.named_registry_value::<_, rlua::Function<'_>>("vector_func")?;
             func.call(())?;
-
             globals.get::<_, Option<Event>>("event")
-        })
+        });
+        self.lua.gc_collect()?;
+        result
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/1721.

This PR adds explicit call to the garbage collector after each invocation of the `lua` transform. It fixes the issues with growing RAM consumption mentioned in https://github.com/timberio/vector/issues/1721. As I understand it, Lua runtime sometimes didn't call GC automatically, that's why there was leak-like pattern of memory usage.

Now the RAM usage of Vector with `lua` transform is flat, even with high event rates.

This explicit call doesn't significantly change the benchmarks because GC is called not after each invocation of the transform, but only each 16th invocation of the transform.