### PR TITLE
chore(sources): Wire `ShutdownSignal` to multiple sources with `take_until`

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -102,7 +102,13 @@ impl SourceConfig for SocketConfig {
                     .host_key
                     .clone()
                     .unwrap_or(event::log_schema().host_key().to_string());
-                Ok(unix::unix(config.path, config.max_length, host_key, out))
+                Ok(unix::unix(
+                    config.path,
+                    config.max_length,
+                    host_key,
+                    shutdown,
+                    out,
+                ))
             }
         }
     }

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -1,6 +1,7 @@
 use crate::{
     event::{self, Event},
     internal_events::UnixSocketEventReceived,
+    shutdown::ShutdownSignal,
     sources::{util::build_unix_source, Source},
 };
 use bytes::Bytes;
@@ -52,7 +53,8 @@ pub fn unix(
     path: PathBuf,
     max_length: usize,
     host_key: String,
+    shutdown: ShutdownSignal,
     out: mpsc::Sender<Event>,
 ) -> Source {
-    build_unix_source(path, max_length, host_key, out, build_event)
+    build_unix_source(path, max_length, host_key, shutdown, out, build_event)
 }


### PR DESCRIPTION
ref. #2108 

Wires `ShutdownSignal` to  
 - `kafka` source
 - `prometheus` source
 - `statsd` source
 - `syslog` source
 - `socket` source

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
