### PR TITLE
chore(operations): Copying docker images directly to minikube VMs

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -182,14 +182,13 @@ jobs:
           minikube version: 'v1.9.2'
           kubernetes version: '${{ matrix.kubernetes }}'
           github token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Login to DockerHub Registry
-        run: docker login -u "${{ secrets.K8S_INTEGRATION_CI_DOCKER_USERNAME }}" -p "${{ secrets.K8S_INTEGRATION_CI_DOCKER_PASSWORD }}"
       - name: Checkout
         uses: actions/checkout@v1
       - run: make slim-builds
       - run: make test-integration-kubernetes
         env:
-          CONTAINER_IMAGE_REPO: ${{ secrets.K8S_INTEGRATION_CI_DOCKER_REPO }}
+          USE_MINIKUBE_DOCKER: "true"
+          CONTAINER_IMAGE_REPO: vector-test
           PACKAGE_DEB_USE_CONTAINER: docker
 
   test-unit:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -165,7 +165,6 @@ jobs:
       - run: make test-integration-splunk
 
   test-integration-kubernetes:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/scripts/copy-docker-image-to-minikube.sh
+++ b/scripts/copy-docker-image-to-minikube.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# copy-docker-image-to-minikube.sh
+#
+# SUMMARY
+#
+#   Copies a list of images from the host docker engine to the minikube docker
+#   engine via save/load commands.
+#
+#   Requires minikube and docker to be available.
+#
+# USAGE
+#
+#   copy-docker-image-to-minikube.sh timberio/vector:latest
+
+# Image to copy.
+IMAGES=("${@:?"Specify the images to copy in the arguments list"}")
+
+# Prepare temp dir to store the images archive.
+TD="$(mktemp -d)"
+IMAGES_ARCHIVE="$TD/images.tar.gz"
+
+# Save images.
+docker save "${IMAGES[@]}" | gzip >"$IMAGES_ARCHIVE"
+
+# Start a subshell to preserve the env state.
+(
+  # Switch to minikube docker.
+  eval "$(minikube --shell bash docker-env)"
+
+  # Load images.
+  docker load -i "$IMAGES_ARCHIVE"
+)
+
+# Clear temp dir.
+rm -rf "$TD"

--- a/scripts/test-integration-kubernetes.sh
+++ b/scripts/test-integration-kubernetes.sh
@@ -44,12 +44,21 @@ if [[ -z "${SKIP_PACKAGE_DEB:-}" ]]; then
   make package-deb-x86_64 USE_CONTAINER="${PACKAGE_DEB_USE_CONTAINER:-"docker"}"
 fi
 
+# Prepare test image parameters.
+VERSION_TAG="test-$TEST_RUN_ID"
+BASE_TAG="alpine"
+
 # Build docker image with Vector - the same way it's done for releses. Don't
 # do the push - we'll handle it later.
-REPO="$CONTAINER_IMAGE_REPO" CHANNEL="test" TAG="$TEST_RUN_ID" PUSH="" scripts/build-docker.sh
+REPO="$CONTAINER_IMAGE_REPO" \
+  CHANNEL="test" \
+  BASE="$BASE_TAG" \
+  TAG="$VERSION_TAG" \
+  PUSH="" \
+  scripts/build-docker.sh
 
 # Prepare the container image for the deployment command.
-export CONTAINER_IMAGE="$CONTAINER_IMAGE_REPO:$TEST_RUN_ID"
+export CONTAINER_IMAGE="$CONTAINER_IMAGE_REPO:$VERSION_TAG-$BASE_TAG"
 
 # Make the container image accessible to the k8s cluster.
 if [[ "$USE_MINIKUBE_DOCKER" == "true" ]]; then

--- a/scripts/test-integration-kubernetes.sh
+++ b/scripts/test-integration-kubernetes.sh
@@ -16,13 +16,26 @@ random-string() {
   echo
 }
 
-# Require a repo to put image at.
+# Require a repo to put the container image at.
 #
-# Hint: you can use `scripts/start-docker-registry.sh`, but it requires
+# Hint #1: you can use `scripts/start-docker-registry.sh`, but it requires
 # manually preparing the environment to allow insecure registries, and it can
 # also not work if you k8s cluster doesn't have network connectivity to the
 # registry.
+#
+# Hint #2: if using with minikube, set `USE_MINIKUBE_DOCKER` to `true` and use
+# any value for `CONTAINER_IMAGE_REPO` (for instance, `vector-test` will do).
+#
 CONTAINER_IMAGE_REPO="${CONTAINER_IMAGE_REPO:?"You have to specify CONTAINER_IMAGE_REPO to upload the test image to."}"
+
+# Whether to use minikube docker.
+# After we build vector docker image, instead of pushing to the remote repo,
+# we'll be exporting it to a file after (from the "host" docker engine), and
+# then importing that file into the minikube in-cluster docker engine, that
+# nodes have access to.
+# This effectively eliminates the requirement to have a docker registry, but
+# it requires that we run against minikube cluster.
+USE_MINIKUBE_DOCKER="${USE_MINIKUBE_DOCKER:-"false"}"
 
 # Assign a default test run ID if none is provided by the user.
 TEST_RUN_ID="${TEST_RUN_ID:-"test-$(date +%s)-$(random-string)"}"
@@ -31,15 +44,23 @@ if [[ -z "${SKIP_PACKAGE_DEB:-}" ]]; then
   make package-deb-x86_64 USE_CONTAINER="${PACKAGE_DEB_USE_CONTAINER:-"docker"}"
 fi
 
-# Build docker image with Vector - the same way it's done for releses - and push
-# it into the docker configured repo.
-REPO="$CONTAINER_IMAGE_REPO" CHANNEL="test" TAG="$TEST_RUN_ID" PUSH=1 scripts/build-docker.sh
+# Build docker image with Vector - the same way it's done for releses. Don't
+# do the push - we'll handle it later.
+REPO="$CONTAINER_IMAGE_REPO" CHANNEL="test" TAG="$TEST_RUN_ID" PUSH="" scripts/build-docker.sh
+
+# Prepare the container image for the deployment command.
+export CONTAINER_IMAGE="$CONTAINER_IMAGE_REPO:$TEST_RUN_ID"
+
+# Make the container image accessible to the k8s cluster.
+if [[ "$USE_MINIKUBE_DOCKER" == "true" ]]; then
+  scripts/copy-docker-image-to-minikube.sh "$CONTAINER_IMAGE"
+else
+  docker push "$CONTAINER_IMAGE"
+fi
 
 # Set the deployment command for integration tests.
 export KUBE_TEST_DEPLOY_COMMAND="scripts/deploy-kubernetes-test.sh"
 
-# Configure the deploy command to use our repo file.
-export CONTAINER_IMAGE="$CONTAINER_IMAGE_REPO:$TEST_RUN_ID"
 
 # TODO: enable kubernetes tests when they're implemented
 exit 0 # disable the test and make them pass


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
This PR introduces special support for uploading images directly to the `minikube` nodes, eliminating the need to go through a docker registry.