### PR TITLE
docs: Adding spaces to condition docs

### DIFF
--- a/.meta/_partials/fields/_conditions_options.toml.erb
+++ b/.meta/_partials/fields/_conditions_options.toml.erb
@@ -34,7 +34,7 @@ examples = [
 common = true
 relevant_when = {type = "check_fields"}
 description = """\
-Check whether a fields contents exactly matches the value specified.\
+Check whether a fields contents exactly matches the value specified. \
 This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches.\
 """
 
@@ -47,7 +47,7 @@ examples = [
 common = false
 relevant_when = {type = "check_fields"}
 description = """\
-Check whether a fields contents does not match the value specified.\
+Check whether a fields contents does not match the value specified. \
 This may be a single string or a list of strings, in which case this evaluates to false if any of the list matches.\
 """
 
@@ -72,7 +72,7 @@ examples = [
 common = true
 relevant_when = {type = "check_fields"}
 description = """\
-Checks whether a string field contains a string argument.\
+Checks whether a string field contains a string argument. \
 This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches.\
 """
 
@@ -85,7 +85,7 @@ examples = [
 common = true
 relevant_when = {type = "check_fields"}
 description = """\
-Checks whether a string field ends with a string argument.\
+Checks whether a string field ends with a string argument. \
 This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches.\
 """
 
@@ -98,7 +98,7 @@ examples = [
 common = true
 relevant_when = {type = "check_fields"}
 description = """\
-Checks whether a string field starts with a string argument.\
+Checks whether a string field starts with a string argument. \
 This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches.\
 """
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1611,6 +1611,16 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [transforms.filter.condition]
+    # The type of the condition to execute.
+    #
+    # * optional
+    # * default: "check_fields"
+    # * type: string
+    # * enum: "check_fields", "is_log", and "is_metric"
+    type = "check_fields"
+    type = "is_log"
+    type = "is_metric"
+
     # Check whether a fields contents exactly matches the value specified. This may
     # be a single string or a list of strings, in which case this evaluates to true
     # if any of the list matches.
@@ -1621,16 +1631,6 @@ dns_servers = ["0.0.0.0:53"]
     # * relevant when type = "check_fields"
     "message.eq" = "this is the content to match against"
     "message.eq" = ["match this", "or this"]
-
-    # The type of the condition to execute.
-    #
-    # * optional
-    # * default: "check_fields"
-    # * type: string
-    # * enum: "check_fields", "is_log", and "is_metric"
-    type = "check_fields"
-    type = "is_log"
-    type = "is_metric"
 
     # Check whether a field exists or does not exist, depending on the provided
     # value being `true` or `false` respectively.
@@ -2535,6 +2535,16 @@ require('custom_module')
 
   [transforms.swimlanes.lanes]
     [transforms.swimlanes.lanes.`[swimlane-id]`]
+      # The type of the condition to execute.
+      #
+      # * optional
+      # * default: "check_fields"
+      # * type: string
+      # * enum: "check_fields", "is_log", and "is_metric"
+      type = "check_fields"
+      type = "is_log"
+      type = "is_metric"
+
       # Check whether a fields contents exactly matches the value specified. This may
       # be a single string or a list of strings, in which case this evaluates to true
       # if any of the list matches.
@@ -2545,16 +2555,6 @@ require('custom_module')
       # * relevant when type = "check_fields"
       "message.eq" = "this is the content to match against"
       "message.eq" = ["match this", "or this"]
-
-      # The type of the condition to execute.
-      #
-      # * optional
-      # * default: "check_fields"
-      # * type: string
-      # * enum: "check_fields", "is_log", and "is_metric"
-      type = "check_fields"
-      type = "is_log"
-      type = "is_metric"
 
       # Check whether a field exists or does not exist, depending on the provided
       # value being `true` or `false` respectively.

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1611,17 +1611,7 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [transforms.filter.condition]
-    # The type of the condition to execute.
-    #
-    # * optional
-    # * default: "check_fields"
-    # * type: string
-    # * enum: "check_fields", "is_log", and "is_metric"
-    type = "check_fields"
-    type = "is_log"
-    type = "is_metric"
-
-    # Check whether a fields contents exactly matches the value specified.This may
+    # Check whether a fields contents exactly matches the value specified. This may
     # be a single string or a list of strings, in which case this evaluates to true
     # if any of the list matches.
     #
@@ -1632,6 +1622,16 @@ dns_servers = ["0.0.0.0:53"]
     "message.eq" = "this is the content to match against"
     "message.eq" = ["match this", "or this"]
 
+    # The type of the condition to execute.
+    #
+    # * optional
+    # * default: "check_fields"
+    # * type: string
+    # * enum: "check_fields", "is_log", and "is_metric"
+    type = "check_fields"
+    type = "is_log"
+    type = "is_metric"
+
     # Check whether a field exists or does not exist, depending on the provided
     # value being `true` or `false` respectively.
     #
@@ -1641,7 +1641,7 @@ dns_servers = ["0.0.0.0:53"]
     # * relevant when type = "check_fields"
     "host.exists" = true
 
-    # Check whether a fields contents does not match the value specified.This may
+    # Check whether a fields contents does not match the value specified. This may
     # be a single string or a list of strings, in which case this evaluates to
     # false if any of the list matches.
     #
@@ -1662,9 +1662,9 @@ dns_servers = ["0.0.0.0:53"]
     "unit.not_starts_with" = "sys-"
     "unit.not_ends_with" = ".device"
 
-    # Checks whether a string field contains a string argument.This may be a single
-    # string or a list of strings, in which case this evaluates to true if any of
-    # the list matches.
+    # Checks whether a string field contains a string argument. This may be a
+    # single string or a list of strings, in which case this evaluates to true if
+    # any of the list matches.
     #
     # * optional
     # * no default
@@ -1673,7 +1673,7 @@ dns_servers = ["0.0.0.0:53"]
     "message.contains" = "foo"
     "message.contains" = ["foo", "bar"]
 
-    # Checks whether a string field ends with a string argument.This may be a
+    # Checks whether a string field ends with a string argument. This may be a
     # single string or a list of strings, in which case this evaluates to true if
     # any of the list matches.
     #
@@ -1707,7 +1707,7 @@ dns_servers = ["0.0.0.0:53"]
     # * relevant when type = "check_fields"
     "message.regex" = " (any|of|these|five|words) "
 
-    # Checks whether a string field starts with a string argument.This may be a
+    # Checks whether a string field starts with a string argument. This may be a
     # single string or a list of strings, in which case this evaluates to true if
     # any of the list matches.
     #
@@ -2535,17 +2535,7 @@ require('custom_module')
 
   [transforms.swimlanes.lanes]
     [transforms.swimlanes.lanes.`[swimlane-id]`]
-      # The type of the condition to execute.
-      #
-      # * optional
-      # * default: "check_fields"
-      # * type: string
-      # * enum: "check_fields", "is_log", and "is_metric"
-      type = "check_fields"
-      type = "is_log"
-      type = "is_metric"
-
-      # Check whether a fields contents exactly matches the value specified.This may
+      # Check whether a fields contents exactly matches the value specified. This may
       # be a single string or a list of strings, in which case this evaluates to true
       # if any of the list matches.
       #
@@ -2556,6 +2546,16 @@ require('custom_module')
       "message.eq" = "this is the content to match against"
       "message.eq" = ["match this", "or this"]
 
+      # The type of the condition to execute.
+      #
+      # * optional
+      # * default: "check_fields"
+      # * type: string
+      # * enum: "check_fields", "is_log", and "is_metric"
+      type = "check_fields"
+      type = "is_log"
+      type = "is_metric"
+
       # Check whether a field exists or does not exist, depending on the provided
       # value being `true` or `false` respectively.
       #
@@ -2565,7 +2565,7 @@ require('custom_module')
       # * relevant when type = "check_fields"
       "host.exists" = true
 
-      # Check whether a fields contents does not match the value specified.This may
+      # Check whether a fields contents does not match the value specified. This may
       # be a single string or a list of strings, in which case this evaluates to
       # false if any of the list matches.
       #
@@ -2586,9 +2586,9 @@ require('custom_module')
       "unit.not_starts_with" = "sys-"
       "unit.not_ends_with" = ".device"
 
-      # Checks whether a string field contains a string argument.This may be a single
-      # string or a list of strings, in which case this evaluates to true if any of
-      # the list matches.
+      # Checks whether a string field contains a string argument. This may be a
+      # single string or a list of strings, in which case this evaluates to true if
+      # any of the list matches.
       #
       # * optional
       # * no default
@@ -2597,7 +2597,7 @@ require('custom_module')
       "message.contains" = "foo"
       "message.contains" = ["foo", "bar"]
 
-      # Checks whether a string field ends with a string argument.This may be a
+      # Checks whether a string field ends with a string argument. This may be a
       # single string or a list of strings, in which case this evaluates to true if
       # any of the list matches.
       #
@@ -2631,7 +2631,7 @@ require('custom_module')
       # * relevant when type = "check_fields"
       "message.regex" = " (any|of|these|five|words) "
 
-      # Checks whether a string field starts with a string argument.This may be a
+      # Checks whether a string field starts with a string argument. This may be a
       # single string or a list of strings, in which case this evaluates to true if
       # any of the list matches.
       #

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -60,9 +60,9 @@ vector test /etc/vector/*.toml
   # Outputs
   [[tests.outputs]]
     # Conditions
-    conditions.type = "check_fields" # optional, default
     conditions."message.eq" = "this is the content to match against" # example
     conditions."message.eq" = ["match this", "or this"] # example
+    conditions.type = "check_fields" # optional, default
     conditions."message.contains" = "foo" # example
     conditions."message.contains" = ["foo", "bar"] # example
     conditions."environment.ends_with" = "-staging" # example
@@ -115,9 +115,9 @@ vector test /etc/vector/*.toml
   # Outputs
   [[tests.outputs]]
     # Conditions
-    conditions.type = "check_fields" # optional, default
     conditions."message.eq" = "this is the content to match against" # example
     conditions."message.eq" = ["match this", "or this"] # example
+    conditions.type = "check_fields" # optional, default
     conditions."host.exists" = true # example
     conditions."method.neq" = "POST" # example
     conditions."method.neq" = ["POST", "GET"] # example
@@ -596,6 +596,31 @@ target without checking its values.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
+  groups={[]}
+  name={"`[field-name]`.eq"}
+  path={"outputs.conditions"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+##### `[field-name]`.eq
+
+Check whether a fields contents exactly matches the value specified. This may
+be a single string or a list of strings, in which case this evaluates to true
+if any of the list matches.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={"check_fields"}
   enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
   examples={["check_fields","is_log","is_metric"]}
@@ -613,31 +638,6 @@ target without checking its values.
 ##### type
 
 The type of the condition to execute.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
-  groups={[]}
-  name={"`[field-name]`.eq"}
-  path={"outputs.conditions"}
-  relevantWhen={{"type":"check_fields"}}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-##### `[field-name]`.eq
-
-Check whether a fields contents exactly matches the value specified.This may be
-a single string or a list of strings, in which case this evaluates to true if
-any of the list matches.
 
 
 
@@ -684,7 +684,7 @@ being `true` or `false` respectively.
 
 ##### `[field-name]`.neq
 
-Check whether a fields contents does not match the value specified.This may be
+Check whether a fields contents does not match the value specified. This may be
 a single string or a list of strings, in which case this evaluates to false if
 any of the list matches.
 
@@ -732,7 +732,7 @@ Check if the given `[condition]` does not match.
 
 ##### `[field_name]`.contains
 
-Checks whether a string field contains a string argument.This may be a single
+Checks whether a string field contains a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -757,7 +757,7 @@ list matches.
 
 ##### `[field_name]`.ends_with
 
-Checks whether a string field ends with a string argument.This may be a single
+Checks whether a string field ends with a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -835,7 +835,7 @@ preferred where possible.
 
 ##### `[field_name]`.starts_with
 
-Checks whether a string field starts with a string argument.This may be a
+Checks whether a string field starts with a string argument. This may be a
 single string or a list of strings, in which case this evaluates to true if any
 of the list matches.
 

--- a/website/docs/reference/tests.md
+++ b/website/docs/reference/tests.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-16"
+last_modified_on: "2020-06-24"
 title: Unit Tests
 description: Vector's unit test configuration options, allowing you to unit test your Vector configuration files.
 status: beta
@@ -60,9 +60,9 @@ vector test /etc/vector/*.toml
   # Outputs
   [[tests.outputs]]
     # Conditions
+    conditions.type = "check_fields" # optional, default
     conditions."message.eq" = "this is the content to match against" # example
     conditions."message.eq" = ["match this", "or this"] # example
-    conditions.type = "check_fields" # optional, default
     conditions."message.contains" = "foo" # example
     conditions."message.contains" = ["foo", "bar"] # example
     conditions."environment.ends_with" = "-staging" # example
@@ -115,9 +115,9 @@ vector test /etc/vector/*.toml
   # Outputs
   [[tests.outputs]]
     # Conditions
+    conditions.type = "check_fields" # optional, default
     conditions."message.eq" = "this is the content to match against" # example
     conditions."message.eq" = ["match this", "or this"] # example
-    conditions.type = "check_fields" # optional, default
     conditions."host.exists" = true # example
     conditions."method.neq" = "POST" # example
     conditions."method.neq" = ["POST", "GET"] # example
@@ -596,6 +596,29 @@ target without checking its values.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={"check_fields"}
+  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
+  examples={["check_fields","is_log","is_metric"]}
+  groups={[]}
+  name={"type"}
+  path={"outputs.conditions"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+##### type
+
+The type of the condition to execute.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={null}
   enumValues={null}
   examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
@@ -615,29 +638,6 @@ target without checking its values.
 Check whether a fields contents exactly matches the value specified. This may
 be a single string or a list of strings, in which case this evaluates to true
 if any of the list matches.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={"check_fields"}
-  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
-  examples={["check_fields","is_log","is_metric"]}
-  groups={[]}
-  name={"type"}
-  path={"outputs.conditions"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-##### type
-
-The type of the condition to execute.
 
 
 

--- a/website/docs/reference/transforms/filter.md
+++ b/website/docs/reference/transforms/filter.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-16"
+last_modified_on: "2020-06-24"
 component_title: "Filter"
 description: "The Vector `filter` transform accepts and outputs `log` and `metric` events, allowing you to select events based on a set of logical conditions."
 event_types: ["log","metric"]
@@ -46,9 +46,9 @@ on a set of logical conditions.
   inputs = ["my-source-or-transform-id"] # required
 
   # Condition
+  condition.type = "check_fields" # optional, default
   condition."message.eq" = "this is the content to match against" # example
   condition."message.eq" = ["match this", "or this"] # example
-  condition.type = "check_fields" # optional, default
   condition."message.contains" = "foo" # example
   condition."message.contains" = ["foo", "bar"] # example
   condition."environment.ends_with" = "-staging" # example
@@ -68,9 +68,9 @@ on a set of logical conditions.
   inputs = ["my-source-or-transform-id"] # required
 
   # Condition
+  condition.type = "check_fields" # optional, default
   condition."message.eq" = "this is the content to match against" # example
   condition."message.eq" = ["match this", "or this"] # example
-  condition.type = "check_fields" # optional, default
   condition."host.exists" = true # example
   condition."method.neq" = "POST" # example
   condition."method.neq" = ["POST", "GET"] # example
@@ -117,6 +117,29 @@ messages that pass all conditions will be forwarded.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={"check_fields"}
+  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
+  examples={["check_fields","is_log","is_metric"]}
+  groups={[]}
+  name={"type"}
+  path={"condition"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### type
+
+The type of the condition to execute.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={null}
   enumValues={null}
   examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
@@ -136,29 +159,6 @@ messages that pass all conditions will be forwarded.
 Check whether a fields contents exactly matches the value specified. This may
 be a single string or a list of strings, in which case this evaluates to true
 if any of the list matches.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={"check_fields"}
-  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
-  examples={["check_fields","is_log","is_metric"]}
-  groups={[]}
-  name={"type"}
-  path={"condition"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-#### type
-
-The type of the condition to execute.
 
 
 

--- a/website/docs/reference/transforms/filter.md
+++ b/website/docs/reference/transforms/filter.md
@@ -46,9 +46,9 @@ on a set of logical conditions.
   inputs = ["my-source-or-transform-id"] # required
 
   # Condition
-  condition.type = "check_fields" # optional, default
   condition."message.eq" = "this is the content to match against" # example
   condition."message.eq" = ["match this", "or this"] # example
+  condition.type = "check_fields" # optional, default
   condition."message.contains" = "foo" # example
   condition."message.contains" = ["foo", "bar"] # example
   condition."environment.ends_with" = "-staging" # example
@@ -68,9 +68,9 @@ on a set of logical conditions.
   inputs = ["my-source-or-transform-id"] # required
 
   # Condition
-  condition.type = "check_fields" # optional, default
   condition."message.eq" = "this is the content to match against" # example
   condition."message.eq" = ["match this", "or this"] # example
+  condition.type = "check_fields" # optional, default
   condition."host.exists" = true # example
   condition."method.neq" = "POST" # example
   condition."method.neq" = ["POST", "GET"] # example
@@ -117,6 +117,31 @@ messages that pass all conditions will be forwarded.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
+  groups={[]}
+  name={"`[field-name]`.eq"}
+  path={"condition"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### `[field-name]`.eq
+
+Check whether a fields contents exactly matches the value specified. This may
+be a single string or a list of strings, in which case this evaluates to true
+if any of the list matches.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={"check_fields"}
   enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
   examples={["check_fields","is_log","is_metric"]}
@@ -134,31 +159,6 @@ messages that pass all conditions will be forwarded.
 #### type
 
 The type of the condition to execute.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
-  groups={[]}
-  name={"`[field-name]`.eq"}
-  path={"condition"}
-  relevantWhen={{"type":"check_fields"}}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-#### `[field-name]`.eq
-
-Check whether a fields contents exactly matches the value specified.This may be
-a single string or a list of strings, in which case this evaluates to true if
-any of the list matches.
 
 
 
@@ -205,7 +205,7 @@ being `true` or `false` respectively.
 
 #### `[field-name]`.neq
 
-Check whether a fields contents does not match the value specified.This may be
+Check whether a fields contents does not match the value specified. This may be
 a single string or a list of strings, in which case this evaluates to false if
 any of the list matches.
 
@@ -253,7 +253,7 @@ Check if the given `[condition]` does not match.
 
 #### `[field_name]`.contains
 
-Checks whether a string field contains a string argument.This may be a single
+Checks whether a string field contains a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -278,7 +278,7 @@ list matches.
 
 #### `[field_name]`.ends_with
 
-Checks whether a string field ends with a string argument.This may be a single
+Checks whether a string field ends with a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -356,7 +356,7 @@ preferred where possible.
 
 #### `[field_name]`.starts_with
 
-Checks whether a string field starts with a string argument.This may be a
+Checks whether a string field starts with a string argument. This may be a
 single string or a list of strings, in which case this evaluates to true if any
 of the list matches.
 

--- a/website/docs/reference/transforms/swimlanes.md
+++ b/website/docs/reference/transforms/swimlanes.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-16"
+last_modified_on: "2020-06-24"
 component_title: "Swimlanes"
 description: "The Vector `swimlanes` transform accepts and outputs `log` events, allowing you to route events across parallel streams using logical filters."
 event_types: ["log"]
@@ -46,9 +46,9 @@ events across parallel streams using logical filters.
 
   # Lanes
   [transforms.my_transform_id.lanes.`[swimlane-id]`]
+    type = "check_fields" # optional, default
     "message.eq" = "this is the content to match against" # example
     "message.eq" = ["match this", "or this"] # example
-    type = "check_fields" # optional, default
     "message.contains" = "foo" # example
     "message.contains" = ["foo", "bar"] # example
     "environment.ends_with" = "-staging" # example
@@ -69,9 +69,9 @@ events across parallel streams using logical filters.
 
   # Lanes
   [transforms.my_transform_id.lanes.`[swimlane-id]`]
+    type = "check_fields" # optional, default
     "message.eq" = "this is the content to match against" # example
     "message.eq" = ["match this", "or this"] # example
-    type = "check_fields" # optional, default
     "host.exists" = true # example
     "method.neq" = "POST" # example
     "method.neq" = ["POST", "GET"] # example
@@ -141,6 +141,29 @@ The identifier of a swimlane.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={"check_fields"}
+  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
+  examples={["check_fields","is_log","is_metric"]}
+  groups={[]}
+  name={"type"}
+  path={"lanes.`[swimlane-id]`"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+##### type
+
+The type of the condition to execute.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={null}
   enumValues={null}
   examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
@@ -160,29 +183,6 @@ The identifier of a swimlane.
 Check whether a fields contents exactly matches the value specified. This may
 be a single string or a list of strings, in which case this evaluates to true
 if any of the list matches.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={"check_fields"}
-  enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
-  examples={["check_fields","is_log","is_metric"]}
-  groups={[]}
-  name={"type"}
-  path={"lanes.`[swimlane-id]`"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-##### type
-
-The type of the condition to execute.
 
 
 

--- a/website/docs/reference/transforms/swimlanes.md
+++ b/website/docs/reference/transforms/swimlanes.md
@@ -46,9 +46,9 @@ events across parallel streams using logical filters.
 
   # Lanes
   [transforms.my_transform_id.lanes.`[swimlane-id]`]
-    type = "check_fields" # optional, default
     "message.eq" = "this is the content to match against" # example
     "message.eq" = ["match this", "or this"] # example
+    type = "check_fields" # optional, default
     "message.contains" = "foo" # example
     "message.contains" = ["foo", "bar"] # example
     "environment.ends_with" = "-staging" # example
@@ -69,9 +69,9 @@ events across parallel streams using logical filters.
 
   # Lanes
   [transforms.my_transform_id.lanes.`[swimlane-id]`]
-    type = "check_fields" # optional, default
     "message.eq" = "this is the content to match against" # example
     "message.eq" = ["match this", "or this"] # example
+    type = "check_fields" # optional, default
     "host.exists" = true # example
     "method.neq" = "POST" # example
     "method.neq" = ["POST", "GET"] # example
@@ -141,6 +141,31 @@ The identifier of a swimlane.
 <Fields filters={false}>
 <Field
   common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
+  groups={[]}
+  name={"`[field-name]`.eq"}
+  path={"lanes.`[swimlane-id]`"}
+  relevantWhen={{"type":"check_fields"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+##### `[field-name]`.eq
+
+Check whether a fields contents exactly matches the value specified. This may
+be a single string or a list of strings, in which case this evaluates to true
+if any of the list matches.
+
+
+
+</Field>
+<Field
+  common={true}
   defaultValue={"check_fields"}
   enumValues={{"check_fields":"Allows you to check individual fields against a list of conditions.","is_log":"Returns true if the event is a log.","is_metric":"Returns true if the event is a metric."}}
   examples={["check_fields","is_log","is_metric"]}
@@ -158,31 +183,6 @@ The identifier of a swimlane.
 ##### type
 
 The type of the condition to execute.
-
-
-
-</Field>
-<Field
-  common={true}
-  defaultValue={null}
-  enumValues={null}
-  examples={[{"message.eq":"this is the content to match against"},{"message.eq":["match this","or this"]}]}
-  groups={[]}
-  name={"`[field-name]`.eq"}
-  path={"lanes.`[swimlane-id]`"}
-  relevantWhen={{"type":"check_fields"}}
-  required={false}
-  templateable={false}
-  type={"string"}
-  unit={null}
-  warnings={[]}
-  >
-
-##### `[field-name]`.eq
-
-Check whether a fields contents exactly matches the value specified.This may be
-a single string or a list of strings, in which case this evaluates to true if
-any of the list matches.
 
 
 
@@ -229,7 +229,7 @@ being `true` or `false` respectively.
 
 ##### `[field-name]`.neq
 
-Check whether a fields contents does not match the value specified.This may be
+Check whether a fields contents does not match the value specified. This may be
 a single string or a list of strings, in which case this evaluates to false if
 any of the list matches.
 
@@ -277,7 +277,7 @@ Check if the given `[condition]` does not match.
 
 ##### `[field_name]`.contains
 
-Checks whether a string field contains a string argument.This may be a single
+Checks whether a string field contains a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -302,7 +302,7 @@ list matches.
 
 ##### `[field_name]`.ends_with
 
-Checks whether a string field ends with a string argument.This may be a single
+Checks whether a string field ends with a string argument. This may be a single
 string or a list of strings, in which case this evaluates to true if any of the
 list matches.
 
@@ -380,7 +380,7 @@ preferred where possible.
 
 ##### `[field_name]`.starts_with
 
-Checks whether a string field starts with a string argument.This may be a
+Checks whether a string field starts with a string argument. This may be a
 single string or a list of strings, in which case this evaluates to true if any
 of the list matches.
 


### PR DESCRIPTION
Noticed I messed up the spaces in the docs I added for #2745 

In the website there wasn't any space between sentences, e.g.

> Check whether a fields contents exactly matches the value specified.This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches.