### PR TITLE
chore: Reorder Tower service layers

### DIFF
--- a/src/sinks/util/service2.rs
+++ b/src/sinks/util/service2.rs
@@ -14,7 +14,7 @@ use tower03::{
 
 pub use compat::TowerCompat;
 
-pub type Svc<S, L> = ConcurrencyLimit<RateLimit<Retry<FixedRetryPolicy<L>, Timeout<S>>>>;
+pub type Svc<S, L> = RateLimit<Retry<FixedRetryPolicy<L>, ConcurrencyLimit<Timeout<S>>>>;
 pub type TowerBatchedSink<S, B, L, Request> = BatchSink<TowerCompat<Svc<S, L>>, B, Request>;
 
 pub trait ServiceBuilderExt<L> {
@@ -127,9 +127,9 @@ impl TowerRequestSettings {
     {
         let policy = self.retry_policy(retry_logic);
         let service = ServiceBuilder::new()
-            .concurrency_limit(self.in_flight_limit)
             .rate_limit(self.rate_limit_num, self.rate_limit_duration)
             .retry(policy)
+            .concurrency_limit(self.in_flight_limit)
             .timeout(self.timeout)
             .service(service);
 


### PR DESCRIPTION
The new auto concurrency limiter will need to be able to see temporary
errors before they are retried. As such, it needs to run before the
Retry layer instead of after it. This micro-patch simply reorders the
standard service layers to that effect, and is separated out to ensure
it isn't the cause of unanticipated problems.

Signed-off-by: Bruce Guenter <bruce@timber.io>