### PR TITLE
chore(tests): Use `UTC` instead of `Europe/London` in ClickHouse tests

### DIFF
--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -324,7 +324,7 @@ mod integration_tests {
         let client = ClickhouseClient::new(host);
         client.create_table(
             &table,
-            "host String, timestamp DateTime('Europe/London'), message String",
+            "host String, timestamp DateTime('UTC'), message String",
         );
 
         let (sink, _hc) = config.build(SinkContext::new_test(rt.executor())).unwrap();
@@ -382,7 +382,7 @@ compression = "none"
         let client = ClickhouseClient::new(host);
         client.create_table(
             &table,
-            "host String, timestamp DateTime('Europe/London'), message String",
+            "host String, timestamp DateTime('UTC'), message String",
         );
 
         let (sink, _hc) = config.build(SinkContext::new_test(rt.executor())).unwrap();


### PR DESCRIPTION
The `Europe/London` timezone which was used in the integration tests recently switched to
daylight saving time, which caused the integration tests to break.

This PR changes the tests to use `UTC` time instead.