### PR TITLE
chore(stdin source): Wire `ShutdownSignal`

### DIFF
--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -5,9 +5,16 @@ use crate::{
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
 };
 use bytes::Bytes;
-use futures01::{future, sync::mpsc, Future, Sink, Stream};
+use futures::compat::Compat;
+use futures01::{sync::mpsc, Future, Sink, Stream};
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use std::{io, thread, time::Duration};
+use std::{io, sync::Mutex, thread};
+use tokio::sync::broadcast::{channel, Sender};
+
+lazy_static! {
+    static ref CRITICAL_SECTION: Mutex<Option<Sender<Bytes>>> = Mutex::default();
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields, default)]
@@ -43,12 +50,7 @@ impl SourceConfig for StdinConfig {
         shutdown: ShutdownSignal,
         out: mpsc::Sender<Event>,
     ) -> crate::Result<super::Source> {
-        Ok(stdin_source(
-            io::BufReader::new(io::stdin()),
-            self.clone(),
-            shutdown,
-            out,
-        ))
+        stdin_source(io::BufReader::new(io::stdin()), self.clone(), shutdown, out)
     }
 
     fn output_type(&self) -> DataType {
@@ -65,52 +67,99 @@ pub fn stdin_source<R>(
     config: StdinConfig,
     shutdown: ShutdownSignal,
     out: mpsc::Sender<Event>,
-) -> super::Source
+) -> crate::Result<super::Source>
 where
     R: Send + io::BufRead + 'static,
 {
-    Box::new(future::lazy(move || {
-        info!("Capturing STDIN");
+    // The idea is to have one dedicated future for reading stdin running in the background,
+    // and the sources would recieve the lines thorugh a multi consumer channel.
+    //
+    // Implemented solution relies on having a copy of optional sender behind a global mutex,
+    // and have stdin sources and background thread synchronize on it.
+    //
+    // When source is builded it must:
+    // 1. enter critical section by locking mutex.
+    // 2. if sender isn't present start background thread and set sender.
+    // 3. gain receiver by calling subscribe on the sender.
+    // 4. release lock.
+    //
+    // When source has finished it should just drop it's receiver.
+    //
+    // Background thread should be started with copy of the sender.
+    //
+    // Once background thread want's to stop it must:
+    // 1. enter critical section by locking mutex.
+    // 2. if there are receivers it must abort the stop.
+    // 3. remove sender.
+    // 4. release lock.
+    //
+    // Although it's possible to implement this in a lock free, maybe even wait free manner,
+    // this should be easier to reason about and performance shouldn't suffer since this procedure
+    // is cold compared to the rest of the source.
 
-        let host_key = config
-            .host_key
-            .clone()
-            .unwrap_or(event::log_schema().host_key().to_string());
-        let hostname = hostname::get_hostname();
-        let (mut tx, rx) = futures01::sync::mpsc::channel(1024);
+    let host_key = config
+        .host_key
+        .clone()
+        .unwrap_or(event::log_schema().host_key().to_string());
+    let hostname = hostname::get_hostname();
 
+    let mut guard = CRITICAL_SECTION
+        .lock()
+        .map_err(|_| "CRITICAL_SECTION poisoned.")?;
+    let receiver = if let Some(sender) = guard.as_ref() {
+        sender.subscribe()
+    } else {
+        let (sender, receiver) = channel(1024);
+        *guard = Some(sender.clone());
+
+        // Start the background thread
         thread::spawn(move || {
+            info!("Capturing STDIN.");
+
             for line in stdin.lines() {
                 match line {
                     Err(e) => {
                         error!(message = "Unable to read from source.", error = %e);
                         break;
                     }
-                    Ok(string_data) => {
-                        let msg = Bytes::from(string_data);
-                        while let Err(e) = tx.try_send(msg.clone()) {
-                            if e.is_full() {
-                                thread::sleep(Duration::from_millis(10));
-                            } else if e.is_disconnected() {
-                                return;
-                            } else {
-                                error!(message = "Unable to send event.", error = %e);
-                                break;
+                    Ok(line) => {
+                        if sender.send(Bytes::from(line)).is_err() {
+                            // There are no active receivers.
+                            // Try to stop.
+                            match CRITICAL_SECTION.lock() {
+                                Ok(mut guard) => {
+                                    if sender.receiver_count() > 0 {
+                                        // It's fine to not try sending line since it came from
+                                        // before this new receiver has shown up.
+                                        continue;
+                                    }
+                                    guard.take();
+                                }
+                                Err(_) => error!(message = "CRITICAL_SECTION poisoned."),
                             }
+                            break;
                         }
                     }
                 }
             }
+
+            info!("Stopped capturing STDIN.");
         });
 
-        rx.take_until(shutdown)
+        receiver
+    };
+    std::mem::drop(guard);
+
+    Ok(Box::new(
+        Compat::new(receiver)
+            .take_until(shutdown)
             .map(move |line| create_event(line, &host_key, &hostname))
             .map_err(|e| error!("error reading line: {:?}", e))
             .forward(
                 out.sink_map_err(|e| error!(message = "Unable to send event to out.", error = %e)),
             )
-            .map(|_| info!("finished sending"))
-    }))
+            .map(|_| info!("finished sending")),
+    ))
 }
 
 fn create_event(line: Bytes, host_key: &str, hostname: &Option<String>) -> Event {
@@ -161,7 +210,7 @@ mod tests {
         let buf = Cursor::new(String::from("hello world\nhello world again"));
 
         let mut rt = Runtime::new().unwrap();
-        let source = stdin_source(buf, config, ShutdownSignal::noop(), tx);
+        let source = stdin_source(buf, config, ShutdownSignal::noop(), tx).unwrap();
 
         rt.block_on(source).unwrap();
 


### PR DESCRIPTION
closes #2108 

### Open questions
- [x] Just `take_until` will work fine in normal cases, but there are cases when reloading for which this will break. Breakage is caused by :
    - the `stdin.lines()` thread won't be stopped until newline has been read. 
    - the new `stdin` source would start working in parallel with the old thread which could cause interference between the two.
  The simplest way I see to solve this is to rewrite the `stdin.lines()` thread into a stream with `tokio::io::Stdin`.   ~~(EDIT: I'll make an issue for it)~~ (EDIT: we'll implement it here)


@bruceg @LucioFranco What do you think?


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
