### PR TITLE
enhancement(regex_parser transform): Add RegexSet support to regex

### DIFF
--- a/.meta/transforms/regex_parser.toml.erb
+++ b/.meta/transforms/regex_parser.toml.erb
@@ -38,17 +38,17 @@ If `target_field` is set and the log contains a field of the same name \
 as the target, it will only be overwritten if this is set to `true`.\
 """
 
-[transforms.regex_parser.options.regex]
+[transforms.regex_parser.options.patterns]
 type = "string"
 common = true
 examples = [
 """\
-^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$\
+['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']\
 """
 ]
 required = true
 description = """\
-The Regular Expression to apply. Do not include the leading or trailing `/`.\
+The Regular Expressions to apply. Do not include the leading or trailing `/` in any of the expressions.\
 """
 
 [transforms.regex_parser.options.target_field]
@@ -85,7 +85,7 @@ And the following configuration:
 [transforms.<transform-id>]
   type = "regex_parser"
   field = "message"
-  regex = '^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$'
+  patterns = ['^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$']
 
 [transforms.<transform-id>.types]
   bytes_in = "int"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -346,7 +346,7 @@ fn benchmark_transforms(c: &mut Criterion) {
                         "parser",
                         &["in"],
                         transforms::regex_parser::RegexParserConfig {
-                            regex: r"status=(?P<status>\d+)".to_string(),
+                            patterns: vec![r"status=(?P<status>\d+)".to_string()],
                             field: None,
                             ..Default::default()
                         },
@@ -410,7 +410,7 @@ fn benchmark_regex(c: &mut Criterion) {
                     let rt = vector::runtime::Runtime::single_threaded().unwrap();
                     let parser =transforms::regex_parser::RegexParserConfig {
                         // Many captures to stress the regex parser
-                        regex: r#"^(?P<addr>\d+\.\d+\.\d+\.\d+) (?P<user>\S+) (?P<auth>\S+) \[(?P<date>\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ [+-]\d{4})\] "(?P<method>[A-Z]+) (?P<uri>[^"]+) HTTP/\d\.\d" (?P<code>\d+) (?P<size>\d+) "(?P<referrer>[^"]+)" "(?P<browser>[^"]+)""#.into(),
+                        patterns: vec![r#"^(?P<addr>\d+\.\d+\.\d+\.\d+) (?P<user>\S+) (?P<auth>\S+) \[(?P<date>\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ [+-]\d{4})\] "(?P<method>[A-Z]+) (?P<uri>[^"]+) HTTP/\d\.\d" (?P<code>\d+) (?P<size>\d+) "(?P<referrer>[^"]+)" "(?P<browser>[^"]+)""#.into()],
                         field: None,
                         drop_failed: true,
                         ..Default::default()
@@ -465,7 +465,7 @@ fn benchmark_complex(c: &mut Criterion) {
                         "parser",
                         &["in1", "in2"],
                         transforms::regex_parser::RegexParserConfig {
-                            regex: r"status=(?P<status>\d+)".to_string(),
+                            patterns: vec![r"status=(?P<status>\d+)".to_string()],
                             field: None,
                             ..Default::default()
                         },

--- a/config/examples/docs_example.toml
+++ b/config/examples/docs_example.toml
@@ -11,7 +11,7 @@ data_dir = "/var/lib/vector"
 [transforms.apache_parser]
   inputs       = ["apache_logs"]
   type         = "regex_parser"                # fast/powerful regex
-  regex        = '^(?P<host>[w.]+) - (?P<user>[w]+) (?P<bytes_in>[d]+) [(?P<timestamp>.*)] "(?P<method>[w]+) (?P<path>.*)" (?P<status>[d]+) (?P<bytes_out>[d]+)$'
+  patterns      = ['^(?P<host>[w.]+) - (?P<user>[w]+) (?P<bytes_in>[d]+) [(?P<timestamp>.*)] "(?P<method>[w]+) (?P<path>.*)" (?P<status>[d]+) (?P<bytes_out>[d]+)$']
 
 # Sample the data to save on cost
 [transforms.apache_sampler]

--- a/config/examples/file_to_cloudwatch_metrics.toml
+++ b/config/examples/file_to_cloudwatch_metrics.toml
@@ -14,7 +14,7 @@ start_at_beginning = true
 [transforms.regex_parser]
 inputs = ["file"]
 type = "regex_parser"
-regex = '^(?P<host>[\w\.]+) - (?P<user>[\w-]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$'
+patterns = ['^(?P<host>[\w\.]+) - (?P<user>[\w-]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$']
 
 # Transform into metrics
 [transforms.log_to_metric]

--- a/config/examples/file_to_prometheus.toml
+++ b/config/examples/file_to_prometheus.toml
@@ -14,7 +14,7 @@ start_at_beginning = true
 [transforms.regex_parser]
 inputs = ["file"]
 type = "regex_parser"
-regex = '^(?P<host>[\w\.]+) - (?P<user>[\w-]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$'
+patterns = ['^(?P<host>[\w\.]+) - (?P<user>[\w-]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$']
 
 # Transform into metrics
 [transforms.log_to_metric]

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -5,7 +5,7 @@ use crate::{
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
     types::{parse_check_conversion_map, Conversion},
 };
-use regex::bytes::{CaptureLocations, Regex};
+use regex::bytes::{CaptureLocations, Regex, RegexSet};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::collections::HashMap;
@@ -16,7 +16,11 @@ use string_cache::DefaultAtom as Atom;
 #[derivative(Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct RegexParserConfig {
-    pub regex: String,
+    /// Deprecated. Use `patterns` instead.
+    /// See #2469.
+    /// TODO: Remove at a future point in time.
+    pub regex: Option<String>,
+    pub patterns: Vec<String>,
     pub field: Option<Atom>,
     #[derivative(Default(value = "true"))]
     pub drop_field: bool,
@@ -51,14 +55,15 @@ impl TransformConfig for RegexParserConfig {
 }
 
 pub struct RegexParser {
-    regex: Regex,
+    regexset: RegexSet,
+    patterns: Vec<Regex>,
     field: Atom,
     drop_field: bool,
     drop_failed: bool,
     target_field: Option<Atom>,
     overwrite_target: bool,
     capture_names: Vec<(usize, Atom, Conversion)>,
-    capture_locs: CaptureLocations,
+    capture_locs: Vec<CaptureLocations>,
 }
 
 impl RegexParser {
@@ -68,16 +73,57 @@ impl RegexParser {
             .as_ref()
             .unwrap_or(&event::log_schema().message_key());
 
-        let regex = Regex::new(&config.regex).context(super::InvalidRegex)?;
+        let patterns = match (&config.regex, &config.patterns.len()) {
+            (None, 0) => {
+                return Err(
+                    "At least one regular expression must be defined, but `patterns` is empty"
+                        .into(),
+                );
+            }
+            (None, _) => config.patterns.clone(),
+            (Some(regex), 0) => {
+                // Still using the old `regex` syntax.
+                // Printing a warning and wrapping input in a `vec`.
+                warn!(
+                    "Usage of `regex` is deprecated and will be removed in a future version. \
+                     Please upgrade your config to use `patterns` instead: \
+                     `patterns = ['{}']`. For more info, take a look at the documentation at \
+                     https://vector.dev/docs/reference/transforms/regex_parser/",
+                    &regex
+                );
+                vec![regex.clone()]
+            }
+            _ => {
+                return Err("`patterns = [...]` is not defined".into());
+            }
+        };
 
-        let names = &regex
-            .capture_names()
-            .filter_map(|s| s.map(Into::into))
+        let regexset = RegexSet::new(&patterns).context(super::InvalidRegex)?;
+
+        // Pre-compile individual patterns
+        let patterns: Result<Vec<Regex>, _> = regexset
+            .patterns()
+            .iter()
+            .map(|pattern| Regex::new(pattern))
+            .collect();
+        let patterns = patterns.context(super::InvalidRegex)?;
+
+        let names = &patterns
+            .iter()
+            .map(|regex| {
+                regex
+                    .capture_names()
+                    .filter_map(|s| s.map(Into::into))
+                    .collect::<Vec<_>>()
+            })
+            .flatten()
             .collect::<Vec<_>>();
+
         let types = parse_check_conversion_map(&config.types, names)?;
 
         Ok(Box::new(RegexParser::new(
-            regex,
+            regexset,
+            patterns,
             field.clone(),
             config.drop_field,
             config.drop_failed,
@@ -88,7 +134,8 @@ impl RegexParser {
     }
 
     pub fn new(
-        regex: Regex,
+        regexset: RegexSet,
+        patterns: Vec<Regex>,
         field: Atom,
         mut drop_field: bool,
         drop_failed: bool,
@@ -98,27 +145,38 @@ impl RegexParser {
     ) -> Self {
         // Build a buffer of the regex capture locations to avoid
         // repeated allocations.
-        let capture_locs = regex.capture_locations();
+        let capture_locs = patterns
+            .iter()
+            .map(|regex| regex.capture_locations())
+            .collect();
 
         // Calculate the location (index into the capture locations) of
         // each named capture, and the required type coercion.
-        let capture_names: Vec<(usize, Atom, Conversion)> = regex
-            .capture_names()
-            .enumerate()
-            .filter_map(|(idx, cn)| {
-                cn.map(|cn| {
-                    let cn: Atom = cn.into();
-                    let conv = types.get(&cn).unwrap_or(&Conversion::Bytes);
-                    (idx, cn, conv.clone())
-                })
+        let capture_names: Vec<(usize, Atom, Conversion)> = patterns
+            .iter()
+            .map(|regex| {
+                let capture_names: Vec<(usize, Atom, Conversion)> = regex
+                    .capture_names()
+                    .enumerate()
+                    .filter_map(|(idx, cn)| {
+                        cn.map(|cn| {
+                            let cn: Atom = cn.into();
+                            let conv = types.get(&cn).unwrap_or(&Conversion::Bytes);
+                            (idx, cn, conv.clone())
+                        })
+                    })
+                    .collect();
+                capture_names
             })
+            .flatten()
             .collect();
 
         // Pre-calculate if the source field name should be dropped.
         drop_field = drop_field && !capture_names.iter().any(|(_, f, _)| *f == field);
 
         Self {
-            regex,
+            regexset,
+            patterns,
             field,
             drop_field,
             drop_failed,
@@ -137,9 +195,29 @@ impl Transform for RegexParser {
         emit!(RegexEventProcessed);
 
         if let Some(value) = &value {
-            if self
-                .regex
-                .captures_read(&mut self.capture_locs, &value)
+            let regex_id = self.regexset.matches(&value).into_iter().nth(0);
+            let id = match regex_id {
+                Some(id) => id,
+                None => {
+                    emit!(RegexFailedMatch { value });
+                    if self.drop_failed {
+                        return None;
+                    } else {
+                        return Some(event);
+                    }
+                }
+            };
+
+            let mut capture_locs = match self.capture_locs.get_mut(id) {
+                Some(capture_locs) => capture_locs,
+                None => {
+                    error!(message = "Cannot find capture locations for pattern", %id, rate_limit_secs = 30);
+                    return None;
+                }
+            };
+
+            if self.patterns[id]
+                .captures_read(&mut capture_locs, &value)
                 .is_some()
             {
                 // Handle optional overwriting of the target field
@@ -155,7 +233,7 @@ impl Transform for RegexParser {
                 }
 
                 for (idx, name, conversion) in &self.capture_names {
-                    if let Some((start, end)) = self.capture_locs.get(*idx) {
+                    if let Some((start, end)) = capture_locs.get(*idx) {
                         let capture: Value = value[start..end].into();
                         match conversion.convert(capture) {
                             Ok(value) => {
@@ -204,15 +282,15 @@ mod tests {
         Event,
     };
 
-    fn do_transform(event: &str, regex: &str, config: &str) -> Option<LogEvent> {
+    fn do_transform(event: &str, patterns: &str, config: &str) -> Option<LogEvent> {
         let rt = crate::runtime::Runtime::single_threaded().unwrap();
         let event = Event::from(event);
         let mut parser = toml::from_str::<RegexParserConfig>(&format!(
             r#"
-                regex = {:?}
+                patterns = {}
                 {}
             "#,
-            regex, config
+            patterns, config
         ))
         .unwrap()
         .build(TransformContext::new_test(rt.executor()))
@@ -225,7 +303,7 @@ mod tests {
     fn adds_parsed_field_to_event() {
         let log = do_transform(
             "status=1234 time=5678",
-            r"status=(?P<status>\d+) time=(?P<time>\d+)",
+            r#"['status=(?P<status>\d+) time=(?P<time>\d+)']"#,
             "drop_field = false",
         )
         .unwrap();
@@ -237,8 +315,12 @@ mod tests {
 
     #[test]
     fn doesnt_do_anything_if_no_match() {
-        let log =
-            do_transform("asdf1234", r"status=(?P<status>\d+)", "drop_field = false").unwrap();
+        let log = do_transform(
+            "asdf1234",
+            r#"['status=(?P<status>\d+)']"#,
+            "drop_field = false",
+        )
+        .unwrap();
 
         assert_eq!(log.get(&"status".into()), None);
         assert!(log.get(&"message".into()).is_some());
@@ -248,7 +330,7 @@ mod tests {
     fn does_drop_parsed_field() {
         let log = do_transform(
             "status=1234 time=5678",
-            r"status=(?P<status>\d+) time=(?P<time>\d+)",
+            r#"['status=(?P<status>\d+) time=(?P<time>\d+)']"#,
             r#"field = "message""#,
         )
         .unwrap();
@@ -262,7 +344,7 @@ mod tests {
     fn does_not_drop_same_name_parsed_field() {
         let log = do_transform(
             "status=1234 message=yes",
-            r"status=(?P<status>\d+) message=(?P<message>\S+)",
+            r#"['status=(?P<status>\d+) message=(?P<message>\S+)']"#,
             r#"field = "message""#,
         )
         .unwrap();
@@ -275,7 +357,7 @@ mod tests {
     fn does_not_drop_field_if_no_match() {
         let log = do_transform(
             "asdf1234",
-            r"status=(?P<message>\S+)",
+            r#"['status=(?P<message>\S+)']"#,
             r#"field = "message""#,
         )
         .unwrap();
@@ -287,7 +369,7 @@ mod tests {
     fn respects_target_field() {
         let mut log = do_transform(
             "status=1234 time=5678",
-            r"status=(?P<status>\d+) time=(?P<time>\d+)",
+            r#"['status=(?P<status>\d+) time=(?P<time>\d+)']"#,
             r#"
                target_field = "prefix"
                drop_field = false
@@ -313,7 +395,7 @@ mod tests {
         let message = "status=1234 time=5678";
         let log = do_transform(
             message,
-            r"status=(?P<status>\d+) time=(?P<time>\d+)",
+            r#"['status=(?P<status>\d+) time=(?P<time>\d+)']"#,
             r#"
                target_field = "message"
                overwrite_target = false
@@ -330,7 +412,7 @@ mod tests {
     fn overwrites_target_field() {
         let mut log = do_transform(
             "status=1234 time=5678",
-            r"status=(?P<status>\d+) time=(?P<time>\d+)",
+            r#"['status=(?P<status>\d+) time=(?P<time>\d+)']"#,
             r#"
                target_field = "message"
                drop_field = false
@@ -352,25 +434,25 @@ mod tests {
 
     #[test]
     fn does_not_drop_event_if_match() {
-        let log = do_transform("asdf1234", r"asdf", "drop_failed = true");
+        let log = do_transform("asdf1234", r#"['asdf']"#, "drop_failed = true");
         assert!(log.is_some());
     }
 
     #[test]
     fn does_drop_event_if_no_match() {
-        let log = do_transform("asdf1234", r"something", "drop_failed = true");
+        let log = do_transform("asdf1234", r#"['something']"#, "drop_failed = true");
         assert!(log.is_none());
     }
 
     #[test]
     fn handles_valid_optional_capture() {
-        let log = do_transform("1234", r"(?P<status>\d+)?", "").unwrap();
+        let log = do_transform("1234", r#"['(?P<status>\d+)?']"#, "").unwrap();
         assert_eq!(log[&"status".into()], "1234".into());
     }
 
     #[test]
     fn handles_missing_optional_capture() {
-        let log = do_transform("none", r"(?P<status>\d+)?", "").unwrap();
+        let log = do_transform("none", r#"['(?P<status>\d+)?']"#, "").unwrap();
         assert!(log.get(&"status".into()).is_none());
     }
 
@@ -378,7 +460,7 @@ mod tests {
     fn coerces_fields_to_types() {
         let log = do_transform(
             "1234 6789.01 false",
-            r"(?P<status>\d+) (?P<time>[\d.]+) (?P<check>\S+)",
+            r#"['(?P<status>\d+) (?P<time>[\d.]+) (?P<check>\S+)']"#,
             r#"
             [types]
             status = "int"
@@ -390,5 +472,29 @@ mod tests {
         assert_eq!(log[&"check".into()], Value::Boolean(false));
         assert_eq!(log[&"status".into()], Value::Integer(1234));
         assert_eq!(log[&"time".into()], Value::Float(6789.01));
+    }
+
+    #[test]
+    fn supports_multiple_patterns() {
+        let log = do_transform(
+            "1234 235.42 true",
+            r#"[
+                '^(?P<id>\d+)$',
+                '^(?P<id>\d+) (?P<time>[\d.]+) (?P<check>\S+)$',
+            ]"#,
+            r#"
+            drop_field = false
+            [types]
+            id = "int"
+            time = "float"
+            check = "boolean"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(log[&"id".into()], Value::Integer(1234));
+        assert_eq!(log[&"time".into()], Value::Float(235.42));
+        assert_eq!(log[&"check".into()], Value::Boolean(true));
+        assert!(log.get(&"message".into()).is_some());
     }
 }

--- a/tests/behavior/transforms/regex_parser.toml
+++ b/tests/behavior/transforms/regex_parser.toml
@@ -1,7 +1,7 @@
 [transforms.regex_parser_simple]
   inputs = []
   type = "regex_parser"
-  regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
+  patterns = ["^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"]
 [[tests]]
   name = "regex_parser_simple"
   [tests.input]
@@ -18,7 +18,7 @@
 [transforms.regex_parser_target]
   inputs = []
   type = "regex_parser"
-  regex = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
+  patterns = ["^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"]
   target_field = "something"
 [[tests]]
   name = "regex_parser_target"

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -214,7 +214,7 @@ fn bad_regex() {
         [transforms.parser]
         type = "regex_parser"
         inputs = ["in"]
-        regex = "(["
+        patterns = ["(["]
 
         [sinks.out]
         type = "socket"


### PR DESCRIPTION
This allows to specify multiple regular expressions to be defined
that will be matched on the input using `regex::RegexSet`.
Fixes #2469.

Note that this is a **breaking change**, as it requires all configs to be rewritten
to use `regexes = ["..."]` instead of `regex = "..."`. Alternatively, we could
support both fields in the config; although I think this would lead to confusion down
the road.

## Design decisions

- The individual regular expressions are kept in a vector named `regexes`, while
  the actual `RegexSet` is called `regexset` in the transform. The reason for keeping both is that
  [RegexSet::matches] returns the set of regular expressions that match in the given text.
  The set returned contains the index of each regular expression that matches in the given text.
  The index is in correspondence with the order of regular expressions given to 
  RegexSet's constructor, which matches with the index in the vector.
- Type coercions are applied to all captures with the same name across all patterns.
  The reasoning behind this was that types with the same name will probably be
  used similarly further down the pipeline, no matter which pattern was matching.
  Also, splitting up the coercions for each pattern would likely cause additional duplication
  and make the configuration syntax harder to understand for beginners.

## Open questions

- If possible, we should avoid the two calls to `clone()`. Was considering to store references
  to the regular expressions inside the vector instead of the expressions themselves,
  but I was hoping to avoid lifetimes to keep the code more maintainable. Maybe it's a trade-off,
  worth considering, though - or there is a better way.

As discussed with @Hoverbear and @lukesteensen.

[RegexSet::matches]: https://docs.rs/regex/1.3.7/regex/struct.RegexSet.html#method.matches