### PR TITLE
docs: Remove the dns-server options from docs

### DIFF
--- a/.meta/options.toml
+++ b/.meta/options.toml
@@ -8,16 +8,6 @@ file checkpoints, and more. Please make sure the Vector project has write \
 permissions to this dir.\
 """
 
-[options.dns_servers]
-type = "[string]"
-examples = [["0.0.0.0:53"]]
-description = """\
-The list of DNS servers Vector will use to resolve DNS requests. When set \
-Vector will ignore the system configuration and use only the list of DNS \
-servers provided. If this option is not set then Vector will attempt to use \
-the system configuration.\
-"""
-
 [options.log_schema]
 type = "table"
 description = """\

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ To learn more about our correctness tests, please see the [Vector test harness][
 * **Multi-platform** - [Linux, MacOS, Windows, x86_64, ARM64, and ARMv7][docs.installation].
 * **CI friendly** - [Config validating][docs.administration.validating] and [unit tests][guides.advanced.unit-testing] make Vector CI friendly.
 * **Configurable concurrency** - All CPU cores ([service][docs.strategies#service]) or just one ([daemon][docs.strategies#daemon]) via the [`--threads` flag][docs.process-management#starting].
-* **Custom DNS** - [Custom DNS][docs.global-options#dns_servers] makes service discovery possible.
 * **Optional static binary** - [Optional MUSL static binaries][pages.releases] mean zero required dependencies.
 * **TLS support** - All relevant Vector components offer TLS options for secure communication.
 
@@ -214,7 +213,6 @@ Or use your own [preferred method][docs.installation].
 [docs.deployment]: https://vector.dev/docs/setup/deployment/
 [docs.from-archives]: https://vector.dev/docs/setup/installation/manual/from-archives/
 [docs.from-source]: https://vector.dev/docs/setup/installation/manual/from-source/
-[docs.global-options#dns_servers]: https://vector.dev/docs/reference/global-options/#dns_servers
 [docs.global-options#log_schema]: https://vector.dev/docs/reference/global-options/#log_schema
 [docs.guarantees]: https://vector.dev/docs/about/guarantees/
 [docs.installation]: https://vector.dev/docs/setup/installation/

--- a/README.md.erb
+++ b/README.md.erb
@@ -127,7 +127,6 @@ To learn more about our correctness tests, please see the [Vector test harness][
 * **Multi-platform** - [Linux, MacOS, Windows, x86_64, ARM64, and ARMv7][docs.installation].
 * **CI friendly** - [Config validating][docs.administration.validating] and [unit tests][guides.advanced.unit-testing] make Vector CI friendly.
 * **Configurable concurrency** - All CPU cores ([service][docs.strategies#service]) or just one ([daemon][docs.strategies#daemon]) via the [`--threads` flag][docs.process-management#starting].
-* **Custom DNS** - [Custom DNS][docs.global-options#dns_servers] makes service discovery possible.
 * **Optional static binary** - [Optional MUSL static binaries][pages.releases] mean zero required dependencies.
 * **TLS support** - All relevant Vector components offer TLS options for secure communication.
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -38,16 +38,6 @@ data_dir = "/var/lib/vector"
 data_dir = "/var/local/lib/vector/"
 data_dir = "/home/user/vector/"
 
-# The list of DNS servers Vector will use to resolve DNS requests. When set
-# Vector will ignore the system configuration and use only the list of DNS
-# servers provided. If this option is not set then Vector will attempt to use
-# the system configuration.
-#
-# * optional
-# * no default
-# * type: [string]
-dns_servers = ["0.0.0.0:53"]
-
 #
 # Log schema
 #

--- a/rfcs/2020-04-15-2341-wasm-plugins.md
+++ b/rfcs/2020-04-15-2341-wasm-plugins.md
@@ -319,7 +319,6 @@ In your `target/wasm-wasi/release/` verify that the `echo.wasm` file exists. Nex
 
 ```toml
 data_dir = "/var/lib/vector/"
-dns_servers = []
 
 [sources.source0]
 max_length = 102400

--- a/website/docs/reference/global-options.md
+++ b/website/docs/reference/global-options.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-02"
+last_modified_on: "2020-07-10"
 title: Global Options
 description: "Vector's global options, allowing you configure global Vector-wide behavior."
 ---
@@ -24,7 +24,6 @@ Vector as a whole and set defaults for component options.
 ```toml title="vector.toml"
 # General
 data_dir = "/var/lib/vector/" # optional, default
-dns_servers = ["0.0.0.0:53"] # optional, no default
 
 # Log schema
 log_schema.host_key = "host" # optional, default
@@ -56,32 +55,6 @@ The directory used for persisting Vector state, such as on-disk buffers, file
 checkpoints, and more. Please make sure the Vector project has write
 permissions to this dir.
  See [Data Directory](#data-directory) for more info.
-
-
-</Field>
-<Field
-  common={false}
-  defaultValue={null}
-  enumValues={null}
-  examples={[["0.0.0.0:53"]]}
-  groups={[]}
-  name={"dns_servers"}
-  path={null}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"[string]"}
-  unit={null}
-  warnings={[]}
-  >
-
-### dns_servers
-
-The list of DNS servers Vector will use to resolve DNS requests. When set
-Vector will ignore the system configuration and use only the list of DNS
-servers provided. If this option is not set then Vector will attempt to use the
-system configuration.
-
 
 
 </Field>


### PR DESCRIPTION
This cleans up all the website docs in prep for #2961 