### PR TITLE
chore: move topology building into tokio context, take 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,11 +4703,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-executor"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
+checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils 0.7.0",
  "futures 0.1.29",
 ]
 
@@ -5604,6 +5604,7 @@ dependencies = [
  "tokio 0.2.13",
  "tokio-codec",
  "tokio-compat",
+ "tokio-executor",
  "tokio-openssl 0.3.0",
  "tokio-retry",
  "tokio-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ tokio-openssl = "0.3.0"
 tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-compat = { version = "0.1", features = ["rt-full"] }
+# TODO: remove when pulsar is upgraded
+tokio-executor = "0.1.10"
 tokio-util = { version = "0.3.1", features = ["compat"] }
 async-trait = "0.1"
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -415,7 +415,7 @@ fn benchmark_regex(c: &mut Criterion) {
                         field: None,
                         drop_failed: true,
                         ..Default::default()
-                    }.build(TransformContext::new_test(rt.executor())).unwrap();
+                    }.build(TransformContext::new_test()).unwrap();
 
                     let src_lines = http_access_log_lines()
                         .take(num_lines)

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -71,7 +71,8 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -122,7 +123,8 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -173,7 +175,8 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -225,7 +228,8 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -300,7 +304,8 @@ fn benchmark_interconnected(c: &mut Criterion) {
                     let output_lines1 = count_receive(&out_addr1);
                     let output_lines2 = count_receive(&out_addr2);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr1);
                     wait_for_tcp(in_addr2);
 
@@ -371,7 +376,8 @@ fn benchmark_transforms(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -408,7 +414,6 @@ fn benchmark_regex(c: &mut Criterion) {
         Benchmark::new("regex", move |b| {
             b.iter_with_setup(
                 || {
-                    let rt = vector::runtime::Runtime::single_threaded().unwrap();
                     let parser =transforms::regex_parser::RegexParserConfig {
                         // Many captures to stress the regex parser
                         patterns: vec![r#"^(?P<addr>\d+\.\d+\.\d+\.\d+) (?P<user>\S+) (?P<auth>\S+) \[(?P<date>\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ [+-]\d{4})\] "(?P<method>[A-Z]+) (?P<uri>[^"]+) HTTP/\d\.\d" (?P<code>\d+) (?P<size>\d+) "(?P<referrer>[^"]+)" "(?P<browser>[^"]+)""#.into()],
@@ -546,7 +551,8 @@ fn benchmark_complex(c: &mut Criterion) {
                     let output_lines_200 = count_receive(&out_addr_200);
                     let output_lines_404 = count_receive(&out_addr_404);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr1);
                     wait_for_tcp(in_addr2);
 

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -46,7 +46,8 @@ fn benchmark_buffers(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -88,7 +89,8 @@ fn benchmark_buffers(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)
@@ -129,7 +131,8 @@ fn benchmark_buffers(c: &mut Criterion) {
 
                     let output_lines = count_receive(&out_addr);
 
-                    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                    let (topology, _crash) =
+                        rt.block_on_std(topology::start(config, false)).unwrap();
                     wait_for_tcp(in_addr);
 
                     (rt, topology, output_lines)

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -56,7 +56,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
                 );
 
                 let mut rt = runtime::Runtime::new().unwrap();
-                let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
                 let mut options = OpenOptions::new();
                 options.create(true).write(true);

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -49,7 +49,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
 
                 let mut rt = runtime::Runtime::new().unwrap();
 
-                let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
                 wait_for_tcp(in_addr);
 
                 (rt, topology)
@@ -107,7 +107,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
 
                 let mut rt = runtime::Runtime::new().unwrap();
 
-                let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+                let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
                 wait_for_tcp(in_addr);
 
                 (rt, topology)

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -95,7 +95,7 @@ fn field_filter(c: &mut Criterion) {
                         field: "the_field".to_string(),
                         value: "0".to_string(),
                     }
-                    .build(TransformContext::new_test(rt.executor()))
+                    .build(TransformContext::new_test())
                     .unwrap()
                 },
                 |mut transform| {

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -90,7 +90,6 @@ fn field_filter(c: &mut Criterion) {
         Benchmark::new("native", move |b| {
             b.iter_with_setup(
                 || {
-                    let rt = vector::runtime::Runtime::single_threaded().unwrap();
                     transforms::field_filter::FieldFilterConfig {
                         field: "the_field".to_string(),
                         value: "0".to_string(),

--- a/scripts/check-component-features.sh
+++ b/scripts/check-component-features.sh
@@ -25,7 +25,7 @@ cargo check --tests --no-default-features
 
 echo "Checking that all components have corresponding features in Cargo.toml..."
 COMPONENTS="$(cargo run --no-default-features -- list)"
-if (echo "$COMPONENTS" | grep -E -v "^(Sources:|Transforms:|Sinks:|)$" >/dev/null); then
+if (echo "$COMPONENTS" | grep -E -v "(Log level|^(Sources:|Transforms:|Sinks:|)$)" >/dev/null); then
   echo "Some of the components do not have a corresponding feature flag in Cargo.toml:"
   # shellcheck disable=SC2001
   echo "$COMPONENTS" | sed "s/^/    /"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,130 @@
+use crate::{generate, list, unit_test, validate};
+use std::path::PathBuf;
+use structopt::{clap::AppSettings, StructOpt};
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Opts {
+    #[structopt(flatten)]
+    pub root: RootOpts,
+
+    #[structopt(subcommand)]
+    pub sub_command: Option<SubCommand>,
+}
+
+impl Opts {
+    pub fn get_matches() -> Self {
+        let version = crate::get_version();
+        let app = Opts::clap().version(version.as_str()).global_settings(&[
+            AppSettings::ColoredHelp,
+            AppSettings::InferSubcommands,
+            AppSettings::DeriveDisplayOrder,
+        ]);
+        Opts::from_clap(&app.get_matches())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub struct RootOpts {
+    /// Read configuration from one or more files. Wildcard paths are supported.
+    /// If zero files are specified the default config path
+    /// `/etc/vector/vector.toml` will be targeted.
+    #[structopt(name = "config", short, long)]
+    pub config_paths: Vec<PathBuf>,
+
+    /// Exit on startup if any sinks fail healthchecks
+    #[structopt(short, long)]
+    pub require_healthy: bool,
+
+    /// Number of threads to use for processing (default is number of available cores)
+    #[structopt(short, long)]
+    pub threads: Option<usize>,
+
+    /// Enable more detailed internal logging. Repeat to increase level. Overridden by `--quiet`.
+    #[structopt(short, long, parse(from_occurrences))]
+    pub verbose: u8,
+
+    /// Reduce detail of internal logging. Repeat to reduce further. Overrides `--verbose`.
+    #[structopt(short, long, parse(from_occurrences))]
+    pub quiet: u8,
+
+    /// Set the logging format
+    #[structopt(long, default_value = "text", possible_values = &["text", "json"])]
+    pub log_format: LogFormat,
+
+    /// Control when ANSI terminal formatting is used.
+    ///
+    /// By default `vector` will try and detect if `stdout` is a terminal, if it is
+    /// ANSI will be enabled. Otherwise it will be disabled. By providing this flag with
+    /// the `--color always` option will always enable ANSI terminal formatting. `--color never`
+    /// will disable all ANSI terminal formatting. `--color auto` will attempt
+    /// to detect it automatically.
+    #[structopt(long, default_value = "auto", possible_values = &["auto", "always", "never"])]
+    pub color: Color,
+
+    /// Watch for changes in configuration file, and reload accordingly.
+    #[structopt(short, long)]
+    pub watch_config: bool,
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+pub enum SubCommand {
+    /// Validate the target config, then exit.
+    Validate(validate::Opts),
+
+    /// Generate a Vector configuration containing a list of components.
+    Generate(generate::Opts),
+
+    /// List available components, then exit.
+    List(list::Opts),
+
+    /// Run Vector config unit tests, then exit. This command is experimental and therefore subject to change.
+    /// For guidance on how to write unit tests check out: https://vector.dev/docs/setup/guides/unit-testing/
+    Test(unit_test::Opts),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Color {
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+impl std::str::FromStr for Color {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Color::Auto),
+            "always" => Ok(Color::Always),
+            "never" => Ok(Color::Never),
+            s => Err(format!(
+                "{} is not a valid option, expected `auto`, `always` or `never`",
+                s
+            )),
+        }
+    }
+}
+
+impl std::str::FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(LogFormat::Text),
+            "json" => Ok(LogFormat::Json),
+            s => Err(format!(
+                "{} is not a valid option, expected `text` or `json`",
+                s
+            )),
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,26 @@ impl Opts {
         ]);
         Opts::from_clap(&app.get_matches())
     }
+
+    pub fn log_level(&self) -> &'static str {
+        let (quiet_level, verbose_level) = match self.sub_command {
+            Some(SubCommand::Validate(_)) if self.root.verbose == 0 => {
+                (self.root.quiet + 1, self.root.verbose)
+            }
+            Some(SubCommand::Validate(_)) => (self.root.quiet, self.root.verbose - 1),
+            _ => (self.root.quiet, self.root.verbose),
+        };
+        match quiet_level {
+            0 => match verbose_level {
+                0 => "info",
+                1 => "debug",
+                2..=255 => "trace",
+            },
+            1 => "warn",
+            2 => "error",
+            3..=255 => "off",
+        }
+    }
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use crate::{generate, list, unit_test, validate};
 use std::path::PathBuf;
 use structopt::{clap::AppSettings, StructOpt};
+use vector::{generate, list, unit_test, validate};
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
@@ -14,7 +14,7 @@ pub struct Opts {
 
 impl Opts {
     pub fn get_matches() -> Self {
-        let version = crate::get_version();
+        let version = vector::get_version();
         let app = Opts::clap().version(version.as_str()).global_settings(&[
             AppSettings::ColoredHelp,
             AppSettings::InferSubcommands,

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -24,7 +24,7 @@ pub trait Condition: Send + Sync {
 }
 
 #[typetag::serde(tag = "type")]
-pub trait ConditionConfig: std::fmt::Debug {
+pub trait ConditionConfig: std::fmt::Debug + Send + Sync {
     fn build(&self) -> crate::Result<Box<dyn Condition>>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod wasm;
 #[macro_use]
 pub mod internal_events;
 pub mod async_read;
+pub mod cli;
 pub mod hyper;
 #[cfg(feature = "rdkafka")]
 pub mod kafka;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,6 @@ pub mod wasm;
 #[macro_use]
 pub mod internal_events;
 pub mod async_read;
-pub mod cli;
 pub mod hyper;
 #[cfg(feature = "rdkafka")]
 pub mod kafka;

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ fn main() {
 
             let interruption = ctrl_c
                 .select2(to_shutdown)
+                .compat()
                 .await
                 .map_err(|_| ())
                 .expect("Neither stream errors");

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,25 +26,12 @@ use vector::{
 
 fn main() {
     openssl_probe::init_ssl_cert_env_vars();
+
     let root_opts = Opts::get_matches();
+    let level = root_opts.log_level();
+
     let opts = root_opts.root;
     let sub_command = root_opts.sub_command;
-
-    let (quiet_level, verbose_level) = match sub_command {
-        Some(SubCommand::Validate(_)) if opts.verbose == 0 => (opts.quiet + 1, opts.verbose),
-        Some(SubCommand::Validate(_)) => (opts.quiet, opts.verbose - 1),
-        _ => (opts.quiet, opts.verbose),
-    };
-    let level = match quiet_level {
-        0 => match verbose_level {
-            0 => "info",
-            1 => "debug",
-            2..=255 => "trace",
-        },
-        1 => "warn",
-        2 => "error",
-        3..=255 => "off",
-    };
 
     let levels = match std::env::var("LOG").ok() {
         Some(level) => level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@
 #[macro_use]
 extern crate tracing;
 
+mod cli;
+
+use cli::{Color, LogFormat, Opts, SubCommand};
 use futures::compat::Future01CompatExt;
 use futures01::{future, Future, Stream};
 use std::{
@@ -21,7 +24,6 @@ use std::{
 use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use vector::{
-    cli::{Color, LogFormat, Opts, SubCommand},
     config_paths, event, generate, list, metrics, runtime, topology, trace, unit_test, validate,
 };
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -886,7 +886,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let timestamp = chrono::Utc::now();
 
@@ -937,7 +937,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let timestamp = chrono::Utc::now() - chrono::Duration::days(1);
 
@@ -1005,7 +1005,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let now = chrono::Utc::now();
 
@@ -1079,7 +1079,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let timestamp = chrono::Utc::now();
 
@@ -1134,7 +1134,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let timestamp = chrono::Utc::now();
 
@@ -1186,7 +1186,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let (sink, _) = config.build(SinkContext::new_test(rt.executor())).unwrap();
+        let (sink, _) = config.build(SinkContext::new_test()).unwrap();
 
         let timestamp = chrono::Utc::now();
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -451,7 +451,7 @@ mod integration_tests {
     #[test]
     fn cloudwatch_metrics_put_data() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let sink = CloudWatchMetricsSvc::new(config(), cx).unwrap();
 
         let mut events = Vec::new();

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -316,7 +316,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let sink = KinesisFirehoseService::new(config, cx).unwrap();
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -376,7 +376,7 @@ mod integration_tests {
             assume_role: None,
         };
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let sink = KinesisService::new(config, cx).unwrap();
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -558,7 +558,7 @@ mod integration_tests {
     #[test]
     fn s3_insert_message_into() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = config(1000000).await;
@@ -586,7 +586,7 @@ mod integration_tests {
     #[test]
     fn s3_rotate_files_after_the_buffer_size_is_reached() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = S3SinkConfig {
@@ -638,7 +638,7 @@ mod integration_tests {
     #[test]
     fn s3_waits_for_full_batch_or_timeout_before_sending() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let config = rt.block_on_std(async {
             S3SinkConfig {
@@ -707,7 +707,7 @@ mod integration_tests {
     #[test]
     fn s3_gzip() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async {
             let config = S3SinkConfig {

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -253,7 +253,6 @@ mod integration_tests {
         crate::test_util::trace_init();
 
         let mut rt = runtime();
-        let executor = rt.executor();
 
         rt.block_on_std(async move {
             let table = gen_table();

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -279,7 +279,7 @@ mod integration_tests {
                 .create_table(&table, "host String, timestamp String, message String")
                 .await;
 
-            let (sink, _hc) = config.build(SinkContext::new_test(executor)).unwrap();
+            let (sink, _hc) = config.build(SinkContext::new_test()).unwrap();
 
             let mut input_event = Event::from("raw log line");
             input_event.as_mut_log().insert("host", "example.com");
@@ -299,7 +299,6 @@ mod integration_tests {
         crate::test_util::trace_init();
 
         let mut rt = runtime();
-        let executor = rt.executor();
 
         rt.block_on_std(async move {
             let table = gen_table();
@@ -331,7 +330,7 @@ mod integration_tests {
                 )
                 .await;
 
-            let (sink, _hc) = config.build(SinkContext::new_test(executor)).unwrap();
+            let (sink, _hc) = config.build(SinkContext::new_test()).unwrap();
 
             let mut input_event = Event::from("raw log line");
             input_event.as_mut_log().insert("host", "example.com");
@@ -365,7 +364,6 @@ mod integration_tests {
         crate::test_util::trace_init();
 
         let mut rt = runtime();
-        let executor = rt.executor();
 
         rt.block_on_std(async move {
             let table = gen_table();
@@ -394,7 +392,7 @@ timestamp_format = "unix""#,
                 )
                 .await;
 
-            let (sink, _hc) = config.build(SinkContext::new_test(executor)).unwrap();
+            let (sink, _hc) = config.build(SinkContext::new_test()).unwrap();
 
             let mut input_event = Event::from("raw log line");
             input_event.as_mut_log().insert("host", "example.com");
@@ -428,7 +426,6 @@ timestamp_format = "unix""#,
         crate::test_util::trace_init();
 
         let mut rt = runtime();
-        let executor = rt.executor();
 
         rt.block_on_std(async move {
             let table = gen_table();
@@ -452,7 +449,7 @@ timestamp_format = "unix""#,
                 .create_table(&table, "host String, timestamp String")
                 .await;
 
-            let (sink, _hc) = config.build(SinkContext::new_test(executor)).unwrap();
+            let (sink, _hc) = config.build(SinkContext::new_test()).unwrap();
 
             let mut input_event = Event::from("raw log line");
             input_event.as_mut_log().insert("host", "example.com");

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -49,7 +49,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "console")]
 impl SinkConfig for ConsoleSinkConfig {
-    fn build(&self, mut cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let encoding = self.encoding.clone();
 
         let output: Box<dyn io::AsyncWrite + Send + Sync + Unpin> = match self.target {
@@ -58,7 +58,7 @@ impl SinkConfig for ConsoleSinkConfig {
         };
 
         let sink = WriterSink { output, encoding };
-        let sink = streaming_sink::compat::adapt_to_topology(&mut cx, sink);
+        let sink = streaming_sink::compat::adapt_to_topology(sink);
         let sink = StreamSink::new(sink, cx.acker());
 
         Ok((Box::new(sink), Box::new(future::ok(()))))

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -620,7 +620,7 @@ mod integration_tests {
         let common = ElasticSearchCommon::parse_config(&config).expect("Config error");
         let base_url = common.base_url.clone();
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let (sink, _hc) = config.build(cx.clone()).unwrap();
 
         let mut input_event = Event::from("raw log line");
@@ -727,7 +727,7 @@ mod integration_tests {
         let common = ElasticSearchCommon::parse_config(&config).expect("Config error");
         let base_url = common.base_url.clone();
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let (sink, healthcheck) = config.build(cx.clone()).expect("Building config failed");
 
         rt.block_on_std(async move {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -55,9 +55,9 @@ impl Default for Encoding {
 
 #[typetag::serde(name = "file")]
 impl SinkConfig for FileSinkConfig {
-    fn build(&self, mut cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = FileSink::new(&self);
-        let sink = streaming_sink::compat::adapt_to_topology(&mut cx, sink);
+        let sink = streaming_sink::compat::adapt_to_topology(sink);
         let sink = StreamSink::new(sink, cx.acker());
         Ok((Box::new(sink), Box::new(futures01::future::ok(()))))
     }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -196,7 +196,6 @@ async fn healthcheck(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::runtime;
 
     #[test]
     fn fails_missing_creds() {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -207,10 +207,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        if config
-            .build(SinkContext::new_test(runtime().executor()))
-            .is_ok()
-        {
+        if config.build(SinkContext::new_test()).is_ok() {
             panic!("config.build failed to error");
         }
     }
@@ -245,7 +242,7 @@ mod integration_tests {
         rt: &Runtime,
         topic: &str,
     ) -> (crate::sinks::RouterSink, crate::sinks::Healthcheck) {
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         config(topic).build(cx).expect("Building sink failed")
     }
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -216,10 +216,7 @@ mod tests {
 #[cfg(feature = "gcp-pubsub-integration-tests")]
 mod integration_tests {
     use super::*;
-    use crate::{
-        runtime::Runtime,
-        test_util::{random_events_with_stream, random_string, runtime},
-    };
+    use crate::test_util::{random_events_with_stream, random_string, runtime};
     use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use reqwest::{Client, Method, Response};
@@ -237,10 +234,7 @@ mod integration_tests {
         }
     }
 
-    fn config_build(
-        rt: &Runtime,
-        topic: &str,
-    ) -> (crate::sinks::RouterSink, crate::sinks::Healthcheck) {
+    fn config_build(topic: &str) -> (crate::sinks::RouterSink, crate::sinks::Healthcheck) {
         let cx = SinkContext::new_test();
         config(topic).build(cx).expect("Building sink failed")
     }
@@ -251,7 +245,7 @@ mod integration_tests {
 
         let mut rt = runtime();
         let (topic, subscription) = rt.block_on_std(create_topic_subscription());
-        let (sink, healthcheck) = config_build(&rt, &topic);
+        let (sink, healthcheck) = config_build(&topic);
 
         rt.block_on_std(async move {
             healthcheck.compat().await.expect("Health check failed");
@@ -283,7 +277,7 @@ mod integration_tests {
         let mut rt = runtime();
         let (topic, _subscription) = rt.block_on_std(create_topic_subscription());
         let topic = format!("BAD{}", topic);
-        let (_sink, healthcheck) = config_build(&rt, &topic);
+        let (_sink, healthcheck) = config_build(&topic);
         rt.block_on_std(async move {
             healthcheck
                 .compat()

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -422,10 +422,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        if config
-            .build(SinkContext::new_test(runtime().executor()))
-            .is_ok()
-        {
+        if config.build(SinkContext::new_test()).is_ok() {
             panic!("config.build failed to error");
         }
     }

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -385,7 +385,6 @@ mod tests {
         "#;
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        let rt = runtime();
         let cx = SinkContext::new_test();
 
         let _ = config.build(cx).unwrap();

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -386,7 +386,7 @@ mod tests {
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         let rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let _ = config.build(cx).unwrap();
     }
@@ -411,7 +411,7 @@ mod tests {
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
         let (rx, trigger, server) = build_test_server(in_addr, &mut rt);
@@ -474,7 +474,7 @@ mod tests {
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
         let (rx, trigger, server) = build_test_server(in_addr, &mut rt);
@@ -534,7 +534,7 @@ mod tests {
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
         let (rx, trigger, server) = build_test_server(in_addr, &mut rt);

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -609,7 +609,7 @@ mod integration_tests {
 
         let ns = format!("ns-{}", Utc::now().timestamp_nanos());
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = InfluxDBLogsConfig {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -763,7 +763,7 @@ mod integration_tests {
         let mut rt = runtime();
         onboarding_v2();
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         let config = InfluxDBConfig {
             namespace: "ns".to_string(),

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -749,7 +749,7 @@ mod integration_tests {
         let mut rt = runtime();
         onboarding_v2();
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let endpoint = "http://localhost:9999".to_string();
         let influxdb1_settings = None;
         let influxdb2_settings = Some(InfluxDB2Settings {
@@ -773,7 +773,7 @@ mod integration_tests {
         let mut rt = runtime();
         onboarding_v2();
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let endpoint = "http://not_exist:9999".to_string();
         let influxdb1_settings = None;
         let influxdb2_settings = Some(InfluxDB2Settings {
@@ -794,7 +794,7 @@ mod integration_tests {
     #[test]
     fn influxdb1_healthchecks_ok() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let endpoint = "http://localhost:8086".to_string();
         let influxdb1_settings = Some(InfluxDB1Settings {
             database: DATABASE.to_string(),
@@ -818,7 +818,7 @@ mod integration_tests {
     #[test]
     fn influxdb1_healthchecks_fail() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let endpoint = "http://not_exist:8086".to_string();
         let influxdb1_settings = Some(InfluxDB1Settings {
             database: DATABASE.to_string(),

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -274,9 +274,7 @@ mod tests {
 
         let mut rt = runtime();
 
-        let (sink, _healthcheck) = http_config
-            .build(SinkContext::new_test(rt.executor()))
-            .unwrap();
+        let (sink, _healthcheck) = http_config.build(SinkContext::new_test()).unwrap();
         let (rx, trigger, server) = build_test_server(in_addr, &mut rt);
 
         let input_lines = (0..100).map(|i| format!("msg {}", i)).collect::<Vec<_>>();

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -228,7 +228,7 @@ mod integration_tests {
             auth: None,
         };
         let (acker, ack_counter) = Acker::new_for_testing();
-        let rt = runtime();
+        let mut rt = runtime();
 
         let sink = rt.block_on_std(async move { PulsarSink::new(cnf, acker).unwrap() });
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -230,7 +230,7 @@ mod integration_tests {
         let (acker, ack_counter) = Acker::new_for_testing();
         let rt = runtime();
 
-        let sink = PulsarSink::new(cnf, acker).unwrap();
+        let sink = rt.block_on_std(async move { PulsarSink::new(cnf, acker).unwrap() });
 
         let num_events = 1_000;
         let (_input, events) = random_lines_with_stream(100, num_events);

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -109,7 +109,7 @@ mod test {
             }),
         };
         let mut rt = runtime();
-        let context = SinkContext::new_test(rt.executor());
+        let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
 
         let event = Event::from("raw log line");
@@ -141,7 +141,7 @@ mod test {
             }),
         };
         let mut rt = runtime();
-        let context = SinkContext::new_test(rt.executor());
+        let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
 
         let receiver = receive(&addr);
@@ -202,7 +202,7 @@ mod test {
             }),
         };
         let mut rt = runtime();
-        let context = SinkContext::new_test(rt.executor());
+        let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
 
         let msg_counter = Arc::new(AtomicUsize::new(0));

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -405,7 +405,7 @@ mod integration_tests {
     #[test]
     fn splunk_insert_message() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = config(Encoding::Text, vec![]).await;
@@ -425,7 +425,7 @@ mod integration_tests {
     #[test]
     fn splunk_insert_index() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let mut config = config(Encoding::Text, vec![]).await;
@@ -445,7 +445,7 @@ mod integration_tests {
     #[test]
     fn splunk_insert_many() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = config(Encoding::Text, vec![]).await;
@@ -478,7 +478,7 @@ mod integration_tests {
     #[test]
     fn splunk_custom_fields() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let indexed_fields = vec![Atom::from("asdf")];
@@ -501,7 +501,7 @@ mod integration_tests {
     #[test]
     fn splunk_hostname() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let indexed_fields = vec![Atom::from("asdf")];
@@ -527,7 +527,7 @@ mod integration_tests {
     #[test]
     fn splunk_sourcetype() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let indexed_fields = vec![Atom::from("asdf")];
@@ -555,7 +555,7 @@ mod integration_tests {
     #[test]
     fn splunk_configure_hostname() {
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
 
         rt.block_on_std(async move {
             let config = super::HecSinkConfig {

--- a/src/sinks/streaming_sink/compat.rs
+++ b/src/sinks/streaming_sink/compat.rs
@@ -1,6 +1,5 @@
 use super::StreamingSink;
 use crate::sinks;
-use crate::topology::config::SinkContext;
 use crate::Event;
 use futures::channel::mpsc;
 use futures::compat::CompatSink;
@@ -47,13 +46,10 @@ pub type OldSink = Box<dyn Sink<SinkItem = Event, SinkError = ()> + 'static + Se
 /// Among other things, this adapter maintains backpressure through the sink, as
 /// it'll only go as fast as `streaming_sink` is able to poll items, without any
 /// buffering.
-pub fn adapt_to_topology(
-    cx: &mut SinkContext,
-    mut streaming_sink: impl StreamingSink + 'static,
-) -> sinks::RouterSink {
+pub fn adapt_to_topology(mut streaming_sink: impl StreamingSink + 'static) -> sinks::RouterSink {
     let (stream, sink) = sink_interface_compat();
 
-    cx.executor().spawn_std(async move {
+    tokio::spawn(async move {
         streaming_sink
             .run(stream)
             .await

--- a/src/sinks/util/test.rs
+++ b/src/sinks/util/test.rs
@@ -18,7 +18,7 @@ where
 {
     let sink_config: T = toml::from_str(config)?;
     let rt = runtime();
-    let cx = SinkContext::new_test(rt.executor());
+    let cx = SinkContext::new_test();
 
     Ok((sink_config, cx, rt))
 }

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -227,7 +227,7 @@ mod tests {
         // Set up Sink
         let config = UnixSinkConfig::new(out_path.clone(), Encoding::Text.into());
         let mut rt = runtime();
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(cx).unwrap();
 
         // Set up server to receive events from the Sink.

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -188,7 +188,7 @@ mod test {
             },
         );
 
-        let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+        let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
         thread::sleep(Duration::from_secs(1));
 
         let client = Client::new();

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -732,7 +732,7 @@ fn event_error(text: &str, code: u16, event: usize) -> Response {
 #[cfg(test)]
 mod tests {
     use super::{parse_timestamp, SplunkConfig};
-    use crate::runtime::{Runtime, TaskExecutor};
+    use crate::runtime::Runtime;
     use crate::test_util::{self, collect_n, runtime};
     use crate::{
         event::{self, Event},
@@ -783,7 +783,6 @@ mod tests {
         address: SocketAddr,
         encoding: impl Into<EncodingConfigWithDefault<Encoding>>,
         compression: Compression,
-        exec: TaskExecutor,
     ) -> (RouterSink, Healthcheck) {
         HecSinkConfig {
             host: format!("http://{}", address),
@@ -802,7 +801,7 @@ mod tests {
     ) -> (Runtime, RouterSink, mpsc::Receiver<Event>) {
         let mut rt = runtime();
         let (source, address) = source(&mut rt);
-        let (sink, health) = sink(address, encoding, compression, rt.executor());
+        let (sink, health) = sink(address, encoding, compression);
         assert!(rt.block_on(health).is_ok());
         (rt, sink, source)
     }
@@ -1056,7 +1055,7 @@ mod tests {
         let message = "no_autorization";
         let mut rt = runtime();
         let (source, address) = source_with(&mut rt, None);
-        let (sink, health) = sink(address, Encoding::Text, Compression::Gzip, rt.executor());
+        let (sink, health) = sink(address, Encoding::Text, Compression::Gzip);
         assert!(rt.block_on(health).is_ok());
 
         let event = channel_n(vec![message], sink, source, &mut rt).remove(0);

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -792,7 +792,7 @@ mod tests {
             compression,
             ..HecSinkConfig::default()
         }
-        .build(SinkContext::new_test(exec))
+        .build(SinkContext::new_test())
         .unwrap()
     }
 

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -117,7 +117,7 @@ mod test {
 
         let mut rt = runtime();
 
-        let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+        let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
         let bind_addr = next_addr();
         let socket = std::net::UdpSocket::bind(&bind_addr).unwrap();

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -123,7 +123,7 @@ mod test {
         rt.spawn(server);
         wait_for_tcp(addr);
 
-        let cx = SinkContext::new_test(rt.executor());
+        let cx = SinkContext::new_test();
         let (sink, _) = sink.build(cx).unwrap();
 
         let events = vec![

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -18,14 +18,9 @@ pub use self::config::SinkContext;
 use crate::topology::{builder::Pieces, task::Task};
 
 use crate::buffers;
-use crate::runtime;
 use crate::shutdown::SourceShutdownCoordinator;
 use futures::compat::Future01CompatExt;
-use futures01::{
-    future,
-    sync::{mpsc, oneshot},
-    Future, Stream,
-};
+use futures01::{future, sync::mpsc, Future, Stream};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
@@ -33,32 +28,36 @@ use std::time::{Duration, Instant};
 use tokio01::timer;
 use tracing_futures::Instrument;
 
+// TODO: Result is only for compat, remove when not needed
+type TaskHandle = tokio::task::JoinHandle<Result<(), ()>>;
+
 #[allow(dead_code)]
 pub struct RunningTopology {
     inputs: HashMap<String, buffers::BufferInputCloner>,
     outputs: HashMap<String, fanout::ControlChannel>,
-    source_tasks: HashMap<String, oneshot::SpawnHandle<(), ()>>,
-    tasks: HashMap<String, oneshot::SpawnHandle<(), ()>>,
+    source_tasks: HashMap<String, TaskHandle>,
+    tasks: HashMap<String, TaskHandle>,
     shutdown_coordinator: SourceShutdownCoordinator,
     config: Config,
     abort_tx: mpsc::UnboundedSender<()>,
 }
 
-pub fn start(
+pub async fn start(
     config: Config,
-    rt: &mut runtime::Runtime,
     require_healthy: bool,
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     let diff = ConfigDiff::initial(&config);
-    validate(&config, &diff, rt.executor())
-        .and_then(|pieces| start_validated(config, diff, pieces, rt, require_healthy))
+    if let Some(pieces) = validate(&config, &diff) {
+        start_validated(config, diff, pieces, require_healthy).await
+    } else {
+        None
+    }
 }
 
-pub fn start_validated(
+pub async fn start_validated(
     config: Config,
     diff: ConfigDiff,
     mut pieces: Pieces,
-    rt: &mut runtime::Runtime,
     require_healthy: bool,
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     let (abort_tx, abort_rx) = mpsc::unbounded();
@@ -73,18 +72,21 @@ pub fn start_validated(
         abort_tx,
     };
 
-    if !running_topology.run_healthchecks(&diff, &mut pieces, rt, require_healthy) {
+    if !running_topology
+        .run_healthchecks(&diff, &mut pieces, require_healthy)
+        .await
+    {
         return None;
     }
     running_topology.connect_diff(&diff, &mut pieces);
-    running_topology.spawn_diff(&diff, pieces, rt);
+    running_topology.spawn_diff(&diff, pieces);
     running_topology.config = config;
 
     Some((running_topology, abort_rx))
 }
 
-pub fn validate(config: &Config, diff: &ConfigDiff, exec: runtime::TaskExecutor) -> Option<Pieces> {
-    match builder::check_build(config, diff, exec) {
+pub fn validate(config: &Config, diff: &ConfigDiff) -> Option<Pieces> {
+    match builder::check_build(config, diff) {
         Err(errors) => {
             for error in errors {
                 error!("Configuration error: {}", error);
@@ -137,7 +139,8 @@ impl RunningTopology {
         // We need to give some time to the sources to gracefully shutdown, so we will merge
         // them with other tasks.
         for (name, task) in self.tasks.into_iter().chain(self.source_tasks.into_iter()) {
-            let task = task
+            let task = futures::compat::Compat::new(task)
+                .map(|_result| ())
                 .or_else(|_| future::ok(())) // Consider an errored task to be shutdown
                 .shared();
 
@@ -223,10 +226,9 @@ impl RunningTopology {
     }
 
     /// On Error, topology is in invalid state.
-    pub fn reload_config_and_respawn(
+    pub async fn reload_config_and_respawn(
         &mut self,
         new_config: Config,
-        rt: &mut runtime::Runtime,
         require_healthy: bool,
     ) -> Result<bool, ()> {
         if self.config.global.data_dir != new_config.global.data_dir {
@@ -244,13 +246,16 @@ impl RunningTopology {
         let diff = ConfigDiff::new(&self.config, &new_config);
 
         // Checks passed so let's shutdown the difference.
-        self.shutdown_diff(&diff, rt);
+        self.shutdown_diff(&diff).await;
 
         // Now let's actually build the new pieces.
-        if let Some(mut new_pieces) = validate(&new_config, &diff, rt.executor()) {
-            if self.run_healthchecks(&diff, &mut new_pieces, rt, require_healthy) {
+        if let Some(mut new_pieces) = validate(&new_config, &diff) {
+            if self
+                .run_healthchecks(&diff, &mut new_pieces, require_healthy)
+                .await
+            {
                 self.connect_diff(&diff, &mut new_pieces);
-                self.spawn_diff(&diff, new_pieces, rt);
+                self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
                 // We have succesfully changed to new config.
                 return Ok(true);
@@ -260,10 +265,13 @@ impl RunningTopology {
         // We need to rebuild the removed.
         info!("Rebuilding old configuration.");
         let diff = diff.flip();
-        if let Some(mut new_pieces) = validate(&self.config, &diff, rt.executor()) {
-            if self.run_healthchecks(&diff, &mut new_pieces, rt, require_healthy) {
+        if let Some(mut new_pieces) = validate(&self.config, &diff) {
+            if self
+                .run_healthchecks(&diff, &mut new_pieces, require_healthy)
+                .await
+            {
                 self.connect_diff(&diff, &mut new_pieces);
-                self.spawn_diff(&diff, new_pieces, rt);
+                self.spawn_diff(&diff, new_pieces);
                 // We have succesfully returned to old config.
                 return Ok(false);
             }
@@ -275,11 +283,10 @@ impl RunningTopology {
         Err(())
     }
 
-    fn run_healthchecks(
+    async fn run_healthchecks(
         &mut self,
         diff: &ConfigDiff,
         pieces: &mut Pieces,
-        rt: &mut runtime::Runtime,
         require_healthy: bool,
     ) -> bool {
         let healthchecks = take_healthchecks(diff, pieces)
@@ -289,9 +296,8 @@ impl RunningTopology {
 
         info!("Running healthchecks.");
         if require_healthy {
-            let jh = rt.spawn_handle_std(healthchecks.compat());
-            let success = rt
-                .block_on_std(jh)
+            let success = tokio::spawn(healthchecks.compat())
+                .await
                 .expect("Task panicked or runtime shutdown unexpectedly");
 
             if success.is_ok() {
@@ -302,13 +308,13 @@ impl RunningTopology {
                 false
             }
         } else {
-            rt.spawn(healthchecks);
+            tokio::spawn(healthchecks.compat());
             true
         }
     }
 
     /// Shutdowns removed and replaced pieces of topology.
-    fn shutdown_diff(&mut self, diff: &ConfigDiff, rt: &mut runtime::Runtime) {
+    async fn shutdown_diff(&mut self, diff: &ConfigDiff) {
         // Sources
         let timeout = Duration::from_secs(30); //sec
 
@@ -328,7 +334,8 @@ impl RunningTopology {
         for name in &diff.sources.to_remove {
             info!("Removing source {:?}", name);
 
-            self.tasks.remove(name).unwrap().forget();
+            let previous = self.tasks.remove(name).unwrap();
+            drop(previous); // detach and forget
 
             self.remove_outputs(name);
             source_shutdown_complete_futures
@@ -350,22 +357,29 @@ impl RunningTopology {
             );
         }
 
-        rt.block_on(future::join_all(source_shutdown_complete_futures))
+        future::join_all(source_shutdown_complete_futures)
+            .compat()
+            .await
             .unwrap();
 
         // Second pass now that all sources have shut down for final cleanup.
         for name in &diff.sources.to_remove {
-            self.source_tasks.remove(name).wait().unwrap();
+            if let Some(task) = self.source_tasks.remove(name) {
+                task.await.unwrap().unwrap();
+            }
         }
         for name in &diff.sources.to_change {
-            self.source_tasks.remove(name).wait().unwrap();
+            if let Some(task) = self.source_tasks.remove(name) {
+                task.await.unwrap().unwrap();
+            }
         }
 
         // Transforms
         for name in &diff.transforms.to_remove {
             info!("Removing transform {:?}", name);
 
-            self.tasks.remove(name).unwrap().forget();
+            let previous = self.tasks.remove(name).unwrap();
+            drop(previous); // detach and forget
 
             self.remove_inputs(&name);
             self.remove_outputs(&name);
@@ -375,7 +389,8 @@ impl RunningTopology {
         for name in &diff.sinks.to_remove {
             info!("Removing sink {:?}", name);
 
-            self.tasks.remove(name).unwrap().forget();
+            let previous = self.tasks.remove(name).unwrap();
+            drop(previous); // detach and forget
 
             self.remove_inputs(&name);
         }
@@ -414,83 +429,68 @@ impl RunningTopology {
     }
 
     /// Starts new and changed pieces of topology.
-    fn spawn_diff(&mut self, diff: &ConfigDiff, mut new_pieces: Pieces, rt: &mut runtime::Runtime) {
+    fn spawn_diff(&mut self, diff: &ConfigDiff, mut new_pieces: Pieces) {
         // Sources
         for name in &diff.sources.to_change {
             info!("Rebuilding source {:?}", name);
-            self.spawn_source(name, &mut new_pieces, rt);
+            self.spawn_source(name, &mut new_pieces);
         }
 
         for name in &diff.sources.to_add {
             info!("Starting source {:?}", name);
-            self.spawn_source(&name, &mut new_pieces, rt);
+            self.spawn_source(&name, &mut new_pieces);
         }
 
         // Transforms
         for name in &diff.transforms.to_change {
             info!("Rebuilding transform {:?}", name);
-            self.spawn_transform(&name, &mut new_pieces, rt);
+            self.spawn_transform(&name, &mut new_pieces);
         }
 
         for name in &diff.transforms.to_add {
             info!("Starting transform {:?}", name);
-            self.spawn_transform(&name, &mut new_pieces, rt);
+            self.spawn_transform(&name, &mut new_pieces);
         }
 
         // Sinks
         for name in &diff.sinks.to_change {
             info!("Rebuilding sink {:?}", name);
-            self.spawn_sink(&name, &mut new_pieces, rt);
+            self.spawn_sink(&name, &mut new_pieces);
         }
 
         for name in &diff.sinks.to_add {
             info!("Starting sink {:?}", name);
-            self.spawn_sink(&name, &mut new_pieces, rt);
+            self.spawn_sink(&name, &mut new_pieces);
         }
     }
 
-    fn spawn_sink(
-        &mut self,
-        name: &str,
-        new_pieces: &mut builder::Pieces,
-        rt: &mut runtime::Runtime,
-    ) {
+    fn spawn_sink(&mut self, name: &str, new_pieces: &mut builder::Pieces) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("sink", name = %task.name(), r#type = %task.typetag());
         let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
-        let spawned = oneshot::spawn(task, &rt.executor());
+        let spawned = tokio::spawn(task.compat());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
-            previous.forget();
+            drop(previous); // detach and forget
         }
     }
 
-    fn spawn_transform(
-        &mut self,
-        name: &str,
-        new_pieces: &mut builder::Pieces,
-        rt: &mut runtime::Runtime,
-    ) {
+    fn spawn_transform(&mut self, name: &str, new_pieces: &mut builder::Pieces) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("transform", name = %task.name(), r#type = %task.typetag());
         let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
-        let spawned = oneshot::spawn(task, &rt.executor());
+        let spawned = tokio::spawn(task.compat());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
-            previous.forget();
+            drop(previous); // detach and forget
         }
     }
 
-    fn spawn_source(
-        &mut self,
-        name: &str,
-        new_pieces: &mut builder::Pieces,
-        rt: &mut runtime::Runtime,
-    ) {
+    fn spawn_source(&mut self, name: &str, new_pieces: &mut builder::Pieces) {
         let task = new_pieces.tasks.remove(name).unwrap();
         let span = info_span!("source", name = %task.name(), r#type = %task.typetag());
         let task = handle_errors(task, self.abort_tx.clone()).instrument(span.clone());
-        let spawned = oneshot::spawn(task, &rt.executor());
+        let spawned = tokio::spawn(task.compat());
         if let Some(previous) = self.tasks.insert(name.to_string(), spawned) {
-            previous.forget();
+            drop(previous); // detach and forget
         }
 
         self.shutdown_coordinator
@@ -498,10 +498,8 @@ impl RunningTopology {
 
         let source_task = new_pieces.source_tasks.remove(name).unwrap();
         let source_task = handle_errors(source_task, self.abort_tx.clone()).instrument(span);
-        self.source_tasks.insert(
-            name.to_string(),
-            oneshot::spawn(source_task, &rt.executor()),
-        );
+        self.source_tasks
+            .insert(name.to_string(), tokio::spawn(source_task.compat()));
     }
 
     fn remove_outputs(&mut self, name: &str) {
@@ -745,7 +743,9 @@ mod tests {
 
         new_config.global.data_dir = Some(Path::new("/qwerty").to_path_buf());
 
-        let _ = topology.reload_config_and_respawn(new_config, &mut rt, false);
+        let _ = topology
+            .reload_config_and_respawn(new_config, &mut rt, false)
+            .unwrap();
 
         assert_eq!(
             topology.config.global.data_dir,

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -1,7 +1,6 @@
 use crate::{
     conditions::{Condition, ConditionConfig},
     event::{Event, Value},
-    runtime::Runtime,
     topology::config::{
         TestCondition, TestDefinition, TestInput, TestInputValue, TransformContext,
     },
@@ -315,7 +314,6 @@ fn build_unit_test(
     expansions: &IndexMap<String, Vec<String>>,
     config: &super::Config,
 ) -> Result<UnitTest, Vec<String>> {
-    let rt = Runtime::single_threaded().unwrap();
     let mut errors = vec![];
 
     let inputs = match build_inputs(&definition, &expansions) {
@@ -381,10 +379,7 @@ fn build_unit_test(
     let mut transforms: IndexMap<String, UnitTestTransform> = IndexMap::new();
     for (name, transform_config) in &config.transforms {
         if let Some(outputs) = transform_outputs.remove(name) {
-            match transform_config
-                .inner
-                .build(TransformContext::new_test(rt.executor()))
-            {
+            match transform_config.inner.build(TransformContext::new_test()) {
                 Ok(transform) => {
                     transforms.insert(
                         name.clone(),

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -513,9 +513,7 @@ mod integration_tests {
             host: Some(HOST.clone()),
             ..Default::default()
         };
-        let mut transform = config
-            .build(TransformContext::new_test(rt.executor()))
-            .unwrap();
+        let mut transform = config.build(TransformContext::new_test()).unwrap();
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -563,9 +561,7 @@ mod integration_tests {
             fields: Some(vec!["public-ipv4".into(), "region".into()]),
             ..Default::default()
         };
-        let mut transform = config
-            .build(TransformContext::new_test(rt.executor()))
-            .unwrap();
+        let mut transform = config.build(TransformContext::new_test()).unwrap();
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -595,9 +591,7 @@ mod integration_tests {
             namespace: Some("ec2.metadata".into()),
             ..Default::default()
         };
-        let mut transform = config
-            .build(TransformContext::new_test(rt.executor()))
-            .unwrap();
+        let mut transform = config.build(TransformContext::new_test()).unwrap();
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -622,9 +616,7 @@ mod integration_tests {
             namespace: Some("".into()),
             ..Default::default()
         };
-        let mut transform = config
-            .build(TransformContext::new_test(rt.executor()))
-            .unwrap();
+        let mut transform = config.build(TransformContext::new_test()).unwrap();
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -507,7 +507,7 @@ mod integration_tests {
     #[test]
     fn enrich() {
         crate::test_util::trace_init();
-        let rt = runtime();
+        let mut rt = runtime();
 
         let config = Ec2Metadata {
             host: Some(HOST.clone()),
@@ -555,7 +555,7 @@ mod integration_tests {
 
     #[test]
     fn fields() {
-        let rt = runtime();
+        let mut rt = runtime();
 
         let config = Ec2Metadata {
             host: Some(HOST.clone()),
@@ -586,7 +586,7 @@ mod integration_tests {
 
     #[test]
     fn namespace() {
-        let rt = runtime();
+        let mut rt = runtime();
 
         let config = Ec2Metadata {
             host: Some(HOST.clone()),

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -147,7 +147,7 @@ impl TransformConfig for Ec2Metadata {
 
         let http_client = HttpClient::new(cx.resolver(), None)?;
 
-        cx.executor().spawn_std(
+        tokio::spawn(
             async move {
                 let mut client =
                     MetadataClient::new(http_client, host, keys, write, refresh_interval, fields);

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -619,7 +619,8 @@ mod integration_tests {
             namespace: Some("".into()),
             ..Default::default()
         };
-        let mut transform = config.build(TransformContext::new_test()).unwrap();
+        let mut transform =
+            rt.block_on_std(async move { config.build(TransformContext::new_test()).unwrap() });
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -513,7 +513,8 @@ mod integration_tests {
             host: Some(HOST.clone()),
             ..Default::default()
         };
-        let mut transform = config.build(TransformContext::new_test()).unwrap();
+        let mut transform =
+            rt.block_on_std(async move { config.build(TransformContext::new_test()).unwrap() });
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -561,7 +562,8 @@ mod integration_tests {
             fields: Some(vec!["public-ipv4".into(), "region".into()]),
             ..Default::default()
         };
-        let mut transform = config.build(TransformContext::new_test()).unwrap();
+        let mut transform =
+            rt.block_on_std(async move { config.build(TransformContext::new_test()).unwrap() });
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -591,7 +593,8 @@ mod integration_tests {
             namespace: Some("ec2.metadata".into()),
             ..Default::default()
         };
-        let mut transform = config.build(TransformContext::new_test()).unwrap();
+        let mut transform =
+            rt.block_on_std(async move { config.build(TransformContext::new_test()).unwrap() });
 
         // We need to sleep to let the background task fetch the data.
         std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -131,7 +131,7 @@ mod tests {
             extra
         ))
         .unwrap()
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
         coercer.transform(event).unwrap().into_log()
     }

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -103,14 +103,12 @@ mod tests {
     use super::CoercerConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
-        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
     use pretty_assertions::assert_eq;
 
     fn parse_it(extra: &str) -> LogEvent {
-        let rt = runtime();
         let mut event = Event::from("dummy message");
         for &(key, value) in &[
             ("number", "1234"),

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -156,7 +156,7 @@ mod tests {
             drop_field,
             types: types.iter().map(|&(k, v)| (k.into(), v.into())).collect(),
         }
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
         parser.transform(event).unwrap().into_log()
     }

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -134,7 +134,6 @@ mod tests {
     use crate::event::LogEvent;
     use crate::{
         event,
-        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -148,7 +147,6 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = runtime();
         let event = Event::from(event);
         let mut parser = GrokParserConfig {
             pattern: pattern.into(),

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -111,7 +111,6 @@ mod tests {
     use super::LogfmtConfig;
     use crate::{
         event::{LogEvent, Value},
-        test_util,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -119,7 +118,6 @@ mod tests {
     fn parse_log(text: &str, drop_field: bool, types: &[(&str, &str)]) -> LogEvent {
         let event = Event::from(text);
 
-        let rt = test_util::runtime();
         let mut parser = LogfmtConfig {
             field: None,
             drop_field,

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -125,7 +125,7 @@ mod tests {
             drop_field,
             types: types.iter().map(|&(k, v)| (k.into(), v.into())).collect(),
         }
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
 
         parser.transform(event).unwrap().into_log()

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -278,13 +278,11 @@ mod tests {
     use super::RegexParserConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
-        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
 
     fn do_transform(event: &str, patterns: &str, config: &str) -> Option<LogEvent> {
-        let rt = runtime();
         let event = Event::from(event);
         let mut parser = toml::from_str::<RegexParserConfig>(&format!(
             r#"

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -294,7 +294,7 @@ mod tests {
             patterns, config
         ))
         .unwrap()
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
 
         parser.transform(event).map(|event| event.into_log())

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -190,7 +190,7 @@ mod tests {
             types: types.iter().map(|&(k, v)| (k.into(), v.into())).collect(),
             ..Default::default()
         }
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
 
         parser.transform(event).unwrap().into_log()

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -143,7 +143,6 @@ mod tests {
     use super::SplitConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
-        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -178,7 +177,6 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = runtime();
         let event = Event::from(text);
         let field_names = fields.split(' ').map(|s| s.into()).collect::<Vec<Atom>>();
         let field = field.map(|f| f.into());

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -162,7 +162,6 @@ mod tests {
     use super::TokenizerConfig;
     use crate::event::{LogEvent, Value};
     use crate::{
-        test_util::runtime,
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
@@ -266,7 +265,6 @@ mod tests {
         drop_field: bool,
         types: &[(&str, &str)],
     ) -> LogEvent {
-        let rt = runtime();
         let event = Event::from(text);
         let field_names = fields.split(' ').map(|s| s.into()).collect::<Vec<Atom>>();
         let field = field.map(|f| f.into());

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -277,7 +277,7 @@ mod tests {
             types: types.iter().map(|&(k, v)| (k.into(), v.into())).collect(),
             ..Default::default()
         }
-        .build(TransformContext::new_test(rt.executor()))
+        .build(TransformContext::new_test())
         .unwrap();
 
         parser.transform(event).unwrap().into_log()

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -60,7 +60,7 @@ fn test_buffering() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let (input_events, input_events_stream) =
         test_util::random_events_with_stream(line_length, num_events);
@@ -103,7 +103,7 @@ fn test_buffering() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let (input_events2, input_events_stream) =
         test_util::random_events_with_stream(line_length, num_events);
@@ -162,7 +162,7 @@ fn test_max_size() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let send = in_tx
         .sink_map_err(|err| panic!(err))
@@ -204,7 +204,7 @@ fn test_max_size() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let output_events = test_util::receive_events(out_rx);
 
@@ -249,7 +249,7 @@ fn test_max_size_resume() {
     // Use a multi-thread runtime here.
     let mut rt = runtime::Runtime::new().unwrap();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     // Send all of the input events _before_ the output sink is ready.
     // This causes the writers to stop writing to the on-disk buffer, and once
@@ -305,7 +305,7 @@ fn test_reclaim_disk_space() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let (input_events, input_events_stream) =
         test_util::random_events_with_stream(line_length, num_events);
@@ -350,7 +350,7 @@ fn test_reclaim_disk_space() {
 
     let mut rt = test_util::runtime();
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let (input_events2, input_events_stream) =
         test_util::random_events_with_stream(line_length, num_events);

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,12 +1,8 @@
-use vector::{
-    test_util::runtime,
-    topology::{self, Config, ConfigDiff},
-};
+use vector::topology::{self, Config, ConfigDiff};
 
 fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
-    let rt = runtime();
     Config::load(config.as_bytes())
-        .and_then(|c| topology::builder::check_build(&c, &ConfigDiff::initial(&c), rt.executor()))
+        .and_then(|c| topology::builder::check_build(&c, &ConfigDiff::initial(&c)))
         .map(|(_topology, warnings)| warnings)
 }
 

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -75,7 +75,7 @@ fn test_sink_panic() {
 
     let output_lines = receive(&out_addr);
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -157,7 +157,7 @@ fn test_sink_error() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -225,7 +225,7 @@ fn test_source_error() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -296,7 +296,7 @@ fn test_source_panic() {
     let output_lines = receive(&out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -272,7 +272,7 @@ enum HealthcheckError {
 #[typetag::serialize(name = "mock")]
 impl<T> SinkConfig for MockSinkConfig<T>
 where
-    T: Sink<SinkItem = Event> + std::fmt::Debug + Clone + Send + 'static,
+    T: Sink<SinkItem = Event> + std::fmt::Debug + Clone + Send + Sync + 'static,
     <T as Sink>::SinkError: std::fmt::Debug,
 {
     fn build(&self, cx: SinkContext) -> Result<(RouterSink, Healthcheck), vector::Error> {

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -46,7 +46,7 @@ fn test_tcp_syslog() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
 
@@ -92,7 +92,7 @@ fn test_udp_syslog() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
 
     let input_messages: Vec<SyslogMessageRFC5424> = (0..num_messages)
         .map(|i| SyslogMessageRFC5424::random(i, 30, 4, 3, 3))
@@ -161,7 +161,7 @@ fn test_unix_stream_syslog() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     while std::os::unix::net::UnixStream::connect(&in_path).is_err() {}
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -38,7 +38,7 @@ fn pipe() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
 
@@ -86,7 +86,7 @@ fn sample() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
 
@@ -142,7 +142,7 @@ fn merge() {
 
     let output_lines = receive(&out_addr);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr1);
     wait_for_tcp(in_addr2);
@@ -208,7 +208,7 @@ fn fork() {
     let output_lines1 = receive(&out_addr1);
     let output_lines2 = receive(&out_addr2);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
 
@@ -264,7 +264,7 @@ fn merge_and_fork() {
     let output_lines1 = receive(&out_addr1);
     let output_lines2 = receive(&out_addr2);
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr1);
     wait_for_tcp(in_addr2);
@@ -336,7 +336,7 @@ fn reconnect() {
         .collect();
     let output_lines = futures01::sync::oneshot::spawn(output_lines, &output_rt.executor());
 
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+    let (topology, _crash) = rt.block_on_std(topology::start(config, false)).unwrap();
     // Wait for server to accept traffic
     wait_for_tcp(in_addr);
 


### PR DESCRIPTION
Outside of `src/topology`, these changes are almost entirely mechanical. Reading each commit individually should make that clearer.

We can't go all the way to `#[tokio::test]` until we no longer depend on tokio-compat, which is why this isn't quite as red as #2902. Otherwise, this still helps unblock making `build` methods async and tackles a little bit of the code organization tech debt in `src/main.rs`.