### PR TITLE
chore: Fix the globs at .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-*
+**/*
 !scripts/Gemfile
 !scripts/Gemfile.lock
 !scripts/ci-docker-images/verifier-nixos/Gemfile

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,6 +13,7 @@ on:
       - "tests/**"
       - "Cargo.lock"
       - "Cargo.toml"
+      - ".dockerignore"
       - "docker-compose.yml"
       - "rust-toolchain"
 


### PR DESCRIPTION
This PR reduces the size of the docker context.
Partially solves #2628.