### PR TITLE
chore: Use only the filename part of the paths to extract dates

### DIFF
--- a/scripts/util/metadata/highlight.rb
+++ b/scripts/util/metadata/highlight.rb
@@ -16,7 +16,7 @@ class Highlight
     :title
 
   def initialize(path)
-    path_parts = path.split("-", 4)
+    path_parts = File.basename(path).split("-", 4)
 
     @date = Date.parse("#{path_parts.fetch(0)}-#{path_parts.fetch(1)}-#{path_parts.fetch(2)}")
     @path = Pathname.new(path).relative_path_from(ROOT_DIR).to_s


### PR DESCRIPTION
This PR changes uses only the filename part of the path to extract dates of the highlights.

It is necessary because otherwise `make generate` gives an error when the base path contains `-` characters.