### PR TITLE
chore(operations): Add aws-integration-tests & gcp-integration-tests feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ docker = [
   "splunk-integration-tests",
 ]
 
-aws-integration-tests = ["sinks-aws_cloudwatch_logs", "aws_cloudwatch_metrics", "transforms-aws_ec2_metadata", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-elasticsearch", "sinks-aws_s3"]
+aws-integration-tests = ["sinks-aws_cloudwatch_logs", "sinks-aws_cloudwatch_metrics", "sinks-elasticsearch", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-aws_s3" "transforms-aws_ec2_metadata"]
 aws-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
 aws-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
 aws-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,36 +373,33 @@ nightly = []
 
 # Testing-related features
 docker = [
+  "aws-integration-tests",
   "clickhouse-integration-tests",
-  "cloudwatch-logs-integration-tests",
-  "cloudwatch-metrics-integration-tests",
   "docker-integration-tests",
-  "ec2-metadata-integration-tests",
   "es-integration-tests",
-  "firehose-integration-tests",
-  "gcp-pubsub-integration-tests",
-  "gcs-integration-tests",
-  "kafka-integration-tests",
-  "kinesis-integration-tests",
-  "s3-integration-tests",
+  "gcp-integration-tests",
   "influxdb-integration-tests",
-  "splunk-integration-tests",
+  "kafka-integration-tests",
   "pulsar-integration-tests",
+  "splunk-integration-tests",
 ]
+
+aws-integration-tests = ["sinks-aws_cloudwatch_logs", "aws_cloudwatch_metrics", "transforms-aws_ec2_metadata", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-elasticsearch", "sinks-aws_s3"]
+aws-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
+aws-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
+aws-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]
+aws-kinesis-firehose-integration-tests = ["sinks-aws_kinesis_firehose", "sinks-elasticsearch"]
+aws-kinesis-streams-integration-tests = ["sinks-aws_kinesis_streams"]
+aws-s3-integration-tests = ["sinks-aws_s3"]
 clickhouse-integration-tests = ["sinks-clickhouse"]
-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
 docker-integration-tests = ["sources-docker", "unix"]
-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]
 es-integration-tests = ["sinks-elasticsearch"]
-firehose-integration-tests = ["sinks-aws_kinesis_firehose", "sinks-elasticsearch"]
+gcp-integration-tests = ["sinks-gcp"]
 gcp-pubsub-integration-tests = ["sinks-gcp"]
-gcs-integration-tests = ["sinks-gcp"]
+gcp-cloud-storage-integration-tests = ["sinks-gcp"]
 influxdb-integration-tests = ["sinks-influxdb_metrics"]
 kafka-integration-tests = ["sinks-kafka"]
-kinesis-integration-tests = ["sinks-aws_kinesis_streams"]
 pulsar-integration-tests = ["sinks-pulsar"]
-s3-integration-tests = ["sinks-aws_s3"]
 splunk-integration-tests = ["sinks-splunk_hec", "warp"]
 
 kubernetes = ["kubernetes-integration-tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ docker = [
   "splunk-integration-tests",
 ]
 
-aws-integration-tests = ["sinks-aws_cloudwatch_logs", "sinks-aws_cloudwatch_metrics", "sinks-elasticsearch", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-aws_s3" "transforms-aws_ec2_metadata"]
+aws-integration-tests = ["sinks-aws_cloudwatch_logs", "sinks-aws_cloudwatch_metrics", "sinks-elasticsearch", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-aws_s3", "transforms-aws_ec2_metadata"]
 aws-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
 aws-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
 aws-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -481,7 +481,7 @@ services:
       - dependencies-aws
     network_mode: host
     working_dir: $PWD
-    command: cargo test --all --no-default-features --features default-musl,cloudwatch-logs-integration-tests,cloudwatch-metrics-integration-tests,ec2-metadata-integration-tests,firehose-integration-tests,kinesis-integration-tests,s3-integration-tests --target x86_64-unknown-linux-musl
+    command: cargo test --all --no-default-features --features default-musl,aws-integration-tests --target x86_64-unknown-linux-musl
 
   test-behavior:
     image: ubuntu:18.04

--- a/scripts/test-integration-aws.sh
+++ b/scripts/test-integration-aws.sh
@@ -9,4 +9,4 @@
 set -euo pipefail
 
 docker-compose up -d dependencies-aws
-cargo test --no-default-features --features cloudwatch-logs-integration-tests,cloudwatch-metrics-integration-tests,ec2-metadata-integration-tests,firehose-integration-tests,kinesis-integration-tests,s3-integration-tests
+cargo test --no-default-features --features aws-integration-tests

--- a/scripts/test-integration-gcp.sh
+++ b/scripts/test-integration-gcp.sh
@@ -9,4 +9,4 @@
 set -euo pipefail
 
 docker-compose up -d dependencies-gcp
-cargo test --no-default-features --features gcp-pubsub-integration-tests, gcs-integration-tests
+cargo test --no-default-features --features gcp-integration-tests

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -737,7 +737,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "cloudwatch-logs-integration-tests")]
+#[cfg(feature = "aws-cloudwatch-logs-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -429,7 +429,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "cloudwatch-metrics-integration-tests")]
+#[cfg(feature = "aws-cloudwatch-metrics-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -255,7 +255,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "firehose-integration-tests")]
+#[cfg(feature = "aws-kinesis-firehose-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -318,7 +318,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "kinesis-integration-tests")]
+#[cfg(feature = "aws-kinesis-streams-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -506,7 +506,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "s3-integration-tests")]
+#[cfg(feature = "aws-s3-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -466,7 +466,7 @@ enum Ec2MetadataError {
 }
 
 #[cfg(test)]
-#[cfg(feature = "ec2-metadata-integration-tests")]
+#[cfg(feature = "aws-ec2-metadata-integration-tests")]
 mod tests {
     use super::*;
     use crate::{event::Event, test_util::runtime};


### PR DESCRIPTION
This adds `aws-integration-tests` and `gcp-integration-tests` features to align with our `make` targets. It also prevents duplication, removing the need to specify every AWS and GCP service whenever we want to test those clouds.