### PR TITLE
chore(dependencies): Upgrade `regex` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2956,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ smpl_jwt = { version = "0.4.0", optional = true }
 derivative = "1.0"
 chrono = "0.4.6"
 rand = "0.5.5"
-regex = "1.0.5"
+regex = "1.3.5"
 bytes = { version = "0.4.10", features = ["serde"] }
 stream-cancel = "0.4.3"
 hyper = "0.12.35"


### PR DESCRIPTION
Ref https://github.com/timberio/vector/issues/2080.