### PR TITLE
docs: Fix for "download source code" step in install from source

### DIFF
--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -71,7 +71,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.2 | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8 | \
       tar xzf - -C vector --strip-components=1
     ```
 

--- a/website/docs/setup/installation/manual/from-source.md
+++ b/website/docs/setup/installation/manual/from-source.md
@@ -57,13 +57,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 2.  Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
     on your system.
 
-3.  Create the `vector` directory
-
-    ```bash
-    mkdir vector
-    ```
-
-4.  Download Vector's Source
+3.  Download Vector's Source
 
     <Tabs
       className="mini"
@@ -77,7 +71,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.X | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v0.8.2 | \
       tar xzf - -C vector --strip-components=1
     ```
 
@@ -93,13 +87,13 @@ The following steps should be used to compile Vector directly on Linux based sys
     </TabItem>
     </Tabs>
 
-5.  Change into the `vector` directory
+4.  Change into the `vector` directory
 
     ```bash
     cd vector
     ```
 
-6.  Compile Vector
+5.  Compile Vector
 
     ```bash
     [FEATURES="<flag1>,<flag2>,..."] make build
@@ -114,7 +108,7 @@ The following steps should be used to compile Vector directly on Linux based sys
     is `x86_64-apple-darwin`, and the Vector binary will be located at
     `target/x86_64-apple-darwin/release/vector`.
 
-7.  Start Vector
+6.  Start Vector
 
     Finally, start vector:
 

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -61,7 +61,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version %> | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version.major %>.<%= metadata.latest_version.minor %> | \
       tar xzf - -C vector --strip-components=1
     ```
 

--- a/website/docs/setup/installation/manual/from-source.md.erb
+++ b/website/docs/setup/installation/manual/from-source.md.erb
@@ -47,13 +47,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 2.  Install C and C++ compilers (GCC or Clang) and GNU `make` if they are not pre-installed
     on your system.
 
-3.  Create the `vector` directory
-
-    ```bash
-    mkdir vector
-    ```
-
-4.  Download Vector's Source
+3.  Download Vector's Source
 
     <Tabs
       className="mini"
@@ -67,7 +61,7 @@ The following steps should be used to compile Vector directly on Linux based sys
 
     ```bash
     mkdir -p vector && \
-      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version.minor_x %> | \
+      curl -sSfL --proto '=https' --tlsv1.2 https://api.github.com/repos/timberio/vector/tarball/v<%= metadata.latest_version %> | \
       tar xzf - -C vector --strip-components=1
     ```
 
@@ -83,13 +77,13 @@ The following steps should be used to compile Vector directly on Linux based sys
     </TabItem>
     </Tabs>
 
-5.  Change into the `vector` directory
+4.  Change into the `vector` directory
 
     ```bash
     cd vector
     ```
 
-6.  Compile Vector
+5.  Compile Vector
 
     ```bash
     [FEATURES="<flag1>,<flag2>,..."] make build
@@ -104,7 +98,7 @@ The following steps should be used to compile Vector directly on Linux based sys
     is `x86_64-apple-darwin`, and the Vector binary will be located at
     `target/x86_64-apple-darwin/release/vector`.
 
-7.  Start Vector
+6.  Start Vector
 
     Finally, start vector:
 


### PR DESCRIPTION
I've made some minor changes in "install from source code" document:
1. Remove 3-d step because its already included in 4-th step (mkdir -p vector)
2. Fixed download link used by curl, so you can paste it in console and its just work 