### PR TITLE
chore: Add `target` directory to `.markdownlintignore`

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 website/node_modules
+target


### PR DESCRIPTION
The `target` directory is created by `cargo` when Vector is built and contains various Markdown files with documentation for crates, which don't pass the linting.

Because of that, the `target` directory is added to `.markdownlintignore` in this PR.