### PR TITLE
chore: Support ARM architectures in the install script

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -157,6 +157,12 @@ install_from_archive() {
         x86_64-*linux*)
             _archive_arch="x86_64-unknown-linux-musl"
             ;;
+        armv7-*linux*hf)
+            _archive_arch="armv7-unknown-linux-musleabihf"
+            ;;
+        aarch64-*linux*)
+            _archive_arch="aarch64-unknown-linux-musl"
+            ;;
         *)
             err "unsupported arch: $_arch"
             ;;


### PR DESCRIPTION
The `get_architecture` function already supports them, so it is enough to add them to the `install_from_archive` function.