### PR TITLE
chore(operations): Don't use `buildx` plugin by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -537,6 +537,7 @@ jobs:
       - *restore-artifacts-from-workspace
       - run:
           name: Build & verify Docker
+          environment: "linux/amd64,linux/arm64,linux/arm"
           command: |
             ./scripts/upgrade-docker.sh
             export VERSION=$(make version)


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/2235.

This PR makes it possible to build Docker images for the host platform without using `buildx` plugin, while still building multi-arch images using `buildx` in CI.

By default only images for the host platform are built, enabling specific platforms is possible by setting `PLATFORM` environment variable.

Now the steps to build Docker images on a fresh clone of the Vector's repository are the following:

```sh
PASS_TARGET=x86_64-unknown-linux-musl PASS_FEATURES=default-musl ./scripts/docker-run.sh builder-x86_64-unknown-linux-musl make build-archive package-deb
make build-docker
```