### PR TITLE
chore: Build docker compose images nightly and use them in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,9 +385,9 @@ jobs:
           name: Verify installation
           command: vector --version
 
-  verify-deb-artifact-on-ubuntu-19-04:
+  verify-deb-artifact-on-ubuntu-20-04:
     docker:
-      - image: timberiodev/vector-verifier-ubuntu-19-04:latest
+      - image: timberiodev/vector-verifier-ubuntu-20-04:latest
     steps:
       - *restore-artifacts-from-workspace
       - run:
@@ -519,9 +519,9 @@ jobs:
       - *install-vector
       - *test-install-script
 
-  test-install-script-on-unbuntu-19-04:
+  test-install-script-on-unbuntu-20-04:
     docker:
-      - image: timberiodev/vector-verifier-ubuntu-19-04:latest
+      - image: timberiodev/vector-verifier-ubuntu-20-04:latest
     steps:
       - checkout
       - *install-vector
@@ -699,7 +699,7 @@ require-tests-checks-and-verifications: &require-tests-checks-and-verifications
     - verify-deb-artifact-on-deb-10
     - verify-deb-artifact-on-ubuntu-16-04
     - verify-deb-artifact-on-ubuntu-18-04
-    - verify-deb-artifact-on-ubuntu-19-04
+    - verify-deb-artifact-on-ubuntu-20-04
     - verify-zip-artifact-on-wine
     - verify-docker
     - verify-rpm-artifact-on-amazon-linux-1
@@ -722,7 +722,7 @@ require-artifacts: &require-artifacts
     - verify-deb-artifact-on-deb-10
     - verify-deb-artifact-on-ubuntu-16-04
     - verify-deb-artifact-on-ubuntu-18-04
-    - verify-deb-artifact-on-ubuntu-19-04
+    - verify-deb-artifact-on-ubuntu-20-04
     - verify-zip-artifact-on-wine
     - verify-docker
     - verify-rpm-artifact-on-amazon-linux-1
@@ -785,7 +785,7 @@ workflows:
       - verify-deb-artifact-on-ubuntu-18-04:
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
-      - verify-deb-artifact-on-ubuntu-19-04:
+      - verify-deb-artifact-on-ubuntu-20-04:
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
       - verify-zip-artifact-on-wine:
@@ -859,7 +859,7 @@ workflows:
           <<: *release-filters
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
-      - verify-deb-artifact-on-ubuntu-19-04:
+      - verify-deb-artifact-on-ubuntu-20-04:
           <<: *release-filters
           requires:
             - build-x86_64-unknown-linux-musl-archive-and-deb-package
@@ -930,7 +930,7 @@ workflows:
           <<: *prerelease-filters
       - test-install-script-on-unbuntu-18-04:
           <<: *prerelease-filters
-      - test-install-script-on-unbuntu-19-04:
+      - test-install-script-on-unbuntu-20-04:
           <<: *prerelease-filters
       - test-install-script-without-sudo:
           <<: *prerelease-filters
@@ -948,7 +948,7 @@ workflows:
             - test-install-script-on-mac-homebrew
             - test-install-script-on-unbuntu-16-04
             - test-install-script-on-unbuntu-18-04
-            - test-install-script-on-unbuntu-19-04
+            - test-install-script-on-unbuntu-20-04
             - test-install-script-without-sudo
 
   remote-checks:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -37,6 +37,7 @@ env:
   TARGET: x86_64-unknown-linux-gnu
   TEST_LOG: debug
   USE_CONTAINER: none
+  DOCKER_IMAGES_STRATEGY: pull
 
 jobs:
   check-advisories:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -38,6 +38,7 @@ env:
   TEST_LOG: debug
   USE_CONTAINER: docker
   DOCKER_IMAGES_STRATEGY: pull
+  PASS_RUSTFLAGS: "-D warnings"
 
 jobs:
   check-advisories:
@@ -50,39 +51,27 @@ jobs:
 
   check-component-features:
     runs-on: ubuntu-latest
-    env:
-      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
-      - run: sudo apt install -y python3-pip python3-setuptools python3-wheel
-      - run: sudo python3 -m pip install remarshal
       - run: make check-component-features
 
   check-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: rustup component add rustfmt
       - run: make check-fmt
-        env:
-          PASS_RUSTFLAGS: "-D warnings"
-          USE_CONTAINER: docker
 
   check-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: make check-code
-        env:
-          PASS_RUSTFLAGS: "-D warnings"
 
   check-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: make check-version
-        env:
-          USE_CONTAINER: docker
 
   check-scripts:
     runs-on: ubuntu-latest

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -38,7 +38,6 @@ env:
   TEST_LOG: debug
   USE_CONTAINER: docker
   DOCKER_IMAGES_STRATEGY: pull
-  PASS_RUSTFLAGS: "-D warnings"
 
 jobs:
   check-advisories:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -36,7 +36,7 @@ env:
   RUST_BACKTRACE: full
   TARGET: x86_64-unknown-linux-gnu
   TEST_LOG: debug
-  USE_CONTAINER: none
+  USE_CONTAINER: docker
   DOCKER_IMAGES_STRATEGY: pull
 
 jobs:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -96,66 +96,88 @@ jobs:
 
   test-integration-aws:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-aws
 
   test-integration-clickhouse:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-clickhouse
 
   test-integration-docker:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-docker
 
   test-integration-elasticsearch:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-elasticsearch
 
   test-integration-gcp:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-gcp
 
   test-integration-influxdb:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-influxdb
 
   test-integration-kafka:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-kafka
 
   test-integration-loki:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-loki
 
   test-integration-pulsar:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-pulsar
 
   test-integration-splunk:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-integration-splunk
 
   test-shutdown:
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     steps:
       - uses: actions/checkout@v1
       - run: make test-shutdown
@@ -165,6 +187,8 @@ jobs:
     # workflow, but keep it executing on every build to gather stats.
     continue-on-error: true
     runs-on: ubuntu-latest
+    env:
+      USE_CONTAINER: none
     strategy:
       matrix:
         kubernetes:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -269,3 +269,4 @@ jobs:
       - run: make build-ci-docker-images
         env:
           NIGHTLY_BUILD: "true"
+          LOW_DISK_SPACE: "true"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -259,3 +259,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
           USE_CONTAINER: none
         run: make release-s3
+
+  build-ci-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to docker registry
+        run: docker login -u "${{ secrets.CI_DOCKER_USERNAME }}" -p "${{ secrets.CI_DOCKER_PASSWORD }}"
+      - uses: actions/checkout@v1
+      - run: make build-ci-docker-images
+        env:
+          NIGHTLY_BUILD: "true"

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ verify-rpm-amazonlinux-2: package-rpm-x86_64 ## Verify the rpm package on Amazon
 verify-rpm-centos-7: package-rpm-x86_64 ## Verify the rpm package on CentOS 7
 	$(RUN) verify-rpm-centos-7
 
-verify-deb: verify-deb-artifact-on-deb-8 verify-deb-artifact-on-deb-9 verify-deb-artifact-on-deb-10 verify-deb-artifact-on-ubuntu-16-04 verify-deb-artifact-on-ubuntu-18-04 verify-deb-artifact-on-ubuntu-19-04 ## Verify all deb packages
+verify-deb: verify-deb-artifact-on-deb-8 verify-deb-artifact-on-deb-9 verify-deb-artifact-on-deb-10 verify-deb-artifact-on-ubuntu-16-04 verify-deb-artifact-on-ubuntu-18-04 verify-deb-artifact-on-ubuntu-20-04 ## Verify all deb packages
 
 verify-deb-artifact-on-deb-8: package-deb-x86_64 ## Verify the deb package on Debian 8
 	$(RUN) verify-deb-artifact-on-deb-8
@@ -255,8 +255,8 @@ verify-deb-artifact-on-ubuntu-16-04: package-deb-x86_64 ## Verify the deb packag
 verify-deb-artifact-on-ubuntu-18-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 18.04
 	$(RUN) verify-deb-artifact-on-ubuntu-18-04
 
-verify-deb-artifact-on-ubuntu-19-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 19.04
-	$(RUN) verify-deb-artifact-on-ubuntu-19-04
+verify-deb-artifact-on-ubuntu-20-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 20.04
+	$(RUN) verify-deb-artifact-on-ubuntu-20-04
 
 verify-nixos:  ## Verify that Vector can be built on NixOS
 	$(RUN) verify-nixos

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bench: build ## Run benchmarks in /benches
 
 test: test-behavior test-integration test-unit ## Runs all tests, unit, behaviorial, and integration.
 
-test-behavior: build ## Runs behaviorial tests
+test-behavior: build-x86_64-unknown-linux-musl ## Runs behaviorial tests
 	$(RUN) test-behavior
 
 test-integration: ## Runs all integration tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -600,6 +600,14 @@ services:
         "./target/x86_64-unknown-linux-musl/debug/vector test tests/behavior/**/*.toml",
       ]
 
+  slim-builds:
+    image: ubuntu:18.04
+    volumes:
+      - $PWD:$PWD
+    working_dir: $PWD
+    user: $USER
+    command: ./scripts/slim-builds.sh
+
   #
   # Dependencies
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   #
 
   build-x86_64-unknown-linux-musl:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -23,6 +24,7 @@ services:
     command: scripts/build.sh
 
   build-armv7-unknown-linux-musleabihf:
+    image: timberiodev/vector-builder-armv7-unknown-linux-musleabihf:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -41,6 +43,7 @@ services:
     command: scripts/build.sh
 
   build-aarch64-unknown-linux-musl:
+    image: timberiodev/vector-builder-aarch64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -59,6 +62,7 @@ services:
     command: scripts/build.sh
 
   bench:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -74,6 +78,7 @@ services:
     command: cargo bench --all --no-default-features --features default-musl --target x86_64-unknown-linux-musl
 
   generate:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -86,6 +91,7 @@ services:
     command: ./scripts/generate.rb
 
   check-code:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -102,6 +108,7 @@ services:
     command: scripts/check-code.sh
 
   check-component-features:
+    image: timberiodev/vector-checker-component-features:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker-component-features/Dockerfile
@@ -118,6 +125,7 @@ services:
     command: ./scripts/check-component-features.sh
 
   check-fmt:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -133,6 +141,7 @@ services:
     command: scripts/check-fmt.sh
 
   check-style:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -143,6 +152,7 @@ services:
     command: ./scripts/check-style.sh
 
   check-markdown:
+    image: timberiodev/vector-checker-markdown:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker-markdown/Dockerfile
@@ -153,6 +163,7 @@ services:
     command: markdownlint .
 
   check-generate:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -163,6 +174,7 @@ services:
     command: ./scripts/check-generate.sh
 
   check-version:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -186,6 +198,7 @@ services:
       ]
 
   check-blog:
+    image: timberiodev/vector-checker:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
@@ -196,6 +209,7 @@ services:
     command: ./scripts/check-blog-signatures.rb
 
   check-scripts:
+    image: timberiodev/vector-checker-shellcheck:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/checker-shellcheck/Dockerfile
@@ -206,6 +220,7 @@ services:
     command: ./scripts/check-scripts.sh
 
   package-archive-x86_64-unknown-linux-musl:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -224,6 +239,7 @@ services:
     command: ./scripts/package-archive.sh
 
   package-archive-armv7-unknown-linux-musleabihf:
+    image: timberiodev/vector-builder-armv7-unknown-linux-musleabihf:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -242,6 +258,7 @@ services:
     command: ./scripts/package-archive.sh
 
   package-archive-aarch64-unknown-linux-musl:
+    image: timberiodev/vector-builder-aarch64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -260,6 +277,7 @@ services:
     command: ./scripts/package-archive.sh
 
   package-deb-x86_64:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -275,6 +293,7 @@ services:
     command: ./scripts/package-deb.sh
 
   package-deb-armv7:
+    image: timberiodev/vector-builder-armv7-unknown-linux-musleabihf:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -290,6 +309,7 @@ services:
     command: ./scripts/package-deb.sh
 
   package-deb-aarch64:
+    image: timberiodev/vector-builder-aarch64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -305,6 +325,7 @@ services:
     command: ./scripts/package-deb.sh
 
   package-rpm-x86_64:
+    image: timberiodev/vector-packager-rpm:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/packager-rpm/Dockerfile
@@ -317,6 +338,7 @@ services:
     command: ./scripts/package-rpm.sh
 
   package-rpm-armv7:
+    image: timberiodev/vector-packager-rpm:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/packager-rpm/Dockerfile
@@ -330,6 +352,7 @@ services:
     command: ./scripts/package-rpm.sh
 
   package-rpm-aarch64:
+    image: timberiodev/vector-packager-rpm:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/packager-rpm/Dockerfile
@@ -342,6 +365,7 @@ services:
     command: ./scripts/package-rpm.sh
 
   verify-rpm-amazonlinux-1:
+    image: timberiodev/vector-verifier-amazonlinux-1:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-amazonlinux-1/Dockerfile
@@ -352,6 +376,7 @@ services:
       ["sh", "-ec", "rpm -i target/artifacts/*-x86_64.rpm && vector --version"]
 
   verify-rpm-amazonlinux-2:
+    image: timberiodev/vector-verifier-amazonlinux-2:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-amazonlinux-2/Dockerfile
@@ -362,6 +387,7 @@ services:
       ["sh", "-ec", "rpm -i target/artifacts/*-x86_64.rpm && vector --version"]
 
   verify-rpm-centos-7:
+    image: timberiodev/vector-verifier-centos-7:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-centos-7/Dockerfile
@@ -372,6 +398,7 @@ services:
       ["sh", "-ec", "rpm -i target/artifacts/*-x86_64.rpm && vector --version"]
 
   verify-deb-artifact-on-deb-8:
+    image: timberiodev/vector-verifier-deb-8:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-deb-8/Dockerfile
@@ -382,6 +409,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-deb-artifact-on-deb-9:
+    image: timberiodev/vector-verifier-deb-9:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-deb-9/Dockerfile
@@ -392,6 +420,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-deb-artifact-on-deb-10:
+    image: timberiodev/vector-verifier-deb-10:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-deb-10/Dockerfile
@@ -402,6 +431,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-deb-artifact-on-ubuntu-16-04:
+    image: timberiodev/vector-verifier-ubuntu-16-04:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
@@ -412,6 +442,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-deb-artifact-on-ubuntu-18-04:
+    image: timberiodev/vector-verifier-ubuntu-18-04:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-ubuntu-18-04/Dockerfile
@@ -422,6 +453,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-deb-artifact-on-ubuntu-19-04:
+    image: timberiodev/vector-verifier-ubuntu-19-04:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-ubuntu-19-04/Dockerfile
@@ -432,6 +464,7 @@ services:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
   verify-nixos:
+    image: timberiodev/vector-verifier-nixos:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/verifier-nixos/Dockerfile
@@ -441,6 +474,7 @@ services:
     command: ["sh", "-ec", "./scripts/verify-nix.sh && vector --version"]
 
   target-graph:
+    image: timberiodev/vector-target-graph:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/target-graph/Dockerfile
@@ -459,6 +493,7 @@ services:
     command: ["sh", "-ec", "rm -rf target"]
 
   load-qemu-binfmt:
+    image: timberiodev/vector-loader-qemu-binfmt:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/loader-qemu-binfmt/Dockerfile
@@ -466,6 +501,7 @@ services:
     command: dpkg-reconfigure qemu-user-binfmt
 
   test-unit:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -483,6 +519,7 @@ services:
     command: cargo test --no-default-features --features default-musl --target x86_64-unknown-linux-musl
 
   test-integration:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -506,6 +543,7 @@ services:
     command: cargo test --all --no-default-features --features default-musl,docker --target x86_64-unknown-linux-musl -- --test-threads 4
 
   test-integration-aws:
+    image: timberiodev/vector-builder-x86_64-unknown-linux-musl:latest
     build:
       context: .
       dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -593,12 +593,7 @@ services:
       - $PWD:$PWD
     working_dir: $PWD
     user: $USER
-    command:
-      [
-        "sh",
-        "-c",
-        "./target/x86_64-unknown-linux-musl/debug/vector test tests/behavior/**/*.toml",
-      ]
+    command: ./scripts/test-behavior.sh
 
   slim-builds:
     image: ubuntu:18.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -450,11 +450,11 @@ services:
     command:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
-  verify-deb-artifact-on-ubuntu-19-04:
-    image: timberiodev/vector-verifier-ubuntu-19-04:latest
+  verify-deb-artifact-on-ubuntu-20-04:
+    image: timberiodev/vector-verifier-ubuntu-20-04:latest
     build:
       context: .
-      dockerfile: scripts/ci-docker-images/verifier-ubuntu-19-04/Dockerfile
+      dockerfile: scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
     volumes:
       - $PWD:$PWD
     working_dir: $PWD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,6 @@ services:
       context: .
       dockerfile: scripts/ci-docker-images/checker/Dockerfile
     environment:
-      RUSTFLAGS: "-D warnings"
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -113,7 +112,6 @@ services:
       context: .
       dockerfile: scripts/ci-docker-images/checker-component-features/Dockerfile
     environment:
-      RUSTFLAGS: "-D warnings"
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD

--- a/scripts/build-ci-docker-images.sh
+++ b/scripts/build-ci-docker-images.sh
@@ -32,6 +32,10 @@ build-image() {
   for FULL_TAG in "${FULL_TAGS[@]}"; do
     docker push "$FULL_TAG"
   done
+
+  if [[ "${LOW_DISK_SPACE:-"true"}" ]]; then
+    docker image rm -f "${FULL_TAGS[@]}"
+  fi
 }
 
 list-images() {

--- a/scripts/build-ci-docker-images.sh
+++ b/scripts/build-ci-docker-images.sh
@@ -33,7 +33,7 @@ build-image() {
     docker push "$FULL_TAG"
   done
 
-  if [[ "${LOW_DISK_SPACE:-"true"}" ]]; then
+  if [[ "${LOW_DISK_SPACE:-}" == "true" ]]; then
     docker image rm -f "${FULL_TAGS[@]}"
   fi
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,7 +24,12 @@ ABORT="${ABORT:-"false"}"
 FEATURES="${FEATURES:-"default"}"
 NATIVE_BUILD="${NATIVE_BUILD:-"true"}"
 STRIP="${STRIP:-"false"}"
-TARGET="${TARGET:?"You must specify a target triple, ex: x86_64-apple-darwin"}"
+
+if [ "$NATIVE_BUILD" == "true" ]; then
+  TARGET="${TARGET:-}"
+else
+  TARGET="${TARGET:?"You must specify a target triple, ex: x86_64-apple-darwin"}"
+fi
 
 CHANNEL=${CHANNEL:-"$(scripts/util/release-channel.sh)"}
 if [ "$CHANNEL" == "nightly" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,10 +40,10 @@ fi
 # Local Vars
 #
 
-if [ "$NATIVE_BUILD" != "true" ]; then
-  TARGET_DIR="target/$TARGET"
-else
+if [ "$NATIVE_BUILD" == "true" ]; then
   TARGET_DIR="target"
+else
+  TARGET_DIR="target/$TARGET"
 fi
 
 BINARY_PATH="$TARGET_DIR/release/vector"

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -7,4 +7,5 @@ set -euo pipefail
 #
 #   Checks all Vector code
 
+export RUSTFLAGS="${RUSTFLAGS:-"-D warnings"}"
 cargo check --workspace --all-targets

--- a/scripts/check-component-features.sh
+++ b/scripts/check-component-features.sh
@@ -20,6 +20,8 @@ check-listed-features() {
   xargs -I{} sh -cx "(cargo check --tests --no-default-features --features {}) || exit 255"
 }
 
+export RUSTFLAGS="${RUSTFLAGS:-"-D warnings"}"
+
 echo "Checking that Vector and tests can be built without default features..."
 cargo check --tests --no-default-features
 

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -81,16 +81,16 @@ ENV LDFLAGS=""
 RUN mkdir build && \
   cd build && \
   cmake \
-    -DCMAKE_BUILD_TYPE=release \
-    -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
-		-DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
-    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-    -DCOMPILER_RT_BUILD_XRAY=OFF \
-    -DCOMPILER_RT_BUILD_PROFILE=OFF \
-    -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
-    -G Ninja \
-    .. && \
+  -DCMAKE_BUILD_TYPE=release \
+  -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
+  -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
+  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+  -DCOMPILER_RT_BUILD_XRAY=OFF \
+  -DCOMPILER_RT_BUILD_PROFILE=OFF \
+  -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
+  -G Ninja \
+  .. && \
   cmake --build . --target install
 
 # Compile musl.
@@ -310,3 +310,8 @@ ENV TARGET="$TARGET"
 RUN cargo install --git https://github.com/mmstick/cargo-deb --rev cc879930c06fa22e99f2839bad620ac0d0da879e cargo-deb
 
 RUN apt-get install -y rename cmark-gfm
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -81,16 +81,16 @@ ENV LDFLAGS=""
 RUN mkdir build && \
   cd build && \
   cmake \
-    -DCMAKE_BUILD_TYPE=release \
-    -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
-		-DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
-    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-    -DCOMPILER_RT_BUILD_XRAY=OFF \
-    -DCOMPILER_RT_BUILD_PROFILE=OFF \
-    -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
-    -G Ninja \
-    .. && \
+  -DCMAKE_BUILD_TYPE=release \
+  -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
+  -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
+  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+  -DCOMPILER_RT_BUILD_XRAY=OFF \
+  -DCOMPILER_RT_BUILD_PROFILE=OFF \
+  -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
+  -G Ninja \
+  .. && \
   cmake --build . --target install
 
 # Compile musl.
@@ -309,3 +309,8 @@ ENV TARGET="$TARGET"
 RUN cargo install --git https://github.com/mmstick/cargo-deb --rev cc879930c06fa22e99f2839bad620ac0d0da879e cargo-deb
 
 RUN apt-get install -y rename cmark-gfm
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -82,16 +82,16 @@ ENV LDFLAGS=""
 RUN mkdir build && \
   cd build && \
   cmake \
-    -DCMAKE_BUILD_TYPE=release \
-    -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
-		-DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
-    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
-    -DCOMPILER_RT_BUILD_XRAY=OFF \
-    -DCOMPILER_RT_BUILD_PROFILE=OFF \
-    -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
-    -G Ninja \
-    .. && \
+  -DCMAKE_BUILD_TYPE=release \
+  -DLLVM_CONFIG_PATH=$CLANG_PREFIX/bin/llvm-config \
+  -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$TARGET \
+  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+  -DCOMPILER_RT_BUILD_XRAY=OFF \
+  -DCOMPILER_RT_BUILD_PROFILE=OFF \
+  -DCMAKE_INSTALL_PREFIX=$LIBS_PREFIX \
+  -G Ninja \
+  .. && \
   cmake --build . --target install
 
 # Compile musl.
@@ -315,3 +315,8 @@ RUN apt-get install -y rename cmark-gfm
 
 # Install journalctl
 RUN apt-get install -y systemd
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/checker-component-features/Dockerfile
+++ b/scripts/ci-docker-images/checker-component-features/Dockerfile
@@ -21,3 +21,8 @@ RUN rustup component add rustfmt
 
 # Install `remarshal`
 RUN pip3 install remarshal==0.11.2
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/checker-markdown/Dockerfile
+++ b/scripts/ci-docker-images/checker-markdown/Dockerfile
@@ -1,2 +1,7 @@
 FROM node:12-alpine
 RUN npm install --global --production markdownlint-cli@0.22
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/checker-shellcheck/Dockerfile
+++ b/scripts/ci-docker-images/checker-shellcheck/Dockerfile
@@ -4,7 +4,12 @@ FROM debian:buster
 
 RUN apt-get update \
   && apt-get install -y \
-      git \
+  git \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=shellcheck /bin/shellcheck /usr/local/bin/shellcheck
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/checker/Dockerfile
+++ b/scripts/ci-docker-images/checker/Dockerfile
@@ -22,3 +22,8 @@ COPY scripts/Gemfile Gemfile
 COPY scripts/Gemfile.lock Gemfile.lock
 RUN bundle install
 RUN rm Gemfile
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/packager-rpm/Dockerfile
+++ b/scripts/ci-docker-images/packager-rpm/Dockerfile
@@ -8,3 +8,8 @@ RUN yum update -y && \
   make \
   rename \
   rpm-build
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/releaser/Dockerfile
+++ b/scripts/ci-docker-images/releaser/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
   rename \
   ruby-full \
   zlib1g-dev \
-	wget
+  wget
 
 # AWS CLI
 RUN pip3 install --upgrade awscli
@@ -42,3 +42,8 @@ COPY scripts/Gemfile Gemfile
 COPY scripts/Gemfile.lock Gemfile.lock
 RUN bundle install
 RUN rm Gemfile
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/target-graph/Dockerfile
+++ b/scripts/ci-docker-images/target-graph/Dockerfile
@@ -8,3 +8,8 @@ RUN git clone https://github.com/lindenb/makefile2graph && \
   make install && \
   cd .. && \
   rm -rf makefile2graph
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-amazonlinux-1/Dockerfile
+++ b/scripts/ci-docker-images/verifier-amazonlinux-1/Dockerfile
@@ -7,3 +7,8 @@ RUN yum update -y && \
   git \
   systemd \
   tar
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-amazonlinux-2/Dockerfile
+++ b/scripts/ci-docker-images/verifier-amazonlinux-2/Dockerfile
@@ -7,3 +7,8 @@ RUN yum update -y && \
   git \
   systemd \
   tar
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-centos-7/Dockerfile
+++ b/scripts/ci-docker-images/verifier-centos-7/Dockerfile
@@ -7,3 +7,8 @@ RUN yum update -y && \
   git \
   systemd \
   tar
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-deb-10/Dockerfile
+++ b/scripts/ci-docker-images/verifier-deb-10/Dockerfile
@@ -5,3 +5,8 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   git
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-deb-8/Dockerfile
+++ b/scripts/ci-docker-images/verifier-deb-8/Dockerfile
@@ -5,3 +5,8 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   git
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-deb-9/Dockerfile
+++ b/scripts/ci-docker-images/verifier-deb-9/Dockerfile
@@ -5,3 +5,8 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   git
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-nixos/Dockerfile
+++ b/scripts/ci-docker-images/verifier-nixos/Dockerfile
@@ -6,3 +6,8 @@ RUN gem install bundler -v '~> 2.1.4'
 COPY scripts/ci-docker-images/verifier-nixos/Gemfile Gemfile
 RUN bundle install
 RUN rm Gemfile
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
@@ -1,11 +1,14 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && \
-  apt-get install -y \
+ARG DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update \
+  && apt-get install -y \
   ca-certificates \
   curl \
   git \
-  systemd
+  systemd \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure temp dir
 ENV TMPDIR=/docker-tmp

--- a/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
@@ -6,3 +6,8 @@ RUN apt-get update && \
   curl \
   git \
   systemd
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-ubuntu-18-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-18-04/Dockerfile
@@ -1,11 +1,14 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && \
-  apt-get install -y \
+ARG DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update \
+  && apt-get install -y \
   ca-certificates \
   curl \
   git \
-  systemd
+  systemd \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure temp dir
 ENV TMPDIR=/docker-tmp

--- a/scripts/ci-docker-images/verifier-ubuntu-18-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-18-04/Dockerfile
@@ -6,3 +6,8 @@ RUN apt-get update && \
   curl \
   git \
   systemd
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-ubuntu-19-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-19-04/Dockerfile
@@ -6,3 +6,8 @@ RUN apt-get update && \
   curl \
   git \
   systemd
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
@@ -1,11 +1,14 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && \
-  apt-get install -y \
+ARG DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update \
+  && apt-get install -y \
   ca-certificates \
   curl \
   git \
-  systemd
+  systemd \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure temp dir
 ENV TMPDIR=/docker-tmp

--- a/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
   apt-get install -y \

--- a/scripts/ci-docker-images/verifier-wine/Dockerfile
+++ b/scripts/ci-docker-images/verifier-wine/Dockerfile
@@ -1,3 +1,8 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y unzip wine-stable
+
+# Configure temp dir
+ENV TMPDIR=/docker-tmp
+RUN mkdir -p "$TMPDIR" && chmod 0777 "$TMPDIR"
+VOLUME [ "$TMPDIR" ]

--- a/scripts/docker-compose-run.sh
+++ b/scripts/docker-compose-run.sh
@@ -11,10 +11,34 @@ SERVICE="$1"
 
 DOCKER="${USE_CONTAINER:-"docker"}"
 COMPOSE="${COMPOSE:-"${DOCKER}-compose"}"
+DOCKER_IMAGES_STRATEGY="${DOCKER_IMAGES_STRATEGY:-"build"}"
+
+ARGS=()
+case "$DOCKER_IMAGES_STRATEGY" in
+  build)
+    ARGS+=(--build)
+    ;;
+  pull)
+    ARGS+=(--no-build)
+    $COMPOSE pull "$SERVICE"
+    ;;
+  default)
+    # No custom args
+    ;;
+  *)
+    echo "Error: invalid DOCKER_IMAGES_STRATEGY: $DOCKER_IMAGES_STRATEGY" >&2
+    exit 1
+    ;;
+esac
 
 USER="$(id -u):$(id -g)"
 export USER
 
 $COMPOSE rm -svf "$SERVICE" 2>/dev/null || true
-$COMPOSE up --build --abort-on-container-exit --exit-code-from "$SERVICE" "$SERVICE" \
+
+$COMPOSE up \
+  "${ARGS[@]}" \
+  --abort-on-container-exit \
+   --exit-code-from "$SERVICE" \
+   "$SERVICE" \
   | sed $'s/^.*container exit...$/\033[0m\033[1A/'


### PR DESCRIPTION
This is an attempt to finally streamline the CI and ensure we have quick builds in CI and a unified environment configs across local and CI tasks.


To make things work, I had to introduce the following changes:

- configure images for all the services at `docker-compose.yml`
- refresh the CI images build script
- set up automated nightly builds for CI images (the auto builds at the docker hub end are to be disabled)
- made the per-push CI flow use pre-built docker images - this allows us to properly control build environment at CI, but eliminates the image build step, dramatically speeding up the flow
- solve the issue with tmp files being on overlayfs (cause of issues with tests failing in docker)

While working on this, I uncovered a few issues that I'm not planning on solving in this PR:
- build image `Dockerfile`s are not cache-friendly, we should correct this
- `docker-compose.yml`, `Makefile` and `.github/workflow/code.yml` each contains configuration for the same "unit"s, but it's all coded separately; there's way too much attention required to implement keep things in order and consistent, and it's hard to maintain; we should revisit the approach, and root all those places in a single source of truth