### PR TITLE
chore(operations): Check lockfile over cargo.toml

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -2,7 +2,7 @@ paths:
   ".meta/releases/**":
     - "Did you review all commits to ensure they are categorized correctly and user friendly?"
     - "Have you run all test harness benchmarks to compare results? (ex: `/test`)"
-  "Cargo.toml":
+  "Cargo.lock":
     - "Has at least one other team member approved the dependency changes?"
   "rfcs/**":
     - "Have at least 3 team members approved this RFC?"


### PR DESCRIPTION
The lockfile should only be updated if we change dependencies and this is when we should actually audit new deps.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
