### PR TITLE
chore(dependencies): Update `bumpalo` dependency in `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.1.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "byte-tools"


### PR DESCRIPTION
This PR updates `bumpalo` dependency in `Cargo.lock`. It was prepared by removing the dependency from `Cargo.lock` and running `cargo check`.

Fixes the error generated by `cargo-deny`.