### PR TITLE
fix(operations): Use perl rename at builder

### DIFF
--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-gnu/Dockerfile
@@ -7,9 +7,12 @@ RUN yum install -y epel-release && \
     yum makecache
 RUN yum install -y \
         make openssl-devel cmake3 git \
-        gcc gcc-c++ libstdc++-static sudo && \
+        gcc gcc-c++ libstdc++-static sudo \
+        perl-App-cpanminus && \
     yum clean all
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
+RUN cpanm File::Rename \
+ && rename --version
 
 RUN cd /tmp && \
   git clone https://github.com/github/cmark-gfm && \


### PR DESCRIPTION
This solves the issue that appeared when we switched from debian to centos base at builders.
Our script for building `.deb` packages expects Perl `rename` command, but centos uses the one from `util-linux`, that can't do what we want from it.