### PR TITLE
chore: Make `RuntimeTransform` trait available for all transforms

### DIFF
--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -1,13 +1,14 @@
 mod interop;
-mod scripted_transform;
 
 use crate::{
     config_paths::CONFIG_PATHS,
     event::Event,
     topology::config::{DataType, TransformContext},
-    transforms::Transform,
+    transforms::{
+        util::runtime_transform::{RuntimeTransform, Timer},
+        Transform,
+    },
 };
-use scripted_transform::{ScriptedRuntime, Timer};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::path::PathBuf;
@@ -239,7 +240,7 @@ where
     })
 }
 
-impl ScriptedRuntime for Lua {
+impl RuntimeTransform for Lua {
     fn hook_process<F>(self: &mut Self, event: Event, emit_fn: F)
     where
         F: FnMut(Event) -> (),

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -1,6 +1,8 @@
 use crate::Event;
 use snafu::Snafu;
 
+mod util;
+
 #[cfg(feature = "transforms-add_fields")]
 pub mod add_fields;
 #[cfg(feature = "transforms-add_tags")]

--- a/src/transforms/util/mod.rs
+++ b/src/transforms/util/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(any(feature = "transforms-lua"))]
+pub mod runtime_transform;

--- a/src/transforms/util/runtime_transform.rs
+++ b/src/transforms/util/runtime_transform.rs
@@ -11,8 +11,8 @@ pub struct Timer {
 }
 
 /// A trait representing a runtime running user-defined code.
-pub trait ScriptedRuntime {
-    /// Call user-defind "init" hook.
+pub trait RuntimeTransform {
+    /// Call user-defined "init" hook.
     fn hook_init<F>(&mut self, _emit_fn: F)
     where
         F: FnMut(Event) -> (),
@@ -52,9 +52,9 @@ enum Message {
     Timer(Timer),
 }
 
-impl<Runtime> Transform for Runtime
+impl<T> Transform for T
 where
-    Runtime: ScriptedRuntime + Send,
+    T: RuntimeTransform + Send,
 {
     // used only in config tests (cannot be put behind `#[cfg(test)`])
     fn transform(&mut self, event: Event) -> Option<Event> {


### PR DESCRIPTION
This is an internal change extracting the trait used to define scripted transforms from `lua` module to the `transforms` module. It makes it possible to reuse it in other transforms.