### PR TITLE
fix(networking): Fetch system ca certs via schannel on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,6 +5072,7 @@ dependencies = [
  "rusoto_logs",
  "rusoto_s3",
  "rusoto_sts",
+ "schannel",
  "seahash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.6.2",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
  "libc",
 ]
 
@@ -476,6 +486,12 @@ name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crc"
@@ -1866,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libgit2-sys"
@@ -2252,8 +2268,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
- "security-framework-sys",
+ "security-framework 0.3.4",
+ "security-framework-sys 0.3.3",
  "tempfile",
 ]
 
@@ -3490,10 +3506,23 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
 dependencies = [
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.6.4",
+ "core-foundation-sys 0.6.2",
  "libc",
- "security-framework-sys",
+ "security-framework-sys 0.3.3",
+]
+
+[[package]]
+name = "security-framework"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "libc",
+ "security-framework-sys 0.4.3",
 ]
 
 [[package]]
@@ -3502,7 +3531,17 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.6.2",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
 ]
 
 [[package]]
@@ -5074,6 +5113,7 @@ dependencies = [
  "rusoto_sts",
  "schannel",
  "seahash",
+ "security-framework 0.4.3",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,9 @@ bloom = "0.3.2"
 pulsar = { version = "0.3.0", optional = true }
 task-compat = "0.1"
 
+[target.'cfg(windows)'.dependencies]
+schannel = "0.1"
+
 [target.'cfg(unix)'.dependencies]
 atty = "0.2"
 nix = "0.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,9 @@ task-compat = "0.1"
 [target.'cfg(windows)'.dependencies]
 schannel = "0.1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "0.4"
+
 [target.'cfg(unix)'.dependencies]
 atty = "0.2"
 nix = "0.16.1"

--- a/src/sinks/util/rusoto.rs
+++ b/src/sinks/util/rusoto.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "rusoto_core")]
 
-use crate::{dns::Resolver, sinks::util};
+use crate::{dns::Resolver, sinks::util, tls::MaybeTlsSettings};
 use futures01::{
     future::{self, Future, FutureResult},
     Async, Poll, Stream,
@@ -27,7 +27,8 @@ use tower::Service;
 pub type Client = HttpClient<util::http::HttpClient<RusotoBody>>;
 
 pub fn client(resolver: Resolver) -> crate::Result<Client> {
-    let client = util::http::HttpClient::new(resolver, None)?;
+    let settings = MaybeTlsSettings::enable_client()?;
+    let client = util::http::HttpClient::new(resolver, settings)?;
     Ok(HttpClient { client })
 }
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -102,6 +102,14 @@ pub enum TlsError {
     Connect { source: std::io::Error },
     #[snafu(display("Could not get peer address: {}", source))]
     PeerAddress { source: std::io::Error },
+    #[snafu(display("Security Framework Error: {}", source))]
+    #[cfg(target_os = "macos")]
+    SecurityFramework {
+        source: security_framework::base::Error,
+    },
+    #[snafu(display("Schannel Error: {}", source))]
+    #[cfg(windows)]
+    Schannel { source: std::io::Error },
 }
 
 impl MaybeTlsStream<TcpStream> {

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -170,8 +170,13 @@ impl TlsSettings {
                 .set_verify_cert_store(store.build())
                 .context(SetVerifyCert)?;
         } else {
+            debug!("Fetching system root certs.");
+
             #[cfg(windows)]
             load_windows_certs(context).unwrap();
+
+            #[cfg(target_os = "macos")]
+            load_mac_certs(context).unwrap();
         }
 
         Ok(())
@@ -182,18 +187,81 @@ impl TlsSettings {
     }
 }
 
+/// === System Specific Root Cert ===
+///
+/// Most of this code is borrowed from https://github.com/ctz/rustls-native-certs
+
 /// Load the system default certs from `schannel` this should be in place
 /// of openssl-probe on linux.
 #[cfg(windows)]
 fn load_windows_certs(builder: &mut SslContextBuilder) -> Result<()> {
+    use super::Schannel;
+
     let mut store = X509StoreBuilder::new().context(NewStoreBuilder)?;
 
-    let current_user_store = schannel::cert_store::CertStore::open_current_user("ROOT").unwrap();
+    let current_user_store =
+        schannel::cert_store::CertStore::open_current_user("ROOT").context(Schannel)?;
 
     for cert in current_user_store.certs() {
         let cert = cert.to_der().to_vec();
-        let cert = X509::from_der(&cert[..]).unwrap();
-        store.add_cert(cert).unwrap();
+        let cert = X509::from_der(&cert[..]).context(X509ParseError)?;
+        store.add_cert(cert).context(AddCertToStore)?;
+    }
+
+    builder
+        .set_verify_cert_store(store.build())
+        .context(SetVerifyCert)?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn load_mac_certs(builder: &mut SslContextBuilder) -> Result<()> {
+    use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
+    use super::SecurityFramework;
+    use std::collections::HashMap;
+
+    // The various domains are designed to interact like this:
+    //
+    // "Per-user Trust Settings override locally administered
+    //  Trust Settings, which in turn override the System Trust
+    //  Settings."
+    //
+    // So we collect the certificates in this order; as a map of
+    // their DER encoding to what we'll do with them.  We don't
+    // overwrite existing elements, which mean User settings
+    // trump Admin trump System, as desired.
+
+    let mut store = X509StoreBuilder::new().context(NewStoreBuilder)?;
+    let mut all_certs = HashMap::new();
+
+    for domain in &[Domain::User, Domain::Admin, Domain::System] {
+        let ts = TrustSettings::new(*domain);
+
+        for cert in ts.iter().context(SecurityFramework)? {
+            // If there are no specific trust settings, the default
+            // is to trust the certificate as a root cert.  Weird API but OK.
+            // The docs say:
+            //
+            // "Note that an empty Trust Settings array means "always trust this cert,
+            //  with a resulting kSecTrustSettingsResult of kSecTrustSettingsResultTrustRoot".
+            let trusted = ts
+                .tls_trust_settings_for_certificate(&cert)
+                .context(SecurityFramework)?
+                .unwrap_or(TrustSettingsForCertificate::TrustRoot);
+
+            all_certs.entry(cert.to_der()).or_insert(trusted);
+        }
+    }
+
+    for (cert, trusted) in all_certs {
+        if matches!(
+            trusted,
+            TrustSettingsForCertificate::TrustRoot | TrustSettingsForCertificate::TrustAsRoot
+        ) {
+            let cert = X509::from_der(&cert[..]).unwrap();
+            store.add_cert(cert).unwrap();
+        }
     }
 
     builder.set_verify_cert_store(store.build()).unwrap();

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -217,8 +217,8 @@ fn load_windows_certs(builder: &mut SslContextBuilder) -> Result<()> {
 
 #[cfg(target_os = "macos")]
 fn load_mac_certs(builder: &mut SslContextBuilder) -> Result<()> {
-    use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
     use super::SecurityFramework;
+    use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
     use std::collections::HashMap;
 
     // The various domains are designed to interact like this:


### PR DESCRIPTION
This fixes our issues when a user tries to use a sink that needs to use tls to connect to some well known host. This means that the hosts tls identity can be verified by a trusted root cert. Most computers contain them on the system but windows and mac require us to fetch this through their system tls libraries.

Opening this as a draft but it currently works for me, it would be good to get some others testing as well.

cc @bruceg 

Fixes #2256 and #2395

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>