### PR TITLE
enhancement(sinks): Use to_raw_value instead of to_string in JsonArrayBuffer 

### DIFF
--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -1,5 +1,5 @@
 use crate::sinks::util::Batch;
-use serde_json::value::{RawValue, Value};
+use serde_json::value::{to_raw_value, RawValue, Value};
 
 pub type BoxedRawValue = Box<RawValue>;
 
@@ -20,9 +20,8 @@ impl Batch for JsonArrayBuffer {
     }
 
     fn push(&mut self, item: Self::Input) {
-        let encoded = serde_json::to_string(&item).expect("Value should be valid json");
-        self.total_bytes += encoded.len();
-        let item = RawValue::from_string(encoded).expect("Encoded value should be valid json");
+        let item = to_raw_value(&item).expect("Value should be valid json");
+        self.total_bytes += item.get().len();
         self.buffer.push(item);
     }
 


### PR DESCRIPTION
By using to_raw_value it's possible to skip parsing JSON again

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
