### PR TITLE
fix(gcp_cloud_storage sink): Use kebab case for ACL encoding

### DIFF
--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -94,7 +94,7 @@ fn default_config(e: Encoding) -> GcsSinkConfig {
 
 #[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 enum GcsPredefinedAcl {
     AuthenticatedRead,
     BucketOwnerFullControl,


### PR DESCRIPTION
@alathon pointed out in the chat that GCS XML API, unlike the JSON one, uses kebab case instead of camel case.

This PR adds that change, although I haven't tested it myself.