### PR TITLE
enhancement(lua transform): Support metric events in version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,8 +3027,8 @@ dependencies = [
 
 [[package]]
 name = "rlua"
-version = "0.16.4-alpha.0"
-source = "git+https://github.com/timberio/rlua#c41bfa06cfaf3df543796d3104ec910dd1a24c44"
+version = "0.17.1-alpha.0"
+source = "git+https://github.com/kyren/rlua#25bd7e6bffef9597466a98bfca80a3056c9e6320"
 dependencies = [
  "bitflags",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ hostname = "0.1.5"
 seahash = { version = "3.0.6", optional = true }
 jemallocator = { version = "0.3.0", optional = true }
 lazy_static = "1.3.0"
-rlua = { git = "https://github.com/timberio/rlua", optional = true }
+rlua = { git = "https://github.com/kyren/rlua", optional = true }
 num_cpus = "1.10.0"
 bytesize = { version = "1.0.0", optional = true }
 glob = "0.2.11"

--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -1,0 +1,179 @@
+use crate::event::{Event, LogEvent, Metric};
+use rlua::prelude::*;
+
+impl<'a> ToLua<'a> for Event {
+    fn to_lua(self, ctx: LuaContext<'a>) -> LuaResult<LuaValue> {
+        let table = ctx.create_table()?;
+        match self {
+            Event::Log(log) => table.set("log", log.to_lua(ctx)?)?,
+            Event::Metric(metric) => table.set("metric", metric.to_lua(ctx)?)?,
+        }
+        Ok(LuaValue::Table(table))
+    }
+}
+
+impl<'a> FromLua<'a> for Event {
+    fn from_lua(value: LuaValue<'a>, ctx: LuaContext<'a>) -> LuaResult<Self> {
+        let table = match value {
+            LuaValue::Table(t) => t,
+            _ => {
+                return Err(LuaError::FromLuaConversionError {
+                    from: "",
+                    to: "Event",
+                    message: Some("Event should be a Lua table".to_string()),
+                })
+            }
+        };
+        match (table.get("log")?, table.get("metric")?) {
+            (LuaValue::Table(log), LuaValue::Nil) => {
+                Ok(Event::Log(LogEvent::from_lua(LuaValue::Table(log), ctx)?))
+            }
+            (LuaValue::Nil, LuaValue::Table(metric)) => Ok(Event::Metric(Metric::from_lua(
+                LuaValue::Table(metric),
+                ctx,
+            )?)),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: "",
+                to: "Event",
+                message: Some(
+                    "Event should contain either \"log\" or \"metric\" key at the top level"
+                        .to_string(),
+                ),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::event::{
+        metric::{MetricKind, MetricValue},
+        Metric, Value,
+    };
+
+    fn assert_event(event: Event, assertions: Vec<&'static str>) {
+        Lua::new().context(|ctx| {
+            ctx.globals().set("event", event).unwrap();
+            for assertion in assertions {
+                assert!(
+                    ctx.load(assertion).eval::<bool>().expect(assertion),
+                    assertion
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn to_lua_log() {
+        let mut event = Event::new_empty_log();
+        event.as_mut_log().insert("field", "value");
+
+        let assertions = vec![
+            "type(event) == 'table'",
+            "event.metric == nil",
+            "type(event.log) == 'table'",
+            "event.log.field == 'value'",
+        ];
+
+        assert_event(event, assertions);
+    }
+
+    #[test]
+    fn to_lua_metric() {
+        let event = Event::Metric(Metric {
+            name: "example counter".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Counter { value: 0.57721566 },
+        });
+
+        let assertions = vec![
+            "type(event) == 'table'",
+            "event.log == nil",
+            "type(event.metric) == 'table'",
+            "event.metric.name == 'example counter'",
+            "event.metric.counter.value == 0.57721566",
+        ];
+
+        assert_event(event, assertions);
+    }
+
+    #[test]
+    fn from_lua_log() {
+        let lua_event = r#"
+        {
+            log = {
+                field = "example",
+                nested = {
+                    field = "another example"
+                }
+            }
+        }"#;
+
+        Lua::new().context(|ctx| {
+            let event = ctx.load(lua_event).eval::<Event>().unwrap();
+            let log = event.as_log();
+            assert_eq!(log[&"field".into()], Value::Bytes("example".into()));
+            assert_eq!(
+                log[&"nested.field".into()],
+                Value::Bytes("another example".into())
+            );
+        });
+    }
+
+    #[test]
+    fn from_lua_metric() {
+        let lua_event = r#"
+        {
+            metric = {
+                name = "example counter",
+                counter = {
+                    value = 0.57721566
+                }
+            }
+        }"#;
+        let expected = Event::Metric(Metric {
+            name: "example counter".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Counter { value: 0.57721566 },
+        });
+
+        Lua::new().context(|ctx| {
+            let event = ctx.load(lua_event).eval::<Event>().unwrap();
+            assert_eq!(event, expected);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_lua_missing_log_and_metric() {
+        let lua_event = r#"{
+            some_field: {}
+        }"#;
+        Lua::new().context(|ctx| ctx.load(lua_event).eval::<Event>().unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_lua_both_log_and_metric() {
+        let lua_event = r#"{
+            log = {
+                field = "example",
+                nested = {
+                    field = "another example"
+                }
+            },
+            metric = {
+                name = "example counter",
+                counter = {
+                    value = 0.57721566
+                }
+            }
+        }"#;
+        Lua::new().context(|ctx| ctx.load(lua_event).eval::<Event>().unwrap());
+    }
+}

--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -14,11 +14,11 @@ impl<'a> ToLua<'a> for Event {
 
 impl<'a> FromLua<'a> for Event {
     fn from_lua(value: LuaValue<'a>, ctx: LuaContext<'a>) -> LuaResult<Self> {
-        let table = match value {
+        let table = match &value {
             LuaValue::Table(t) => t,
             _ => {
                 return Err(LuaError::FromLuaConversionError {
-                    from: "",
+                    from: value.type_name(),
                     to: "Event",
                     message: Some("Event should be a Lua table".to_string()),
                 })
@@ -33,7 +33,7 @@ impl<'a> FromLua<'a> for Event {
                 ctx,
             )?)),
             _ => Err(LuaError::FromLuaConversionError {
-                from: "",
+                from: value.type_name(),
                 to: "Event",
                 message: Some(
                     "Event should contain either \"log\" or \"metric\" key at the top level"

--- a/src/transforms/lua/v2/interop/log.rs
+++ b/src/transforms/lua/v2/interop/log.rs
@@ -1,0 +1,94 @@
+use crate::event::{Event, LogEvent, Value};
+use rlua::prelude::*;
+
+impl<'a> ToLua<'a> for LogEvent {
+    fn to_lua(self, ctx: LuaContext<'a>) -> LuaResult<LuaValue> {
+        ctx.create_table_from(self.into_iter().map(|(k, v)| (k.to_string(), v)))
+            .map(LuaValue::Table)
+    }
+}
+
+impl<'a> FromLua<'a> for LogEvent {
+    fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
+        match value {
+            LuaValue::Table(t) => {
+                let mut log = Event::new_empty_log().into_log();
+                for pair in t.pairs() {
+                    let (key, value): (String, Value) = pair?;
+                    log.insert_flat(key, value);
+                }
+                Ok(log)
+            }
+            _ => Err(rlua::Error::FromLuaConversionError {
+                from: "",
+                to: "LogEvent",
+                message: Some("LogEvent should ba a Lua table".to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn to_lua() {
+        let mut event = Event::new_empty_log();
+        let log = event.as_mut_log();
+        log.insert("a", 1);
+        log.insert("nested.field", "2");
+        log.insert("nested.array[0]", "example value");
+        log.insert("nested.array[2]", "another value");
+
+        let assertions = vec![
+            "type(log) == 'table'",
+            "log.a == 1",
+            "type(log.nested) == 'table'",
+            "log.nested.field == '2'",
+            "#log.nested.array == 3",
+            "log.nested.array[1] == 'example value'",
+            "log.nested.array[2] == ''",
+            "log.nested.array[3] == 'another value'",
+        ];
+
+        Lua::new().context(move |ctx| {
+            ctx.globals().set("log", log.clone()).unwrap();
+            for assertion in assertions {
+                let result: bool = ctx
+                    .load(assertion)
+                    .eval()
+                    .expect(&format!("Failed to verify assertion {:?}", assertion));
+                assert!(result, assertion);
+            }
+        });
+    }
+
+    #[test]
+    fn from_lua() {
+        let lua_event = r#"
+        {
+            a = 1,
+            nested = {
+                field = '2',
+                array = {'example value', '', 'another value'}
+            }
+        }
+        "#;
+        Lua::new().context(move |ctx| {
+            let event: LogEvent = ctx.load(lua_event).eval().unwrap();
+
+            assert_eq!(event[&"a".into()], Value::Integer(1));
+            assert_eq!(event[&"nested.field".into()], Value::Bytes("2".into()));
+            assert_eq!(
+                event[&"nested.array[0]".into()],
+                Value::Bytes("example value".into())
+            );
+            assert_eq!(event[&"nested.array[1]".into()], Value::Bytes("".into()));
+            assert_eq!(
+                event[&"nested.array[2]".into()],
+                Value::Bytes("another value".into())
+            );
+        });
+    }
+}

--- a/src/transforms/lua/v2/interop/log.rs
+++ b/src/transforms/lua/v2/interop/log.rs
@@ -20,7 +20,7 @@ impl<'a> FromLua<'a> for LogEvent {
                 Ok(log)
             }
             _ => Err(rlua::Error::FromLuaConversionError {
-                from: "",
+                from: value.type_name(),
                 to: "LogEvent",
                 message: Some("LogEvent should ba a Lua table".to_string()),
             }),

--- a/src/transforms/lua/v2/interop/metric.rs
+++ b/src/transforms/lua/v2/interop/metric.rs
@@ -19,7 +19,7 @@ impl<'a> FromLua<'a> for MetricKind {
             LuaValue::String(s) if s == "absolute" => Ok(MetricKind::Absolute),
             LuaValue::String(s) if s == "incremental" => Ok(MetricKind::Incremental),
             _ => Err(LuaError::FromLuaConversionError {
-                from: "",
+                from: value.type_name(),
                 to: "MetricKind",
                 message: Some(
                     "Metric kind should be either \"incremental\" or \"absolute\"".to_string(),
@@ -101,11 +101,11 @@ impl<'a> ToLua<'a> for Metric {
 
 impl<'a> FromLua<'a> for Metric {
     fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
-        let table = match value {
+        let table = match &value {
             LuaValue::Table(table) => table,
-            _ => {
+            other => {
                 return Err(LuaError::FromLuaConversionError {
-                    from: "",
+                    from: other.type_name(),
                     to: "Metric",
                     message: Some("Metric should be a Lua table".to_string()),
                 })
@@ -161,7 +161,7 @@ impl<'a> FromLua<'a> for Metric {
             }
         } else {
             return Err(LuaError::FromLuaConversionError {
-                from: "",
+                from: value.type_name(),
                 to: "Metric",
                 message: Some("Cannot find metric value, expected presence one of \"counter\", \"gauge\", \"set\", \"distribution\", \"aggregated_histogram\", \"aggregated_summary\"".to_string()),
             });

--- a/src/transforms/lua/v2/interop/metric.rs
+++ b/src/transforms/lua/v2/interop/metric.rs
@@ -1,4 +1,4 @@
-use super::util::{table_to_timestamp, timestamp_to_table};
+use super::util::{table_to_set, table_to_timestamp, timestamp_to_table};
 use crate::event::metric::{Metric, MetricKind, MetricValue};
 use rlua::prelude::*;
 use std::collections::BTreeMap;
@@ -132,7 +132,7 @@ impl<'a> FromLua<'a> for Metric {
             }
         } else if let Some(set) = table.get::<_, Option<LuaTable>>("set")? {
             MetricValue::Set {
-                values: set.get::<_, Vec<String>>("values")?.into_iter().collect(), // FIXME
+                values: set.get::<_, LuaTable>("values").and_then(table_to_set)?,
             }
         } else if let Some(distribution) = table.get::<_, Option<LuaTable>>("distribution")? {
             MetricValue::Distribution {

--- a/src/transforms/lua/v2/interop/metric.rs
+++ b/src/transforms/lua/v2/interop/metric.rs
@@ -1,0 +1,539 @@
+use super::util::{table_to_timestamp, timestamp_to_table};
+use crate::event::metric::{Metric, MetricKind, MetricValue};
+use rlua::prelude::*;
+use std::collections::BTreeMap;
+
+impl<'a> ToLua<'a> for MetricKind {
+    fn to_lua(self, ctx: LuaContext<'a>) -> LuaResult<LuaValue> {
+        let kind = match self {
+            MetricKind::Absolute => "absolute",
+            MetricKind::Incremental => "incremental",
+        };
+        ctx.create_string(kind).map(LuaValue::String)
+    }
+}
+
+impl<'a> FromLua<'a> for MetricKind {
+    fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
+        match value {
+            LuaValue::String(s) if s == "absolute" => Ok(MetricKind::Absolute),
+            LuaValue::String(s) if s == "incremental" => Ok(MetricKind::Incremental),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: "",
+                to: "MetricKind",
+                message: Some(
+                    "Metric kind should be either \"incremental\" or \"absolute\"".to_string(),
+                ),
+            }),
+        }
+    }
+}
+
+impl<'a> ToLua<'a> for Metric {
+    fn to_lua(self, ctx: LuaContext<'a>) -> LuaResult<LuaValue> {
+        let tbl = ctx.create_table()?;
+
+        tbl.set("name", self.name)?;
+        if let Some(ts) = self.timestamp {
+            tbl.set("timestamp", timestamp_to_table(ctx, ts)?)?;
+        }
+        if let Some(tags) = self.tags {
+            tbl.set("tags", tags)?;
+        }
+        tbl.set("kind", self.kind)?;
+
+        match self.value {
+            MetricValue::Counter { value } => {
+                let counter = ctx.create_table()?;
+                counter.set("value", value)?;
+                tbl.set("counter", counter)?;
+            }
+            MetricValue::Gauge { value } => {
+                let gauge = ctx.create_table()?;
+                gauge.set("value", value)?;
+                tbl.set("gauge", gauge)?;
+            }
+            MetricValue::Set { values } => {
+                let set = ctx.create_table()?;
+                set.set("values", ctx.create_sequence_from(values.into_iter())?)?;
+                tbl.set("set", set)?;
+            }
+            MetricValue::Distribution {
+                values,
+                sample_rates,
+            } => {
+                let distribution = ctx.create_table()?;
+                distribution.set("values", values)?;
+                distribution.set("sample_rates", sample_rates)?;
+                tbl.set("distribution", distribution)?;
+            }
+            MetricValue::AggregatedHistogram {
+                buckets,
+                counts,
+                count,
+                sum,
+            } => {
+                let aggregated_histogram = ctx.create_table()?;
+                aggregated_histogram.set("buckets", buckets)?;
+                aggregated_histogram.set("counts", counts)?;
+                aggregated_histogram.set("count", count)?;
+                aggregated_histogram.set("sum", sum)?;
+                tbl.set("aggregated_histogram", aggregated_histogram)?;
+            }
+            MetricValue::AggregatedSummary {
+                quantiles,
+                values,
+                count,
+                sum,
+            } => {
+                let aggregated_summary = ctx.create_table()?;
+                aggregated_summary.set("quantiles", quantiles)?;
+                aggregated_summary.set("values", values)?;
+                aggregated_summary.set("count", count)?;
+                aggregated_summary.set("sum", sum)?;
+                tbl.set("aggregated_summary", aggregated_summary)?;
+            }
+        }
+
+        Ok(LuaValue::Table(tbl))
+    }
+}
+
+impl<'a> FromLua<'a> for Metric {
+    fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
+        let table = match value {
+            LuaValue::Table(table) => table,
+            _ => {
+                return Err(LuaError::FromLuaConversionError {
+                    from: "",
+                    to: "Metric",
+                    message: Some("Metric should be a Lua table".to_string()),
+                })
+            }
+        };
+
+        let name: String = table.get("name")?;
+        let timestamp = table
+            .get::<_, Option<LuaTable>>("timestamp")?
+            .map(|t| table_to_timestamp(t))
+            .transpose()?;
+        let tags: Option<BTreeMap<String, String>> = table.get("tags")?;
+        let kind = table
+            .get::<_, Option<MetricKind>>("kind")?
+            .unwrap_or(MetricKind::Absolute);
+
+        let value = if let Some(counter) = table.get::<_, Option<LuaTable>>("counter")? {
+            MetricValue::Counter {
+                value: counter.get("value")?,
+            }
+        } else if let Some(gauge) = table.get::<_, Option<LuaTable>>("gauge")? {
+            MetricValue::Gauge {
+                value: gauge.get("value")?,
+            }
+        } else if let Some(set) = table.get::<_, Option<LuaTable>>("set")? {
+            MetricValue::Set {
+                values: set.get::<_, Vec<String>>("values")?.into_iter().collect(), // FIXME
+            }
+        } else if let Some(distribution) = table.get::<_, Option<LuaTable>>("distribution")? {
+            MetricValue::Distribution {
+                values: distribution.get("values")?,
+                sample_rates: distribution.get("sample_rates")?,
+            }
+        } else if let Some(aggregated_histogram) =
+            table.get::<_, Option<LuaTable>>("aggregated_histogram")?
+        {
+            let counts: Vec<u32> = aggregated_histogram.get("counts")?;
+            let count = counts.iter().sum();
+            MetricValue::AggregatedHistogram {
+                buckets: aggregated_histogram.get("buckets")?,
+                counts,
+                count,
+                sum: aggregated_histogram.get("sum")?,
+            }
+        } else if let Some(aggregated_summary) =
+            table.get::<_, Option<LuaTable>>("aggregated_summary")?
+        {
+            MetricValue::AggregatedSummary {
+                quantiles: aggregated_summary.get("quantiles")?,
+                values: aggregated_summary.get("values")?,
+                count: aggregated_summary.get("count")?,
+                sum: aggregated_summary.get("sum")?,
+            }
+        } else {
+            return Err(LuaError::FromLuaConversionError {
+                from: "",
+                to: "Metric",
+                message: Some("Cannot find metric value, expected presence one of \"counter\", \"gauge\", \"set\", \"distribution\", \"aggregated_histogram\", \"aggregated_summary\"".to_string()),
+            });
+        };
+
+        Ok(Metric {
+            name,
+            timestamp,
+            tags,
+            kind,
+            value,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::{offset::TimeZone, Utc};
+
+    fn assert_metric(metric: Metric, assertions: Vec<&'static str>) {
+        Lua::new().context(|ctx| {
+            ctx.globals().set("metric", metric).unwrap();
+            for assertion in assertions {
+                assert!(
+                    ctx.load(assertion).eval::<bool>().expect(assertion),
+                    assertion
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn to_lua_counter_full() {
+        let metric = Metric {
+            name: "example counter".into(),
+            timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
+            tags: Some(
+                vec![("example tag".to_string(), "example value".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            kind: MetricKind::Incremental,
+            value: MetricValue::Counter { value: 1.0 },
+        };
+        let assertions = vec![
+            "type(metric) == 'table'",
+            "metric.name == 'example counter'",
+            "type(metric.timestamp) == 'table'",
+            "metric.timestamp.year == 2018",
+            "metric.timestamp.month == 11",
+            "metric.timestamp.day == 14",
+            "metric.timestamp.hour == 8",
+            "metric.timestamp.min == 9",
+            "metric.timestamp.sec == 10",
+            "type(metric.tags) == 'table'",
+            "metric.tags['example tag'] == 'example value'",
+            "metric.kind == 'incremental'",
+            "type(metric.counter) == 'table'",
+            "metric.counter.value == 1",
+        ];
+        assert_metric(metric, assertions);
+    }
+
+    #[test]
+    fn to_lua_counter_minimal() {
+        let metric = Metric {
+            name: "example counter".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Counter { value: 0.57721566 },
+        };
+        let assertions = vec![
+            "metric.timestamp == nil",
+            "metric.tags == nil",
+            "metric.kind == 'absolute'",
+            "metric.counter.value == 0.57721566",
+        ];
+        assert_metric(metric, assertions);
+    }
+
+    #[test]
+    fn to_lua_gauge() {
+        let metric = Metric {
+            name: "example gauge".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Gauge { value: 1.6180339 },
+        };
+        let assertions = vec!["metric.gauge.value == 1.6180339", "metric.counter == nil"];
+        assert_metric(metric, assertions);
+    }
+
+    #[test]
+    fn to_lua_set() {
+        let metric = Metric {
+            name: "example set".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Set {
+                values: vec!["value".into(), "another value".into()]
+                    .into_iter()
+                    .collect(),
+            },
+        };
+        let assertions = vec![
+            "type(metric.set) == 'table'",
+            "type(metric.set.values) == 'table'",
+            "#metric.set.values == 2",
+            "metric.set.values[1] == 'another value'",
+            "metric.set.values[2] == 'value'",
+        ];
+        assert_metric(metric, assertions);
+    }
+
+    #[test]
+    fn to_lua_distribution() {
+        let metric = Metric {
+            name: "example distribution".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Distribution {
+                values: vec![1.0, 1.0],
+                sample_rates: vec![10, 20],
+            },
+        };
+        let assertions = vec![
+            "type(metric.distribution) == 'table'",
+            "#metric.distribution.values == 2",
+            "metric.distribution.values[1] == 1",
+            "metric.distribution.values[2] == 1",
+            "#metric.distribution.sample_rates == 2",
+            "metric.distribution.sample_rates[1] == 10",
+            "metric.distribution.sample_rates[2] == 20",
+        ];
+        assert_metric(metric, assertions)
+    }
+
+    #[test]
+    fn to_lua_aggregated_histogram() {
+        let metric = Metric {
+            name: "example histogram".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::AggregatedHistogram {
+                buckets: vec![1.0, 2.0, 4.0, 8.0],
+                counts: vec![20, 10, 45, 12],
+                count: 87,
+                sum: 975.2,
+            },
+        };
+        let assertions = vec![
+            "type(metric.aggregated_histogram) == 'table'",
+            "#metric.aggregated_histogram.buckets == 4",
+            "metric.aggregated_histogram.buckets[1] == 1",
+            "metric.aggregated_histogram.buckets[4] == 8",
+            "#metric.aggregated_histogram.counts == 4",
+            "metric.aggregated_histogram.counts[1] == 20",
+            "metric.aggregated_histogram.counts[4] == 12",
+            "metric.aggregated_histogram.count == 87",
+            "metric.aggregated_histogram.sum == 975.2",
+        ];
+        assert_metric(metric, assertions)
+    }
+
+    #[test]
+    fn to_lua_aggregated_summary() {
+        let metric = Metric {
+            name: "example summary".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::AggregatedSummary {
+                quantiles: vec![0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0],
+                values: vec![2.0, 3.0, 5.0, 8.0, 7.0, 9.0, 10.0],
+                count: 197,
+                sum: 975.2,
+            },
+        };
+        let assertions = vec![
+            "type(metric.aggregated_summary) == 'table'",
+            "#metric.aggregated_summary.quantiles == 7",
+            "metric.aggregated_summary.quantiles[2] == 0.25",
+            "#metric.aggregated_summary.values == 7",
+            "metric.aggregated_summary.values[3] == 5",
+            "metric.aggregated_summary.count == 197",
+            "metric.aggregated_summary.sum == 975.2",
+        ];
+        assert_metric(metric, assertions)
+    }
+
+    #[test]
+    fn from_lua_counter_minimal() {
+        let value = r#"{
+            name = "example counter",
+            counter = {
+                value = 0.57721566
+            }
+        }"#;
+        let expected = Metric {
+            name: "example counter".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Counter { value: 0.57721566 },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_counter_full() {
+        let value = r#"{
+            name = "example counter",
+            timestamp = {
+                year = 2018,
+                month = 11,
+                day = 14,
+                hour = 8,
+                min = 9,
+                sec = 10
+            },
+            tags = {
+                ["example tag"] = "example value"
+            },
+            kind = "incremental",
+            counter = {
+                value = 1
+            }
+        }"#;
+        let expected = Metric {
+            name: "example counter".into(),
+            timestamp: Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10)),
+            tags: Some(
+                vec![("example tag".to_string(), "example value".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            kind: MetricKind::Incremental,
+            value: MetricValue::Counter { value: 1.0 },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_gauge() {
+        let value = r#"{
+            name = "example gauge",
+            gauge = {
+                value = 1.6180339
+            }
+        }"#;
+        let expected = Metric {
+            name: "example gauge".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Gauge { value: 1.6180339 },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_set() {
+        let value = r#"{
+            name = "example set",
+            set = {
+                values = { "value", "another value" }
+            }
+        }"#;
+        let expected = Metric {
+            name: "example set".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Set {
+                values: vec!["value".into(), "another value".into()]
+                    .into_iter()
+                    .collect(),
+            },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_distribution() {
+        let value = r#"{
+            name = "example distribution",
+            distribution = {
+                values = { 1.0, 1.0 },
+                sample_rates = { 10, 20 }
+            }
+        }"#;
+        let expected = Metric {
+            name: "example distribution".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::Distribution {
+                values: vec![1.0, 1.0],
+                sample_rates: vec![10, 20],
+            },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_aggregated_histogram() {
+        let value = r#"{
+            name = "example histogram",
+            aggregated_histogram = {
+                buckets = { 1, 2, 4, 8 },
+                counts = { 20, 10, 45, 12 },
+                sum = 975.2
+            }
+        }"#;
+        let expected = Metric {
+            name: "example histogram".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::AggregatedHistogram {
+                buckets: vec![1.0, 2.0, 4.0, 8.0],
+                counts: vec![20, 10, 45, 12],
+                count: 87,
+                sum: 975.2,
+            },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+
+    #[test]
+    fn from_lua_aggregated_summary() {
+        let value = r#"{
+            name = "example summary",
+            aggregated_summary = {
+                quantiles = { 0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0 },
+                values = { 2.0, 3.0, 5.0, 8.0, 7.0, 9.0, 10.0 },
+                count = 197,
+                sum = 975.2
+            }
+        }"#;
+        let expected = Metric {
+            name: "example summary".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Absolute,
+            value: MetricValue::AggregatedSummary {
+                quantiles: vec![0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0],
+                values: vec![2.0, 3.0, 5.0, 8.0, 7.0, 9.0, 10.0],
+                count: 197,
+                sum: 975.2,
+            },
+        };
+        Lua::new().context(|ctx| {
+            assert_eq!(ctx.load(value).eval::<Metric>().unwrap(), expected);
+        });
+    }
+}

--- a/src/transforms/lua/v2/interop/mod.rs
+++ b/src/transforms/lua/v2/interop/mod.rs
@@ -1,0 +1,7 @@
+/// This module contains implementations of `ToLua` and `FromLua` traits for
+/// Vector data types
+pub mod event;
+pub mod log;
+pub mod metric;
+pub mod util;
+pub mod value;

--- a/src/transforms/lua/v2/interop/util.rs
+++ b/src/transforms/lua/v2/interop/util.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
+use rlua::prelude::*;
+use std::collections::BTreeMap;
+
+pub fn timestamp_to_table<'a>(ctx: LuaContext<'a>, ts: DateTime<Utc>) -> LuaResult<LuaTable> {
+    let table = ctx.create_table()?;
+    table.set("year", ts.year())?;
+    table.set("month", ts.month())?;
+    table.set("day", ts.day())?;
+    table.set("hour", ts.hour())?;
+    table.set("min", ts.minute())?;
+    table.set("sec", ts.second())?;
+    table.set("yday", ts.ordinal())?;
+    table.set("wday", ts.weekday().number_from_sunday())?;
+    table.set("isdst", false)?;
+
+    Ok(table)
+}
+
+pub fn table_is_timestamp<'a>(t: &LuaTable<'a>) -> LuaResult<bool> {
+    for &key in &[
+        "year", "month", "day", "hour", "min", "sec", "wday", "yday", "isdst",
+    ] {
+        if !t.contains_key(key)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+pub fn table_to_timestamp<'a>(t: LuaTable<'a>) -> LuaResult<DateTime<Utc>> {
+    let year = t.get("year")?;
+    let month = t.get("month")?;
+    let day = t.get("day")?;
+    let hour = t.get("hour")?;
+    let min = t.get("min")?;
+    let sec = t.get("sec")?;
+    Ok(Utc.ymd(year, month, day).and_hms(hour, min, sec))
+}
+
+pub fn table_to_map<'a, K, V>(t: LuaTable<'a>) -> LuaResult<BTreeMap<K, V>>
+where
+    K: From<String> + Ord,
+    V: FromLua<'a>,
+{
+    let mut map = BTreeMap::new();
+    for pair in t.pairs() {
+        let (k, v): (String, V) = pair?;
+        map.insert(k.into(), v);
+    }
+    Ok(map)
+}
+
+pub fn table_is_array<'a>(t: &LuaTable<'a>) -> LuaResult<bool> {
+    Ok(t.len()? > 0)
+}
+
+pub fn table_to_array<'a, T>(t: LuaTable<'a>) -> LuaResult<Vec<T>>
+where
+    T: FromLua<'a>,
+{
+    let mut seq = Vec::new();
+    for item in t.sequence_values() {
+        let value = item?;
+        seq.push(value);
+    }
+    Ok(seq)
+}

--- a/src/transforms/lua/v2/interop/util.rs
+++ b/src/transforms/lua/v2/interop/util.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
 use rlua::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn timestamp_to_table<'a>(ctx: LuaContext<'a>, ts: DateTime<Utc>) -> LuaResult<LuaTable> {
     let table = ctx.create_table()?;
@@ -49,6 +49,17 @@ where
         map.insert(k.into(), v);
     }
     Ok(map)
+}
+
+pub fn table_to_set<'a, T>(t: LuaTable<'a>) -> LuaResult<BTreeSet<T>>
+where
+    T: FromLua<'a> + Ord,
+{
+    let mut set = BTreeSet::new();
+    for item in t.sequence_values() {
+        set.insert(item?);
+    }
+    Ok(set)
 }
 
 pub fn table_is_array<'a>(t: &LuaTable<'a>) -> LuaResult<bool> {

--- a/src/transforms/lua/v2/interop/value.rs
+++ b/src/transforms/lua/v2/interop/value.rs
@@ -1,0 +1,202 @@
+use super::util::{
+    table_is_array, table_is_timestamp, table_to_array, table_to_map, table_to_timestamp,
+    timestamp_to_table,
+};
+use crate::event::Value;
+use rlua::prelude::*;
+
+impl<'a> ToLua<'a> for Value {
+    fn to_lua(self, ctx: LuaContext<'a>) -> LuaResult<LuaValue> {
+        match self {
+            Value::Bytes(b) => ctx.create_string(b.as_ref()).map(LuaValue::String),
+            Value::Integer(i) => Ok(LuaValue::Integer(i)),
+            Value::Float(f) => Ok(LuaValue::Number(f)),
+            Value::Boolean(b) => Ok(LuaValue::Boolean(b)),
+            Value::Timestamp(t) => timestamp_to_table(ctx, t).map(LuaValue::Table),
+            Value::Map(m) => ctx
+                .create_table_from(m.into_iter().map(|(k, v)| (k.to_string(), v)))
+                .map(LuaValue::Table),
+            Value::Array(a) => ctx.create_sequence_from(a.into_iter()).map(LuaValue::Table),
+            Value::Null => ctx.create_string("").map(LuaValue::String),
+        }
+    }
+}
+
+impl<'a> FromLua<'a> for Value {
+    fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
+        match value {
+            LuaValue::String(s) => Ok(Value::Bytes(s.as_bytes().into())),
+            LuaValue::Integer(i) => Ok(Value::Integer(i)),
+            LuaValue::Number(f) => Ok(Value::Float(f)),
+            LuaValue::Boolean(b) => Ok(Value::Boolean(b)),
+            LuaValue::Table(t) => {
+                if table_is_array(&t)? {
+                    table_to_array(t).map(Value::Array)
+                } else if table_is_timestamp(&t)? {
+                    table_to_timestamp(t).map(Value::Timestamp)
+                } else {
+                    table_to_map(t).map(Value::Map)
+                }
+            }
+            _ => Err(rlua::Error::FromLuaConversionError {
+                from: "",
+                to: "Value",
+                message: Some("Unsupported Lua type".to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn from_lua() {
+        let pairs = vec![
+            ("'⍺βγ'", Value::Bytes("⍺βγ".into())),
+            ("123", Value::Integer(123)),
+            ("3.14159265359", Value::Float(3.14159265359)),
+            ("true", Value::Boolean(true)),
+            (
+                "{ x = 1, y = '2', nested = { other = 2.718281828 } }",
+                Value::Map(
+                    vec![
+                        ("x".into(), 1.into()),
+                        ("y".into(), "2".into()),
+                        (
+                            "nested".into(),
+                            Value::Map(
+                                vec![("other".into(), 2.718281828.into())]
+                                    .into_iter()
+                                    .collect(),
+                            ),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            ),
+            (
+                "{1, '2', 0.57721566}",
+                Value::Array(vec![1.into(), "2".into(), 0.57721566.into()]),
+            ),
+            (
+                "os.date('!*t', 1584297428)",
+                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+            ),
+        ];
+
+        Lua::new().context(move |ctx| {
+            for (expression, expected) in pairs.into_iter() {
+                let value: Value = ctx.load(expression).eval().unwrap();
+                assert_eq!(value, expected, "expression: {:?}", expression);
+            }
+        });
+    }
+
+    #[test]
+    fn to_lua() {
+        let pairs = vec![
+            (
+                Value::Bytes("⍺βγ".into()),
+                r#"
+                function (value)
+                    return value == '⍺βγ'
+                end
+                "#,
+            ),
+            (
+                Value::Integer(123),
+                r#"
+                function (value)
+                    return value == 123
+                end
+                "#,
+            ),
+            (
+                Value::Float(3.14159265359),
+                r#"
+                function (value)
+                    return value == 3.14159265359
+                end
+                "#,
+            ),
+            (
+                Value::Null,
+                r#"
+                function (value)
+                    return value == ''
+                end
+                "#,
+            ),
+            (
+                Value::Map(
+                    vec![
+                        ("x".into(), 1.into()),
+                        ("y".into(), "2".into()),
+                        (
+                            "nested".into(),
+                            Value::Map(
+                                vec![("other".into(), 2.718281828.into())]
+                                    .into_iter()
+                                    .collect(),
+                            ),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                r#"
+                function (value)
+                    return value.x == 1 and
+                        value['y'] == '2' and
+                        value.nested.other == 2.718281828
+                end
+                "#,
+            ),
+            (
+                Value::Array(vec![1.into(), "2".into(), 0.57721566.into()]),
+                r#"
+                function (value)
+                    return value[1] == 1 and
+                        value[2] == '2' and
+                        value[3] == 0.57721566
+                end
+                "#,
+            ),
+            (
+                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+                r#"
+                function (value)
+                    local expected = os.date("!*t", 1584297428)
+
+                    return os.time(value) == os.time(expected) and
+                        value.yday == expected.yday and
+                        value.wday == expected.wday and
+                        value.isdst == expected.isdst
+                end
+                "#,
+            ),
+        ];
+
+        Lua::new().context(move |ctx| {
+            for (value, test_src) in pairs.into_iter() {
+                let test_fn: LuaFunction = ctx.load(test_src).eval().expect(&format!(
+                    "failed to load {} for value {:?}",
+                    test_src, value
+                ));
+                assert!(
+                    test_fn.call::<_, bool>(value.clone()).expect(&format!(
+                        "failed to call {} for value {:?}",
+                        test_src, value
+                    )),
+                    "test function: {}, value: {:?}",
+                    test_src,
+                    value
+                );
+            }
+        });
+    }
+}

--- a/src/transforms/lua/v2/interop/value.rs
+++ b/src/transforms/lua/v2/interop/value.rs
@@ -38,8 +38,8 @@ impl<'a> FromLua<'a> for Value {
                     table_to_map(t).map(Value::Map)
                 }
             }
-            _ => Err(rlua::Error::FromLuaConversionError {
-                from: "",
+            other => Err(rlua::Error::FromLuaConversionError {
+                from: other.type_name(),
                 to: "Value",
                 message: Some("Unsupported Lua type".to_string()),
             }),

--- a/tests/behavior/transforms/lua_v1.toml
+++ b/tests/behavior/transforms/lua_v1.toml
@@ -36,23 +36,3 @@
     [[tests.outputs.conditions]]
       "a.exists" = false
       "b.equals" = "example value"
-
-[transforms.lua_v2]
-  inputs = []
-  type = "lua"
-  version = "2"
-  source = """
-    event["a"], event["b"] = nil, event["a"]
-  """
-[[tests]]
-  name = "lua_v2"
-  [tests.input]
-    insert_at = "lua_v2"
-    type = "log"
-    [tests.input.log_fields]
-      a = "example value"
-  [[tests.outputs]]
-    extract_from = "lua_v2"
-    [[tests.outputs.conditions]]
-      "a.exists" = false
-      "b.equals" = "example value"

--- a/tests/behavior/transforms/lua_v2.toml
+++ b/tests/behavior/transforms/lua_v2.toml
@@ -1,0 +1,91 @@
+[transforms.lua_v2_log]
+  inputs = []
+  type = "lua"
+  version = "2"
+  source = """
+    event.log.a, event.log.b = nil, event.log.a
+  """
+[[tests]]
+  name = "lua_v2_log"
+  [tests.input]
+    insert_at = "lua_v2_log"
+    type = "log"
+    [tests.input.log_fields]
+      a = "example value"
+  [[tests.outputs]]
+    extract_from = "lua_v2_log"
+    [[tests.outputs.conditions]]
+      "a.exists" = false
+      "b.equals" = "example value"
+
+[transforms.lua_v2_metric]
+  inputs = []
+  type = "lua"
+  version = "2"
+  source = """
+    event.metric.counter.value = event.metric.counter.value + 1
+  """
+[[tests]]
+  name = "lua_v2_metric"
+  [tests.input]
+    insert_at = "lua_v2_metric"
+    type = "metric"
+    [tests.input.metric]
+      name = "example counter"
+      kind = "absolute"
+      value.type = "counter"
+      value.value = 1.0
+  [[tests.outputs]]
+    extract_from = "lua_v2_metric"
+    [[tests.outputs.conditions]]
+      type = "is_metric"
+
+[transforms.lua_v2_log_to_metric]
+  inputs = []
+  type = "lua"
+  version = "2"
+  source = """
+    event.log = nil
+    event.metric = {
+      name = "example metric",
+      counter = {
+        value = 1.0
+      }
+    }
+  """
+[[tests]]
+  name = "lua_v2_log_to_metric"
+  [tests.input]
+    insert_at = "lua_v2_log_to_metric"
+    type = "log"
+    [tests.input.log_fields]
+      a = "example value"
+  [[tests.outputs]]
+    extract_from = "lua_v2_log_to_metric"
+    [[tests.outputs.conditions]]
+      type = "is_metric"
+
+[transforms.lua_v2_metric_to_log]
+  inputs = []
+  type = "lua"
+  version = "2"
+  source = """
+    event.metric = nil
+    event.log = {
+      field = "example value"
+    }
+  """
+[[tests]]
+  name = "lua_v2_metric_to_log"
+  [tests.input]
+    insert_at = "lua_v2_metric_to_log"
+    type = "metric"
+    [tests.input.metric]
+      name = "example metric"
+      kind = "absolute"
+      value.type = "counter"
+      value.value = 1.0
+  [[tests.outputs]]
+    extract_from = "lua_v2_metric_to_log"
+    [[tests.outputs.conditions]]
+      "field.equals" = "example value"


### PR DESCRIPTION
This PR adds support for both metrics and log events in `lua` support APIv2 in accordance to [RFC 1999](https://github.com/timberio/vector/blob/master/rfcs/2020-03-06-1999-api-extensions-for-lua-transform.md).

The change is not documented because Lua API v2 is not stable yet, so it is not advertised in the documentation.

Closes https://github.com/timberio/vector/issues/1563, closes https://github.com/timberio/vector/issues/1406, and closes https://github.com/timberio/vector/issues/706 (for Lua APIv2).