### PR TITLE
chore(kafka sink): Fixup sasl related knobs to allow releases on musl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ leveldb = { git = "https://github.com/timberio/leveldb", optional = true, defaul
 db-key = "0.0.5"
 headers = "0.2.1"
 headers03 = { package = "headers", version = "0.3" }
-rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd", "gssapi"], optional = true }
+rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd"], optional = true }
 hostname = "0.1.5"
 seahash = { version = "3.0.6", optional = true }
 jemallocator = { version = "0.3.0", optional = true }
@@ -201,9 +201,11 @@ assert_cmd = "1.0"
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain"]
+default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain", "sasl"]
+# Default features for *-unknown-linux-musl
+default-musl = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
+default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake", "sasl"]
 # Default features for *-pc-windows-msvc
 default-msvc = ["sources", "transforms", "sinks", "vendored", "leveldb-cmake", "rdkafka-cmake"]
 
@@ -211,6 +213,11 @@ default-msvc = ["sources", "transforms", "sinks", "vendored", "leveldb-cmake", "
 unix = ["jemallocator", "shiplift/unix-socket"]
 # Forces vendoring of OpenSSL and ZLib dependencies
 vendored = ["openssl/vendored", "libz-sys/static"]
+# Waiting for 1.1.25 to try this on musl again...
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/musl/default.nix
+# https://git.musl-libc.org/cgit/musl/commit/?id=7844ecb590893f8344324837956718001402d297
+# https://git.musl-libc.org/cgit/musl/commit/?id=ea9525c8bcf6170df59364c4bcd616de1acf8703
+sasl = ["rdkafka/gssapi"]
 # This feature is less portable, but doesn't require `cmake` as build dependency
 rdkafka-plain = ["rdkafka"]
 # Enables `rdkafka` dependency.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: x86_64-unknown-linux-musl
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -47,7 +47,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: armv7-unknown-linux-musleabihf
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -65,7 +65,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: aarch64-unknown-linux-musl
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -83,7 +83,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: x86_64-unknown-linux-musl
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -119,7 +119,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: armv7-unknown-linux-musleabihf
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -137,7 +137,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: aarch64-unknown-linux-musl
-      FEATURES: default-cmake
+      FEATURES: default-musl
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:jessie
 # support editions, which makes it impossible to install `cargo-deb`.
 RUN rustup update stable
 RUN rustup run stable cargo install cargo-deb --version '^1.24.0'
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y cmake libsasl2-dev
 RUN cd /tmp && \
   git clone https://github.com/github/cmark-gfm && \
   cd cmark-gfm && \


### PR DESCRIPTION
We cannot support sasl on musl yet.

It requires secure_getenv and you can see musl only recently got this: https://www.openwall.com/lists/musl/2019/05/28/3, leads to https://git.musl-libc.org/cgit/musl/commit/?id=7844ecb590893f8344324837956718001402d297, which seems to be released but I can't seem to link to?

It should be part 1.1.24: https://git.musl-libc.org/cgit/musl/commit/?id=ea9525c8bcf6170df59364c4bcd616de1acf8703, which is what we package https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/musl/default.nix

We're revisiting this once we see 1.1.25 in nixpkgs.