### PR TITLE
chore(tests): Adjust buffering tests

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -442,8 +442,11 @@ pub struct CountReceiver {
 }
 
 impl CountReceiver {
-    pub fn wait(self) -> usize {
+    pub fn cancel(self) {
         self.trigger.cancel();
+    }
+
+    pub fn wait(self) -> usize {
         self.handle.wait().unwrap()
     }
 }

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -4,11 +4,10 @@
 
 use futures01::{Future, Sink};
 use prost::Message;
-use std::sync::atomic::Ordering;
 use tempfile::tempdir;
 use tracing::trace;
 use vector::event;
-use vector::test_util::{self, next_addr, wait_for, wait_for_atomic_usize};
+use vector::test_util::{self, next_addr, wait_for_atomic_usize};
 use vector::topology::{self, config};
 use vector::{buffers::BufferConfig, runtime, sinks};
 


### PR DESCRIPTION
This PR does three things:
* Resolves races exclusive to `buffering` tests.
* Moves around `thread::sleep` in `buffering` tests, reducing waiting in total.
* Splits `crate::test_util::CountReceiver::wait` method into `wait` and `cancel`. All of the usages of this method were having a race as they were expecting that the method would wait for the `tcp` channel to close, which wasn't the case. Instead the method was canceling the channel which caused a race.  
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
