### PR TITLE
chore(file source): Wire `ShutdownSignal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,13 +951,13 @@ dependencies = [
  "crc",
  "flate2",
  "futures 0.3.4",
- "futures-timer 3.0.2",
  "glob 0.2.11",
  "indexmap",
  "libc",
  "quickcheck",
  "scan_fmt",
  "tempfile",
+ "tokio 0.2.13",
  "tracing",
  "winapi 0.3.8",
 ]
@@ -1156,12 +1156,6 @@ checksum = "a5cedfe9b6dc756220782cc1ba5bcb1fa091cdcba155e40d3556159c3db58043"
 dependencies = [
  "futures 0.1.29",
 ]
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -2663,7 +2657,7 @@ dependencies = [
  "chrono",
  "crc",
  "futures 0.1.29",
- "futures-timer 0.1.1",
+ "futures-timer",
  "log",
  "nom 5.1.0",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "crc",
  "flate2",
  "futures 0.3.4",
+ "futures-timer 3.0.2",
  "glob 0.2.11",
  "indexmap",
  "libc",
@@ -1155,6 +1156,12 @@ checksum = "a5cedfe9b6dc756220782cc1ba5bcb1fa091cdcba155e40d3556159c3db58043"
 dependencies = [
  "futures 0.1.29",
 ]
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -2656,7 +2663,7 @@ dependencies = [
  "chrono",
  "crc",
  "futures 0.1.29",
- "futures-timer",
+ "futures-timer 0.1.1",
  "log",
  "nom 5.1.0",
  "prost",

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = {version = "1.0.2", features = ["serde-1"]}
 flate2 = "1.0.6"
 winapi = { version = "0.3", features = ["winioctl"] }
 libc =  "0.2"
-futures-timer = "3.0.2"
+tokio = { version = "0.2.13", features = ["time"] }
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -16,6 +16,7 @@ indexmap = {version = "1.0.2", features = ["serde-1"]}
 flate2 = "1.0.6"
 winapi = { version = "0.3", features = ["winioctl"] }
 libc =  "0.2"
+futures-timer = "3.0.2"
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -7,7 +7,6 @@ use futures::{
     stream::StreamExt,
     Future, Sink,
 };
-use futures_timer::Delay;
 use glob::{glob, Pattern};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
@@ -15,6 +14,7 @@ use std::fs::{self, File};
 use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time;
+use tokio::time::delay_for;
 use tracing::field;
 
 use crate::metadata_ext::PortableFileExt;
@@ -290,7 +290,7 @@ impl FileServer {
 
             match block_on(select(
                 shutdown,
-                Delay::new(time::Duration::from_millis(backoff as u64)),
+                delay_for(time::Duration::from_millis(backoff as u64)),
             )) {
                 Either::Left((_, _)) => return,
                 Either::Right((_, future)) => shutdown = future,

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -288,6 +288,11 @@ impl FileServer {
             }
             let backoff = backoff_cap.saturating_sub(global_bytes_read);
 
+            // This works only if run inside tokio context since we are using
+            // tokio's Timer. Outside of such context, this will panic on the first
+            // call. Also since we are using block_on here and in the above code,
+            // this should be run in it's own thread. `spawn_blocking` fulfills
+            // all of these requirements.
             match block_on(select(
                 shutdown,
                 delay_for(time::Duration::from_millis(backoff as u64)),

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -6,7 +6,10 @@ use crate::{
 };
 use bytes::Bytes;
 use file_source::{FileServer, Fingerprinter};
-use futures::compat::{Compat01As03Sink, Future01CompatExt};
+use futures::{
+    compat::{Compat01As03Sink, Future01CompatExt},
+    future::{FutureExt, TryFutureExt},
+};
 use futures01::{future, sync::mpsc, Future, Sink, Stream};
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
@@ -14,7 +17,6 @@ use snafu::{ResultExt, Snafu};
 use std::convert::{TryFrom, TryInto};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
-use stream_cancel::Tripwire;
 use tokio::task::spawn_blocking;
 
 mod line_agg;
@@ -298,18 +300,17 @@ pub fn file_source(
                 .instrument(span),
         );
 
-        let (trigger_source, tripwire_server) = Tripwire::new();
         let span = info_span!("file_server");
-        let _ = spawn_blocking(move || {
+        spawn_blocking(move || {
             let _enter = span.enter();
             file_server.run(
                 Compat01As03Sink::new(tx.sink_map_err(drop)),
-                tripwire_server.compat(),
+                shutdown.compat(),
             );
-        });
-
-        // Once shutdown happens or is dropped, file server will be tripped.
-        shutdown.map(|_| drop(trigger_source))
+        })
+        .boxed()
+        .compat()
+        .map_err(|error| error!(message="File server unexpectedly stopped.",%error))
     }))
 }
 
@@ -350,7 +351,7 @@ mod tests {
         fs::{self, File},
         io::{Seek, Write},
     };
-    use stream_cancel::Tripwire;
+    use stream_cancel::{Trigger, Tripwire};
     use tempfile::tempdir;
     use tokio01::util::FutureExt;
 
@@ -382,6 +383,13 @@ mod tests {
 
     fn sleep() {
         std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    fn shutdown() -> (Trigger, ShutdownSignal, Tripwire) {
+        let (trigger_shutdown, tripwire) = Tripwire::new();
+        let (trigger, shutdown_done) = Tripwire::new();
+        let shutdown = ShutdownSignal::new(tripwire, trigger);
+        (trigger_shutdown, shutdown, shutdown_done)
     }
 
     #[test]
@@ -470,7 +478,7 @@ mod tests {
     fn file_happy_path() {
         let n = 5;
         let (tx, rx) = futures01::sync::mpsc::channel(2 * n);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -478,16 +486,11 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path1 = dir.path().join("file1");
         let path2 = dir.path().join("file2");
@@ -503,7 +506,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(rx.collect());
@@ -537,23 +540,18 @@ mod tests {
     fn file_truncate() {
         let n = 5;
         let (tx, rx) = futures01::sync::mpsc::channel(2 * n);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             ..test_default_file_config(&dir)
         };
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path = dir.path().join("file");
         let mut file = File::create(&path).unwrap();
@@ -577,7 +575,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(rx.collect());
@@ -611,23 +609,18 @@ mod tests {
     fn file_rotate() {
         let n = 5;
         let (tx, rx) = futures01::sync::mpsc::channel(2 * n);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             ..test_default_file_config(&dir)
         };
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path = dir.path().join("file");
         let archive_path = dir.path().join("file");
@@ -652,7 +645,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(rx.collect());
@@ -686,7 +679,7 @@ mod tests {
     fn file_multiple_paths() {
         let n = 5;
         let (tx, rx) = futures01::sync::mpsc::channel(4 * n);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -695,16 +688,11 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path1 = dir.path().join("a.txt");
         let path2 = dir.path().join("b.txt");
@@ -726,7 +714,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(rx.collect());
@@ -751,10 +739,10 @@ mod tests {
     fn file_file_key() {
         let mut rt = runtime::Runtime::new().unwrap();
 
-        let (trigger, tripwire) = Tripwire::new();
-
         // Default
         {
+            let (trigger_shutdown, shutdown, shutdown_done) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let dir = tempdir().unwrap();
             let config = file::FileConfig {
@@ -762,14 +750,9 @@ mod tests {
                 ..test_default_file_config(&dir)
             };
 
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-            rt.spawn(source.select(tripwire.clone()).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             let path = dir.path().join("file");
             let mut file = File::create(&path).unwrap();
@@ -779,6 +762,9 @@ mod tests {
             writeln!(&mut file, "hello there").unwrap();
 
             sleep();
+
+            drop(trigger_shutdown);
+            let _ = rt.block_on(shutdown_done);
 
             let received = wait_with_timeout(rx.into_future()).0.unwrap();
             assert_eq!(
@@ -789,6 +775,8 @@ mod tests {
 
         // Custom
         {
+            let (trigger_shutdown, shutdown, shutdown_done) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let dir = tempdir().unwrap();
             let config = file::FileConfig {
@@ -797,14 +785,9 @@ mod tests {
                 ..test_default_file_config(&dir)
             };
 
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-            rt.spawn(source.select(tripwire.clone()).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             let path = dir.path().join("file");
             let mut file = File::create(&path).unwrap();
@@ -814,6 +797,9 @@ mod tests {
             writeln!(&mut file, "hello there").unwrap();
 
             sleep();
+
+            drop(trigger_shutdown);
+            let _ = rt.block_on(shutdown_done);
 
             let received = wait_with_timeout(rx.into_future()).0.unwrap();
             assert_eq!(
@@ -824,6 +810,8 @@ mod tests {
 
         // Hidden
         {
+            let (trigger_shutdown, shutdown, shutdown_done) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let dir = tempdir().unwrap();
             let config = file::FileConfig {
@@ -832,14 +820,9 @@ mod tests {
                 ..test_default_file_config(&dir)
             };
 
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-            rt.spawn(source.select(tripwire.clone()).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             let path = dir.path().join("file");
             let mut file = File::create(&path).unwrap();
@@ -849,6 +832,9 @@ mod tests {
             writeln!(&mut file, "hello there").unwrap();
 
             sleep();
+
+            drop(trigger_shutdown);
+            let _ = rt.block_on(shutdown_done);
 
             let received = wait_with_timeout(rx.into_future()).0.unwrap();
             assert_eq!(
@@ -863,7 +849,6 @@ mod tests {
             );
         }
 
-        drop(trigger);
         shutdown_on_idle(rt);
     }
 
@@ -882,22 +867,18 @@ mod tests {
 
         // First time server runs it picks up existing lines.
         {
+            let (trigger_shutdown, shutdown, _) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
             let mut rt = runtime::Runtime::new().unwrap();
-            let (trigger, tripwire) = Tripwire::new();
-            rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             sleep();
             writeln!(&mut file, "first line").unwrap();
             sleep();
 
-            drop(trigger);
+            drop(trigger_shutdown);
             shutdown_on_idle(rt);
 
             let received = wait_with_timeout(rx.collect());
@@ -909,22 +890,18 @@ mod tests {
         }
         // Restart server, read file from checkpoint.
         {
+            let (trigger_shutdown, shutdown, _) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
             let mut rt = runtime::Runtime::new().unwrap();
-            let (trigger, tripwire) = Tripwire::new();
-            rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             sleep();
             writeln!(&mut file, "second line").unwrap();
             sleep();
 
-            drop(trigger);
+            drop(trigger_shutdown);
             shutdown_on_idle(rt);
 
             let received = wait_with_timeout(rx.collect());
@@ -936,27 +913,23 @@ mod tests {
         }
         // Restart server, read files from beginning.
         {
+            let (trigger_shutdown, shutdown, _) = shutdown();
+
             let config = file::FileConfig {
                 include: vec![dir.path().join("*")],
                 start_at_beginning: true,
                 ..test_default_file_config(&dir)
             };
             let (tx, rx) = futures01::sync::mpsc::channel(10);
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
             let mut rt = runtime::Runtime::new().unwrap();
-            let (trigger, tripwire) = Tripwire::new();
-            rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             sleep();
             writeln!(&mut file, "third line").unwrap();
             sleep();
 
-            drop(trigger);
+            drop(trigger_shutdown);
             shutdown_on_idle(rt);
 
             let received = wait_with_timeout(rx.collect());
@@ -982,23 +955,19 @@ mod tests {
         let path_for_old_file = dir.path().join("file.old");
         // Run server first time, collect some lines.
         {
+            let (trigger_shutdown, shutdown, _) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
             let mut rt = runtime::Runtime::new().unwrap();
-            let (trigger, tripwire) = Tripwire::new();
-            rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             let mut file = File::create(&path).unwrap();
             sleep();
             writeln!(&mut file, "first line").unwrap();
             sleep();
 
-            drop(trigger);
+            drop(trigger_shutdown);
             shutdown_on_idle(rt);
 
             let received = wait_with_timeout(rx.collect());
@@ -1013,23 +982,19 @@ mod tests {
         // Restart the server and make sure it does not re-read the old file
         // even though it has a new name.
         {
+            let (trigger_shutdown, shutdown, _) = shutdown();
+
             let (tx, rx) = futures01::sync::mpsc::channel(10);
-            let source = file::file_source(
-                &config,
-                config.data_dir.clone().unwrap(),
-                ShutdownSignal::noop(),
-                tx,
-            );
+            let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
             let mut rt = runtime::Runtime::new().unwrap();
-            let (trigger, tripwire) = Tripwire::new();
-            rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+            rt.spawn(source);
 
             let mut file = File::create(&path).unwrap();
             sleep();
             writeln!(&mut file, "second line").unwrap();
             sleep();
 
-            drop(trigger);
+            drop(trigger_shutdown);
             shutdown_on_idle(rt);
 
             let received = wait_with_timeout(rx.collect());
@@ -1049,7 +1014,7 @@ mod tests {
 
         let mut rt = runtime::Runtime::new().unwrap();
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
@@ -1058,14 +1023,9 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let before_path = dir.path().join("before");
         let mut before_file = File::create(&before_path).unwrap();
@@ -1110,7 +1070,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(rx.collect());
@@ -1139,7 +1099,7 @@ mod tests {
     #[test]
     fn file_max_line_bytes() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1148,16 +1108,11 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path = dir.path().join("file");
         let mut file = File::create(&path).unwrap();
@@ -1181,7 +1136,7 @@ mod tests {
         sleep();
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(
@@ -1204,7 +1159,7 @@ mod tests {
     #[test]
     fn test_multi_line_aggregation_legacy() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1214,16 +1169,11 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path = dir.path().join("file");
         let mut file = File::create(&path).unwrap();
@@ -1250,7 +1200,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(
@@ -1282,7 +1232,7 @@ mod tests {
     #[test]
     fn test_multi_line_aggregation() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1296,16 +1246,11 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
         let mut rt = runtime::Runtime::new().unwrap();
 
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         let path = dir.path().join("file");
         let mut file = File::create(&path).unwrap();
@@ -1332,7 +1277,7 @@ mod tests {
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(
@@ -1364,7 +1309,7 @@ mod tests {
     #[test]
     fn test_fair_reads() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1393,18 +1338,13 @@ mod tests {
 
         sleep();
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
         let mut rt = runtime::Runtime::new().unwrap();
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(
@@ -1434,7 +1374,7 @@ mod tests {
     #[test]
     fn test_oldest_first() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1463,18 +1403,13 @@ mod tests {
 
         sleep();
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
         let mut rt = runtime::Runtime::new().unwrap();
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(
@@ -1504,7 +1439,7 @@ mod tests {
     #[test]
     fn test_gzipped_file() {
         let (tx, rx) = futures01::sync::mpsc::channel(10);
-        let (trigger, tripwire) = Tripwire::new();
+        let (trigger_shutdown, shutdown, _) = shutdown();
 
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1512,18 +1447,13 @@ mod tests {
             ..test_default_file_config(&dir)
         };
 
-        let source = file::file_source(
-            &config,
-            config.data_dir.clone().unwrap(),
-            ShutdownSignal::noop(),
-            tx,
-        );
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
         let mut rt = runtime::Runtime::new().unwrap();
-        rt.spawn(source.select(tripwire).map(|_| ()).map_err(|_| ()));
+        rt.spawn(source);
 
         sleep();
 
-        drop(trigger);
+        drop(trigger_shutdown);
         shutdown_on_idle(rt);
 
         let received = wait_with_timeout(

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::convert::{TryFrom, TryInto};
 use std::path::PathBuf;
-use std::thread;
 use std::time::{Duration, SystemTime};
 use stream_cancel::Tripwire;
+use tokio::task::spawn_blocking;
 
 mod line_agg;
 use line_agg::LineAgg;
@@ -300,7 +300,7 @@ pub fn file_source(
 
         let (trigger_source, tripwire_server) = Tripwire::new();
         let span = info_span!("file_server");
-        thread::spawn(move || {
+        let _ = spawn_blocking(move || {
             let _enter = span.enter();
             file_server.run(
                 Compat01As03Sink::new(tx.sink_map_err(drop)),

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -389,6 +389,7 @@ mod tests {
         let (trigger_shutdown, tripwire) = Tripwire::new();
         let (trigger, shutdown_done) = Tripwire::new();
         let shutdown = ShutdownSignal::new(tripwire, trigger);
+
         (trigger_shutdown, shutdown, shutdown_done)
     }
 


### PR DESCRIPTION
ref #2108.

- [x] Is there some nicer way in covering all possible ways of shutdown?

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
