### PR TITLE
chore(dependencies): patch rdkafka for static sasl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
+name = "duct"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90a9c3a25aafbd538c7d40a53f83c4487ee8216c12d1c8ef2c01eb2f6ea1553"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "krb5-src"
+version = "0.2.3+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc5e3404f6c92ef9dbaa4c7f062e1e04ebd5133c06b0fb5c3239943d66d9622"
+dependencies = [
+ "duct",
+ "openssl-sys",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2894,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,8 +3562,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d455ac2a07a27d87b4f0e321dfd8d9a5b574bd96f55e42e6c594712a08051222"
+source = "git+https://github.com/fanatid/rust-rdkafka?rev=244c9922e4a763eef72ba6c52ec87ee3ef088219#244c9922e4a763eef72ba6c52ec87ee3ef088219"
 dependencies = [
  "futures 0.3.4",
  "libc",
@@ -3545,8 +3576,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d770343fbbc6089c750000711a17a906e8b3f7831afcd752d9667d38833e578"
+source = "git+https://github.com/fanatid/rust-rdkafka?rev=244c9922e4a763eef72ba6c52ec87ee3ef088219#244c9922e4a763eef72ba6c52ec87ee3ef088219"
 dependencies = [
  "cmake",
  "libc",
@@ -3554,6 +3584,7 @@ dependencies = [
  "num_enum",
  "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
  "zstd-sys",
 ]
 
@@ -3952,6 +3983,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4362c3cf63a4361e092127c910516238e735a0c260632480e721e1bc8951ed7d"
+dependencies = [
+ "cc",
+ "duct",
+ "krb5-src",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "scan_fmt"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4218,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cebcf3a403e4deafaf34dc882c4a1b6a648b43e5670aa2e4bb985914eaeb2d2"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ vendored = ["openssl/vendored", "libz-sys/static"]
 # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/musl/default.nix
 # https://git.musl-libc.org/cgit/musl/commit/?id=7844ecb590893f8344324837956718001402d297
 # https://git.musl-libc.org/cgit/musl/commit/?id=ea9525c8bcf6170df59364c4bcd616de1acf8703
-sasl = ["rdkafka/gssapi"]
+sasl = ["rdkafka/gssapi-vendored"]
 # This feature is less portable, but doesn't require `cmake` as build dependency
 rdkafka-plain = ["rdkafka"]
 # Enables `rdkafka` dependency.
@@ -446,3 +446,6 @@ required-features = ["transforms-wasm", "transforms-lua"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
+
+[patch.crates-io]
+rdkafka = { git = "https://github.com/timberio/rust-rdkafka", rev = "244c9922e4a763eef72ba6c52ec87ee3ef088219" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ leveldb = { git = "https://github.com/timberio/leveldb", optional = true, defaul
 db-key = "0.0.5"
 headers = "0.2.1"
 headers03 = { package = "headers", version = "0.3" }
-rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd", "gssapi-vendored"], optional = true }
 hostname = "0.1.5"
 seahash = { version = "3.0.6", optional = true }
 jemallocator = { version = "0.3.0", optional = true }
@@ -200,11 +200,9 @@ assert_cmd = "1.0"
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain", "sasl"]
-# Default features for *-unknown-linux-musl
-default-musl = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
+default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake", "sasl"]
+default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
 # Default features for *-pc-windows-msvc
 default-msvc = ["sources", "transforms", "sinks", "vendored", "leveldb-cmake", "rdkafka-cmake"]
 
@@ -212,16 +210,9 @@ default-msvc = ["sources", "transforms", "sinks", "vendored", "leveldb-cmake", "
 unix = ["jemallocator", "shiplift/unix-socket"]
 # Forces vendoring of OpenSSL and ZLib dependencies
 vendored = ["openssl/vendored", "libz-sys/static"]
-# Waiting for 1.1.25 to try this on musl again...
-# https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/musl/default.nix
-# https://git.musl-libc.org/cgit/musl/commit/?id=7844ecb590893f8344324837956718001402d297
-# https://git.musl-libc.org/cgit/musl/commit/?id=ea9525c8bcf6170df59364c4bcd616de1acf8703
-sasl = ["rdkafka/gssapi-vendored"]
 # This feature is less portable, but doesn't require `cmake` as build dependency
 rdkafka-plain = ["rdkafka"]
-# Enables `rdkafka` dependency.
 # This feature is more portable, but requires `cmake` as build dependency. Use it if `rdkafka-plain` doesn't work.
-# The `sasl` feature has to be added because of the limitations of `librdkafka` build scripts for `cmake`.
 rdkafka-cmake = ["rdkafka", "rdkafka/cmake_build"]
 # This feature is less portable, but doesn't require `cmake` as build dependency
 leveldb-plain = ["leveldb", "leveldb/leveldb-sys-2"]

--- a/scripts/environment/definition.nix
+++ b/scripts/environment/definition.nix
@@ -54,7 +54,6 @@ scope@{ pkgs ? import <nixpkgs> {} }:
     autoconf
     cacert
     cmake
-    cyrus_sasl
     git
     gnumake
     nodejs


### PR DESCRIPTION
Discussed with @MOZGIII in DM. Related with #2928 

~`https://github.com/fanatid/rust-rdkafka` because can not push to `https://github.com/timberio/rust-rdkafka`~

Should I change anything else what related with release / building?