### PR TITLE
chore(kafka sink): Fix command for integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,7 +232,7 @@ jobs:
       - run: nix-shell --run "make test-integration-influxdb"
 
   test-integration-kafka:
-    name: Integration - Linux, Kafka)
+    name: Integration - Linux, Kafka
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ ifeq ($(AUTOSPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose up -d dependencies-kafka
 	sleep 5 # Many services are very lazy... Give them a sec...
 endif
-	cargo test --no-default-features --features kafka-integration-tests ::kafka:: -- --nocapture
+	cargo test --no-default-features --features "kafka-integration-tests rdkafka-plain" ::kafka:: -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose stop
 endif

--- a/scripts/environment/definition.nix
+++ b/scripts/environment/definition.nix
@@ -58,8 +58,6 @@ scope@{ pkgs ? import <nixpkgs> {} }:
     pkg-config
     openssl
     protobuf
-    rdkafka
-    openssl
     ruby_2_7
     nodejs
     perl

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
 scope@{ pkgs ? import <nixpkgs> {} }:
 
 let
-  env = (import ./default.nix scope);
   definition = (import ./scripts/environment/definition.nix scope);
 in
 
-pkgs.mkShell ({
-  buildInputs = [ env ];
+pkgs.stdenv.mkDerivation ({
+  name = "vector-shell";
+  buildInputs = definition.packages;
 } // definition.environmentVariables)


### PR DESCRIPTION
Currently Kafka tests not compiled because `rdkafka` feature required.

Also see #2832 

Edit: should fail without #2832 (will rebase after merge).