### PR TITLE
chore: Add support for inline TLS certificates and keys

### DIFF
--- a/.meta/_partials/fields/_tls_acceptor_options.toml
+++ b/.meta/_partials/fields/_tls_acceptor_options.toml
@@ -19,50 +19,7 @@ Require TLS for incoming connections. \
 If this is set, an identity certificate is also required.\
 """
 
-[<%= namespace %>.tls.children.ca_path]
-type = "string"
-examples = ["/path/to/certificate_authority.crt"]
-groups = <%= groups.to_toml %>
-<%= relevant %>
-description = """\
-Absolute path to an additional CA certificate file, in DER or PEM format \
-(X.509).\
-"""
-
-[<%= namespace %>.tls.children.crt_path]
-type = "string"
-common = true
-examples = ["/path/to/host_certificate.crt"]
-groups = <%= groups.to_toml %>
-<%= relevant %>
-description = """\
-Absolute path to a certificate file used to identify this server, in DER \
-or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive, \
-`key_path` must also be set. \
-This is required if `enabled` is set to `true`.\
-"""
-
-[<%= namespace %>.tls.children.key_path]
-type = "string"
-common = true
-examples = ["/path/to/host_certificate.key"]
-groups = <%= groups.to_toml %>
-<%= relevant %>
-description = """\
-Absolute path to a certificate key file used to identify this server, in \
-DER or PEM format (PKCS#8).\
-"""
-
-[<%= namespace %>.tls.children.key_pass]
-type = "string"
-common = true
-examples = ["${KEY_PASS_ENV_VAR}", "PassWord1"]
-groups = <%= groups.to_toml %>
-<%= relevant %>
-description = """\
-Pass phrase used to unlock the encrypted key file. This has no effect unless \
-`key_path` is set.\
-"""
+<%= render("_partials/fields/_tls_common.toml", mode: "server", namespace: namespace, groups: groups, relevant: relevant) %>
 
 [<%= namespace %>.tls.children.verify_certificate]
 type = "bool"

--- a/.meta/_partials/fields/_tls_common.toml
+++ b/.meta/_partials/fields/_tls_common.toml
@@ -1,0 +1,80 @@
+[<%= namespace %>.tls.children.ca_path]
+type = "string"
+examples = ["/path/to/certificate_authority.crt"]
+groups = <%= groups.to_toml %>
+<%= relevant %>
+description = """\
+Absolute path to an additional CA certificate file, in DER or PEM format \
+(X.509). \
+Only one of this and `ca_text` may be set.
+"""
+
+[<%= namespace %>.tls.children.ca_text]
+type = "string"
+examples = ["-----BEGIN CERTIFICATE-----\nMII..."]
+groups = <%= groups.to_toml %>
+<%= relevant %>
+description = """\
+Inline text of an additional CA certificate, in PEM format. \
+Only one of this and `ca_path` may be set.
+"""
+
+[<%= namespace %>.tls.children.crt_path]
+type = "string"
+common = true
+examples = ["/path/to/host_certificate.crt"]
+groups = <%= groups.to_toml %>
+<%= relevant %>
+description = """\
+Absolute path to a certificate file used to identify this <%= mode %>, in DER \
+or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive, \
+`key_path` or `key_text` must also be set. \
+Either this or `crt_text` is required if `enabled` is set to `true`. \
+Only one of this and `crt_path` may be set.\
+"""
+
+[<%= namespace %>.tls.children.crt_text]
+type = "string"
+common = true
+examples = ["-----BEGIN CERTIFICATE-----\nMII..."]
+groups = <%= groups.to_toml %>
+<%= relevant %>
+description = """\
+Inline text of a certificate used to identify this <%= mode %>, in PEM format. \
+If this is set, either `key_path` or `key_text` must also be set. \
+Either this or `crt_path` is required if `enabled` is set to `true`. \
+Only one of this and `crt_path` may be set.\
+"""
+
+[<%= namespace %>.tls.children.key_path]
+type = "string"
+common = true
+examples = ["/path/to/host_certificate.key"]
+groups = <%= groups.to_toml %>
+description = """\
+Absolute path to a certificate key file used to identify this <%= mode %>, in \
+DER or PEM format (PKCS#8). \
+If this is set, either `crt_path` or `crt_text` must also be set. \
+Only one of this and `key_text` may be set.\
+"""
+
+[<%= namespace %>.tls.children.key_text]
+type = "string"
+common = true
+examples = ["-----BEGIN PRIVATE KEY-----\nMII..."]
+groups = <%= groups.to_toml %>
+description = """\
+Inline text of a certificate key file used to identify this <%= mode %>, in \
+PEM format (PKCS#8). \
+If this is set, either `crt_path` or `crt_text` must also be set. \
+Only one of this and `key_path` may be set.\
+"""
+
+[<%= namespace %>.tls.children.key_pass]
+type = "string"
+examples = ["${KEY_PASS_ENV_VAR}", "PassWord1"]
+groups = <%= groups.to_toml %>
+description = """\
+Pass phrase used to unlock the encrypted key file. This has no effect unless \
+either `key_path` or `key_text` is set.\
+"""

--- a/.meta/_partials/fields/_tls_connector_options.toml
+++ b/.meta/_partials/fields/_tls_connector_options.toml
@@ -16,44 +16,7 @@ sort = 1
 description = "Enable TLS during connections to the remote."
 <%- end -%>
 
-[<%= namespace %>.tls.children.ca_path]
-type = "string"
-examples = ["/path/to/certificate_authority.crt"]
-groups = <%= groups.to_toml %>
-description = """\
-Absolute path to an additional CA certificate file, in DER or PEM format \
-(X.509).\
-"""
-
-[<%= namespace %>.tls.children.crt_path]
-type = "string"
-common = true
-examples = ["/path/to/host_certificate.crt"]
-groups = <%= groups.to_toml %>
-description = """\
-Absolute path to a certificate file used to identify this connection, in DER \
-or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive, \
-`key_path` must also be set.\
-"""
-
-[<%= namespace %>.tls.children.key_path]
-type = "string"
-common = true
-examples = ["/path/to/host_certificate.key"]
-groups = <%= groups.to_toml %>
-description = """\
-Absolute path to a certificate key file used to identify this connection, in \
-DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.\
-"""
-
-[<%= namespace %>.tls.children.key_pass]
-type = "string"
-examples = ["${KEY_PASS_ENV_VAR}", "PassWord1"]
-groups = <%= groups.to_toml %>
-description = """\
-Pass phrase used to unlock the encrypted key file. This has no effect unless \
-`key_path` is set.\
-"""
+<%= render("_partials/fields/_tls_common.toml", mode: "connection", namespace: namespace, groups: groups, relevant: "") %>
 
 <%- if can_verify_certificate -%>
 [<%= namespace %>.tls.children.verify_certificate]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -380,21 +380,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.http.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -406,7 +432,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -415,12 +441,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -589,21 +628,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.kafka.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Enable TLS during connections to the remote.
     #
@@ -614,7 +679,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -623,12 +688,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
 # Ingests data through the Heroku Logplex HTTP Drain protocol and outputs `log` events.
 [sources.logplex]
@@ -656,21 +734,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.logplex.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -682,7 +786,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -691,12 +795,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -808,7 +925,7 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.socket.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
@@ -816,15 +933,43 @@ dns_servers = ["0.0.0.0:53"]
     # * relevant when mode = "tcp"
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * relevant when mode = "tcp"
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     # * relevant when mode = "tcp"
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * relevant when mode = "tcp"
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -837,23 +982,34 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
     # * type: string
-    # * relevant when mode = "tcp"
     key_pass = "${KEY_PASS_ENV_VAR}"
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
-    # * relevant when mode = "tcp"
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -903,21 +1059,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.splunk_hec.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -929,7 +1111,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -938,12 +1120,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -1071,21 +1266,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.syslog.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -1097,7 +1318,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -1106,12 +1327,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -1161,21 +1395,47 @@ dns_servers = ["0.0.0.0:53"]
 
   [sources.vector.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this server, in DER or
     # PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-    # `key_path` must also be set. This is required if `enabled` is set to `true`.
+    # `key_path` or `key_text` must also be set. Either this or `crt_text` is
+    # required if `enabled` is set to `true`. Only one of this and `crt_path` may
+    # be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this server, in PEM format. If
+    # this is set, either `key_path` or `key_text` must also be set. Either this or
+    # `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Require TLS for incoming connections. If this is set, an identity certificate
     # is also required.
@@ -1187,7 +1447,7 @@ dns_servers = ["0.0.0.0:53"]
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -1196,12 +1456,25 @@ dns_servers = ["0.0.0.0:53"]
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this server, in DER
-    # or PEM format (PKCS#8).
+    # or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this server, in PEM
+    # format (PKCS#8). If this is set, either `crt_path` or `crt_text` must also be
+    # set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true`, Vector will require a TLS certificate from the connecting host and
     # terminate the connection if it is not valid. If `false` (the default), Vector
@@ -3817,24 +4090,50 @@ end
 
   [sinks.clickhouse.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -3843,12 +4142,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -4060,21 +4372,47 @@ end
 
   [sinks.datadog_logs.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Enable TLS during connections to the remote.
     #
@@ -4085,7 +4423,7 @@ end
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -4094,12 +4432,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -4521,24 +4872,50 @@ end
 
   [sinks.elasticsearch.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -4547,12 +4924,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -4948,24 +5338,50 @@ end
 
   [sinks.gcp_cloud_storage.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -4974,12 +5390,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -5220,24 +5649,50 @@ end
 
   [sinks.gcp_pubsub.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -5246,12 +5701,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -5547,24 +6015,50 @@ end
 
   [sinks.gcp_stackdriver_logs.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -5573,12 +6067,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -6028,24 +6535,50 @@ end
 
   [sinks.http.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -6054,12 +6587,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -6658,21 +7204,47 @@ end
 
   [sinks.kafka.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Enable TLS during connections to the remote.
     #
@@ -6683,7 +7255,7 @@ end
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -6692,12 +7264,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
 # Batches `log` events to LogDna's HTTP Ingestion API.
 [sinks.logdna]
@@ -7207,24 +7792,50 @@ end
 
   [sinks.loki.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -7233,12 +7844,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -8067,21 +8691,47 @@ end
 
   [sinks.socket.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Enable TLS during connections to the remote.
     #
@@ -8092,7 +8742,7 @@ end
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -8101,12 +8751,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -8361,24 +9024,50 @@ end
 
   [sinks.splunk_hec.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
 
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -8387,12 +9076,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of
@@ -8532,21 +9234,47 @@ end
 
   [sinks.vector.tls]
     # Absolute path to an additional CA certificate file, in DER or PEM format
-    # (X.509).
+    # (X.509). Only one of this and `ca_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     ca_path = "/path/to/certificate_authority.crt"
 
+    # Inline text of an additional CA certificate, in PEM format. Only one of this
+    # and `ca_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
+
     # Absolute path to a certificate file used to identify this connection, in DER
     # or PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12
-    # archive, `key_path` must also be set.
+    # archive, `key_path` or `key_text` must also be set. Either this or `crt_text`
+    # is required if `enabled` is set to `true`. Only one of this and `crt_path`
+    # may be set.
     #
     # * optional
     # * no default
     # * type: string
     crt_path = "/path/to/host_certificate.crt"
+
+    # Inline text of a certificate used to identify this connection, in PEM format.
+    # If this is set, either `key_path` or `key_text` must also be set. Either this
+    # or `crt_path` is required if `enabled` is set to `true`. Only one of this and
+    # `crt_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """
 
     # Enable TLS during connections to the remote.
     #
@@ -8557,7 +9285,7 @@ end
     enabled = true
 
     # Pass phrase used to unlock the encrypted key file. This has no effect unless
-    # `key_path` is set.
+    # either `key_path` or `key_text` is set.
     #
     # * optional
     # * no default
@@ -8566,12 +9294,25 @@ end
     key_pass = "PassWord1"
 
     # Absolute path to a certificate key file used to identify this connection, in
-    # DER or PEM format (PKCS#8). If this is set, `crt_path` must also be set.
+    # DER or PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text`
+    # must also be set. Only one of this and `key_text` may be set.
     #
     # * optional
     # * no default
     # * type: string
     key_path = "/path/to/host_certificate.key"
+
+    # Inline text of a certificate key file used to identify this connection, in
+    # PEM format (PKCS#8). If this is set, either `crt_path` or `crt_text` must
+    # also be set. Only one of this and `key_path` may be set.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """
 
     # If `true` (the default), Vector will validate the TLS certificate of the
     # remote host. Do NOT set this to `false` unless you understand the risks of

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -102,6 +102,8 @@ pub enum TlsError {
     Connect { source: std::io::Error },
     #[snafu(display("Could not get peer address: {}", source))]
     PeerAddress { source: std::io::Error },
+    #[snafu(display("Both a {} path and inline text is configured", mode))]
+    BothPathAndText { mode: &'static str },
 }
 
 impl MaybeTlsStream<TcpStream> {

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -73,7 +73,7 @@ impl TlsSettings {
         }
 
         if options.key_path.is_some() && options.crt_path.is_none() {
-            return Err(TlsError::MissingCrtKeyFile.into());
+            return Err(TlsError::MissingCrtKeyFile);
         }
 
         let authority = match options.ca_path {
@@ -206,7 +206,7 @@ impl MaybeTlsSettings {
                         TlsSettings::from_options_base(&Some(config.options.clone()), for_server)?;
                     match (for_server, &tls.identity) {
                         // Servers require an identity certificate
-                        (true, None) => Err(TlsError::MissingRequiredIdentity.into()),
+                        (true, None) => Err(TlsError::MissingRequiredIdentity),
                         _ => Ok(Self::Tls(tls)),
                     }
                 }

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Clickhouse"
 description: "The Vector `clickhouse` sink batches `log` events to Clickhouse via the `HTTP` Interface."
@@ -116,9 +116,21 @@ The Vector `clickhouse` sink
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -923,7 +935,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -950,7 +988,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -976,7 +1044,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1002,7 +1070,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/datadog_logs.md
+++ b/website/docs/reference/sinks/datadog_logs.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Datadog Logs"
 description: "The Vector `datadog_logs` sink streams `log` events to Datadog's logs via the TCP endpoint."
@@ -85,10 +85,22 @@ endpoint][urls.datadog_logs_endpoints].
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -501,7 +513,33 @@ Enable TLS during connections to the remote.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -528,7 +566,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -554,7 +622,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -580,7 +648,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Elasticsearch"
 description: "The Vector `elasticsearch` sink batches `log` events to Elasticsearch via the `_bulk` API endpoint."
@@ -107,9 +107,21 @@ endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-b
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -999,7 +1011,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -1026,7 +1064,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -1052,7 +1120,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1078,7 +1146,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/gcp_cloud_storage.md
+++ b/website/docs/reference/sinks/gcp_cloud_storage.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "GCP Cloud Storage (GCS)"
 description: "The Vector `gcp_cloud_storage` sink batches `log` events to Google Cloud Platform's Cloud Storage service via the XML Interface."
@@ -118,9 +118,21 @@ the [XML Interface](https://cloud.google.com/storage/docs/xml-api/overview).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -1033,7 +1045,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -1060,7 +1098,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -1086,7 +1154,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1112,7 +1180,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "GCP PubSub"
 description: "The Vector `gcp_pubsub` sink batches `log` events to Google Cloud Platform's Pubsub service via the REST Interface."
@@ -95,9 +95,21 @@ Interface][urls.gcp_pubsub_rest].
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -777,7 +789,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -804,7 +842,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -830,7 +898,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -856,7 +924,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/gcp_stackdriver_logs.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logs.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "GCP Stackdriver Logs"
 description: "The Vector `gcp_stackdriver_logs` sink batches [`log`](#log) events to Google Cloud Platform's Stackdriver Logging service via the REST Interface."
@@ -102,9 +102,21 @@ the [REST Interface][urls.gcp_stackdriver_logging_rest].
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -961,7 +973,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -988,7 +1026,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -1014,7 +1082,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1040,7 +1108,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "HTTP"
 description: "The Vector `http` sink batches `log` events to a generic HTTP endpoint."
@@ -122,9 +122,21 @@ The Vector `http` sink
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -958,7 +970,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -985,7 +1023,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -1011,7 +1079,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1037,7 +1105,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` sink streams `log` events to Apache Kafka via the Kafka protocol."
@@ -105,10 +105,22 @@ Kafka][urls.kafka] via the [Kafka protocol][urls.kafka_protocol].
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
 ```
 
 </TabItem>
@@ -651,7 +663,33 @@ Enable TLS during connections to the remote.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -678,7 +716,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -704,7 +772,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -730,7 +798,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Loki"
 description: "The Vector `loki` sink batches `log` events to Loki."
@@ -112,9 +112,21 @@ The Vector `loki` sink
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -1009,7 +1021,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -1036,7 +1074,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -1062,7 +1130,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -1088,7 +1156,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/socket.md
+++ b/website/docs/reference/sinks/socket.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Socket"
 description: "The Vector `socket` sink streams `log` events to a socket, such as a TCP, UDP, or UDS socket."
@@ -128,10 +128,22 @@ The Vector `socket` sink
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -567,7 +579,33 @@ Enable TLS during connections to the remote.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={["tcp"]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -594,7 +632,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={["tcp"]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -620,7 +688,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -646,7 +714,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={["tcp"]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "Splunk HEC"
 description: "The Vector `splunk_hec` sink batches `log` events to a Splunk's HTTP Event Collector."
@@ -103,9 +103,21 @@ HTTP Event Collector][urls.splunk_hec].
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -833,7 +845,33 @@ Configures the TLS options for connections from this sink.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -860,7 +898,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if `enabled` is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if `enabled` is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -886,7 +954,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -912,7 +980,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sinks/vector.md
+++ b/website/docs/reference/sinks/vector.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Vector"
 description: "The Vector `vector` sink streams `log` events to another downstream `vector` source."
@@ -73,10 +73,22 @@ The Vector `vector` sink
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = true # optional, default
   tls.verify_hostname = true # optional, default
 ```
@@ -333,7 +345,33 @@ Enable TLS during connections to the remote.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -360,7 +398,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -386,7 +454,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -412,7 +480,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/http.md
+++ b/website/docs/reference/sources/http.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "HTTP"
 description: "The Vector `http` source ingests data through the HTTP protocol and outputs `log` events."
@@ -75,10 +75,22 @@ events](#output).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default
 ```
 
@@ -209,7 +221,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -236,7 +274,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -271,7 +339,7 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
@@ -288,7 +356,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -314,7 +382,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` source ingests data through Kafka and outputs `log` events."
@@ -85,10 +85,22 @@ ingests data through [Kafka][urls.kafka] and [outputs `log` events](#output).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
 ```
 
 </TabItem>
@@ -400,7 +412,33 @@ Enable TLS during connections to the remote.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -427,7 +465,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this connection, in DER or
 PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this connection, in PEM format.
+If this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this
+or [`crt_path`](#crt_path) is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -453,7 +521,7 @@ PEM format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -479,7 +547,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this connection, in
-DER or PEM format (PKCS#8). If this is set, [`crt_path`](#crt_path) must also be set.
+DER or PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text)
+must also be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this connection, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/logplex.md
+++ b/website/docs/reference/sources/logplex.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "Heroku Logplex"
 description: "The Vector `logplex` source ingests data through the Heroku Logplex HTTP Drain protocol and outputs `log` events."
@@ -71,10 +71,22 @@ protocol][urls.logplex_protocol] and [outputs `log` events](#output).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default
 ```
 
@@ -151,7 +163,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -178,7 +216,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -213,7 +281,7 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
@@ -230,7 +298,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -256,7 +324,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/socket.md
+++ b/website/docs/reference/sources/socket.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Socket"
 description: "The Vector `socket` source ingests data through a socket, such as a TCP, UDP, or UDS socket and outputs `log` events."
@@ -139,10 +139,22 @@ ingests data through a [socket][urls.socket], such as a [TCP][urls.tcp],
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default, relevant when mode = "tcp"
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default, relevant when mode = "tcp"
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default, relevant when mode = "tcp"
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default, relevant when mode = "tcp"
   tls.enabled = false # optional, default, relevant when mode = "tcp"
-  tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default, relevant when mode = "tcp"
-  tls.key_path = "/path/to/host_certificate.key" # optional, no default, relevant when mode = "tcp"
+  tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
+  tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default, relevant when mode = "tcp"
 ```
 
@@ -348,7 +360,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={["tcp"]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={{"mode":"tcp"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -375,7 +413,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={["tcp"]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={{"mode":"tcp"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -410,14 +478,14 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
   groups={["tcp"]}
   name={"key_pass"}
   path={"tls"}
-  relevantWhen={{"mode":"tcp"}}
+  relevantWhen={null}
   required={false}
   templateable={false}
   type={"string"}
@@ -427,7 +495,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -443,7 +511,7 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
   groups={["tcp"]}
   name={"key_path"}
   path={"tls"}
-  relevantWhen={{"mode":"tcp"}}
+  relevantWhen={null}
   required={false}
   templateable={false}
   type={"string"}
@@ -453,7 +521,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={["tcp"]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/splunk_hec.md
+++ b/website/docs/reference/sources/splunk_hec.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "at_least_once"
 component_title: "Splunk HEC"
 description: "The Vector `splunk_hec` source ingests data through the Splunk HTTP Event Collector protocol and outputs `log` events."
@@ -73,10 +73,22 @@ protocol][urls.splunk_hec_protocol] and [outputs `log` events](#output).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default
 ```
 
@@ -153,7 +165,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -180,7 +218,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -215,7 +283,7 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
@@ -232,7 +300,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -258,7 +326,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/syslog.md
+++ b/website/docs/reference/sources/syslog.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Syslog"
 description: "The Vector `syslog` source ingests data through the Syslog protocol and outputs `log` events."
@@ -79,10 +79,22 @@ events](#output).
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default
 ```
 
@@ -262,7 +274,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -289,7 +327,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -324,7 +392,7 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
@@ -341,7 +409,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -367,7 +435,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 

--- a/website/docs/reference/sources/vector.md
+++ b/website/docs/reference/sources/vector.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-03-31"
+last_modified_on: "2020-04-01"
 delivery_guarantee: "best_effort"
 component_title: "Vector"
 description: "The Vector `vector` source ingests data through another upstream `vector` sink and outputs `log` and `metric` events."
@@ -73,10 +73,22 @@ events.
 
   # TLS
   tls.ca_path = "/path/to/certificate_authority.crt" # optional, no default
+  tls.ca_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.crt_path = "/path/to/host_certificate.crt" # optional, no default
+  tls.crt_text = """
+  -----BEGIN CERTIFICATE-----
+  MII...
+  """ # optional, no default
   tls.enabled = false # optional, default
   tls.key_pass = "${KEY_PASS_ENV_VAR}" # optional, no default
   tls.key_path = "/path/to/host_certificate.key" # optional, no default
+  tls.key_text = """
+  -----BEGIN PRIVATE KEY-----
+  MII...
+  """ # optional, no default
   tls.verify_certificate = false # optional, default
 ```
 
@@ -180,7 +192,33 @@ Configures the TLS options for connections from this source.
 #### ca_path
 
 Absolute path to an additional CA certificate file, in DER or PEM format
-(X.509).
+(X.509). Only one of this and [`ca_text`](#ca_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"ca_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### ca_text
+
+Inline text of an additional CA certificate, in PEM format. Only one of this
+and [`ca_path`](#ca_path) may be set.
 
 
 
@@ -207,7 +245,37 @@ Absolute path to an additional CA certificate file, in DER or PEM format
 
 Absolute path to a certificate file used to identify this server, in DER or PEM
 format (X.509) or PKCS#12. If this is set and is not a PKCS#12 archive,
-`key_path` must also be set. This is required if [`enabled`](#enabled) is set to `true`.
+`key_path` or [`key_text`](#key_text) must also be set. Either this or [`crt_text`](#crt_text) is
+required if [`enabled`](#enabled) is set to `true`. Only one of this and [`crt_path`](#crt_path) may be
+set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN CERTIFICATE-----\nMII..."]}
+  groups={[]}
+  name={"crt_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### crt_text
+
+Inline text of a certificate used to identify this server, in PEM format. If
+this is set, either [`key_path`](#key_path) or [`key_text`](#key_text) must also be set. Either this or
+`crt_path` is required if [`enabled`](#enabled) is set to `true`. Only one of this and
+`crt_path` may be set.
 
 
 
@@ -242,7 +310,7 @@ is also required.
 
 
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["${KEY_PASS_ENV_VAR}","PassWord1"]}
@@ -259,7 +327,7 @@ is also required.
 #### key_pass
 
 Pass phrase used to unlock the encrypted key file. This has no effect unless
-`key_path` is set.
+either [`key_path`](#key_path) or [`key_text`](#key_text) is set.
 
 
 
@@ -285,7 +353,35 @@ Pass phrase used to unlock the encrypted key file. This has no effect unless
 #### key_path
 
 Absolute path to a certificate key file used to identify this server, in DER or
-PEM format (PKCS#8).
+PEM format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also
+be set. Only one of this and [`key_text`](#key_text) may be set.
+
+
+
+
+</Field>
+
+
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["-----BEGIN PRIVATE KEY-----\nMII..."]}
+  groups={[]}
+  name={"key_text"}
+  path={"tls"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+#### key_text
+
+Inline text of a certificate key file used to identify this server, in PEM
+format (PKCS#8). If this is set, either [`crt_path`](#crt_path) or [`crt_text`](#crt_text) must also be
+set. Only one of this and [`key_path`](#key_path) may be set.
 
 
 


### PR DESCRIPTION
Ref #2172 

I started writing documentation for the new `*_text` configuration items, but wonder if this would just add confusion on how to configure TLS. If we do document it, the title would have to reflect the enhancement.

This doesn't solve the root Kubernetes issue, but it would allow a source or sink to push key text into the `TlsOptions` before calling `TlsSettings::from_options` (or `from_config`).

I'll also note that Kubernetes doesn't show up in our GitHub labels...