### PR TITLE
enhancement(kafka source): Extract timestamp from event

### DIFF
--- a/.meta/sources/kafka.toml.erb
+++ b/.meta/sources/kafka.toml.erb
@@ -116,5 +116,6 @@ type = "timestamp"
 examples = ["2019-11-01T21:15:47.443232Z"]
 required = true
 description = """\
-The exact time the event was ingested.\
+Timestamp extracted from the event, or, if not present, \
+the exact time the event was ingested.\
 """

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-07-01"
+last_modified_on: "2020-07-05"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` source ingests data through Kafka and outputs `log` events."
@@ -680,7 +680,8 @@ The raw event message, unaltered.
 
 ### timestamp
 
-The exact time the event was ingested.
+Timestamp extracted from the event, or, if not present, the exact time the
+event was ingested.
 
 
 


### PR DESCRIPTION
Closes  #2700 

Extracts timestamp from event in `kafka` source and sets it as timestamp in emitted kafka message from `kafka` sink. Sink will behave like this for all timestamps, not only for those extracted in `kafka` source.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
