### PR TITLE
feat(platforms): Add helm chart for Vector installation

### DIFF
--- a/distribution/helm/vector/.helmignore
+++ b/distribution/helm/vector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/distribution/helm/vector/Chart.yaml
+++ b/distribution/helm/vector/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: vector
+type: application
+icon: https://vector.dev/press/vector-icon.svg
+description: A Helm chart to collect Kubernetes logs with vector
+version: 0.0.1
+appVersion: 0.8
+home: https://vector.dev/
+sources:
+  - https://github.com/timberio/vector/
+maintainers:
+  - name: Vector Contributors
+    email: vector@timber.io

--- a/distribution/helm/vector/README.md
+++ b/distribution/helm/vector/README.md
@@ -11,9 +11,9 @@
 
 This chart will do the following:
 
-* Create a ConfigMap with Vector configuration;
-* Install a Daemonset that provisions Vector;
-* Deploy service and service monitor for integration with prometheus-operator (if enabled);
+- Create a ConfigMap with Vector configuration;
+- Install a Daemonset that provisions Vector;
+- Deploy service and service monitor for integration with prometheus-operator (if enabled);
 
 ## Installing the Chart
 

--- a/distribution/helm/vector/README.md
+++ b/distribution/helm/vector/README.md
@@ -1,0 +1,158 @@
+# Vector Chart
+
+[Vector](https://vector.dev/) - a lightweight and ultra-fast tool for building observability pipelines.
+
+- [Chart Details](#chartdetails)
+- [Installing the cart](#installingthechart)
+- [Configuration](#configuration)
+- [Examples](#examples)
+
+## Chart Details
+
+This chart will do the following:
+
+* Create a ConfigMap with Vector configuration;
+* Install a Daemonset that provisions Vector;
+* Deploy service and service monitor for integration with prometheus-operator (if enabled);
+
+## Installing the Chart
+
+To install the chart with the release name `vector` and namespace `logging`:
+
+### Helm 2
+
+```bash
+$ cd distribution/helm/vector
+$ helm install --namespace logging --name vector .
+```
+
+### Helm 3
+
+```bash
+$ cd distribution/helm/vector
+$ helm install --namespace logging vector .
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Vector chart and the default values.
+
+| Parameter                     | Description                        | Default                 |
+| ----------------------------- | ---------------------------------- | ----------------------- |
+| **General**                   |
+| `image.repository`            | Image                              | `timberio/vector`       |
+| `image.tag`                   | Image tag                          | `0.8.X-debian`          |
+| `image.pullPolicy`            | Image pull policy                  | `Always`                |
+| `image.pullSecrets`           | Image pull secrets                 | `nil`                   |
+| `updateStrategy`              | DaemonSet update strategy          | `RollingUpdate`         |
+| `metrics.enabled`                         | Specifies whether a service for metrics should be exposed                            | `true`      |
+| `metrics.service.type`                    | Metrics service type                                                                 | `ClusterIP` |
+| `metrics.service.port`                    | Metrics service port                                                                 | `2020`      |
+| `metrics.service.annotations`             | Optional metrics service annotations                                                 | `nil`       |
+| `metrics.service.labels`                  | Additional labels for the metrics service definition, specified as a map.            | `nil`       |
+| `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator.                 | `true`      |
+| `metrics.serviceMonitor.endpoint`         | Endpoint to be used by Prometheus to scrape metrics.                                 | `true`      |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used for ServiceMonitor discovery by Prometheus.       | `nil`       |
+| `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonito (default: current namespace).    | `nil`       |
+| `metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used.         | `60s`       |
+| `metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used.           | `10s`       |
+| `rbac.enabled`                      | Specifies whether RBAC should be enabled.                                                    | `true`    |
+| `rbac.apiVersion`                   | Overrides K8S API version for RBAC (by default it's determined using `Capabilities`)         | `nil`     |
+| `rbac.serviceAccount.name`          | Overrides service acount name, if not provided and RBAC is disabled, `default` will be used. | `nil`     |
+| `rbac.serviceAccount.annotations`   | Additional annotation for the created service account.                                       | `{}`      |
+| `rbac.psp.enabled`                  | Specifies whether a PodSecurityPolicy should be created.                                     | `false`   |
+| `rbac.apiVersion`                   | Overrides K8S API version for PSP (by default it's determined using `Capabilities`).         | `nil`     |
+| `env`                    | A list of environment variables to be used for the DaemonSet.  | `[]` |
+| `resources`              | Pod resource requests & limits.                                | `{}` |
+| `tolerations`            | Optional daemonset tolerations.                                | `[]` |
+| `nodeSelector`           | Node labels for pod assignment.                                | `{}` |
+| `affinity`               | Expressions for affinity.                                      | `{}` |
+| `extraVolumes`           | Extra volumes to be assignet to pods.                          | `{}` |
+| `extraVolumeMounts`      | Extra volume mounts for the vector container.                  | `{}` |
+| **ConfigMap**            |
+| `existingConfigMap`           | Name of the exising configmap to be used for Vector configuration. | `nil` |
+| `globalOptions.dataDir`       | Vector's data directory.                | `/var/tmp/vector` |
+| `logSchema.hostKey`           | Log host field.                         | `host`            |
+| `logSchema.messageKey`        | Log message field.                      | `log`             |
+| `logSchema.timestampKey`      | Log generation timestamp field.         | `time`            |
+| `sources.kubernetes.enabled`                | Enables Kubernetes source.                      | `true`       |
+| `sources.kubernetes.sourceId`               | Kubernetes source ID.                           | `kubernetes` |
+| `sources.kubernetes.includeNamespaces`      | A list of namespaces to collect logs from.      | `[]`         |
+| `sources.kubernetes.includeContainerNames`  | A list of container names to collect logs from. | `[]`         |
+| `sources.kubernetes.rawConfig`              | Raw config to be used for the source.           | `nil`        |
+| `sources.additionalSources`                 | An object of additional sources. Key will be used as source ID. | `{}`         |
+| `sources.additionalSources.type`            | Source type.                                                    |              |
+| `sources.additionalSources.rawConfig`       | Raw config to be used for the additional source.                | `nil`        |
+| `transforms`                 | An object of transforms. Key will be used as transform ID. | `{}`  |
+| `transforms.type`            | Tranform type.                                             |       |
+| `transforms.inputs`          | A list of transfor data sources.                           |       |
+| `transforms.rawConfig`       | Raw config to be used for the transform.                   | `nil` |
+| `sinks`                      | An object of sinks. Entry key will be used as sink ID.     | `{}`  |
+| `sinks.type`                 | Sink type.                                                 |       |
+| `sinks.inputs`               | A list of sink data sources.                               |       |
+| `sinks.rawConfig`            | Raw config to be used for the sink.                        | `nil` |
+
+
+## Examples
+
+Here are some snippets for Vector configuration.
+
+### Overriding Kubernetes source namespaces
+
+Whitelisted namespaces (or other options) can be set for the `kubernetes` source,
+just by overriding `sources.kubernetes` options.
+
+```yaml
+sources:
+  kubernetes:
+    includeNamespaces:
+      - default
+```
+
+### Using transforms
+
+```yaml
+transforms:
+  envTagging:
+    type: add_fields
+    inputs:
+      - kubernetes
+    rawConfig: |
+      [transforms.envTagging.fields]
+        env = "dev"
+
+  jsonParser:
+    type: json_parser
+    inputs:
+      - envTagging
+    rawConfig: |
+      field = "message"
+      drop_field = true
+      drop_invalid = false
+```
+
+### Using Splunk sink
+
+In this example the Splunk HEC sink uses token from env variable (referenced from K8S secret).
+
+```yaml
+env:
+  - name: SPLUNK_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: vector-credentials
+        key: SPLUNK_TOKEN
+
+sinks:
+  splunk:
+    type: splunk_hec
+    inputs:
+      - jsonParser
+    rawConfig: |
+      host = "https://splunk-endpoint.net"
+      token = "${SPLUNK_TOKEN}"
+      encoding = "json"
+      healthcheck = true
+      indexed_fields = ["env", "pod_name", "pod_namespace", "container_name"]
+
+```

--- a/distribution/helm/vector/templates/_helpers.tpl
+++ b/distribution/helm/vector/templates/_helpers.tpl
@@ -1,0 +1,98 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "vector.labels" -}}
+helm.sh/chart: {{ include "vector.chart" . }}
+{{ include "vector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vector.serviceAccountName" -}}
+{{- if .Values.rbac.enabled -}}
+    {{ default (include "vector.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.rbac.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define apiVersion for RBAC APIs, depending on availability.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define apiVersion for PSP APIs, depending on availability.
+*/}}
+{{- define "psp.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+policy/v1
+{{- else if .Capabilities.APIVersions.Has "policy/v1beta1" -}}
+policy/v1beta1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the name of the configmap
+*/}}
+{{- define "vector.configMapName" -}}
+{{- if (empty .Values.existingConfigMap) -}}
+{{- include "vector.fullname" . -}}
+{{- else -}}
+{{- .Values.existingConfigMap -}}
+{{- end -}}
+{{- end -}}

--- a/distribution/helm/vector/templates/configmap.yaml
+++ b/distribution/helm/vector/templates/configmap.yaml
@@ -1,0 +1,60 @@
+{{- if (empty .Values.existingConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vector.configMapName" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+data:
+  vector.toml: |
+    data_dir = "{{ .Values.globalOptions.dataDir }}"
+
+    {{- if .Values.logSchema }}
+    [log_schema]
+      host_key = "{{ .Values.logSchema.hostKey }}"
+      message_key = "{{ .Values.logSchema.messageKey }}"
+      timestamp_key = "{{ .Values.logSchema.timestampKey }}"
+    {{- end }}
+
+    {{- if .Values.sources.kubernetes.enabled }}
+    [sources.{{ .Values.sources.kubernetes.sourceId }}]
+      type = "kubernetes"
+      include_namespaces = {{ .Values.sources.kubernetes.includeNamespaces | toJson }}
+      include_container_names = {{ .Values.sources.kubernetes.includeContainerNames | toJson }}
+
+      {{- if not (empty .Values.sources.kubernetes.rawConfig) }}
+      {{- .Values.sources.kubernetes.rawConfig | nindent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $sourceId, $source := .Values.sources.additionalSources }}
+    [sources.{{ $sourceId }}]
+      type = "{{ $source.type }}"
+
+      {{- if not (empty $source.rawConfig )}}
+      {{- $source.rawConfig | nindent 6}}
+      {{- end }}
+    {{- end }}
+
+    {{- range $transformId, $transform := .Values.transforms }}
+    [transforms.{{ $transformId }}]
+      type = "{{ $transform.type }}"
+      inputs = {{ $transform.inputs | toJson }}
+
+      {{- if not (empty $transform.rawConfig )}}
+      {{- $transform.rawConfig | nindent 6}}
+      {{- end }}
+    {{- end }}
+
+    {{- range $sinkId, $sink := .Values.sinks }}
+    [sinks.{{ $sinkId }}]
+      type = "{{ $sink.type }}"
+      inputs = {{ $sink.inputs | toJson }}
+
+      {{- if not (empty $sink.rawConfig )}}
+      {{- $sink.rawConfig | nindent 6}}
+      {{- end }}
+    {{- end }}
+
+
+{{- end }}

--- a/distribution/helm/vector/templates/daemonset.yaml
+++ b/distribution/helm/vector/templates/daemonset.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vector.selectorLabels" . | nindent 6 }}
+  minReadySeconds: 1
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+      labels:
+        {{- include "vector.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: vector
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          args:
+            - "-w"
+            {{- if .Values.metrics.enabled }}
+            - "-m"
+            - "0.0.0.0:{{ .Values.metrics.service.port }}"
+            {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.service.port }}
+              protocol: TCP
+          {{- end }}
+          volumeMounts:
+            - name: var-log
+              mountPath: /var/log/
+              readOnly: true
+            - name: var-lib
+              mountPath: /var/lib
+              readOnly: true
+            - name: data-dir
+              mountPath: "{{ .Values.globalOptions.dataDir }}"
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: var-log
+          hostPath:
+            path: /var/log/
+        - name: var-lib
+          hostPath:
+            path: /var/lib/
+        - name: data-dir
+          emptyDir: {}
+        - name: config-dir
+          configMap:
+            name: {{ include "vector.configMapName" . }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/distribution/helm/vector/templates/rbac.yaml
+++ b/distribution/helm/vector/templates/rbac.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vector.serviceAccountName" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+  {{- with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: {{ default (include "rbac.apiVersion" .) .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ template "vector.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+{{- if .Values.rbac.psp.enabled }}
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "vector.fullname" . }}
+    verbs:
+      - use
+{{- end }}
+---
+apiVersion: {{ default (include "rbac.apiVersion" .) .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "vector.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- if .Values.rbac.psp.enabled }}
+apiVersion: {{ default (include "psp.apiVersion" .) .Values.rbac.psp.apiVersion }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "vector.fullname" . }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'hostPath'
+    - 'configMap'
+    - 'secret'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+      readOnly: true
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+    {{- range .Values.extraVolumes }}
+    {{- if .hostPath }}
+    - pathPrefix: {{ .hostPath.path }}
+    {{- end }}
+    {{- end }}
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector/templates/service.yaml
+++ b/distribution/helm/vector/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml .Values.metrics.service.annotations | nindent 4 }}
+  {{- end }}
+  name: {{ template "vector.fullname" . }}-metrics
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+    {{- if .Values.metrics.service.additionalLabels }}
+    {{ toYaml .Values.metrics.service.additionalLabels }}
+    {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type}}
+  ports:
+  - port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+    name: metrics
+  selector:
+    {{- include "vector.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/distribution/helm/vector/templates/servicemonitor.yaml
+++ b/distribution/helm/vector/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vector.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: {{ .Values.metrics.serviceMonitor.endpoint }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "vector.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -1,0 +1,62 @@
+image:
+  repository: timberio/vector
+  tag: 0.8.X-debian
+  pullPolicy: Always
+
+updateStrategy: RollingUpdate
+
+metrics:
+  enabled: false
+  service:
+    port: 2020
+    type: ClusterIP
+    annotations: {}
+    additionalLabels: {}
+  serviceMonitor:
+    enabled: false
+    endpoint: /
+    additionalLabels: {}
+    interval: 60s
+    scrapeTimeout: 10s
+
+rbac:
+  enabled: true
+  serviceAccount:
+    annotation: {}
+    name:
+  psp:
+    enabled: false
+
+env: []
+
+tolerations: []
+nodeSelector: {}
+affinity: {}
+resources: {}
+
+extraVolumes: []
+
+extraVolumeMounts: []
+
+existingConfigMap: ""
+
+globalOptions:
+  dataDir: "/var/tmp/vector"
+
+logSchema:
+  hostKey: "host"
+  messageKey: "message"
+  timestampKey: "timestamp"
+
+sources:
+  kubernetes:
+    enabled: true
+    sourceId: kubernetes
+    includeNamespaces: []
+    includeContainerNames: []
+
+  additionalSources: {}
+
+transforms: {}
+
+sinks: {}


### PR DESCRIPTION
This PR adds a helm chart for Vector installation in a K8S cluster.
It's inspired from other similar community helm charts and some ideas are taken from #1900 

IMO a community helm chart must support 2 major use cases:
- It should have quite reasonable defaults and allow flexible configuration via `--set` arguments (or a values file);
- It should allow providing entirely custom configuration (e.g. a configmap created separately of this helm chart) - thus allowing such patterns as "umbrella" deployment with highly specific configuration;

This is why in this helm chart the only source enabled by default (and exposed as separate entity in the `sources` object) is the `kubernetes` source. All other components can be easily configuring without coupling helm chart to some specific transforms/sinks.