### PR TITLE
enhancement(humio_logs sink): Enable gzip compression

### DIFF
--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -1,6 +1,8 @@
 use crate::{
     sinks::splunk_hec::{self, HecSinkConfig},
-    sinks::util::{encoding::EncodingConfigWithDefault, BatchBytesConfig, TowerRequestConfig},
+    sinks::util::{
+        encoding::EncodingConfigWithDefault, BatchBytesConfig, Compression, TowerRequestConfig,
+    },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
 use serde::{Deserialize, Serialize};
@@ -16,6 +18,9 @@ pub struct HumioLogsConfig {
         default
     )]
     encoding: EncodingConfigWithDefault<Encoding>,
+
+    #[serde(default=Compression::Gzip)]
+    compression: Compression,
 
     #[serde(default)]
     request: TowerRequestConfig,
@@ -60,6 +65,7 @@ impl SinkConfig for HumioLogsConfig {
             encoding: self.encoding.clone().transmute(),
             batch: self.batch.clone(),
             request: self.request.clone(),
+            compression: Some(self.compression),
             ..Default::default()
         }
         .build(cx)


### PR DESCRIPTION
This enables gzip compression for the humio logs sink.
I believe it's kinda best-practice to have to this always enabled and humio supports it always, so let's just enable it always without exposing a config option.