### PR TITLE
chore(tests): Split `Receiver::cancel` out of `Receiver::wait` 

### DIFF
--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -144,7 +144,7 @@ mod test {
         let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
 
-        let receiver = receive(&addr);
+        let mut receiver = receive(&addr);
 
         let (lines, events) = random_lines_with_stream(10, 100);
         let pump = sink.send_all(events);
@@ -153,6 +153,7 @@ mod test {
         // Some CI machines are very slow, be generous.
         std::thread::sleep(std::time::Duration::from_secs(2));
 
+        receiver.cancel();
         let output = receiver.wait();
         assert_eq!(output.len(), lines.len());
         for (source, received) in lines.iter().zip(output) {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -368,7 +368,7 @@ where
 pub struct Receiver<T> {
     handle: futures01::sync::oneshot::SpawnHandle<Vec<T>, ()>,
     count: Arc<AtomicUsize>,
-    trigger: Trigger,
+    trigger: Option<Trigger>,
     _runtime: Runtime,
 }
 
@@ -377,8 +377,11 @@ impl<T> Receiver<T> {
         self.count.load(Ordering::Relaxed)
     }
 
+    pub fn cancel(&mut self) {
+        self.trigger.take();
+    }
+
     pub fn wait(self) -> Vec<T> {
-        self.trigger.cancel();
         self.handle.wait().unwrap()
     }
 }
@@ -408,7 +411,7 @@ pub fn receive(addr: &SocketAddr) -> Receiver<String> {
     Receiver {
         handle,
         count,
-        trigger,
+        trigger: Some(trigger),
         _runtime: runtime,
     }
 }
@@ -437,7 +440,7 @@ where
     Receiver {
         handle,
         count,
-        trigger,
+        trigger: Some(trigger),
         _runtime: runtime,
     }
 }


### PR DESCRIPTION
Splits `crate::test_util::Receiver::wait` method into `wait` and `cancel`. Somel of the usages of this method were having a race as they were expecting that the method would `wait` for the `tcp` channel to close, which wasn't the case. Instead the method was canceling the channel which caused a race. Only test that needs the `cancel` was `tcp_stream`. 

Similar how in #2862 `crate::test_util::CountReceiver::wait` was split.

Ref. #2978 
Fixes [`test_max_size_resume`](https://github.com/timberio/vector/issues/2978#issuecomment-657133377) 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
