### PR TITLE
chore(dependencies): file-source bytes update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 name = "file-source"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12",
+ "bytes 0.5.4",
  "crc",
  "flate2",
  "futures 0.3.4",

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-bytes = { version = "0.4.10", features = ["serde"] }
+bytes = "0.5"
 crc = "1.8.1"
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 glob = "0.2.11"

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -723,6 +723,23 @@ impl From<Bytes> for Event {
     }
 }
 
+impl From<bytes05::Bytes> for Event {
+    fn from(message: bytes05::Bytes) -> Self {
+        let mut event = Event::Log(LogEvent {
+            fields: BTreeMap::new(),
+        });
+
+        event
+            .as_mut_log()
+            .insert(log_schema().message_key().clone(), message);
+        event
+            .as_mut_log()
+            .insert(log_schema().timestamp_key().clone(), Utc::now());
+
+        event
+    }
+}
+
 impl From<&str> for Event {
     fn from(line: &str) -> Self {
         line.to_owned().into()

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -301,9 +301,7 @@ impl From<Bytes> for Value {
 
 impl From<bytes05::Bytes> for Value {
     fn from(bytes: bytes05::Bytes) -> Self {
-        let mut old_bytes = Bytes::new();
-        old_bytes.extend_from_slice(&bytes);
-        Value::Bytes(old_bytes)
+        Value::Bytes(bytes.as_ref().into())
     }
 }
 

--- a/src/sources/file/line_agg.rs
+++ b/src/sources/file/line_agg.rs
@@ -1,4 +1,4 @@
-use bytes::{Bytes, BytesMut};
+use bytes05::{Bytes, BytesMut};
 use futures01::{Async, Poll, Stream};
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
@@ -186,7 +186,7 @@ where
                             add_next_line(buffered, line);
                             return None;
                         } else {
-                            let buffered = entry.insert(line.into());
+                            let buffered = entry.insert(make_mut(line));
                             return Some((buffered.freeze(), entry.key().clone()));
                         }
                     }
@@ -207,7 +207,7 @@ where
                     // in the group.
                     Mode::HaltBefore => {
                         if condition_matched {
-                            let buffered = entry.insert(line.into());
+                            let buffered = entry.insert(make_mut(line));
                             return Some((buffered.freeze(), entry.key().clone()));
                         } else {
                             let buffered = entry.get_mut();
@@ -237,7 +237,7 @@ where
                     // Set the timeout and buffer this line.
                     self.timeouts
                         .insert(entry.key().clone(), self.config.timeout.clone());
-                    entry.insert(line.into());
+                    entry.insert(make_mut(line));
                     return None;
                 } else {
                     // It's just a regular line we don't really care about.
@@ -246,6 +246,12 @@ where
             }
         }
     }
+}
+
+fn make_mut(bytes: Bytes) -> BytesMut {
+    let mut bytes_mut = BytesMut::new();
+    bytes_mut.extend_from_slice(&bytes);
+    bytes_mut
 }
 
 fn add_next_line(buffered: &mut BytesMut, line: Bytes) {

--- a/src/sources/file/line_agg.rs
+++ b/src/sources/file/line_agg.rs
@@ -186,7 +186,7 @@ where
                             add_next_line(buffered, line);
                             return None;
                         } else {
-                            let buffered = entry.insert(make_mut(line));
+                            let buffered = entry.insert(line.as_ref().into());
                             return Some((buffered.freeze(), entry.key().clone()));
                         }
                     }
@@ -207,7 +207,7 @@ where
                     // in the group.
                     Mode::HaltBefore => {
                         if condition_matched {
-                            let buffered = entry.insert(make_mut(line));
+                            let buffered = entry.insert(line.as_ref().into());
                             return Some((buffered.freeze(), entry.key().clone()));
                         } else {
                             let buffered = entry.get_mut();
@@ -237,7 +237,7 @@ where
                     // Set the timeout and buffer this line.
                     self.timeouts
                         .insert(entry.key().clone(), self.config.timeout.clone());
-                    entry.insert(make_mut(line));
+                    entry.insert(line.as_ref().into());
                     return None;
                 } else {
                     // It's just a regular line we don't really care about.
@@ -246,12 +246,6 @@ where
             }
         }
     }
-}
-
-fn make_mut(bytes: Bytes) -> BytesMut {
-    let mut bytes_mut = BytesMut::new();
-    bytes_mut.extend_from_slice(&bytes);
-    bytes_mut
 }
 
 fn add_next_line(buffered: &mut BytesMut, line: Bytes) {

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
     trace::{current_span, Instrument},
 };
-use bytes::Bytes;
+use bytes05::Bytes;
 use file_source::{
     paths_provider::glob::{Glob, MatchOptions},
     FileServer, Fingerprinter,


### PR DESCRIPTION
Do not like that for creating `BytesMut` from `Bytes` data need to be copied, but looks like there is no way do this in bytes:0.5 without it.