### PR TITLE
chore(operations): Fix local unit test execution

### DIFF
--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -8,4 +8,8 @@
 
 set -euo pipefail
 
-cargo test --all --no-default-features --target ${TARGET}
+if [ -z "${TARGET:-}" ]; then
+    cargo test --all --no-default-features
+else 
+    cargo test --all --no-default-features --target "${TARGET}"
+fi


### PR DESCRIPTION
There are situations when the target-triple is not set, e.g. when calling  
`USE_CONTAINER=none make test-unit`. Since the proper value for `target-triple`
depends on the system architecture, we leave it empty so that `cargo` uses the system default.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
