### PR TITLE
chore(sinks): Only log `200`-`299` responses as successful

### DIFF
--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -6,6 +6,7 @@ use crate::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::RetryLogic,
         rusoto2::{self, AwsCredentialsProvider},
+        sink::Response,
         BatchEventsConfig, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -145,6 +146,8 @@ impl fmt::Debug for KinesisFirehoseService {
             .finish()
     }
 }
+
+impl Response for PutRecordBatchOutput {}
 
 #[derive(Debug, Clone)]
 struct KinesisFirehoseRetryLogic;

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -7,6 +7,7 @@ use crate::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::RetryLogic,
         rusoto::{self, AwsCredentialsProvider},
+        sink::Response,
         BatchEventsConfig, TowerRequestConfig,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -144,6 +145,8 @@ impl fmt::Debug for KinesisService {
             .finish()
     }
 }
+
+impl Response for PutRecordsOutput {}
 
 #[derive(Debug, Clone)]
 struct KinesisRetryLogic;

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -6,7 +6,9 @@ use crate::{
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         retries::RetryLogic,
-        rusoto, BatchBytesConfig, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
+        rusoto,
+        sink::Response,
+        BatchBytesConfig, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
         PartitionInnerBuffer, ServiceBuilderExt, TowerRequestConfig,
     },
     template::Template,
@@ -349,6 +351,8 @@ struct Request {
     content_encoding: Option<String>,
     options: S3Options,
 }
+
+impl Response for PutObjectOutput {}
 
 #[derive(Debug, Clone)]
 struct S3RetryLogic;

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -1,7 +1,7 @@
 use super::{
     retries::{RetryAction, RetryLogic},
     service::{TowerBatchedSink, TowerRequestSettings},
-    Batch, BatchSettings,
+    sink, Batch, BatchSettings,
 };
 use crate::{
     dns::Resolver,
@@ -311,6 +311,12 @@ impl<B> Service<B> for HttpBatchService<B> {
         });
 
         Box::new(fut)
+    }
+}
+
+impl<T: fmt::Debug> sink::Response for http::Response<T> {
+    fn is_successful(&self) -> bool {
+        self.status().is_success()
     }
 }
 

--- a/src/sinks/util/http2.rs
+++ b/src/sinks/util/http2.rs
@@ -1,7 +1,7 @@
 use super::{
     retries2::{RetryAction, RetryLogic},
     service2::{TowerBatchedSink, TowerRequestSettings},
-    Batch, BatchSettings,
+    sink, Batch, BatchSettings,
 };
 use crate::{
     dns::Resolver,
@@ -322,6 +322,11 @@ impl<B> Service<B> for HttpBatchService<B> {
     }
 }
 
+impl<T: fmt::Debug> sink::Response for http02::Response<T> {
+    fn is_successful(&self) -> bool {
+        self.status().is_success()
+    }
+}
 #[derive(Clone)]
 pub struct HttpRetryLogic;
 

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -1,5 +1,6 @@
 use super::{
     retries::{FixedRetryPolicy, RetryLogic},
+    sink::Response,
     Batch, BatchSettings, BatchSink,
 };
 use crate::buffers::Acker;
@@ -134,7 +135,7 @@ impl TowerRequestSettings {
         L: RetryLogic<Response = S::Response> + Send + 'static,
         S: Service<Request> + Clone + Send + 'static,
         S::Error: Into<crate::Error> + Send + Sync + 'static,
-        S::Response: Send + std::fmt::Debug,
+        S::Response: Send + Response,
         S::Future: Send + 'static,
         B: Batch<Output = Request>,
         Request: Send + Clone + 'static,
@@ -163,7 +164,7 @@ pub struct TowerRequestLayer<L, Request> {
 impl<S, L, Request> tower::layer::Layer<S> for TowerRequestLayer<L, Request>
 where
     S: Service<Request> + Send + Clone + 'static,
-    S::Response: Send + 'static,
+    S::Response: Send + 'static + Response,
     S::Error: Into<crate::Error> + Send + Sync + 'static,
     S::Future: Send + 'static,
     L: RetryLogic<Response = S::Response> + Send + 'static,

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -164,7 +164,7 @@ pub struct TowerRequestLayer<L, Request> {
 impl<S, L, Request> tower::layer::Layer<S> for TowerRequestLayer<L, Request>
 where
     S: Service<Request> + Send + Clone + 'static,
-    S::Response: Send + 'static + Response,
+    S::Response: Response + Send + 'static,
     S::Error: Into<crate::Error> + Send + Sync + 'static,
     S::Future: Send + 'static,
     L: RetryLogic<Response = S::Response> + Send + 'static,

--- a/src/sinks/util/service2.rs
+++ b/src/sinks/util/service2.rs
@@ -1,4 +1,5 @@
 use super::retries2::{FixedRetryPolicy, RetryLogic};
+use super::sink::Response;
 use super::{Batch, BatchSettings, BatchSink};
 use crate::buffers::Acker;
 use serde::{Deserialize, Serialize};
@@ -120,7 +121,7 @@ impl TowerRequestSettings {
         L: RetryLogic<Response = S::Response> + Send + 'static,
         S: Service<Request> + Clone + Send + 'static,
         S::Error: Into<crate::Error> + Send + Sync + 'static,
-        S::Response: Send + std::fmt::Debug,
+        S::Response: Send + Response,
         S::Future: Send + 'static,
         B: Batch<Output = Request>,
         Request: Send + Clone + 'static,
@@ -148,7 +149,7 @@ pub struct TowerRequestLayer<L, Request> {
 impl<S, L, Request> Layer<S> for TowerRequestLayer<L, Request>
 where
     S: Service<Request> + Send + Clone + 'static,
-    S::Response: Send + 'static,
+    S::Response: Send + 'static + Response,
     S::Error: Into<crate::Error> + Send + Sync + 'static,
     S::Future: Send + 'static,
     L: RetryLogic<Response = S::Response> + Send + 'static,

--- a/src/sinks/util/service2.rs
+++ b/src/sinks/util/service2.rs
@@ -149,7 +149,7 @@ pub struct TowerRequestLayer<L, Request> {
 impl<S, L, Request> Layer<S> for TowerRequestLayer<L, Request>
 where
     S: Service<Request> + Send + Clone + 'static,
-    S::Response: Send + 'static + Response,
+    S::Response: Response + Send + 'static,
     S::Error: Into<crate::Error> + Send + Sync + 'static,
     S::Future: Send + 'static,
     L: RetryLogic<Response = S::Response> + Send + 'static,

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -720,25 +720,6 @@ pub trait Response: fmt::Debug {
 impl Response for () {}
 impl<'a> Response for &'a str {}
 
-#[cfg(feature = "rusoto_kinesis")]
-impl Response for rusoto_kinesis::PutRecordsOutput {}
-#[cfg(feature = "rusoto_s3")]
-impl Response for rusoto_s3::PutObjectOutput {}
-#[cfg(feature = "rusoto_firehose")]
-impl Response for rusoto_firehose::PutRecordBatchOutput {}
-
-impl<T: fmt::Debug> Response for http::response::Response<T> {
-    fn is_successful(&self) -> bool {
-        self.status().is_success()
-    }
-}
-
-impl<T: fmt::Debug> Response for http02::response::Response<T> {
-    fn is_successful(&self) -> bool {
-        self.status().is_success()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -646,7 +646,7 @@ where
             .map_err(Into::into)
             .then(move |result| {
                 match result {
-                    Ok(response) if response.is_success() => {
+                    Ok(response) if response.is_successful() => {
                         trace!(message = "Response successful.", ?response);
                     }
                     Ok(response) => {
@@ -712,7 +712,7 @@ where
 // === Response ===
 
 pub trait Response: fmt::Debug {
-    fn is_success(&self) -> bool {
+    fn is_successful(&self) -> bool {
         true
     }
 }
@@ -728,13 +728,13 @@ impl Response for rusoto_s3::PutObjectOutput {}
 impl Response for rusoto_firehose::PutRecordBatchOutput {}
 
 impl<T: fmt::Debug> Response for http::response::Response<T> {
-    fn is_success(&self) -> bool {
+    fn is_successful(&self) -> bool {
         self.status().is_success()
     }
 }
 
 impl<T: fmt::Debug> Response for http02::response::Response<T> {
-    fn is_success(&self) -> bool {
+    fn is_successful(&self) -> bool {
         self.status().is_success()
     }
 }

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -719,8 +719,12 @@ pub trait Response: fmt::Debug {
 
 impl Response for () {}
 impl<'a> Response for &'a str {}
+
+#[cfg(feature = "rusoto_kinesis")]
 impl Response for rusoto_kinesis::PutRecordsOutput {}
+#[cfg(feature = "rusoto_s3")]
 impl Response for rusoto_s3::PutObjectOutput {}
+#[cfg(feature = "rusoto_firehose")]
 impl Response for rusoto_firehose::PutRecordBatchOutput {}
 
 impl<T: fmt::Debug> Response for http::response::Response<T> {


### PR DESCRIPTION
Closes #2426

Fix for all `http` sinks that were using `ServiceSink`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
