### PR TITLE
chore: Clarify dependencies of the `package-*` job in `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,10 @@ build-ci-docker-images: ## Build the various Docker images used for CI
 build-docker: ## Build the Vector docker images from artifacts created via `package-deb`, but do not push
 	@scripts/build-docker.sh
 
-package-deb: ## Create a .deb package from artifacts created via `build`
+package-deb: ## Create a .deb package from artifacts created via `build-archive`
 	@scripts/package-deb.sh
 
-package-rpm: ## Create a .rpm package from artifacts created via `build`
+package-rpm: ## Create a .rpm package from artifacts created via `build-archive`
 	@scripts/package-rpm.sh
 
 release-commit: ## Commits release changes


### PR DESCRIPTION
This updates the description of the `package-*` jobs in Makefile, as they require the artifacts produced by `make build-archive`.