### PR TITLE
chore(website): Use cat with heredoc instead of echo and quotes

### DIFF
--- a/website/src/components/ConfigExample/index.js
+++ b/website/src/components/ConfigExample/index.js
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 function Command({format, path, source, sink}) {
-  let command = `echo '\n${source.config_examples.toml}\n\n${sink.config_examples.toml}\n' > ${path}`;
+  let command = `cat <<-VECTORCFG > ${path}\n${source.config_examples.toml}\n\n${sink.config_examples.toml}\nVECTORCFG'`;
 
   return (
     <>


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

Switches from

```shell
echo '
qwerty
'  > config\vector.toml
```
to

```shell
cat <<-VECTORCFG > config\vector.toml
qwerty
VECTORCFG  
```

The benefit is there's no need to escape quotes anymore.