### PR TITLE
chore(dependencies): remove native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,7 +5691,6 @@ dependencies = [
  "metrics",
  "metrics-core",
  "metrics-runtime",
- "native-tls",
  "nix 0.16.1",
  "nom 5.1.0",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ bytes05 = { package = "bytes", version = "0.5", features = ["serde"] }
 stream-cancel = "0.4.3"
 hyper = "0.13"
 hyper-openssl = "0.8"
-native-tls = "0.2.3"
 openssl = "0.10.26"
 openssl-probe = "0.1.2"
 string_cache = "0.7.3"

--- a/lib/codec/Cargo.toml
+++ b/lib/codec/Cargo.toml
@@ -8,4 +8,6 @@ edition = "2018"
 bytes = { version = "0.4.10", features = ["serde"] }
 tokio-codec = "0.1"
 tracing = "0.1.15"
+
+[dev-dependencies]
 serde_json = "1.0.33"


### PR DESCRIPTION
While `vector` itself do not use `native-tls` crate still used in dependencies...

```
$ cargo tree -i -p native-tls
native-tls v0.2.3
├── hyper-tls v0.3.2
│   └── reqwest v0.9.24
│       └── vector v0.10.0 (/home/kirill/projects/vector)
├── hyper-tls v0.4.1
│   ├── reqwest v0.10.6
│   │   └── goauth v0.7.1
│   │       └── vector v0.10.0 (/home/kirill/projects/vector)
│   └── rusoto_core v0.44.0
│       ├── rusoto_cloudwatch v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       ├── rusoto_firehose v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       ├── rusoto_kinesis v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       ├── rusoto_logs v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       ├── rusoto_s3 v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       ├── rusoto_sts v0.44.0
│       │   └── vector v0.10.0 (/home/kirill/projects/vector)
│       └── vector v0.10.0 (/home/kirill/projects/vector)
├── reqwest v0.9.24 (*)
├── reqwest v0.10.6 (*)
└── tokio-tls v0.3.1
    ├── hyper-tls v0.4.1 (*)
    └── reqwest v0.10.6 (*)
```