### PR TITLE
chore(operations): Add test harness GH action

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -35,22 +35,43 @@ jobs:
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
+    - name: Get Pull Request info
+      id: pr-info
+      uses: MOZGIII/github-script@core-access
+      with:
+        script: |
+          const pr_info_response = await github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          const pr_info = pr_info_response.data;
+          core.setOutput("head_ref", pr_info.head.ref);
+          core.setOutput("head_sha", pr_info.head.sha);
+          core.setOutput("base_ref", pr_info.base.ref);
+          core.setOutput("base_sha", pr_info.base.sha);
+          return pr_info;
+
     # Clone vector source and build .deb
     - name: Clone the PR branch
       uses: actions/checkout@v2
       with:
         lfs: true
-        ref: 'refs/pull/${{ github.event.issue.number }}/head'
-    - name: Gather info on the cloned code
-      id: cloned
-      run: echo "::set-output name=head_rev::$(git rev-parse HEAD)"
+        ref: '${{ steps.pr-info.outputs.head_sha }}'
+    - name: Complete repo clone and gather info on the cloned code
+      id: cloned-repo-info
+      run: |
+        git fetch --no-tags --prune --depth=350 origin \
+          +refs/heads/${{ steps.pr-info.outputs.head_ref }}:refs/remotes/origin/${{ steps.pr-info.outputs.head_ref }} \
+          +refs/heads/${{ steps.pr-info.outputs.base_ref }}:refs/remotes/origin/${{ steps.pr-info.outputs.base_ref }}
+        echo "::set-output name=test_harness_vector_version::dev-${{ steps.pr-info.outputs.head_ref }}-$(git rev-list --count '${{ steps.pr-info.outputs.base_sha }}..${{ steps.pr-info.outputs.head_sha }}')-$(git rev-parse --short HEAD)"
     # Doesn't work yet, see https://github.com/actions/cache/issues/176
     - name: Cache deb
       id: deb-cache
       uses: actions/cache@v1
       with:
         path: target/artifacts/vector-amd64.deb
-        key: vector-test-harness-packaged-deb-${{ steps.cloned.outputs.head_rev }}
+        key: vector-test-harness-packaged-deb-${{ steps.pr-info.outputs.head_sha }}
     - name: Make deb
       if: steps.deb-cache.outputs.cache-hit != 'true'
       run: PASS_FEATURES=default-musl ./scripts/docker-run.sh builder-x86_64-unknown-linux-musl make build-archive package-deb
@@ -59,16 +80,15 @@ jobs:
       uses: docker://timberiodev/vector-test-harness:latest
       with:
         args: |
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          git_branch=${GITHUB_REF##*/}
-          git_count=$(git rev-list --count $git_branch)
           bash -o pipefail -xc "cd /vector-test-harness \
-          && bin/test -t tcp_to_tcp_performance -s vector -v dev-${git_branch}-${git_count}-${git_hash}"
+          && bin/test $(echo '${{ github.event.comment.body }}' | head -n 1 | sed 's|^/test ||')"
       env:
         GENERATE_SSH_KEY: true
         VECTOR_TEST_VECTOR_DEB_PATH: '${{ github.workspace }}/target/artifacts/vector-amd64.deb'
         VECTOR_TEST_USER_ID: 'gha_${{ github.event.issue.number }}'
         VECTOR_TEST_RESULTS_S3_BUCKET_NAME: test-results.vector.dev
+        VECTOR_TEST_SUBJECT: vector
+        VECTOR_VERSION_TO_TEST: '${{ steps.cloned-repo-info.outputs.test_harness_vector_version }}'
         AWS_ACCESS_KEY_ID: '${{ secrets.TEST_HARNESS_AWS_ACCESS_KEY_ID }}'
         AWS_SECRET_ACCESS_KEY: '${{ secrets.TEST_HARNESS_AWS_SECRET_ACCESS_KEY }}'
         AWS_DEFAULT_REGION: '${{ secrets.AWS_DEFAULT_REGION }}'
@@ -77,7 +97,7 @@ jobs:
       with:
         args: |
           bash -o pipefail -xc "cd /vector-test-harness \
-          && bin/cohort -s vector | tee \"$GITHUB_WORKSPACE/output\""
+          && bin/compare -s vector -c default $(echo '${{ github.event.comment.body }}' | head -n 1 | sed 's|^/test ||') | tee \"$GITHUB_WORKSPACE/output\""
       env:
         GENERATE_SSH_KEY: true
         VECTOR_TEST_RESULTS_S3_BUCKET_NAME: test-results.vector.dev

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -1,0 +1,121 @@
+name: Test Harness
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  test-harness:
+
+    runs-on: ubuntu-latest
+
+    # Only run if we're invoked with a new command comment on a pull request.
+    if: |
+      github.event_name == 'issue_comment' && github.event.action == 'created'
+      && github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/test')
+
+    steps:
+    - name: Indicate that we picked up the command with a comment reaction
+      uses: actions/github-script@0.4.0
+      with:
+        github-token: '${{secrets.GITHUB_TOKEN}}'
+        script: |
+          github.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: "rocket"
+          })
+
+    - name: Check user permissions
+      uses: MOZGIII/repo-permission-check-action@input-fix
+      with:
+        permission: write
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+    # Clone vector source and build .deb
+    - name: Clone the PR branch
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+        ref: 'refs/pull/${{ github.event.issue.number }}/head'
+    - name: Gather info on the cloned code
+      id: cloned
+      run: echo "::set-output name=head_rev::$(git rev-parse HEAD)"
+    # Doesn't work yet, see https://github.com/actions/cache/issues/176
+    - name: Cache deb
+      id: deb-cache
+      uses: actions/cache@v1
+      with:
+        path: target/artifacts/vector-amd64.deb
+        key: vector-test-harness-packaged-deb-${{ steps.cloned.outputs.head_rev }}
+    - name: Make deb
+      if: steps.deb-cache.outputs.cache-hit != 'true'
+      run: PASS_FEATURES=default-musl ./scripts/docker-run.sh builder-x86_64-unknown-linux-musl make build-archive package-deb
+
+    - name: Invoke test harness
+      uses: docker://timberiodev/vector-test-harness:latest
+      with:
+        args: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_branch=${GITHUB_REF##*/}
+          git_count=$(git rev-list --count $git_branch)
+          bash -o pipefail -xc "cd /vector-test-harness \
+          && bin/test -t tcp_to_tcp_performance -s vector -v dev-${git_branch}-${git_count}-${git_hash}"
+      env:
+        GENERATE_SSH_KEY: true
+        VECTOR_TEST_VECTOR_DEB_PATH: '${{ github.workspace }}/target/artifacts/vector-amd64.deb'
+        VECTOR_TEST_USER_ID: 'gha_${{ github.event.issue.number }}'
+        VECTOR_TEST_RESULTS_S3_BUCKET_NAME: test-results.vector.dev
+        AWS_ACCESS_KEY_ID: '${{ secrets.TEST_HARNESS_AWS_ACCESS_KEY_ID }}'
+        AWS_SECRET_ACCESS_KEY: '${{ secrets.TEST_HARNESS_AWS_SECRET_ACCESS_KEY }}'
+        AWS_DEFAULT_REGION: '${{ secrets.AWS_DEFAULT_REGION }}'
+    - name: Gather test harness execution results
+      uses: docker://timberiodev/vector-test-harness:latest
+      with:
+        args: |
+          bash -o pipefail -xc "cd /vector-test-harness \
+          && bin/cohort -s vector | tee \"$GITHUB_WORKSPACE/output\""
+      env:
+        GENERATE_SSH_KEY: true
+        VECTOR_TEST_RESULTS_S3_BUCKET_NAME: test-results.vector.dev
+        AWS_ACCESS_KEY_ID: '${{ secrets.TEST_HARNESS_RESULTS_AWS_ACCESS_KEY_ID }}'
+        AWS_SECRET_ACCESS_KEY: '${{ secrets.TEST_HARNESS_RESULTS_AWS_SECRET_ACCESS_KEY }}'
+        AWS_DEFAULT_REGION: '${{ secrets.AWS_DEFAULT_REGION }}'
+
+    - name: Post a comment with the results
+      uses: actions/github-script@0.4.0
+      with:
+        github-token: '${{secrets.GITHUB_TOKEN}}'
+        script: |
+          const fs = require('fs');
+          const { promisify } = require('util');
+          const readFileAsync = promisify(fs.readFile);
+
+          console.log(process.env);
+          console.log(context);
+
+          let output;
+          try {
+            output = await readFileAsync(`${process.env.GITHUB_WORKSPACE}/output`);
+            output = '```\n' + output + '\n```\n';
+          } catch {
+            output = "Something went wrong, see log for more details.\n"
+          }
+
+          const body =
+            `Test harness invocation requested by ${context.payload.comment.html_url} is complete!\n` +
+            '\n' +
+            output +
+            '\n' +
+            `You can check the [execution log](${context.payload.repository.html_url}/actions/runs/${process.env.GITHUB_RUN_ID}) to learn more!`;
+
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body
+          })
+      if: always()

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -12,6 +12,7 @@
 set -e
 
 VERSION="$(sed -n 's/^version\s=\s"\(.*\)"/\1/p' Cargo.toml)"
+echo $VERSION
 CHANNEL="$(scripts/util/release-channel.sh)"
 if [ "$CHANNEL" == "nightly" ]; then
   VERSION="$VERSION-nightly"


### PR DESCRIPTION
Closes #1416

This adds a `test-harness.yml` Github Action that automates running the test harness on the current branch. Things left to do:

- [x] Add secrets to the vector repo
- [x] Verify that the `-v` flag is set properly.
- [ ] https://github.com/timberio/vector-test-harness/issues/19 - will be completed later
- [x] Accepting arguments as part of the `/test` comment to target specific tests.