### PR TITLE
fix(journald source): Fix `units`/`include_units` switch 

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -87,7 +87,9 @@ impl SourceConfig for JournaldConfig {
                 warn!("The `units` setting is deprecated, use `include_units` instead");
                 &self.units
             }
-            (_, false) => &self.include_units,
+            // include_units is either empty or not, both cases are fine since units is 
+            // certainly empty.
+            _ => &self.include_units,
         };
 
         let include_units: HashSet<String> = include_units.iter().map(fixup_unit).collect();

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -87,7 +87,7 @@ impl SourceConfig for JournaldConfig {
                 warn!("The `units` setting is deprecated, use `include_units` instead");
                 &self.units
             }
-            // include_units is either empty or not, both cases are fine since units is 
+            // include_units is either empty or not, both cases are fine since units is
             // certainly empty.
             _ => &self.include_units,
         };

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -83,11 +83,11 @@ impl SourceConfig for JournaldConfig {
 
         let include_units = match (self.units.is_empty(), self.include_units.is_empty()) {
             (false, false) => return Err(BuildError::BothUnitsAndIncludeUnits.into()),
-            (true, false) => {
+            (false, true) => {
                 warn!("The `units` setting is deprecated, use `include_units` instead");
                 &self.units
             }
-            (_, true) => &self.include_units,
+            (_, false) => &self.include_units,
         };
 
         let include_units: HashSet<String> = include_units.iter().map(fixup_unit).collect();

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -81,15 +81,13 @@ impl SourceConfig for JournaldConfig {
         let data_dir = globals.resolve_and_make_data_subdir(self.data_dir.as_ref(), name)?;
         let batch_size = self.batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
-        let include_units = match (self.units.is_empty(), self.include_units.is_empty()) {
-            (false, false) => return Err(BuildError::BothUnitsAndIncludeUnits.into()),
-            (false, true) => {
+        let include_units = match (!self.units.is_empty(), !self.include_units.is_empty()) {
+            (true, true) => return Err(BuildError::BothUnitsAndIncludeUnits.into()),
+            (true, false) => {
                 warn!("The `units` setting is deprecated, use `include_units` instead");
                 &self.units
             }
-            // include_units is either empty or not, both cases are fine since units is
-            // certainly empty.
-            _ => &self.include_units,
+            (false, _) => &self.include_units,
         };
 
         let include_units: HashSet<String> = include_units.iter().map(fixup_unit).collect();


### PR DESCRIPTION
Fixes the bug of getting
>May 08 11:05:28.428 WARN vector::sources::journald: The units setting is deprecated, use include_units instead

and using `units` even if `include_units` is used. 

ref #2558. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
