### PR TITLE
chore(operations): Retry failed cargo network requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,3 +420,6 @@ codegen-units = 1
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
+
+[net]
+retry = 4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ license-file = "LICENSE"
 readme = "README.md"
 publish = false
 
-[profile.bench]
-debug = true
-
 [package.metadata.deb]
 maintainer-scripts = "distribution/debian/scripts/"
 conf-files = ["/etc/vector/vector.toml"]
@@ -413,6 +410,9 @@ disable-resolv-conf = []
 [[bench]]
 name = "bench"
 harness = false
+
+[profile.bench]
+debug = true
 
 [profile.release]
 lto = true


### PR DESCRIPTION
We had a nightly build [fail](https://github.com/timberio/vector/actions/runs/84805009) due to a failed Cargo network request. The default retry limit is 2, raising this to 4 might help. It's the first light-weight solution before implementing retries in Github Actions.