### PR TITLE
chore: Bump cargo.toml version to `0.10.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,7 +5116,7 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "vector"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "approx",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,7 +5116,7 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "vector"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
I am getting CI failure and it looks like the version didn't get bumped. So I think this is correct?

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>