### PR TITLE
enhancement(aws_s3 sink): Correct AWS Console behaviour via S3 object Metadata

### DIFF
--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -287,7 +287,7 @@ impl Service<Request> for S3Sink {
             body: Some(request.body.into()),
             bucket: request.bucket,
             key: request.key,
-            content_encoding: request.content_encoding,
+            content_type: request.content_type,
             acl: options.acl.map(to_string),
             grant_full_control: options.grant_full_control,
             grant_read: options.grant_read,
@@ -342,7 +342,11 @@ fn build_request(
         body: inner,
         bucket,
         key,
-        content_encoding: compression.content_encoding().map(|ce| ce.to_string()),
+        content_type: if compression == Compression::Gzip {
+            Some("application/x-gzip".to_string())
+        } else {
+            Some("application/octet-stream".to_string())
+        },
         options,
     }
 }
@@ -352,7 +356,7 @@ struct Request {
     body: Vec<u8>,
     bucket: String,
     key: String,
-    content_encoding: Option<String>,
+    content_type: Option<String>,
     options: S3Options,
 }
 
@@ -572,6 +576,10 @@ mod integration_tests {
 
             let obj = get_object(key).await;
             assert_eq!(obj.content_encoding, None);
+            assert_eq!(
+                obj.content_type,
+                Some("application/octet-stream".to_string())
+            );
 
             let response_lines = get_lines(obj).await;
             assert_eq!(lines, response_lines);
@@ -725,7 +733,8 @@ mod integration_tests {
                 assert!(key.ends_with(".log.gz"));
 
                 let obj = get_object(key).await;
-                assert_eq!(obj.content_encoding, Some("gzip".to_string()));
+                assert_eq!(obj.content_encoding, None);
+                assert_eq!(obj.content_type, Some("application/x-gzip".to_string()));
 
                 acc.append(&mut get_gzipped_lines(obj).await);
                 acc


### PR DESCRIPTION
Following on from #2769 I played around with setting content-type and content-encoding options of the `aws s3` CLI command, and found `text/plain` has an unfortunate side-effect of forcing the file extension from the uploaded `.log` to `.txt` when Downloading in Chrome & Firefox, so is a no-go.

Also & more seriously, content-encoding=gzip, i.e. compression=gzip in the sink, leads to corrupt files when downloading via the browser (CLI/API access is fine).  I recommend dropping that completely, instead using just content-type=application/x-gzip.

Playing around with some other content-types, these all avoid the renaming problems but have their own issues:

* application/x-ndjson, application/octet-stream: OK, but "Open" merely acts the same as "Download".
* application/ld+json: Open works in Chrome & Mozilla, but Mozilla thinks it's simple JSON and so shows a parsing error (but you can switch to view the raw text on a tab so it's not that bad).
* text/event-stream: Open works in Chrome, Mozilla just acts like Download.

As a mostly Chrome user I might prefer either of the latter two options for non-compressed files, but really they are being mis-understood by the browsers & only working by accident.  Hence this PR as I'd expect you'd prefer it simple & least-bad instead.

PR against your v0.9 branch as that's what I'm using currently, and master looks a little different.