### PR TITLE
chore(sinks): Build `HttpClient` once

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -1,5 +1,4 @@
 use crate::{
-    dns::Resolver,
     emit,
     event::Event,
     internal_events::{ElasticSearchEventReceived, ElasticSearchMissingKeys},
@@ -103,7 +102,9 @@ inventory::submit! {
 impl SinkConfig for ElasticSearchConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let common = ElasticSearchCommon::parse_config(&self)?;
-        let healthcheck = healthcheck(cx.resolver(), common).boxed().compat();
+        let client = HttpClient::new(cx.resolver(), common.tls_settings.clone())?;
+
+        let healthcheck = healthcheck(client.clone(), common).boxed().compat();
 
         let common = ElasticSearchCommon::parse_config(&self)?;
         let compression = common.compression;
@@ -117,7 +118,6 @@ impl SinkConfig for ElasticSearchConfig {
                     .timeout(1),
             );
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
-        let tls_settings = common.tls_settings.clone();
 
         let sink = BatchedHttpSink::with_retry_logic(
             common,
@@ -125,8 +125,8 @@ impl SinkConfig for ElasticSearchConfig {
             ElasticSearchRetryLogic,
             request,
             batch.timeout,
-            tls_settings,
-            &cx,
+            client,
+            cx.acker(),
         )
         .sink_map_err(|e| error!("Fatal elasticsearch sink error: {}", e));
 
@@ -446,7 +446,7 @@ impl ElasticSearchCommon {
     }
 }
 
-async fn healthcheck(resolver: Resolver, common: ElasticSearchCommon) -> crate::Result<()> {
+async fn healthcheck(mut client: HttpClient, common: ElasticSearchCommon) -> crate::Result<()> {
     let mut builder = Request::get(format!("{}/_cluster/health", common.base_url));
 
     match &common.credentials {
@@ -461,7 +461,6 @@ async fn healthcheck(resolver: Resolver, common: ElasticSearchCommon) -> crate::
         }
     }
     let request = builder.body(Body::empty())?;
-    let mut client = HttpClient::new(resolver, common.tls_settings.clone())?;
     let response = client.send(request).await?;
 
     match response.status() {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -570,6 +570,7 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::{
+        dns::Resolver,
         event,
         sinks::util::http::HttpClient,
         test_util::{random_events_with_stream, random_string, runtime},

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -5,7 +5,7 @@ use crate::{
         Field, InfluxDB1Settings, InfluxDB2Settings, ProtocolVersion,
     },
     sinks::util::{
-        http::{HttpBatchService, HttpRetryLogic},
+        http::{HttpBatchService, HttpClient, HttpRetryLogic},
         service2::TowerRequestConfig,
         BatchConfig, BatchSettings, MetricBuffer,
     },
@@ -62,13 +62,14 @@ inventory::submit! {
 #[typetag::serde(name = "influxdb_metrics")]
 impl SinkConfig for InfluxDBConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+        let client = HttpClient::new(cx.resolver(), None)?;
         let healthcheck = healthcheck(
             self.clone().endpoint,
             self.clone().influxdb1_settings,
             self.clone().influxdb2_settings,
-            cx.resolver(),
+            client.clone(),
         )?;
-        let sink = InfluxDBSvc::new(self.clone(), cx)?;
+        let sink = InfluxDBSvc::new(self.clone(), cx, client)?;
         Ok((sink, healthcheck))
     }
 
@@ -82,7 +83,11 @@ impl SinkConfig for InfluxDBConfig {
 }
 
 impl InfluxDBSvc {
-    pub fn new(config: InfluxDBConfig, cx: SinkContext) -> crate::Result<super::RouterSink> {
+    pub fn new(
+        config: InfluxDBConfig,
+        cx: SinkContext,
+        client: HttpClient,
+    ) -> crate::Result<super::RouterSink> {
         let settings = influxdb_settings(
             config.influxdb1_settings.clone(),
             config.influxdb2_settings.clone(),
@@ -101,8 +106,7 @@ impl InfluxDBSvc {
 
         let uri = settings.write_uri(endpoint)?;
 
-        let http_service =
-            HttpBatchService::new(cx.resolver(), None, create_build_request(uri, token));
+        let http_service = HttpBatchService::new(client, create_build_request(uri, token));
 
         let influxdb_http_service = InfluxDBSvc {
             config,

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -734,6 +734,7 @@ mod integration_tests {
     use crate::sinks::influxdb::metrics::{InfluxDBConfig, InfluxDBSvc};
     use crate::sinks::influxdb::test_util::{onboarding_v2, BUCKET, ORG, TOKEN};
     use crate::sinks::influxdb::InfluxDB2Settings;
+    use crate::sinks::util::http::HttpClient;
     use crate::test_util::runtime;
     use crate::topology::SinkContext;
     use crate::Event;

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -801,7 +801,8 @@ mod integration_tests {
             events.push(event);
         }
 
-        let sink = InfluxDBSvc::new(config, cx).unwrap();
+        let client = HttpClient::new(cx.resolver(), None).unwrap();
+        let sink = InfluxDBSvc::new(config, cx, client).unwrap();
 
         let stream = stream01::iter_ok(events.clone().into_iter());
 

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -727,6 +727,7 @@ mod tests {
 mod integration_tests {
     use crate::sinks::influxdb::test_util::{onboarding_v2, BUCKET, DATABASE, ORG, TOKEN};
     use crate::sinks::influxdb::{healthcheck, InfluxDB1Settings, InfluxDB2Settings};
+    use crate::sinks::util::http::HttpClient;
     use crate::test_util::runtime;
     use crate::topology::SinkContext;
 

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -3,7 +3,7 @@ pub mod metrics;
 
 pub(self) use super::{Healthcheck, RouterSink};
 
-use crate::{dns::Resolver, sinks::util::http::HttpClient};
+use crate::sinks::util::http::HttpClient;
 use chrono::{DateTime, Utc};
 use futures::TryFutureExt;
 use futures01::Future;
@@ -148,15 +148,13 @@ fn healthcheck(
     endpoint: String,
     influxdb1_settings: Option<InfluxDB1Settings>,
     influxdb2_settings: Option<InfluxDB2Settings>,
-    resolver: Resolver,
+    mut client: HttpClient,
 ) -> crate::Result<super::Healthcheck> {
     let settings = influxdb_settings(influxdb1_settings, influxdb2_settings)?;
 
     let uri = settings.healthcheck_uri(endpoint)?;
 
     let request = hyper::Request::get(uri).body(hyper::Body::empty()).unwrap();
-
-    let mut client = HttpClient::new(resolver, None)?;
 
     let healthcheck = client
         .call(request)

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -743,14 +743,10 @@ mod integration_tests {
             bucket: BUCKET.to_string(),
             token: TOKEN.to_string(),
         });
+        let client = HttpClient::new(cx.resolver(), None).unwrap();
 
-        let healthcheck = healthcheck(
-            endpoint,
-            influxdb1_settings,
-            influxdb2_settings,
-            cx.resolver(),
-        )
-        .unwrap();
+        let healthcheck =
+            healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client).unwrap();
         rt.block_on(healthcheck).unwrap();
     }
 
@@ -767,13 +763,10 @@ mod integration_tests {
             bucket: BUCKET.to_string(),
             token: TOKEN.to_string(),
         });
-        let healthcheck = healthcheck(
-            endpoint,
-            influxdb1_settings,
-            influxdb2_settings,
-            cx.resolver(),
-        )
-        .unwrap();
+        let client = HttpClient::new(cx.resolver(), None).unwrap();
+
+        let healthcheck =
+            healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client).unwrap();
         rt.block_on(healthcheck).unwrap_err();
     }
 
@@ -790,14 +783,10 @@ mod integration_tests {
             password: None,
         });
         let influxdb2_settings = None;
+        let client = HttpClient::new(cx.resolver(), None).unwrap();
 
-        let healthcheck = healthcheck(
-            endpoint,
-            influxdb1_settings,
-            influxdb2_settings,
-            cx.resolver(),
-        )
-        .unwrap();
+        let healthcheck =
+            healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client).unwrap();
         rt.block_on(healthcheck).unwrap();
     }
 
@@ -814,14 +803,10 @@ mod integration_tests {
             password: None,
         });
         let influxdb2_settings = None;
+        let client = HttpClient::new(cx.resolver(), None).unwrap();
 
-        let healthcheck = healthcheck(
-            endpoint,
-            influxdb1_settings,
-            influxdb2_settings,
-            cx.resolver(),
-        )
-        .unwrap();
+        let healthcheck =
+            healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client).unwrap();
         rt.block_on(healthcheck).unwrap_err();
     }
 }

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -13,7 +13,6 @@
 //! does not match, we will add a default label `{agent="vector"}`.
 
 use crate::{
-    dns::Resolver,
     event::{self, Event, Value},
     runtime::FutureExt,
     sinks::util::{
@@ -87,18 +86,19 @@ impl SinkConfig for LokiConfig {
                 .timeout(1),
         );
         let tls = TlsSettings::from_options(&self.tls)?;
+        let client = HttpClient::new(cx.resolver(), tls)?;
 
         let sink = BatchedHttpSink::new(
             self.clone(),
             VecBuffer::new(batch_settings.size),
             request_settings,
             batch_settings.timeout,
-            Some(tls),
-            &cx,
+            client.clone(),
+            cx.acker(),
         )
         .sink_map_err(|e| error!("Fatal loki sink error: {}", e));
 
-        let healthcheck = healthcheck(self.clone(), cx.resolver()).boxed_compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed_compat();
 
         Ok((Box::new(sink), Box::new(healthcheck)))
     }
@@ -228,11 +228,8 @@ impl HttpSink for LokiConfig {
     }
 }
 
-async fn healthcheck(config: LokiConfig, resolver: Resolver) -> crate::Result<()> {
+async fn healthcheck(config: LokiConfig, mut client: HttpClient) -> crate::Result<()> {
     let uri = format!("{}ready", config.endpoint);
-
-    let tls = TlsSettings::from_options(&config.tls)?;
-    let mut client = HttpClient::new(resolver, tls)?;
 
     let req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -584,7 +584,7 @@ mod integration_tests {
         let mut rt = runtime();
         let resolver = crate::dns::Resolver;
 
-        let config_to_healthcheck = |config| {
+        let config_to_healthcheck = move |config: super::HecSinkConfig| {
             let tls_settings = TlsSettings::from_options(&config.tls).unwrap();
             let client = HttpClient::new(resolver, tls_settings).unwrap();
             sinks::splunk_hec::healthcheck(config, client)

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -1,5 +1,4 @@
 use crate::{
-    dns::Resolver,
     event::{self, Event, LogEvent, Value},
     internal_events::{SplunkEventEncodeError, SplunkEventSent},
     sinks::util::{
@@ -89,18 +88,19 @@ impl SinkConfig for HecSinkConfig {
         );
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
+        let client = HttpClient::new(cx.resolver(), tls_settings)?;
 
         let sink = BatchedHttpSink::new(
             self.clone(),
             Buffer::new(batch.size, self.compression),
             request,
             batch.timeout,
-            tls_settings,
-            &cx,
+            client.clone(),
+            cx.acker(),
         )
         .sink_map_err(|e| error!("Fatal splunk_hec sink error: {}", e));
 
-        let healthcheck = healthcheck(self.clone(), cx.resolver()).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
         Ok((Box::new(sink), Box::new(healthcheck)))
     }
@@ -205,7 +205,7 @@ enum HealthcheckError {
     QueuesFull,
 }
 
-pub async fn healthcheck(config: HecSinkConfig, resolver: Resolver) -> crate::Result<()> {
+pub async fn healthcheck(config: HecSinkConfig, mut client: HttpClient) -> crate::Result<()> {
     let uri =
         build_uri(&config.host, "/services/collector/health/1.0").context(super::UriParseError)?;
 
@@ -213,9 +213,6 @@ pub async fn healthcheck(config: HecSinkConfig, resolver: Resolver) -> crate::Re
         .header("Authorization", format!("Splunk {}", config.token))
         .body(Body::empty())
         .unwrap();
-
-    let tls = TlsSettings::from_options(&config.tls)?;
-    let mut client = HttpClient::new(resolver, tls)?;
 
     let response = client.send(request).await?;
     match response.status() {

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -585,8 +585,8 @@ mod integration_tests {
         let resolver = crate::dns::Resolver;
 
         let config_to_healthcheck = |config| {
-            let tls_settings = TlsSettings::from_options(&config.tls)?;
-            let client = HttpClient::new(resolver, tls_settings)?;
+            let tls_settings = TlsSettings::from_options(&config.tls).unwrap();
+            let client = HttpClient::new(resolver, tls_settings).unwrap();
             sinks::splunk_hec::healthcheck(config, client)
         };
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -8,7 +8,6 @@ use crate::{
     dns::Resolver,
     event::Event,
     tls::{tls_connector_builder, MaybeTlsSettings},
-    topology::config::SinkContext,
 };
 use bytes05::{Buf, Bytes};
 use futures::future::BoxFuture;

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -437,7 +437,8 @@ mod test {
             .unwrap();
 
         let request = b"hello".to_vec();
-        let mut service = HttpBatchService::new(resolver, None, move |body: Vec<u8>| {
+        let client = HttpClient::new(resolver, None).unwrap();
+        let mut service = HttpBatchService::new(client, move |body: Vec<u8>| {
             Box::pin(ready(Request::post(&uri).body(body).map_err(Into::into)))
         });
 


### PR DESCRIPTION
Ref #2237 

Moves building of `HttpClient` from two locations, one for sink and one for healthcheck, to `build` method.

There are two sinks that had different behavior for sink and healthcheck:
- `honeycomb`
- `logdna`

In both cases healthchecks were using `TLS`, but sinks weren't. This PR changes that to not using `TLS`.
 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
