### PR TITLE
chore: Set minimal supported Kubernetes version

### DIFF
--- a/.meta/supported_versions.toml
+++ b/.meta/supported_versions.toml
@@ -1,5 +1,5 @@
-# This file holds generic specification of version constraints of the third-pary
-# components that Vector integrates with.
+# This file holds the generic specification of version constraints of the
+# third-party components that Vector integrates with.
 # It's designed to be a signle source of truth for the decisions at the other
 # project domains: implementation, distribution, data models and etc.
 

--- a/.meta/supported_versions.toml
+++ b/.meta/supported_versions.toml
@@ -1,0 +1,7 @@
+# This file holds generic specification of version constraints of the third-pary
+# components that Vector integrates with.
+# It's designed to be a signle source of truth for the decisions at the other
+# project domains: implementation, distribution, data models and etc.
+
+# The minimal supported kubernetes version.
+kubernetes = "v1.14"


### PR DESCRIPTION
Specify the minimal supported Kubernetes version, according to the #2222.

The file location is not set in stone, I'm open to changes.

I think this format is the best fit, since the supported versions aren't really a part of the installation domain.

The proposals at #2222 are conceptual and not concrete - that's by the design of the RFC process. We didn't complete the discussion at #2222, so we can finish it here.