### PR TITLE
chore(security): Ignore `RUSTSEC-2020-0014`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,7 @@
 [advisories]
 ignore = [
+    "RUSTSEC-2020-0014", # Advisory for dev dependency of `trust-dns` for testing
+                         # dns servers.
     "RUSTSEC-2020-0002", # tracked in #1639
     "RUSTSEC-2020-0001", # dev dependency only
     "RUSTSEC-2019-0031", # spin is unmaintained


### PR DESCRIPTION
This dependency is only used in a test for our dns server which should
get swapped out very shortly via #2464. This is to unblock CI from
failing.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>