### PR TITLE
chore: Simplify domains for labels, etc

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,6 +1,3 @@
-- name: "domain: blog"
-  description: Anything blog related
-  color: 212f3e
 - name: "domain: buffers"
   description: Anything buffers related
   color: 212f3e
@@ -13,15 +10,6 @@
 - name: "domain: dependencies"
   description: Anything dependencies related
   color: 212f3e
-- name: "domain: docs"
-  description: Anything docs related
-  color: 212f3e
-- name: "domain: guides"
-  description: Anything guides related
-  color: 212f3e
-- name: "domain: marketing"
-  description: Anything marketing related
-  color: 212f3e
 - name: "domain: networking"
   description: Anything networking related
   color: 212f3e
@@ -31,14 +19,8 @@
 - name: "domain: operations"
   description: Anything operations related
   color: 212f3e
-- name: "domain: platforms"
-  description: Anything platforms related
-  color: 212f3e
 - name: "domain: security"
   description: Anything security related
-  color: 212f3e
-- name: "domain: setup"
-  description: Anything setup related
   color: 212f3e
 - name: "domain: sinks"
   description: Anything sinks related
@@ -46,17 +28,17 @@
 - name: "domain: sources"
   description: Anything sources related
   color: 212f3e
-- name: "domain: templating"
-  description: Anything templating related
-  color: 212f3e
-- name: "domain: testing"
-  description: Anything testing related
+- name: "domain: tests"
+  description: Anything tests related
   color: 212f3e
 - name: "domain: topology"
   description: Anything topology related
   color: 212f3e
 - name: "domain: transforms"
   description: Anything transforms related
+  color: 212f3e
+- name: "domain: ux"
+  description: Anything ux related
   color: 212f3e
 - name: "domain: website"
   description: Anything website related
@@ -67,6 +49,9 @@
   color: 1cd1a1
 - name: "event type: metric"
   description: Anything metric event related
+  color: 1cd1a1
+- name: "event type: trace"
+  description: Anything trace event related
   color: 1cd1a1
 - name: "meta: announcement"
   description: Any issues that serve as announcements (pinned issues)

--- a/.github/labels.yml.erb
+++ b/.github/labels.yml.erb
@@ -10,6 +10,9 @@
 - name: "event type: metric"
   description: Anything metric event related
   color: 1cd1a1
+- name: "event type: trace"
+  description: Anything trace event related
+  color: 1cd1a1
 - name: "meta: announcement"
   description: Any issues that serve as announcements (pinned issues)
   color: c8d6e5

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -17,26 +17,20 @@ scopes:
   - new sink
 
   # domains
-  - blog
   - buffers
   - cli
   - config
   - dependencies
-  - docs
-  - guides
-  - marketing
   - networking
   - observability
   - operations
-  - platforms
   - security
-  - setup
   - sinks
   - sources
-  - templating
-  - testing
+  - tests
   - topology
   - transforms
+  - ux
   - website
 
   # platforms

--- a/.meta/domains.toml
+++ b/.meta/domains.toml
@@ -1,7 +1,4 @@
 [[domains]]
-name = "blog"
-
-[[domains]]
 name = "buffers"
 
 [[domains]]
@@ -14,15 +11,6 @@ name = "config"
 name = "dependencies"
 
 [[domains]]
-name = "docs"
-
-[[domains]]
-name = "guides"
-
-[[domains]]
-name = "marketing"
-
-[[domains]]
 name = "networking"
 
 [[domains]]
@@ -32,13 +20,7 @@ name = "observability"
 name = "operations"
 
 [[domains]]
-name = "platforms"
-
-[[domains]]
 name = "security"
-
-[[domains]]
-name = "setup"
 
 [[domains]]
 name = "sinks"
@@ -47,16 +29,16 @@ name = "sinks"
 name = "sources"
 
 [[domains]]
-name = "templating"
-
-[[domains]]
-name = "testing"
+name = "tests"
 
 [[domains]]
 name = "topology"
 
 [[domains]]
 name = "transforms"
+
+[[domains]]
+name = "ux"
 
 [[domains]]
 name = "website"


### PR DESCRIPTION
This change simplifies our "domains" that are used for labels, blog posts, and now guides. I want a single set of domains that we expose to users, and they should generally be broad. Changes are:

1. blog -> website
2. docs -> website
3. guides -> website
4. marketing -> website
5. platforms -> operations
6. setup -> ux
7. templating -> config
8. testing -> tests (for naming consistency)
9. +ux