### PR TITLE
chore: reduce std::io::Cursor usage

### DIFF
--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -542,7 +542,7 @@ mod integration_tests {
         test_util::{random_lines_with_stream, random_string, runtime},
         topology::config::SinkContext,
     };
-    use bytes05::BytesMut;
+    use bytes05::{buf::BufExt, BytesMut};
     use flate2::read::GzDecoder;
     use futures::compat::Future01CompatExt;
     use futures::stream::{self, StreamExt};
@@ -550,7 +550,7 @@ mod integration_tests {
     use pretty_assertions::assert_eq;
     use rusoto_core::region::Region;
     use rusoto_s3::{S3Client, S3};
-    use std::io::{BufRead, BufReader, Cursor};
+    use std::io::{BufRead, BufReader};
 
     const BUCKET: &str = "router-tests";
 
@@ -863,7 +863,7 @@ mod integration_tests {
         buf_read.lines().map(|l| l.unwrap()).collect()
     }
 
-    async fn get_object_output_body(obj: rusoto_s3::GetObjectOutput) -> Cursor<Bytes> {
+    async fn get_object_output_body(obj: rusoto_s3::GetObjectOutput) -> impl std::io::Read {
         let bytes = obj
             .body
             .unwrap()
@@ -872,6 +872,6 @@ mod integration_tests {
                 store
             })
             .await;
-        Cursor::new(bytes.freeze())
+        bytes.freeze().reader()
     }
 }

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -300,6 +300,7 @@ mod tests {
         test_util::{next_addr, random_lines_with_stream, runtime, shutdown_on_idle},
         topology::config::SinkContext,
     };
+    use bytes05::buf::BufExt;
     use futures01::{Sink, Stream};
     use headers::{Authorization, HeaderMapExt};
     use hyper::Method;
@@ -433,9 +434,8 @@ mod tests {
                     Some(Authorization::basic("waldo", "hunter2")),
                     parts.headers.typed_get()
                 );
-                body
+                body.reader()
             })
-            .map(std::io::Cursor::new)
             .map(flate2::read::GzDecoder::new)
             .map(BufReader::new)
             .flat_map(BufRead::lines)
@@ -496,9 +496,8 @@ mod tests {
                     Some(Authorization::basic("waldo", "hunter2")),
                     parts.headers.typed_get()
                 );
-                body
+                body.reader()
             })
-            .map(std::io::Cursor::new)
             .map(flate2::read::GzDecoder::new)
             .map(BufReader::new)
             .flat_map(BufRead::lines)
@@ -560,9 +559,8 @@ mod tests {
                     Some("quux"),
                     parts.headers.get("baz").map(|v| v.to_str().unwrap())
                 );
-                body
+                body.reader()
             })
-            .map(std::io::Cursor::new)
             .map(flate2::read::GzDecoder::new)
             .map(BufReader::new)
             .flat_map(BufRead::lines)

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -149,6 +149,7 @@ mod tests {
         test_util::{next_addr, runtime, shutdown_on_idle},
         topology::config::SinkConfig,
     };
+    use bytes05::buf::BufExt;
     use futures01::{stream, Sink, Stream};
     use hyper::Method;
     use serde_json::Value;
@@ -300,9 +301,8 @@ mod tests {
                         .and_then(|v| v.to_str().ok()),
                     Some("foo")
                 );
-                body
+                body.reader()
             })
-            .map(std::io::Cursor::new)
             .flat_map(BufRead::lines)
             .map(Result::unwrap)
             .flat_map(|s| -> Vec<String> {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -263,7 +263,7 @@ mod integration_test {
         shutdown::ShutdownSignal,
         test_util::{collect_n, random_string, runtime},
     };
-    use chrono::{TimeZone, Utc};
+    use chrono::Utc;
     use futures::compat::Compat;
     use futures01::{sync::mpsc, Future};
     use rdkafka::{

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -5,12 +5,12 @@ use crate::{
     tls::TlsConfig,
     topology::config::{DataType, GlobalOptions, SourceConfig},
 };
-use bytes05::Bytes;
+use bytes05::{buf::BufExt, Bytes};
 use chrono::{DateTime, Utc};
 use futures01::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use std::{
-    io::{BufRead, BufReader, Cursor},
+    io::{BufRead, BufReader},
     net::SocketAddr,
     str::FromStr,
 };
@@ -102,7 +102,7 @@ fn header_error_message(name: &str, msg: &str) -> ErrorMessage {
 }
 
 fn body_to_events(body: Bytes) -> Vec<Event> {
-    let rdr = BufReader::new(Cursor::new(body));
+    let rdr = BufReader::new(body.reader());
     rdr.lines()
         .filter_map(|res| {
             res.map_err(|error| error!(message = "Error reading request body", ?error))

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -217,7 +217,7 @@ mod tests {
         crate::test_util::trace_init();
         let (tx, mut rx) = mpsc::channel(10);
         let config = StdinConfig::default();
-        let buf = Cursor::new(String::from("hello world\nhello world again"));
+        let buf = Cursor::new("hello world\nhello world again");
 
         let mut rt = runtime();
         let source = stdin_source(buf, config, ShutdownSignal::noop(), tx).unwrap();


### PR DESCRIPTION
While checked `bytes` docs, found that [method reader](https://docs.rs/bytes/0.5.5/bytes/buf/ext/trait.BufExt.html#method.reader) exists, so we do not need [std::io::Cursor](https://doc.rust-lang.org/std/io/struct.Cursor.html) in few places.