### PR TITLE
chore(loki sink): Make encoding optional

### DIFF
--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -17,7 +17,7 @@ use crate::{
     event::{self, Event, Value},
     runtime::FutureExt,
     sinks::util::{
-        encoding::{EncodingConfig, EncodingConfiguration},
+        encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
         BatchBytesConfig, UriSerde,
@@ -38,7 +38,8 @@ type Labels = Vec<(String, String)>;
 #[serde(deny_unknown_fields)]
 pub struct LokiConfig {
     endpoint: UriSerde,
-    encoding: EncodingConfig<Encoding>,
+    #[serde(default)]
+    encoding: EncodingConfigWithDefault<Encoding>,
 
     tenant_id: Option<String>,
     labels: HashMap<String, Template>,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -702,7 +702,7 @@ fn handle_errors(
         .map_err(|_| ())
         .flatten()
         .or_else(move |()| {
-            error!("Unhandled error");
+            error!("An error occured that vector can't fix");
             let _ = abort_tx.unbounded_send(());
             Err(())
         })

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -462,7 +462,7 @@ impl RunningTopology {
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("sink", name = %task.name(), r#type = %task.typetag());
-        let task = handle_errors(task.instrument(span), self.abort_tx.clone());
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
         let spawned = oneshot::spawn(task, &rt.executor());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
             previous.forget();
@@ -477,7 +477,7 @@ impl RunningTopology {
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("transform", name = %task.name(), r#type = %task.typetag());
-        let task = handle_errors(task.instrument(span), self.abort_tx.clone());
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
         let spawned = oneshot::spawn(task, &rt.executor());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
             previous.forget();
@@ -492,8 +492,7 @@ impl RunningTopology {
     ) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("source", name = %task.name(), r#type = %task.typetag());
-
-        let task = handle_errors(task.instrument(span.clone()), self.abort_tx.clone());
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span.clone());
         let spawned = oneshot::spawn(task, &rt.executor());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
             previous.forget();
@@ -503,7 +502,7 @@ impl RunningTopology {
             .takeover_source(name, &mut new_pieces.shutdown_coordinator);
 
         let source_task = new_pieces.source_tasks.remove(name).unwrap();
-        let source_task = handle_errors(source_task.instrument(span), self.abort_tx.clone());
+        let source_task = handle_errors(source_task, self.abort_tx.clone()).instrument(span);
         self.source_tasks.insert(
             name.to_string(),
             oneshot::spawn(source_task, &rt.executor()),
@@ -702,7 +701,7 @@ fn handle_errors(
         .map_err(|_| ())
         .flatten()
         .or_else(move |()| {
-            error!("An error occured that vector can't fix");
+            error!("An error occurred that vector couldn't handle.");
             let _ = abort_tx.unbounded_send(());
             Err(())
         })


### PR DESCRIPTION
Ref. #2778

Makes `encoding` optional and enhances `Unhandled error` message.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
