### PR TITLE
docs(gcp_cloud_storage sink): Document default value for `acl`

### DIFF
--- a/.meta/sinks/gcp_cloud_storage.toml
+++ b/.meta/sinks/gcp_cloud_storage.toml
@@ -68,6 +68,7 @@ category = "Object Attributes"
 common = false
 required = false
 description = "Predefined ACL to apply to the created objects. For more information, see [Predefined ACLs][urls.gcs_predefined_acl]."
+default = "projectPrivate"
 
 [sinks.gcp_cloud_storage.options.acl.enum]
 authenticatedRead = "Gives the bucket or object owner OWNER permission, and gives all authenticated Google account holders READER permission."

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -5089,7 +5089,7 @@ require('custom_module')
   # Predefined ACLs.
   #
   # * optional
-  # * no default
+  # * default: "projectPrivate"
   # * type: string
   # * enum: "authenticatedRead", "bucketOwnerFullControl", "bucketOwnerRead", "private", "projectPrivate", and "publicRead"
   acl = "authenticatedRead"

--- a/website/docs/reference/sinks/gcp_cloud_storage.md
+++ b/website/docs/reference/sinks/gcp_cloud_storage.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-04-06"
+last_modified_on: "2020-04-07"
 delivery_guarantee: "at_least_once"
 component_title: "GCP Cloud Storage (GCS)"
 description: "The Vector `gcp_cloud_storage` sink batches `log` events to Google Cloud Platform's Cloud Storage service via the XML Interface."
@@ -91,7 +91,7 @@ the [XML Interface](https://cloud.google.com/storage/docs/xml-api/overview).
   encoding.timestamp_format = "rfc3339" # optional, default
 
   # Object Attributes
-  acl = "authenticatedRead" # optional, no default
+  acl = "projectPrivate" # optional, default
   metadata.Key1 = "Value1" # example
   storage_class = "STANDARD" # optional, no default
 
@@ -541,7 +541,7 @@ Enables/disables the sink healthcheck upon start.
 </Field>
 <Field
   common={false}
-  defaultValue={null}
+  defaultValue={"projectPrivate"}
   enumValues={{"authenticatedRead":"Gives the bucket or object owner OWNER permission, and gives all authenticated Google account holders READER permission.","bucketOwnerFullControl":"Gives the object and bucket owners OWNER permission.","bucketOwnerRead":"Gives the object owner OWNER permission, and gives the bucket owner READER permission.","private":"Gives the bucket or object owner OWNER permission for a bucket or object.","projectPrivate":"Gives permission to the project team based on their roles. Anyone who is part of the team has READER permission. Project owners and project editors have OWNER permission. This the default.","publicRead":"Gives the bucket or object owner OWNER permission, and gives all users, both authenticated and anonymous, READER permission. When you apply this to an object, anyone on the Internet can read the object without authenticating."}}
   examples={["authenticatedRead","bucketOwnerFullControl","bucketOwnerRead","private","projectPrivate","publicRead"]}
   groups={[]}


### PR DESCRIPTION
The [`acl`](https://vector.dev/docs/reference/sinks/gcp_cloud_storage/#acl) configuration option is documented to have no default value. However, in fact Vector sends `projectPrivate` ACL by default.

This PR updates the documentation to make it the actual behavior.