### PR TITLE
chore(operations): Build debian docker image from the archive instead of package

### DIFF
--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,14 +1,19 @@
 FROM debian:buster-slim AS builder
 
-COPY vector-*.deb ./
-RUN dpkg -i vector-$(dpkg --print-architecture).deb
+WORKDIR /vector
+
+COPY vector-*-unknown-linux-gnu*.tar.gz ./
+RUN tar -xvf vector-$(uname -m)-unknown-linux-gnu*.tar.gz --strip-components=2
 
 FROM debian:buster-slim
 
-RUN apt-get update && apt-get install -y ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+    tzdata \
+  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/bin/vector /usr/bin/vector
-COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
-COPY --from=builder /etc/vector /etc/vector
+COPY --from=builder /vector/bin/vector /usr/local/bin/vector
+COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
 
-ENTRYPOINT ["/usr/bin/vector"]
+ENTRYPOINT ["/usr/local/bin/vector"]


### PR DESCRIPTION
The motivation for this change is that currently we, either way, unpack `.deb` at a builder image and only use the binary and configs in the final image.
We can eliminate the extra step of building a `.deb` file and just use the `.tar.gz` archive, just like we do with `alpine` build. This saves some time when iterating on things that require docker image rebuilds (E2E tests for instance).

Some extra work might be required to make nightly and release builds work, CC @Hoverbear.