### PR TITLE
chore(operations): Move over homebrew/s3 release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,5 +413,5 @@ jobs:
           path: target/artifacts
       - run: |
           export PASS_VERSION=$(make version)
-          export PASS_GITHUB_TOKEN="${{ secrets.BRADY_BOT_TOKEN }}"
+          export PASS_GITHUB_TOKEN="${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}"
           make release-homebrew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,417 @@
+name: Release Suite
+
+on:
+  push:
+    tags:
+      - v0.*
+      - v1.*
+
+env:
+  CHANNEL: nightly
+
+jobs:
+  build-x86_64-unknown-linux-musl-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - env:
+          PASS_FEATURES: "default-cmake"
+        run: make package-x86_64-unknown-linux-musl-all
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x86_64-unknown-linux-musl.tar.gz"
+          path: "./target/artifacts/vector-x86_64-unknown-linux-musl.tar.gz"
+
+  build-x86_64-unknown-linux-gnu-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - env:
+          PASS_FEATURES: "default"
+        run: make package-x86_64-unknown-linux-gnu-all
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x86_64-unknown-linux-gnu.tar.gz"
+          path: "./target/artifacts/vector-x86_64-unknown-linux-gnu.tar.gz"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-amd64.deb"
+          path: "./target/artifacts/vector-amd64.deb"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x86_64.rpm"
+          path: "./target/artifacts/vector-x86_64.rpm"
+
+  build-aarch64-unknown-linux-musl-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - env:
+          DOCKER_PRIVILEGED: "true"
+          PASS_FEATURES: "default-cmake"
+        run: make package-aarch64-unknown-linux-musl-all
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-aarch64-unknown-linux-musl.tar.gz"
+          path: "./target/artifacts/vector-aarch64-unknown-linux-musl.tar.gz"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-arm64.deb"
+          path: "./target/artifacts/vector-arm64.deb"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-aarch64.rpm"
+          path: "./target/artifacts/vector-aarch64.rpm"
+
+  build-armv7-unknown-linux-musleabihf-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - env:
+          DOCKER_PRIVILEGED: "true"
+          PASS_FEATURES: "default-cmake"
+        run: make package-armv7-unknown-linux-musleabihf-all
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-armv7-unknown-linux-musleabihf.tar.gz"
+          path: "./target/artifacts/vector-armv7-unknown-linux-musleabihf.tar.gz"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-armhf.deb"
+          path: "./target/artifacts/vector-armhf.deb"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-armv7hl.rpm"
+          path: "./target/artifacts/vector-armv7hl.rpm"
+
+  build-x86_64-apple-darwin-packages:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v1
+      - name: "Upgrade bash"
+        run: brew install bash
+      - name: "Install realpath dependency"
+        run: brew install coreutils
+      - name: "Build archive"
+        env:
+          TARGET: "x86_64-apple-darwin"
+          USE_CONTAINER: none
+          NATIVE_BUILD: true
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          make package-archive
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x86_64-apple-darwin.tar.gz"
+          path: "./target/artifacts/vector-x86_64-apple-darwin.tar.gz"
+
+  build-x86_64-pc-windows-msvc-packages:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+      - name: "Download Perl"
+        shell: bash
+        env:
+          VERSION: "5.30.0.1"
+          SHA256SUM: "459de13a284a4c83213208c9caa1c372c81136b6e863a3f13d42f631048e0b12" # we need to verify checksum because strawberryperl.com doesn't support HTTPS
+        run: |
+          curl -sSf http://strawberryperl.com/download/$VERSION/strawberry-perl-$VERSION-64bit.msi > perl-installer.msi
+          echo "$SHA256SUM perl-installer.msi" | sha256sum --check --status
+      - name: "Install Perl"
+        shell: cmd # msiexec fails when called from bash
+        run: |
+          msiexec /quiet /i perl-installer.msi
+          del perl-installer.msi
+      - name: "Download CMake"
+        shell: bash
+        env:
+          VERSION: "3.15.5"
+        run: |
+          curl -sSfL https://github.com/Kitware/CMake/releases/download/v$VERSION/cmake-$VERSION-win64-x64.msi > cmake-installer.msi
+      - name: "Install CMake"
+        shell: cmd # msiexec fails when called from bash
+        run: |
+          msiexec /quiet /i cmake-installer.msi
+          del cmake-installer.msi
+      - name: "Install Wix"
+        shell: bash
+        run: |
+          mkdir -p /c/wix
+          cd /c/wix
+          curl -sSfL https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip > wix-binaries.zip
+          unzip wix-binaries.zip
+          rm wix-binaries.zip
+      - name: "Build archive"
+        shell: bash
+        run: |
+          export PATH="$HOME/.cargo/bin:/c/Strawberry/perl/bin:/c/Program Files/CMake/bin:$PATH"
+          export RUSTFLAGS=-Ctarget-feature=+crt-static
+          export FEATURES="default-msvc"
+          export ARCHIVE_TYPE="zip"
+          export KEEP_SYMBOLS="true"
+          export RUST_LTO=""
+          export TARGET="x86_64-pc-windows-msvc"
+          export NATIVE_BUILD="true"
+          export USE_CONTAINER="none"
+          make package-archive
+      - name: "Build package"
+        shell: bash
+        run: |
+          export PATH="/c/wix:$PATH"
+          ./scripts/package-msi.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x86_64-pc-windows-msvc.zip"
+          path: "./target/artifacts/vector-x86_64-pc-windows-msvc.zip"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "vector-x64.msi"
+          path: "./target/artifacts/vector-x64.msi"
+
+  release-docker:
+    runs-on: ubuntu-latest
+    needs:
+      - build-x86_64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-amd64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armhf.deb
+          path: target/artifacts
+      - env:
+          DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
+          PLATFORM: "linux/amd64,linux/arm64,linux/arm"
+          USE_CONTAINER: none
+        run: |
+          ./scripts/upgrade-docker.sh
+          export VERSION=$(make version)
+          make release-docker
+
+  release-s3:
+    runs-on: ubuntu-latest
+    needs:
+      - build-x86_64-unknown-linux-gnu-packages
+      - build-x86_64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+      - build-x86_64-apple-darwin-packages
+      - build-x86_64-pc-windows-msvc-packages
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-gnu.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-amd64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armhf.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-apple-darwin.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-pc-windows-msvc.zip
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x64.msi
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7hl.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64.rpm
+          path: target/artifacts
+      - env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
+          USE_CONTAINER: none
+        run: make release-s3
+
+  release-github:
+    runs-on: ubuntu-latest
+    needs:
+      - build-x86_64-unknown-linux-gnu-packages
+      - build-x86_64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+      - build-x86_64-apple-darwin-packages
+      - build-x86_64-pc-windows-msvc-packages
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-gnu.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-amd64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armhf.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-apple-darwin.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-pc-windows-msvc.zip
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x64.msi
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7hl.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64.rpm
+          path: target/artifacts
+      - run: |
+          export PASS_VERSION=$(make version)
+          export PASS_CIRCLE_SHA1="${{ github.sha }}"
+          export PASS_GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          make release-github
+
+  release-homebrew:
+    runs-on: ubuntu-latest
+    needs:
+      - build-x86_64-unknown-linux-gnu-packages
+      - build-x86_64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+      - build-x86_64-apple-darwin-packages
+      - build-x86_64-pc-windows-msvc-packages
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-gnu.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64-unknown-linux-musl.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-amd64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armhf.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-apple-darwin.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64-pc-windows-msvc.zip
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x64.msi
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-x86_64.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-armv7hl.rpm
+          path: target/artifacts
+      - uses: actions/download-artifact@v1
+        with:
+          name: vector-aarch64.rpm
+          path: target/artifacts
+      - run: |
+          export PASS_VERSION=$(make version)
+          export PASS_GITHUB_TOKEN="${{ secrets.BRADY_BOT_TOKEN }}"
+          make release-homebrew


### PR DESCRIPTION
This PR goes ahead and creates an entirely new workflow for releases that only trigger on release tags. It seemed to be intended from https://github.com/timberio/vector/issues/2797 and I think that it makes sense.

In the future we can adopt more distinction between "Nightly jobs, such as audits/fuzzing/prop-testing/benching" and "release tasks, such as publishing artifacts, images, releases, and binaries". For now, they are coarsely similar.

This PR is **incomplete** as it depends on a `BRADY_BOT_TOKEN` set in the https://github.com/timberio/vector/settings/secrets to publish to the homebrew tap.

Please note I haven't tested this, I wasn't able to find any sort of check/dry run options and I'm not entirely comfortable with just running random release scripts and seeing what happens.
