### PR TITLE
chore: Drop 3 more clippy exclusions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::approx_constant)]
 #![allow(clippy::block_in_if_condition_stmt)]
-#![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]
-#![allow(clippy::large_enum_variant)]
 #![allow(clippy::match_wild_err_arm)]
 #![allow(clippy::new_ret_no_self)]
 #![allow(clippy::ptr_arg)]
@@ -10,7 +8,6 @@
 #![allow(clippy::trivial_regex)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
-#![allow(clippy::unreadable_literal)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
These 3 don't currently trigger any clippy warnings, so there doesn't
seem to be much point in keeping clippy from checking them.

Signed-off-by: Bruce Guenter <bruce@timber.io>