### PR TITLE
chore(splunk_hec source): Enable tests

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -694,7 +694,7 @@ fn event_error(text: &str, code: u16, event: usize) -> Response<Body> {
     }
 }
 
-#[cfg(features = "sinks-splunk_hec")]
+#[cfg(feature = "sinks-splunk_hec")]
 #[cfg(test)]
 mod tests {
     use super::SplunkConfig;
@@ -702,6 +702,7 @@ mod tests {
     use crate::test_util::{self, collect_n};
     use crate::{
         event::{self, Event},
+        shutdown::ShutdownSignal,
         sinks::{
             splunk_hec::{Encoding, HecSinkConfig},
             util::{encoding::EncodingConfigWithDefault, Compression},
@@ -727,9 +728,18 @@ mod tests {
         let (sender, recv) = mpsc::channel(CHANNEL_CAPACITY);
         let address = test_util::next_addr();
         rt.spawn(
-            SplunkConfig { address, token }
-                .build("default", &GlobalOptions::default(), sender)
-                .unwrap(),
+            SplunkConfig {
+                address,
+                token,
+                tls: None,
+            }
+            .build(
+                "default",
+                &GlobalOptions::default(),
+                ShutdownSignal::noop(),
+                sender,
+            )
+            .unwrap(),
         );
         (recv, address)
     }


### PR DESCRIPTION
Tests of `splunk_hec` source haven't been running. The cause was this line:
```
#[cfg(features = "sinks-splunk_hec")]
```
which should have `feature` and not `features`. 

Because of this they weren't even compiled.

This PR fixes this and updates the test to compile.

Fortunately, all the tests are passing.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
