### PR TITLE
chore(tests): Test with `default` feature in CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -206,3 +206,10 @@ jobs:
       - uses: actions/checkout@v1
       - run: make slim-builds
       - run: make test-unit
+
+  test-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: make slim-builds
+      - run: make test-default

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-aarch64-unknown-linux-musl: load-qemu-binfmt ## Build static binary in rel
 bench: build ## Run benchmarks in /benches
 	$(RUN) bench
 
-test: test-behavior test-integration test-unit ## Runs all tests, unit, behaviorial, and integration.
+test: test-behavior test-integration test-unit test-default## Runs all tests, unit, behaviorial, default, and integration.
 
 test-behavior: build ## Runs behaviorial tests
 	$(RUN) test-behavior
@@ -100,6 +100,9 @@ test-shutdown: ## Runs shutdown tests
 
 test-unit: ## Runs unit tests, tests which do not require additional services to be present
 	$(RUN) test-unit
+
+test-default: ## Runs tests in default feature
+	$(RUN) test-default
 
 ##@ Checking
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -598,6 +598,24 @@ services:
         "./target/x86_64-unknown-linux-musl/debug/vector test tests/behavior/**/*.toml",
       ]
 
+  test-default:
+    build:
+      context: .
+      dockerfile: scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+    environment:
+      CARGO_TERM_COLOR: always
+      TEST_LOG: debug
+      RUST_BACKTRACE: full
+    volumes:
+      - $PWD:$PWD
+      - ./target/x86_64-unknown-linux-musl/cargo/registry:/opt/rust/cargo/registry
+      - ./target/x86_64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
+      - ./target/x86_64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
+    network_mode: host
+    working_dir: $PWD
+    user: $USER
+    command: cargo test --lib --no-default-features --features default-cmake --target x86_64-unknown-linux-musl
+
   #
   # Dependencies
   #

--- a/scripts/test-default.sh
+++ b/scripts/test-default.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-sources.sh
+#
+# SUMMARY
+#
+#   Run lib tests with default feature
+
+cargo test --lib

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -344,6 +344,7 @@ mod test {
             );
             expected.insert(event::log_schema().source_type_key().clone(), "syslog");
             expected.insert("host", "74794bfb6795");
+            expected.insert("hostname", "74794bfb6795");
 
             expected.insert("meta.sequenceId", "1");
             expected.insert("meta.sysUpTime", "37");
@@ -380,6 +381,7 @@ mod test {
                 chrono::Utc.ymd(2019, 2, 13).and_hms(19, 48, 34),
             );
             expected.insert(event::log_schema().host_key().clone(), "74794bfb6795");
+            expected.insert("hostname", "74794bfb6795");
             expected.insert(event::log_schema().source_type_key().clone(), "syslog");
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
@@ -471,6 +473,7 @@ mod test {
             );
             expected.insert(event::log_schema().host_key().clone(), "74794bfb6795");
             expected.insert(event::log_schema().source_type_key().clone(), "syslog");
+            expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
             expected.insert("appname", "root");
@@ -500,6 +503,7 @@ mod test {
             );
             expected.insert(event::log_schema().source_type_key().clone(), "syslog");
             expected.insert("host", "74794bfb6795");
+            expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");
             expected.insert("facility", "local7");
             expected.insert("appname", "liblogging-stdlog");
@@ -534,6 +538,7 @@ mod test {
             );
             expected.insert(event::log_schema().source_type_key().clone(), "syslog");
             expected.insert("host", "74794bfb6795");
+            expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");
             expected.insert("facility", "local7");
             expected.insert("appname", "liblogging-stdlog");

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -496,7 +496,7 @@ enum Ec2MetadataError {
 }
 
 #[cfg(test)]
-#[cfg(feature = "aws-ec2-metadata-integration-tests")]
+#[cfg(feature = "aws-integration-tests")]
 mod tests {
     use super::*;
     use crate::{event::Event, test_util::runtime};

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -548,7 +548,7 @@ mod tests {
             log.get(&"ami-id".into()),
             Some(&"ami-05f27d4d6770a43d2".into())
         );
-        assert_eq!(log.get(&"instance-type".into()), Some(&"m5a.xlarge".into()));
+        assert_eq!(log.get(&"instance-type".into()), Some(&"t2.micro".into()));
         assert_eq!(log.get(&"region".into()), Some(&"us-east-1".into()));
         assert_eq!(log.get(&"vpc-id".into()), Some(&"mock-vpc-id".into()));
         assert_eq!(log.get(&"subnet-id".into()), Some(&"mock-subnet-id".into()));


### PR DESCRIPTION
Closes #2673

Most of `source`, `transform`, and `sink` tests haven't been running in CI or more accurately they aren't tested with `USE_CONTAINER=none`, but are with a container.   

This PR: 
 * Adds `test-default` which runs tests in library with `default` feature. 
 * Changes `aws-ec2-metadata-integration-tests` feature with  `aws-integration-tests`, since it wasn't being used anywhere else so it wasn't run at all.
 * Updates `syslog` tests that were failing.


### Open questions

- [x] We could split testing for `sources`, `transforms`, and `sinks`. But either we would need to compile the same things three times, or we could compile with their features but anytime that we add a test that uses a component from other group we would need to remember to update the feature list with the additional feature. Currently only some source tests use sinks. (EDIT: No. There are changes coming to how we test, so let's keep it simple)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
