### PR TITLE
chore(networking)!: Remove custom DNS resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,7 +5862,6 @@ dependencies = [
  "tracing-tower",
  "trust-dns",
  "trust-dns-proto",
- "trust-dns-resolver",
  "trust-dns-server",
  "typetag",
  "url 1.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,8 +142,6 @@ url = "1.7"
 base64 = { version = "0.10.1", optional = true }
 shiplift = { version = "0.6", default-features = false, features = ["tls"], optional = true }
 owning_ref = { version = "0.4.0", optional = true }
-trust-dns-resolver = { version = "0.12", features = ["serde-config"]}
-trust-dns-proto = { version = "0.8" }
 listenfd = { version = "0.3.3", optional = true }
 inventory = "0.1"
 maxminddb = { version = "0.14.0", optional = true }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -30,7 +30,10 @@ impl Resolver {
         // Any port will do, but `9` is a well defined port for discarding
         // packets.
         let dummy_port = 9;
+        // https://tools.ietf.org/html/rfc6761#section-6.3
         if name == "localhost" {
+            // Not all operating systems support `localhost` as IPv6 `::1`, so
+            // we resolving it to it's IPv4 value.
             Ok(LookupIp(
                 vec![SocketAddr::new(Ipv4Addr::LOCALHOST.into(), dummy_port)].into_iter(),
             ))

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,100 +1,50 @@
-use crate::runtime::TaskExecutor;
-use futures::{compat::Future01CompatExt, future::BoxFuture, FutureExt};
-use futures01::{future, Future};
+use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures01::Future;
 use hyper::client::connect::dns::{Name, Resolve};
 use hyper13::client::connect::dns::Name as Name13;
-use snafu::{futures01::FutureExt as _, ResultExt};
+use snafu::ResultExt;
 use std::{
-    fmt,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, SocketAddr, ToSocketAddrs},
     str::FromStr,
     task::{Context, Poll},
 };
+use tokio::task::spawn_blocking;
 use tower03::Service;
-use trust_dns_resolver::{
-    config::{LookupIpStrategy, NameServerConfig, Protocol, ResolverConfig, ResolverOpts},
-    lookup_ip::LookupIpIntoIter,
-    system_conf, AsyncResolver,
-};
-
-/// Default port for DNS service.
-const DNS_PORT: u16 = 53;
 
 pub type ResolverFuture = Box<dyn Future<Item = LookupIp, Error = DnsError> + Send + 'static>;
 
-#[derive(Debug, Clone)]
-pub struct Resolver {
-    inner: AsyncResolver,
-}
-
 pub enum LookupIp {
     Single(Option<IpAddr>),
-    Query(LookupIpIntoIter),
+    Query(std::vec::IntoIter<SocketAddr>),
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct Resolver;
+
 impl Resolver {
-    pub fn new(dns_servers: Vec<String>, exec: TaskExecutor) -> Result<Self, DnsError> {
-        let (config, opt) = if !dns_servers.is_empty() {
-            let mut config = ResolverConfig::new();
-
-            let mut errors = Vec::new();
-
-            for s in dns_servers.iter() {
-                let parsed = s
-                    .parse::<SocketAddr>()
-                    .or_else(|_| s.parse::<IpAddr>().map(|ip| SocketAddr::new(ip, DNS_PORT)));
-
-                match parsed {
-                    Ok(socket_addr) => config.add_name_server(NameServerConfig {
-                        socket_addr,
-                        protocol: Protocol::Udp,
-                        tls_dns_name: None,
-                    }),
-                    Err(error) => errors.push(format!(
-                        "Unable to parse dns server: {}, because {}",
-                        s, error
-                    )),
-                }
-            }
-
-            if !errors.is_empty() {
-                return Err(DnsError::ServerList { errors });
-            }
-
-            let mut opts = ResolverOpts::default();
-            opts.attempts = 2;
-            opts.validate = false;
-            opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
-            // FIXME: multipe requests fails when this is commented out
-            opts.num_concurrent_reqs = 1;
-
-            (config, opts)
-        } else {
-            #[cfg(feature = "disable-resolv-conf")]
-            let res = (Default::default(), Default::default());
-            #[cfg(not(feature = "disable-resolv-conf"))]
-            let res = system_conf::read_system_conf().context(ReadSystemConf)?;
-            res
-        };
-
-        let (inner, bg_task) = AsyncResolver::new(config, opt);
-
-        exec.spawn(bg_task);
-
-        Ok(Self { inner })
+    pub fn lookup_ip_01(self, name: String) -> ResolverFuture {
+        let fut = self.lookup_ip(name).boxed().compat();
+        Box::new(fut)
     }
 
-    pub fn lookup_ip(&self, name: impl AsRef<str>) -> ResolverFuture {
-        if let Ok(ip) = IpAddr::from_str(name.as_ref()) {
-            return Box::new(future::ok(LookupIp::Single(Some(ip))));
+    pub async fn lookup_ip(self, name: String) -> Result<LookupIp, DnsError> {
+        if let Ok(ip) = IpAddr::from_str(&name) {
+            Ok(LookupIp::Single(Some(ip)))
+        } else {
+            // name is indeed a domain.
+            spawn_blocking(move || {
+                // We need to add port with the domain so that `to_socket_addrs`
+                // resolves it properly. We will be discarding the port afterwards.
+                //
+                // Any port will do, but `9` is a well defined port for discarding
+                // packets.
+                (name.as_ref(), 9).to_socket_addrs()
+            })
+            .await
+            .context(JoinError)?
+            .map(LookupIp::Query)
+            .context(UnableLookup)
         }
-
-        Box::new(
-            self.inner
-                .lookup_ip(name.as_ref())
-                .context(UnableLookup)
-                .map(|lu| LookupIp::Query(lu.into_iter())),
-        )
     }
 }
 
@@ -104,27 +54,31 @@ impl Iterator for LookupIp {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             LookupIp::Single(ip) => ip.take(),
-            LookupIp::Query(iter) => iter.next(),
+            LookupIp::Query(iter) => iter.next().map(|address| address.ip()),
         }
     }
 }
 
 impl Resolve for Resolver {
     type Addrs = LookupIp;
-    type Future = Box<dyn Future<Item = Self::Addrs, Error = std::io::Error> + Send + 'static>;
+    type Future = Box<dyn Future<Item = LookupIp, Error = std::io::Error> + Send + 'static>;
 
     fn resolve(&self, name: Name) -> Self::Future {
-        let fut = self.lookup_ip(name.as_str()).map_err(|e| {
-            use std::io;
-            io::Error::new(io::ErrorKind::Other, e)
-        });
+        let fut = self
+            .lookup_ip(name.as_str().to_owned())
+            .boxed()
+            .compat()
+            .map_err(|e| {
+                use std::io;
+                io::Error::new(io::ErrorKind::Other, e)
+            });
         Box::new(fut)
     }
 }
 
 impl Service<Name13> for Resolver {
     type Response = LookupIp;
-    type Error = std::io::Error;
+    type Error = DnsError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -132,293 +86,48 @@ impl Service<Name13> for Resolver {
     }
 
     fn call(&mut self, name: Name13) -> Self::Future {
-        self.lookup_ip(name.as_str())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-            .compat()
-            .boxed()
+        self.lookup_ip(name.as_str().to_owned()).boxed()
     }
 }
 
 #[derive(Debug, snafu::Snafu)]
 pub enum DnsError {
-    #[snafu(display("Unable to parse dns servers: {}", errors.join(", ")))]
-    ServerList { errors: Vec<String> },
-    #[cfg(windows)]
-    #[snafu(display("Unable to read system dns config: {}", source))]
-    ReadSystemConf {
-        #[snafu(source(from(trust_dns_resolver::error::ResolveError, ResolveError::from)))]
-        source: ResolveError,
-    },
-    #[cfg(unix)]
-    #[snafu(display("Unable to read system dns config: {}", source))]
-    ReadSystemConf { source: std::io::Error },
     #[snafu(display("Unable to resolve name: {}", source))]
-    UnableLookup {
-        #[snafu(source(from(trust_dns_resolver::error::ResolveError, ResolveError::from)))]
-        source: ResolveError,
-    },
-    #[snafu(display("Invalid dns name: {}", source))]
-    InvalidName {
-        #[snafu(source(from(trust_dns_proto::error::ProtoError, ProtoError::from)))]
-        source: ProtoError,
-    },
-}
-
-// TODO: Upstream this change, we require this newtype to impl `std::error::Error`.
-#[derive(Debug)]
-pub struct ResolveError(trust_dns_resolver::error::ResolveError);
-
-impl fmt::Display for ResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for ResolveError {}
-
-impl From<trust_dns_resolver::error::ResolveError> for ResolveError {
-    fn from(t: trust_dns_resolver::error::ResolveError) -> Self {
-        ResolveError(t)
-    }
-}
-
-// TODO: Upstream this change, we require this newtype to impl `std::error::Error`.
-#[derive(Debug)]
-pub struct ProtoError(trust_dns_proto::error::ProtoError);
-
-impl fmt::Display for ProtoError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for ProtoError {}
-
-impl From<trust_dns_proto::error::ProtoError> for ProtoError {
-    fn from(t: trust_dns_proto::error::ProtoError) -> Self {
-        ProtoError(t)
-    }
+    UnableLookup { source: tokio::io::Error },
+    #[snafu(display("Failed to join with resolving future: {}", source))]
+    JoinError { source: tokio::task::JoinError },
 }
 
 #[cfg(test)]
 mod tests {
     use super::Resolver;
-    use crate::runtime::Runtime;
-    use crate::test_util::{next_addr, runtime};
-    use crate::topology::config::GlobalOptions;
-    use std::collections::BTreeMap;
-    use std::net::{IpAddr, SocketAddr, UdpSocket};
-    use std::str::FromStr;
-    use tokio01::prelude::{future::poll_fn, Async};
-    use trust_dns::rr::{record_data::RData, LowerName, Name, RecordSet, RecordType, RrKey};
-    use trust_dns_proto::rr::rdata::soa::SOA;
-    use trust_dns_server::{
-        authority::{Catalog, ZoneType},
-        store::in_memory::InMemoryAuthority,
-        ServerFuture,
-    };
+    use crate::test_util::runtime;
 
-    fn join(subdomain: &str, domain: &str) -> String {
-        subdomain.to_owned() + "." + domain
-    }
-
-    fn lower_name(name: &str) -> LowerName {
-        LowerName::new(&Name::from_str(name).unwrap())
-    }
-
-    /// subdomain.domain
-    fn dns_authority(subdomains: &[(&str, IpAddr)], domain: &str) -> Catalog {
-        let mut map = BTreeMap::new();
-
-        // SOA record
-        let key = RrKey::new(lower_name(domain), RecordType::SOA);
-        let mut records = RecordSet::new(&Name::from_str(domain).unwrap(), RecordType::SOA, 0);
-        records.new_record(&RData::SOA(SOA::new(
-            Name::from_str(domain).unwrap(),
-            Name::from_str(join("admin\\", domain).as_str()).unwrap(),
-            0,
-            3600,
-            1800,
-            604800,
-            86400,
-        )));
-        map.insert(key, records);
-
-        for &(subdomain, ip) in subdomains.iter() {
-            match ip {
-                IpAddr::V4(ip) => {
-                    // A record
-                    let key =
-                        RrKey::new(lower_name(join(subdomain, domain).as_str()), RecordType::A);
-                    let mut records = RecordSet::new(
-                        &Name::from_str(join(subdomain, domain).as_str()).unwrap(),
-                        RecordType::A,
-                        0,
-                    );
-                    records.new_record(&RData::A(ip));
-                    map.insert(key, records);
-                }
-                IpAddr::V6(ip) => {
-                    // AAAA record
-                    let key = RrKey::new(
-                        lower_name(join(subdomain, domain).as_str()),
-                        RecordType::AAAA,
-                    );
-                    let mut records = RecordSet::new(
-                        &Name::from_str(join(subdomain, domain).as_str()).unwrap(),
-                        RecordType::AAAA,
-                        0,
-                    );
-                    records.new_record(&RData::AAAA(ip));
-                    map.insert(key, records);
-                }
-            }
-        }
-
-        let authority = InMemoryAuthority::new(
-            Name::from_str(domain).unwrap(),
-            map,
-            ZoneType::Master,
-            false,
-        )
-        .unwrap();
-        let mut handler = Catalog::new();
-        handler.upsert(lower_name(domain), Box::new(authority));
-
-        handler
-    }
-
-    /// subdomain.domain
-    fn dns_server(
-        subdomains: &[(&'static str, IpAddr)],
-        domain: &'static str,
-        rt: &mut Runtime,
-    ) -> SocketAddr {
-        let subdomains = subdomains.iter().map(|&v| v).collect::<Vec<_>>();
-        let address = next_addr();
-
-        // Start DNS server
-        rt.spawn(poll_fn(move || {
-            let handler = dns_authority(subdomains.as_slice(), domain);
-            let server = ServerFuture::new(handler);
-            let socket = UdpSocket::bind(address).unwrap();
-            server.register_socket_std(socket);
-            debug!("DNS started at: {}", address);
-            Ok(Async::Ready(()))
-        }));
-
-        // Wait for DNS server to start
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
-        address
-    }
-
-    fn resolver_for(
-        subdomains: &[(&'static str, IpAddr)],
-        domain: &'static str,
-        rt: &mut Runtime,
-    ) -> Resolver {
-        let server = dns_server(subdomains, domain, rt);
-        let mut config = GlobalOptions::default();
-        config.dns_servers = vec![format!("{}", server)];
-
-        Resolver::new(config.dns_servers.clone(), rt.executor()).unwrap()
-    }
-
-    #[test]
-    fn resolve_host() {
+    fn resolve(name: &str) -> bool {
         let mut runtime = runtime();
-        let domain = "vector.test";
 
-        let target = "10.45.12.34".parse().unwrap();
-        let resolver = resolver_for(&[("name", target)], domain, &mut runtime);
-
-        assert_eq!(
-            target,
-            runtime
-                .block_on(resolver.lookup_ip(join("name", domain).as_str()))
-                .unwrap()
-                .next()
-                .unwrap()
-        );
+        let resolver = Resolver;
+        let fut = resolver.lookup_ip(name.to_owned());
+        runtime.block_on_std(fut).is_ok()
     }
 
     #[test]
-    fn multiple_dns_servers() {
-        let mut runtime = Runtime::with_thread_count(3).unwrap();
-        let domain_a = "meta.vec";
-        let domain_b = "metab.fvec";
-        let domain_c = "vectorc.test";
+    fn resolve_vector() {
+        assert!(resolve("vector.dev"));
+    }
 
-        let target_a = "10.45.12.34".parse().unwrap();
-        let target_b = "10.45.13.34".parse().unwrap();
-        let target_c = "10.45.14.35".parse().unwrap();
-        let server0 = dns_server(&[("a", target_a)], domain_a, &mut runtime);
-        let server1 = dns_server(&[("b", target_b)], domain_b, &mut runtime);
-        let server2 = dns_server(&[("c", target_c)], domain_c, &mut runtime);
-        let mut config = GlobalOptions::default();
-        config.dns_servers = vec![
-            format!("{}", server0),
-            format!("{}", server1),
-            format!("{}", server2),
-        ];
-
-        let resolver = Resolver::new(config.dns_servers.clone(), runtime.executor()).unwrap();
-
-        assert_eq!(
-            target_a,
-            runtime
-                .block_on(resolver.lookup_ip(join("a", domain_a).as_str()))
-                .unwrap()
-                .next()
-                .unwrap()
-        );
-
-        assert_eq!(
-            target_b,
-            runtime
-                .block_on(resolver.lookup_ip(join("b", domain_b).as_str()))
-                .unwrap()
-                .next()
-                .unwrap()
-        );
-
-        assert_eq!(
-            target_c,
-            runtime
-                .block_on(resolver.lookup_ip(join("c", domain_c).as_str()))
-                .unwrap()
-                .next()
-                .unwrap()
-        );
+    #[test]
+    fn resolve_localhost() {
+        assert!(resolve("localhost"));
     }
 
     #[test]
     fn resolve_ipv4() {
-        let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
-
-        let mut res = rt.block_on(resolver.lookup_ip("127.0.0.1")).unwrap();
-
-        assert_eq!(res.next(), Some(IpAddr::from_str("127.0.0.1").unwrap()));
+        assert!(resolve("10.0.4.0"));
     }
 
     #[test]
     fn resolve_ipv6() {
-        let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
-
-        let mut res = rt.block_on(resolver.lookup_ip("::0")).unwrap();
-
-        assert_eq!(res.next(), Some(IpAddr::from_str("::0").unwrap()));
-
-        let mut res = rt
-            .block_on(resolver.lookup_ip("2001:0db8:85a3:0000:0000:8a2e:0370:7334"))
-            .unwrap();
-
-        assert_eq!(
-            res.next(),
-            Some(IpAddr::from_str("2001:0db8:85a3:0000:0000:8a2e:0370:7334").unwrap())
-        );
+        assert!(resolve("::1"));
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -338,7 +338,6 @@ mod tests {
         assert_eq!(
             generate_example(true, "stdin/json_parser/console"),
             Ok(r#"data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [sources.source0]
 max_length = 102400
@@ -366,7 +365,6 @@ when_full = "block"
         assert_eq!(
             generate_example(true, "stdin|json_parser|console"),
             Ok(r#"data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [sources.source0]
 max_length = 102400
@@ -394,7 +392,6 @@ when_full = "block"
         assert_eq!(
             generate_example(true, "stdin//console"),
             Ok(r#"data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [sources.source0]
 max_length = 102400
@@ -416,7 +413,6 @@ when_full = "block"
         assert_eq!(
             generate_example(true, "//console"),
             Ok(r#"data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [sinks.sink0]
 healthcheck = true
@@ -434,7 +430,6 @@ when_full = "block"
         assert_eq!(
             generate_example(true, "/add_fields,json_parser,remove_fields"),
             Ok(r#"data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [transforms.transform0]
 inputs = []

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -653,7 +653,6 @@ mod tests {
         dns::Resolver,
         event::{self, Event, Value},
         region::RegionOrEndpoint,
-        test_util::runtime,
     };
     use std::collections::HashMap;
     use std::convert::{TryFrom, TryInto};
@@ -753,8 +752,7 @@ mod tests {
             stream: "stream".into(),
             group: "group".into(),
         };
-        let rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
         CloudwatchLogsSvc::new(&config, &key, resolver).unwrap()
     }
 
@@ -843,7 +841,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_event() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let stream_name = gen_name();
 
@@ -900,7 +898,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_events_sorted() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let stream_name = gen_name();
 
@@ -975,7 +973,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_out_of_range_timestamp() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let stream_name = gen_name();
 
@@ -1056,7 +1054,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_dynamic_group_and_stream_creation() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let group_name = gen_name();
         let stream_name = gen_name();
@@ -1113,7 +1111,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_event_batched() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let group_name = gen_name();
         let stream_name = gen_name();
@@ -1175,7 +1173,7 @@ mod integration_tests {
     fn cloudwatch_insert_log_event_partitioned() {
         crate::test_util::trace_init();
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let stream_name = gen_name();
 
@@ -1292,14 +1290,14 @@ mod integration_tests {
         };
 
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         rt.block_on_std(healthcheck(config, resolver)).unwrap();
     }
 
     fn ensure_group(region: Region) {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let client = create_client(region, None, resolver).unwrap();
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -271,7 +271,6 @@ mod tests {
     use super::*;
     use crate::dns::Resolver;
     use crate::event::metric::{Metric, MetricKind, MetricValue};
-    use crate::test_util::runtime;
     use chrono::offset::TimeZone;
     use pretty_assertions::assert_eq;
     use rusoto_cloudwatch::PutMetricDataInput;
@@ -285,8 +284,7 @@ mod tests {
     }
 
     fn svc() -> CloudWatchMetricsSvc {
-        let rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
         let config = config();
         let region = (&config.region).try_into().unwrap();
         let client = CloudWatchMetricsSvc::create_client(region, None, resolver).unwrap();
@@ -453,7 +451,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_metrics_healthchecks() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
         let _ = rt.block_on_std(CloudWatchMetricsSvc::healthcheck(config(), resolver));
     }
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -738,7 +738,7 @@ mod integration_tests {
     #[test]
     fn s3_healthchecks() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         rt.block_on_std(async move {
             let config = config(1).await;
@@ -749,7 +749,7 @@ mod integration_tests {
     #[test]
     fn s3_healthchecks_invalid_bucket() {
         let mut rt = runtime();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         rt.block_on_std(async move {
             let config = S3SinkConfig {

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -634,7 +634,7 @@ mod integration_tests {
     #[test]
     fn splunk_healthcheck() {
         let mut rt = runtime();
-        let resolver = crate::dns::Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = crate::dns::Resolver;
 
         // OK
         {

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -410,9 +410,8 @@ mod test {
 
     #[test]
     fn util_http_it_makes_http_requests() {
-        let rt = crate::test_util::runtime();
         let addr = crate::test_util::next_addr();
-        let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
+        let resolver = Resolver;
 
         let uri = format!("http://{}:{}/", addr.ip(), addr.port())
             .parse::<Uri>()

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -108,7 +108,7 @@ impl TcpSink {
             self.state = match self.state {
                 TcpSinkState::Disconnected => {
                     debug!(message = "resolving dns.", host = %self.host);
-                    let fut = self.resolver.lookup_ip(&self.host);
+                    let fut = self.resolver.lookup_ip_01(self.host.clone());
 
                     TcpSinkState::ResolvingDns(fut)
                 }
@@ -275,7 +275,7 @@ pub fn tcp_healthcheck(host: String, port: u16, resolver: Resolver) -> Healthche
     // Lazy to avoid immediately connecting
     let check = future::lazy(move || {
         resolver
-            .lookup_ip(host)
+            .lookup_ip_01(host)
             .map_err(|source| HealthcheckError::DnsError { source }.into())
             .and_then(|mut ip| {
                 ip.next()

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -111,7 +111,7 @@ impl UdpSink {
             self.state = match self.state {
                 State::Initializing => {
                     debug!(message = "resolving dns", host = %self.host);
-                    State::ResolvingDns(self.resolver.lookup_ip(&self.host))
+                    State::ResolvingDns(self.resolver.lookup_ip_01(self.host.clone()))
                 }
                 State::ResolvingDns(ref mut dns) => match dns.poll() {
                     Ok(Async::Ready(mut addrs)) => match addrs.next() {

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -373,7 +373,7 @@ mod test {
         let sink = TcpSink::new(
             "localhost".to_owned(),
             addr.port(),
-            Resolver::new(Vec::new(), rt.executor()).unwrap(),
+            Resolver,
             MaybeTlsSettings::Raw(()),
         );
         rt.spawn(
@@ -405,6 +405,7 @@ mod test {
 
     #[test]
     fn tcp_gracefull_shutdown() {
+        crate::test_util::trace_init();
         let n = 10000;
         // It's important that the buffer be large enough that the TCP source doesn't have
         // to block trying to forward its input into the Sender because the channel is full,
@@ -438,7 +439,7 @@ mod test {
         let sink = TcpSink::new(
             "localhost".to_owned(),
             addr.port(),
-            Resolver::new(Vec::new(), rt.executor()).unwrap(),
+            Resolver,
             MaybeTlsSettings::Raw(()),
         );
         rt.spawn(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -124,7 +124,7 @@ pub fn build_pieces(
     let mut errors = vec![];
 
     // TODO: remove the unimplemented
-    let resolver = Resolver::new(config.global.dns_servers.clone(), exec.clone()).unwrap();
+    let resolver = Resolver;
 
     // Build sources
     for (name, source) in config

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -234,11 +234,6 @@ impl RunningTopology {
             return Ok(false);
         }
 
-        if self.config.global.dns_servers != new_config.global.dns_servers {
-            error!("dns_servers cannot be changed while reloading config file; reload aborted. Current value: {:?}", self.config.global.dns_servers);
-            return Ok(false);
-        }
-
         if let Err(errors) = builder::check(&new_config) {
             for error in errors {
                 error!("Configuration error: {}", error);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -359,6 +359,7 @@ fn reconnect() {
 #[test]
 fn healthcheck() {
     let addr = next_addr();
+    let mut rt = runtime();
     let resolver = vector::dns::Resolver;
 
     let _listener = TcpListener::bind(&addr).unwrap();
@@ -366,7 +367,7 @@ fn healthcheck() {
     let healthcheck =
         vector::sinks::util::tcp::tcp_healthcheck(addr.ip().to_string(), addr.port(), resolver);
 
-    assert!(healthcheck.wait().is_ok());
+    assert!(rt.block_on(healthcheck).is_ok());
 
     let bad_addr = next_addr();
     let bad_healthcheck = vector::sinks::util::tcp::tcp_healthcheck(
@@ -375,5 +376,5 @@ fn healthcheck() {
         resolver,
     );
 
-    assert!(bad_healthcheck.wait().is_err());
+    assert!(rt.block_on(bad_healthcheck).is_err());
 }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -359,8 +359,7 @@ fn reconnect() {
 #[test]
 fn healthcheck() {
     let addr = next_addr();
-    let rt = vector::test_util::runtime();
-    let resolver = vector::dns::Resolver::new(Vec::new(), rt.executor()).unwrap();
+    let resolver = vector::dns::Resolver;
 
     let _listener = TcpListener::bind(&addr).unwrap();
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -363,11 +363,8 @@ fn healthcheck() {
 
     let _listener = TcpListener::bind(&addr).unwrap();
 
-    let healthcheck = vector::sinks::util::tcp::tcp_healthcheck(
-        addr.ip().to_string(),
-        addr.port(),
-        resolver.clone(),
-    );
+    let healthcheck =
+        vector::sinks::util::tcp::tcp_healthcheck(addr.ip().to_string(), addr.port(), resolver);
 
     assert!(healthcheck.wait().is_ok());
 


### PR DESCRIPTION
Closes #2635.

### Open questions

- [x] If we don't have intention to have `dns` configurable and it's fine to not call `spawn_blocking` through a runtime handle, then we can further remove passing `Resolver` through contexts and functions, and instead construct `Resolver` directly at call site. EDIT: We'll keep it as it is.


cc. @lukesteensen 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
