### PR TITLE
chore(statsd sink): Reshuffle timeout in test

### DIFF
--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -354,6 +354,14 @@ mod test {
 
         let stream = stream::iter_ok(events.clone().into_iter());
         let sender = sink.send_all(stream);
+        let deadline = Instant::now() + Duration::from_millis(100);
+
+        // Add a delay to the write side to let the read side
+        // poll for read interest. Otherwise, this could cause
+        // a race condition in noisy environments.
+        let sender = tokio::timer::Delay::new(deadline)
+            .map_err(drop)
+            .and_then(|_| sender);
 
         let (tx, rx) = mpsc::channel(1);
 
@@ -361,12 +369,6 @@ mod test {
             future::lazy(|| {
                 let socket = UdpSocket::bind(&default_address()).unwrap();
                 future::ok(socket)
-            })
-            .and_then(|socket| {
-                let deadline = Instant::now() + Duration::from_millis(100);
-                tokio::timer::Delay::new(deadline)
-                    .map(|_| socket)
-                    .map_err(drop)
             })
             .and_then(|socket| {
                 UdpFramed::new(socket, BytesCodec::new())


### PR DESCRIPTION
This reshuffles our timeout that was added in #2026 to correctly delay the write side of the test. This should give enough time to let the read side spawned task to poll for read interest. This should avoid a race condition where the read side has not gotten enough time to bind and poll for read interest by the time the write task has sent the packet. This is mostly an internal detail to this test and does not affect the actual sink.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>