### PR TITLE
fix(topology): Improve topology shutdown logs

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -265,7 +265,13 @@ impl RunningTopology {
         let mut source_shutdown_complete_futures = Vec::new();
         // TODO: Once all Sources properly look for the ShutdownSignal, up this time limit to something
         // more like 30-60 seconds.
-        info!("Waiting for up to 3 seconds for sources to finish shutting down");
+
+        // Only log that we are waiting for shutdown if we are actually removing
+        // sources.
+        if !sources_to_remove.is_empty() {
+            info!("Waiting for up to 3 seconds for sources to finish shutting down");
+        }
+
         let deadline = Instant::now() + Duration::from_secs(3);
         for name in &sources_to_remove {
             info!("Removing source {:?}", name);
@@ -285,7 +291,12 @@ impl RunningTopology {
         }
 
         // Wait for the shutdowns to complete
-        info!("Waiting for up to 3 seconds for sources to finish shutting down");
+
+        // Only log message if there are actual futures to check.
+        if !source_shutdown_complete_futures.is_empty() {
+            info!("Waiting for up to 3 seconds for sources to finish shutting down");
+        }
+
         rt.block_on(future::join_all(source_shutdown_complete_futures))
             .unwrap();
 


### PR DESCRIPTION
This allows us to avoid logging messages about shutdown when there is actually no shutdown work to do!

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
