### PR TITLE
chore(splunk_hec sink)!: Rename `host_field` to `host_key`

### DIFF
--- a/.meta/sinks/splunk_hec.toml
+++ b/.meta/sinks/splunk_hec.toml
@@ -46,6 +46,16 @@ examples = ["http://my-splunk-host.com"]
 required = true
 description = "Your Splunk HEC host."
 
+[sinks.splunk_hec.options.host_key]
+type = "string"
+common = true
+examples = ["hostname"]
+required = false
+description = """\
+The name of the log field to be used as the hostname sent to Splunk HEC. This overrides the \
+[global `host_key` option][docs.reference.global-options#host_key].\
+"""
+
 [sinks.splunk_hec.options.token]
 type = "string"
 common = true

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -7520,6 +7520,14 @@ end
   healthcheck = true
   healthcheck = false
 
+  # The name of the log field to be used as the hostname sent to Splunk HEC. This
+  # overrides the global `host_key` option.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  host_key = "hostname"
+
   # Fields to be added to Splunk index.
   #
   # * optional

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -31,8 +31,8 @@ pub enum BuildError {
 pub struct HecSinkConfig {
     pub token: String,
     pub host: String,
-    #[serde(default = "default_host_field")]
-    pub host_field: Atom,
+    #[serde(default = "default_host_key")]
+    pub host_key: Atom,
     #[serde(default)]
     pub indexed_fields: Vec<Atom>,
     #[serde(skip_serializing_if = "skip_serializing_if_default", default)]
@@ -62,7 +62,7 @@ pub enum Encoding {
     Json,
 }
 
-fn default_host_field() -> Atom {
+fn default_host_key() -> Atom {
     event::LogSchema::default().host_key().clone()
 }
 
@@ -92,7 +92,7 @@ impl SinkConfig for HecSinkConfig {
 pub fn hec(config: HecSinkConfig, cx: SinkContext) -> crate::Result<super::RouterSink> {
     let host = config.host.clone();
     let token = config.token.clone();
-    let host_field = config.host_field;
+    let host_key = config.host_key;
 
     let gzip = match config.compression.unwrap_or(Compression::None) {
         Compression::None => false,
@@ -132,7 +132,7 @@ pub fn hec(config: HecSinkConfig, cx: SinkContext) -> crate::Result<super::Route
     let sink = request
         .batch_sink(HttpRetryLogic, http_service, cx.acker())
         .batched_with_min(Buffer::new(gzip), &batch)
-        .with_flat_map(move |e| iter_ok(encode_event(&host_field, e, &indexed_fields, &encoding)));
+        .with_flat_map(move |e| iter_ok(encode_event(&host_key, e, &indexed_fields, &encoding)));
 
     Ok(Box::new(sink))
 }
@@ -197,7 +197,7 @@ fn event_to_json(event: LogEvent, indexed_fields: &[Atom], timestamp: i64) -> Js
 }
 
 fn encode_event(
-    host_field: &Atom,
+    host_key: &Atom,
     mut event: Event,
     indexed_fields: &[Atom],
     encoding: &EncodingConfigWithDefault<Encoding>,
@@ -205,7 +205,7 @@ fn encode_event(
     encoding.apply_rules(&mut event);
     let mut event = event.into_log();
 
-    let host = event.get(&host_field).cloned();
+    let host = event.get(&host_key).cloned();
     let timestamp =
         if let Some(Value::Timestamp(ts)) = event.remove(&event::log_schema().timestamp_key()) {
             ts.timestamp()
@@ -439,7 +439,7 @@ mod integration_tests {
         let cx = SinkContext::new_test(rt.executor());
 
         let config = super::HecSinkConfig {
-            host_field: "roast".into(),
+            host_key: "roast".into(),
             ..config(Encoding::Json, vec![Atom::from("asdf")])
         };
 
@@ -556,7 +556,7 @@ mod integration_tests {
         super::HecSinkConfig {
             host: "http://localhost:8088/".into(),
             token: get_token(),
-            host_field: "host".into(),
+            host_key: "host".into(),
             compression: Some(Compression::None),
             encoding: encoding.into(),
             batch: BatchBytesConfig {

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -50,6 +50,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   host = "http://my-splunk-host.com" # required
   token = "${TOKEN_ENV_VAR}" # required
   healthcheck = true # optional, default
+  host_key = "hostname" # optional, no default
   indexed_fields = ["field1", "field2"] # optional, no default, relevant when encoding = "json"
 
   # Encoding
@@ -69,6 +70,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   host = "http://my-splunk-host.com" # required
   token = "${TOKEN_ENV_VAR}" # required
   healthcheck = true # optional, default
+  host_key = "hostname" # optional, no default
   indexed_fields = ["field1", "field2"] # optional, no default, relevant when encoding = "json"
 
   # Batch
@@ -468,6 +470,29 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 ### host
 
 Your Splunk HEC host. See [Setup](#setup) for more info.
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["hostname"]}
+  groups={[]}
+  name={"host_key"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### host_key
+
+The name of the log field to be used as the hostname sent to Splunk HEC. This overrides the [global [`host_key`](#host_key) option][docs.reference.global-options#host_key].
 
 
 </Field>
@@ -936,6 +961,7 @@ should supply to the [`host`](#host) and [`token`](#token) options.
 [docs.data-model.log]: /docs/about/data-model/log/
 [docs.data-model]: /docs/about/data-model/
 [docs.guarantees]: /docs/about/guarantees/
+[docs.reference.global-options#host_key]: /docs/reference/global-options/#host_key
 [urls.new_splunk_hec_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+splunk_hec
 [urls.splunk_hec]: http://dev.splunk.com/view/event-collector/SP-CAAAE6M
 [urls.splunk_hec_indexed_fields]: https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC


### PR DESCRIPTION
Closes #1764 