### PR TITLE
chore(gcp_cloud_storage sink): Change default variant in enum Compression

### DIFF
--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -145,8 +145,8 @@ impl Encoding {
 #[derivative(Default)]
 enum Compression {
     #[derivative(Default)]
-    Gzip,
     None,
+    Gzip,
 }
 
 impl Compression {


### PR DESCRIPTION
Extracted from https://github.com/timberio/vector/pull/2637#discussion_r427447512

Currently default value used only in tests.