### PR TITLE
chore(tests): Shutdown write side only in test `tcp_stream_detects_disconnect`

### DIFF
--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -182,7 +182,6 @@ mod test {
             atomic::{AtomicUsize, Ordering},
             Arc,
         };
-        use tokio01::io::AsyncWrite;
 
         crate::test_util::trace_init();
 

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -177,11 +177,14 @@ mod test {
         use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
         use futures01::{Async, Stream};
         use std::io::{ErrorKind, Read};
+        use std::net::Shutdown;
         use std::sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
         };
         use tokio01::io::AsyncWrite;
+
+        crate::test_util::trace_init();
 
         let addr = next_addr();
         let config = SocketSinkConfig {
@@ -230,8 +233,7 @@ mod test {
                 conn_counter1.fetch_add(1, Ordering::SeqCst);
                 loop {
                     if let Ok(Async::Ready(_)) = close_rx.poll() {
-                        socket.shutdown().unwrap();
-                        break;
+                        socket.get_ref().unwrap().shutdown(Shutdown::Write).unwrap();
                     }
 
                     let mut buf = vec![0u8; 11];


### PR DESCRIPTION
`tcp_stream_detects_disconnect` test is commented as testing for a case when a proper server side write side shutdown happens, which wasn't been done in the test. This PR changes that. 

This should fix it's flakines. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
