### PR TITLE
docs: fix "issie" typo and minor issues with Loki sink docs

### DIFF
--- a/scripts/generate/templates/_partials/_component_sections.md.erb
+++ b/scripts/generate/templates/_partials/_component_sections.md.erb
@@ -248,7 +248,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_<%= component.id %>_issue].
+with the Vector team by [opening an issue][urls.new_<%= component.id %>_issue].
 <%- end -%>
 <%- if component.options.respond_to?(:request) -%>
 

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -981,7 +981,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_aws_cloudwatch_logs_sink_issue].
+with the Vector team by [opening an issue][urls.new_aws_cloudwatch_logs_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -888,7 +888,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_aws_kinesis_firehose_sink_issue].
+with the Vector team by [opening an issue][urls.new_aws_kinesis_firehose_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -931,7 +931,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_aws_kinesis_streams_sink_issue].
+with the Vector team by [opening an issue][urls.new_aws_kinesis_streams_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -1329,7 +1329,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_aws_s3_sink_issue].
+with the Vector team by [opening an issue][urls.new_aws_s3_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/clickhouse.md
+++ b/website/docs/reference/sinks/clickhouse.md
@@ -1041,7 +1041,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_clickhouse_sink_issue].
+with the Vector team by [opening an issue][urls.new_clickhouse_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/datadog_metrics.md
+++ b/website/docs/reference/sinks/datadog_metrics.md
@@ -502,7 +502,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_datadog_metrics_sink_issue].
+with the Vector team by [opening an issue][urls.new_datadog_metrics_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -1264,7 +1264,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_elasticsearch_sink_issue].
+with the Vector team by [opening an issue][urls.new_elasticsearch_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/gcp_cloud_storage.md
+++ b/website/docs/reference/sinks/gcp_cloud_storage.md
@@ -1236,7 +1236,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_gcp_cloud_storage_sink_issue].
+with the Vector team by [opening an issue][urls.new_gcp_cloud_storage_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/gcp_pubsub.md
+++ b/website/docs/reference/sinks/gcp_pubsub.md
@@ -959,7 +959,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_gcp_pubsub_sink_issue].
+with the Vector team by [opening an issue][urls.new_gcp_pubsub_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/gcp_stackdriver_logs.md
+++ b/website/docs/reference/sinks/gcp_stackdriver_logs.md
@@ -1106,7 +1106,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_gcp_stackdriver_logs_sink_issue].
+with the Vector team by [opening an issue][urls.new_gcp_stackdriver_logs_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/honeycomb.md
+++ b/website/docs/reference/sinks/honeycomb.md
@@ -605,7 +605,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_honeycomb_sink_issue].
+with the Vector team by [opening an issue][urls.new_honeycomb_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/http.md
+++ b/website/docs/reference/sinks/http.md
@@ -1171,7 +1171,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_http_sink_issue].
+with the Vector team by [opening an issue][urls.new_http_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/humio_logs.md
+++ b/website/docs/reference/sinks/humio_logs.md
@@ -730,7 +730,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_humio_logs_sink_issue].
+with the Vector team by [opening an issue][urls.new_humio_logs_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/influxdb_metrics.md
+++ b/website/docs/reference/sinks/influxdb_metrics.md
@@ -727,7 +727,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_influxdb_metrics_sink_issue].
+with the Vector team by [opening an issue][urls.new_influxdb_metrics_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/logdna.md
+++ b/website/docs/reference/sinks/logdna.md
@@ -818,7 +818,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_logdna_sink_issue].
+with the Vector team by [opening an issue][urls.new_logdna_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -1134,7 +1134,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_loki_sink_issue].
+with the Vector team by [opening an issue][urls.new_loki_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -180,7 +180,7 @@ The authentication strategy to use.
 
 #### password
 
-The basic authentication password.If using GrafanaLab's hosted Loki then this
+The basic authentication password. If using GrafanaLab's hosted Loki then this
 must be setto your `instanceId`.
 
 
@@ -204,7 +204,7 @@ must be setto your `instanceId`.
 
 #### user
 
-The basic authentication user name.If using GrafanaLab's hosted Loki then this
+The basic authentication user name. If using GrafanaLab's hosted Loki then this
 must be setto your Grafana.com api key.
 
 
@@ -582,10 +582,10 @@ Enables/disables the sink healthcheck upon start.
 
 ### labels
 
-A set of labels that will be attached to each batch of events. These valuesare
-also templateable to allow events to provide dynamic label values.Note: If the
-set of label values has high cardinality this can cause drasticperformance
-issues with Loki. To ensure this does not happen one should tryto reduce the
+A set of labels that will be attached to each batch of events. These values are
+also templateable to allow events to provide dynamic label values. Note: If the
+set of label values has high cardinality this can cause drastic performance
+issues with Loki. To ensure this does not happen one should try to reduce the
 amount of unique label values.
 
 
@@ -659,7 +659,7 @@ fields will also get removed from the event.
 ### remove_timestamp
 
 If this is set to `true` then the timestamp will be removed from the event.
-This is useful because loki uses the timestamp to index the event.
+This is useful because Loki uses the timestamp to index the event.
 
 
 
@@ -798,7 +798,7 @@ The maximum number of retries to make for failed requests.
 #### retry_initial_backoff_secs
 
 The amount of time to wait before attempting the first retry for a failed
-request. Once, the first retry has failed the fibonacci sequence will be used
+request. Once, the first retry has failed the Fibonacci sequence will be used
 to select future backoffs.
 
 
@@ -875,7 +875,7 @@ duplicate data downstream.
 ### tenant_id
 
 The tenant id that will be sent with every request, by default this is not
-required since a proxy should set this header. When running loki locally a
+required since a proxy should set this header. When running Loki locally a
 tenant id is not required either.
 
 You can read more about tenant id's [here][urls.loki_multi_tenancy]
@@ -1080,7 +1080,7 @@ are contained and [delivery guarantees][docs.guarantees] are honored.
 ### Decentralized Deployments
 
 Loki currently does not support out-of-order inserts. If Vector is deployed in
-a decentralized setup  then there is the possiblity that logs might get
+a decentralized setup  then there is the possibility that logs might get
 rejected due to data races between Vector instances. To avoid this we suggest
 either assigning each Vector instance with a unique label or deploying a
 centralized Vector which will ensure no logs will get sent out-of-order.

--- a/website/docs/reference/sinks/loki.md.erb
+++ b/website/docs/reference/sinks/loki.md.erb
@@ -25,7 +25,7 @@
 ### Decentralized Deployments
 
 Loki currently does not support out-of-order inserts. If Vector is deployed in
-a decentralized setup  then there is the possiblity that logs might get
+a decentralized setup then there is the possibility that logs might get
 rejected due to data races between Vector instances. To avoid this we suggest
 either assigning each Vector instance with a unique label or deploying a
 centralized Vector which will ensure no logs will get sent out-of-order.

--- a/website/docs/reference/sinks/new_relic_logs.md
+++ b/website/docs/reference/sinks/new_relic_logs.md
@@ -751,7 +751,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_new_relic_logs_sink_issue].
+with the Vector team by [opening an issue][urls.new_new_relic_logs_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/sematext_logs.md
+++ b/website/docs/reference/sinks/sematext_logs.md
@@ -729,7 +729,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_sematext_logs_sink_issue].
+with the Vector team by [opening an issue][urls.new_sematext_logs_sink_issue].
 
 ### Retry Policy
 

--- a/website/docs/reference/sinks/splunk_hec.md
+++ b/website/docs/reference/sinks/splunk_hec.md
@@ -982,7 +982,7 @@ any given time.
 
 Please note, Vector's defaults are carefully chosen and it should be rare that
 you need to adjust these. If you found a good reason to do so please share it
-with the Vector team by [opening an issie][urls.new_splunk_hec_sink_issue].
+with the Vector team by [opening an issue][urls.new_splunk_hec_sink_issue].
 
 ### Retry Policy
 


### PR DESCRIPTION
Corrected what appears to be a copy-and-paste typo of "issie" instead of "issue".  And fixed minor capitalization, spelling, and whitespace with Loki sink documentation.