### PR TITLE
chore(operations): Add smoke tests to docker images

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -11,4 +11,7 @@ RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
 
+# Smoke test
+RUN ["vector", "--version"]
+
 ENTRYPOINT ["/usr/local/bin/vector"]

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -11,4 +11,7 @@ COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
 
+# Smoke test
+RUN ["vector", "--version"]
+
 ENTRYPOINT ["/usr/bin/vector"]


### PR DESCRIPTION
This should help us track issues with bad docker images early.