### PR TITLE
chore: Mark GeneratorConfig::repeat with #[allow(dead_code)]

### DIFF
--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -26,6 +26,7 @@ pub(crate) struct GeneratorConfig {
 }
 
 impl GeneratorConfig {
+    #[allow(dead_code)] // to make check-component-features pass
     #[cfg(test)]
     pub fn repeat(lines: Vec<String>, count: usize) -> Self {
         Self {


### PR DESCRIPTION
I was working on fixing our CI, and I found out `check-component-features` is supposed to be failing currently: https://github.com/timberio/vector/runs/668802095?check_suite_focus=true

This is my take on working around it. This should work for now, a proper solution can be applied later.