### PR TITLE
fix(datadog_metrics sink): Use header auth

### DIFF
--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -115,7 +115,7 @@ impl SinkConfig for DatadogConfig {
         let batch = self.batch.unwrap_or(20, 1);
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
-        let uri = format!("{}/api/v1/series?api_key={}", self.host, self.api_key)
+        let uri = format!("{}/api/v1/series", self.host)
             .parse::<Uri>()
             .context(super::UriParseError)?;
         let timestamp = Utc::now().timestamp();

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -159,17 +159,21 @@ impl HttpSink for DatadogSink {
 
         http::Request::get(self.uri.clone())
             .header("Content-Type", "application/json")
+            .header("DD-API-KEY", self.config.api_key.clone())
             .body(body)
             .unwrap()
     }
 }
 
 fn healthcheck(config: DatadogConfig, resolver: Resolver) -> crate::Result<super::Healthcheck> {
-    let uri = format!("{}/api/v1/validate?api_key={}", config.host, config.api_key)
+    let uri = format!("{}/api/v1/validate", config.host)
         .parse::<Uri>()
         .context(super::UriParseError)?;
 
-    let request = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
+    let request = http::Request::get(uri)
+        .header("DD-API-KEY", config.api_key)
+        .body(hyper::Body::empty())
+        .unwrap();
 
     let mut client = HttpClient::new(resolver, None)?;
 


### PR DESCRIPTION
Fixes #2441 

I am having some trouble actually sending metrics to datadog as I am getting a 404. That said, I've verified the healthcheck passes and we are getting the same 404 with the new changes. Since, this is my first time actually using this sink I could totally be doing something wrong so if someone has more experience could get that working that would be super helpful. Beyond that, this conforms to the docs and the healthcheck passes and we don't get any unauthenticated responses.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
