### PR TITLE
fix(splunk_hec sink): Send time in <sec>.<ms> format

### DIFF
--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -117,13 +117,11 @@ impl HttpSink for HecSinkConfig {
 
         let host = event.get(&self.host_key).cloned();
 
-        let timestamp = if let Some(Value::Timestamp(ts)) =
-            event.remove(&event::log_schema().timestamp_key())
-        {
-            ts.timestamp_nanos()
-        } else {
-            chrono::Utc::now().timestamp_nanos()
+        let timestamp = match event.remove(&event::log_schema().timestamp_key()) {
+            Some(Value::Timestamp(ts)) => ts,
+            _ => chrono::Utc::now(),
         };
+        let timestamp = (timestamp.timestamp_millis() as f64) / 1000f64;
 
         let sourcetype = event.get(&event::log_schema().source_type_key()).cloned();
 
@@ -251,14 +249,14 @@ mod tests {
 
     #[derive(Deserialize, Debug)]
     struct HecEventJson {
-        time: i64,
+        time: f64,
         event: BTreeMap<String, String>,
         fields: BTreeMap<String, String>,
     }
 
     #[derive(Deserialize, Debug)]
     struct HecEventText {
-        time: i64,
+        time: f64,
         event: String,
         fields: BTreeMap<String, String>,
     }

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -242,8 +242,9 @@ pub fn validate_host(host: &str) -> crate::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{self, Event};
-    use crate::sinks::util::http::HttpSink;
+    use crate::event::Event;
+    use crate::sinks::util::{http::HttpSink, test::load_sink};
+    use chrono::Utc;
     use serde::Deserialize;
     use std::collections::BTreeMap;
 
@@ -266,7 +267,7 @@ mod tests {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("key", "value");
 
-        let (config, _, _) = crate::sinks::util::test::load_sink::<HecSinkConfig>(
+        let (config, _, _) = load_sink::<HecSinkConfig>(
             r#"
             host = "test.com"
             token = "alksjdfo"
@@ -299,6 +300,10 @@ mod tests {
             hec_event.fields.get("key").map(|s| s.as_str()),
             Some("value")
         );
+
+        let now = Utc::now().timestamp_millis() as f64 / 1000f64;
+        assert!((hec_event.time - now).abs() < 0.1);
+        assert_eq!((hec_event.time * 1000f64).fract(), 0f64);
     }
 
     #[test]
@@ -306,7 +311,7 @@ mod tests {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("key", "value");
 
-        let (config, _, _) = crate::sinks::util::test::load_sink::<HecSinkConfig>(
+        let (config, _, _) = load_sink::<HecSinkConfig>(
             r#"
             host = "test.com"
             token = "alksjdfo"
@@ -329,6 +334,10 @@ mod tests {
             hec_event.fields.get("key").map(|s| s.as_str()),
             Some("value")
         );
+
+        let now = Utc::now().timestamp_millis() as f64 / 1000f64;
+        assert!((hec_event.time - now).abs() < 0.1);
+        assert_eq!((hec_event.time * 1000f64).fract(), 0f64);
     }
 
     #[test]


### PR DESCRIPTION
From splunk docs "Format events for HTTP Event Collector" event key
"time" should be formatted as "\<sec>.\<ms>".

https://docs.splunk.com/Documentation/Splunk/8.0.3/Data/FormateventsforHTTPEventCollector

Signed-off-by: Kirill Fomichev <fanatid@ya.ru>

Should resolve #2568 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
