### PR TITLE
chore(socket sink): Test stream disconnect with tls

### DIFF
--- a/benches/isolated_buffering.rs
+++ b/benches/isolated_buffering.rs
@@ -55,8 +55,8 @@ fn benchmark_buffers(c: &mut Criterion) {
                 |(mut rt, writer, read_loop)| {
                     let send = writer.send_all(random_events(line_size).take(num_lines as u64));
 
-                    let read_handle = rt.spawn_handle(read_loop.compat());
-                    let write_handle = rt.spawn_handle(send.compat());
+                    let read_handle = rt.spawn_handle_std(read_loop.compat());
+                    let write_handle = rt.spawn_handle_std(send.compat());
 
                     let (writer, _stream) = rt.block_on_std(write_handle).unwrap().unwrap();
                     drop(writer);
@@ -73,12 +73,14 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let (writer, mut reader) = tokio::sync::mpsc::channel(100);
 
                     let read_handle =
-                        rt.spawn_handle(async move { while let Some(_) = reader.next().await {} });
+                        rt.spawn_handle_std(
+                            async move { while let Some(_) = reader.next().await {} },
+                        );
 
                     (rt, writer, read_handle)
                 },
                 |(mut rt, mut writer, read_handle)| {
-                    let write_handle = rt.spawn_handle(async move {
+                    let write_handle = rt.spawn_handle_std(async move {
                         let mut stream = random_events(line_size).take(num_lines as u64).compat();
                         while let Some(e) = stream.next().await {
                             writer.send(e).await.unwrap();
@@ -110,7 +112,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                 },
                 |(mut rt, writer)| {
                     let send = writer.send_all(random_events(line_size).take(num_lines as u64));
-                    let write_handle = rt.spawn_handle(send.compat());
+                    let write_handle = rt.spawn_handle_std(send.compat());
                     let _ = rt.block_on_std(write_handle).unwrap().unwrap();
                 },
             );
@@ -132,7 +134,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         leveldb_buffer::Buffer::build(path, plenty_of_room).unwrap();
 
                     let send = writer.send_all(random_events(line_size).take(num_lines as u64));
-                    let write_handle = rt.spawn_handle(send.compat());
+                    let write_handle = rt.spawn_handle_std(send.compat());
                     let (writer, _stream) = rt.block_on_std(write_handle).unwrap().unwrap();
                     drop(writer);
 
@@ -141,7 +143,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     (rt, read_loop)
                 },
                 |(mut rt, read_loop)| {
-                    let read_handle = rt.spawn_handle(read_loop.compat());
+                    let read_handle = rt.spawn_handle_std(read_loop.compat());
                     rt.block_on_std(read_handle).unwrap().unwrap();
                 },
             );
@@ -169,8 +171,8 @@ fn benchmark_buffers(c: &mut Criterion) {
                 |(mut rt, writer, read_loop)| {
                     let send = writer.send_all(random_events(line_size).take(num_lines as u64));
 
-                    let read_handle = rt.spawn_handle(read_loop.compat());
-                    let write_handle = rt.spawn_handle(send.compat());
+                    let read_handle = rt.spawn_handle_std(read_loop.compat());
+                    let write_handle = rt.spawn_handle_std(send.compat());
 
                     let _ = rt.block_on_std(write_handle).unwrap().unwrap();
                     rt.block_on_std(read_handle).unwrap().unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,7 +41,7 @@ impl Runtime {
         self
     }
 
-    pub fn spawn_handle<F>(&mut self, future: F) -> JoinHandle<F::Output>
+    pub fn spawn_handle_std<F>(&mut self, future: F) -> JoinHandle<F::Output>
     where
         F: std::future::Future + Send + 'static,
         F::Output: Send + 'static,

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -320,6 +320,7 @@ mod integration_test {
         test_util::{block_on, random_lines_with_stream, random_string, wait_for},
         tls::TlsOptions,
     };
+    use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use rdkafka::{
         consumer::{BaseConsumer, Consumer},
@@ -349,8 +350,7 @@ mod integration_test {
         };
 
         let mut rt = crate::test_util::runtime();
-        use futures::compat::Future01CompatExt;
-        let jh = rt.spawn_handle(super::healthcheck(config).unwrap().compat());
+        let jh = rt.spawn_handle_std(super::healthcheck(config).unwrap());
 
         rt.block_on_std(jh).unwrap().unwrap();
     }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -91,14 +91,10 @@ mod test {
         test_util::{next_addr, random_lines_with_stream, receive, runtime},
         topology::config::SinkContext,
     };
+    use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use serde_json::Value;
     use std::net::UdpSocket;
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    };
-    use tokio::{io::AsyncReadExt, net::TcpListener};
 
     #[test]
     fn udp_message() {
@@ -169,63 +165,91 @@ mod test {
     // This is a test that checks that we properly receieve all events in the
     // case of a proper server side write side shutdown.
     //
-    // This test basically sends 10 events shutsdown the server and forces a
+    // This test basically sends 10 events, shutsdown the server and forces a
     // reconnect. It then forces another 10 events through and we should get a
     // total of 20 events.
     //
     // If this test hangs that means somewhere we are not collecting the correct
     // events.
+    #[cfg(feature = "sources-tls")]
     #[test]
     fn tcp_stream_detects_disconnect() {
-        crate::test_util::trace_init();
+        use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
+        use futures01::{Async, Stream};
+        use std::io::{ErrorKind, Read};
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+        use tokio01::io::AsyncWrite;
+
         let addr = next_addr();
         let config = SocketSinkConfig {
             mode: Mode::Tcp(TcpSinkConfig {
                 address: addr.to_string(),
                 encoding: Encoding::Text.into(),
-                // TODO: enable TLS here since this is where
-                // ran into the issue before!
-                tls: None,
+                tls: Some(TlsConfig {
+                    enabled: Some(true),
+                    options: TlsOptions {
+                        verify_certificate: Some(false),
+                        verify_hostname: Some(false),
+                        ca_file: Some("tests/data/localhost.crt".into()),
+                        ..Default::default()
+                    },
+                }),
             }),
         };
         let mut rt = runtime();
         let context = SinkContext::new_test(rt.executor());
         let (sink, _healthcheck) = config.build(context).unwrap();
 
-        let close = Arc::new(tokio::sync::Notify::new());
-        let counter = Arc::new(AtomicUsize::new(0));
+        let msg_counter = Arc::new(AtomicUsize::new(0));
+        let msg_counter1 = msg_counter.clone();
+        let conn_counter = Arc::new(AtomicUsize::new(0));
+        let conn_counter1 = conn_counter.clone();
 
-        let close1 = close.clone();
-        let counter1 = counter.clone();
-        let mut listener = rt.block_on_std(TcpListener::bind(addr)).unwrap();
-        let jh = rt.spawn_handle(async move {
-            // Only accept a few connections after the second connection is done
-            // we can exit.
-            for _ in 0..2 {
-                let (mut conn, _) = listener.accept().await.unwrap();
+        let (mut close_tx, mut close_rx) = tokio01::sync::mpsc::unbounded_channel::<()>();
 
+        let config = Some(TlsConfig {
+            enabled: Some(true),
+            options: TlsOptions {
+                crt_file: Some("tests/data/localhost.crt".into()),
+                key_file: Some("tests/data/localhost.key".into()),
+                ..Default::default()
+            },
+        });
+        let stream = MaybeTlsSettings::from_config(&config, true).unwrap();
+
+        // Only accept two connections.
+        let fut = stream
+            .bind(&addr)
+            .unwrap()
+            .incoming()
+            .take(2)
+            .for_each(move |mut socket| {
+                conn_counter1.fetch_add(1, Ordering::SeqCst);
                 loop {
+                    if let Ok(Async::Ready(_)) = close_rx.poll() {
+                        socket.shutdown().unwrap();
+                        break;
+                    }
+
                     let mut buf = vec![0u8; 11];
-
-                    tokio::select! {
-                        _ = close1.notified() => {
-                            conn.shutdown(std::net::Shutdown::Write).unwrap();
-                            break;
-                        }
-
-                        res = conn.read(&mut buf) => {
-                            let n = res.unwrap();
-
-                           if  n == 0 {
-                               break;
-                           } else {
-                               counter1.fetch_add(1, Ordering::SeqCst);
-                           }
+                    match socket.read(&mut buf) {
+                        Err(error) if error.kind() == ErrorKind::WouldBlock => {}
+                        Err(error) => panic!("{}", error),
+                        Ok(n) => {
+                            if n == 0 {
+                                break;
+                            } else {
+                                msg_counter1.fetch_add(1, Ordering::SeqCst);
+                            }
                         }
                     };
                 }
-            }
-        });
+                Ok(())
+            });
+        let jh = rt.spawn_handle_std(fut.compat());
 
         let (_, events) = random_lines_with_stream(10, 10);
         let pump = sink.send_all(events);
@@ -235,17 +259,18 @@ mod test {
         // we have 10 events we can tell the server to shutdown to simulate the
         // remote shutting down on an idle connection.
         for _ in 0..100 {
-            let amnt = counter.load(Ordering::SeqCst);
+            let amnt = msg_counter.load(Ordering::SeqCst);
 
             if amnt == 10 {
+                close_tx.try_send(()).unwrap();
                 break;
             }
 
             // Some CI machines are very slow, be generous.
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
-        assert!(counter.load(Ordering::SeqCst) >= 10);
-        close.notify();
+        assert_eq!(msg_counter.load(Ordering::SeqCst), 10);
+        assert_eq!(conn_counter.load(Ordering::SeqCst), 1);
 
         // Send another 10 events
         let (_, events) = random_lines_with_stream(10, 10);
@@ -260,9 +285,10 @@ mod test {
         drop(pump);
 
         // Wait for server task to be complete.
-        rt.block_on_std(jh).unwrap();
+        let _ = rt.block_on_std(jh).unwrap();
 
-        // Check that there are exactly 20 events.
-        assert_eq!(counter.load(Ordering::SeqCst), 20);
+        // Check that there are exacty 20 events.
+        assert_eq!(msg_counter.load(Ordering::SeqCst), 20);
+        assert_eq!(conn_counter.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     sinks::util::{encode_event, encoding::EncodingConfig, Encoding, SinkBuildError, StreamSink},
     sinks::{Healthcheck, RouterSink},
-    tls::{MaybeTls, MaybeTlsConnector, MaybeTlsSettings, MaybeTlsStream, TlsConfig},
+    tls::{MaybeTlsConnector, MaybeTlsSettings, MaybeTlsStream, TlsConfig},
     topology::config::SinkContext,
 };
 use bytes::Bytes;
@@ -175,14 +175,6 @@ impl Sink for TcpSink {
 
         match self.poll_connection() {
             Ok(Async::Ready(connection)) => {
-                // This type internally is either a `TcpStream` or a
-                // `SslStream<TcpStream>`. This match will provide the inner
-                // `TcpStream`.
-                let conn = match connection.get_mut() {
-                    MaybeTls::Raw(t) => t,
-                    MaybeTls::Tls(t) => t.get_mut().get_mut(),
-                };
-
                 // Test if the remote has issued a disconnect by calling read(2)
                 // with a 1 sized buffer.
                 //
@@ -191,7 +183,7 @@ impl Sink for TcpSink {
                 //
                 // If this returns `WouldBlock` we know the connection is still
                 // valid and the write will most likely succeed.
-                match conn.read(&mut [0u8; 1]) {
+                match connection.get_mut().read(&mut [0u8; 1]) {
                     Err(error) if error.kind() != ErrorKind::WouldBlock => {
                         emit!(TcpConnectionDisconnected { error });
                         self.state = TcpSinkState::Disconnected;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -291,7 +291,7 @@ impl RunningTopology {
 
         info!("Running healthchecks.");
         if require_healthy {
-            let jh = rt.spawn_handle(healthchecks.compat());
+            let jh = rt.spawn_handle_std(healthchecks.compat());
             let success = rt
                 .block_on_std(jh)
                 .expect("Task panicked or runtime shutdown unexpectedly");

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -239,7 +239,7 @@ fn validate_healthchecks(
             fmt.error(error);
         };
 
-        let handle = rt.spawn_handle(healthcheck.compat());
+        let handle = rt.spawn_handle_std(healthcheck.compat());
         match rt.block_on_std(handle) {
             Ok(Ok(())) => {
                 if config

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::skip_while_next)]
-#![cfg(all(feature = "sources-socket", feature = "sinks-socket"))]
+#![cfg(all(
+    feature = "sources-socket",
+    feature = "transforms-sampler",
+    feature = "sinks-socket"
+))]
 
 use approx::assert_relative_eq;
 use futures01::{Future, Stream};


### PR DESCRIPTION
This changes add TLS layer to tcp stream detects disconnect test.

Signed-off-by: Kirill Fomichev <fanatid@ya.ru>

Not sure that I interpreted issue #2431 correct, but this add TLS layer.
- Because internal TlsListener use futures01 I changed test to futures01, not perfect, but never work with it and not obvious as std futures.
- On socket shutdown: is it ok make proper shutdown with SslStream or should be shutdown by TcpStream? (currently SslStream shutdown)
- ~Do not know how filter `HandshakeNotReady` error.~