### PR TITLE
chore(operations): Point nightly GHA workflow to tests/Makefile

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,15 +67,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - name: "Install realpath dependency"
+        run: brew install coreutils
       - name: "Build archive"
         env:
           TARGET: "x86_64-apple-darwin"
           USE_CONTAINER: none
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
-          realpath() {
-            [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-          }
           cd tests && make build-archive
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,6 +73,9 @@ jobs:
           USE_CONTAINER: none
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
+          realpath() {
+            [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+          }
           cd tests && make build-archive
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,6 +180,7 @@ jobs:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
           PLATFORM: "linux/amd64,linux/arm64,linux/arm"
+          USE_CONTAINER: none
         run: |
           ./scripts/upgrade-docker.sh
           cd tests
@@ -235,4 +236,5 @@ jobs:
       - env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
+          USE_CONTAINER: none
         run: cd tests && make release-s3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,9 @@ name: nightly
 
 on:
   schedule:
-    - cron:  "0 14 * * *"
+    - cron: "0 14 * * *"
+
+  pull_request: {}
 
 env:
   CHANNEL: nightly
@@ -13,10 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Build archive and package"
-        run: |
-          ./scripts/docker-run.sh builder-x86_64-unknown-linux-musl make build-archive package-deb
         env:
           PASS_FEATURES: "default-musl"
+        run: cd tests && make package-deb-x86_64
       - uses: actions/upload-artifact@v1
         with:
           name: "vector-x86_64-unknown-linux-musl.tar.gz"
@@ -31,11 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Build archive and package"
-        run: |
-          ./scripts/docker-run.sh builder-aarch64-unknown-linux-musl make build-archive package-deb
         env:
           DOCKER_PRIVILEGED: "true"
           PASS_FEATURES: "default-musl"
+        run: cd tests && make package-deb-aarch64
       - uses: actions/upload-artifact@v1
         with:
           name: "vector-aarch64-unknown-linux-musl.tar.gz"
@@ -50,11 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Build archive and package"
-        run: |
-          ./scripts/docker-run.sh builder-armv7-unknown-linux-musleabihf make build-archive package-deb
         env:
           DOCKER_PRIVILEGED: "true"
           PASS_FEATURES: "default-musl"
+        run: cd tests && make package-deb-armv7
       - uses: actions/upload-artifact@v1
         with:
           name: "vector-armv7-unknown-linux-musleabihf.tar.gz"
@@ -69,11 +68,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: "Build archive"
-        run: |
-          export PATH="$HOME/.cargo/bin:$PATH"
-          make build-archive
         env:
           TARGET: "x86_64-apple-darwin"
+          USE_CONTAINER: none
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          cd tests && make build-archive
       - uses: actions/upload-artifact@v1
         with:
           name: "vector-x86_64-apple-darwin.tar.gz"
@@ -85,12 +85,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: "Download Perl"
         shell: bash
-        run: |
-          curl -sSf http://strawberryperl.com/download/$VERSION/strawberry-perl-$VERSION-64bit.msi > perl-installer.msi
-          echo "$SHA256SUM perl-installer.msi" | sha256sum --check --status
         env:
           VERSION: "5.30.0.1"
           SHA256SUM: "459de13a284a4c83213208c9caa1c372c81136b6e863a3f13d42f631048e0b12" # we need to verify checksum because strawberryperl.com doesn't support HTTPS
+        run: |
+          curl -sSf http://strawberryperl.com/download/$VERSION/strawberry-perl-$VERSION-64bit.msi > perl-installer.msi
+          echo "$SHA256SUM perl-installer.msi" | sha256sum --check --status
       - name: "Install Perl"
         shell: cmd # msiexec fails when called from bash
         run: |
@@ -98,10 +98,10 @@ jobs:
           del perl-installer.msi
       - name: "Download CMake"
         shell: bash
-        run: |
-          curl -sSfL https://github.com/Kitware/CMake/releases/download/v$VERSION/cmake-$VERSION-win64-x64.msi > cmake-installer.msi
         env:
           VERSION: "3.15.5"
+        run: |
+          curl -sSfL https://github.com/Kitware/CMake/releases/download/v$VERSION/cmake-$VERSION-win64-x64.msi > cmake-installer.msi
       - name: "Install CMake"
         shell: cmd # msiexec fails when called from bash
         run: |
@@ -117,6 +117,8 @@ jobs:
           rm wix-binaries.zip
       - name: "Build archive"
         shell: bash
+        env:
+          USE_CONTAINER: none
         run: |
           export PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
           export RUSTFLAGS=-Ctarget-feature=+crt-static
@@ -125,9 +127,7 @@ jobs:
           export STRIP="false"
           export RUST_LTO=""
           export TARGET="x86_64-pc-windows-msvc"
-
-          ./scripts/build-archive.sh
-          ls -lha target/artifacts
+          cd tests && make build-archive
       - name: "Build package"
         shell: bash
         run: |
@@ -174,14 +174,15 @@ jobs:
         with:
           name: vector-armhf.deb
           path: target/artifacts
-      - run: |
+      - env:
+          DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
+          PLATFORM: "linux/amd64,linux/arm64,linux/arm"
+        run: |
           ./scripts/upgrade-docker.sh
+          cd tests
           export VERSION=$(make version)
           make release-docker
-        env:
-          DOCKER_USERNAME: '${{ secrets.CI_DOCKER_USERNAME }}'
-          DOCKER_PASSWORD: '${{ secrets.CI_DOCKER_PASSWORD }}'
-          PLATFORM: "linux/amd64,linux/arm64,linux/arm"
 
   release-s3:
     runs-on: ubuntu-latest
@@ -229,7 +230,7 @@ jobs:
         with:
           name: vector-x64.msi
           path: target/artifacts
-      - run: make release-s3
-        env:
-          AWS_ACCESS_KEY_ID: '${{ secrets.CI_AWS_ACCESS_KEY_ID }}'
-          AWS_SECRET_ACCESS_KEY: '${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}'
+      - env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
+        run: cd tests && make release-s3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ env:
   CHANNEL: nightly
 
 jobs:
-  build-x86_64-unknown-linux-musl-archive-and-deb-package:
+  package-archive-x86_64-unknown-linux-musl-and-deb:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -27,7 +27,7 @@ jobs:
           name: "vector-amd64.deb"
           path: "./target/artifacts/vector-amd64.deb"
 
-  build-aarch64-unknown-linux-musl-archive-and-deb-package:
+  package-archive-aarch64-unknown-linux-musl-and-deb:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -45,7 +45,7 @@ jobs:
           name: "vector-arm64.deb"
           path: "./target/artifacts/vector-arm64.deb"
 
-  build-armv7-unknown-linux-musleabihf-archive-and-deb-package:
+  pachakge-archive-armv7-unknown-linux-musleabihf-and-deb:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -63,7 +63,7 @@ jobs:
           name: "vector-armhf.deb"
           path: "./target/artifacts/vector-armhf.deb"
 
-  build-x86_64-apple-darwin-archive:
+  package-archive-x86_64-apple-darwin:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
@@ -75,13 +75,13 @@ jobs:
           USE_CONTAINER: none
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
-          cd tests && make build-archive
+          cd tests && make package-archive
       - uses: actions/upload-artifact@v1
         with:
           name: "vector-x86_64-apple-darwin.tar.gz"
           path: "./target/artifacts/vector-x86_64-apple-darwin.tar.gz"
 
-  build-x86_64-pc-windows-msvc-archive-and-msi-package:
+  package-archive-x86_64-pc-windows-msvc-and-msi:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -129,7 +129,7 @@ jobs:
           export STRIP="false"
           export RUST_LTO=""
           export TARGET="x86_64-pc-windows-msvc"
-          cd tests && make build-archive
+          cd tests && make package-archive
       - name: "Build package"
         shell: bash
         run: |
@@ -147,9 +147,9 @@ jobs:
   release-docker:
     runs-on: ubuntu-latest
     needs:
-      - build-x86_64-unknown-linux-musl-archive-and-deb-package
-      - build-aarch64-unknown-linux-musl-archive-and-deb-package
-      - build-armv7-unknown-linux-musleabihf-archive-and-deb-package
+      - package-archive-x86_64-unknown-linux-musl-and-deb
+      - package-archive-aarch64-unknown-linux-musl-and-deb
+      - pachakge-archive-armv7-unknown-linux-musleabihf-and-deb
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -189,11 +189,11 @@ jobs:
   release-s3:
     runs-on: ubuntu-latest
     needs:
-      - build-x86_64-unknown-linux-musl-archive-and-deb-package
-      - build-aarch64-unknown-linux-musl-archive-and-deb-package
-      - build-armv7-unknown-linux-musleabihf-archive-and-deb-package
-      - build-x86_64-apple-darwin-archive
-      - build-x86_64-pc-windows-msvc-archive-and-msi-package
+      - package-archive-x86_64-unknown-linux-musl-and-deb
+      - package-archive-aarch64-unknown-linux-musl-and-deb
+      - pachakge-archive-armv7-unknown-linux-musleabihf-and-deb
+      - package-archive-x86_64-apple-darwin
+      - package-archive-x86_64-pc-windows-msvc-and-msi
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,7 +226,7 @@ services:
     working_dir: $PWD
     command: ./scripts/build-archive.sh
 
-  package-deb-x86_64-unknown-linux-musl:
+  package-deb-x86_64:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -240,7 +240,7 @@ services:
     working_dir: $PWD
     command: ./scripts/package-deb.sh
 
-  package-deb-armv7-unknown-linux-musleabihf:
+  package-deb-armv7:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -254,7 +254,7 @@ services:
     working_dir: $PWD
     command: ./scripts/package-deb.sh
 
-  package-deb-aarch64-aarch64-unknown-linux-musl:
+  package-deb-aarch64:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
     environment:
+      TARGET: x86_64-unknown-linux-musl
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -16,13 +18,15 @@ services:
       - ./target/x86_64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/x86_64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: cargo build --no-default-features --features default-musl --target x86_64-unknown-linux-musl
+    command: scripts/build.sh
 
   build-armv7-unknown-linux-musleabihf:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
     environment:
+      TARGET: armv7-unknown-linux-musleabihf
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -30,13 +34,15 @@ services:
       - ./target/armv7-unknown-linux-musleabihf/cargo/git:/opt/rust/cargo/git
       - ./target/armv7-unknown-linux-musleabihf/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: cargo build --no-default-features --features default-musl --target armv7-unknown-linux-musleabihf
+    command: scripts/build.sh
 
   build-aarch64-unknown-linux-musl:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
     environment:
+      TARGET: aarch64-unknown-linux-musl
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -44,7 +50,7 @@ services:
       - ./target/aarch64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/aarch64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: cargo build --no-default-features --features default-musl --target aarch64-unknown-linux-musl
+    command: scripts/build.sh
 
   bench:
     build:
@@ -178,7 +184,7 @@ services:
     working_dir: $PWD
     command: ./scripts/check-blog-signatures.rb
 
-  build-archive-x86_64-unknown-linux-musl:
+  package-archive-x86_64-unknown-linux-musl:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -192,9 +198,9 @@ services:
       - ./target/x86_64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/x86_64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: ./scripts/build-archive.sh
+    command: ./scripts/package-archive.sh
 
-  build-archive-armv7-unknown-linux-musleabihf:
+  package-archive-armv7-unknown-linux-musleabihf:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -208,9 +214,9 @@ services:
       - ./target/armv7-unknwon-linux-musleabihf/cargo/git:/opt/rust/cargo/git
       - ./target/armv7-unknwon-linux-musleabihf/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: ./scripts/build-archive.sh
+    command: ./scripts/package-archive.sh
 
-  build-archive-aarch64-unknown-linux-musl:
+  package-archive-aarch64-unknown-linux-musl:
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -224,7 +230,7 @@ services:
       - ./target/aarch64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/aarch64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    command: ./scripts/build-archive.sh
+    command: ./scripts/package-archive.sh
 
   package-deb-x86_64:
     build:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,8 +45,6 @@ echo "Features: $FEATURES"
 # Setup directories
 #
 
-artifacts_dir="target/artifacts"
-
 if [ -z "$NATIVE_BUILD" ]; then
   target_dir="target/$TARGET"
 else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# build.sh
+#
+# SUMMARY
+#
+#   Used to build a binary for the specified $TARGET
+#
+# ENV VARS
+#
+#   $FEATURES - a list of Vector features to include when building, defaults to all
+#   $NATIVE_BUILD - whether to pass the --target flag when building via cargo
+#   $STRIP - whether or not to strip the binary
+#   $TARGET - a target triple. ex: x86_64-apple-darwin
+
+#
+# Env vars
+#
+
+NATIVE_BUILD=${NATIVE_BUILD:-}
+STRIP=${STRIP:-}
+FEATURES=${FEATURES:-}
+
+if [ -z "$FEATURES" ]; then
+    FEATURES="default"
+fi
+
+CHANNEL=${CHANNEL:-$(scripts/util/release-channel.sh)}
+if [ "$CHANNEL" == "nightly" ]; then
+  FEATURES="$FEATURES nightly"
+fi
+
+#
+# Header
+#
+
+set -eu
+
+echo "Building Vector binary"
+echo "Target: $TARGET"
+echo "Native build: $NATIVE_BUILD"
+echo "Features: $FEATURES"
+
+#
+# Setup directories
+#
+
+artifacts_dir="target/artifacts"
+
+if [ -z "$NATIVE_BUILD" ]; then
+  target_dir="target/$TARGET"
+else
+  target_dir="target"
+fi
+
+#
+# Build
+#
+
+build_flags="--release"
+
+if [ -z "$NATIVE_BUILD" ]; then
+  build_flags="$build_flags --target $TARGET"
+fi
+
+on_exit=""
+
+if [ "$FEATURES" != "default" ]; then
+    cargo build $build_flags --no-default-features --features "$FEATURES"
+else
+    cargo build $build_flags
+fi
+
+#
+# Strip the output binary
+#
+
+if [ "$STRIP" != "false" ]; then
+  strip $target_dir/release/vector
+fi

--- a/scripts/package-archive.sh
+++ b/scripts/package-archive.sh
@@ -11,9 +11,11 @@
 # ENV VARS
 #
 #   $ARCHIVE_TYPE - archive type, either "tar.gz" or "zip"
+#   $NATIVE_BUILD - whether to pass the --target flag when building via cargo
 #   $TARGET - a target triple. ex: x86_64-apple-darwin
 
 ARCHIVE_TYPE=${ARCHIVE_TYPE:-tar.gz}
+NATIVE_BUILD=${NATIVE_BUILD:-}
 
 set -eu
 
@@ -24,6 +26,12 @@ echo "Target: $TARGET"
 #
 # Build the archive directory
 #
+
+if [ -z "$NATIVE_BUILD" ]; then
+  target_dir="target/$TARGET"
+else
+  target_dir="target"
+fi
 
 archive_dir_name="vector-$TARGET"
 archive_dir="$target_dir/$archive_dir_name"

--- a/scripts/package-archive.sh
+++ b/scripts/package-archive.sh
@@ -93,6 +93,7 @@ cd $_old_dir
 # Move to the artifacts dir
 #
 
+artifacts_dir="target/artifacts"
 mkdir -p $artifacts_dir
 mv -v $target_dir/vector-$TARGET.$ARCHIVE_TYPE $artifacts_dir
 echo "Moved $target_dir/vector-$TARGET.$ARCHIVE_TYPE to $artifacts_dir"

--- a/scripts/package-archive.sh
+++ b/scripts/package-archive.sh
@@ -1,76 +1,38 @@
 #!/usr/bin/env bash
 
-# build.sh
+# package-archive.sh
 #
 # SUMMARY
 #
-#   Used to build a tar.gz archive for the specified $TARGET
+#   Used to package a tar.gz archive for the specified $TARGET. This assumes
+#   that the binary is already built and in the proper $TARGET dir. See
+#   buid.sh for more info.
 #
 # ENV VARS
 #
-#   $FEATURES - a list of Vector features to include when building, defaults to all
-#   $NATIVE_BUILD - whether to pass the --target flag when building via cargo
-#   $STRIP - whether or not to strip the binary
-#   $TARGET - a target triple. ex: x86_64-apple-darwin
 #   $ARCHIVE_TYPE - archive type, either "tar.gz" or "zip"
+#   $TARGET - a target triple. ex: x86_64-apple-darwin
 
-NATIVE_BUILD=${NATIVE_BUILD:-}
-STRIP=${STRIP:-}
-FEATURES=${FEATURES:-}
 ARCHIVE_TYPE=${ARCHIVE_TYPE:-tar.gz}
-
-if [ -z "$FEATURES" ]; then
-    FEATURES="default"
-fi
-
-CHANNEL=${CHANNEL:-$(scripts/util/release-channel.sh)}
-if [ "$CHANNEL" == "nightly" ]; then
-  FEATURES="$FEATURES nightly"
-fi
 
 set -eu
 
-echo "Building Vector archive"
+echo "Packaging the Vector archive"
+echo "Archive Type: $ARCHIVE_TYPE"
 echo "Target: $TARGET"
-echo "Native build: $NATIVE_BUILD"
-echo "Features: $FEATURES"
 
-# Setup directories
-artifacts_dir="target/artifacts"
-
-if [ -z "$NATIVE_BUILD" ]; then
-  target_dir="target/$TARGET"
-else
-  target_dir="target"
-fi
+#
+# Build the archive directory
+#
 
 archive_dir_name="vector-$TARGET"
 archive_dir="$target_dir/$archive_dir_name"
-
-# Build
-build_flags="--release"
-
-if [ -z "$NATIVE_BUILD" ]; then
-  build_flags="$build_flags --target $TARGET"
-fi
-
-on_exit=""
-
-if [ "$FEATURES" != "default" ]; then
-    cargo build $build_flags --no-default-features --features "$FEATURES"
-else
-    cargo build $build_flags
-fi
-
-
-# Strip the output binary
-if [ "$STRIP" != "false" ]; then
-  strip $target_dir/release/vector
-fi
-
-# Build the archive directory
 rm -rf $archive_dir
 mkdir -p $archive_dir
+
+#
+# Copy files to archive dir
+#
 
 # Copy root level files
 
@@ -84,23 +46,29 @@ cp -av README.md $archive_dir/README.md$suffix
 cat LICENSE NOTICE > $archive_dir/LICENSE$suffix
 
 # Copy the vector binary to /bin
+
 mkdir -p $archive_dir/bin
 cp -av $target_dir/release/vector $archive_dir/bin
 
 # Copy the entire config dir to /config
+
 cp -rv config $archive_dir/config
 # Remove templates sources
 rm $archive_dir/config/*.erb
 
+# Copy /etc useful files
+
 if [[ $TARGET == *linux* ]]; then
-  # Copy /etc useful files
   mkdir -p $archive_dir/etc/systemd
   cp -av distribution/systemd/vector.service $archive_dir/etc/systemd
   mkdir -p $archive_dir/etc/init.d
   cp -av distribution/init.d/vector $archive_dir/etc/init.d
 fi
 
+#
 # Build the release archive
+#
+
 _old_dir=$(pwd)
 cd $target_dir
 if [ "$ARCHIVE_TYPE" == "tar.gz" ]; then
@@ -113,10 +81,16 @@ else
 fi
 cd $_old_dir
 
+#
 # Move to the artifacts dir
+#
+
 mkdir -p $artifacts_dir
 mv -v $target_dir/vector-$TARGET.$ARCHIVE_TYPE $artifacts_dir
 echo "Moved $target_dir/vector-$TARGET.$ARCHIVE_TYPE to $artifacts_dir"
 
+#
 # Cleanup
+#
+
 rm -rf $archive_dir

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -119,11 +119,10 @@ check-blog: ## check that all blog posts are signed and valid
 
 ##@ Packaging
 
-package: build-archive package-deb package-rpm ## default target, package x86_84
-
 package-all: build-archive-all package-deb-all package-rpm-all ## package everything
 
-build-archive: build-archive-x86_64-unknown-linux-musl ## default target, build the x86_64 archives
+build-archive: ## build the Vector archive
+	$(RUN) build-archive
 
 build-archive-all: build-archive-x86_64-unknown-linux-musl build-archive-armv7-unknown-linux-musleabihf build-archive-aarch64-unknown-linux-musl ## build all archives
 
@@ -136,31 +135,56 @@ build-archive-armv7-unknown-linux-musleabihf: build-armv7-unknown-linux-musleabi
 build-archive-aarch6-unknown-linux-musl: build-aarch64-unknown-linux-musl ## build the aarch64 archive
 	$(RUN) build-archive-aarch64-unknown-linux-musl
 
-package-deb: package-deb-x86_64 ## default target, build the x86_64 deb package
+package-deb: ## build the x86_64 deb package
+	$(RUN) package-deb
 
 package-deb-all: package-deb-x86_64 package-deb-armv7 package-deb-aarch64 ## build all deb packages
 
-package-deb-x86_64: build-archive-x86_64 ## build the x86_64 deb package
+package-deb-x86_64: build-archive-x86_64-unknown-linux-musl ## build the x86_64 deb package
 	$(RUN) package-deb-x86_64
 
-package-deb-armv7: build-archive-armv7 ## build the armv7 deb package
+package-deb-armv7: build-archive-armv7-unknown-linux-musleabihf ## build the armv7 deb package
 	$(RUN) package-deb-armv7
 
-package-deb-aarch64: build-archive-aarch64  ## build the aarch64 deb package
+package-deb-aarch64: build-archive-aarch64-unknown-linux-musl  ## build the aarch64 deb package
 	$(RUN) package-deb-aarch64
 
-package-rpm: package-rpm-x86_64 ## default target, build the x86_64 rpm package
+package-rpm: ## default target, build the x86_64 rpm package
+	$(RUN) package-rpm
 
 package-rpm-all: package-rpm-x86_64 package-rpm-armv7 package-rpm-aarch64 ## build all rpm packages
 
-package-rpm-x86_64: build-archive-x86_64 ## build the x86_64 rpm package
+package-rpm-x86_64: build-archive-x86_64-unknown-linux-musl ## build the x86_64 rpm package
 	$(RUN) package-rpm-x86_64
 
-package-rpm-armv7: build-archive-armv7 ## build the armv7 rpm package
+package-rpm-armv7: build-archive-armv7-unknown-linux-musleabihf ## build the armv7 rpm package
 	$(RUN) package-rpm-armv7
 
-package-rpm-aarch64: build-archive-aarch64 ## build the aarch64 rpm package
+package-rpm-aarch64: build-archive-aarch64-unknown-linux-musl ## build the aarch64 rpm package
 	$(RUN) package-rpm-aarch64
+
+##@ Releasing
+
+release-commit: ## Commits release changes
+	$(RUN) release-commit
+
+release-docker: ## Release to Docker Hub
+	$(RUN) release-docker
+
+release-github: ## Release to Github
+	$(RUN) release-github
+
+release-homebrew: ## Release to timberio Homebrew tap
+	$(RUN) release-homebrew
+
+release-prepare: ## Prepares the release with metadata and highlights
+	$(RUN) release-prepare
+
+release-rollback:
+	$(RUN) release-rollback
+
+release-s3: ## Release artifacts to S3
+	$(RUN) release-s3
 
 ##@ Verifying
 
@@ -168,33 +192,33 @@ verify: verify-rpm verify-deb ## default target, verify all packages
 
 verify-rpm: verify-rpm-amazonlinux-1 verify-rpm-amazonlinux-2 verify-rpm-centos-7 ## verify all rpm packages
 
-verify-rpm-amazonlinux-1: package-rpm ## verify the rpm package on Amazon Linux 1
+verify-rpm-amazonlinux-1: package-rpm-x86_64 ## verify the rpm package on Amazon Linux 1
 	$(RUN) verify-rpm-amazonlinux-1
 
-verify-rpm-amazonlinux-2: package-rpm ## verify the rpm package on Amazon Linux 2
+verify-rpm-amazonlinux-2: package-rpm-x86_64 ## verify the rpm package on Amazon Linux 2
 	$(RUN) verify-rpm-amazonlinux-2
 
-verify-rpm-centos-7: package-rpm ## verify the rpm package on CentOS 7
+verify-rpm-centos-7: package-rpm-x86_64 ## verify the rpm package on CentOS 7
 	$(RUN) verify-rpm-centos-7
 
 verify-deb: verify-deb-artifact-on-deb-8 verify-deb-artifact-on-deb-9 verify-deb-artifact-on-deb-10 verify-deb-artifact-on-ubuntu-16-04 verify-deb-artifact-on-ubuntu-18-04 verify-deb-artifact-on-ubuntu-19-04 ## verify all deb packages
 
-verify-deb-artifact-on-deb-8: package-deb ## verify the deb package on Debian 8
+verify-deb-artifact-on-deb-8: package-deb-x86_64 ## verify the deb package on Debian 8
 	$(RUN) verify-deb-artifact-on-deb-8
 
-verify-deb-artifact-on-deb-9: package-deb ## verify the deb package on Debian 9
+verify-deb-artifact-on-deb-9: package-deb-x86_64 ## verify the deb package on Debian 9
 	$(RUN) verify-deb-artifact-on-deb-9
 
-verify-deb-artifact-on-deb-10: package-deb ## verify the deb package on Debian 10
+verify-deb-artifact-on-deb-10: package-deb-x86_64 ## verify the deb package on Debian 10
 	$(RUN) verify-deb-artifact-on-deb-10
 
-verify-deb-artifact-on-ubuntu-16-04: package-deb ## verify the deb package on Ubuntu 16.04
+verify-deb-artifact-on-ubuntu-16-04: package-deb-x86_64 ## verify the deb package on Ubuntu 16.04
 	$(RUN) verify-deb-artifact-on-ubuntu-16-04
 
-verify-deb-artifact-on-ubuntu-18-04: package-deb ## verify the deb package on Ubuntu 18.04
+verify-deb-artifact-on-ubuntu-18-04: package-deb-x86_64 ## verify the deb package on Ubuntu 18.04
 	$(RUN) verify-deb-artifact-on-ubuntu-18-04
 
-verify-deb-artifact-on-ubuntu-19-04: package-deb ## verify the deb package on Ubuntu 19.04
+verify-deb-artifact-on-ubuntu-19-04: package-deb-x86_64 ## verify the deb package on Ubuntu 19.04
 	$(RUN) verify-deb-artifact-on-ubuntu-19-04
 
 verify-nixos:  ## verify that Vector can be built on NixOS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -132,7 +132,7 @@ build-archive-x86_64-unknown-linux-musl: build-x86_64-unknown-linux-musl ## buil
 build-archive-armv7-unknown-linux-musleabihf: build-armv7-unknown-linux-musleabihf ## build the armv7 archive
 	$(RUN) build-archive-armv7-unknown-linux-musleabihf
 
-build-archive-aarch6-unknown-linux-musl: build-aarch64-unknown-linux-musl ## build the aarch64 archive
+build-archive-aarch64-unknown-linux-musl: build-aarch64-unknown-linux-musl ## build the aarch64 archive
 	$(RUN) build-archive-aarch64-unknown-linux-musl
 
 package-deb: ## build the x86_64 deb package

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -119,34 +119,34 @@ check-blog: ## check that all blog posts are signed and valid
 
 ##@ Packaging
 
-package-all: build-archive-all package-deb-all package-rpm-all ## package everything
+package-all: package-archive-all package-deb-all package-rpm-all ## package everything
 
-build-archive: ## build the Vector archive
-	$(RUN) build-archive
+package-archive: ## package the Vector archive
+	$(RUN) package-archive
 
-build-archive-all: build-archive-x86_64-unknown-linux-musl build-archive-armv7-unknown-linux-musleabihf build-archive-aarch64-unknown-linux-musl ## build all archives
+package-archive-all: package-archive-x86_64-unknown-linux-musl package-archive-armv7-unknown-linux-musleabihf package-archive-aarch64-unknown-linux-musl ## package all archives
 
-build-archive-x86_64-unknown-linux-musl: build-x86_64-unknown-linux-musl ## build the x86_64 archive
-	$(RUN) build-archive-x86_64-unknown-linux-musl
+package-archive-x86_64-unknown-linux-musl: build-x86_64-unknown-linux-musl ## package the x86_64 archive
+	$(RUN) package-archive-x86_64-unknown-linux-musl
 
-build-archive-armv7-unknown-linux-musleabihf: build-armv7-unknown-linux-musleabihf ## build the armv7 archive
-	$(RUN) build-archive-armv7-unknown-linux-musleabihf
+package-archive-armv7-unknown-linux-musleabihf: build-armv7-unknown-linux-musleabihf ## package the armv7 archive
+	$(RUN) package-archive-armv7-unknown-linux-musleabihf
 
-build-archive-aarch64-unknown-linux-musl: build-aarch64-unknown-linux-musl ## build the aarch64 archive
-	$(RUN) build-archive-aarch64-unknown-linux-musl
+package-archive-aarch64-unknown-linux-musl: build-aarch64-unknown-linux-musl ## package the aarch64 archive
+	$(RUN) package-archive-aarch64-unknown-linux-musl
 
 package-deb: ## build the x86_64 deb package
 	$(RUN) package-deb
 
 package-deb-all: package-deb-x86_64 package-deb-armv7 package-deb-aarch64 ## build all deb packages
 
-package-deb-x86_64: build-archive-x86_64-unknown-linux-musl ## build the x86_64 deb package
+package-deb-x86_64: package-archive-x86_64-unknown-linux-musl ## build the x86_64 deb package
 	$(RUN) package-deb-x86_64
 
-package-deb-armv7: build-archive-armv7-unknown-linux-musleabihf ## build the armv7 deb package
+package-deb-armv7: package-archive-armv7-unknown-linux-musleabihf ## build the armv7 deb package
 	$(RUN) package-deb-armv7
 
-package-deb-aarch64: build-archive-aarch64-unknown-linux-musl  ## build the aarch64 deb package
+package-deb-aarch64: package-archive-aarch64-unknown-linux-musl  ## build the aarch64 deb package
 	$(RUN) package-deb-aarch64
 
 package-rpm: ## default target, build the x86_64 rpm package
@@ -154,13 +154,13 @@ package-rpm: ## default target, build the x86_64 rpm package
 
 package-rpm-all: package-rpm-x86_64 package-rpm-armv7 package-rpm-aarch64 ## build all rpm packages
 
-package-rpm-x86_64: build-archive-x86_64-unknown-linux-musl ## build the x86_64 rpm package
+package-rpm-x86_64: package-archive-x86_64-unknown-linux-musl ## build the x86_64 rpm package
 	$(RUN) package-rpm-x86_64
 
-package-rpm-armv7: build-archive-armv7-unknown-linux-musleabihf ## build the armv7 rpm package
+package-rpm-armv7: package-archive-armv7-unknown-linux-musleabihf ## build the armv7 rpm package
 	$(RUN) package-rpm-armv7
 
-package-rpm-aarch64: build-archive-aarch64-unknown-linux-musl ## build the aarch64 rpm package
+package-rpm-aarch64: package-archive-aarch64-unknown-linux-musl ## build the aarch64 rpm package
 	$(RUN) package-rpm-aarch64
 
 ##@ Releasing

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,7 +22,8 @@ all: check build-all package-all test-docker test-behavior verify ## run all tes
 
 ##@ Building
 
-build: build-x86_64-unknown-linux-musl ## default target, build the project in debug mode
+build: ## build a project binary
+	$(RUN) build
 
 build-all: build-x86_64-unknown-linux-musl build-armv7-unknown-linux-musleabihf build-aarch64-unknown-linux-musl ## build the project in debug mode for all platforms
 
@@ -121,7 +122,7 @@ check-blog: ## check that all blog posts are signed and valid
 
 package-all: package-archive-all package-deb-all package-rpm-all ## package everything
 
-package-archive: ## package the Vector archive
+package-archive: build ## package the Vector archive
 	$(RUN) package-archive
 
 package-archive-all: package-archive-x86_64-unknown-linux-musl package-archive-armv7-unknown-linux-musleabihf package-archive-aarch64-unknown-linux-musl ## package all archives


### PR DESCRIPTION
This is pull request 5 (after https://github.com/timberio/vector/pull/2453) in a series of pull requests for #2368. This points the nightly workflow to the `tests/Makefile`. This is the final change to centralize all GH workflows around the `tests/Makefile`. Once this is done we can drop the root `Makefile` and consolidate everything. This also sets the stage for #2337 since well be updating our release process to move to glibc.

cc @a-rodin 