### PR TITLE
feat(internal_metrics source): Instrument few more components with metrics

### DIFF
--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -1,0 +1,14 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct AddFieldsEventProcessed;
+
+impl InternalEvent for RegexEventProcessed {
+    fn emit_metrics(&self) {
+        counter!("events_processed", 1,
+            "component_kind" => "transform",
+            "component_type" => "add_fields",
+        );
+    }
+}

--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -4,7 +4,7 @@ use metrics::counter;
 #[derive(Debug)]
 pub struct AddFieldsEventProcessed;
 
-impl InternalEvent for RegexEventProcessed {
+impl InternalEvent for AddFieldsEventProcessed {
     fn emit_metrics(&self) {
         counter!("events_processed", 1,
             "component_kind" => "transform",

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -1,0 +1,22 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct AwsKinesisStreamsEventSent {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for AwsKinesisStreamsEventSent {
+    fn emit_metrics(&self) {
+        counter!(
+            "events_processed", 1,
+            "component_kind" => "sink",
+            "component_type" => "aws_kinesis_streams",
+        );
+        counter!(
+            "bytes_processed", self.byte_size as u64,
+            "component_kind" => "sink",
+            "component_type" => "aws_kinesis_streams",
+        );
+    }
+}

--- a/src/internal_events/json.rs
+++ b/src/internal_events/json.rs
@@ -1,0 +1,39 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct JsonEventProcessed;
+
+impl InternalEvent for JsonEventProcessed {
+    fn emit_metrics(&self) {
+        counter!("events_processed", 1,
+            "component_kind" => "transform",
+            "component_type" => "json_parser",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonFailedParse<'a> {
+    pub field: &'a Atom,
+    pub error: Error,
+}
+
+impl InternalEvent for JsonFailedParse {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Event failed to parse as JSON",
+            field = %self.field(),
+            %error,
+            rate_limit_secs = 30
+        )
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processing_error", 1,
+            "component_kind" => "transform",
+            "component_type" => "json_parser",
+            "error_type" => "failed_parse",
+        );
+    }
+}

--- a/src/internal_events/json.rs
+++ b/src/internal_events/json.rs
@@ -1,5 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
+use serde_json::Error;
+use string_cache::DefaultAtom as Atom;
 
 #[derive(Debug)]
 pub struct JsonEventProcessed;
@@ -19,12 +21,12 @@ pub struct JsonFailedParse<'a> {
     pub error: Error,
 }
 
-impl InternalEvent for JsonFailedParse {
+impl InternalEvent for JsonFailedParse<'_> {
     fn emit_logs(&self) {
         warn!(
             message = "Event failed to parse as JSON",
-            field = %self.field(),
-            %error,
+            field = %self.field,
+            %self.error,
             rate_limit_secs = 30
         )
     }

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -6,6 +6,7 @@ mod lua;
 #[cfg(feature = "sources-prometheus")]
 mod prometheus;
 mod regex;
+mod splunk_hec;
 mod syslog;
 mod tcp;
 mod udp;
@@ -20,6 +21,7 @@ pub use self::lua::*;
 #[cfg(feature = "sources-prometheus")]
 pub use self::prometheus::*;
 pub use self::regex::*;
+pub use self::splunk_hec::*;
 pub use self::syslog::*;
 pub use self::tcp::*;
 pub use self::udp::*;

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -3,6 +3,7 @@ mod aws_kinesis_streams;
 mod blackhole;
 mod elasticsearch;
 mod file;
+mod json;
 #[cfg(feature = "transforms-lua")]
 mod lua;
 #[cfg(feature = "sources-prometheus")]
@@ -20,6 +21,7 @@ pub use self::aws_kinesis_streams::*;
 pub use self::blackhole::*;
 pub use self::elasticsearch::*;
 pub use self::file::*;
+pub use self::json::*;
 #[cfg(feature = "transforms-lua")]
 pub use self::lua::*;
 #[cfg(feature = "sources-prometheus")]

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -1,3 +1,4 @@
+mod aws_kinesis_streams;
 mod blackhole;
 mod elasticsearch;
 mod file;
@@ -13,6 +14,7 @@ mod udp;
 mod unix;
 mod vector;
 
+pub use self::aws_kinesis_streams::*;
 pub use self::blackhole::*;
 pub use self::elasticsearch::*;
 pub use self::file::*;

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -1,3 +1,4 @@
+mod add_fields;
 mod aws_kinesis_streams;
 mod blackhole;
 mod elasticsearch;
@@ -14,6 +15,7 @@ mod udp;
 mod unix;
 mod vector;
 
+pub use self::add_fields::*;
 pub use self::aws_kinesis_streams::*;
 pub use self::blackhole::*;
 pub use self::elasticsearch::*;

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -1,0 +1,48 @@
+use super::InternalEvent;
+use metrics::counter;
+use serde_json::Error;
+
+#[derive(Debug)]
+pub struct SplunkEventSent {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for SplunkEventSent {
+    fn emit_metrics(&self) {
+        counter!(
+            "events_processed", 1,
+            "component_kind" => "sink",
+            "component_type" => "splunk_hec",
+        );
+        counter!(
+            "bytes_processed", self.byte_size as u64,
+            "component_kind" => "sink",
+            "component_type" => "splunk_hec",
+        );
+    }
+}
+
+
+#[derive(Debug)]
+pub struct SplunkEventEncodeError {
+    pub error: Error,
+}
+
+
+impl InternalEvent for SplunkEventEncodeError {
+    fn emit_logs(&self) {
+        error!(
+            message = "Error encoding Splunk HEC event to json",
+            error = ?self.error,
+            rate_limit_secs = 30,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "encode_errors", 1,
+            "component_kind" => "sink",
+            "component_type" => "splunk_hec",
+        );
+    }
+}

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -22,12 +22,10 @@ impl InternalEvent for SplunkEventSent {
     }
 }
 
-
 #[derive(Debug)]
 pub struct SplunkEventEncodeError {
     pub error: Error,
 }
-
 
 impl InternalEvent for SplunkEventEncodeError {
     fn emit_logs(&self) {

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -1,6 +1,7 @@
 use crate::{
     dns::Resolver,
     event::{self, Event},
+    internal_events::AwsKinesisStreamsEventSent,
     region::RegionOrEndpoint,
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
@@ -251,6 +252,9 @@ fn encode_event(
 
     let data = Bytes::from(data);
 
+    emit!(AwsKinesisStreamsEventSent {
+        byte_size: data.len()
+    });
     Some(PutRecordsRequestEntry {
         data,
         partition_key,

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -172,9 +172,6 @@ impl HttpSink for HecSinkConfig {
                 None
             }
         }
-        // serde_json::to_vec(&body)
-        //     .map_err(|e| error!("Error encoding json body: {}", e))
-        //     .ok()
     }
 
     fn build_request(&self, events: Self::Output) -> http::Request<Vec<u8>> {

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -168,9 +168,7 @@ impl HttpSink for HecSinkConfig {
                 Some(value)
             }
             Err(e) => {
-                emit!(SplunkEventEncodeError {
-                    error: e
-                });
+                emit!(SplunkEventEncodeError { error: e });
                 None
             }
         }

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -1,6 +1,7 @@
 use crate::{
     dns::Resolver,
     event::{self, Event, LogEvent, Value},
+    internal_events::{SplunkEventEncodeError, SplunkEventSent},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpClient, HttpSink},
@@ -159,9 +160,23 @@ impl HttpSink for HecSinkConfig {
             body["sourcetype"] = json!(sourcetype);
         }
 
-        serde_json::to_vec(&body)
-            .map_err(|e| error!("Error encoding json body: {}", e))
-            .ok()
+        match serde_json::to_vec(&body) {
+            Ok(value) => {
+                emit!(SplunkEventSent {
+                    byte_size: value.len()
+                });
+                Some(value)
+            }
+            Err(e) => {
+                emit!(SplunkEventEncodeError {
+                    error: e
+                });
+                None
+            }
+        }
+        // serde_json::to_vec(&body)
+        //     .map_err(|e| error!("Error encoding json body: {}", e))
+        //     .ok()
     }
 
     fn build_request(&self, events: Self::Output) -> http::Request<Vec<u8>> {

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -2,6 +2,7 @@ use super::Transform;
 use crate::serde::Fields;
 use crate::{
     event::{Event, Value},
+    internal_events::AddFieldsEventProcessed,
     template::Template,
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
 };
@@ -124,7 +125,7 @@ impl Transform for AddFields {
                 }
             }
         }
-
+        emit!(AddFieldsEventProcessed);
         Some(event)
     }
 }

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -90,6 +90,8 @@ impl AddFields {
 
 impl Transform for AddFields {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
+        emit!(AddFieldsEventProcessed);
+
         for (key, value_or_template) in self.fields.clone() {
             let value = match value_or_template {
                 TemplateOrValue::Template(v) => match v.render_string(&event) {
@@ -125,7 +127,7 @@ impl Transform for AddFields {
                 }
             }
         }
-        emit!(AddFieldsEventProcessed);
+
         Some(event)
     }
 }

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -1,7 +1,7 @@
 use super::Transform;
 use crate::{
     event::{self, Event},
-    internal_events::{JsonFailedParse, JsonParserEventProcessed},
+    internal_events::{JsonEventProcessed, JsonFailedParse},
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
 };
 use serde::{Deserialize, Serialize};
@@ -75,7 +75,7 @@ impl Transform for JsonParser {
         let log = event.as_mut_log();
         let to_parse = log.get(&self.field).map(|s| s.as_bytes());
 
-        emit!(JsonParserEventProcessed);
+        emit!(JsonEventProcessed);
 
         let parsed = to_parse
             .and_then(|to_parse| {

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -1,7 +1,7 @@
 use super::Transform;
 use crate::{
     event::{self, Event},
-    internal_events::{JsonParserEventProcessed, JsonFailedParse},
+    internal_events::{JsonFailedParse, JsonParserEventProcessed},
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
 };
 use serde::{Deserialize, Serialize};

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -1,6 +1,7 @@
 use super::Transform;
 use crate::{
     event::{self, Event},
+    internal_events::{JsonParserEventProcessed, JsonFailedParse},
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
 };
 use serde::{Deserialize, Serialize};
@@ -74,16 +75,16 @@ impl Transform for JsonParser {
         let log = event.as_mut_log();
         let to_parse = log.get(&self.field).map(|s| s.as_bytes());
 
+        emit!(JsonParserEventProcessed);
+
         let parsed = to_parse
             .and_then(|to_parse| {
                 serde_json::from_slice::<Value>(to_parse.as_ref())
                     .map_err(|error| {
-                        warn!(
-                            message = "Event failed to parse as JSON",
-                            field = self.field.as_ref(),
-                            %error,
-                            rate_limit_secs = 30
-                        )
+                        emit!(JsonFailedParse {
+                            field: &self.field,
+                            error: error
+                        })
                     })
                     .ok()
             })


### PR DESCRIPTION
This PR instruments few components with metrics following checklist from #2007 
I've followed initial implementation from #1953 

I have few open questions though:
- Is there a convention for internal events naming? I've got a bit confused. E.g. `ElasticSearchEventReceived` defined for `sink` component, however most internal events define `*Sent` events for sinks and `*Received` events for sources. And since corresponding metric name in most places is `events|bytes_processed`, it's a bit confusing adding metrics for the first time.
- Would it be possible to include component name as metric tag? Since same component type can be used multiple times in the config, it's super useful to be able to distinguish them.
