### PR TITLE
chore(platforms): Optimize binaries in `test-stable` CI to reduce binary sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,20 @@ jobs:
       USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
+      - run: |
+          mkdir -p .cargo/
+          cat <<-EOF >> ./.cargo/config
+            # focus on fast, lean builds
+            [build]
+            incremental = false
+          EOF
+          cat <<-EOF >> ./Cargo.toml
+            # focus on fast, lean builds
+            [profile.dev]
+            debug = false
+            opt-level = "s" # Binary size
+            lto = false # Don't LTO on CI
+          EOF
       - run: cargo test --no-run --target $TARGET
       - name: Save vector
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Reduce our disk usage on the `test-stable` CI job to try to stabilize the test a bit more. This also turns off LTO and does some other risky stuff, so these binaries should only be used for testing.

If this works out, we should consider applying this across our debug/test pipeline, and far, far away from our release builds.