### PR TITLE
fix(sinks): Reduce credentials fetch timeout

### DIFF
--- a/src/sinks/util/rusoto.rs
+++ b/src/sinks/util/rusoto.rs
@@ -16,9 +16,8 @@ use rusoto_core::{
     ByteStream, CredentialsError, Region,
 };
 use rusoto_credential::{
-    AutoRefreshingProvider, AutoRefreshingProviderFuture, AwsCredentials,
-    DefaultCredentialsProvider, DefaultCredentialsProviderFuture, ProvideAwsCredentials,
-    StaticProvider,
+    AutoRefreshingProvider, AutoRefreshingProviderFuture, AwsCredentials, ChainProvider,
+    ProvideAwsCredentials, StaticProvider,
 };
 use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
 use snafu::{ResultExt, Snafu};
@@ -40,7 +39,7 @@ enum RusotoError {
 
 // A place-holder for the types of AWS credentials we support
 pub enum AwsCredentialsProvider {
-    Default(DefaultCredentialsProvider),
+    Default(AutoRefreshingProvider<ChainProvider>),
     Role(AutoRefreshingProvider<StsAssumeRoleSessionCredentialsProvider>),
     Static(StaticProvider),
 }
@@ -48,6 +47,7 @@ pub enum AwsCredentialsProvider {
 impl AwsCredentialsProvider {
     pub fn new(region: &Region, assume_role: Option<String>) -> crate::Result<Self> {
         if let Some(role) = assume_role {
+            debug!("using sts assume role credentials for AWS.");
             let sts = StsClient::new(region.clone());
 
             let provider = StsAssumeRoleSessionCredentialsProvider::new(
@@ -63,7 +63,14 @@ impl AwsCredentialsProvider {
             let creds = AutoRefreshingProvider::new(provider).context(InvalidAWSCredentials)?;
             Ok(Self::Role(creds))
         } else {
-            let creds = DefaultCredentialsProvider::new().context(InvalidAWSCredentials)?;
+            debug!("using default credentials provider for AWS.");
+            let mut chain = ChainProvider::new();
+            // 8 seconds because our default healthcheck timeout
+            // is 10 seconds.
+            chain.set_timeout(Duration::from_secs(8));
+
+            let creds = AutoRefreshingProvider::new(chain)?;
+
             Ok(Self::Default(creds))
         }
     }
@@ -88,7 +95,7 @@ impl ProvideAwsCredentials for AwsCredentialsProvider {
 }
 
 pub enum AwsCredentialsProviderFuture {
-    Default(DefaultCredentialsProviderFuture),
+    Default(AutoRefreshingProviderFuture<ChainProvider>),
     Role(AutoRefreshingProviderFuture<StsAssumeRoleSessionCredentialsProvider>),
     Static(FutureResult<AwsCredentials, CredentialsError>),
 }

--- a/src/sinks/util/rusoto.rs
+++ b/src/sinks/util/rusoto.rs
@@ -69,7 +69,7 @@ impl AwsCredentialsProvider {
             // is 10 seconds.
             chain.set_timeout(Duration::from_secs(8));
 
-            let creds = AutoRefreshingProvider::new(chain)?;
+            let creds = AutoRefreshingProvider::new(chain).context(InvalidAWSCredentials)?;
 
             Ok(Self::Default(creds))
         }


### PR DESCRIPTION
This PR improves our logging of lack of AWS credentials, before we were using the `DefaultCredentialsProvider` from `rusoto` but this set a deadline of 30seconds while our topology sets a hard limit of 10 seconds for a healthcheck. This would cause a poor error when the healthcheck timed out because it could not fetch credentials.

Before 

```
Apr 15 15:04:58.285 ERROR vector::topology::builder: Healthcheck: Failed Reason: deadline has elapsed
```

After

```
Apr 15 15:39:27.456 ERROR vector::topology::builder: Healthcheck: Failed Reason: DescribeLogStreams failed: Couldn't find AWS credentials in environment, credentials file, or IAM role.

```


Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
