### PR TITLE
chore(lua transform): Avoid hanging on timers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,7 @@ loki-integration-tests = ["sinks-loki"]
 pulsar-integration-tests = ["sinks-pulsar"]
 splunk-integration-tests = ["sinks-splunk_hec", "warp"]
 
-shutdown-tests = ["sources","sinks-console","sinks-prometheus","sinks-blackhole","unix","rdkafka","transforms-log_to_metric"]
+shutdown-tests = ["sources","sinks-console","sinks-prometheus","sinks-blackhole","unix","rdkafka","transforms-log_to_metric","transforms-lua"]
 disable-resolv-conf = []
 
 [[bench]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -583,7 +583,7 @@ services:
     network_mode: host
     working_dir: $PWD
     user: $USER
-    command: cargo test --no-default-features --features default-musl,shutdown-tests --target x86_64-unknown-linux-musl --test shutdown -- --test-threads 4
+    command: cargo test --no-default-features --features default-cmake,shutdown-tests --target x86_64-unknown-linux-musl --test shutdown -- --test-threads 4
 
   test-behavior:
     image: ubuntu:18.04

--- a/src/transforms/util/runtime_transform.rs
+++ b/src/transforms/util/runtime_transform.rs
@@ -113,7 +113,6 @@ where
                 .map(move |msg| -> Vec<Event> {
                     let mut acc = Vec::new(); // TODO: create a stream adaptor to avoid buffering all events
                     if is_shutdown {
-                        info!("return acc: {}", is_shutdown);
                         return acc;
                     }
                     match msg {

--- a/src/transforms/util/runtime_transform.rs
+++ b/src/transforms/util/runtime_transform.rs
@@ -1,4 +1,4 @@
-use crate::{event::Event, transforms::Transform};
+use crate::{event::Event, stream::StreamExt, transforms::Transform};
 use futures01::{stream, Future, Stream as FutureStream};
 use std::time::Duration;
 use tokio01::timer::Interval;
@@ -97,7 +97,7 @@ where
 
                     init_msg
                         .chain(first_event)
-                        .chain(rest_events_and_shutdown_msg.select(timer_msgs))
+                        .chain(rest_events_and_shutdown_msg.weak_select(timer_msgs))
                 })
                 .map_err(|_| ())
                 .into_stream()
@@ -113,6 +113,7 @@ where
                 .map(move |msg| -> Vec<Event> {
                     let mut acc = Vec::new(); // TODO: create a stream adaptor to avoid buffering all events
                     if is_shutdown {
+                        info!("return acc: {}", is_shutdown);
                         return acc;
                     }
                     match msg {

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -336,3 +336,45 @@ fn timely_shutdown_internal_metrics() {
     type = "internal_metrics""#,
     ));
 }
+
+#[test]
+fn timely_shutdown_lua_timer() {
+    test_timely_shutdown(vector(
+        r#"
+[sources.source]
+   type = "stdin"
+
+[transforms.transform]
+  type = "lua"
+  inputs = ["source"]
+  version = "2"
+
+  hooks.process = "process"
+
+  timers = [
+  {interval_seconds = 5, handler = "timer_handler"}
+  ]
+
+  source = """
+    function process(event, emit)
+      emit(event)
+    end
+
+    function timer_handler(emit)
+      event = {
+        log = {
+          message = "Heartbeat",
+        }
+      }
+      return event
+    end
+  """
+
+[sinks.sink]
+  type = "console"
+  inputs = ["transform"]
+  encoding = "text"
+  target = "stdout"
+"#,
+    ));
+}


### PR DESCRIPTION
Closes #2654.

`lua` transform wasn't shutting down because it was waiting for the timers stream to end, which wasn't going to happen. 

The fix adds a new structure `WeakSelect` which behaves like `select` but will end if any of it's streams end. Also a test for this case has been added.

 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
