### PR TITLE
fix(lua transform): support sub-second timestamp resolution

### DIFF
--- a/src/transforms/lua/v2/interop/util.rs
+++ b/src/transforms/lua/v2/interop/util.rs
@@ -10,6 +10,7 @@ pub fn timestamp_to_table<'a>(ctx: LuaContext<'a>, ts: DateTime<Utc>) -> LuaResu
     table.set("hour", ts.hour())?;
     table.set("min", ts.minute())?;
     table.set("sec", ts.second())?;
+    table.set("nanosec", ts.nanosecond())?;
     table.set("yday", ts.ordinal())?;
     table.set("wday", ts.weekday().number_from_sunday())?;
     table.set("isdst", false)?;
@@ -33,7 +34,8 @@ pub fn table_to_timestamp<'a>(t: LuaTable<'a>) -> LuaResult<DateTime<Utc>> {
     let hour = t.get("hour")?;
     let min = t.get("min")?;
     let sec = t.get("sec")?;
-    Ok(Utc.ymd(year, month, day).and_hms(hour, min, sec))
+    let nano = t.get::<_, Option<u32>>("nanosec")?.unwrap_or(0);
+    Ok(Utc.ymd(year, month, day).and_hms_nano(hour, min, sec, nano))
 }
 
 pub fn table_to_map<'a, K, V>(t: LuaTable<'a>) -> LuaResult<BTreeMap<K, V>>

--- a/src/transforms/lua/v2/interop/value.rs
+++ b/src/transforms/lua/v2/interop/value.rs
@@ -86,6 +86,14 @@ mod test {
                 "os.date('!*t', 1584297428)",
                 Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
             ),
+            (
+                "{year=2020, month=3, day=15, hour=18, min=37, sec=8}",
+                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+            ),
+            (
+                "{year=2020, month=3, day=15, hour=18, min=37, sec=8, nanosec=666666666}",
+                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms_nano(18, 37, 8, 666666666)),
+            ),
         ];
 
         Lua::new().context(move |ctx| {
@@ -167,12 +175,14 @@ mod test {
                 "#,
             ),
             (
-                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms_nano(18, 37, 8, 666666666)),
                 r#"
                 function (value)
                     local expected = os.date("!*t", 1584297428)
+                    expected.nanosec = 666666666
 
                     return os.time(value) == os.time(expected) and
+                        value.nanosec == expected.nanosec and
                         value.yday == expected.yday and
                         value.wday == expected.wday and
                         value.isdst == expected.isdst

--- a/website/docs/reference/transforms/lua.md
+++ b/website/docs/reference/transforms/lua.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-04-10"
+last_modified_on: "2020-04-20"
 component_title: "Lua"
 description: "The Vector `lua` transform accepts and outputs `log` and `metric` events allowing you to transform events with a full embedded Lua engine."
 event_types: ["log","metric"]
@@ -534,7 +534,7 @@ encode both log and metric events in a consistent fashion:
 
 * [Log events][docs.about.data-model.log] are represented as values of a key
   named `log`.
-* [Metric events][docs.about.data-model.metric] are represnted as values of a
+* [Metric events][docs.about.data-model.metric] are represented as values of a
   key named `metric`.
 
 <Tabs
@@ -640,7 +640,7 @@ event = {
 </TabItem>
 <TabItem value="distribution">
 
-```javascript
+```lua
 event = {
   metric = {
     name = "response_time_ms",
@@ -717,7 +717,7 @@ by the following table:
 | [`Integer`][docs.about.data-model.log#ints] | [`integer`][urls.lua_integer] ||
 | [`Float`][docs.about.data-model.log#floats] | [`number`][urls.lua_number] ||
 | [`Boolean`][docs.about.data-model.log#booleans] | [`boolean`][urls.lua_boolean] ||
-| [`Timestamp`][docs.about.data-model.log#timestamps] | [`table`][urls.lua_table] | There is no dedicated timestamp type in Lua. Because of that timestamps are represented as tables using the convention defined by [`os.date`][urls.lua_os_date] and [`os.time`][urls.lua_os_time]. The table representation of a timestamp  contain fields `year`, `month`, `day`, `hour`, `min`, `sec`, `yday`, `wday`, `isdst`. If such a table is passed from Lua to Vector, the fields  `yday`, `wday`, and `isdst` can be omitted. |
+| [`Timestamp`][docs.about.data-model.log#timestamps] | [`table`][urls.lua_table] | There is no dedicated timestamp type in Lua. Timestamps are represented as tables using the convention defined by [`os.date`][urls.lua_os_date] and [`os.time`][urls.lua_os_time]. The table representation of a timestamp contains the fields `year`, `month`, `day`, `hour`, `min`, `sec`, `yday`, `wday`, and `isdst`. If such a table is passed from Lua to Vector, the fields  `yday`, `wday`, and `isdst` can be omitted. In addition to the `os.time` representation, Vector supports sub-second resolution with a `nanosec` field in the table. |
 | [`Null`][docs.about.data-model.log#null-values] | empty string | In Lua setting the value of a table field to `nil` means deletion of this field. In addition, the length operator `#` does not work in the expected way with sequences containing nulls. Because of that `Null` values are encoded as empty strings. |
 | [`Map`][docs.about.data-model.log#maps]| [`table`][urls.lua_table] | |
 | [`Array`][docs.about.data-model.log#arrays] | [`sequence`][urls.lua_sequence] | Sequences are a special case of tables. Indexes start from 1, following the Lua convention. |
@@ -738,6 +738,34 @@ function (event, emit)
 
   emit(event)
 end
+```
+
+### Defining timestamps
+
+To parse a timestamp with an optional milliseconds field, like `2020-04-07 06:26:02.643` or `2020-04-07 06:26:02`:
+
+```lua
+timestamp_pattern = "(%d%d%d%d)[-](%d%d)[-](%d%d) (%d%d):(%d%d):(%d%d).?(%d*)"
+
+function parse_timestamp(str)
+  local year, month, day, hour, min, sec, millis = string.match(str, timestamp_pattern)
+  local ms = 0
+  if millis and millis ~= "" then
+    ms = tonumber(millis)
+  end
+  return {
+    year    = tonumber(year),
+    month   = tonumber(month),
+    day     = tonumber(day),
+    hour    = tonumber(hour),
+    min     = tonumber(min),
+    sec     = tonumber(sec),
+    nanosec = ms * 1000000
+  }
+end
+
+parse_timestamp('2020-04-07 06:26:02.643')
+parse_timestamp('2020-04-07 06:26:02')
 ```
 
 ### Search Directories

--- a/website/docs/reference/transforms/lua.md.erb
+++ b/website/docs/reference/transforms/lua.md.erb
@@ -84,7 +84,7 @@ encode both log and metric events in a consistent fashion:
 
 * [Log events][docs.about.data-model.log] are represented as values of a key
   named `log`.
-* [Metric events][docs.about.data-model.metric] are represnted as values of a
+* [Metric events][docs.about.data-model.metric] are represented as values of a
   key named `metric`.
 
 <Tabs
@@ -190,7 +190,7 @@ event = {
 </TabItem>
 <TabItem value="distribution">
 
-```javascript
+```lua
 event = {
   metric = {
     name = "response_time_ms",
@@ -267,7 +267,7 @@ by the following table:
 | [`Integer`][docs.about.data-model.log#ints] | [`integer`][urls.lua_integer] ||
 | [`Float`][docs.about.data-model.log#floats] | [`number`][urls.lua_number] ||
 | [`Boolean`][docs.about.data-model.log#booleans] | [`boolean`][urls.lua_boolean] ||
-| [`Timestamp`][docs.about.data-model.log#timestamps] | [`table`][urls.lua_table] | There is no dedicated timestamp type in Lua. Because of that timestamps are represented as tables using the convention defined by [`os.date`][urls.lua_os_date] and [`os.time`][urls.lua_os_time]. The table representation of a timestamp  contain fields `year`, `month`, `day`, `hour`, `min`, `sec`, `yday`, `wday`, `isdst`. If such a table is passed from Lua to Vector, the fields  `yday`, `wday`, and `isdst` can be omitted. |
+| [`Timestamp`][docs.about.data-model.log#timestamps] | [`table`][urls.lua_table] | There is no dedicated timestamp type in Lua. Timestamps are represented as tables using the convention defined by [`os.date`][urls.lua_os_date] and [`os.time`][urls.lua_os_time]. The table representation of a timestamp contains the fields `year`, `month`, `day`, `hour`, `min`, `sec`, `yday`, `wday`, and `isdst`. If such a table is passed from Lua to Vector, the fields  `yday`, `wday`, and `isdst` can be omitted. In addition to the `os.time` representation, Vector supports sub-second resolution with a `nanosec` field in the table. |
 | [`Null`][docs.about.data-model.log#null-values] | empty string | In Lua setting the value of a table field to `nil` means deletion of this field. In addition, the length operator `#` does not work in the expected way with sequences containing nulls. Because of that `Null` values are encoded as empty strings. |
 | [`Map`][docs.about.data-model.log#maps]| [`table`][urls.lua_table] | |
 | [`Array`][docs.about.data-model.log#arrays] | [`sequence`][urls.lua_sequence] | Sequences are a special case of tables. Indexes start from 1, following the Lua convention. |
@@ -288,6 +288,34 @@ function (event, emit)
 
   emit(event)
 end
+```
+
+### Defining timestamps
+
+To parse a timestamp with an optional milliseconds field, like `2020-04-07 06:26:02.643` or `2020-04-07 06:26:02`:
+
+```lua
+timestamp_pattern = "(%d%d%d%d)[-](%d%d)[-](%d%d) (%d%d):(%d%d):(%d%d).?(%d*)"
+
+function parse_timestamp(str)
+  local year, month, day, hour, min, sec, millis = string.match(str, timestamp_pattern)
+  local ms = 0
+  if millis and millis ~= "" then
+    ms = tonumber(millis)
+  end
+  return {
+    year    = tonumber(year),
+    month   = tonumber(month),
+    day     = tonumber(day),
+    hour    = tonumber(hour),
+    min     = tonumber(min),
+    sec     = tonumber(sec),
+    nanosec = ms * 1000000
+  }
+end
+
+parse_timestamp('2020-04-07 06:26:02.643')
+parse_timestamp('2020-04-07 06:26:02')
 ```
 
 ### Search Directories


### PR DESCRIPTION
Add an optional `nanosecond` field to the `FromLua` code to support
sub-second resolution in timestamps.

The default Lua table format for timestamps has an integer seconds
field. There's no sub-second field like milliseconds in the table
timestamp format. This means it's not possible to send timestamps
with sub-second resolution from Lua to Vector using the timestamp
table format alone.

Closes #2332.