### PR TITLE
chore(operations): RPM for aarch64 was using armv7

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -115,7 +115,7 @@ package-rpm-armv7: build-archive-armv7
 	$(RUN) package-rpm-armv7
 
 package-rpm-aarch64: build-archive-aarch64
-	$(RUN) package-rpm-armv7
+	$(RUN) package-rpm-aarch64
 
 # verifications
 verify: verify-rpm verify-deb


### PR DESCRIPTION
Please double-check me here.  I'm still getting my head around the build process and relying on naive pattern matching at this point.