### PR TITLE
chore(tests): Use `test_util::runtime()` in tests

### DIFF
--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -286,14 +286,14 @@ impl SourceShutdownCoordinator {
 
 #[cfg(test)]
 mod test {
-    use crate::runtime;
     use crate::shutdown::SourceShutdownCoordinator;
+    use crate::test_util::runtime;
     use futures01::future::Future;
     use std::time::{Duration, Instant};
 
     #[test]
     fn shutdown_coordinator_shutdown_source_clean() {
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         let mut shutdown = SourceShutdownCoordinator::new();
         let name = "test";
 
@@ -310,7 +310,7 @@ mod test {
 
     #[test]
     fn shutdown_coordinator_shutdown_source_force() {
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         let mut shutdown = SourceShutdownCoordinator::new();
         let name = "test";
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -820,8 +820,7 @@ mod integration_tests {
     use super::*;
     use crate::{
         region::RegionOrEndpoint,
-        runtime::Runtime,
-        test_util::{random_lines, random_lines_with_stream, random_string},
+        test_util::{random_lines, random_lines_with_stream, random_string, runtime},
         topology::config::{SinkConfig, SinkContext},
     };
     use futures01::{
@@ -836,7 +835,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_insert_log_event() {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let stream_name = gen_name();
@@ -891,7 +890,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_insert_log_events_sorted() {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let stream_name = gen_name();
@@ -964,7 +963,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_insert_out_of_range_timestamp() {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let stream_name = gen_name();
@@ -1044,7 +1043,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_dynamic_group_and_stream_creation() {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let group_name = gen_name();
@@ -1099,7 +1098,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_insert_log_event_batched() {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let group_name = gen_name();
@@ -1159,7 +1158,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_event_partitioned() {
         crate::test_util::trace_init();
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let stream_name = gen_name();
@@ -1271,14 +1270,14 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         rt.block_on(healthcheck(config, resolver).unwrap()).unwrap();
     }
 
     fn ensure_group(region: Region) {
-        let mut rt = Runtime::single_threaded().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let client = create_client(region, None, resolver).unwrap();

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -261,12 +261,11 @@ mod integration_tests {
     use super::*;
     use crate::{
         region::RegionOrEndpoint,
-        runtime,
         sinks::{
             elasticsearch::{ElasticSearchAuth, ElasticSearchCommon, ElasticSearchConfig},
             util::BatchEventsConfig,
         },
-        test_util::{random_events_with_stream, random_string},
+        test_util::{random_events_with_stream, random_string, runtime},
         topology::config::SinkContext,
     };
     use futures01::Sink;
@@ -305,7 +304,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let sink = KinesisFirehoseService::new(config, cx).unwrap();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -328,8 +328,7 @@ mod integration_tests {
     use super::*;
     use crate::{
         region::RegionOrEndpoint,
-        runtime,
-        test_util::{random_lines_with_stream, random_string},
+        test_util::{random_lines_with_stream, random_string, runtime},
         topology::config::SinkContext,
     };
     use futures01::{Future, Sink};
@@ -361,7 +360,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let sink = KinesisService::new(config, cx).unwrap();

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -526,7 +526,6 @@ mod integration_tests {
         dns::Resolver,
         event::Event,
         region::RegionOrEndpoint,
-        runtime::Runtime,
         sinks::aws_s3::{S3Sink, S3SinkConfig},
         test_util::{random_lines_with_stream, random_string, runtime},
         topology::config::SinkContext,
@@ -636,7 +635,7 @@ mod integration_tests {
         let (tx, rx) = futures01::sync::mpsc::channel(1);
         let pump = sink.send_all(rx).map(|_| ()).map_err(|_| ());
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         rt.spawn(pump);
 
         let mut tx = tx.wait();
@@ -720,7 +719,7 @@ mod integration_tests {
 
     #[test]
     fn s3_healthchecks() {
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let healthcheck = S3Sink::healthcheck(&config(1), resolver).unwrap();
@@ -729,7 +728,7 @@ mod integration_tests {
 
     #[test]
     fn s3_healthchecks_invalid_bucket() {
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
         let config = S3SinkConfig {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -218,7 +218,7 @@ mod integration_tests {
     use super::*;
     use crate::{
         runtime::Runtime,
-        test_util::{block_on, random_events_with_stream, random_string},
+        test_util::{block_on, random_events_with_stream, random_string, runtime},
     };
     use futures01::Sink;
     use reqwest::{Client, Method, Response};
@@ -248,7 +248,7 @@ mod integration_tests {
     fn publish_events() {
         crate::test_util::trace_init();
 
-        let rt = Runtime::new().unwrap();
+        let rt = runtime();
         let (topic, subscription) = create_topic_subscription();
         let (sink, healthcheck) = config_build(&rt, &topic);
 
@@ -275,7 +275,7 @@ mod integration_tests {
 
     #[test]
     fn checks_for_valid_topic() {
-        let rt = Runtime::new().unwrap();
+        let rt = runtime();
         let (topic, _subscription) = create_topic_subscription();
         let topic = format!("BAD{}", topic);
         let (_sink, healthcheck) = config_build(&rt, &topic);

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -289,10 +289,9 @@ mod tests {
     use super::*;
     use crate::{
         assert_downcast_matches,
-        runtime::Runtime,
         sinks::http::HttpSinkConfig,
         sinks::util::http2::HttpSink,
-        test_util::{next_addr, random_lines_with_stream, shutdown_on_idle},
+        test_util::{next_addr, random_lines_with_stream, runtime, shutdown_on_idle},
         topology::config::SinkContext,
     };
     use bytes::Buf;
@@ -382,7 +381,7 @@ mod tests {
         "#;
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        let rt = Runtime::new().unwrap();
+        let rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let _ = config.build(cx).unwrap();
@@ -407,7 +406,7 @@ mod tests {
         .replace("$IN_ADDR", &format!("{}", in_addr));
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let (sink, _) = config.build(cx).unwrap();
@@ -470,7 +469,7 @@ mod tests {
         .replace("$IN_ADDR", &format!("{}", in_addr));
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let (sink, _) = config.build(cx).unwrap();
@@ -530,7 +529,7 @@ mod tests {
         .replace("$IN_ADDR", &format!("{}", in_addr));
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let (sink, _) = config.build(cx).unwrap();

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -519,10 +519,10 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use crate::runtime::Runtime;
     use crate::sinks::influxdb::logs::InfluxDBLogsConfig;
     use crate::sinks::influxdb::test_util::{onboarding_v2, BUCKET, ORG, TOKEN};
     use crate::sinks::influxdb::InfluxDB2Settings;
+    use crate::test_util::runtime;
     use crate::topology::SinkContext;
     use chrono::Utc;
     use futures01::Sink;
@@ -533,7 +533,7 @@ mod integration_tests {
 
         let ns = format!("ns-{}", Utc::now().timestamp_nanos());
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let config = InfluxDBLogsConfig {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -582,10 +582,10 @@ mod tests {
 mod integration_tests {
     use crate::event::metric::{MetricKind, MetricValue};
     use crate::event::Metric;
-    use crate::runtime::Runtime;
     use crate::sinks::influxdb::metrics::{InfluxDBConfig, InfluxDBSvc};
     use crate::sinks::influxdb::test_util::{onboarding_v2, BUCKET, ORG, TOKEN};
     use crate::sinks::influxdb::InfluxDB2Settings;
+    use crate::test_util::runtime;
     use crate::topology::SinkContext;
     use crate::Event;
     use chrono::Utc;
@@ -615,7 +615,7 @@ mod integration_tests {
     fn influxdb2_metrics_put_data() {
         onboarding_v2();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
 
         let config = InfluxDBConfig {

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -678,16 +678,16 @@ mod tests {
 #[cfg(feature = "influxdb-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
-    use crate::runtime::Runtime;
     use crate::sinks::influxdb::test_util::{onboarding_v2, BUCKET, DATABASE, ORG, TOKEN};
     use crate::sinks::influxdb::{healthcheck, InfluxDB1Settings, InfluxDB2Settings};
+    use crate::test_util::runtime;
     use crate::topology::SinkContext;
 
     #[test]
     fn influxdb2_healthchecks_ok() {
         onboarding_v2();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
         let endpoint = "http://localhost:9999".to_string();
         let influxdb1_settings = None;
@@ -711,7 +711,7 @@ mod integration_tests {
     fn influxdb2_healthchecks_fail() {
         onboarding_v2();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
         let endpoint = "http://not_exist:9999".to_string();
         let influxdb1_settings = None;
@@ -732,7 +732,7 @@ mod integration_tests {
 
     #[test]
     fn influxdb1_healthchecks_ok() {
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
         let endpoint = "http://localhost:8086".to_string();
         let influxdb1_settings = Some(InfluxDB1Settings {
@@ -756,7 +756,7 @@ mod integration_tests {
 
     #[test]
     fn influxdb1_healthchecks_fail() {
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
         let endpoint = "http://not_exist:8086".to_string();
         let influxdb1_settings = Some(InfluxDB1Settings {

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -141,8 +141,7 @@ mod tests {
     use super::*;
     use crate::{
         event::Event,
-        runtime::Runtime,
-        test_util::{next_addr, shutdown_on_idle},
+        test_util::{next_addr, runtime, shutdown_on_idle},
         topology::config::SinkConfig,
     };
     use bytes::Buf;
@@ -305,7 +304,7 @@ mod tests {
             .unwrap()
             .into();
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
 
         let (sink, _healthcheck) = http_config
             .build(SinkContext::new_test(rt.executor()))

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -212,7 +212,7 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use crate::test_util::{block_on, random_lines_with_stream, random_string};
+    use crate::test_util::{block_on, random_lines_with_stream, random_string, runtime};
     use pulsar::Message;
     use std::{
         sync::atomic::AtomicUsize,
@@ -229,7 +229,7 @@ mod integration_tests {
             auth: None,
         };
         let (acker, ack_counter) = Acker::new_for_testing();
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
 
         let sink = PulsarSink::new(cnf, acker, rt.executor()).unwrap();
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -369,6 +369,7 @@ impl Auth {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::test_util::runtime;
     use futures01::{Future, Sink, Stream};
     use http::Method;
     use hyper::service::service_fn;
@@ -438,7 +439,7 @@ mod test {
             .serve(new_service)
             .map_err(|e| eprintln!("server error: {}", e));
 
-        let mut rt = crate::runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(server);
 

--- a/src/sinks/util/test.rs
+++ b/src/sinks/util/test.rs
@@ -1,5 +1,6 @@
 use crate::{
     runtime::Runtime,
+    test_util::runtime,
     topology::config::{SinkConfig, SinkContext},
 };
 use futures01::{sync::mpsc, Future, Sink, Stream};
@@ -11,7 +12,7 @@ where
     for<'a> T: Deserialize<'a> + SinkConfig,
 {
     let sink_config: T = toml::from_str(config)?;
-    let rt = crate::test_util::runtime();
+    let rt = runtime();
     let cx = SinkContext::new_test(rt.executor());
 
     Ok((sink_config, cx, rt))

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -197,8 +197,7 @@ impl Sink for UnixSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::Runtime;
-    use crate::test_util::{random_lines_with_stream, shutdown_on_idle};
+    use crate::test_util::{random_lines_with_stream, runtime, shutdown_on_idle};
     use futures01::{sync::mpsc, Sink, Stream};
     use stream_cancel::{StreamExt, Tripwire};
     use tokio01::codec::{FramedRead, LinesCodec};
@@ -227,7 +226,7 @@ mod tests {
 
         // Set up Sink
         let config = UnixSinkConfig::new(out_path.clone(), Encoding::Text.into());
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let cx = SinkContext::new_test(rt.executor());
         let (sink, _healthcheck) = config.build(cx).unwrap();
 

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -944,13 +944,13 @@ fn remove_slash(s: &str) -> &str {
 #[cfg(all(test, feature = "docker-integration-tests"))]
 mod tests {
     use super::*;
-    use crate::runtime;
-    use crate::test_util::{self, collect_n, trace_init};
+    use crate::runtime::Runtime;
+    use crate::test_util::{self, collect_n, runtime, runtime, trace_init};
     use futures01::future;
 
     static BUXYBOX_IMAGE_TAG: &'static str = "latest";
 
-    fn pull(image: &str, docker: &Docker, rt: &mut runtime::Runtime) {
+    fn pull(image: &str, docker: &Docker, rt: &mut Runtime) {
         let list_option = shiplift::ImageListOptions::builder()
             .filter_name(image)
             .build();
@@ -977,8 +977,8 @@ mod tests {
     fn source<'a, L: Into<Option<&'a str>>>(
         names: &[&str],
         label: L,
-    ) -> (mpsc::Receiver<Event>, runtime::Runtime) {
-        let mut rt = test_util::runtime();
+    ) -> (mpsc::Receiver<Event>, Runtime) {
+        let mut rt = runtime();
         let source = source_with(names, label, &mut rt);
         (source, rt)
     }
@@ -987,7 +987,7 @@ mod tests {
     fn source_with<'a, L: Into<Option<&'a str>>>(
         names: &[&str],
         label: L,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> mpsc::Receiver<Event> {
         source_with_config(
             DockerConfig {
@@ -1000,10 +1000,7 @@ mod tests {
     }
 
     /// None if docker is not present on the system
-    fn source_with_config(
-        config: DockerConfig,
-        rt: &mut runtime::Runtime,
-    ) -> mpsc::Receiver<Event> {
+    fn source_with_config(config: DockerConfig, rt: &mut Runtime) -> mpsc::Receiver<Event> {
         trace_init();
         let (sender, recv) = mpsc::channel(100);
         rt.spawn(
@@ -1029,7 +1026,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> String {
         cmd_container(
             name,
@@ -1047,7 +1044,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> String {
         cmd_container(
             name,
@@ -1068,7 +1065,7 @@ mod tests {
         label: L,
         cmd: Vec<String>,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> String {
         if let Some(id) = cmd_container_for_real(name, label, cmd, docker, rt) {
             id
@@ -1088,7 +1085,7 @@ mod tests {
         label: L,
         cmd: Vec<String>,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> Option<String> {
         pull("busybox", docker, rt);
         trace!("Creating container");
@@ -1114,7 +1111,7 @@ mod tests {
     fn container_start(
         id: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         trace!("Starting container");
         let future = docker.containers().get(id).start();
@@ -1126,7 +1123,7 @@ mod tests {
     fn container_wait(
         id: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         trace!("Waiting container");
         let future = docker.containers().get(id).wait();
@@ -1139,7 +1136,7 @@ mod tests {
     fn container_kill(
         id: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         trace!("Waiting container");
         let future = docker.containers().get(id).kill(None);
@@ -1151,13 +1148,13 @@ mod tests {
     fn container_run(
         id: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> Result<(), shiplift::errors::Error> {
         container_start(id, docker, rt)?;
         container_wait(id, docker, rt)
     }
 
-    fn container_remove(id: &str, docker: &Docker, rt: &mut runtime::Runtime) {
+    fn container_remove(id: &str, docker: &Docker, rt: &mut Runtime) {
         trace!("Removing container");
         let future = docker
             .containers()
@@ -1175,7 +1172,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> String {
         let id = log_container(name, label, log, docker, rt);
         for _ in 0..n {
@@ -1194,7 +1191,7 @@ mod tests {
         label: L,
         log: &str,
         docker: &Docker,
-        rt: &mut runtime::Runtime,
+        rt: &mut Runtime,
     ) -> String {
         let out = source_with(&[name], None, rt);
 

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -349,10 +349,10 @@ fn create_event(
 mod tests {
     use super::*;
     use crate::{
-        event, runtime,
+        event,
         shutdown::ShutdownSignal,
         sources::file,
-        test_util::{block_on, shutdown_on_idle},
+        test_util::{block_on, runtime, shutdown_on_idle},
         topology::Config,
     };
     use futures01::{Future, Stream};
@@ -492,7 +492,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -553,7 +553,7 @@ mod tests {
         };
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -622,7 +622,7 @@ mod tests {
         };
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -694,7 +694,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -741,7 +741,7 @@ mod tests {
 
     #[test]
     fn file_file_key() {
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         // Default
         {
@@ -876,7 +876,7 @@ mod tests {
 
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-            let mut rt = runtime::Runtime::new().unwrap();
+            let mut rt = runtime();
             rt.spawn(source);
 
             sleep();
@@ -899,7 +899,7 @@ mod tests {
 
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-            let mut rt = runtime::Runtime::new().unwrap();
+            let mut rt = runtime();
             rt.spawn(source);
 
             sleep();
@@ -927,7 +927,7 @@ mod tests {
             };
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-            let mut rt = runtime::Runtime::new().unwrap();
+            let mut rt = runtime();
             rt.spawn(source);
 
             sleep();
@@ -964,7 +964,7 @@ mod tests {
 
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-            let mut rt = runtime::Runtime::new().unwrap();
+            let mut rt = runtime();
             rt.spawn(source);
 
             let mut file = File::create(&path).unwrap();
@@ -991,7 +991,7 @@ mod tests {
 
             let (tx, rx) = futures01::sync::mpsc::channel(10);
             let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-            let mut rt = runtime::Runtime::new().unwrap();
+            let mut rt = runtime();
             rt.spawn(source);
 
             let mut file = File::create(&path).unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
         use std::os::unix::io::AsRawFd;
         use std::time::{Duration, SystemTime};
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         let (tx, rx) = futures01::sync::mpsc::channel(10);
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
         let dir = tempdir().unwrap();
@@ -1115,7 +1115,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -1176,7 +1176,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -1253,7 +1253,7 @@ mod tests {
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         rt.spawn(source);
 
@@ -1344,7 +1344,7 @@ mod tests {
         sleep();
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         rt.spawn(source);
 
         sleep();
@@ -1409,7 +1409,7 @@ mod tests {
         sleep();
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         rt.spawn(source);
 
         sleep();
@@ -1453,7 +1453,7 @@ mod tests {
         };
 
         let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         rt.spawn(source);
 
         sleep();

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -208,7 +208,7 @@ mod tests {
     use crate::{
         event::{self, Event},
         runtime::Runtime,
-        test_util::{self, collect_n},
+        test_util::{self, collect_n, runtime},
         topology::config::{GlobalOptions, SourceConfig},
     };
     use futures01::sync::mpsc;
@@ -268,7 +268,7 @@ mod tests {
     fn http_multiline_text() {
         let body = "test body\n\ntest body 2";
 
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt, Encoding::default(), vec![]);
 
         assert_eq!(200, send(addr, body));
@@ -298,7 +298,7 @@ mod tests {
         //same as above test but with a newline at the end
         let body = "test body\n\ntest body 2\n";
 
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt, Encoding::default(), vec![]);
 
         assert_eq!(200, send(addr, body));
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn http_json_parsing() {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt, Encoding::Json, vec![]);
 
         assert_eq!(400, send(addr, "{")); //malformed
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn http_json_values() {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt, Encoding::Json, vec![]);
 
         assert_eq!(200, send(addr, r#"[{"key":"value"}]"#));
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn http_ndjson() {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt, Encoding::Ndjson, vec![]);
 
         assert_eq!(400, send(addr, r#"[{"key":"value"}]"#)); //one object per line
@@ -407,7 +407,7 @@ mod tests {
         headers.insert("User-Agent", "test_client".parse().unwrap());
         headers.insert("Upgrade-Insecure-Requests", "false".parse().unwrap());
 
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(
             &mut rt,
             Encoding::Ndjson,

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -164,7 +164,7 @@ mod tests {
     use crate::{
         event::{self, Event},
         runtime::Runtime,
-        test_util::{self, collect_n},
+        test_util::{self, collect_n, runtime},
         topology::config::{GlobalOptions, SourceConfig},
     };
     use chrono::{DateTime, Utc};
@@ -208,7 +208,7 @@ mod tests {
     fn logplex_handles_router_log() {
         let body = r#"267 <158>1 2020-01-08T22:33:57.353034+00:00 host heroku router - at=info method=GET path="/cart_link" host=lumberjack-store.timber.io request_id=05726858-c44e-4f94-9a20-37df73be9006 fwd="73.75.38.87" dyno=web.1 connect=1ms service=22ms status=304 bytes=656 protocol=http"#;
 
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (rx, addr) = source(&mut rt);
 
         assert_eq!(200, send(addr, body));

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -716,7 +716,7 @@ fn event_error(text: &str, code: u16, event: usize) -> Response<Body> {
 mod tests {
     use super::{parse_timestamp, SplunkConfig};
     use crate::runtime::{Runtime, TaskExecutor};
-    use crate::test_util::{self, collect_n};
+    use crate::test_util::{self, collect_n, runtime};
     use crate::{
         event::{self, Event},
         shutdown::ShutdownSignal,
@@ -783,7 +783,7 @@ mod tests {
         encoding: impl Into<EncodingConfigWithDefault<Encoding>>,
         compression: Compression,
     ) -> (Runtime, RouterSink, mpsc::Receiver<Event>) {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (source, address) = source(&mut rt);
         let (sink, health) = sink(address, encoding, compression, rt.executor());
         assert!(rt.block_on(health).is_ok());
@@ -993,7 +993,7 @@ mod tests {
     #[test]
     fn raw() {
         let message = "raw";
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (source, address) = source(&mut rt);
 
         assert_eq!(200, post(address, "services/collector/raw", message));
@@ -1016,7 +1016,7 @@ mod tests {
 
     #[test]
     fn no_data() {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (_source, address) = source(&mut rt);
 
         assert_eq!(400, post(address, "services/collector/event", ""));
@@ -1024,7 +1024,7 @@ mod tests {
 
     #[test]
     fn invalid_token() {
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (_source, address) = source(&mut rt);
 
         assert_eq!(
@@ -1042,7 +1042,7 @@ mod tests {
     #[test]
     fn no_autorization() {
         let message = "no_autorization";
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (source, address) = source_with(&mut rt, None);
         let (sink, health) = sink(address, Encoding::Text, Compression::Gzip, rt.executor());
         assert!(rt.block_on(health).is_ok());
@@ -1058,7 +1058,7 @@ mod tests {
     #[test]
     fn partial() {
         let message = r#"{"event":"first"}{"event":"second""#;
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (source, address) = source(&mut rt);
 
         assert_eq!(400, post(address, "services/collector/event", message));
@@ -1081,7 +1081,7 @@ mod tests {
     #[test]
     fn default() {
         let message = r#"{"event":"first","source":"main"}{"event":"second"}{"event":"third","source":"secondary"}"#;
-        let mut rt = test_util::runtime();
+        let mut rt = runtime();
         let (source, address) = source(&mut rt);
 
         assert_eq!(200, post(address, "services/collector/event", message));

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -191,11 +191,10 @@ fn create_event(line: Bytes, host_key: &str, hostname: &Option<String>) -> Event
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event;
+    use crate::{event, test_util::runtime};
     use futures01::sync::mpsc;
     use futures01::Async::*;
     use std::io::Cursor;
-    use tokio01::runtime::current_thread::Runtime;
 
     #[test]
     fn stdin_create_event() {
@@ -221,7 +220,7 @@ mod tests {
         let config = StdinConfig::default();
         let buf = Cursor::new(String::from("hello world\nhello world again"));
 
-        let mut rt = Runtime::new().unwrap();
+        let mut rt = runtime();
         let source = stdin_source(buf, config, ShutdownSignal::noop(), tx).unwrap();
 
         rt.block_on(source).unwrap();

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -100,7 +100,7 @@ mod test {
             Metric,
         },
         sinks::vector::VectorSinkConfig,
-        test_util::{next_addr, wait_for_tcp, CollectCurrent},
+        test_util::{next_addr, runtime, wait_for_tcp, CollectCurrent},
         tls::{TlsConfig, TlsOptions},
         topology::config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig},
         Event,
@@ -119,7 +119,7 @@ mod test {
                 tx,
             )
             .unwrap();
-        let mut rt = crate::runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
         rt.spawn(server);
         wait_for_tcp(addr);
 

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -143,8 +143,7 @@ impl Sink for Fanout {
 #[cfg(test)]
 mod tests {
     use super::{ControlMessage, Fanout};
-    use crate::runtime;
-    use crate::test_util::{self, CollectCurrent};
+    use crate::test_util::{self, runtime, CollectCurrent};
     use crate::Event;
     use futures01::sync::mpsc;
     use futures01::{stream, Future, Sink, Stream};
@@ -196,7 +195,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -307,7 +306,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -347,7 +346,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));
@@ -387,7 +386,7 @@ mod tests {
         let rec2 = Event::from("line 2".to_string());
         let rec3 = Event::from("line 3".to_string());
 
-        let mut rt = runtime::Runtime::new().unwrap();
+        let mut rt = runtime();
 
         let recs = vec![rec1.clone(), rec2.clone(), rec3.clone()];
         let send = fanout.send_all(stream::iter_ok(recs.clone()));

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -103,13 +103,14 @@ mod tests {
     use super::CoercerConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
+        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
     use pretty_assertions::assert_eq;
 
     fn parse_it(extra: &str) -> LogEvent {
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
         let mut event = Event::from("dummy message");
         for &(key, value) in &[
             ("number", "1234"),

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -134,6 +134,7 @@ mod tests {
     use crate::event::LogEvent;
     use crate::{
         event,
+        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -147,7 +148,7 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
         let event = Event::from(event);
         let mut parser = GrokParserConfig {
             pattern: pattern.into(),

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -278,12 +278,13 @@ mod tests {
     use super::RegexParserConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
+        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
 
     fn do_transform(event: &str, patterns: &str, config: &str) -> Option<LogEvent> {
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
         let event = Event::from(event);
         let mut parser = toml::from_str::<RegexParserConfig>(&format!(
             r#"

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -143,6 +143,7 @@ mod tests {
     use super::SplitConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
+        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -177,7 +178,7 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
         let event = Event::from(text);
         let field_names = fields.split(' ').map(|s| s.into()).collect::<Vec<Atom>>();
         let field = field.map(|f| f.into());

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -162,6 +162,7 @@ mod tests {
     use super::TokenizerConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
+        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -265,7 +266,7 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = crate::runtime::Runtime::single_threaded().unwrap();
+        let rt = runtime();
         let event = Event::from(text);
         let field_names = fields.split(' ').map(|s| s.into()).collect::<Vec<Atom>>();
         let field = field.map(|f| f.into());

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,7 +1,10 @@
-use vector::topology::{self, Config, ConfigDiff};
+use vector::{
+    test_util::runtime,
+    topology::{self, Config, ConfigDiff},
+};
 
 fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
-    let rt = vector::runtime::Runtime::single_threaded().unwrap();
+    let rt = runtime();
     Config::load(config.as_bytes())
         .and_then(|c| topology::builder::build_pieces(&c, &ConfigDiff::initial(&c), rt.executor()))
         .map(|(_topology, warnings)| warnings)

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -13,12 +13,12 @@ use tokio01::codec::{FramedWrite, LinesCodec};
 #[cfg(unix)]
 use tokio_uds::UnixStream;
 use vector::test_util::{
-    block_on, next_addr, random_maps, random_string, receive, send_lines, shutdown_on_idle,
-    wait_for_tcp,
+    block_on, next_addr, random_maps, random_string, receive, runtime, send_lines,
+    shutdown_on_idle, wait_for_tcp,
 };
 use vector::topology::{self, config};
 use vector::{
-    runtime, sinks,
+    sinks,
     sources::syslog::{Mode, SyslogConfig},
 };
 
@@ -39,7 +39,7 @@ fn test_tcp_syslog() {
     );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = runtime::Runtime::new().unwrap();
+    let mut rt = runtime();
 
     let output_lines = receive(&out_addr);
 
@@ -80,7 +80,7 @@ fn test_udp_syslog() {
     config.add_source("in", SyslogConfig::new(Mode::Udp { address: in_addr }));
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = runtime::Runtime::new().unwrap();
+    let mut rt = runtime();
 
     let output_lines = receive(&out_addr);
 
@@ -144,7 +144,7 @@ fn test_unix_stream_syslog() {
     );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));
 
-    let mut rt = runtime::Runtime::new().unwrap();
+    let mut rt = runtime();
 
     let output_lines = receive(&out_addr);
 


### PR DESCRIPTION
Closes #716.

Only replaces uses of `Runtime::new` in tests that can run with one thread. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
