### PR TITLE
fix(sinks): upgrade tower-limit to fix rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,9 +4740,9 @@ checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
 name = "tower-limit"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2807e2531b621e23e18693d49d0663bc617240ac0da8ed9b0c64cacd5c67fb"
+checksum = "c21ba835a08fd54b63cd91ae0548a7b6e2a91075147dfa3dc8e1a940c1b6f18f"
 dependencies = [
  "futures 0.1.29",
  "tokio-sync",


### PR DESCRIPTION
Closes #2748 

Upstream fix was here: https://github.com/tower-rs/tower/pull/459
