### PR TITLE
docs: Fix wrong example in tokenizer module (version 0.9.1)

### DIFF
--- a/.meta/transforms/tokenizer.toml.erb
+++ b/.meta/transforms/tokenizer.toml.erb
@@ -54,7 +54,7 @@ And the following configuration:
 [transforms.<transform-id>]
 type = "tokenizer"
 field = "message"
-fields = ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
+field_names = ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
 ```
 
 A [`log` event][docs.data-model.log] will be output with the following structure:

--- a/website/docs/reference/transforms/tokenizer.md
+++ b/website/docs/reference/transforms/tokenizer.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-01"
+last_modified_on: "2020-06-03"
 component_title: "Tokenizer"
 description: "The Vector `tokenizer` transform accepts and outputs `log` events, allowing you to tokenize a field's value by splitting on white space, ignoring special wrapping characters, and zip the tokens into ordered field names."
 event_types: ["log"]
@@ -218,7 +218,7 @@ And the following configuration:
 [transforms.<transform-id>]
 type = "tokenizer"
 field = "message"
-fields = ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
+field_names = ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
 ```
 
 A [`log` event][docs.data-model.log] will be output with the following structure:


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

In current version (0.9.1), some examples + options are wrong. Just fix docs.
