### PR TITLE
fix(config): Force `symlink` re-evaluation

### DIFF
--- a/src/sources/kubernetes/test.rs
+++ b/src/sources/kubernetes/test.rs
@@ -112,7 +112,7 @@ spec:
         emptyDir: {}
       containers:
       - name: vector
-        image: ktff/vector-kube-biger-test-logs:latest
+        image: ktff/vector-kube-watch-fix:latest
         imagePullPolicy: Always
         volumeMounts:
         - name: var-log

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -41,7 +41,7 @@ pub fn config_watcher(config_paths: Vec<PathBuf>, delay: Duration) -> Result<(),
                     // Consume events until delay amount of time has passed since the latest event.
                     while let Ok(..) = receiver.recv_timeout(delay) {}
 
-                    // We need to readd paths to resolve any symlink changes that may have happened.
+                    // We need to readd paths to resolve any inode changes that may have happened.
                     // And we need to do it before raising sighup to avoid missing any change.
                     if let Err(error) = add_paths(&mut watcher, &config_paths) {
                         error!(message = "Failed to readd files to watch.", ?error);
@@ -102,9 +102,7 @@ fn create_watcher(
 #[cfg(unix)]
 fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &Vec<PathBuf>) -> Result<(), Error> {
     for path in config_paths {
-        // We need to canonicalize paths to resolve any symlink.
-        let canonical_path = path.canonicalize()?;
-        watcher.watch(&canonical_path, RecursiveMode::NonRecursive)?;
+        watcher.watch(path, RecursiveMode::NonRecursive)?;
     }
     Ok(())
 }

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -33,13 +33,20 @@ pub fn config_watcher(config_paths: Vec<PathBuf>, delay: Duration) -> Result<(),
     info!("Watching configuration files.");
 
     thread::spawn(move || loop {
-        if let Some((_, receiver)) = watcher.take() {
+        if let Some((mut watcher, receiver)) = watcher.take() {
             while let Ok(RawEvent { op: Ok(event), .. }) = receiver.recv() {
                 if event.intersects(Op::CREATE | Op::REMOVE | Op::WRITE | Op::CLOSE_WRITE) {
                     debug!(message = "Configuration file change detected.", ?event);
 
                     // Consume events until delay amount of time has passed since the latest event.
                     while let Ok(..) = receiver.recv_timeout(delay) {}
+
+                    // We need to readd paths to resolve any symlink changes that may have happened.
+                    // And we need to do it before raising sighup to avoid missing any change.
+                    if let Err(error) = add_paths(&mut watcher, &config_paths) {
+                        error!(message = "Failed to readd files to watch.", ?error);
+                        break;
+                    }
 
                     info!("Configuration file changed.");
                     raise_sighup();
@@ -80,6 +87,7 @@ fn raise_sighup() {
         error!(message = "Unable to reload configuration file. Restart Vector to reload it.", cause = ?error)
     });
 }
+
 #[cfg(unix)]
 fn create_watcher(
     config_paths: &Vec<PathBuf>,
@@ -87,10 +95,18 @@ fn create_watcher(
     info!("Creating configuration file watcher.");
     let (sender, receiver) = channel();
     let mut watcher = raw_watcher(sender)?;
-    for path in config_paths {
-        watcher.watch(path, RecursiveMode::NonRecursive)?;
-    }
+    add_paths(&mut watcher, config_paths)?;
     Ok((watcher, receiver))
+}
+
+#[cfg(unix)]
+fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &Vec<PathBuf>) -> Result<(), Error> {
+    for path in config_paths {
+        // We need to canonicalize paths to resolve any symlink.
+        let canonical_path = path.canonicalize()?;
+        watcher.watch(&canonical_path, RecursiveMode::NonRecursive)?;
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -106,15 +122,7 @@ mod tests {
     #[cfg(unix)]
     use tokio_signal::unix::{Signal, SIGHUP};
 
-    #[test]
-    fn file_update() {
-        crate::test_util::trace_init();
-        let delay = Duration::from_secs(1);
-        let file_path = temp_file();
-        let mut file = File::create(&file_path).unwrap();
-
-        let _ = config_watcher(vec![file_path], delay).unwrap();
-
+    fn test(file: &mut File, timeout: Duration) -> bool {
         file.write_all(&[0]).unwrap();
         std::mem::drop(file);
 
@@ -125,14 +133,60 @@ mod tests {
             .block_on(
                 signal
                     .into_future()
-                    .select2(Delay::new(Instant::now() + delay * 5)),
+                    .select2(Delay::new(Instant::now() + timeout)),
             )
             .ok()
             .unwrap();
 
         match result {
-            future::Either::A(_) => (), //OK
-            future::Either::B(_) => panic!("Test timed out"),
+            future::Either::A(_) => true, //OK
+            future::Either::B(_) => false,
+        }
+    }
+
+    #[test]
+    fn file_update() {
+        crate::test_util::trace_init();
+        let delay = Duration::from_secs(1);
+        let file_path = temp_file();
+        let mut file = File::create(&file_path).unwrap();
+
+        let _ = config_watcher(vec![file_path], delay).unwrap();
+
+        if !test(&mut file, delay * 5) {
+            panic!("Test timed out");
+        }
+    }
+
+    #[test]
+    fn multi_file_update() {
+        crate::test_util::trace_init();
+        let delay = Duration::from_secs(1);
+        let file_path = temp_file();
+        let mut file = File::create(&file_path).unwrap();
+
+        let _ = config_watcher(vec![file_path], delay).unwrap();
+
+        for i in 0..3 {
+            if !test(&mut file, delay * 5) {
+                panic!("Test timed out on {}. update", i + 1);
+            }
+        }
+    }
+
+    #[test]
+    fn sym_file_update() {
+        crate::test_util::trace_init();
+        let delay = Duration::from_secs(1);
+        let file_path = temp_file();
+        let sym_file = temp_file();
+        let mut file = File::create(&file_path).unwrap();
+        std::os::unix::fs::symlink(&file_path, &sym_file).unwrap();
+
+        let _ = config_watcher(vec![sym_file], delay).unwrap();
+
+        if !test(&mut file, delay * 5) {
+            panic!("Test timed out");
         }
     }
 }


### PR DESCRIPTION
Fixes the 1. point in #2002 

(Edit: closes #2002)

The problem was in `notify`/`inotify` interaction with `symlinks` and a pattern of changing files by switching from an old file to the new file with the same path. 

The fix re canonicalizes configuration paths after any change has been detected. That way we aren't watching over any `symlink` and are forcing `inotify` to re watch files.  

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
