### PR TITLE
feat(cli): Add -qqq command line flag to disable logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,21 +175,24 @@ fn main() {
             2..=255 => "trace",
         },
         1 => "warn",
-        2..=255 => "error",
+        2 => "error",
+        3..=255 => "off",
     };
 
-    let levels = if let Ok(level) = std::env::var("LOG") {
-        level
-    } else {
-        [
-            format!("vector={}", level),
-            format!("codec={}", level),
-            format!("file_source={}", level),
-            format!("tower_limit=trace"),
-            format!("rdkafka={}", level),
-        ]
-        .join(",")
-        .to_string()
+    let levels = match std::env::var("LOG").ok() {
+        Some(level) => level,
+        None => match level {
+            "off" => "off".to_string(),
+            _ => [
+                format!("vector={}", level),
+                format!("codec={}", level),
+                format!("file_source={}", level),
+                format!("tower_limit=trace"),
+                format!("rdkafka={}", level),
+            ]
+            .join(",")
+            .to_string(),
+        },
     };
 
     let color = match opts.color.clone().unwrap_or(Color::Auto) {

--- a/website/docs/administration/monitoring.md.erb
+++ b/website/docs/administration/monitoring.md.erb
@@ -22,7 +22,8 @@ a variety of methods:
 | [`-vv` flag][docs.process-management#flags] | Drops the log level to `trace`. |
 | [`-q` flag][docs.process-management#flags] | Raises the log level to `warn`. |
 | [`-qq` flag][docs.process-management#flags] | Raises the log level to `error`. |
-| `LOG=<level>` env var | Set the log level. Must be one of `trace`, `debug`, `info`, `warn`, `error`. |
+| [`-qqq` flag][docs.process-management#flags] | Raises the log level to `off`. |
+| `LOG=<level>` env var | Set the log level. Must be one of `trace`, `debug`, `info`, `warn`, `error`, `off`. |
 
 ### Full Backtraces
 

--- a/website/docs/administration/process-management.md.erb
+++ b/website/docs/administration/process-management.md.erb
@@ -22,7 +22,8 @@ Vector.
 | **Optional**            |                                                                                                                     |  |
 | `-d, --dry-run`         | Vector will [validate configuration][docs.validating] and exit.                                                     |  |
 | `-q, --quiet`           | Raises the log level to `warn`.                                                                                     |  |
-| `-qq`                   | Raises the log level to `error`, the highest level possible.                                                        |  |
+| `-qq`                   | Raises the log level to `error`.                                                        |  |
+| `-qqq`                  | Raises the log level to `off`, the highest level possible. Disables logs.                                                        |  |
 | `-r, --require-healthy` | Causes vector to immediately exit if any sinks fail their healthchecks.                                             |  |
 | `-t, --threads`         | Limits the number of internal threads Vector can spawn.                                                             |  |
 | `-v, --verbose`         | Drops the log level to `debug`.                                                                                     |  |


### PR DESCRIPTION
Resolves #1742 

This PR adds an option to pass `-qqq` (with 3 or more `q`'s) via the command line to disable all logs.

This is done by passing `off` as the trace level to the `tracing` crate.

See [EnvFilter](https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/filter/struct.EnvFilter.html) and  [LevelFilter](https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/filter/struct.LevelFilter.html) to why that works.

Note: Only logs written through the tracing crate are effected. Outputs through `println!` and  `eprintln!` are not effected.

Open questions:
-  Is a change in documentation required?

This is my first code contribution to vector. Feel free to to hint me on the correct formalities regarding PRs in this project.

Signed-off-by: Felix Stegmaier <stegmaier.felix@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
