### PR TITLE
chore: Add LogEvent::new

### DIFF
--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -157,12 +157,8 @@ fn hash_null<H: Hasher>(hasher: &mut H) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::Event;
+    use crate::event::LogEvent;
     use std::collections::{hash_map::DefaultHasher, HashMap};
-
-    fn new_log_event() -> LogEvent {
-        Event::new_empty_log().into_log()
-    }
 
     fn hash<H: Hash>(hash: H) -> u64 {
         let mut hasher = DefaultHasher::new();
@@ -172,7 +168,7 @@ mod tests {
 
     #[test]
     fn equal() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("hostname", "localhost");
         event_1.insert("irrelevant", "not even used");
         let mut event_2 = event_1.clone();
@@ -189,7 +185,7 @@ mod tests {
 
     #[test]
     fn not_equal() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("hostname", "localhost");
         event_1.insert("container_id", "abc");
         let mut event_2 = event_1.clone();
@@ -206,10 +202,10 @@ mod tests {
 
     #[test]
     fn field_order() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("a", "a");
         event_1.insert("b", "b");
-        let mut event_2 = new_log_event();
+        let mut event_2 = LogEvent::new();
         event_2.insert("b", "b");
         event_2.insert("a", "a");
 
@@ -224,10 +220,10 @@ mod tests {
 
     #[test]
     fn map_values_key_order() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("nested.a", "a");
         event_1.insert("nested.b", "b");
-        let mut event_2 = new_log_event();
+        let mut event_2 = LogEvent::new();
         event_2.insert("nested.b", "b");
         event_2.insert("nested.a", "a");
 
@@ -242,10 +238,10 @@ mod tests {
 
     #[test]
     fn map_values_array() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("array[0]", "a");
         event_1.insert("array[1]", "b");
-        let mut event_2 = new_log_event();
+        let mut event_2 = LogEvent::new();
         event_2.insert("array[1]", "b");
         event_2.insert("array[0]", "a");
 
@@ -260,9 +256,9 @@ mod tests {
 
     #[test]
     fn map_values_matter_1() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
-        let event_2 = new_log_event(); // empty event
+        let event_2 = LogEvent::new(); // empty event
 
         let discriminant_fields = vec![Atom::from("nested")];
 
@@ -275,9 +271,9 @@ mod tests {
 
     #[test]
     fn map_values_matter_2() {
-        let mut event_1 = new_log_event();
+        let mut event_1 = LogEvent::new();
         event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
-        let mut event_2 = new_log_event();
+        let mut event_2 = LogEvent::new();
         event_2.insert("nested", "x"); // `nested` is a `Value::String`
 
         let discriminant_fields = vec![Atom::from("nested")];
@@ -294,21 +290,21 @@ mod tests {
         let mut map: HashMap<Discriminant, usize> = HashMap::new();
 
         let event_stream_1 = {
-            let mut event = new_log_event();
+            let mut event = LogEvent::new();
             event.insert("hostname", "a.test");
             event.insert("container_id", "abc");
             event
         };
 
         let event_stream_2 = {
-            let mut event = new_log_event();
+            let mut event = LogEvent::new();
             event.insert("hostname", "b.test");
             event.insert("container_id", "def");
             event
         };
 
         let event_stream_3 = {
-            let event = new_log_event();
+            let event = LogEvent::new();
             // no `hostname` or `container_id`
             event
         };

--- a/src/event/merge.rs
+++ b/src/event/merge.rs
@@ -30,7 +30,6 @@ pub fn merge_value(current: &mut Value, incoming: Value) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::event::Event;
 
     fn assert_merge_value(
         current: impl Into<Value>,
@@ -55,10 +54,6 @@ mod test {
         assert_merge_value(1, 2, 2);
     }
 
-    fn new_log_event() -> LogEvent {
-        Event::new_empty_log().into_log()
-    }
-
     #[test]
     fn merge_event_combines_values_accordingly() {
         // Specify the fields that will be merged.
@@ -72,7 +67,7 @@ mod test {
         ];
 
         let current = {
-            let mut log = new_log_event();
+            let mut log = LogEvent::new();
 
             log.insert("merge", "hello "); // will be concatenated with the `merged` from `incoming`.
             log.insert("do_not_merge", "my_first_value"); // will remain as is, since it's not selected for merging.
@@ -90,7 +85,7 @@ mod test {
         };
 
         let incoming = {
-            let mut log = new_log_event();
+            let mut log = LogEvent::new();
 
             log.insert("merge", "world"); // will be concatenated to the `merge` from `current`.
             log.insert("do_not_merge", "my_second_value"); // will be ignored, since it's not selected for merge.
@@ -110,7 +105,7 @@ mod test {
         merge_log_event(&mut merged, incoming, &fields_to_merge);
 
         let expected = {
-            let mut log = new_log_event();
+            let mut log = LogEvent::new();
             log.insert("merge", "hello world");
             log.insert("do_not_merge", "my_first_value");
             log.insert("a", true);

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -46,9 +46,7 @@ pub struct LogEvent {
 
 impl Event {
     pub fn new_empty_log() -> Self {
-        Event::Log(LogEvent {
-            fields: BTreeMap::new(),
-        })
+        Event::Log(LogEvent::new())
     }
 
     pub fn as_log(&self) -> &LogEvent {
@@ -95,6 +93,12 @@ impl Event {
 }
 
 impl LogEvent {
+    pub fn new() -> Self {
+        Self {
+            fields: BTreeMap::new(),
+        }
+    }
+
     pub fn get(&self, key: &Atom) -> Option<&Value> {
         util::log::get(&self.fields, key)
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -187,7 +187,7 @@ impl<K: Into<Atom>, V: Into<Value>> Extend<(K, V)> for LogEvent {
 // Allow converting any kind of appropriate key/value iterator directly into a LogEvent.
 impl<K: Into<Atom>, V: Into<Value>> FromIterator<(K, V)> for LogEvent {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        let mut log_event = Event::new_empty_log().into_log();
+        let mut log_event = LogEvent::new();
         log_event.extend(iter);
         log_event
     }

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -1,6 +1,6 @@
 use crate::{
     event::merge_state::LogEventMergeState,
-    event::{self, Event, Value},
+    event::{self, Event, LogEvent, Value},
     shutdown::ShutdownSignal,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
 };
@@ -799,7 +799,7 @@ impl ContainerLogInfo {
 
         // Prepare the log event.
         let mut log_event = {
-            let mut log_event = Event::new_empty_log().into_log();
+            let mut log_event = LogEvent::new();
 
             // The log message.
             log_event.insert(

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,5 @@
 use crate::runtime::Runtime;
-use crate::Event;
+use crate::{event::LogEvent, Event};
 
 use futures01::{future, stream, sync::mpsc, try_ready, Async, Future, Poll, Sink, Stream};
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
@@ -152,7 +152,7 @@ pub fn random_nested_events_with_stream(
     count: usize,
 ) -> (Vec<Event>, impl Stream<Item = Event, Error = ()>) {
     random_events_with_stream_generic(count, move || {
-        let mut log = Event::new_empty_log().into_log();
+        let mut log = LogEvent::new();
 
         let tree = random_pseudonested_map(len, breadth, depth);
         for (k, v) in tree.into_iter() {

--- a/src/transforms/lua/v2/interop/log.rs
+++ b/src/transforms/lua/v2/interop/log.rs
@@ -1,4 +1,4 @@
-use crate::event::{Event, LogEvent, Value};
+use crate::event::{LogEvent, Value};
 use rlua::prelude::*;
 
 impl<'a> ToLua<'a> for LogEvent {
@@ -12,7 +12,7 @@ impl<'a> FromLua<'a> for LogEvent {
     fn from_lua(value: LuaValue<'a>, _: LuaContext<'a>) -> LuaResult<Self> {
         match value {
             LuaValue::Table(t) => {
-                let mut log = Event::new_empty_log().into_log();
+                let mut log = LogEvent::new();
                 for pair in t.pairs() {
                     let (key, value): (String, Value) = pair?;
                     log.insert_flat(key, value);
@@ -31,6 +31,7 @@ impl<'a> FromLua<'a> for LogEvent {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::event::Event;
 
     #[test]
     fn to_lua() {


### PR DESCRIPTION
This is an internal life quality improvement, allows us to get rid of doing `Event::new_empty_log().into_log()`.