### PR TITLE
feat(swimlanes transform): Add `contains` and `prefix` predicates to `check_fields`

### DIFF
--- a/.meta/_partials/_conditions.toml
+++ b/.meta/_partials/_conditions.toml
@@ -40,3 +40,25 @@ description = """\
 Check whether a field exists or does not exist, depending on the provided value\
 being `true` or `false` respectively.\
 """
+
+[<%= namespace %>."`<field_name>`.contains"]
+type = "string"
+examples = [
+  { "message.contains" = "foo" }
+]
+common = true
+relevant_when = {type = "check_fields"}
+description = """\
+Checks whether a string field contains a string argument.\
+"""
+
+[<%= namespace %>."`<field_name>`.prefix"]
+type = "string"
+examples = [
+  { "environment.prefix" = "staging-" }
+]
+common = true
+relevant_when = {type = "check_fields"}
+description = """\
+Checks whether a string field has a string argument prefix.\
+"""

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2005,6 +2005,14 @@ end
       type = "is_log"
       type = "is_metric"
 
+      # Checks whether a string field contains a string argument.
+      #
+      # * optional
+      # * no default
+      # * type: string
+      # * relevant when type = "check_fields"
+      "message.contains" = "foo"
+
       # Check whether a fields contents exactly matches the value specified.
       #
       # * optional
@@ -2029,6 +2037,14 @@ end
       # * type: string
       # * relevant when type = "check_fields"
       "method.neq" = "POST"
+
+      # Checks whether a string field has a string argument prefix.
+      #
+      # * optional
+      # * no default
+      # * type: string
+      # * relevant when type = "check_fields"
+      "environment.prefix" = "staging-"
 
 # Accepts and outputs `log` events allowing you to tokenize a field's value by splitting on white space, ignoring special wrapping characters, and zip the tokens into ordered field names.
 [transforms.tokenizer]

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -96,9 +96,11 @@ import CodeHeader from '@site/src/components/CodeHeader';
       type = "check_fields" # example
 
       # OPTIONAL
+      "message.contains" = "foo"
       "message.eq" = "this is the content to match against"
       "host.exists" = true
       "method.neq" = "POST"
+      "environment.prefix" = "staging-"
 ```
 
 </TabItem>
@@ -158,9 +160,11 @@ import CodeHeader from '@site/src/components/CodeHeader';
       type = "check_fields" # example
 
       # OPTIONAL
+      "message.contains" = "foo"
       "message.eq" = "this is the content to match against"
       "host.exists" = true
       "method.neq" = "POST"
+      "environment.prefix" = "staging-"
 ```
 
 </TabItem>
@@ -633,6 +637,29 @@ A table that defines a collection of conditions to check against the output of a
   common={true}
   defaultValue={null}
   enumValues={null}
+  examples={[{"message.contains":"foo"}]}
+  groups={[]}
+  name={"`<field_name>`.contains"}
+  path={"outputs.conditions"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.contains
+
+Checks whether a string field contains a string argument.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
   examples={[{"message.eq":"this is the content to match against"}]}
   groups={[]}
   name={"`<field_name>`.eq"}
@@ -693,6 +720,29 @@ Check whether a field exists or does not exist, depending on the provided valueb
 ##### `<field_name>`.neq
 
 Check whether a fields contents does not match the value specified.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"environment.prefix":"staging-"}]}
+  groups={[]}
+  name={"`<field_name>`.prefix"}
+  path={"outputs.conditions"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.prefix
+
+Checks whether a string field has a string argument prefix.
 
 
 </Field>

--- a/website/docs/reference/transforms/swimlanes.md
+++ b/website/docs/reference/transforms/swimlanes.md
@@ -39,9 +39,11 @@ import CodeHeader from '@site/src/components/CodeHeader';
     type = "check_fields" # example
 
     # OPTIONAL
+    "message.contains" = "foo"
     "message.eq" = "this is the content to match against"
     "host.exists" = true
     "method.neq" = "POST"
+    "environment.prefix" = "staging-"
 ```
 
 ## Options
@@ -95,6 +97,29 @@ A table of swimlane identifiers to logical conditions representing the filter of
 The identifier of a swimlane.
 
 <Fields filters={false}>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"message.contains":"foo"}]}
+  groups={[]}
+  name={"`<field_name>`.contains"}
+  path={"lanes.`<swimlane_id>`"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.contains
+
+Checks whether a string field contains a string argument.
+
+
+</Field>
 
 
 <Field
@@ -161,6 +186,29 @@ Check whether a field exists or does not exist, depending on the provided valueb
 ##### `<field_name>`.neq
 
 Check whether a fields contents does not match the value specified.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"environment.prefix":"staging-"}]}
+  groups={[]}
+  name={"`<field_name>`.prefix"}
+  path={"lanes.`<swimlane_id>`"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+##### `<field_name>`.prefix
+
+Checks whether a string field has a string argument prefix.
 
 
 </Field>


### PR DESCRIPTION
This adds two new predicates `contains` and `prefix` for the `check_fields` condition, expanding the logical expressions of both unit test outputs and the swimlanes transform.