### PR TITLE
chore(kafka sink): disable sasl feature

### DIFF
--- a/.meta/_partials/fields/_kafka_options.toml.erb
+++ b/.meta/_partials/fields/_kafka_options.toml.erb
@@ -30,29 +30,24 @@ The options and their values. Accepts `string` values.
 [<%= namespace %>.sasl]
 type = "table"
 category = "SASL"
-common = false
-description = "Options for SASL/SCRAM authentication support."
+description = "Options for SASL/SCRAM authentication support. Not supported in provided Vector binaries, you need build Vector with feature `sasl`."
 
 [<%= namespace %>.sasl.children.enabled]
 type = "bool"
-common = true
 description = "Enable SASL/SCRAM authentication to the remote."
 
 [<%= namespace %>.sasl.children.username]
 type = "string"
-common = true
 examples = ["username"]
 description = "The Kafka SASL/SCRAM authentication username."
 
 [<%= namespace %>.sasl.children.password]
 type = "string"
-common = true
 examples = ["password"]
 description = "The Kafka SASL/SCRAM authentication password."
 
 [<%= namespace %>.sasl.children.mechanism]
 type = "string"
-common = true
 examples = ["SCRAM-SHA-256", "SCRAM-SHA-512"]
 description = "The Kafka SASL/SCRAM mechanisms."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,11 +200,9 @@ assert_cmd = "1.0"
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain", "sasl"]
-# Default features for *-unknown-linux-musl
-default-musl = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
+default = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-plain", "rdkafka-plain"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake", "sasl"]
+default-cmake = ["sources", "transforms", "sinks", "vendored", "unix", "leveldb-cmake", "rdkafka-cmake"]
 # Default features for *-pc-windows-msvc
 default-msvc = ["sources", "transforms", "sinks", "vendored", "leveldb-cmake", "rdkafka-cmake"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: x86_64-unknown-linux-musl
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -47,7 +47,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: armv7-unknown-linux-musleabihf
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -65,7 +65,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: aarch64-unknown-linux-musl
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -83,7 +83,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: x86_64-unknown-linux-musl
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -119,7 +119,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: armv7-unknown-linux-musleabihf
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD
@@ -137,7 +137,7 @@ services:
     environment:
       NATIVE_BUILD: "false"
       TARGET: aarch64-unknown-linux-musl
-      FEATURES: default-musl
+      FEATURES: default-cmake
       CARGO_TERM_COLOR: always
     volumes:
       - $PWD:$PWD

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:jessie
 # support editions, which makes it impossible to install `cargo-deb`.
 RUN rustup update stable
 RUN rustup run stable cargo install cargo-deb --version '^1.24.0'
-RUN apt-get update && apt-get install -y cmake libsasl2-dev
+RUN apt-get update && apt-get install -y cmake
 RUN cd /tmp && \
   git clone https://github.com/github/cmark-gfm && \
   cd cmark-gfm && \

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-24"
+last_modified_on: "2020-07-01"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` sink streams `log` events to Apache Kafka via the Kafka protocol."
@@ -536,12 +536,13 @@ Local message timeout.
 
 ### sasl
 
-Options for SASL/SCRAM authentication support.
+Options for SASL/SCRAM authentication support. Not supported in provided Vector
+binaries, you need build Vector with feature [`sasl`](#sasl).
 
 
 <Fields filters={false}>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={[true,false]}
@@ -564,7 +565,7 @@ Enable SASL/SCRAM authentication to the remote.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["SCRAM-SHA-256","SCRAM-SHA-512"]}
@@ -587,7 +588,7 @@ The Kafka SASL/SCRAM mechanisms.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["password"]}
@@ -610,7 +611,7 @@ The Kafka SASL/SCRAM authentication password.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["username"]}

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-24"
+last_modified_on: "2020-07-01"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` source ingests data through Kafka and outputs `log` events."
@@ -309,12 +309,13 @@ The options and their values. Accepts `string` values.
 
 ### sasl
 
-Options for SASL/SCRAM authentication support.
+Options for SASL/SCRAM authentication support. Not supported in provided Vector
+binaries, you need build Vector with feature [`sasl`](#sasl).
 
 
 <Fields filters={false}>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={[true,false]}
@@ -337,7 +338,7 @@ Enable SASL/SCRAM authentication to the remote.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["SCRAM-SHA-256","SCRAM-SHA-512"]}
@@ -360,7 +361,7 @@ The Kafka SASL/SCRAM mechanisms.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["password"]}
@@ -383,7 +384,7 @@ The Kafka SASL/SCRAM authentication password.
 
 </Field>
 <Field
-  common={true}
+  common={false}
   defaultValue={null}
   enumValues={null}
   examples={["username"]}


### PR DESCRIPTION
Revert part of https://github.com/timberio/vector/pull/2915.

`sasl` is problematic right now. Problems with building statically linked, problems with using new not published vendored feature in rdkafka-sys (win32 not supported yet). `sasl` still will be available, but users will need build binaries themselves.

This PR close #2928 and #2929. After landing we need create issue for tracking.