### PR TITLE
chore(file source): Add Fingerprinter::FirstLineChecksum

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -457,8 +457,7 @@ fn fingerprinter_read_until(mut r: impl Read, delim: u8, mut buf: &mut [u8]) -> 
             break;
         }
 
-        let tmp = buf;
-        buf = &mut tmp[read..];
+        buf = &mut buf[read..];
     }
     Ok(())
 }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -536,8 +536,8 @@ mod test {
         let incomlete_line = prepare_test("incomlete_line.log", b"missing newline char");
         let one_line = prepare_test("one_line.log", b"hello world\n");
         let one_line_duplicate = prepare_test("one_line_duplicate.log", b"hello world\n");
-        let one_line_continuied =
-            prepare_test("one_line_continuied.log", b"hello world\nthe next line\n");
+        let one_line_continued =
+            prepare_test("one_line_continued.log", b"hello world\nthe next line\n");
         let different_two_lines = prepare_test("different_two_lines.log", b"line one\nline two\n");
 
         let exactly_max_line_length =
@@ -558,13 +558,13 @@ mod test {
 
         assert!(run(&one_line).is_ok());
         assert!(run(&one_line_duplicate).is_ok());
-        assert!(run(&one_line_continuied).is_ok());
+        assert!(run(&one_line_continued).is_ok());
         assert!(run(&different_two_lines).is_ok());
         assert!(run(&exactly_max_line_length).is_ok());
         assert!(run(&exceeding_max_line_length).is_ok());
 
         assert_eq!(run(&one_line).unwrap(), run(&one_line_duplicate).unwrap());
-        assert_eq!(run(&one_line).unwrap(), run(&one_line_continuied).unwrap());
+        assert_eq!(run(&one_line).unwrap(), run(&one_line_continued).unwrap());
 
         assert_ne!(run(&one_line).unwrap(), run(&different_two_lines).unwrap());
 


### PR DESCRIPTION
This PR implements first-line-checksum fingerprinter outlined at https://github.com/timberio/vector/issues/2890.

It is a concrete implementation proposal, and also a proof of concept. Tests ensure that we achieve the desired behavior and also serve as the illustration for the properties of the solution.

---

One of the questionable moments is filling the buffer with `0` before leaving the match arm. We could alternatively pass the shorter slice to the `checksum_ecma`, but I'm not sure what we'd prefer here.