### PR TITLE
chore(operations): Allow the invocation of local script from the tests/Makefile

### DIFF
--- a/scripts/docker-compose-run.sh
+++ b/scripts/docker-compose-run.sh
@@ -8,8 +8,7 @@
 
 set -euo pipefail
 
-cd $(dirname $0)/..
-
 export USER=$(id -u):$(id -g)
-docker-compose rm -svf $1 2>/dev/null || true
-docker-compose up --build --abort-on-container-exit --exit-code-from $1 $1 | sed $'s/^.*container exit...$/\033[0m\033[1A/'
+DOCKER=${USE_CONTAINER:-docker}
+${DOCKER}-compose rm -svf $1 2>/dev/null || true
+${DOCKER}-compose up --build --abort-on-container-exit --exit-code-from $1 $1 | sed $'s/^.*container exit...$/\033[0m\033[1A/'

--- a/scripts/run2.sh
+++ b/scripts/run2.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# run.sh
+#
+# SUMMARY
+#
+#   A simple script that runs a make target in a container environment based
+#   on the presence of the `USE_CONTAINER` environment variable.
+#
+#   This helps to reduce friction for first-time contributors, since running
+#   basic commands through containers ensures they work. It is recommended
+#   that frequent contributors setup local environments to improve the speed
+#   of commands they are running frequently. This can be achieved by setting
+#   USE_CONTAINER to none:
+#
+#       export USE_CONTAINER=none
+#
+
+set -eou pipefail
+
+cd $(dirname $0)/..
+
+case "$USE_CONTAINER" in
+  docker | podman)
+    echo "Executing within $USE_CONTAINER. To disable set USE_CONTAINER to none"
+    echo ""
+    echo "  make ... USE_CONTAINER=none"
+    echo ""
+
+    scripts/docker-compose-run.sh "$1"
+    ;;
+
+  *)
+    echo "Executing locally. To use Docker set USE_CONTAINER to docker or podman"
+    echo ""
+    echo "  make ... USE_CONTAINER=docker"
+    echo "  make ... USE_CONTAINER=podman"
+    echo ""
+
+    FILE=$(find ./scripts -name "${1}.*")
+
+    if [ -z "$FILE" ]; then
+        echo "Local invocation failed. Script not found!"
+        echo ""
+        echo "    scripts/${1}.*"
+        echo ""
+        echo "To run the ${1} target locally you must place a script in the"
+        echo "/scripts folder that can be executed. Otherwise, you can use the"
+        echo "service defined in /docker-compose.yml."
+        exit 1
+    fi
+    ${FILE}
+esac

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,8 @@
 .PHONY: help
 .DEFAULT_GOAL := help
-RUN := $(shell realpath $(shell dirname $(firstword $(MAKEFILE_LIST)))/../scripts/docker-compose-run.sh)
+RUN := $(shell realpath $(shell dirname $(firstword $(MAKEFILE_LIST)))/../scripts/run2.sh)
+
+export USE_CONTAINER ?= docker
 
 help:
 	@echo "                                      __   __  __"


### PR DESCRIPTION
This change is pull request 3 (after https://github.com/timberio/vector/pull/2451) in a series of pull requests for #2368. This change makes it possible for the `tests/Makefile` to execute local scripts based on the presence of the `USE_CONTAINER` environment variable (default `docker`). We default to `docker` since it is guaranteed to work and the least surprising for first-time contributors. Regular contributors should set `USE_CONTAINER=none` and set up the appropriate dependencies if they prefer.

The process works like the following

* `USE_CONTAINER=docker make generate` -> `docker compose up --build --abort-on-container-exit generate`
* `USE_CONTAINER=none make generate` -> `scripts/generate.rb`

The local script detection uses `find` to locate the appropriate file:

```
FILE=$(find ./scripts -name "${1}.*")
${FILE}
```

If the file does not exist a friendly error message is presented:

```
echo "Local invocation failed. Script not found!"
echo ""
echo "    scripts/${1}.*"
echo ""
echo "To run the ${1} target locally you must place a script in the"
echo "/scripts folder that can be executed. Otherwise, you can use the"
echo "service defined in /docker-compose.yml."
exit 1
```

This makes it possible to consolidate the `Makefile` for both local and CI use.

cc @a-rodin 