### PR TITLE
chore(deps): Fix dependency label to be longer again.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -21,7 +21,7 @@ update_configs:
     default_assignees:
       - "hoverbear"
     default_labels:
-      - "domain: dependencies"
+      - "domain: deps"
     # https://dependabot.com/docs/config-file/#version_requirement_updates
     version_requirement_updates: "off" # We should consider switching this to "auto"
     commit_message:
@@ -34,7 +34,7 @@ update_configs:
     default_assignees:
       - "hoverbear"
     default_labels:
-      - "domain: dependencies"
+      - "domain: deps"
     # https://dependabot.com/docs/config-file/#version_requirement_updates
     version_requirement_updates: "off" # We should consider switching this to "auto"
     commit_message:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,7 +12,7 @@ update_configs:
     # https://dependabot.com/docs/config-file/#version_requirement_updates
     version_requirement_updates: "off" # We should consider switching this to "auto"
     commit_message:
-      prefix: "chore(dependencies)"
+      prefix: "chore(deps)"
   - package_manager: "ruby:bundler"
     directory: "/scripts"
     update_schedule: "weekly"
@@ -25,7 +25,7 @@ update_configs:
     # https://dependabot.com/docs/config-file/#version_requirement_updates
     version_requirement_updates: "off" # We should consider switching this to "auto"
     commit_message:
-      prefix: "chore(dependencies)"
+      prefix: "chore(deps)"
   - package_manager: "javascript"
     directory: "/website"
     update_schedule: "weekly"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,8 +11,8 @@
 - name: "domain: config"
   description: Anything config related
   color: 212f3e
-- name: "domain: deps"
-  description: Anything deps related
+- name: "domain: dependencies"
+  description: Anything dependency related
   color: 212f3e
 - name: "domain: networking"
   description: Anything networking related

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,8 +11,8 @@
 - name: "domain: config"
   description: Anything config related
   color: 212f3e
-- name: "domain: dependencies"
-  description: Anything dependency related
+- name: "domain: deps"
+  description: Anything deps related
   color: 212f3e
 - name: "domain: networking"
   description: Anything networking related


### PR DESCRIPTION
Continuing on #2781 #2980 , I didn't like the shortened label names, this reverts us to the longer label names and the short PR prefixes.