### PR TITLE
chore(journald source): Wire `ShutdownSignal`

### DIFF
--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -63,6 +63,15 @@ impl ShutdownSignal {
             shutdown_complete: Some(ShutdownSignalToken::new(trigger)),
         }
     }
+
+    #[cfg(test)]
+    pub fn new_wired() -> (Trigger, ShutdownSignal, Tripwire) {
+        let (trigger_shutdown, tripwire) = Tripwire::new();
+        let (trigger, shutdown_done) = Tripwire::new();
+        let shutdown = ShutdownSignal::new(tripwire, trigger);
+
+        (trigger_shutdown, shutdown, shutdown_done)
+    }
 }
 
 pub struct SourceShutdownCoordinator {


### PR DESCRIPTION
ref. #2108 

Has basically the same wiring as `file` source.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
