### PR TITLE
chore(operations): Compare test harness output with nightly/latest

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         args: |
           bash -o pipefail -xc "cd /vector-test-harness \
-          && bin/compare -s vector -c default $(echo '${{ github.event.comment.body }}' | head -n 1 | sed 's|^/test ||') | tee \"$GITHUB_WORKSPACE/output\""
+          && bin/compare -s vector -c default -v nightly/latest -v ${{ steps.cloned-repo-info.outputs.test_harness_vector_version }} $(echo '${{ github.event.comment.body }}' | head -n 1 | sed 's|^/test ||') | tee \"$GITHUB_WORKSPACE/output\""
       env:
         GENERATE_SSH_KEY: true
         VECTOR_TEST_RESULTS_S3_BUCKET_NAME: test-results.vector.dev


### PR DESCRIPTION
This defaults the test harness output to compare to the `nightly/latest` version. The only outstanding issue here is the use `-c default` since this is not always the case. For example, https://github.com/timberio/vector/pull/2145#issuecomment-607508062 run a test with the `-c big-vms` flag which also needs to be passed to the `bin/compare` command.