### PR TITLE
chore(testing): Fix `check-component-features` test

### DIFF
--- a/scripts/ci-docker-images/checker-component-features/Dockerfile
+++ b/scripts/ci-docker-images/checker-component-features/Dockerfile
@@ -17,4 +17,4 @@ ENV PATH="$PATH:/root/.cargo/bin"
 RUN rustup component add rustfmt
 
 # Install `remarshal`
-RUN pip3 install remarshal
+RUN pip3 install remarshal==0.11.2


### PR DESCRIPTION
Yesterday a [new version](https://pypi.org/project/remarshal/#history) of `remarshal` utility was released, which caused issues with installing it uisng `pip3` on Ubuntu 18.04 (see https://github.com/dbohdan/remarshal/issues/24).

This PR pins the version to the one which was used before.