### PR TITLE
enhancement(json_parser transform): log parse errors as warnings

### DIFF
--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -78,7 +78,7 @@ impl Transform for JsonParser {
             .and_then(|to_parse| {
                 serde_json::from_slice::<Value>(to_parse.as_ref())
                     .map_err(|error| {
-                        debug!(
+                        warn!(
                             message = "Event failed to parse as JSON",
                             field = self.field.as_ref(),
                             %error,


### PR DESCRIPTION
Closes #2552 

Warning seems more appropriate here and the log message is already properly rate limited.
