### PR TITLE
enhancement(cli): Show possible values for --log-format --color and list --format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f62a139c59ae846c3964c392f12aac68f1997d1a40e9d3b40a89a4ab553e04a0"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error 0.4.9",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "syn 1.0.14",
@@ -2616,11 +2616,24 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 0.4.9",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "rustversion",
  "syn 1.0.14",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+dependencies = [
+ "proc-macro-error-attr 1.0.2",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -2634,6 +2647,19 @@ dependencies = [
  "rustversion",
  "syn 1.0.14",
  "syn-mid",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
+ "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -3824,24 +3850,26 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.2.18"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
 dependencies = [
  "clap",
+ "lazy_static",
  "structopt-derive",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.2.18"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
 dependencies = [
  "heck",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro-error 1.0.2",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ openssl = "0.10.26"
 openssl-probe = "0.1.2"
 string_cache = "0.7.3"
 flate2 = "1.0.6"
-structopt = "0.2.16"
+structopt = "0.3.13"
 indexmap = {version = "1.0.2", features = ["serde-1"]}
 http = "0.1.14"
 typetag = "0.1"

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,9 +6,7 @@ use structopt::StructOpt;
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
     /// Format the list in an encoding scheme.
-    ///
-    /// Options: `text`, `json`
-    #[structopt(long, default_value = "text")]
+    #[structopt(long, default_value = "text", possible_values = &["text", "json"])]
     format: Format,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,21 +52,19 @@ struct RootOpts {
     #[structopt(short, long, parse(from_occurrences))]
     quiet: u8,
 
-    /// Set the logging format. Options are "text" or "json". Defaults to "text".
-    #[structopt(long)]
-    log_format: Option<LogFormat>,
+    /// Set the logging format
+    #[structopt(long, default_value = "text", possible_values = &["text", "json"])]
+    log_format: LogFormat,
 
     /// Control when ANSI terminal formatting is used.
     ///
     /// By default `vector` will try and detect if `stdout` is a terminal, if it is
     /// ANSI will be enabled. Otherwise it will be disabled. By providing this flag with
     /// the `--color always` option will always enable ANSI terminal formatting. `--color never`
-    /// will disable all ANSI terminal formatting. `--color auto`, the default option, will attempt
+    /// will disable all ANSI terminal formatting. `--color auto` will attempt
     /// to detect it automatically.
-    ///
-    /// Options: `auto`, `always` or `never`
-    #[structopt(long)]
-    color: Option<Color>,
+    #[structopt(long, default_value = "auto", possible_values = &["auto", "always", "never"])]
+    color: Color,
 
     /// Watch for changes in configuration file, and reload accordingly.
     #[structopt(short, long)]
@@ -189,7 +187,7 @@ fn main() {
         },
     };
 
-    let color = match opts.color.clone().unwrap_or(Color::Auto) {
+    let color = match opts.color.clone() {
         #[cfg(unix)]
         Color::Auto => atty::is(atty::Stream::Stdout),
         #[cfg(windows)]
@@ -198,7 +196,7 @@ fn main() {
         Color::Never => false,
     };
 
-    let json = match &opts.log_format.unwrap_or(LogFormat::Text) {
+    let json = match &opts.log_format {
         LogFormat::Text => false,
         LogFormat::Json => true,
     };


### PR DESCRIPTION
Resolves #1750 

This PR updates the cli options for `--log-format` `--color` and `list --format`.
Now all possible values and the default value for each option are shown in the help text.
The changes are visible to the user when running `vector help` `vector help list` `vector -h` or `vector --help`.

The new annotation in structopt requires an upgrade of the used `structopt ` version.

Open Questions:

- Should any documentation be updated?
- Should any tests be updated?
- Is including the ` Cargo.lock` file in the PR the correct workflow?

New help message:
```plain
$ cargo run -- help    
vector 0.9.0 (g9d97e1e x86_64-unknown-linux-gnu 2020-04-11)

USAGE:
    vector [FLAGS] [OPTIONS] [SUBCOMMAND]

FLAGS:
    -r, --require-healthy    Exit on startup if any sinks fail healthchecks
    -d, --dry-run            Exit on startup after config verification and optional healthchecks are run
    -v, --verbose            Enable more detailed internal logging. Repeat to increase level. Overridden by `--quiet`
    -q, --quiet              Reduce detail of internal logging. Repeat to reduce further. Overrides `--verbose`
    -w, --watch-config       Watch for changes in configuration file, and reload accordingly
    -h, --help               Prints help information
    -V, --version            Prints version information

OPTIONS:
    -c, --config <config>...         Read configuration from one or more files. Wildcard paths are supported. If zero
                                     files are specified the default config path `/etc/vector/vector.toml` will be
                                     targeted
    -t, --threads <threads>          Number of threads to use for processing (default is number of available cores)
        --log-format <log-format>    Set the logging format [default: text]  [possible values: text,
                                     json]
        --color <color>              Control when ANSI terminal formatting is used [default: auto]  [possible
                                     values: auto, always, never]

SUBCOMMANDS:
    validate    Validate the target config, then exit
    generate    Generate a Vector configuration containing a list of components
    list        List available components, then exit
    test        Run Vector config unit tests, then exit. This command is experimental and therefore subject to
                change. For guidance on how to write unit tests check out:
                https://vector.dev/docs/setup/guides/unit-testing/
    help        Prints this message or the help of the given subcommand(s)
```
```plain
$ cargo run -- help list
vector-list 0.9.0
List available components, then exit

USAGE:
    vector list [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --format <format>    Format the list in an encoding scheme [default: text]  [possible values:
                             text, json]

```

Bonus: The options now have suggestions if the user does not enter a correct value:

```plain
$ cargo run -- --color foo       
error: 'foo' isn't a valid value for '--color <color>'
	[possible values: always, auto, never]


USAGE:
    vector --color <color> --log-format <log-format>

For more information try --help
```

Signed-off-by: Felix Stegmaier <stegmaier.felix@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

