### PR TITLE
enhancement(aws_s3 sink): Add content options

### DIFF
--- a/.meta/sinks/aws_s3.toml.erb
+++ b/.meta/sinks/aws_s3.toml.erb
@@ -204,6 +204,13 @@ type = "string"
 examples = [ {"Tag1" = "Value1"} ]
 description = "A custom tag to be added to the created objects."
 
+[sinks.aws_s3.options.content_encoding]
+type = "string"
+category = "Content Type"
+common = false
+description = "Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. By default calculated from `compression` value."
+examples = ["gzip"]
+
 [sinks.aws_s3.options.content_type]
 type = "string"
 category = "Content Type"

--- a/.meta/sinks/aws_s3.toml.erb
+++ b/.meta/sinks/aws_s3.toml.erb
@@ -203,3 +203,10 @@ description = "The tag-set for the object."
 type = "string"
 examples = [ {"Tag1" = "Value1"} ]
 description = "A custom tag to be added to the created objects."
+
+[sinks.aws_s3.options.content_type]
+type = "string"
+category = "Content Type"
+common = false
+description = "A standard MIME type describing the format of the contents."
+default = "text/x-log"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -3736,6 +3736,16 @@ require('custom_module')
   # Content Type
   #
 
+  # Specifies what content encodings have been applied to the object and thus
+  # what decoding mechanisms must be applied to obtain the media-type referenced
+  # by the Content-Type header field. By default calculated from `compression`
+  # value.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  content_encoding = "gzip"
+
   # A standard MIME type describing the format of the contents.
   #
   # * optional

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -3733,6 +3733,17 @@ require('custom_module')
     when_full = "drop_newest"
 
   #
+  # Content Type
+  #
+
+  # A standard MIME type describing the format of the contents.
+  #
+  # * optional
+  # * default: "text/x-log"
+  # * type: string
+  content_type = "text/x-log"
+
+  #
   # Encoding
   #
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -78,6 +78,7 @@ struct S3Options {
     ssekms_key_id: Option<String>,
     storage_class: Option<S3StorageClass>,
     tags: Option<BTreeMap<String, String>>,
+    content_type: Option<String>, // default `text/x-log`
 }
 
 #[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
@@ -288,6 +289,9 @@ impl Service<Request> for S3Sink {
             bucket: request.bucket,
             key: request.key,
             content_encoding: request.content_encoding,
+            content_type: options
+                .content_type
+                .or_else(|| Some("text/x-log".to_owned())),
             acl: options.acl.map(to_string),
             grant_full_control: options.grant_full_control,
             grant_read: options.grant_read,

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -78,7 +78,8 @@ struct S3Options {
     ssekms_key_id: Option<String>,
     storage_class: Option<S3StorageClass>,
     tags: Option<BTreeMap<String, String>>,
-    content_type: Option<String>, // default `text/x-log`
+    content_encoding: Option<String>, // inherit from compression value
+    content_type: Option<String>,     // default `text/x-log`
 }
 
 #[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
@@ -275,6 +276,14 @@ impl Service<Request> for S3Sink {
     fn call(&mut self, request: Request) -> Self::Future {
         let options = request.options;
 
+        let content_encoding = request.content_encoding;
+        let content_encoding = options
+            .content_encoding
+            .or_else(|| content_encoding.map(|ce| ce.to_string()));
+        let content_type = options
+            .content_type
+            .or_else(|| Some("text/x-log".to_owned()));
+
         let mut tagging = url::form_urlencoded::Serializer::new(String::new());
         if let Some(tags) = options.tags {
             for (p, v) in tags {
@@ -288,10 +297,8 @@ impl Service<Request> for S3Sink {
             body: Some(request.body.into()),
             bucket: request.bucket,
             key: request.key,
-            content_encoding: request.content_encoding,
-            content_type: options
-                .content_type
-                .or_else(|| Some("text/x-log".to_owned())),
+            content_encoding,
+            content_type,
             acl: options.acl.map(to_string),
             grant_full_control: options.grant_full_control,
             grant_read: options.grant_read,
@@ -346,7 +353,7 @@ fn build_request(
         body: inner,
         bucket,
         key,
-        content_encoding: compression.content_encoding().map(|ce| ce.to_string()),
+        content_encoding: compression.content_encoding(),
         options,
     }
 }
@@ -356,7 +363,7 @@ struct Request {
     body: Vec<u8>,
     bucket: String,
     key: String,
-    content_encoding: Option<String>,
+    content_encoding: Option<&'static str>,
     options: S3Options,
 }
 

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -99,6 +99,7 @@ endpoint](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html).
   buffer.when_full = "block" # optional, default
 
   # Content Type
+  content_encoding = "gzip" # optional, no default
   content_type = "text/x-log" # optional, default
 
   # Encoding
@@ -415,6 +416,31 @@ The behavior when the buffer becomes full.
 
 The compression strategy used to compress the encoded event data before
 transmission.
+
+
+
+</Field>
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["gzip"]}
+  groups={[]}
+  name={"content_encoding"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### content_encoding
+
+Specifies what content encodings have been applied to the object and thus what
+decoding mechanisms must be applied to obtain the media-type referenced by the
+Content-Type header field. By default calculated from [`compression`](#compression) value.
 
 
 

--- a/website/docs/reference/sinks/aws_s3.md
+++ b/website/docs/reference/sinks/aws_s3.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-24"
+last_modified_on: "2020-06-18"
 delivery_guarantee: "at_least_once"
 component_title: "AWS S3"
 description: "The Vector `aws_s3` sink batches `log` events to Amazon Web Service's S3 service via the `PutObject` API endpoint."
@@ -97,6 +97,9 @@ endpoint](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html).
   buffer.max_size = 104900000 # required, bytes, required when type = "disk"
   buffer.type = "memory" # optional, default
   buffer.when_full = "block" # optional, default
+
+  # Content Type
+  content_type = "text/x-log" # optional, default
 
   # Encoding
   encoding.codec = "ndjson" # required
@@ -412,6 +415,29 @@ The behavior when the buffer becomes full.
 
 The compression strategy used to compress the encoded event data before
 transmission.
+
+
+
+</Field>
+<Field
+  common={false}
+  defaultValue={"text/x-log"}
+  enumValues={null}
+  examples={["text/x-log"]}
+  groups={[]}
+  name={"content_type"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### content_type
+
+A standard MIME type describing the format of the contents.
 
 
 


### PR DESCRIPTION
Closes #2769 and #2773 

- `content_type` is `text/x-log` by default, but can be redefined
- `content_encoding` calculated from `compression` option by default, but can be redefined

cc @tyrken