### PR TITLE
chore(tests): Debug `topology_reuse_old_port` test

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -758,12 +758,13 @@ mod tests {
 mod reload_tests {
     use crate::sinks::console::{ConsoleSinkConfig, Encoding, Target};
     use crate::sources::splunk_hec::SplunkConfig;
-    use crate::test_util::{next_addr, runtime};
+    use crate::test_util::{next_addr, runtime, trace_init};
     use crate::topology;
     use crate::topology::config::Config;
 
     #[test]
     fn topology_reuse_old_port() {
+        trace_init();
         let address = next_addr();
 
         let mut rt = runtime();


### PR DESCRIPTION
This PR doesn't fix anything at moment, it just adds more logging for `topology_reuse_old_port` test to determine why it's failing in CI on Windows.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
