### PR TITLE
fix(transforms): Fix array insertion in field path notation

### DIFF
--- a/src/event/util/log/insert.rs
+++ b/src/event/util/log/insert.rs
@@ -42,10 +42,10 @@ where
 {
     match (path_iter.next(), path_iter.peek()) {
         (Some(PathComponent::Index(current)), None) => {
-            while values.len() < current {
+            while values.len() <= current {
                 values.push(Value::Null);
             }
-            values.insert(current, value);
+            values[current] = value;
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Key(_))) => {
             if let Some(Value::Map(map)) = values.get_mut(current) {
@@ -53,10 +53,10 @@ where
             } else {
                 let mut map = BTreeMap::new();
                 map_insert(&mut map, path_iter, value);
-                while values.len() < current {
+                while values.len() <= current {
                     values.push(Value::Null);
                 }
-                values.insert(current, Value::Map(map));
+                values[current] = Value::Map(map);
             }
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Index(next))) => {
@@ -65,10 +65,10 @@ where
             } else {
                 let mut array = Vec::with_capacity(next + 1);
                 array_insert(&mut array, path_iter, value);
-                while values.len() < current {
+                while values.len() <= current {
                     values.push(Value::Null);
                 }
-                values.insert(current, Value::Array(array));
+                values[current] = Value::Array(array);
             }
         }
         _ => return,
@@ -101,11 +101,12 @@ mod test {
     fn test_insert_array() {
         let mut fields = BTreeMap::new();
         insert(&mut fields, "a.b[0].c[2]".into(), Value::Integer(10));
+        insert(&mut fields, "a.b[0].c[0]".into(), Value::Integer(5));
 
         let expected = fields_from_json(json!({
             "a": {
                 "b": [{
-                    "c": [null, null, 10]
+                    "c": [5, null, 10]
                 }]
             }
         }));

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -18,6 +18,33 @@
       "x.y.equals" = 456
       "x.z.equals" = 789
 
+[transforms.add_fields_array]
+  inputs = []
+  type = "add_fields"
+  [transforms.add_fields_array.fields]
+    "a[0]" = 0
+    "a[1]" = "1"
+    "a[2]" = 2.0
+
+    "b[2]" = "two"
+    "b[0]" = 0
+[[tests]]
+  name = "add_fields_array"
+  [tests.input]
+    insert_at = "add_fields_array"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_fields_array"
+    [[tests.outputs.conditions]]
+      "a[0].equals" = 0
+      "a[1].equals" = "1"
+      "a[2].equals" = 2.0
+
+      "b[0].equals" = 0
+      "b[1].equals" = "<null>"
+      "b[2].equals" = "two"
+
 [transforms.add_fields_scalar_then_nested_1]
   inputs = []
   type = "add_fields"


### PR DESCRIPTION
This PR fixes a bug in the new implementation of field path notation.

When value was inserted in the middle of an array, then instead of replacing the already present value with the same index, it shifted all values to the right. This was not consistent with what we had with in the previous `flatten`/`unflatten` implementation.