### PR TITLE
chore: Optimize CI workflow with slim builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: cloudwatch-logs-integration-tests,cloudwatch-metrics-integration-tests,ec2-metadata-integration-tests,firehose-integration-tests,kinesis-integration-tests,s3-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d localstack mockwatchlogs ec2_metadata minio
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-aws
 
   test-integration-clickhouse:
     runs-on: ubuntu-latest
@@ -112,12 +110,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: clickhouse-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d clickhouse
       - run: make slim-builds
-      - run: cargo test --no-default-features  --features $FEATURES
+      - run: make test-integration-clickhouse
 
   test-integration-docker:
     runs-on: ubuntu-latest
@@ -128,11 +124,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: docker-integration-tests
     steps:
       - uses: actions/checkout@v1
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-docker
 
   test-integration-elasticsearch:
     runs-on: ubuntu-latest
@@ -143,12 +138,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: es-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d elasticsearch elasticsearch-tls localstack
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-elasticsearch
 
   test-integration-gcp:
     runs-on: ubuntu-latest
@@ -159,12 +152,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: gcp-pubsub-integration-tests, gcs-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d gcloud-pubsub
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-gcp
 
   test-integration-influxdb:
     runs-on: ubuntu-latest
@@ -175,12 +166,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: influxdb-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d influxdb_v1 influxdb_v2
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-influxdb
 
   test-integration-kafka:
     runs-on: ubuntu-latest
@@ -191,12 +180,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: kafka-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d kafka
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-kafka
 
   test-integration-pulsar:
     runs-on: ubuntu-latest
@@ -207,12 +194,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: pulsar-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d pulsar
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-pulsar
 
   test-integration-splunk:
     runs-on: ubuntu-latest
@@ -223,12 +208,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: splunk-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d splunk
       - run: make slim-builds
-      - run: cargo test --no-default-features --features $FEATURES
+      - run: make test-integration-splunk
 
   test-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: EmbarkStudios/cargo-deny-action@v0
         with:
-          command: "check advisories"
-  test-behavior:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: "cd tests && make test-behavior"
+          command: check advisories
+
   check-component-features:
     runs-on: ubuntu-latest
     env:
@@ -48,84 +44,50 @@ jobs:
       - uses: actions/checkout@v1
       - run: sudo apt install -y python3-pip python3-setuptools python3-wheel
       - run: sudo python3 -m pip install remarshal
-      - run: "make check-component-features"
+      - run: make check-component-features
+
   check-code:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: "make check-code"
+      - run: make check-code
         env:
           PASS_RUSTFLAGS: "-D warnings"
+
   check-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: "make check-fmt"
+      - run: make check-fmt
         env:
           PASS_RUSTFLAGS: "-D warnings"
+
   check-generate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: "make check-fmt"
+      - run: make check-generate
+
   check-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: "make check-version"
+      - run: make check-version
+
   check-blog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: "make check-blog"
-  test-stable:
+      - run: make check-blog
+
+  test-behavior:
     runs-on: ubuntu-latest
-    env:
-      RUST_BACKTRACE: full
-      TEST_LOG: debug
-      AWS_ACCESS_KEY_ID: fake-aws-key
-      AWS_SECRET_ACCESS_KEY: fake-aws-key
-      TARGET: x86_64-unknown-linux-gnu
-      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
-      - run: |
-          mkdir -p .cargo/
-          cat <<-EOF >> ./.cargo/config
-            # focus on fast, lean builds
-            [build]
-            incremental = false
-          EOF
-          cat <<-EOF >> ./Cargo.toml
-            # focus on fast, lean builds
-            [profile.dev]
-            debug = false
-            opt-level = "s" # Binary size
-            lto = false # Don't LTO on CI
-          EOF
-      - run: cargo test --no-run --target $TARGET
-      - name: Save vector
-        uses: actions/upload-artifact@v1
-        with:
-          name: binary
-          path: ./target/x86_64-unknown-linux-gnu/debug/vector
+      - run: make slim-builds
+      - run: make test-behavior
 
-  clickhouse-integration-tests:
-    runs-on: ubuntu-latest
-    env:
-      RUST_BACKTRACE: full
-      TEST_LOG: debug
-      AWS_ACCESS_KEY_ID: fake-aws-key
-      AWS_SECRET_ACCESS_KEY: fake-aws-key
-      TARGET: x86_64-unknown-linux-gnu
-      USE_CONTAINER: none
-      FEATURES: clickhouse-integration-tests
-    steps:
-      - uses: actions/checkout@v1
-      - run: docker-compose up -d clickhouse
-      - run: cargo test --no-default-features  --features $FEATURES
-
-  aws-integration-tests:
+  test-integration-aws:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -138,9 +100,26 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: docker-compose up -d localstack mockwatchlogs ec2_metadata minio
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  docker-integration-tests:
+  test-integration-clickhouse:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: full
+      TEST_LOG: debug
+      AWS_ACCESS_KEY_ID: fake-aws-key
+      AWS_SECRET_ACCESS_KEY: fake-aws-key
+      TARGET: x86_64-unknown-linux-gnu
+      USE_CONTAINER: none
+      FEATURES: clickhouse-integration-tests
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker-compose up -d clickhouse
+      - run: make slim-builds
+      - run: cargo test --no-default-features  --features $FEATURES
+
+  test-integration-docker:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -152,9 +131,10 @@ jobs:
       FEATURES: docker-integration-tests
     steps:
       - uses: actions/checkout@v1
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  es-integration-tests:
+  test-integration-elasticsearch:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -167,9 +147,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: docker-compose up -d elasticsearch elasticsearch-tls localstack
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  gcp-integration-tests:
+  test-integration-gcp:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -182,24 +163,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: docker-compose up -d gcloud-pubsub
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  kafka-integration-tests:
-    runs-on: ubuntu-latest
-    env:
-      RUST_BACKTRACE: full
-      TEST_LOG: debug
-      AWS_ACCESS_KEY_ID: fake-aws-key
-      AWS_SECRET_ACCESS_KEY: fake-aws-key
-      TARGET: x86_64-unknown-linux-gnu
-      USE_CONTAINER: none
-      FEATURES: kafka-integration-tests
-    steps:
-      - uses: actions/checkout@v1
-      - run: docker-compose up -d kafka
-      - run: cargo test --no-default-features --features $FEATURES
-
-  influxdb-integration-tests:
+  test-integration-influxdb:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -212,9 +179,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: docker-compose up -d influxdb_v1 influxdb_v2
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  splunk-integration-tests:
+  test-integration-kafka:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -223,13 +191,14 @@ jobs:
       AWS_SECRET_ACCESS_KEY: fake-aws-key
       TARGET: x86_64-unknown-linux-gnu
       USE_CONTAINER: none
-      FEATURES: splunk-integration-tests
+      FEATURES: kafka-integration-tests
     steps:
       - uses: actions/checkout@v1
-      - run: docker-compose up -d splunk
+      - run: docker-compose up -d kafka
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-  pulsar-integration-tests:
+  test-integration-pulsar:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: full
@@ -242,10 +211,41 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: docker-compose up -d pulsar
+      - run: make slim-builds
       - run: cargo test --no-default-features --features $FEATURES
 
-## Kubernetes
-# Build exectuables in parallel, and then tests on different Kubernetes versions in parallel.
+  test-integration-splunk:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: full
+      TEST_LOG: debug
+      AWS_ACCESS_KEY_ID: fake-aws-key
+      AWS_SECRET_ACCESS_KEY: fake-aws-key
+      TARGET: x86_64-unknown-linux-gnu
+      USE_CONTAINER: none
+      FEATURES: splunk-integration-tests
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker-compose up -d splunk
+      - run: make slim-builds
+      - run: cargo test --no-default-features --features $FEATURES
+
+  test-unit:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: full
+      TEST_LOG: debug
+      AWS_ACCESS_KEY_ID: fake-aws-key
+      AWS_SECRET_ACCESS_KEY: fake-aws-key
+      TARGET: x86_64-unknown-linux-gnu
+      USE_CONTAINER: none
+    steps:
+      - uses: actions/checkout@v1
+      - run: make slim-builds
+      - run: make test-unit
+
+  ## Kubernetes
+  # Build exectuables in parallel, and then tests on different Kubernetes versions in parallel.
 
   # Builds vector executable that will be tested.
   build-vector-kubernetes:
@@ -277,7 +277,7 @@ jobs:
 
   # Uses two previosuly builded vector executables to do testing.
   test-kubernetes:
-    needs: [build-vector-kubernetes,build-test-vector-kubernetes]
+    needs: [build-vector-kubernetes, build-test-vector-kubernetes]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,15 @@ sign-blog: ## Sign newly added blog articles using GPG
 slim-builds: ## Updates the Cargo config to product disk optimized builds, useful for CI
 	@scripts/slim-builds.sh
 
-test: ## Spins up Docker resources and runs _every_ test
-	@cargo test --no-default-features --features ${DEFAULT_FEATURES} --all --features docker --no-run
-	@docker-compose up -d test-runtime-deps
-	@cargo test --no-default-features --features ${DEFAULT_FEATURES} --all --features docker -- --test-threads 4
+test: test-behavior test-integration test-unit
 
 test-behavior: ## Runs behavioral tests
 	@cargo run --no-default-features --features ${DEFAULT_FEATURES} -- test tests/behavior/**/*.toml
+
+test-integration:
+	@cargo test --no-default-features --features ${DEFAULT_FEATURES} --all --features docker --no-run
+	@docker-compose up -d test-runtime-deps
+	@cargo test --no-default-features --features ${DEFAULT_FEATURES} --all --features docker -- --test-threads 4
 
 test-integration-aws: ## Runs Clickhouse integration tests
 	@docker-compose up -d localstack mockwatchlogs ec2_metadata minio

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test-integration-splunk: ## Runs Kafka integration tests
 	@cargo test --no-default-features --features splunk-integration-tests
 
 test-unit: ## Runs unit tests that do not require network dependencies
-	@cargo test --no-run --target $TARGET
+	@cargo test --no-run --target ${TARGET}
 
 ##@ Releasing
 

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ export ARTICLE ?= true
 sign-blog: ## Sign newly added blog articles using GPG
 	@scripts/sign-blog.sh
 
+slim-builds: ## Updates the Cargo config to product disk optimized builds, useful for CI
+	@scripts/slim-builds.sh
+
 test: ## Spins up Docker resources and runs _every_ test
 	@cargo test --no-default-features --features ${DEFAULT_FEATURES} --all --features docker --no-run
 	@docker-compose up -d test-runtime-deps
@@ -96,6 +99,48 @@ test: ## Spins up Docker resources and runs _every_ test
 
 test-behavior: ## Runs behavioral tests
 	@cargo run --no-default-features --features ${DEFAULT_FEATURES} -- test tests/behavior/**/*.toml
+
+test-integration-aws: ## Runs Clickhouse integration tests
+	@docker-compose up -d localstack mockwatchlogs ec2_metadata minio
+	@cargo test --no-default-features --features cloudwatch-logs-integration-tests,cloudwatch-metrics-integration-tests,ec2-metadata-integration-tests,firehose-integration-tests,kinesis-integration-tests,s3-integration-tests
+
+test-integration-clickhouse: ## Runs Clickhouse integration tests
+	@docker-compose up -d clickhouse
+	@cargo test --no-default-features --features clickhouse-integration-tests
+
+test-integration-docker: ## Runs Docker integration tests
+	@cargo test --no-default-features --features docker-integration-tests
+
+test-integration-elasticsearch: ## Runs Elasticsearch integration tests
+	@docker-compose up -d elasticsearch elasticsearch-tls localstack
+	@cargo test --no-default-features --features es-integration-tests
+
+test-integration-gcp: ## Runs GCP integration tests
+	@docker-compose up -d gcloud-pubsub
+	@cargo test --no-default-features --features gcp-pubsub-integration-tests, gcs-integration-tests
+
+test-integration-influxdb: ## Runs Kafka integration tests
+	@docker-compose up -d influxdb_v1 influxdb_v2
+	@cargo test --no-default-features --features influxdb-integration-tests
+
+test-integration-kafka: ## Runs Kafka integration tests
+	@docker-compose up -d kafka
+	@cargo test --no-default-features --features kafka-integration-tests
+
+test-integration-kubernetes: ## Runs Kubernetes integration tests
+	@docker-compose up -d kafka
+	@cargo test --no-default-features --features kafka-integration-tests
+
+test-integration-pulsar: ## Runs Kafka integration tests
+	@docker-compose up -d pulsar
+	@cargo test --no-default-features --features pulsar-integration-tests
+
+test-integration-splunk: ## Runs Kafka integration tests
+	@docker-compose up -d splunk
+	@cargo test --no-default-features --features splunk-integration-tests
+
+test-unit: ## Runs unit tests that do not require network dependencies
+	@cargo test --no-run --target $TARGET
 
 ##@ Releasing
 

--- a/Makefile
+++ b/Makefile
@@ -35,38 +35,41 @@ build: ## Build the project in release mode
 
 check: check-code check-fmt check-generate check-examples
 
+check-blog: ## Checks that all blog articles are signed by their authors
+	@scripts/run.sh checker scripts/check-blog-signatures.rb
+
 check-code: ## Checks code for compilation errors (only default features)
 	@scripts/run.sh checker cargo check --all --all-targets --features docker,kubernetes
+
+check-component-features: ## Checks that all component are behind corresponding features
+	@scripts/run.sh checker-component-features scripts/check-component-features.sh
+
+check-examples: ## Validates the config examples
+	@cargo run -q -- validate --topology --deny-warnings ./config/examples/*.toml
 
 check-fmt: ## Checks code formatting correctness
 	@scripts/run.sh checker scripts/check-style.sh
 	@scripts/run.sh checker cargo fmt -- --check
 
-check-markdown: ## Check Markdown style
-	@scripts/run.sh checker-markdown markdownlint .
-
 check-generate: ## Checks for pending `make generate` changes
 	@scripts/run.sh checker scripts/check-generate.sh
 
-check-examples: ## Validates the config examples
-	@cargo run -q -- validate --topology --deny-warnings ./config/examples/*.toml
+check-markdown: ## Check Markdown style
+	@scripts/run.sh checker-markdown markdownlint .
 
 check-version: ## Checks that the version in Cargo.toml is up-to-date
 	@scripts/run.sh checker scripts/check-version.rb
 
-check-blog: ## Checks that all blog articles are signed by their authors
-	@scripts/run.sh checker scripts/check-blog-signatures.rb
-
-check-component-features: ## Checks that all component are behind corresponding features
-	@scripts/run.sh checker-component-features scripts/check-component-features.sh
-
-export CHECK_URLS ?= true
-generate: ## Generates files across the repo using the data in /.meta
-	@scripts/run.sh checker scripts/generate.rb
+clean: ## Remove build artifacts
+	@cargo clean
 
 fmt: ## Format code
 	@scripts/check-style.sh --fix
 	@cargo fmt
+
+export CHECK_URLS ?= true
+generate: ## Generates files across the repo using the data in /.meta
+	@scripts/run.sh checker scripts/generate.rb
 
 release: ## Release a new Vector version
 	@$(MAKE) release-prepare
@@ -93,9 +96,6 @@ test: ## Spins up Docker resources and runs _every_ test
 
 test-behavior: ## Runs behavioral tests
 	@cargo run --no-default-features --features ${DEFAULT_FEATURES} -- test tests/behavior/**/*.toml
-
-clean: ## Remove build artifacts
-	@cargo clean
 
 ##@ Releasing
 

--- a/scripts/slim-builds.sh
+++ b/scripts/slim-builds.sh
@@ -11,18 +11,18 @@ set -euo pipefail
 #   and this solves that.
 #
 
-mkdir -p .cargo/
+# mkdir -p .cargo/
 
-cat <<-EOF >> ./.cargo/config
-# focus on fast, lean builds
-[build]
-incremental = false
-EOF
+# cat <<-EOF >> ./.cargo/config
+# # focus on fast, lean builds
+# [build]
+# incremental = false
+# EOF
 
-cat <<-EOF >> ./Cargo.toml
-# focus on fast, lean builds
-[profile.dev]
-debug = false
-opt-level = "s" # Binary size
-lto = false # Don't LTO on CI
-EOF
+# cat <<-EOF >> ./Cargo.toml
+# # focus on fast, lean builds
+# [profile.dev]
+# debug = false
+# opt-level = "s" # Binary size
+# lto = false # Don't LTO on CI
+# EOF

--- a/scripts/slim-builds.sh
+++ b/scripts/slim-builds.sh
@@ -12,11 +12,13 @@ set -euo pipefail
 #
 
 mkdir -p .cargo/
+
 cat <<-EOF >> ./.cargo/config
 # focus on fast, lean builds
 [build]
 incremental = false
 EOF
+
 cat <<-EOF >> ./Cargo.toml
 # focus on fast, lean builds
 [profile.dev]

--- a/scripts/slim-builds.sh
+++ b/scripts/slim-builds.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# slim-builds.sh
+#
+# SUMMARY
+#
+#   Sets various settings that produce disk optimized builds.
+#   This is useful for CI where we currently only have 12gb
+#   of disk space. We have routinely run into disk space errors
+#   and this solves that.
+#
+
+mkdir -p .cargo/
+cat <<-EOF >> ./.cargo/config
+# focus on fast, lean builds
+[build]
+incremental = false
+EOF
+cat <<-EOF >> ./Cargo.toml
+# focus on fast, lean builds
+[profile.dev]
+debug = false
+opt-level = "s" # Binary size
+lto = false # Don't LTO on CI
+EOF


### PR DESCRIPTION
This change optimizes our CI workflow to take advantage of settings that produce slim builds. This is required because the CI machines only have 12gb of disk space, something we were routinely running out of. This should make CI and it's tests much more stable.

Supercedes https://github.com/timberio/vector/pull/2383