### PR TITLE
chore(vector source): Rate limit TCP connection errors, downgrade their severity

### DIFF
--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -80,7 +80,7 @@ pub struct TcpConnectionError {
 
 impl InternalEvent for TcpConnectionError {
     fn emit_logs(&self) {
-        warn!(message = "connection error.", error = %self.error);
+        info!(message = "connection error.", error = %self.error, rate_limit_secs = 10);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -80,7 +80,7 @@ pub struct TcpConnectionError {
 
 impl InternalEvent for TcpConnectionError {
     fn emit_logs(&self) {
-        info!(message = "connection error.", error = %self.error, rate_limit_secs = 10);
+        warn!(message = "connection error.", error = %self.error, rate_limit_secs = 10);
     }
 
     fn emit_metrics(&self) {


### PR DESCRIPTION
Fixes https://github.com/timberio/vector/issues/2664 by:

* Rate limiting `TCP Connection Error` logs
* Reduces their severity to `INFO` from `WARN` (Issue suggested `DEBUG`, looking for consensus here)