### PR TITLE
chore(testing): Pin tag for `loki` Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -560,7 +560,7 @@ services:
       environment:
         - PUBSUB_PROJECT1=testproject,topic1:subscription1
     loki:
-      image: grafana/loki
+      image: grafana/loki:master-89263b0-amd64
       ports:
         - "3100:3100"
       command: -config.file=/etc/loki/loki-config.yaml


### PR DESCRIPTION
The latest `loki` image [breaks](https://circleci.com/gh/timberio/vector/89754) our CI job `test-stable`. I'm pinning the previous version for now, but I'm not sure is it an issue with `loki` itself or we need to update our config file.