### PR TITLE
chore(operations): Run ci workflow on pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,13 @@
 name: ci
+
 on:
-  push:
-    branches:
-      - master
+  pull_request:
     paths:
       - ".github/workflows/ci.yml"
       - "src/**"
       - "tests/**"
       - "Cargo.lock"
       - "Cargo.toml"
-  pull_request: {}
-
 
 jobs:
   cargo-deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,24 @@
 name: ci
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/ci.yml"
+      - "lib/*s"
+      - "proto/**"
+      - "src/**"
+      - "tests/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "docker-compose.yml"
+      - "rust-toolchain"
+
   pull_request:
     paths:
       - ".github/workflows/ci.yml"
-      - "lib/**"
+      - "lib/*s"
       - "proto/**"
       - "src/**"
       - "tests/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ci.yml"
+      - "lib/**"
+      - "proto/**"
       - "src/**"
       - "tests/**"
       - "Cargo.lock"
       - "Cargo.toml"
+      - "docker-compose.yml"
+      - "rust-toolchain"
 
 jobs:
   cargo-deny:


### PR DESCRIPTION
This change runs the `ci` workflow on pull requests only. I don't see the need to run these checks again on `master`.