### PR TITLE
fix(config): Shutdown topology pieces before building new ones

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -334,10 +334,11 @@ fn main() {
             trace!("Parsing config");
             let config = handle_config_errors(config);
             if let Some(config) = config {
-                let success =
-                    topology.reload_config_and_respawn(config, &mut rt, opts.require_healthy);
-                if !success {
-                    error!("Reload was not successful.");
+                match topology.reload_config_and_respawn(config, &mut rt, opts.require_healthy) {
+                    Ok(true) => (),
+                    Ok(false) => error!("Reload was not successful."),
+                    // Trigger graceful shutdown for what remains of the topology
+                    Err(()) => break SIGINT,
                 }
             } else {
                 error!("Reload aborted.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() {
         info!("Dry run enabled, exiting after config validation.");
     }
 
-    let diff = topology::ConfigDiff::inital(&config);
+    let diff = topology::ConfigDiff::initial(&config);
     let pieces = topology::validate(&config, &diff, rt.executor()).unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,8 @@ fn main() {
         info!("Dry run enabled, exiting after config validation.");
     }
 
-    let pieces = topology::validate(&config, rt.executor()).unwrap_or_else(|| {
+    let diff = topology::ConfigDiff::inital(&config);
+    let pieces = topology::validate(&config, &diff, rt.executor()).unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
     });
 
@@ -284,7 +285,7 @@ fn main() {
         std::process::exit(exitcode::OK);
     }
 
-    let result = topology::start_validated(config, pieces, &mut rt, opts.require_healthy);
+    let result = topology::start_validated(config, diff, pieces, &mut rt, opts.require_healthy);
     let (topology, mut graceful_crash) = result.unwrap_or_else(|| {
         std::process::exit(exitcode::CONFIG);
     });

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -40,6 +40,16 @@ pub struct SplunkConfig {
     tls: Option<TlsConfig>,
 }
 
+impl SplunkConfig {
+    #[cfg(test)]
+    pub fn on(address: SocketAddr) -> Self {
+        SplunkConfig {
+            address,
+            ..Self::default()
+        }
+    }
+}
+
 impl Default for SplunkConfig {
     fn default() -> Self {
         SplunkConfig {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -49,7 +49,7 @@ pub fn start(
     rt: &mut runtime::Runtime,
     require_healthy: bool,
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
-    let diff = ConfigDiff::inital(&config);
+    let diff = ConfigDiff::initial(&config);
     validate(&config, &diff, rt.executor())
         .and_then(|pieces| start_validated(config, diff, pieces, rt, require_healthy))
 }
@@ -576,7 +576,7 @@ pub struct ConfigDiff {
 }
 
 impl ConfigDiff {
-    pub fn inital(initial: &Config) -> Self {
+    pub fn initial(initial: &Config) -> Self {
         Self::new(&Config::empty(), initial)
     }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -695,3 +695,101 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, feature = "sinks-console", feature = "sources-splunk_hec"))]
+mod reload_tests {
+    use crate::sinks::console::{ConsoleSinkConfig, Encoding, Target};
+    use crate::sources::splunk_hec::SplunkConfig;
+    use crate::test_util::{next_addr, runtime};
+    use crate::topology;
+    use crate::topology::config::Config;
+
+    #[test]
+    fn topology_reuse_old_port() {
+        let address = next_addr();
+
+        let mut rt = runtime();
+
+        let mut old_config = Config::empty();
+        old_config.add_source("in1", SplunkConfig::on(address));
+        old_config.add_sink(
+            "out",
+            &[&"in1"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let mut new_config = Config::empty();
+        new_config.add_source("in2", SplunkConfig::on(address));
+        new_config.add_sink(
+            "out",
+            &[&"in2"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let (mut topology, _crash) = topology::start(old_config, &mut rt, false).unwrap();
+
+        assert!(topology.reload_config_and_respawn(new_config, &mut rt, false));
+    }
+
+    #[test]
+    fn topology_rebuild_old() {
+        let address = next_addr();
+
+        let mut rt = runtime();
+
+        let mut old_config = Config::empty();
+        old_config.add_source("in1", SplunkConfig::on(address));
+        old_config.add_sink(
+            "out",
+            &[&"in1"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let mut new_config = Config::empty();
+        old_config.add_source("in1", SplunkConfig::on(address));
+        new_config.add_source("in2", SplunkConfig::on(address));
+        new_config.add_sink(
+            "out",
+            &[&"in1", &"in2"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let (mut topology, _crash) = topology::start(old_config, &mut rt, false).unwrap();
+
+        assert!(!topology.reload_config_and_respawn(new_config, &mut rt, false));
+    }
+
+    #[test]
+    fn topology_old() {
+        let address = next_addr();
+
+        let mut rt = runtime();
+
+        let mut old_config = Config::empty();
+        old_config.add_source("in1", SplunkConfig::on(address));
+        old_config.add_sink(
+            "out",
+            &[&"in1"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let (mut topology, _crash) = topology::start(old_config.clone(), &mut rt, false).unwrap();
+
+        assert!(topology.reload_config_and_respawn(old_config, &mut rt, false));
+    }
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -690,7 +690,7 @@ mod tests {
 
         new_config.global.data_dir = Some(Path::new("/qwerty").to_path_buf());
 
-        topology.reload_config_and_respawn(new_config, &mut rt, false);
+        let _ = topology.reload_config_and_respawn(new_config, &mut rt, false);
 
         assert_eq!(
             topology.config.global.data_dir,
@@ -737,7 +737,9 @@ mod reload_tests {
 
         let (mut topology, _crash) = topology::start(old_config, &mut rt, false).unwrap();
 
-        assert!(topology.reload_config_and_respawn(new_config, &mut rt, false));
+        assert!(topology
+            .reload_config_and_respawn(new_config, &mut rt, false)
+            .unwrap());
     }
 
     #[test]
@@ -771,7 +773,9 @@ mod reload_tests {
 
         let (mut topology, _crash) = topology::start(old_config, &mut rt, false).unwrap();
 
-        assert!(!topology.reload_config_and_respawn(new_config, &mut rt, false));
+        assert!(!topology
+            .reload_config_and_respawn(new_config, &mut rt, false)
+            .unwrap());
     }
 
     #[test]
@@ -793,6 +797,8 @@ mod reload_tests {
 
         let (mut topology, _crash) = topology::start(old_config.clone(), &mut rt, false).unwrap();
 
-        assert!(topology.reload_config_and_respawn(old_config, &mut rt, false));
+        assert!(topology
+            .reload_config_and_respawn(old_config, &mut rt, false)
+            .unwrap());
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,9 +1,9 @@
-use vector::topology::{self, Config};
+use vector::topology::{self, Config, ConfigDiff};
 
 fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
     let rt = vector::runtime::Runtime::single_threaded().unwrap();
     Config::load(config.as_bytes())
-        .and_then(|c| topology::builder::build_pieces(&c, rt.executor()))
+        .and_then(|c| topology::builder::build_pieces(&c, &ConfigDiff::initial(&c), rt.executor()))
         .map(|(_topology, warnings)| warnings)
 }
 

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -227,7 +227,9 @@ fn topology_remove_one_source() {
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink1);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event1 = Event::from("this");
     let event2 = Event::from("that");
@@ -260,7 +262,9 @@ fn topology_remove_one_sink() {
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink(10).1);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event = Event::from("this");
 
@@ -299,7 +303,9 @@ fn topology_remove_one_transform() {
     config.add_transform("t2", &["in1"], transform2);
     config.add_sink("out1", &["t2"], sink(10).1);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event = Event::from("this");
     let h_out1 = oneshot::spawn(out1.map(into_message).collect(), &rt.executor());
@@ -330,7 +336,9 @@ fn topology_swap_source() {
     config.add_source("in2", source2);
     config.add_sink("out1", &["in2"], sink1v2);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event1 = Event::from("this");
     let event2 = Event::from("that");
@@ -368,7 +376,9 @@ fn topology_swap_sink() {
     config.add_source("in1", source().1);
     config.add_sink("out2", &["in1"], sink2);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event = Event::from("this");
     let h_out1 = oneshot::spawn(out1.collect(), &rt.executor());
@@ -405,7 +415,9 @@ fn topology_swap_transform() {
     config.add_transform("t2", &["in1"], transform2);
     config.add_sink("out1", &["t2"], sink1v2);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 
     let event = Event::from("this");
     let h_out1v1 = oneshot::spawn(out1v1.map(into_message).collect(), &rt.executor());
@@ -469,7 +481,9 @@ fn topology_swap_transform_is_atomic() {
     config.add_transform("t1", &["in1"], transform1v2);
     config.add_sink("out1", &["t1"], sink(10).1);
 
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
     std::thread::sleep(std::time::Duration::from_millis(10));
 
     run_control.store(false, Ordering::Release);
@@ -501,7 +515,9 @@ fn topology_optional_healthcheck_does_not_fail_reload() {
     let config = basic_config();
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     let config = basic_config_with_sink_failing_healthcheck();
-    assert!(topology.reload_config_and_respawn(config, &mut rt, false));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, false)
+        .unwrap());
 }
 
 #[test]
@@ -510,7 +526,9 @@ fn topology_healthcheck_not_run_on_unchanged_reload() {
     let config = basic_config();
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     let config = basic_config_with_sink_failing_healthcheck();
-    assert!(topology.reload_config_and_respawn(config, &mut rt, true));
+    assert!(topology
+        .reload_config_and_respawn(config, &mut rt, true)
+        .unwrap());
 }
 
 #[test]
@@ -521,5 +539,10 @@ fn topology_healthcheck_run_for_changes_on_reload() {
     let mut config = Config::empty();
     config.add_source("in1", source().1);
     config.add_sink("out2", &["in1"], sink_failing_healthcheck(10).1);
-    assert!(topology.reload_config_and_respawn(config, &mut rt, true) == false);
+    assert!(
+        topology
+            .reload_config_and_respawn(config, &mut rt, true)
+            .unwrap()
+            == false
+    );
 }


### PR DESCRIPTION
Closes #2011.

Refactors the topology reload code to move shutdown procedure before building the new pieces. Also to facilitate that, only the pieces that will be added are built.

### Open questions

One interesting scenario is when we go through:
 1. shutdown some of the old pieces
 2. fail in building new pieces
 3. fail in rebuilding the old shutdown pieces
At this point the topology is consisted only of pieces common to both old and new configuration. This situation is currently resolved by shutting down `vector`.

- [x] Should we do something different in this scenario? Something like, continue running with the topology we have and periodically try to rebuild old topology?  (EDIT: No)

cc. @binarylogic @LucioFranco





<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
