### PR TITLE
chore: Disable duplicated version output in `make version`

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -12,7 +12,6 @@
 set -e
 
 VERSION="$(sed -n 's/^version\s=\s"\(.*\)"/\1/p' Cargo.toml)"
-echo $VERSION
 CHANNEL="$(scripts/util/release-channel.sh)"
 if [ "$CHANNEL" == "nightly" ]; then
   VERSION="$VERSION-nightly"


### PR DESCRIPTION
The line https://github.com/timberio/vector/blob/f2f9b269d9f9dfe9b1d2af60821711c4c101cdd9/scripts/version.sh#L15 was added in https://github.com/timberio/vector/pull/2028, but it [breaks RPM packaging](https://app.circleci.com/pipelines/github/timberio/vector/6478/workflows/00fb6374-bac5-4d8f-87a4-44a1d63766ce/jobs/91413).

This PR removes it, which fixes RPM builds, but I'm not sure was it added just for debugging, or is it actually necessary for the test harness. If it is used, then this PR can be changed to modify  `package-rpm.sh` to take only the second part of the output produced by `make version`.