### PR TITLE
chore(humio_logs sink): improve time validation in tests

### DIFF
--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -112,7 +112,10 @@ mod tests {
         let hec_event = serde_json::from_slice::<HecEventJson>(&bytes[..]).unwrap();
 
         let now = Utc::now().timestamp_millis() as f64 / 1000f64;
-        assert!((hec_event.time - now).abs() < 0.1);
+        assert!(
+            (hec_event.time - now).abs() < 0.2,
+            format!("hec_event.time = {}, now = {}", hec_event.time, now)
+        );
         assert_eq!((hec_event.time * 1000f64).fract(), 0f64);
     }
 }

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -297,7 +297,10 @@ mod tests {
         );
 
         let now = Utc::now().timestamp_millis() as f64 / 1000f64;
-        assert!((hec_event.time - now).abs() < 0.1);
+        assert!(
+            (hec_event.time - now).abs() < 0.2,
+            format!("hec_event.time = {}, now = {}", hec_event.time, now)
+        );
         assert_eq!((hec_event.time * 1000f64).fract(), 0f64);
     }
 
@@ -331,7 +334,10 @@ mod tests {
         );
 
         let now = Utc::now().timestamp_millis() as f64 / 1000f64;
-        assert!((hec_event.time - now).abs() < 0.1);
+        assert!(
+            (hec_event.time - now).abs() < 0.2,
+            format!("hec_event.time = {}, now = {}", hec_event.time, now)
+        );
         assert_eq!((hec_event.time * 1000f64).fract(), 0f64);
     }
 


### PR DESCRIPTION
Closes #2749 

I did not found that HEC accept string, all examples show only float. I think it's ok send float even if will be encoded as `1591976882.3333`.
I set threshold to `0.001` and get on first run (18ms diff):
```rust
thread 'sinks::humio_logs::tests::humio_valid_time_field' panicked at 'hec_event.time = 1591976882.733, now = 1591976882.751', src/sinks/humio_logs.rs:115:9
```
so I think problem in slow CPU on CI run. Threshold bumped to 200ms. Also added assert message, so if test will fail again it should be clear why.