### PR TITLE
fix(file source): Fix the bug with channel closing at file server

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -59,11 +59,15 @@ impl<PP> FileServer<PP>
 where
     PP: PathsProvider,
 {
-    pub fn run(
+    pub fn run<C>(
         self,
-        mut chans: impl Sink<(Bytes, String), Error = ()> + Unpin,
+        mut chans: C,
         mut shutdown: impl Future + Unpin,
-    ) {
+    ) -> Result<Shutdown, <C as Sink<(Bytes, String)>>::Error>
+    where
+        C: Sink<(Bytes, String)> + Unpin,
+        <C as Sink<(Bytes, String)>>::Error: std::error::Error,
+    {
         let mut line_buffer = Vec::new();
         let mut fingerprint_buffer = Vec::new();
 
@@ -233,11 +237,14 @@ where
             // If the FileWatcher is dead we don't retain it; it will be deallocated.
             fp_map.retain(|_file_id, watcher| !watcher.dead());
 
-            let mut stream = stream::iter(lines.drain(..).map(Result::<_, ()>::Ok));
+            let mut stream = stream::iter(lines.drain(..).map(Ok));
             let result = block_on(chans.send_all(&mut stream));
-            if result.is_err() {
-                debug!("Output channel closed.");
-                return;
+            match result {
+                Ok(()) => {}
+                Err(error) => {
+                    error!(message = "output channel closed", ?error);
+                    return Err(error);
+                }
             }
 
             // When no lines have been read we kick the backup_cap up by twice,
@@ -265,7 +272,7 @@ where
                 shutdown,
                 delay_for(time::Duration::from_millis(backoff as u64)),
             )) {
-                Either::Left((_, _)) => return,
+                Either::Left((_, _)) => return Ok(Shutdown),
                 Either::Right((_, future)) => shutdown = future,
             }
         }
@@ -298,6 +305,14 @@ where
         };
     }
 }
+
+/// A sentinel type to signal that file server was gracefully shut down.
+///
+/// The purpose of this type is to clarify the semantics of the result values
+/// returned from the [`FileServer::run`] for both the users of the file server,
+/// and the implementors.
+#[derive(Debug)]
+pub struct Shutdown;
 
 pub struct Checkpointer {
     directory: PathBuf,

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -3,9 +3,7 @@ use bytes::Bytes;
 use futures::{
     executor::block_on,
     future::{select, Either},
-    stream,
-    stream::StreamExt,
-    Future, Sink,
+    stream, Future, Sink, SinkExt,
 };
 use glob::glob;
 use indexmap::IndexMap;
@@ -235,8 +233,8 @@ where
             // If the FileWatcher is dead we don't retain it; it will be deallocated.
             fp_map.retain(|_file_id, watcher| !watcher.dead());
 
-            let stream = stream::iter(lines.drain(..).map(Result::<_, ()>::Ok));
-            let result = block_on(stream.forward(&mut chans));
+            let mut stream = stream::iter(lines.drain(..).map(Result::<_, ()>::Ok));
+            let result = block_on(chans.send_all(&mut stream));
             if result.is_err() {
                 debug!("Output channel closed.");
                 return;

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -8,7 +8,7 @@ mod file_watcher;
 mod metadata_ext;
 pub mod paths_provider;
 
-pub use self::file_server::{FileServer, Fingerprinter};
+pub use self::file_server::{FileServer, Fingerprinter, Shutdown as FileServerShutdown};
 
 type FileFingerprint = u64;
 type FilePosition = u64;

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -308,10 +308,11 @@ pub fn file_source(
         let span = info_span!("file_server");
         spawn_blocking(move || {
             let _enter = span.enter();
-            file_server.run(
-                Compat01As03Sink::new(tx.sink_map_err(drop)),
-                shutdown.compat(),
-            );
+            let result = file_server.run(Compat01As03Sink::new(tx), shutdown.compat());
+            // Panic if we encounter any error originating from the file server.
+            // We're at the `spawn_blocking` call, the panic will be caught and
+            // passed to the `JoinHandle` error, similar to the usual threads.
+            result.unwrap();
         })
         .boxed()
         .compat()


### PR DESCRIPTION
This PR fixes a bug at the `file_server`, that caused it to close the output channel.
I stumbled upon this while working on k8s integration.

Additionally, it improves the error handling at the `file_server` and file source, such that errors should be easier to track.

~It was introduced at https://github.com/timberio/vector/commit/271bcbd13d81e728b814d1273784147e5647a2b5#diff-55f9c2b436571d015f880127293d295f.~ Apparently, the bug was present even before that.
We might want to backport this fix ~to `0.9`, as that release is affected~ to a yet-to-be-specified set of the past releases. See [UPD3](#upd3).
I'm surprised how we didn't catch it in tests, we should think about improving the tests at the file server to prevent bugs like this in the future.

The problem in the current code is that `forward` will close the sink once the stream is exhausted. The code is supposed to continue after that, but it wasn't able to do so.

#### UPD1

After some additional code audit, it looks like this is a *critical* bug that breaks the file source. We might want to investigate this - look for bug reports mentioning the behavior caused by this bug. It baffles me how this wasn't discovered earlier. This is crazy. How is it not affecting the users? Or if it does - why don't we get flooded with the bug reports?

#### UPD2

Possible related issues:
- https://github.com/timberio/vector/issues/828

#### UPD3

The bug was introduced at https://github.com/timberio/vector/commit/30ab0e64c8c16479d214cd39e9c17600f283a29f#diff-9625d82d1fec1a0eec11341def9f729e. The earliest release with this bug is v0.3.0.

#### UPD4:

Nope, the bus is since 0.9 and the futures update. See the PR discusstion.
