### PR TITLE
docs: Fix for "download source code" step in install from source

### DIFF
--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -77,7 +77,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.X | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.2 | \
       tar xzf - -C vector --strip-components=1
     ```
 


### PR DESCRIPTION
If you directly copy and paste provided command it will not work
mkdir -p vector && \
  curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.X | \
  tar xzf - -C vector --strip-components=1
You need to replace  https://api.github.com/repos/timberio/vector/tarball/v0.8.X with correct version number (v0.8.2) in my case
I'm not sure if proposed solution is correct, but I do not know how to automatically substitute v0.8.X with correct version number

