### PR TITLE
perf(tokenizer transform): Cache paths for parsed fields

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -18,7 +18,7 @@ mod util;
 
 pub use metric::Metric;
 pub(crate) use util::log::PathComponent;
-#[cfg(feature = "transforms-grok_parser")]
+#[cfg(any(feature = "transforms-grok_parser", feature = "transforms-tokenizer"))]
 pub(crate) use util::log::PathIter;
 
 pub mod proto {


### PR DESCRIPTION
Closes #2314.

This haven't been benchmarked yet, as LTO builds are slow.