### PR TITLE
chore(topology): Add SourceContext

### DIFF
--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     event::{self, Event},
     internal_events::FileEventReceived,
     shutdown::ShutdownSignal,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
     trace::{current_span, Instrument},
 };
 use bytes::Bytes;
@@ -188,13 +188,14 @@ inventory::submit! {
 
 #[typetag::serde(name = "file")]
 impl SourceConfig for FileConfig {
-    fn build(
-        &self,
-        name: &str,
-        globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext {
+            name,
+            globals,
+            shutdown,
+            out,
+            ..
+        } = cx;
         // add the source name as a subdir, so that multiple sources can
         // operate within the same given data_dir (e.g. the global one)
         // without the file servers' checkpointers interfering with each

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -1,7 +1,7 @@
 use crate::{
     event::Event,
     shutdown::ShutdownSignal,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
 };
 use futures::{
     compat::Future01CompatExt,
@@ -42,13 +42,8 @@ inventory::submit! {
 
 #[typetag::serde(name = "generator")]
 impl SourceConfig for GeneratorConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         Ok(self.clone().generator(shutdown, out))
     }
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -1,7 +1,7 @@
 use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     shutdown::ShutdownSignal,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
     Event,
 };
 use chrono::Utc;
@@ -26,13 +26,8 @@ inventory::submit! {
 
 #[typetag::serde(name = "internal_metrics")]
 impl SourceConfig for InternalMetricsConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         let fut = run(get_controller()?, out, shutdown).boxed().compat();
         Ok(Box::new(fut))
     }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -2,7 +2,7 @@ use crate::{
     event,
     event::{Event, LogEvent, Value},
     shutdown::ShutdownSignal,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
 };
 use chrono::TimeZone;
 use futures::{
@@ -71,13 +71,15 @@ type Record = HashMap<Atom, String>;
 
 #[typetag::serde(name = "journald")]
 impl SourceConfig for JournaldConfig {
-    fn build(
-        &self,
-        name: &str,
-        globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext {
+            name,
+            globals,
+            shutdown,
+            out,
+            ..
+        } = cx;
+
         let data_dir = globals.resolve_and_make_data_subdir(self.data_dir.as_ref(), name)?;
         let batch_size = self.batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -3,7 +3,7 @@ use crate::{
     kafka::{KafkaCompression, KafkaTlsConfig},
     shutdown::ShutdownSignal,
     stream::StreamExt,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
 };
 use bytes::Bytes;
 use futures::compat::Compat;
@@ -77,13 +77,8 @@ inventory::submit! {
 
 #[typetag::serde(name = "kafka")]
 impl SourceConfig for KafkaSourceConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         kafka_source(self.clone(), shutdown, out)
     }
 

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     internal_events::{PrometheusHttpError, PrometheusParseError, PrometheusRequestCompleted},
     shutdown::ShutdownSignal,
     stream::StreamExt,
-    topology::config::GlobalOptions,
+    topology::config::SourceContext,
     Event,
 };
 use futures01::{sync::mpsc, Future, Sink, Stream};
@@ -28,13 +28,8 @@ pub fn default_scrape_interval_secs() -> u64 {
 
 #[typetag::serde(name = "prometheus")]
 impl crate::topology::config::SourceConfig for PrometheusConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         let mut urls = Vec::new();
         for host in self.hosts.iter() {
             let base_uri = host.parse::<Uri>().context(super::UriParseError)?;

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,4 +1,4 @@
-use crate::{shutdown::ShutdownSignal, stream::StreamExt, topology::config::GlobalOptions, Event};
+use crate::{shutdown::ShutdownSignal, stream::StreamExt, topology::config::SourceContext, Event};
 use futures01::{future, sync::mpsc, Future, Sink, Stream};
 use parser::parse;
 use serde::{Deserialize, Serialize};
@@ -19,13 +19,8 @@ struct StatsdConfig {
 
 #[typetag::serde(name = "statsd")]
 impl crate::topology::config::SourceConfig for StatsdConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         Ok(statsd(self.address, shutdown, out))
     }
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -2,7 +2,7 @@ use crate::{
     event::{self, Event},
     shutdown::ShutdownSignal,
     stream::StreamExt,
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
 };
 use bytes::Bytes;
 use futures::compat::Compat;
@@ -50,13 +50,8 @@ inventory::submit! {
 
 #[typetag::serde(name = "stdin")]
 impl SourceConfig for StdinConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         stdin_source(io::BufReader::new(io::stdin()), self.clone(), shutdown, out)
     }
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -7,7 +7,7 @@ use crate::{
     shutdown::ShutdownSignal,
     stream::StreamExt,
     tls::{MaybeTlsSettings, TlsConfig},
-    topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    topology::config::{DataType, SourceConfig, SourceContext, SourceDescription},
 };
 use bytes::Bytes;
 use chrono::{Datelike, Utc};
@@ -72,13 +72,8 @@ inventory::submit! {
 
 #[typetag::serde(name = "syslog")]
 impl SourceConfig for SyslogConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<super::Source> {
+    fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        let SourceContext { shutdown, out, .. } = cx;
         let host_key = self
             .host_key
             .clone()

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1,5 +1,5 @@
 use super::{
-    config::{DataType, SinkContext, TransformContext},
+    config::{DataType, SinkContext, SourceContext, TransformContext},
     fanout::{self, Fanout},
     task::Task,
     ConfigDiff,
@@ -126,7 +126,14 @@ pub fn build_pieces(
 
         let (shutdown_signal, force_shutdown_tripwire) = shutdown_coordinator.register_source(name);
 
-        let server = match source.build(&name, &config.global, shutdown_signal, tx) {
+        let cx = SourceContext {
+            name,
+            globals: &config.global,
+            shutdown: shutdown_signal,
+            out: tx,
+        };
+
+        let server = match source.build(cx) {
             Err(error) => {
                 errors.push(format!("Source \"{}\": {}", name, error));
                 continue;

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -253,6 +253,7 @@ pub struct TransformContext {
 }
 
 impl TransformContext {
+    #[cfg(test)]
     pub fn new_test(exec: TaskExecutor) -> Self {
         Self {
             resolver: Resolver::new(Vec::new(), exec.clone()).unwrap(),

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -253,7 +253,6 @@ pub struct TransformContext {
 }
 
 impl TransformContext {
-    #[cfg(test)]
     pub fn new_test(exec: TaskExecutor) -> Self {
         Self {
             resolver: Resolver::new(Vec::new(), exec.clone()).unwrap(),

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -143,6 +143,7 @@ pub struct SourceContext<'a> {
 }
 
 impl<'a> SourceContext<'a> {
+    #[cfg(test)]
     pub fn new_test(
         name: &'a str,
         globals: &'a GlobalOptions,

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -127,17 +127,35 @@ pub enum DataType {
 
 #[typetag::serde(tag = "type")]
 pub trait SourceConfig: core::fmt::Debug {
-    fn build(
-        &self,
-        name: &str,
-        globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
-    ) -> crate::Result<sources::Source>;
+    fn build(&self, cx: SourceContext) -> crate::Result<sources::Source>;
 
     fn output_type(&self) -> DataType;
 
     fn source_type(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceContext<'a> {
+    pub name: &'a str,
+    pub globals: &'a GlobalOptions,
+    pub shutdown: ShutdownSignal,
+    pub out: mpsc::Sender<Event>,
+}
+
+impl<'a> SourceContext<'a> {
+    pub fn new_test(
+        name: &'a str,
+        globals: &'a GlobalOptions,
+        shutdown: ShutdownSignal,
+        out: mpsc::Sender<Event>,
+    ) -> Self {
+        Self {
+            name,
+            globals,
+            shutdown,
+            out,
+        }
+    }
 }
 
 pub type SourceDescription = ComponentDescription<Box<dyn SourceConfig>>;

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -1,16 +1,15 @@
 #![cfg(all(feature = "sources-socket", feature = "sinks-socket"))]
 
-use futures01::{future, sync::mpsc, Async, AsyncSink, Sink, Stream};
+use futures01::{future, Async, AsyncSink, Sink, Stream};
 use serde::{Deserialize, Serialize};
 use vector::{
-    shutdown::ShutdownSignal,
     test_util::{
         block_on, next_addr, random_lines, receive, runtime, send_lines, shutdown_on_idle,
         wait_for_tcp,
     },
     topology::{
         self,
-        config::{self, GlobalOptions, SinkContext},
+        config::{self, SinkContext, SourceContext},
     },
     Event, {sinks, sources},
 };
@@ -183,13 +182,7 @@ struct ErrorSourceConfig;
 
 #[typetag::serde(name = "tcp")]
 impl config::SourceConfig for ErrorSourceConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        _shutdown: ShutdownSignal,
-        _out: mpsc::Sender<Event>,
-    ) -> Result<sources::Source, vector::Error> {
+    fn build(&self, _cx: SourceContext) -> Result<sources::Source, vector::Error> {
         Ok(Box::new(future::err(())))
     }
 
@@ -251,13 +244,7 @@ struct PanicSourceConfig;
 
 #[typetag::serde(name = "tcp")]
 impl config::SourceConfig for PanicSourceConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        _shutdown: ShutdownSignal,
-        _out: mpsc::Sender<Event>,
-    ) -> Result<sources::Source, vector::Error> {
+    fn build(&self, _cx: SourceContext) -> Result<sources::Source, vector::Error> {
         Ok(Box::new(future::lazy::<_, future::FutureResult<(), ()>>(
             || panic!(),
         )))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -17,12 +17,11 @@ use std::sync::{
 };
 use tracing::{error, info};
 use vector::event::{self, metric::MetricValue, Event, Value};
-use vector::shutdown::ShutdownSignal;
 use vector::sinks::{util::StreamSink, Healthcheck, RouterSink};
 use vector::sources::Source;
 use vector::stream::StreamExt;
 use vector::topology::config::{
-    DataType, GlobalOptions, SinkConfig, SinkContext, SourceConfig, TransformConfig,
+    DataType, SinkConfig, SinkContext, SourceConfig, SourceContext, TransformConfig,
     TransformContext,
 };
 use vector::transforms::Transform;
@@ -99,13 +98,8 @@ impl MockSourceConfig {
 
 #[typetag::serde(name = "mock")]
 impl SourceConfig for MockSourceConfig {
-    fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        shutdown: ShutdownSignal,
-        out: Sender<Event>,
-    ) -> Result<Source, vector::Error> {
+    fn build(&self, cx: SourceContext) -> Result<Source, vector::Error> {
+        let SourceContext { shutdown, out, .. } = cx;
         let wrapped = self.receiver.clone();
         let event_counter = self.event_counter.clone();
         let source = future::lazy(move || {


### PR DESCRIPTION
This PR adds `SourceContext` to the topology, analogous to `SinkContext` and `TransportContext`.

The rationale for adding this is it's going to be easier to add new fields to the context later on.

This PR doesn't contain additions like DNS resolver or executor. I need those for my k8s work, so I'll submit another PR once this one is merged.

Closes #1954.

Note that the interface is different. I suggest this new form, and you can see how it's usage is different. I think it's better, as it's more concise and allows by-value access to the fields. I think we should change `SinkContext` and `TransportContext` to the same form.