### PR TITLE
chore: fix aws integration tests ci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,7 +399,14 @@ docker = [
   "splunk-integration-tests",
 ]
 
-aws-integration-tests = ["sinks-aws_cloudwatch_logs", "sinks-aws_cloudwatch_metrics", "sinks-elasticsearch", "sinks-aws_kinesis_firehose", "sinks-aws_kinesis_streams", "sinks-aws_s3", "transforms-aws_ec2_metadata"]
+aws-integration-tests = [
+  "aws-cloudwatch-logs-integration-tests",
+  "aws-cloudwatch-metrics-integration-tests",
+  "aws-ec2-metadata-integration-tests",
+  "aws-kinesis-firehose-integration-tests",
+  "aws-kinesis-streams-integration-tests",
+  "aws-s3-integration-tests",
+]
 aws-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
 aws-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
 aws-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]
@@ -440,4 +447,3 @@ required-features = ["transforms-wasm", "transforms-lua"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
-

--- a/Makefile
+++ b/Makefile
@@ -188,16 +188,12 @@ test-integration: test-integration-aws test-integration-clickhouse test-integrat
 test-integration: test-integration-gcp test-integration-influxdb test-integration-kafka test-integration-loki
 test-integration: test-integration-pulsar test-integration-splunk
 
-test-integration-aws: ## Runs Clickhouse integration tests
+test-integration-aws: ## Runs AWS integration tests
 ifeq ($(AUTOSPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose up -d dependencies-aws
 	sleep 5 # Many services are very lazy... Give them a sec...
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_cloudwatch_logs:: -- --nocapture
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_cloudwatch_metrics:: -- --nocapture
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_kinesis_firehose:: -- --nocapture
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_kinesis_streams:: -- --nocapture
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_s3:: -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features aws-integration-tests ::aws_ -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose stop
 endif
@@ -235,7 +231,7 @@ ifeq ($(AUTODESPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose stop
 endif
 
-test-integration-influxdb: ## Runs Kafka integration tests
+test-integration-influxdb: ## Runs InfluxDB integration tests
 ifeq ($(AUTOSPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose up -d dependencies-influxdb
 	sleep 5 # Many services are very lazy... Give them a sec...

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -505,9 +505,9 @@ async fn body_to_bytes(body: Body) -> Result<Bytes, hyper13::Error> {
         .map(Into::into)
 }
 
+#[cfg(feature = "aws-ec2-metadata-integration-tests")]
 #[cfg(test)]
-#[cfg(feature = "aws-integration-tests")]
-mod tests {
+mod integration_tests {
     use super::*;
     use crate::{event::Event, test_util::runtime};
 


### PR DESCRIPTION
Moved from #2777

- Change features dependencies for compiling integration tests
- Change testname filter in Makefile for `test-integration-aws`
- Fix `aws-cloudwatch-logs` integration tests for Template (introduced in https://github.com/timberio/vector/pull/2737)
- Fix test `cloudwatch_insert_out_of_range_timestamp` -- ~but there still question about order https://github.com/timberio/vector/pull/2777#discussion_r439056336 -- which events should be pushed first: oldest or newest?~