### PR TITLE
chore(sinks): Part 1 of `HttpSink` refactor

### DIFF
--- a/src/sinks/datadog_metrics.rs
+++ b/src/sinks/datadog_metrics.rs
@@ -1,14 +1,20 @@
 use crate::{
-    event::metric::{Metric, MetricKind, MetricValue},
+    event::{
+        metric::{Metric, MetricKind, MetricValue},
+        Event,
+    },
     sinks::util::{
-        http::{Error as HttpError, HttpBatchService, HttpRetryLogic, Response as HttpResponse},
+        http::{
+            BatchedHttpSink, Error as HttpError, HttpBatchService, HttpRetryLogic, HttpSink,
+            Response as HttpResponse,
+        },
         BatchEventsConfig, MetricBuffer, SinkExt, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
 use chrono::{DateTime, Utc};
-use futures01::{Future, Poll};
-use http::{uri::InvalidUri, Method, StatusCode, Uri};
+use futures01::Future;
+use http::{uri::InvalidUri, StatusCode, Uri};
 use hyper;
 use hyper_openssl::HttpsConnector;
 use lazy_static::lazy_static;
@@ -16,7 +22,10 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use tower::Service;
+use std::sync::atomic::{
+    AtomicI64,
+    Ordering::{Acquire, Release},
+};
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -27,13 +36,6 @@ enum BuildError {
 #[derive(Clone)]
 struct DatadogState {
     last_sent_timestamp: i64,
-}
-
-#[derive(Clone)]
-struct DatadogSvc {
-    config: DatadogConfig,
-    state: DatadogState,
-    inner: HttpBatchService,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -49,6 +51,12 @@ pub struct DatadogConfig {
     pub request: TowerRequestConfig,
 }
 
+struct DatadogSink {
+    config: DatadogConfig,
+    last_sent_timestamp: AtomicI64,
+    uri: Uri,
+}
+
 lazy_static! {
     static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
         retry_attempts: Some(5),
@@ -58,12 +66,6 @@ lazy_static! {
 
 pub fn default_host() -> String {
     String::from("https://api.datadoghq.com")
-}
-
-// https://docs.datadoghq.com/api/?lang=bash#post-timeseries-points
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct DatadogRequest {
-    series: Vec<DatadogMetric>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -104,9 +106,25 @@ inventory::submit! {
 #[typetag::serde(name = "datadog_metrics")]
 impl SinkConfig for DatadogConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let sink = DatadogSvc::new(self.clone(), cx)?;
-        let healthcheck = DatadogSvc::healthcheck(self.clone())?;
-        Ok((sink, healthcheck))
+        let healthcheck = healthcheck(self.clone())?;
+
+        let batch = self.batch.unwrap_or(20, 1);
+        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+
+        let uri = format!("{}/api/v1/series?api_key={}", self.host, self.api_key)
+            .parse::<Uri>()
+            .context(super::UriParseError)?;
+        let timestamp = Utc::now().timestamp();
+
+        let sink = DatadogSink {
+            config: self.clone(),
+            uri,
+            last_sent_timestamp: AtomicI64::new(timestamp),
+        };
+
+        let sink = BatchedHttpSink::new(sink, MetricBuffer::new(), request, batch, None, &cx);
+
+        Ok((Box::new(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {
@@ -118,82 +136,48 @@ impl SinkConfig for DatadogConfig {
     }
 }
 
-impl DatadogSvc {
-    pub fn new(config: DatadogConfig, cx: SinkContext) -> crate::Result<super::RouterSink> {
-        let batch = config.batch.unwrap_or(20, 1);
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+impl HttpSink for DatadogSink {
+    type Input = Event;
+    type Output = Vec<Metric>;
 
-        let uri = format!("{}/api/v1/series?api_key={}", config.host, config.api_key)
-            .parse::<Uri>()
-            .context(super::UriParseError)?;
-
-        let build_request = move |body: Vec<u8>| {
-            let mut builder = hyper::Request::builder();
-            builder.method(Method::POST);
-            builder.uri(uri.clone());
-
-            builder.header("Content-Type", "application/json");
-            builder.body(body).unwrap()
-        };
-
-        let http_service = HttpBatchService::new(cx.resolver(), None, build_request);
-
-        let datadog_http_service = DatadogSvc {
-            config,
-            state: DatadogState {
-                last_sent_timestamp: Utc::now().timestamp(),
-            },
-            inner: http_service,
-        };
-
-        let sink = request
-            .batch_sink(HttpRetryLogic, datadog_http_service, cx.acker())
-            .batched_with_min(MetricBuffer::new(), &batch);
-
-        Ok(Box::new(sink))
+    fn encode_event(&self, event: Event) -> Option<Self::Input> {
+        Some(event)
     }
 
-    fn healthcheck(config: DatadogConfig) -> crate::Result<super::Healthcheck> {
-        let uri = format!("{}/api/v1/validate?api_key={}", config.host, config.api_key)
-            .parse::<Uri>()
-            .context(super::UriParseError)?;
+    fn build_request(&self, events: Self::Output) -> http::Request<Vec<u8>> {
+        let now = Utc::now().timestamp();
+        let interval = now - self.last_sent_timestamp.load(Acquire);
+        self.last_sent_timestamp.store(now, Release);
 
-        let request = hyper::Request::get(uri).body(hyper::Body::empty()).unwrap();
+        let input = encode_events(events, interval, &self.config.namespace);
+        let body = serde_json::to_vec(&input).unwrap();
 
-        let https = HttpsConnector::new(4).expect("TLS initialization failed");
-        let client = hyper::Client::builder().build(https);
-
-        let healthcheck = client
-            .request(request)
-            .map_err(|err| err.into())
-            .and_then(|response| match response.status() {
-                StatusCode::OK => Ok(()),
-                other => Err(super::HealthcheckError::UnexpectedStatus { status: other }.into()),
-            });
-
-        Ok(Box::new(healthcheck))
+        http::Request::get(self.uri.clone())
+            .header("Content-Type", "application/json")
+            .body(body)
+            .unwrap()
     }
 }
 
-impl Service<Vec<Metric>> for DatadogSvc {
-    type Response = HttpResponse;
-    type Error = HttpError;
-    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+fn healthcheck(config: DatadogConfig) -> crate::Result<super::Healthcheck> {
+    let uri = format!("{}/api/v1/validate?api_key={}", config.host, config.api_key)
+        .parse::<Uri>()
+        .context(super::UriParseError)?;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
-    }
+    let request = hyper::Request::get(uri).body(hyper::Body::empty()).unwrap();
 
-    fn call(&mut self, items: Vec<Metric>) -> Self::Future {
-        let now = Utc::now().timestamp();
-        let interval = now - self.state.last_sent_timestamp;
-        self.state.last_sent_timestamp = now;
+    let https = HttpsConnector::new(4).expect("TLS initialization failed");
+    let client = hyper::Client::builder().build(https);
 
-        let input = encode_events(items, interval, &self.config.namespace);
-        let body = serde_json::to_vec(&input).unwrap();
+    let healthcheck = client
+        .request(request)
+        .map_err(|err| err.into())
+        .and_then(|response| match response.status() {
+            StatusCode::OK => Ok(()),
+            other => Err(super::HealthcheckError::UnexpectedStatus { status: other }.into()),
+        });
 
-        self.inner.call(body)
-    }
+    Ok(Box::new(healthcheck))
 }
 
 fn encode_tags(tags: BTreeMap<String, String>) -> Vec<String> {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -3,15 +3,15 @@ use crate::{
     event::Event,
     sinks::util::{
         encoding::{skip_serializing_if_default, EncodingConfigWithDefault, EncodingConfiguration},
-        http::{HttpBatchService, HttpClient, HttpRetryLogic, HttpSink},
-        BatchBytesConfig, Buffer, Compression, SinkExt, TowerRequestConfig,
+        http::{BatchedHttpSink, HttpClient, HttpSink},
+        BatchBytesConfig, Buffer, Compression, TowerRequestConfig,
     },
     template::Template,
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
-use futures01::{stream::iter_ok, Future, Sink};
-use http::{uri::InvalidUri, Method, Uri};
+use futures01::Future;
+use http::{uri::InvalidUri, Uri};
 use hyper::{
     header::{HeaderName, HeaderValue},
     Body, Request,
@@ -88,9 +88,19 @@ impl SinkConfig for ElasticSearchConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let common = ElasticSearchCommon::parse_config(&self)?;
         let healthcheck = healthcheck(cx.resolver(), &common)?;
-        let sink = es(self, common, cx);
 
-        Ok((sink, healthcheck))
+        let batch = self.batch.unwrap_or(bytesize::mib(10u64), 1);
+        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let tls_settings = common.tls_settings.clone();
+
+        // Only apply gzip if gzip is selected and/or we are running with no credentials.
+        let gzip = matches!(&self.compression, Some(Compression::Gzip) | None)
+            && common.credentials.is_none();
+
+        let sink =
+            BatchedHttpSink::new(common, Buffer::new(gzip), request, batch, tls_settings, &cx);
+
+        Ok((Box::new(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {
@@ -108,6 +118,7 @@ pub struct ElasticSearchCommon {
     authorization: Option<String>,
     credentials: Option<AwsCredentials>,
     index: Template,
+    doc_type: String,
     tls_settings: TlsSettings,
     path_and_query: String,
     config: ElasticSearchConfig,
@@ -143,11 +154,12 @@ impl HttpSink for ElasticSearchCommon {
                 );
             })
             .ok()?;
+        info!("inserting into index: {}", index);
 
         let mut action = json!({
             "index": {
                 "_index": index,
-                "_type": self.config.doc_type,
+                "_type": self.doc_type,
             }
         });
         maybe_set_id(
@@ -156,17 +168,20 @@ impl HttpSink for ElasticSearchCommon {
             &event,
         );
 
+        println!("event: {}", action);
         let mut body = serde_json::to_vec(&action).unwrap();
         body.push(b'\n');
 
         serde_json::to_writer(&mut body, &event.into_log()).unwrap();
         body.push(b'\n');
+
         Some(body)
     }
 
     fn build_request(&self, events: Self::Output) -> http::Request<Vec<u8>> {
-        let uri = format!("{}{}", self.base_url, self.path_and_query);
-        let uri = uri.parse::<Uri>().unwrap(); // Already tested that this parses above.
+        let uri = format!("{}{}", self.base_url, self.path_and_query)
+            .parse::<Uri>()
+            .unwrap();
         let mut builder = Request::post(&uri);
 
         if let Some(credentials) = &self.credentials {
@@ -208,6 +223,7 @@ impl HttpSink for ElasticSearchCommon {
                 builder.header("Authorization", &auth[..]);
             }
 
+            println!("REQUEST len: {}", events.len());
             builder.body(events).unwrap()
         }
     }
@@ -222,8 +238,6 @@ impl ElasticSearchCommon {
             }
             _ => None,
         };
-
-        // let provider = config.provider.unwrap_or(Provider::Default);
 
         let base_url = config.host.clone();
 
@@ -261,6 +275,8 @@ impl ElasticSearchCommon {
             Template::from("vector-%Y.%m.%d")
         };
 
+        let doc_type = config.doc_type.clone().unwrap_or("_doc".into());
+
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let path = format!("/_bulk?timeout={}s", request.timeout.as_secs());
@@ -280,161 +296,20 @@ impl ElasticSearchCommon {
             authorization,
             credentials,
             index,
+            doc_type,
             path_and_query,
             tls_settings,
             config,
         })
     }
-
-    fn request_builder(&self, method: Method, path: &str) -> (Uri, http::request::Builder) {
-        let uri = format!("{}{}", self.base_url, path);
-        let uri = uri.parse::<Uri>().unwrap(); // Already tested that this parses above.
-        let mut builder = Request::builder();
-        builder.method(method);
-        builder.uri(&uri);
-        (uri, builder)
-    }
-}
-
-fn es(
-    config: &ElasticSearchConfig,
-    common: ElasticSearchCommon,
-    cx: SinkContext,
-) -> super::RouterSink {
-    let id_key = config.id_key.clone();
-    let mut gzip = match config.compression.unwrap_or(Compression::Gzip) {
-        Compression::None => false,
-        Compression::Gzip => true,
-    };
-    let encoding = config.encoding.clone();
-    let batch = config.batch.unwrap_or(bytesize::mib(10u64), 1);
-    let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
-
-    let index = if let Some(idx) = &config.index {
-        Template::from(idx.as_str())
-    } else {
-        Template::from("vector-%Y.%m.%d")
-    };
-    let doc_type = config.doc_type.clone().unwrap_or("_doc".into());
-
-    let headers = config
-        .headers
-        .as_ref()
-        .unwrap_or(&HashMap::default())
-        .clone();
-
-    let path = format!("/_bulk?timeout={}s", request.timeout.as_secs());
-    let mut path_query = url::form_urlencoded::Serializer::new(path);
-    if let Some(ref query) = config.query {
-        for (p, v) in query {
-            path_query.append_pair(&p[..], &v[..]);
-        }
-    }
-    let path_query = path_query.finish();
-
-    if common.credentials.is_some() {
-        gzip = false;
-    }
-
-    let tls_settings = common.tls_settings.clone();
-    let build_request = move |body: Vec<u8>| {
-        let (uri, mut builder) = common.request_builder(Method::POST, &path_query);
-
-        match common.credentials {
-            None => {
-                builder.header("Content-Type", "application/x-ndjson");
-                if gzip {
-                    builder.header("Content-Encoding", "gzip");
-                }
-
-                for (header, value) in &headers {
-                    builder.header(&header[..], &value[..]);
-                }
-
-                if let Some(ref auth) = common.authorization {
-                    builder.header("Authorization", &auth[..]);
-                }
-
-                builder.body(body).unwrap()
-            }
-            Some(ref credentials) => {
-                let mut request = signed_request("POST", &uri);
-
-                request.add_header("Content-Type", "application/x-ndjson");
-
-                for (header, value) in &headers {
-                    request.add_header(header, value);
-                }
-
-                request.set_payload(Some(body));
-
-                finish_signer(&mut request, &credentials, &mut builder);
-
-                // The SignedRequest ends up owning the body, so we have
-                // to play games here
-                let body = request.payload.take().unwrap();
-                match body {
-                    SignedRequestPayload::Buffer(body) => builder.body(body.to_vec()).unwrap(),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-
-    let http_service = HttpBatchService::new(cx.resolver(), tls_settings, build_request);
-
-    let sink = request
-        .batch_sink(HttpRetryLogic, http_service, cx.acker())
-        .batched_with_min(Buffer::new(gzip), &batch)
-        .with_flat_map(move |e| iter_ok(encode_event(e, &index, &doc_type, &id_key, &encoding)));
-
-    Box::new(sink)
-}
-
-fn encode_event(
-    mut event: Event,
-    index: &Template,
-    doc_type: &str,
-    id_key: &Option<String>,
-    encoding: &EncodingConfigWithDefault<Encoding>,
-) -> Option<Vec<u8>> {
-    encoding.apply_rules(&mut event);
-    let index = index
-        .render_string(&event)
-        .map_err(|missing_keys| {
-            warn!(
-                message = "Keys do not exist on the event; Dropping event.",
-                ?missing_keys,
-                rate_limit_secs = 30,
-            );
-        })
-        .ok()?;
-
-    let mut action = json!({
-        "index": {
-            "_index": index,
-            "_type": doc_type,
-        }
-    });
-    maybe_set_id(
-        id_key.as_ref(),
-        action.pointer_mut("/index").unwrap(),
-        &event,
-    );
-
-    let mut body = serde_json::to_vec(&action).unwrap();
-    body.push(b'\n');
-
-    serde_json::to_writer(&mut body, &event.into_log()).unwrap();
-    body.push(b'\n');
-    Some(body)
 }
 
 fn healthcheck(
     resolver: Resolver,
     common: &ElasticSearchCommon,
 ) -> crate::Result<super::Healthcheck> {
-    let (uri, mut builder) = common.request_builder(Method::GET, "/_cluster/health");
+    let mut builder = Request::get(format!("{}/_cluster/health", common.base_url));
+
     match &common.credentials {
         None => {
             if let Some(authorization) = &common.authorization {
@@ -442,7 +317,7 @@ fn healthcheck(
             }
         }
         Some(credentials) => {
-            let mut signer = signed_request("GET", &uri);
+            let mut signer = signed_request("GET", builder.uri_ref().unwrap());
             finish_signer(&mut signer, &credentials, &mut builder);
         }
     }
@@ -646,6 +521,7 @@ mod integration_tests {
     }
 
     fn run_insert_tests(mut config: ElasticSearchConfig) {
+        crate::test_util::trace_init();
         let mut rt = runtime();
 
         let index = gen_index();
@@ -688,6 +564,7 @@ mod integration_tests {
             .json::<elastic_responses::search::SearchResponse<Value>>()
             .unwrap();
 
+        println!("response {:?}", response);
         assert_eq!(input.len() as u64, response.total());
         let input = input
             .into_iter()

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -168,7 +168,6 @@ impl HttpSink for ElasticSearchCommon {
             &event,
         );
 
-        println!("event: {}", action);
         let mut body = serde_json::to_vec(&action).unwrap();
         body.push(b'\n');
 
@@ -223,7 +222,6 @@ impl HttpSink for ElasticSearchCommon {
                 builder.header("Authorization", &auth[..]);
             }
 
-            println!("REQUEST len: {}", events.len());
             builder.body(events).unwrap()
         }
     }
@@ -564,7 +562,6 @@ mod integration_tests {
             .json::<elastic_responses::search::SearchResponse<Value>>()
             .unwrap();
 
-        println!("response {:?}", response);
         assert_eq!(input.len() as u64, response.total());
         let input = input
             .into_iter()

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -103,7 +103,6 @@ where
     }
 
     pub fn from_settings(inner: S, batch: B, settings: BatchSettings) -> Self {
-        println!("settings: {:?}", settings);
         Self::new_min(inner, batch, settings.size, settings.timeout.into())
     }
 

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -33,6 +33,7 @@ impl BatchEventsConfig {
     }
 }
 
+#[derive(Debug)]
 pub struct BatchSettings {
     pub size: usize,
     pub timeout: Duration,
@@ -102,6 +103,7 @@ where
     }
 
     pub fn from_settings(inner: S, batch: B, settings: BatchSettings) -> Self {
+        println!("settings: {:?}", settings);
         Self::new_min(inner, batch, settings.size, settings.timeout.into())
     }
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -61,7 +61,7 @@ where
         batch: B,
         request_settings: TowerRequestSettings,
         batch_settings: BatchSettings,
-        tls_settings: Option<TlsSettings>,
+        tls_settings: impl Into<Option<TlsSettings>>,
         cx: &SinkContext,
     ) -> Self {
         let sink = Arc::new(sink);


### PR DESCRIPTION
This PR is the first PR int he process of finishing off the `HttpSink` and general sink based http refactoring. This sink only touches `clickhouse`, `elasticsearch` and `datadog_metrics` but internally simplifies things.

Related to #1659 