### PR TITLE
chore(sinks): Build `aws` sinks clients only once

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -124,7 +124,7 @@ pub struct CloudwatchLogsPartitionSvc {
     config: CloudwatchLogsSinkConfig,
     clients: HashMap<CloudwatchKey, Svc>,
     request_settings: TowerRequestSettings,
-    resolver: Resolver,
+    client: CloudWatchLogsClient,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
@@ -171,12 +171,13 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
         let log_group = self.group_name.clone();
         let log_stream = self.stream_name.clone();
 
+        let client = self.create_client(cx.resolver())?;
         let svc = ServiceBuilder::new()
             .concurrency_limit(request.in_flight_limit)
             .service(CloudwatchLogsPartitionSvc::new(
                 self.clone(),
-                cx.resolver(),
-            )?);
+                client.clone(),
+            ));
 
         let encoding = self.encoding.clone();
         let sink = {
@@ -189,7 +190,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             Box::new(svc_sink)
         };
 
-        let healthcheck = healthcheck(self.clone(), cx.resolver()).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
         Ok((sink, Box::new(healthcheck)))
     }
@@ -204,15 +205,15 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 }
 
 impl CloudwatchLogsPartitionSvc {
-    pub fn new(config: CloudwatchLogsSinkConfig, resolver: Resolver) -> crate::Result<Self> {
+    pub fn new(config: CloudwatchLogsSinkConfig, client: CloudWatchLogsClient) -> Self {
         let request_settings = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
-        Ok(Self {
+        Self {
             config,
             clients: HashMap::new(),
             request_settings,
-            resolver,
-        })
+            client,
+        }
     }
 }
 
@@ -239,7 +240,7 @@ impl Service<PartitionInnerBuffer<Vec<InputLogEvent>, CloudwatchKey>>
             let svc = {
                 let policy = self.request_settings.retry_policy(CloudwatchRetryLogic);
 
-                let cloudwatch = CloudwatchLogsSvc::new(&self.config, &key, self.resolver).unwrap();
+                let cloudwatch = CloudwatchLogsSvc::new(&self.config, &key, self.client.clone());
                 let timeout = Timeout::new(cloudwatch, self.request_settings.timeout);
 
                 let buffer = Buffer::new(timeout, 1);
@@ -273,17 +274,15 @@ impl CloudwatchLogsSvc {
     pub fn new(
         config: &CloudwatchLogsSinkConfig,
         key: &CloudwatchKey,
-        resolver: Resolver,
-    ) -> crate::Result<Self> {
-        let client = config.create_client(resolver)?;
-
+        client: CloudWatchLogsClient,
+    ) -> Self {
         let group_name = String::from_utf8_lossy(&key.group[..]).into_owned();
         let stream_name = String::from_utf8_lossy(&key.stream[..]).into_owned();
 
         let create_missing_group = config.create_missing_group.unwrap_or(true);
         let create_missing_stream = config.create_missing_stream.unwrap_or(true);
 
-        Ok(CloudwatchLogsSvc {
+        CloudwatchLogsSvc {
             client,
             stream_name,
             group_name,
@@ -291,7 +290,7 @@ impl CloudwatchLogsSvc {
             create_missing_stream,
             token: None,
             token_rx: None,
-        })
+        }
     }
 
     pub fn process_events(&self, events: Vec<InputLogEvent>) -> Vec<Vec<InputLogEvent>> {
@@ -488,7 +487,10 @@ enum HealthcheckError {
     GroupNameMismatch { expected: String, name: String },
 }
 
-async fn healthcheck(config: CloudwatchLogsSinkConfig, resolver: Resolver) -> crate::Result<()> {
+async fn healthcheck(
+    config: CloudwatchLogsSinkConfig,
+    client: CloudWatchLogsClient,
+) -> crate::Result<()> {
     if config.group_name.is_dynamic() {
         info!("cloudwatch group_name is dynamic; skipping healthcheck.");
         return Ok(());
@@ -496,8 +498,6 @@ async fn healthcheck(config: CloudwatchLogsSinkConfig, resolver: Resolver) -> cr
 
     let group_name = String::from_utf8_lossy(&config.group_name.get_ref()[..]).into_owned();
     let expected_group_name = group_name.clone();
-
-    let client = config.create_client(resolver)?;
 
     let request = DescribeLogGroupsRequest {
         limit: Some(1),

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -782,8 +782,8 @@ mod tests {
             stream: "stream".into(),
             group: "group".into(),
         };
-        let resolver = Resolver;
-        CloudwatchLogsSvc::new(&config, &key, resolver).unwrap()
+        let client = config.create_client(Resolver).unwrap();
+        CloudwatchLogsSvc::new(&config, &key, client)
     }
 
     #[test]
@@ -1273,9 +1273,9 @@ mod integration_tests {
         };
 
         let mut rt = runtime();
-        let resolver = Resolver;
 
-        rt.block_on_std(healthcheck(config, resolver)).unwrap();
+        let client = config.create_client(Resolver).unwrap();
+        rt.block_on_std(healthcheck(config, client)).unwrap();
     }
 
     fn create_client_test() -> CloudWatchLogsClient {

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -442,15 +442,18 @@ mod integration_tests {
     #[test]
     fn cloudwatch_metrics_healthchecks() {
         let mut rt = runtime();
-        let resolver = Resolver;
-        let _ = rt.block_on_std(config().healthcheck(resolver));
+        let config = config();
+        let client = config.create_client(Resolver).unwrap();
+        let _ = rt.block_on_std(config.healthcheck(client));
     }
 
     #[test]
     fn cloudwatch_metrics_put_data() {
         let mut rt = runtime();
         let cx = SinkContext::new_test();
-        let sink = CloudWatchMetricsSvc::new(config(), cx).unwrap();
+        let config = config();
+        let client = config.create_client(cx.resolver()).unwrap();
+        let sink = CloudWatchMetricsSvc::new(config, client, cx).unwrap();
 
         let mut events = Vec::new();
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -317,7 +317,8 @@ mod integration_tests {
 
         let cx = SinkContext::new_test();
 
-        let sink = KinesisFirehoseService::new(config, cx).unwrap();
+        let client = config.create_client(cx.resolver()).unwrap();
+        let sink = KinesisFirehoseService::new(config, client, cx).unwrap();
 
         let (input, events) = random_events_with_stream(100, 100);
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -74,8 +74,9 @@ inventory::submit! {
 #[typetag::serde(name = "aws_kinesis_firehose")]
 impl SinkConfig for KinesisFirehoseSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let healthcheck = self.clone().healthcheck(cx.resolver()).boxed().compat();
-        let sink = KinesisFirehoseService::new(self.clone(), cx)?;
+        let client = self.create_client(cx.resolver())?;
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let sink = KinesisFirehoseService::new(self.clone(), client, cx)?;
         Ok((Box::new(sink), Box::new(healthcheck)))
     }
 
@@ -89,8 +90,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
 }
 
 impl KinesisFirehoseSinkConfig {
-    async fn healthcheck(self, resolver: Resolver) -> crate::Result<()> {
-        let client = self.create_client(resolver)?;
+    async fn healthcheck(self, client: KinesisFirehoseClient) -> crate::Result<()> {
         let stream_name = self.stream_name;
 
         let req = client.describe_delivery_stream(DescribeDeliveryStreamInput {
@@ -126,10 +126,9 @@ impl KinesisFirehoseSinkConfig {
 impl KinesisFirehoseService {
     pub fn new(
         config: KinesisFirehoseSinkConfig,
+        client: KinesisFirehoseClient,
         cx: SinkContext,
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
-        let client = config.create_client(cx.resolver())?;
-
         let batch = config
             .batch
             .disallow_max_bytes()?

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -79,8 +79,9 @@ inventory::submit! {
 #[typetag::serde(name = "aws_kinesis_streams")]
 impl SinkConfig for KinesisSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let healthcheck = self.clone().healthcheck(cx.resolver()).boxed().compat();
-        let sink = KinesisService::new(self.clone(), cx)?;
+        let client = self.create_client(cx.resolver())?;
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let sink = KinesisService::new(self.clone(), client, cx)?;
         Ok((Box::new(sink), Box::new(healthcheck)))
     }
 
@@ -94,8 +95,7 @@ impl SinkConfig for KinesisSinkConfig {
 }
 
 impl KinesisSinkConfig {
-    async fn healthcheck(self, resolver: Resolver) -> crate::Result<()> {
-        let client = self.create_client(resolver)?;
+    async fn healthcheck(self, client: KinesisClient) -> crate::Result<()> {
         let stream_name = self.stream_name;
 
         let req = client.describe_stream(DescribeStreamInput {
@@ -131,9 +131,10 @@ impl KinesisSinkConfig {
 impl KinesisService {
     pub fn new(
         config: KinesisSinkConfig,
+        client: KinesisClient,
         cx: SinkContext,
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
-        let client = Arc::new(config.create_client(cx.resolver())?);
+        let client = Arc::new(client);
 
         let batch = config
             .batch

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -379,7 +379,8 @@ mod integration_tests {
 
         let cx = SinkContext::new_test();
 
-        let sink = KinesisService::new(config, cx).unwrap();
+        let client = config.create_client(cx.resolver()).unwrap();
+        let sink = KinesisService::new(config, client, cx).unwrap();
 
         let timestamp = chrono::Utc::now().timestamp_millis();
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -559,7 +559,8 @@ mod integration_tests {
         rt.block_on_std(async move {
             let config = config(1000000).await;
             let prefix = config.key_prefix.clone();
-            let sink = config.new(cx).unwrap();
+            let client = config.create_client(cx.resolver()).unwrap();
+            let sink = config.new(client, cx).unwrap();
 
             let (lines, events) = random_lines_with_stream(100, 10);
 
@@ -592,7 +593,8 @@ mod integration_tests {
                 ..config(1010).await
             };
             let prefix = config.key_prefix.clone();
-            let sink = config.new(cx).unwrap();
+            let client = config.create_client(cx.resolver()).unwrap();
+            let sink = config.new(client, cx).unwrap();
 
             let (lines, _events) = random_lines_with_stream(100, 30);
 
@@ -646,7 +648,8 @@ mod integration_tests {
         });
 
         let prefix = config.key_prefix.clone();
-        let sink = config.new(cx).unwrap();
+        let client = config.create_client(cx.resolver()).unwrap();
+        let sink = config.new(client, cx).unwrap();
 
         let (lines, _) = random_lines_with_stream(100, 30);
 
@@ -713,7 +716,8 @@ mod integration_tests {
             };
 
             let prefix = config.key_prefix.clone();
-            let sink = config.new(cx).unwrap();
+            let client = config.create_client(cx.resolver()).unwrap();
+            let sink = config.new(client, cx).unwrap();
 
             let (lines, events) = random_lines_with_stream(100, 500);
 
@@ -743,7 +747,8 @@ mod integration_tests {
 
         rt.block_on_std(async move {
             let config = config(1).await;
-            config.healthcheck(resolver).await.unwrap();
+            let client = config.create_client(resolver).unwrap();
+            config.healthcheck(client).await.unwrap();
         });
     }
 
@@ -757,8 +762,9 @@ mod integration_tests {
                 bucket: "asdflkjadskdaadsfadf".to_string(),
                 ..config(1).await
             };
+            let client = config.create_client(resolver).unwrap();
             assert_downcast_matches!(
-                config.healthcheck(resolver).await.unwrap_err(),
+                config.healthcheck(client).await.unwrap_err(),
                 HealthcheckError,
                 HealthcheckError::UnknownBucket{ .. }
             );


### PR DESCRIPTION
Ref. #2237 

Moves building of various `aws` sink clients from two locations, one for sink and one for healthcheck, to build method.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
