### PR TITLE
chore: Add vector-macro to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -688,6 +688,41 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 dependencies = [
+ "quote 1.0.2",
+ "syn 1.0.14",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "strsim 0.9.3",
+ "syn 1.0.14",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
  "quote 1.0.2",
  "syn 1.0.14",
 ]
@@ -1620,6 +1655,12 @@ dependencies = [
  "tokio-io",
  "tokio-uds",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3862,6 +3903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
 name = "structopt"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,8 +5176,18 @@ dependencies = [
  "typetag",
  "url 1.7.2",
  "uuid 0.7.4",
+ "vector-macro",
  "walkdir",
  "warp",
+]
+
+[[package]]
+name = "vector-macro"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "lib/codec",
   "lib/file-source",
   "lib/tracing-limit",
+  "lib/vector-macro",
 ]
 
 [dependencies]
@@ -38,6 +39,7 @@ members = [
 codec = { path = "lib/codec" }
 file-source = { path = "lib/file-source" }
 tracing-limit = { path = "lib/tracing-limit" }
+vector-macro = { path = "lib/vector-macro" }
 
 # Tokio / Futures
 futures01 = { package = "futures", version = "0.1.25" }

--- a/lib/vector-macro/Cargo.toml
+++ b/lib/vector-macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vector-macro"
+version = "0.1.0"
+authors = ["Vector Contributors <vector@timber.io>"]
+edition = "2018"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling = "0.10.2"
+quote = "1.0.2"
+syn = { version = "1.0.14", features = ["full"] }

--- a/lib/vector-macro/src/lib.rs
+++ b/lib/vector-macro/src/lib.rs
@@ -1,0 +1,75 @@
+// Can not be used on `stable` channel.
+// #![feature(proc_macro_diagnostic)]
+
+use darling::FromMeta;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, AttributeArgs, ImplItem, Item, Type};
+
+#[derive(Debug, FromMeta)]
+struct ImplSinkConfigArgs {
+    name: String,
+    input_type: String,
+    component: String,
+}
+
+#[proc_macro_attribute]
+pub fn impl_sink_config(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(metadata as AttributeArgs);
+    let args = match ImplSinkConfigArgs::from_list(&args) {
+        Ok(v) => v,
+        Err(e) => {
+            return TokenStream::from(e.write_errors());
+        }
+    };
+    let (name, input_type, component) = (args.name, args.input_type, args.component);
+    let input_type = syn::parse_str::<syn::Path>(&input_type)
+        .expect("Failed to parse input_type into `syn::Path`");
+    let component = syn::parse_str::<syn::Path>(&component)
+        .expect("Failed to parse component into `syn::Path`");
+
+    let mut item: Item = syn::parse(input).expect("Failed to parse input into `syn::Item`");
+    let self_ty = match item {
+        Item::Impl(ref mut item) => {
+            item.items.push(ImplItem::Verbatim(quote! {
+                fn input_type(&self) -> DataType {
+                    #input_type
+                }
+            }));
+
+            item.items.push(ImplItem::Verbatim(quote! {
+                fn sink_type(&self) -> &'static str {
+                    #name
+                }
+            }));
+
+            match *item.self_ty {
+                Type::Path(ref item) => Some(item.path.clone()),
+                _ => {
+                    // item.self_ty.span().unstable().error("This is not a `syn::Type::Path`").emit();
+                    // None
+                    panic!(
+                        "This is not a `syn::Type::Path`.\n{:?}",
+                        item.self_ty.span()
+                    );
+                }
+            }
+        }
+        _ => {
+            // item.span().unstable().error("This is not a `syn::Item::Impl`").emit();
+            // None
+            panic!("This is not a `syn::Item::Impl`.\n{:?}", item.span());
+        }
+    };
+
+    let output = quote! {
+        #[typetag::serde(name = #name)]
+        #item
+
+        inventory::submit! {
+            #component::<#self_ty>(#name)
+        }
+    };
+    output.into()
+}

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -94,11 +94,11 @@ pub enum Encoding {
     Json,
 }
 
-inventory::submit! {
-    SinkDescription::new_without_default::<HttpSinkConfig>("http")
-}
-
-#[typetag::serde(name = "http")]
+#[vector_macro::impl_sink_config(
+    name = "http",
+    input_type = "DataType::Log",
+    component = "SinkDescription::new_without_default"
+)]
 impl SinkConfig for HttpSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         validate_headers(&self.headers, &self.auth)?;
@@ -134,14 +134,6 @@ impl SinkConfig for HttpSinkConfig {
             }
             None => Ok((sink, Box::new(future::ok(())))),
         }
-    }
-
-    fn input_type(&self) -> DataType {
-        DataType::Log
-    }
-
-    fn sink_type(&self) -> &'static str {
-        "http"
     }
 }
 


### PR DESCRIPTION
I noticed that every sink config implement same simple methods, I also never created procedural macros in the past, so.. done this as learning for myself, but maybe also useful for vector :)

Does such macro make sense? If so, I'll change rest sinks and add same for transform/source.