### PR TITLE
enhancement(aws_cloudwatch_logs sink): Enforce age requirements

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -284,6 +284,66 @@ impl CloudwatchLogsSvc {
             }
         }
     }
+
+    pub fn process_events(&self, events: Vec<Event>) -> Vec<Vec<InputLogEvent>> {
+        let now = Utc::now();
+        // Acceptable range of Event timestamps.
+        let age_range = (now - Duration::days(14)).timestamp_millis()
+            ..(now + Duration::hours(2)).timestamp_millis();
+
+        let mut events = events
+            .into_iter()
+            .map(|mut e| {
+                self.encoding.apply_rules(&mut e);
+                e
+            })
+            .map(|e| e.into_log())
+            .map(|e| self.encode_log(e))
+            .filter(|e| age_range.contains(&e.timestamp))
+            .collect::<Vec<_>>();
+
+        // Sort by timestamp
+        events.sort_by_key(|e| e.timestamp);
+
+        info!(message = "Sending events.", events = %events.len());
+
+        let mut event_batches = Vec::new();
+        if events.is_empty() {
+            // This should happen rarely.
+            event_batches.push(Vec::new());
+        } else {
+            // We will split events into 24h batches.
+            // Relies on log_events being sorted by timestamp in ascending order.
+            while let Some(oldest) = events.first() {
+                let limit = oldest.timestamp + Duration::days(1).num_milliseconds();
+
+                if events.last().expect("Events can't be empty").timestamp <= limit {
+                    // Fast path.
+                    // In most cases the difference between oldest and newest event
+                    // is less than 24h.
+                    event_batches.push(events);
+                    break;
+                }
+
+                // At this point we know that an event older than the limit exists.
+                //
+                // We will find none or one of the events with timestamp==limit.
+                // In the case of more events with limit, we can just split them
+                // at found event, and send those before at with this batch, and
+                // those after at with the next batch.
+                let at = events
+                    .binary_search_by_key(&limit, |e| e.timestamp)
+                    .unwrap_or_else(|at| at);
+
+                // Can't be empty
+                let remainder = events.split_off(at);
+                event_batches.push(events);
+                events = remainder;
+            }
+        }
+
+        event_batches
+    }
 }
 
 impl Service<Vec<Event>> for CloudwatchLogsSvc {
@@ -315,60 +375,7 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
 
     fn call(&mut self, req: Vec<Event>) -> Self::Future {
         if self.token_rx.is_none() {
-            let now = Utc::now();
-            // Acceptable range of Event timestamps.
-            let age_range = (now - Duration::days(14)).timestamp_millis()
-                ..(now + Duration::hours(2)).timestamp_millis();
-
-            let mut events = req
-                .into_iter()
-                .map(|mut e| {
-                    self.encoding.apply_rules(&mut e);
-                    e
-                })
-                .map(|e| e.into_log())
-                .map(|e| self.encode_log(e))
-                .filter(|e| age_range.contains(&e.timestamp))
-                .collect::<Vec<_>>();
-
-            // Sort by timestamp
-            events.sort_by_key(|e| e.timestamp);
-
-            info!(message = "Sending events.", events = %events.len());
-
-            let mut event_batches = Vec::new();
-            if events.is_empty() {
-                event_batches.push(Vec::new());
-            } else {
-                // We will split events into 24h batches.
-                // Relies on log_events being sorted by timestamp in ascending order.
-                while let Some(oldest) = events.first() {
-                    let limit = oldest.timestamp + Duration::days(1).num_milliseconds();
-
-                    if events.last().expect("Events can't be empty").timestamp <= limit {
-                        // Fast path.
-                        // In most cases the difference between oldest and newest event
-                        // is less than 24h.
-                        event_batches.push(events);
-                        break;
-                    }
-
-                    // At this point we know that an event older than the limit exists.
-                    //
-                    // We will find none or one of the events with timestamp==limit.
-                    // In the case of more events with limit, we can just split them
-                    // at found event, and send those before at with this batch, and
-                    // those after at with the next batch.
-                    let at = events
-                        .binary_search_by_key(&limit, |e| e.timestamp)
-                        .unwrap_or_else(|at| at);
-
-                    // Can't be empty
-                    let remainder = events.split_off(at);
-                    event_batches.push(events);
-                    events = remainder;
-                }
-            }
+            let event_batches = self.process_events(req);
 
             let (tx, rx) = oneshot::channel();
             self.token_rx = Some(rx);
@@ -779,6 +786,31 @@ mod tests {
         event.insert("key", "value");
         let encoded = svc(config).encode_log(event.clone());
         assert_eq!(encoded.message, "hello world");
+    }
+
+    #[test]
+    fn cloudwatch_24h_split() {
+        let now = Utc::now();
+        let events = (0..100)
+            .into_iter()
+            .map(|i| now - Duration::hours(i))
+            .map(|timestamp| {
+                let mut event = Event::new_empty_log();
+                event
+                    .as_mut_log()
+                    .insert(&event::log_schema().timestamp_key(), timestamp);
+                event
+            })
+            .collect();
+
+        let batches = svc(default_config(Encoding::Text)).process_events(events);
+
+        let day = Duration::days(1).num_milliseconds();
+        for batch in batches.iter() {
+            assert!((batch.last().unwrap().timestamp - batch.first().unwrap().timestamp) <= day);
+        }
+
+        assert_eq!(batches.len(), 5);
     }
 }
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -315,14 +315,10 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
 
     fn call(&mut self, req: Vec<Event>) -> Self::Future {
         if self.token_rx.is_none() {
-            // We need to take into account the flight time from here to aws servers,
-            // so we are reducing timestamp acceptable range from both sides
-            // for this amount.
-            let buffer_time = Duration::minutes(1);
             let now = Utc::now();
             // Acceptable range of Event timestamps.
-            let age_range = (now - Duration::days(14) + buffer_time).timestamp_millis()
-                ..(now + Duration::hours(2) - buffer_time).timestamp_millis();
+            let age_range = (now - Duration::days(14)).timestamp_millis()
+                ..(now + Duration::hours(2)).timestamp_millis();
 
             let mut events = req
                 .into_iter()

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -364,7 +364,7 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
                         .unwrap_or_else(|at| at);
 
                     // Can't be empty
-                    let remainder = events.drain(at..).collect();
+                    let remainder = events.split_off(at);
                     event_batches.push(events);
                     events = remainder;
                 }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     topology::config::{DataType, SinkConfig, SinkContext},
 };
 use bytes::Bytes;
-use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use chrono::{Duration, Utc};
 use futures01::{future, stream::iter_ok, sync::oneshot, Async, Future, Poll, Sink};
 use lazy_static::lazy_static;
 use rusoto_core::{request::BufferedHttpResponse, Region, RusotoError};
@@ -315,17 +315,17 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
 
     fn call(&mut self, req: Vec<Event>) -> Self::Future {
         if self.token_rx.is_none() {
-            // Addresses cases when we have an event who is close to be
-            // filtered out now, and could age enough, between now and it being
-            // delivered to AWS, to being filtered out.
+            // We need to take into account the flight time from here to aws servers,
+            // so we are reducing timestamp acceptable range from both sides
+            // for this amount.
             let buffer_time = Duration::minutes(1);
             let now = Utc::now();
             // Acceptable range of Event timestamps.
-            let age_range =
-                (now - Duration::days(14) + buffer_time)..(now + Duration::hours(2) - buffer_time);
+            let age_range = (now - Duration::days(14) + buffer_time).timestamp_millis()
+                ..(now + Duration::hours(2) - buffer_time).timestamp_millis();
             // TODO: 4. point and retention period of the log group.
 
-            let events = req
+            let mut events = req
                 .into_iter()
                 .map(|mut e| {
                     self.encoding.apply_rules(&mut e);
@@ -333,16 +333,11 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
                 })
                 .map(|e| e.into_log())
                 .map(|e| self.encode_log(e))
-                .filter(|e| {
-                    age_range.contains(&DateTime::from_utc(
-                        NaiveDateTime::from_timestamp(
-                            e.timestamp / 1000,
-                            (e.timestamp % 1000) * 1000 * 1000,
-                        ),
-                        Utc,
-                    ))
-                })
+                .filter(|e| age_range.contains(&e.timestamp))
                 .collect::<Vec<_>>();
+
+            // Sort by timestamp
+            events.sort_by_key(|e| e.timestamp);
 
             let (tx, rx) = oneshot::channel();
             self.token_rx = Some(rx);

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -323,7 +323,6 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
             // Acceptable range of Event timestamps.
             let age_range = (now - Duration::days(14) + buffer_time).timestamp_millis()
                 ..(now + Duration::hours(2) - buffer_time).timestamp_millis();
-            // TODO: 4. point and retention period of the log group.
 
             let mut events = req
                 .into_iter()

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -334,6 +334,8 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
             // Sort by timestamp
             events.sort_by_key(|e| e.timestamp);
 
+            info!(message = "Sending events.", events = %events.len());
+
             let mut event_batches = Vec::new();
             if events.is_empty() {
                 event_batches.push(Vec::new());
@@ -371,7 +373,6 @@ impl Service<Vec<Event>> for CloudwatchLogsSvc {
             let (tx, rx) = oneshot::channel();
             self.token_rx = Some(rx);
 
-            info!(message = "Sending events.", events = %events.len());
             request::CloudwatchFuture::new(
                 self.client.clone(),
                 self.stream_name.clone(),

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -1,5 +1,4 @@
 use super::CloudwatchError;
-use chrono::Duration;
 use futures01::{sync::oneshot, try_ready, Async, Future, Poll};
 use rusoto_core::{RusotoError, RusotoFuture};
 use rusoto_logs::{

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -214,7 +214,7 @@ impl Client {
                     .enumerate()
                     .find(|e| e.1.timestamp >= limit)
                     .map(|(at, _)| at)
-                    .map(|at| log_events.drain(..at).collect::<Vec<_>>())
+                    .map(|at| log_events.drain(at..).collect::<Vec<_>>())
             });
 
         let request = PutLogEventsRequest {


### PR DESCRIPTION
Closes #1483 

### Open questions
 - [x] Regarding 

    > or older than the retention period of the log group

    part of the second constraint I'm unsure in how to deal with it? 
    Actually implementing this would somewhat complicate the sink, for a case which would happen rarely. If this isn't added, in the worst case `aws` may drop that batch which would have a limited effect since we are splitting the batches into 24h pieces. And dropping older messages also shouldn't be a problem since there is already a precedent of dropping messages older than 14 days. (EDIT: filtering on 14day should be enough) 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
