### PR TITLE
fix(sources): Shutdown starting from `tcp` and `unix` sockets 

### DIFF
--- a/src/async_read.rs
+++ b/src/async_read.rs
@@ -16,11 +16,11 @@ pub struct ReadUntil<S, F, O> {
 
 /// This `AsyncRead` extension trait provides a `read_until` method that terminates the reader once
 /// the given future resolves.
-pub trait AsyncReadExt: AsyncRead {
+pub trait AsyncAllowReadExt: AsyncRead {
     /// Read data from this reader until the given future resolves.
     ///
     /// If the future produces an error, the read will be allowed to continue indefinitely.
-    fn read_until<U, O>(self, until: U) -> ReadUntil<Self, U::Future, O>
+    fn allow_read_until<U, O>(self, until: U) -> ReadUntil<Self, U::Future, O>
     where
         U: IntoFuture<Item = O, Error = ()>,
         Self: Sized,
@@ -34,7 +34,7 @@ pub trait AsyncReadExt: AsyncRead {
     }
 }
 
-impl<S> AsyncReadExt for S where S: AsyncRead {}
+impl<S> AsyncAllowReadExt for S where S: AsyncRead {}
 
 impl<S, F, O> Read for ReadUntil<S, F, O>
 where

--- a/src/async_read.rs
+++ b/src/async_read.rs
@@ -7,7 +7,7 @@ use tokio01::io::AsyncRead;
 ///
 /// This structure is produced by the [`AsyncReadExt::read_until`] method.
 #[derive(Clone, Debug)]
-pub struct ReadUntil<S, F, O> {
+pub struct AllowReadUntil<S, F, O> {
     reader: S,
     until: F,
     until_res: Option<O>,
@@ -20,12 +20,12 @@ pub trait AsyncAllowReadExt: AsyncRead {
     /// Read data from this reader until the given future resolves.
     ///
     /// If the future produces an error, the read will be allowed to continue indefinitely.
-    fn allow_read_until<U, O>(self, until: U) -> ReadUntil<Self, U::Future, O>
+    fn allow_read_until<U, O>(self, until: U) -> AllowReadUntil<Self, U::Future, O>
     where
         U: IntoFuture<Item = O, Error = ()>,
         Self: Sized,
     {
-        ReadUntil {
+        AllowReadUntil {
             reader: self,
             until: until.into_future(),
             until_res: None,
@@ -36,7 +36,7 @@ pub trait AsyncAllowReadExt: AsyncRead {
 
 impl<S> AsyncAllowReadExt for S where S: AsyncRead {}
 
-impl<S, F, O> Read for ReadUntil<S, F, O>
+impl<S, F, O> Read for AllowReadUntil<S, F, O>
 where
     S: Read,
 {
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<S, F, O> AsyncRead for ReadUntil<S, F, O>
+impl<S, F, O> AsyncRead for AllowReadUntil<S, F, O>
 where
     S: AsyncRead,
     F: Future<Item = O, Error = ()>,

--- a/src/async_read.rs
+++ b/src/async_read.rs
@@ -1,0 +1,80 @@
+use bytes::BufMut;
+use futures01::{Async, Future, IntoFuture, Poll};
+use std::io::Read;
+use tokio01::io::AsyncRead;
+
+/// A AsyncRead combinator which reads from a reader until a future resolves.
+///
+/// This structure is produced by the [`AsyncReadExt::read_until`] method.
+#[derive(Clone, Debug)]
+pub struct ReadUntil<S, F, O> {
+    reader: S,
+    until: F,
+    until_res: Option<O>,
+    free: bool,
+}
+
+/// This `AsyncRead` extension trait provides a `read_until` method that terminates the reader once
+/// the given future resolves.
+pub trait AsyncReadExt: AsyncRead {
+    /// Read data from this reader until the given future resolves.
+    ///
+    /// If the future produces an error, the read will be allowed to continue indefinitely.
+    fn read_until<U, O>(self, until: U) -> ReadUntil<Self, U::Future, O>
+    where
+        U: IntoFuture<Item = O, Error = ()>,
+        Self: Sized,
+    {
+        ReadUntil {
+            reader: self,
+            until: until.into_future(),
+            until_res: None,
+            free: false,
+        }
+    }
+}
+
+impl<S> AsyncReadExt for S where S: AsyncRead {}
+
+impl<S, F, O> Read for ReadUntil<S, F, O>
+where
+    S: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        self.reader.read(buf)
+    }
+}
+
+impl<S, F, O> AsyncRead for ReadUntil<S, F, O>
+where
+    S: AsyncRead,
+    F: Future<Item = O, Error = ()>,
+{
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.reader.prepare_uninitialized_buffer(buf)
+    }
+
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, std::io::Error>
+    where
+        Self: Sized,
+    {
+        if !self.free {
+            match self.until.poll() {
+                Ok(Async::Ready(res)) => {
+                    // future resolved -- terminate reader
+                    self.until_res = Some(res);
+                    return Ok(Async::Ready(0));
+                }
+                Err(_) => {
+                    // future failed -- unclear whether we should stop or continue?
+                    // to provide a mechanism for the creator to let the stream run forever,
+                    // we interpret this as "run forever".
+                    self.free = true;
+                }
+                Ok(Async::NotReady) => {}
+            }
+        }
+
+        self.reader.read_buf(buf)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod expiring_hash_map;
 pub mod generate;
 #[macro_use]
 pub mod internal_events;
+pub mod async_read;
 #[cfg(feature = "rdkafka")]
 pub mod kafka;
 pub mod list;

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -347,7 +347,6 @@ mod test {
 
     #[test]
     fn tcp_shutdown_infinite_stream() {
-        crate::test_util::trace_init();
         // It's important that the buffer be large enough that the TCP source doesn't have
         // to block trying to forward its input into the Sender because the channel is full,
         // otherwise even sending the signal to shut down won't wake it up.
@@ -402,6 +401,116 @@ mod test {
 
         // Ensure that the source has actually shut down.
         rt.block_on(source_handle).unwrap();
+    }
+
+    #[test]
+    fn tcp_gracefull_shutdown() {
+        let n = 10000;
+        // It's important that the buffer be large enough that the TCP source doesn't have
+        // to block trying to forward its input into the Sender because the channel is full,
+        // otherwise even sending the signal to shut down won't wake it up.
+        let (tx, rx) = mpsc::channel(n);
+        let source_name = "tcp_gracefull_shutdown_0";
+
+        let addr = next_addr();
+
+        let mut shutdown = SourceShutdownCoordinator::new();
+        let (shutdown_signal, _) = shutdown.register_source(source_name);
+
+        // Start TCP Source
+        let server = SocketConfig::from(TcpConfig {
+            shutdown_timeout_secs: 10,
+            ..TcpConfig::new(addr.into())
+        })
+        .build(
+            source_name,
+            &GlobalOptions::default(),
+            shutdown_signal,
+            tx.clone(),
+        )
+        .unwrap();
+        let mut rt = runtime::Runtime::with_thread_count(4).unwrap();
+        let source_handle = oneshot::spawn(server, &rt.executor());
+        wait_for_tcp(addr);
+
+        // Spawn future that keeps sending n lines to the TCP source.
+        info!("Start sink");
+        let sink = TcpSink::new(
+            "localhost".to_owned(),
+            addr.port(),
+            Resolver::new(Vec::new(), rt.executor()).unwrap(),
+            MaybeTlsSettings::Raw(()),
+        );
+        rt.spawn(
+            stream::iter_ok::<_, ()>(0..n)
+                .map(|i| Bytes::from(format!("{}\n", i)))
+                .forward(sink)
+                .map(|_| ()),
+        );
+
+        // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.
+        info!("Collect 100 events");
+        let (rx, events) = rt.block_on(CollectN::new(rx, 100)).ok().unwrap();
+        assert_eq!(100, events.len());
+        let mut count = 0;
+        for event in events {
+            assert_eq!(
+                event.as_log()[&event::log_schema().message_key()],
+                format!("{}", count).into()
+            );
+            count += 1;
+        }
+
+        info!("Shutdown first source");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let shutdown_complete = shutdown.shutdown_source(source_name, deadline);
+        let shutdown_success = rt.block_on(shutdown_complete).unwrap();
+        assert_eq!(true, shutdown_success);
+
+        // Ensure that the source has actually shut down.
+        rt.block_on(source_handle).unwrap();
+
+        // Start second source
+        info!("Start second source");
+        let source_name = "tcp_gracefull_shutdown_1";
+        let (shutdown_signal, _tripwire) = shutdown.register_source(source_name);
+
+        // Start TCP Source
+        let server = SocketConfig::from(TcpConfig {
+            shutdown_timeout_secs: 10,
+            ..TcpConfig::new(addr.into())
+        })
+        .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
+        .unwrap();
+        let source_handle = oneshot::spawn(server, &rt.executor());
+
+        // Consume rest of the events
+        info!("Collect rest of the events");
+        let (_rx, _) = rt
+            .block_on(CollectN::new(
+                rx.map(move |event| {
+                    assert_eq!(
+                        event.as_log()[&event::log_schema().message_key()],
+                        format!("{}", count).into()
+                    );
+                    count += 1;
+                }),
+                n - count,
+            ))
+            .ok()
+            .unwrap();
+
+        info!("Shutdown second source");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let shutdown_complete = shutdown.shutdown_source(source_name, deadline);
+        let shutdown_success = rt.block_on(shutdown_complete).unwrap();
+        assert_eq!(true, shutdown_success);
+
+        // Ensure that the source has actually shut down.
+        rt.block_on(source_handle).unwrap();
+
+        // Ensure that the sink has actually shut down.
+        assert!(rt.shutdown_on_idle().wait().is_ok());
     }
 
     //////// UDP TESTS ////////

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -129,17 +129,21 @@ mod test {
     #[cfg(unix)]
     use super::unix::UnixConfig;
     use super::SocketConfig;
+    use crate::dns::Resolver;
     use crate::event;
     use crate::runtime;
     use crate::shutdown::{ShutdownSignal, SourceShutdownCoordinator};
+    use crate::sinks::util::tcp::TcpSink;
     use crate::test_util::{
         block_on, collect_n, next_addr, send_lines, send_lines_tls, wait_for_tcp, CollectN,
     };
-    use crate::tls::{TlsConfig, TlsOptions};
+    use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
     use crate::topology::config::{GlobalOptions, SourceConfig};
+    use bytes::Bytes;
     #[cfg(unix)]
     use futures01::Sink;
     use futures01::{
+        stream,
         sync::{mpsc, oneshot},
         Future, Stream,
     };
@@ -343,10 +347,11 @@ mod test {
 
     #[test]
     fn tcp_shutdown_infinite_stream() {
+        crate::test_util::trace_init();
         // It's important that the buffer be large enough that the TCP source doesn't have
         // to block trying to forward its input into the Sender because the channel is full,
         // otherwise even sending the signal to shut down won't wake it up.
-        let (tx, rx) = mpsc::channel(1000);
+        let (tx, rx) = mpsc::channel(10000);
         let source_name = "tcp_shutdown_infinite_stream";
 
         let addr = next_addr();
@@ -355,24 +360,30 @@ mod test {
         let (shutdown_signal, _) = shutdown.register_source(source_name);
 
         // Start TCP Source
-        let server = SocketConfig::from(TcpConfig::new(addr.into()))
-            .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
-            .unwrap();
+        let server = SocketConfig::from(TcpConfig {
+            shutdown_timeout_secs: 1,
+            ..TcpConfig::new(addr.into())
+        })
+        .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
+        .unwrap();
         let mut rt = runtime::Runtime::new().unwrap();
         let source_handle = oneshot::spawn(server, &rt.executor());
         wait_for_tcp(addr);
 
         // Spawn future that keeps sending lines to the TCP source forever.
-        let run_pump_atomic_sender = Arc::new(AtomicBool::new(true));
-        let run_pump_atomic_receiver = run_pump_atomic_sender.clone();
-        let pump_future = send_lines(
-            addr,
-            std::iter::repeat("test".to_string())
-                .take_while(move |_| run_pump_atomic_receiver.load(Ordering::Relaxed)),
+        let sink = TcpSink::new(
+            "localhost".to_owned(),
+            addr.port(),
+            Resolver::new(Vec::new(), rt.executor()).unwrap(),
+            MaybeTlsSettings::Raw(()),
         );
-        let pump_handle = std::thread::spawn(move || {
-            pump_future.wait().ok().unwrap();
-        });
+        rt.spawn(
+            stream::iter_ok::<_, ()>(std::iter::repeat(()))
+                .map(|_| Bytes::from("test\n"))
+                .map_err(|_| ())
+                .forward(sink)
+                .map(|_| ()),
+        );
 
         // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.
         let (_rx, events) = rt.block_on(CollectN::new(rx, 100)).ok().unwrap();
@@ -391,10 +402,6 @@ mod test {
 
         // Ensure that the source has actually shut down.
         rt.block_on(source_handle).unwrap();
-
-        // Stop the pump from sending lines forever.
-        run_pump_atomic_sender.store(false, Ordering::Relaxed);
-        assert!(pump_handle.join().is_ok());
     }
 
     //////// UDP TESTS ////////

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -145,7 +145,6 @@ pub trait TcpSource: Clone + Send + 'static {
                     });
                     Ok(())
                 });
-            // .inspect(|_| trigger.cancel());
             future::Either::A(future)
         });
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -1,25 +1,22 @@
 use crate::{
-    async_read::AsyncAllowReadExt,
     internal_events::TcpConnectionError,
     shutdown::ShutdownSignal,
     stream::StreamExt,
-    tls::{MaybeTlsListener, MaybeTlsSettings},
+    tls::{MaybeTlsIncomingStream, MaybeTlsListener, MaybeTlsSettings},
     Event,
 };
 use bytes::Bytes;
-use futures01::{future, sync::mpsc, Future, Sink, Stream};
+use futures01::{future, stream, sync::mpsc, Async, Future, Sink, Stream};
 use listenfd::ListenFd;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{
     fmt, io,
-    net::SocketAddr,
+    net::{Shutdown, SocketAddr},
     time::{Duration, Instant},
 };
-use stream_cancel::Tripwire;
 use tokio01::{
     codec::{Decoder, FramedRead},
-    net::TcpListener,
-    prelude::AsyncRead,
+    net::{TcpListener, TcpStream},
     reactor::Handle,
     timer,
 };
@@ -98,9 +95,8 @@ pub trait TcpSource: Clone + Send + 'static {
                 )
             );
 
-            let (trigger, tripwire) = Tripwire::new();
-            let tripwire = tripwire.select2(shutdown.clone());
-            let tripwire = tripwire
+            let tripwire = shutdown
+                .clone()
                 .and_then(move |_| {
                     timer::Delay::new(Instant::now() + Duration::from_secs(shutdown_timeout_secs))
                         .map_err(|err| panic!("Timer error: {:?}", err))
@@ -109,7 +105,7 @@ pub trait TcpSource: Clone + Send + 'static {
 
             let future = listener
                 .incoming()
-                .take_until(shutdown)
+                .take_until(shutdown.clone())
                 .map_err(|error| {
                     error!(
                         message = "failed to accept socket",
@@ -139,15 +135,17 @@ pub trait TcpSource: Clone + Send + 'static {
                         debug!(message = "accepted a new connection", %peer_addr);
                         handle_stream(
                             span.clone(),
-                            socket.allow_read_until(tripwire),
+                            shutdown.clone(),
+                            socket,
                             source,
+                            tripwire,
                             host,
                             out.clone(),
                         )
                     });
                     Ok(())
-                })
-                .inspect(|_| trigger.cancel());
+                });
+            // .inspect(|_| trigger.cancel());
             future::Either::A(future)
         });
 
@@ -157,22 +155,55 @@ pub trait TcpSource: Clone + Send + 'static {
 
 fn handle_stream(
     span: Span,
-    socket: impl AsyncRead + Send + 'static,
+    shutdown: ShutdownSignal,
+    socket: MaybeTlsIncomingStream<TcpStream>,
     source: impl TcpSource,
+    tripwire: impl Future<Item = (), Error = ()> + Send + 'static,
     host: Bytes,
     out: impl Sink<SinkItem = Event, SinkError = ()> + Send + 'static,
 ) {
-    let handler = FramedRead::new(socket, source.decoder())
-        .filter_map(move |frame| {
-            let host = host.clone();
-            source.build_event(frame, host)
-        })
-        .map_err(|error| {
-            emit!(TcpConnectionError { error });
-        })
-        .forward(out)
-        .map(|_| debug!("connection closed."))
-        .map_err(|_| warn!("Error received while processing TCP source"));
+    let mut shutdown = Some(shutdown);
+    let mut token = None;
+    let mut reader = FramedRead::new(socket, source.decoder());
+    let handler = stream::poll_fn(move || {
+        // Gracefull shutdown procedure
+        if let Some(future) = shutdown.as_mut() {
+            match future.poll() {
+                Ok(Async::Ready(tk)) => {
+                    debug!("Start gracefull shutdown");
+                    // Close our write part of TCP socket to signal the other side
+                    // that it should stop writing and close the channel.
+                    if let Some(socket) = reader.get_ref().get_ref() {
+                        if let Err(error)=socket.shutdown(Shutdown::Write){
+                            warn!(message = "Failed in signalling to the other side to close the TCP channel.",%error);
+                        }
+                    } else {
+                        // Connection hasn't yet been established so we are done here.
+                        debug!("Closing connection that hasn't yet been fully established.");
+                        return Ok(Async::Ready(None));
+                    }
+                    token = Some(tk);
+                    shutdown = None;
+                }
+                Err(()) => shutdown = None,
+                Ok(Async::NotReady) => (),
+            }
+        }
+
+        // Actual work
+        reader.poll()
+    })
+    .take_until(tripwire)
+    .filter_map(move |frame| {
+        let host = host.clone();
+        source.build_event(frame, host)
+    })
+    .map_err(|error| {
+        emit!(TcpConnectionError { error });
+    })
+    .forward(out)
+    .map(|_| debug!("connection closed."))
+    .map_err(|_| warn!("Error received while processing TCP source"));
     tokio01::spawn(handler.instrument(span));
 }
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -1,5 +1,5 @@
 use crate::{
-    async_read::AsyncReadExt,
+    async_read::AsyncAllowReadExt,
     internal_events::TcpConnectionError,
     shutdown::ShutdownSignal,
     stream::StreamExt,
@@ -139,7 +139,7 @@ pub trait TcpSource: Clone + Send + 'static {
                         debug!(message = "accepted a new connection", %peer_addr);
                         handle_stream(
                             span.clone(),
-                            socket.read_until(tripwire),
+                            socket.allow_read_until(tripwire),
                             source,
                             host,
                             out.clone(),

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,6 +1,6 @@
 use crate::{
-    emit, event::Event, internal_events::UnixSocketError, shutdown::ShutdownSignal,
-    sources::Source, stream::StreamExt,
+    async_read::AsyncReadExt, emit, event::Event, internal_events::UnixSocketError,
+    shutdown::ShutdownSignal, sources::Source, stream::StreamExt,
 };
 use bytes::Bytes;
 use futures01::{future, sync::mpsc, Future, Sink, Stream};
@@ -62,15 +62,17 @@ pub fn build_unix_source(
                 let build_event = build_event.clone();
                 let received_from: Option<Bytes> =
                     path.map(|p| p.to_string_lossy().into_owned().into());
-                let lines_in = FramedRead::new(socket, LinesCodec::new_with_max_length(max_length))
-                    .take_until(shutdown.clone())
-                    .filter_map(move |line| build_event(&host_key, received_from.clone(), &line))
-                    .map_err(move |error| {
-                        emit!(UnixSocketError {
-                            error,
-                            path: &listen_path,
-                        });
+                let lines_in = FramedRead::new(
+                    socket.read_until(shutdown.clone()),
+                    LinesCodec::new_with_max_length(max_length),
+                )
+                .filter_map(move |line| build_event(&host_key, received_from.clone(), &line))
+                .map_err(move |error| {
+                    emit!(UnixSocketError {
+                        error,
+                        path: &listen_path,
                     });
+                });
 
                 let handler = lines_in.forward(out).map(|_| info!("finished sending"));
                 tokio01::spawn(handler.instrument(span))

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,5 +1,5 @@
 use crate::{
-    async_read::AsyncReadExt, emit, event::Event, internal_events::UnixSocketError,
+    async_read::AsyncAllowReadExt, emit, event::Event, internal_events::UnixSocketError,
     shutdown::ShutdownSignal, sources::Source, stream::StreamExt,
 };
 use bytes::Bytes;
@@ -63,7 +63,7 @@ pub fn build_unix_source(
                 let received_from: Option<Bytes> =
                     path.map(|p| p.to_string_lossy().into_owned().into());
                 let lines_in = FramedRead::new(
-                    socket.read_until(shutdown.clone()),
+                    socket.allow_read_until(shutdown.clone()),
                     LinesCodec::new_with_max_length(max_length),
                 )
                 .filter_map(move |line| build_event(&host_key, received_from.clone(), &line))

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -123,6 +123,26 @@ impl<S> MaybeTlsIncomingStream<S> {
     pub fn peer_addr(&self) -> SocketAddr {
         self.peer_addr
     }
+
+    /// None if connection still hasen't been established.
+    pub fn get_ref(&self) -> Option<&S> {
+        match &self.state {
+            StreamState::Accepted(stream) => {
+                if let Some(raw) = stream.raw() {
+                    Some(raw)
+                } else {
+                    Some(
+                        stream
+                            .tls()
+                            .expect("Stream not raw nor tls")
+                            .get_ref()
+                            .get_ref(),
+                    )
+                }
+            }
+            StreamState::Accepting(_) => None,
+        }
+    }
 }
 
 impl MaybeTlsIncomingStream<TcpStream> {

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -17,7 +17,7 @@ mod outgoing;
 mod settings;
 
 #[cfg(feature = "sources-tls")]
-pub(crate) use incoming::MaybeTlsListener;
+pub(crate) use incoming::{MaybeTlsIncomingStream, MaybeTlsListener};
 pub(crate) use maybe_tls::MaybeTls;
 pub(crate) use outgoing::MaybeTlsConnector;
 pub use settings::{MaybeTlsSettings, TlsConfig, TlsOptions, TlsSettings};

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -2,6 +2,7 @@
 
 use futures01::{Future, Sink};
 use prost::Message;
+use std::sync::atomic::Ordering;
 use tempfile::tempdir;
 use tracing::trace;
 use vector::event;
@@ -69,10 +70,7 @@ fn test_buffering() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| {
-        assert!(x == num_events);
-        true
-    });
+    assert_eq!(source_event_counter.load(Ordering::Acquire), num_events);
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -111,10 +109,7 @@ fn test_buffering() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| {
-        assert!(x == num_events);
-        true
-    });
+    assert_eq!(source_event_counter.load(Ordering::Acquire), num_events);
 
     terminate_gracefully(rt, topology);
 
@@ -172,10 +167,7 @@ fn test_max_size() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| {
-        assert!(x == num_events);
-        true
-    });
+    assert_eq!(source_event_counter.load(Ordering::Acquire), num_events);
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -313,10 +305,7 @@ fn test_reclaim_disk_space() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| {
-        assert!(x == num_events);
-        true
-    });
+    assert_eq!(source_event_counter.load(Ordering::Acquire), num_events);
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -357,10 +346,7 @@ fn test_reclaim_disk_space() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| {
-        assert!(x == num_events);
-        true
-    });
+    assert_eq!(source_event_counter.load(Ordering::Acquire), num_events);
 
     terminate_gracefully(rt, topology);
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -67,12 +67,9 @@ fn test_buffering() {
         .send_all(input_events_stream);
     let _ = rt.block_on(send).unwrap();
 
-    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
-    // reason, at times less events than were sent actually arrive to the
-    // `source`.
-    // We mitigate that by waiting on the event counter provided by our source
-    // mock.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+    // There was a race caused by a channel in the mock source, and this
+    // check is here to ensure it's really gone.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -109,12 +106,9 @@ fn test_buffering() {
 
     let output_events = test_util::receive_events(out_rx);
 
-    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
-    // reason, at times less events than were sent actually arrive to the
-    // `source`.
-    // We mitigate that by waiting on the event counter provided by our source
-    // mock.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+    // There was a race caused by a channel in the mock source, and this
+    // check is here to ensure it's really gone.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
 
     terminate_gracefully(rt, topology);
 
@@ -170,12 +164,9 @@ fn test_max_size() {
         .send_all(input_events_stream);
     let _ = rt.block_on(send).unwrap();
 
-    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
-    // reason, at times less events than were sent actually arrive to the
-    // `source`.
-    // We mitigate that by waiting on the event counter provided by our source
-    // mock.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+    // There was a race caused by a channel in the mock source, and this
+    // check is here to ensure it's really gone.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -311,12 +302,9 @@ fn test_reclaim_disk_space() {
         .send_all(input_events_stream);
     let _ = rt.block_on(send).unwrap();
 
-    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
-    // reason, at times less events than were sent actually arrive to the
-    // `source`.
-    // We mitigate that by waiting on the event counter provided by our source
-    // mock.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+    // There was a race caused by a channel in the mock source, and this
+    // check is here to ensure it's really gone.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -355,12 +343,9 @@ fn test_reclaim_disk_space() {
 
     let output_events = test_util::receive_events(out_rx);
 
-    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
-    // reason, at times less events than were sent actually arrive to the
-    // `source`.
-    // We mitigate that by waiting on the event counter provided by our source
-    // mock.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+    // There was a race caused by a channel in the mock source, and this
+    // check is here to ensure it's really gone.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
 
     terminate_gracefully(rt, topology);
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -69,7 +69,10 @@ fn test_buffering() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
+    test_util::wait_for_atomic_usize(source_event_counter, |x| {
+        assert!(x == num_events);
+        true
+    });
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -108,7 +111,10 @@ fn test_buffering() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
+    test_util::wait_for_atomic_usize(source_event_counter, |x| {
+        assert!(x == num_events);
+        true
+    });
 
     terminate_gracefully(rt, topology);
 
@@ -166,7 +172,10 @@ fn test_max_size() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
+    test_util::wait_for_atomic_usize(source_event_counter, |x| {
+        assert!(x == num_events);
+        true
+    });
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -304,7 +313,10 @@ fn test_reclaim_disk_space() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
+    test_util::wait_for_atomic_usize(source_event_counter, |x| {
+        assert!(x == num_events);
+        true
+    });
 
     // Give the topology some time to process the received data and simulate
     // a crash.
@@ -345,7 +357,10 @@ fn test_reclaim_disk_space() {
 
     // There was a race caused by a channel in the mock source, and this
     // check is here to ensure it's really gone.
-    test_util::wait_for_atomic_usize(source_event_counter, |x| assert!(x == num_events));
+    test_util::wait_for_atomic_usize(source_event_counter, |x| {
+        assert!(x == num_events);
+        true
+    });
 
     terminate_gracefully(rt, topology);
 


### PR DESCRIPTION
Closes #2604.

Adds `ReadUntil` for `AsyncRead` similar to `TakeUntil` for `Stream`.

This wraps `tcp` and `unix` sockets with `ReadUntil` and `ShutdownSignal`. So once the shutdown starts there will be no more reads from the sockets, but all that have been read will be processed.  

This also fixes `mock` source.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
