### PR TITLE
chore: add_fields, remove_fields, or rename_fields debug log on replaced or non-existing fields

### DIFF
--- a/src/event/merge.rs
+++ b/src/event/merge.rs
@@ -9,7 +9,9 @@ pub fn merge_log_event(current: &mut LogEvent, mut incoming: LogEvent, merge_fie
             Some(val) => val,
         };
         match current.get_mut(merge_field) {
-            None => current.insert(merge_field, incoming_val),
+            None => {
+                current.insert(merge_field, incoming_val);
+            }
             Some(current_val) => merge_value(current_val, incoming_val),
         }
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -119,7 +119,7 @@ impl LogEvent {
         self.fields.contains_key(key)
     }
 
-    pub fn insert<K, V>(&mut self, key: K, value: V)
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<Value>
     where
         K: AsRef<str>,
         V: Into<Value>,

--- a/src/event/util/log/insert.rs
+++ b/src/event/util/log/insert.rs
@@ -34,7 +34,7 @@ where
                 fields.insert(current, Value::Array(array))
             }
         }
-        _ => return None,
+        _ => None,
     }
 }
 
@@ -51,9 +51,7 @@ where
             while values.len() <= current {
                 values.push(Value::Null);
             }
-            let mut swapper = value;
-            std::mem::swap(&mut values[current], &mut swapper);
-            Some(swapper)
+            Some(std::mem::replace(&mut values[current], value))
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Key(_))) => {
             if let Some(Value::Map(map)) = values.get_mut(current) {
@@ -64,9 +62,7 @@ where
                 while values.len() <= current {
                     values.push(Value::Null);
                 }
-                let mut swapper = Value::Map(map);
-                std::mem::swap(&mut values[current], &mut swapper);
-                Some(swapper)
+                Some(std::mem::replace(&mut values[current], Value::Map(map)))
             }
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Index(next))) => {
@@ -78,12 +74,10 @@ where
                 while values.len() <= current {
                     values.push(Value::Null);
                 }
-                let mut swapper = Value::Array(array);
-                std::mem::swap(&mut values[current], &mut swapper);
-                Some(swapper)
+                Some(std::mem::replace(&mut values[current], Value::Array(array)))
             }
         }
-        _ => return None,
+        _ => None,
     }
 }
 

--- a/src/event/util/log/insert.rs
+++ b/src/event/util/log/insert.rs
@@ -2,41 +2,47 @@ use super::{Atom, PathComponent, PathIter, Value};
 use std::{collections::BTreeMap, iter::Peekable};
 
 /// Inserts field value using a path specified using `a.b[1].c` notation.
-pub fn insert(fields: &mut BTreeMap<Atom, Value>, path: &str, value: Value) {
-    map_insert(fields, PathIter::new(path).peekable(), value);
+pub fn insert(fields: &mut BTreeMap<Atom, Value>, path: &str, value: Value) -> Option<Value> {
+    map_insert(fields, PathIter::new(path).peekable(), value)
 }
 
-fn map_insert<I>(fields: &mut BTreeMap<Atom, Value>, mut path_iter: Peekable<I>, value: Value)
+fn map_insert<I>(
+    fields: &mut BTreeMap<Atom, Value>,
+    mut path_iter: Peekable<I>,
+    value: Value,
+) -> Option<Value>
 where
     I: Iterator<Item = PathComponent>,
 {
     match (path_iter.next(), path_iter.peek()) {
-        (Some(PathComponent::Key(current)), None) => {
-            fields.insert(current, value);
-        }
+        (Some(PathComponent::Key(current)), None) => fields.insert(current, value),
         (Some(PathComponent::Key(current)), Some(PathComponent::Key(_))) => {
             if let Some(Value::Map(map)) = fields.get_mut(&current) {
-                map_insert(map, path_iter, value);
+                map_insert(map, path_iter, value)
             } else {
                 let mut map = BTreeMap::new();
                 map_insert(&mut map, path_iter, value);
-                fields.insert(current, Value::Map(map));
+                fields.insert(current, Value::Map(map))
             }
         }
         (Some(PathComponent::Key(current)), Some(&PathComponent::Index(next))) => {
             if let Some(Value::Array(array)) = fields.get_mut(&current) {
-                array_insert(array, path_iter, value);
+                array_insert(array, path_iter, value)
             } else {
                 let mut array = Vec::with_capacity(next + 1);
                 array_insert(&mut array, path_iter, value);
-                fields.insert(current, Value::Array(array));
+                fields.insert(current, Value::Array(array))
             }
         }
-        _ => return,
+        _ => return None,
     }
 }
 
-fn array_insert<I>(values: &mut Vec<Value>, mut path_iter: Peekable<I>, value: Value)
+fn array_insert<I>(
+    values: &mut Vec<Value>,
+    mut path_iter: Peekable<I>,
+    value: Value,
+) -> Option<Value>
 where
     I: Iterator<Item = PathComponent>,
 {
@@ -45,33 +51,39 @@ where
             while values.len() <= current {
                 values.push(Value::Null);
             }
-            values[current] = value;
+            let mut swapper = value;
+            std::mem::swap(&mut values[current], &mut swapper);
+            Some(swapper)
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Key(_))) => {
             if let Some(Value::Map(map)) = values.get_mut(current) {
-                map_insert(map, path_iter, value);
+                map_insert(map, path_iter, value)
             } else {
                 let mut map = BTreeMap::new();
                 map_insert(&mut map, path_iter, value);
                 while values.len() <= current {
                     values.push(Value::Null);
                 }
-                values[current] = Value::Map(map);
+                let mut swapper = Value::Map(map);
+                std::mem::swap(&mut values[current], &mut swapper);
+                Some(swapper)
             }
         }
         (Some(PathComponent::Index(current)), Some(PathComponent::Index(next))) => {
             if let Some(Value::Array(array)) = values.get_mut(current) {
-                array_insert(array, path_iter, value);
+                array_insert(array, path_iter, value)
             } else {
                 let mut array = Vec::with_capacity(next + 1);
                 array_insert(&mut array, path_iter, value);
                 while values.len() <= current {
                     values.push(Value::Null);
                 }
-                values[current] = Value::Array(array);
+                let mut swapper = Value::Array(array);
+                std::mem::swap(&mut values[current], &mut swapper);
+                Some(swapper)
             }
         }
-        _ => return,
+        _ => return None,
     }
 }
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -130,7 +130,9 @@ fn kafka_source(
                                 Some(Err(e)) => {
                                     return Err(error!(message = "Cannot extract key", error = ?e))
                                 }
-                                Some(Ok(key)) => event.as_mut_log().insert(key_field.clone(), key),
+                                Some(Ok(key)) => {
+                                    event.as_mut_log().insert(key_field.clone(), key);
+                                }
                             }
                         }
                         consumer_ref.store_offset(&msg).map_err(

--- a/src/sources/kubernetes/message_parser.rs
+++ b/src/sources/kubernetes/message_parser.rs
@@ -57,10 +57,12 @@ impl Transform for DockerMessageTransformer {
             match DateTime::parse_from_rfc3339(
                 String::from_utf8_lossy(timestamp_bytes.as_ref()).as_ref(),
             ) {
-                Ok(timestamp) => log.insert(
-                    event::log_schema().timestamp_key(),
-                    timestamp.with_timezone(&Utc),
-                ),
+                Ok(timestamp) => {
+                    log.insert(
+                        event::log_schema().timestamp_key(),
+                        timestamp.with_timezone(&Utc),
+                    );
+                }
                 Err(error) => {
                     debug!(message = "Non rfc3339 timestamp.", %error, rate_limit_secs = 10);
                     return None;

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -387,7 +387,7 @@ impl<R: Read> Stream for EventStream<R> {
                     if string.is_empty() {
                         return Err(ApiError::EmptyEventField { event: self.events }.into());
                     }
-                    log.insert(event::log_schema().message_key().clone(), string)
+                    log.insert(event::log_schema().message_key().clone(), string);
                 }
                 JsonValue::Object(mut object) => {
                     if object.is_empty() {
@@ -398,8 +398,12 @@ impl<R: Read> Stream for EventStream<R> {
                     if let Some(line) = object.remove("line") {
                         match line {
                             // This don't quite fit the meaning of a event::schema().message_key
-                            JsonValue::Array(_) | JsonValue::Object(_) => log.insert("line", line),
-                            _ => log.insert(event::log_schema().message_key(), line),
+                            JsonValue::Array(_) | JsonValue::Object(_) => {
+                                log.insert("line", line);
+                            }
+                            _ => {
+                                log.insert(event::log_schema().message_key(), line);
+                            }
                         }
                     }
 
@@ -453,7 +457,7 @@ impl<R: Read> Stream for EventStream<R> {
         match self.time.clone() {
             Time::Provided(time) => log.insert(event::log_schema().timestamp_key().clone(), time),
             Time::Now(time) => log.insert(event::log_schema().timestamp_key().clone(), time),
-        }
+        };
 
         // Extract default extracted fields
         for de in self.extractors.iter_mut() {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -156,7 +156,7 @@ pub fn random_nested_events_with_stream(
 
         let tree = random_pseudonested_map(len, breadth, depth);
         for (k, v) in tree.into_iter() {
-            log.insert(k, v)
+            log.insert(k, v);
         }
 
         Event::Log(log)

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -97,8 +97,7 @@ impl Transform for AddFields {
                 .into(),
                 TemplateOrValue::Value(v) => v,
             };
-            let old_val = event.as_mut_log().insert(&key, value);
-            if old_val.is_some() {
+            if let Some(_) = event.as_mut_log().insert(&key, value) {
                 debug!(
                     message = "Field overwritten",
                     field = key.as_ref(),

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -97,7 +97,14 @@ impl Transform for AddFields {
                 .into(),
                 TemplateOrValue::Value(v) => v,
             };
-            event.as_mut_log().insert(key, value);
+            let old_val = event.as_mut_log().insert(&key, value);
+            if old_val.is_some() {
+                debug!(
+                    message = "Field overwritten",
+                    field = key.as_ref(),
+                    rate_limit_secs = 30,
+                )
+            }
         }
 
         Some(event)

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -60,7 +60,9 @@ impl Transform for Coercer {
             for (field, conv) in &self.types {
                 if let Some(value) = log.remove(field) {
                     match conv.convert(value) {
-                        Ok(converted) => new_log.insert(field, converted),
+                        Ok(converted) => {
+                            new_log.insert(field, converted);
+                        }
                         Err(error) => {
                             warn!(
                                 message = "Could not convert types.",
@@ -77,7 +79,9 @@ impl Transform for Coercer {
             for (field, conv) in &self.types {
                 if let Some(value) = log.remove(field) {
                     match conv.convert(value) {
-                        Ok(converted) => log.insert(field, converted),
+                        Ok(converted) => {
+                            log.insert(field, converted);
+                        }
                         Err(error) => {
                             warn!(
                                 message = "Could not convert types.",

--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -159,7 +159,9 @@ impl Transform for Geoip {
             let e = event.as_mut_log();
             let d = e.get(&Atom::from(field.to_string()));
             match d {
-                None => e.insert(Atom::from(field.to_string()), Value::from("")),
+                None => {
+                    e.insert(Atom::from(field.to_string()), Value::from(""));
+                }
                 _ => (),
             }
         }

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -89,7 +89,9 @@ impl Transform for GrokParser {
                     let name: Atom = name.into();
                     let conv = self.types.get(&name).unwrap_or(&Conversion::Bytes);
                     match conv.convert(value.into()) {
-                        Ok(value) => event.insert(name, value),
+                        Ok(value) => {
+                            event.insert(name, value);
+                        }
                         Err(error) => {
                             debug!(
                                 message = "Could not convert types.",

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -74,7 +74,9 @@ impl Transform for Logfmt {
 
                 if let Some(conv) = self.conversions.get(&key) {
                     match conv.convert(val.as_bytes().into()) {
-                        Ok(value) => event.as_mut_log().insert(key, value),
+                        Ok(value) => {
+                            event.as_mut_log().insert(key, value);
+                        }
                         Err(error) => {
                             debug!(
                                 message = "Could not convert types.",

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -143,7 +143,9 @@ impl Transform for RegexParser {
                     if let Some((start, end)) = self.capture_locs.get(*idx) {
                         let capture: Value = value[start..end].into();
                         match conversion.convert(capture) {
-                            Ok(value) => event.as_mut_log().insert(name.clone(), value),
+                            Ok(value) => {
+                                event.as_mut_log().insert(name.clone(), value);
+                            }
                             Err(error) => {
                                 debug!(
                                     message = "Could not convert types.",

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -54,7 +54,14 @@ impl Transform for RemoveFields {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
         let log = event.as_mut_log();
         for field in &self.fields {
-            log.remove_prune(field, self.drop_empty);
+            let old_val = log.remove_prune(field, self.drop_empty);
+            if old_val.is_none() {
+                debug!(
+                    message = "Field did not exist",
+                    field = field.as_ref(),
+                    rate_limit_secs = 30,
+                )
+            }
         }
 
         Some(event)

--- a/src/transforms/rename_fields.rs
+++ b/src/transforms/rename_fields.rs
@@ -60,8 +60,24 @@ impl Transform for RenameFields {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
         for (old_key, new_key) in &self.fields {
             let log = event.as_mut_log();
-            if let Some(v) = log.remove_prune(&old_key, self.drop_empty) {
-                log.insert(new_key.clone(), v)
+            match log.remove_prune(&old_key, self.drop_empty) {
+                Some(v) => {
+                    let old_val = log.insert(new_key.clone(), v);
+                    if old_val.is_some() {
+                        debug!(
+                            message = "Field overwritten",
+                            field = old_key.as_ref(),
+                            rate_limit_secs = 30,
+                        )
+                    }
+                }
+                None => {
+                    debug!(
+                        message = "Field did not exist",
+                        field = old_key.as_ref(),
+                        rate_limit_secs = 30,
+                    );
+                }
             }
         }
 

--- a/src/transforms/rename_fields.rs
+++ b/src/transforms/rename_fields.rs
@@ -62,8 +62,7 @@ impl Transform for RenameFields {
             let log = event.as_mut_log();
             match log.remove_prune(&old_key, self.drop_empty) {
                 Some(v) => {
-                    let old_val = log.insert(new_key.clone(), v);
-                    if old_val.is_some() {
+                    if let Some(_) = event.as_mut_log().insert(&new_key.clone(), v) {
                         debug!(
                             message = "Field overwritten",
                             field = old_key.as_ref(),

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -102,7 +102,9 @@ impl Transform for Split {
                 .zip(split(value, self.separator.clone()).into_iter())
             {
                 match conversion.convert(value.as_bytes().into()) {
-                    Ok(value) => event.as_mut_log().insert(name.clone(), value),
+                    Ok(value) => {
+                        event.as_mut_log().insert(name.clone(), value);
+                    }
                     Err(error) => {
                         debug!(
                             message = "Could not convert types.",

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -101,7 +101,9 @@ impl Transform for Tokenizer {
             for ((name, conversion), value) in self.field_names.iter().zip(parse(value).into_iter())
             {
                 match conversion.convert(value.as_bytes().into()) {
-                    Ok(value) => event.as_mut_log().insert(name.clone(), value),
+                    Ok(value) => {
+                        event.as_mut_log().insert(name.clone(), value);
+                    }
                     Err(error) => {
                         debug!(
                             message = "Could not convert types.",


### PR DESCRIPTION
Closes #2045, Closes #2046, Closes #2044 

Output a rate limited log on replaced or non-existing fields operated on by `add_fields`, `remove_fields`, or `rename_fields`

![image](https://user-images.githubusercontent.com/130903/77566290-a9b16300-6e82-11ea-81ca-1f43e175a810.png)
