### PR TITLE
chore(operations): Add smoke test for cmark-gfm at builder

### DIFF
--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
@@ -17,7 +17,8 @@ RUN cd /tmp && \
   git checkout 0.29.0.gfm.0 && \
   make install INSTALL_PREFIX=/usr && \
   cd .. && \
-  rm -rf cmark-gfm
+  rm -rf cmark-gfm && \
+  cmark-gfm --version
 
 RUN echo "%sudo         ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/sudo
 RUN useradd -m -G wheel \


### PR DESCRIPTION
Similar to #2974, this allows us to find problems with builder docker images early.