### PR TITLE
chore: Rename tokio -> tokio01 and tokio02 -> tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ tracing-limit = { path = "lib/tracing-limit" }
 # Tokio / Futures
 futures01 = { package = "futures", version = "0.1.25" }
 futures = { version = "0.3", default-features = false, features = ["compat"] }
-tokio = { version = "0.1.22", features = ["io", "uds", "tcp", "rt-full", "experimental-tracing"], default-features = false }
-tokio02 = { package = "tokio", version = "0.2.13", features = ["blocking", "fs", "sync", "macros", "test-util", "rt-core", "io-std"] }
+tokio01 = { package = "tokio", version = "0.1.22", features = ["io", "uds", "tcp", "rt-full", "experimental-tracing"], default-features = false }
+tokio = { version = "0.2.13", features = ["blocking", "fs", "sync", "macros", "test-util", "rt-core", "io-std"] }
 tokio-codec = "0.1.0"
 tokio-openssl = "0.3.0"
 tokio-retry = "0.2.0"

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -3,8 +3,8 @@ use criterion::{criterion_group, Benchmark, Criterion, Throughput};
 use futures01::{sink::Sink, stream::Stream, Future};
 use std::path::PathBuf;
 use tempfile::tempdir;
-use tokio::codec::{BytesCodec, FramedWrite};
-use tokio::fs::OpenOptions;
+use tokio01::codec::{BytesCodec, FramedWrite};
+use tokio01::fs::OpenOptions;
 use vector::test_util::random_lines;
 use vector::{
     runtime, sinks, sources,

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -133,7 +133,7 @@ fn serve(addr: SocketAddr) {
             .serve(make_service)
             .map_err(|e| panic!(e));
 
-        tokio::runtime::current_thread::run(fut);
+        tokio01::runtime::current_thread::run(fut);
     });
 }
 

--- a/src/buffers/disk.rs
+++ b/src/buffers/disk.rs
@@ -189,7 +189,7 @@ impl Stream for Reader {
 
         // This will usually complete instantly, but in the case of a large queue (or a fresh launch of
         // the app), this will have to go to disk.
-        let next = tokio02::task::block_in_place(|| {
+        let next = tokio::task::block_in_place(|| {
             self.db
                 .get(ReadOptions::new(), Key(self.read_offset))
                 .unwrap()

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -188,7 +188,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::net::{IpAddr, SocketAddr, UdpSocket};
     use std::str::FromStr;
-    use tokio::prelude::{future::poll_fn, Async};
+    use tokio01::prelude::{future::poll_fn, Async};
     use trust_dns::rr::{record_data::RData, LowerName, Name, RecordSet, RecordType, RrKey};
     use trust_dns_proto::rr::rdata::soa::SOA;
     use trust_dns_server::{

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
-use tokio02::time::{delay_queue, DelayQueue, Error};
+use tokio::time::{delay_queue, DelayQueue, Error};
 
 /// An expired item, holding the value and the key with an expiration
 /// information.
@@ -150,7 +150,6 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # use tokio02 as tokio;
     /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
     /// # rt.block_on(async {
     /// use vector::expiring_hash_map::ExpiringHashMap;
@@ -201,7 +200,6 @@ where
 mod tests {
     use super::*;
     use std::task::Poll;
-    use tokio02 as tokio;
     use tokio_test::{assert_pending, assert_ready, task};
 
     fn unwrap_ready<T>(poll: Poll<T>) -> T {

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 use stream_cancel::{Trigger, Tripwire};
-use tokio::timer;
+use tokio01::timer;
 
 /// When this struct goes out of scope and its internal refcount goes to 0 it is a signal that its
 /// corresponding Source has completed executing and may be cleaned up.  It is the responsibility

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -249,7 +249,7 @@ mod integration_tests {
     use futures01::Sink;
     use serde_json::Value;
     use std::time::Duration;
-    use tokio::util::FutureExt;
+    use tokio01::util::FutureExt;
 
     #[test]
     fn insert_events() {

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -9,7 +9,7 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use futures01::future;
 use serde::{Deserialize, Serialize};
-use tokio02::io::{self, AsyncWriteExt};
+use tokio::io::{self, AsyncWriteExt};
 
 use super::streaming_sink::{self, StreamingSink};
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -260,7 +260,7 @@ impl ElasticSearchCommon {
                 let provider =
                     DefaultCredentialsProvider::new().context(AWSCredentialsProviderFailed)?;
 
-                let mut rt = tokio::runtime::current_thread::Runtime::new()?;
+                let mut rt = tokio01::runtime::current_thread::Runtime::new()?;
 
                 let credentials = rt
                     .block_on(provider.credentials())

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -14,7 +14,7 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
-use tokio02::{
+use tokio::{
     fs::{self, File},
     io::AsyncWriteExt,
 };
@@ -115,7 +115,7 @@ impl FileSink {
     async fn run(&mut self, input: impl Stream<Item = Event> + Send + Sync) -> crate::Result<()> {
         pin_mut!(input);
         loop {
-            tokio02::select! {
+            tokio::select! {
                 event = input.next() => {
                     match event {
                         None => {

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -11,7 +11,7 @@ use smpl_jwt::Jwt;
 use snafu::{ResultExt, Snafu};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio::timer::Interval;
+use tokio01::timer::Interval;
 
 pub mod cloud_storage;
 pub mod pubsub;
@@ -102,7 +102,7 @@ impl GcpCredentials {
                 |error| error!(message = "GCP authentication token regenerate interval failed", %error),
             );
 
-        tokio::spawn(renew_task);
+        tokio01::spawn(renew_task);
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -572,7 +572,7 @@ mod tests {
                 let (parts, body) = req.into_parts();
 
                 let tx = tx.clone();
-                tokio::spawn(
+                tokio01::spawn(
                     body.concat2()
                         .map_err(|e| panic!(e))
                         .and_then(|body| tx.send((parts, body)))

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -212,7 +212,7 @@ impl Sink for KafkaSink {
 fn healthcheck(config: KafkaSinkConfig) -> super::Healthcheck {
     let consumer: BaseConsumer = config.to_rdkafka().unwrap().create().unwrap();
 
-    let check = tokio02::task::block_in_place(|| {
+    let check = tokio::task::block_in_place(|| {
         consumer
             .fetch_metadata(Some(&config.topic), Duration::from_secs(3))
             .map(|_| ())

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -274,7 +274,7 @@ mod tests {
                 let (parts, body) = req.into_parts();
 
                 let tx = tx.clone();
-                tokio::spawn(
+                tokio01::spawn(
                     body.concat2()
                         .map_err(|e| panic!(e))
                         .and_then(|body| tx.send((parts, body)))

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -359,7 +359,7 @@ impl PrometheusSink {
             .with_graceful_shutdown(tripwire.clone())
             .map_err(|e| eprintln!("server error: {}", e));
 
-        tokio::spawn(server);
+        tokio01::spawn(server);
         self.server_shutdown_trigger = Some(trigger);
     }
 }

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -192,7 +192,7 @@ fn encode_event(event: Event, namespace: &str) -> Result<Vec<u8>, ()> {
 
 impl Service<Vec<u8>> for StatsdSvc {
     type Response = ();
-    type Error = tokio::io::Error;
+    type Error = tokio01::io::Error;
     type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -221,7 +221,7 @@ mod test {
     use bytes::Bytes;
     use futures01::{stream, stream::Stream, sync::mpsc, Sink};
     use std::time::{Duration, Instant};
-    use tokio::{
+    use tokio01::{
         self,
         codec::BytesCodec,
         net::{UdpFramed, UdpSocket},
@@ -361,7 +361,7 @@ mod test {
         // Add a delay to the write side to let the read side
         // poll for read interest. Otherwise, this could cause
         // a race condition in noisy environments.
-        let sender = tokio::timer::Delay::new(deadline)
+        let sender = tokio01::timer::Delay::new(deadline)
             .map_err(drop)
             .and_then(|_| sender);
 

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -1,7 +1,7 @@
 use futures01::{try_ready, Async, AsyncSink, Future, Poll, Sink, StartSend};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
-use tokio::timer::Delay;
+use tokio01::timer::Delay;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BatchBytesConfig {

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -9,7 +9,7 @@ use std::{
     hash::Hash,
     time::{Duration, Instant},
 };
-use tokio::timer::Delay;
+use tokio01::timer::Delay;
 
 pub trait Partition<K> {
     fn partition(&self) -> K;

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -20,7 +20,7 @@ use hyper::Client;
 use hyper_openssl::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use std::{fmt, sync::Arc};
-use tokio::executor::DefaultExecutor;
+use tokio01::executor::DefaultExecutor;
 use tower::Service;
 use tracing::Span;
 use tracing_futures::Instrument;

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -4,7 +4,7 @@ use std::{
     cmp,
     time::{Duration, Instant},
 };
-use tokio::timer::Delay;
+use tokio01::timer::Delay;
 use tower::{retry::Policy, timeout::error::Elapsed};
 
 pub enum RetryAction {

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
-use tokio::{
+use tokio01::{
     codec::{BytesCodec, FramedWrite},
     net::tcp::TcpStream,
     timer::Delay,

--- a/src/sinks/util/test.rs
+++ b/src/sinks/util/test.rs
@@ -31,7 +31,7 @@ pub fn build_test_server(
             let (parts, body) = req.into_parts();
 
             let tx = tx.clone();
-            tokio::spawn(
+            tokio01::spawn(
                 body.concat2()
                     .map_err(|e| panic!(e))
                     .and_then(|body| tx.send((parts, body)))

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -13,8 +13,8 @@ use snafu::Snafu;
 use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
-use tokio::codec::{BytesCodec, FramedWrite};
-use tokio::timer::Delay;
+use tokio01::codec::{BytesCodec, FramedWrite};
+use tokio01::timer::Delay;
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_uds::UnixStream;
 use tracing::field;
@@ -197,7 +197,7 @@ mod tests {
     use crate::test_util::{random_lines_with_stream, shutdown_on_idle};
     use futures01::{sync::mpsc, Sink, Stream};
     use stream_cancel::{StreamExt, Tripwire};
-    use tokio::codec::{FramedRead, LinesCodec};
+    use tokio01::codec::{FramedRead, LinesCodec};
     use tokio_uds::UnixListener;
 
     fn temp_uds_path(name: &str) -> PathBuf {

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -525,7 +525,7 @@ impl EventStreamBuilder {
             this.start_event_stream(ContainerLogInfo::new(id, metadata, this.core.now_timestamp))
         });
 
-        tokio::spawn(task);
+        tokio01::spawn(task);
 
         ContainerState::new()
     }
@@ -533,7 +533,7 @@ impl EventStreamBuilder {
     /// If info is present, restarts event stream
     fn restart(&self, container: &mut ContainerState) {
         if let Some(info) = container.take_info() {
-            tokio::spawn(self.start_event_stream(info));
+            tokio01::spawn(self.start_event_stream(info));
         }
     }
 
@@ -563,7 +563,7 @@ impl EventStreamBuilder {
         let partial_event_marker_field = self.core.config.partial_event_marker_field.clone();
         let auto_partial_merge = self.core.config.auto_partial_merge;
         let mut partial_event_merge_state = None;
-        tokio::prelude::stream::poll_fn(move || {
+        tokio01::prelude::stream::poll_fn(move || {
             // !Hot code: from here
             if let Some(&mut (_, ref mut info)) = state.as_mut() {
                 // Main event loop
@@ -609,7 +609,7 @@ impl EventStreamBuilder {
                     id = field::display(info.id.as_str())
                 );
                 // TODO: I am not sure that it's necessary to drive this future to completition
-                tokio::spawn(
+                tokio01::spawn(
                     main.send(info)
                         .map_err(|e| error!(message="Unable to return ContainerLogInfo to main",%e))
                         .map(|_| ()),

--- a/src/sources/file/line_agg.rs
+++ b/src/sources/file/line_agg.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use std::hash::Hash;
 use std::time::Duration;
-use tokio::timer::DelayQueue;
+use tokio01::timer::DelayQueue;
 
 #[derive(Debug, Hash, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -279,7 +279,7 @@ pub fn file_source(
 
         let span = current_span();
         let span2 = span.clone();
-        tokio::spawn(
+        tokio01::spawn(
             messages
                 .map(move |(msg, file): (Bytes, String)| {
                     let _enter = span2.enter();
@@ -348,7 +348,7 @@ mod tests {
     };
     use stream_cancel::Tripwire;
     use tempfile::tempdir;
-    use tokio::util::FutureExt;
+    use tokio01::util::FutureExt;
 
     fn test_default_file_config(dir: &tempfile::TempDir) -> file::FileConfig {
         file::FileConfig {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -446,7 +446,7 @@ mod tests {
     use std::time::Duration;
     use stream_cancel::Tripwire;
     use tempfile::tempdir;
-    use tokio::util::FutureExt;
+    use tokio01::util::FutureExt;
 
     const FAKE_JOURNAL: &str = r#"{"_SYSTEMD_UNIT":"sysinit.target","MESSAGE":"System Initialization","__CURSOR":"1","_SOURCE_REALTIME_TIMESTAMP":"1578529839140001"}
 {"_SYSTEMD_UNIT":"unit.service","MESSAGE":"unit message","__CURSOR":"2","_SOURCE_REALTIME_TIMESTAMP":"1578529839140002"}

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -6,7 +6,7 @@ use hyper_openssl::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::time::{Duration, Instant};
-use tokio::timer::Interval;
+use tokio01::timer::Interval;
 
 pub mod parser;
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -144,7 +144,7 @@ mod test {
     use std::sync::Arc;
     use std::{net::SocketAddr, thread, time::Duration, time::Instant};
     #[cfg(unix)]
-    use tokio::codec::{FramedWrite, LinesCodec};
+    use tokio01::codec::{FramedWrite, LinesCodec};
     #[cfg(unix)]
     use tokio_uds::UnixStream;
 
@@ -608,7 +608,7 @@ mod test {
                     .map(|(_source, sink)| sink)
                     .and_then(|sink| {
                         let socket = sink.into_inner().into_inner();
-                        tokio::io::shutdown(socket)
+                        tokio01::io::shutdown(socket)
                             .map(|_| ())
                             .map_err(|e| panic!("{:}", e))
                     })

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -8,7 +8,7 @@ use futures01::{future, sync::mpsc, Future, Sink, Stream};
 use serde::{Deserialize, Serialize};
 use std::{io, net::SocketAddr};
 use string_cache::DefaultAtom as Atom;
-use tokio::net::udp::{UdpFramed, UdpSocket};
+use tokio01::net::udp::{UdpFramed, UdpSocket};
 
 /// UDP processes messages per packet, where messages are separated by newline.
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -3,7 +3,7 @@ use futures01::{future, sync::mpsc, Future, Sink, Stream};
 use parser::parse;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use tokio::{
+use tokio01::{
     self,
     codec::BytesCodec,
     net::{UdpFramed, UdpSocket},

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -120,7 +120,7 @@ mod tests {
     use futures01::sync::mpsc;
     use futures01::Async::*;
     use std::io::Cursor;
-    use tokio::runtime::current_thread::Runtime;
+    use tokio01::runtime::current_thread::Runtime;
 
     #[test]
     fn stdin_create_event() {

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 #[cfg(unix)]
 use std::path::PathBuf;
 use syslog_loose::{self, IncompleteDate, Message, ProcId, Protocol};
-use tokio::{
+use tokio01::{
     self,
     codec::{BytesCodec, LinesCodec},
     net::{UdpFramed, UdpSocket},

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -13,7 +13,7 @@ use std::{
     time::{Duration, Instant},
 };
 use stream_cancel::Tripwire;
-use tokio::{
+use tokio01::{
     codec::{Decoder, FramedRead},
     net::{TcpListener, TcpStream},
     prelude::AsyncRead,
@@ -31,7 +31,7 @@ pub trait TcpSource: Clone + Send + 'static {
 
     fn build_event(
         &self,
-        frame: <Self::Decoder as tokio::codec::Decoder>::Item,
+        frame: <Self::Decoder as tokio01::codec::Decoder>::Item,
         host: Option<Bytes>,
     ) -> Option<Event>;
 
@@ -162,7 +162,7 @@ fn accept_socket(
                     .map_err(|error| warn!(message = "TLS connection accept error.", %error))
                     .map(|socket| handle_stream(inner_span, socket, source, tripwire, host, out));
 
-                tokio::spawn(handler.instrument(span.clone()));
+                tokio01::spawn(handler.instrument(span.clone()));
             }
         },
         _ => handle_stream(span, socket, source, tripwire, host, out),
@@ -187,7 +187,7 @@ fn handle_stream(
         .forward(out)
         .map(|_| debug!("connection closed."))
         .map_err(|_| warn!("Error received while processing TCP source"));
-    tokio::spawn(handler.instrument(span));
+    tokio01::spawn(handler.instrument(span));
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -3,7 +3,7 @@ use crate::sources::Source;
 use bytes::Bytes;
 use futures01::{future, sync::mpsc, Future, Sink, Stream};
 use std::path::PathBuf;
-use tokio::{
+use tokio01::{
     self,
     codec::{FramedRead, LinesCodec},
 };
@@ -62,7 +62,7 @@ pub fn build_unix_source(
                     .map_err(|e| error!("error reading line: {:?}", e));
 
                 let handler = lines_in.forward(out).map(|_| info!("finished sending"));
-                tokio::spawn(handler.instrument(span))
+                tokio01::spawn(handler.instrument(span))
             })
     }))
 }

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -10,7 +10,7 @@ use bytes::{Bytes, BytesMut};
 use futures01::sync::mpsc;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use tokio::codec::LengthDelimitedCodec;
+use tokio01::codec::LengthDelimitedCodec;
 use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -49,12 +49,12 @@ pub trait StreamExt: Stream {
     /// extern crate futures;
     ///
     /// use stream_cancel::StreamExt;
-    /// use tokio::prelude::*;
+    /// use tokio01::prelude::*;
     ///
-    /// let listener = tokio::net::TcpListener::bind(&"0.0.0.0:0".parse().unwrap()).unwrap();
+    /// let listener = tokio01::net::TcpListener::bind(&"0.0.0.0:0".parse().unwrap()).unwrap();
     /// let (tx, rx) = futures01::sync::oneshot::channel();
     ///
-    /// let mut rt = tokio::runtime::Runtime::new().unwrap();
+    /// let mut rt = tokio01::runtime::Runtime::new().unwrap();
     /// rt.spawn(
     ///     listener
     ///         .incoming()
@@ -62,8 +62,8 @@ pub trait StreamExt: Stream {
     ///         .map_err(|e| eprintln!("accept failed = {:?}", e))
     ///         .for_each(|sock| {
     ///             let (reader, writer) = sock.split();
-    ///             tokio::spawn(
-    ///                 tokio::io::copy(reader, writer)
+    ///             tokio01::spawn(
+    ///                 tokio01::io::copy(reader, writer)
     ///                     .map(|amt| println!("wrote {:?} bytes", amt))
     ///                     .map_err(|err| eprintln!("IO error {:?}", err)),
     ///             )

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -15,9 +15,9 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use stream_cancel::{StreamExt, Trigger, Tripwire};
-use tokio::codec::{FramedRead, FramedWrite, LinesCodec};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::util::FutureExt;
+use tokio01::codec::{FramedRead, FramedWrite, LinesCodec};
+use tokio01::net::{TcpListener, TcpStream};
+use tokio01::util::FutureExt;
 use tokio_openssl::SslConnectorExt;
 
 #[macro_export]
@@ -109,7 +109,7 @@ pub fn send_lines_tls(
                             // and tests will be checking that contents
                             // are received anyways.
                             stream.get_mut().shutdown().ok();
-                            //tokio::io::shutdown(stream).map_err(|e| panic!("{:}", e))
+                            //tokio01::io::shutdown(stream).map_err(|e| panic!("{:}", e))
                             Ok(())
                         })
                         .map(|_| ())

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -7,7 +7,7 @@ use openssl::ssl::{SslAcceptor, SslMethod};
 use snafu::ResultExt;
 use std::fmt::{self, Debug, Formatter};
 use std::net::SocketAddr;
-use tokio::net::{tcp::Incoming, TcpListener, TcpStream};
+use tokio01::net::{tcp::Incoming, TcpListener, TcpStream};
 use tokio_openssl::{AcceptAsync, SslAcceptorExt};
 
 pub(crate) struct MaybeTlsIncoming<I: Stream> {

--- a/src/tls/maybe_tls.rs
+++ b/src/tls/maybe_tls.rs
@@ -1,7 +1,7 @@
 use futures01::Poll;
 use std::fmt::{self, Debug, Formatter};
 use std::io::{self, Read, Write};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio01::io::{AsyncRead, AsyncWrite};
 
 /// A type wrapper for objects that can exist in either a raw state or
 /// wrapped by TLS handling.

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use std::io::Error as IoError;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use tokio::net::TcpStream;
+use tokio01::net::TcpStream;
 use tokio_openssl::SslStream;
 
 #[cfg(feature = "sources-tls")]

--- a/src/tls/outgoing.rs
+++ b/src/tls/outgoing.rs
@@ -2,7 +2,7 @@ use super::{tls_connector, MaybeTlsSettings, MaybeTlsStream, Result, TlsError};
 use futures01::{Async, Future};
 use openssl::ssl::ConnectConfiguration;
 use std::net::SocketAddr;
-use tokio::net::tcp::{ConnectFuture, TcpStream};
+use tokio01::net::tcp::{ConnectFuture, TcpStream};
 use tokio_openssl::{ConnectAsync, ConnectConfigurationExt};
 
 enum State {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -10,7 +10,7 @@ use futures01::{
     Future, Stream,
 };
 use std::{collections::HashMap, time::Duration};
-use tokio::util::FutureExt;
+use tokio01::util::FutureExt;
 
 pub struct Pieces {
     pub inputs: HashMap<String, (buffers::BufferInputCloner, Vec<String>)>,

--- a/src/topology/config/watcher.rs
+++ b/src/topology/config/watcher.rs
@@ -116,7 +116,7 @@ mod tests {
     use futures01::{Future, Stream};
     use std::time::{Duration, Instant};
     use std::{fs::File, io::Write};
-    use tokio::timer::Delay;
+    use tokio01::timer::Delay;
     #[cfg(unix)]
     use tokio_signal::unix::{Signal, SIGHUP};
 

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -45,7 +45,7 @@ impl Fanout {
 
         let (_name, mut removed) = self.sinks.remove(i);
 
-        tokio::spawn(future::poll_fn(move || removed.close()));
+        tokio01::spawn(future::poll_fn(move || removed.close()));
 
         if self.i > i {
             self.i -= 1;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -21,7 +21,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
-use tokio::timer;
+use tokio01::timer;
 use tracing_futures::Instrument;
 
 #[allow(dead_code)]

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::RandomState, HashSet};
 use std::time::{Duration, Instant};
 use string_cache::DefaultAtom as Atom;
-use tokio::timer::Delay;
+use tokio01::timer::Delay;
 use tracing_futures::Instrument;
 
 type WriteHandle = evmap::WriteHandle<Atom, Bytes, (), RandomState>;

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -9,7 +9,7 @@ use sinks::socket::SocketSinkConfig;
 use sinks::util::{encoding::EncodingConfig, Encoding};
 use std::{collections::HashMap, thread, time::Duration};
 #[cfg(unix)]
-use tokio::codec::{FramedWrite, LinesCodec};
+use tokio01::codec::{FramedWrite, LinesCodec};
 #[cfg(unix)]
 use tokio_uds::UnixStream;
 use vector::test_util::{
@@ -170,7 +170,7 @@ fn test_unix_stream_syslog() {
                 .map(|(_source, sink)| sink)
                 .and_then(|sink| {
                     let socket = sink.into_inner().into_inner();
-                    tokio::io::shutdown(socket)
+                    tokio01::io::shutdown(socket)
                         .map(|_| ())
                         .map_err(|e| panic!("{:}", e))
                 })

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -3,8 +3,8 @@
 use approx::assert_relative_eq;
 use futures01::{Future, Stream};
 use stream_cancel::{StreamExt, Tripwire};
-use tokio::codec::{FramedRead, LinesCodec};
-use tokio::net::TcpListener;
+use tokio01::codec::{FramedRead, LinesCodec};
+use tokio01::net::TcpListener;
 use vector::test_util::{
     block_on, next_addr, random_lines, receive, runtime, send_lines, shutdown_on_idle, wait_for_tcp,
 };


### PR DESCRIPTION
Rename `tokio` to `tokio01` and `tokio02` to `tokio`.