### PR TITLE
chore: Relax PR check list to only fire on important changes

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -6,9 +6,3 @@ paths:
     - "Has at least one other team member approved the dependency changes?"
   "rfcs/**":
     - "Have at least 3 team members approved this RFC?"
-  "src/**":
-    - "For each failure path, is there sufficient context logged for users to investigate the issue?"
-    - "Do the tests ensure that behavior is sane for inputs that don't meet normal assumptions (e.g. missing field, non-string, etc)?"
-    - "Did you add adequate documentation?"
-  "src/transforms/**":
-    - "Did you add behavior tests (`tests/behavior`) that represent the behavior of this change? For example, testing for Vector's field path notation for nested fields."


### PR DESCRIPTION
The PR checklist both is pretty noisy which defeats the purpose. This reduces the checks to only important checks that do not happen regularly.