### PR TITLE
chore(tests): Use `localhost` for `prometheus` shutdown test

### DIFF
--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -32,7 +32,7 @@ const PROMETHEUS_CONFIG: &'static str = r#"
 
     [sources.in]
         type = "prometheus"
-        hosts = ["http://${VECTOR_TEST_ADDRESS}"]
+        hosts = ["http://${VECTOR_LOCALHOST_TEST_ADDRESS}"]
 
     [sinks.out]
         type = "prometheus"
@@ -83,13 +83,18 @@ data_dir = "${{VECTOR_DATA_DIR}}"
 }
 
 fn run_vector(config: &str) -> Command {
+    let address = next_addr();
     let mut cmd = Command::cargo_bin("vector").unwrap();
     cmd.arg("-c")
         .arg(create_file(config))
         .arg("--quiet")
         .env("VECTOR_DATA_DIR", create_directory())
         .env("VECTOR_TEST_UNIX_PATH", temp_file())
-        .env("VECTOR_TEST_ADDRESS", format!("{}", next_addr()));
+        .env("VECTOR_TEST_ADDRESS", format!("{}", address))
+        .env(
+            "VECTOR_LOCALHOST_TEST_ADDRESS",
+            format!("localhost:{}", address.port()),
+        );
 
     cmd
 }


### PR DESCRIPTION
Use `localhost` for `prometheus` shutdown test so to avoid the firewall.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
