### PR TITLE
chore: Enable debug for package-deb script

### DIFF
--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -x
 
 # package-deb.sh
 #


### PR DESCRIPTION
We need to figure out where this error 141 comes from.

I'll remove this once we finish with debugging, for now I need this in `master` to gather data across various runs.