### PR TITLE
chore(json_parser transform): Ensure white-space dooes not break parsing

### DIFF
--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -186,6 +186,25 @@ mod test {
     }
 
     #[test]
+    fn json_parser_parse_raw_with_whitespace() {
+        let mut parser = JsonParser::from(JsonParserConfig {
+            drop_field: false,
+            ..Default::default()
+        });
+
+        let event = Event::from(r#" {"greeting": "hello", "name": "bob"}    "#);
+
+        let event = parser.transform(event).unwrap();
+
+        assert_eq!(event.as_log()[&Atom::from("greeting")], "hello".into());
+        assert_eq!(event.as_log()[&Atom::from("name")], "bob".into());
+        assert_eq!(
+            event.as_log()[&event::log_schema().message_key()],
+            r#"{"greeting": "hello", "name": "bob"}"#.into()
+        );
+    }
+
+    #[test]
     fn json_parser_parse_field() {
         let mut parser = JsonParser::from(JsonParserConfig {
             field: Some("data".into()),

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -200,7 +200,7 @@ mod test {
         assert_eq!(event.as_log()[&Atom::from("name")], "bob".into());
         assert_eq!(
             event.as_log()[&event::log_schema().message_key()],
-            r#"{"greeting": "hello", "name": "bob"}"#.into()
+            r#" {"greeting": "hello", "name": "bob"}    "#.into()
         );
     }
 


### PR DESCRIPTION
I wanted to add a test to ensure white-space does not break JSON parsing since this is a pretty common scenario.