### PR TITLE
fix(cli): Cleanup `generate` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,13 +25,12 @@ impl Opts {
 
     pub fn log_level(&self) -> &'static str {
         let (quiet_level, verbose_level) = match self.sub_command {
-            Some(SubCommand::Validate(_)) | Some(SubCommand::Generate(_))
-                if self.root.verbose == 0 =>
-            {
-                (self.root.quiet + 1, self.root.verbose)
-            }
             Some(SubCommand::Validate(_)) | Some(SubCommand::Generate(_)) => {
-                (self.root.quiet, self.root.verbose - 1)
+                if self.root.verbose == 0 {
+                    (self.root.quiet + 1, self.root.verbose)
+                } else {
+                    (self.root.quiet, self.root.verbose - 1)
+                }
             }
             _ => (self.root.quiet, self.root.verbose),
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,10 +25,14 @@ impl Opts {
 
     pub fn log_level(&self) -> &'static str {
         let (quiet_level, verbose_level) = match self.sub_command {
-            Some(SubCommand::Validate(_)) if self.root.verbose == 0 => {
+            Some(SubCommand::Validate(_)) | Some(SubCommand::Generate(_))
+                if self.root.verbose == 0 =>
+            {
                 (self.root.quiet + 1, self.root.verbose)
             }
-            Some(SubCommand::Validate(_)) => (self.root.quiet, self.root.verbose - 1),
+            Some(SubCommand::Validate(_)) | Some(SubCommand::Generate(_)) => {
+                (self.root.quiet, self.root.verbose - 1)
+            }
             _ => (self.root.quiet, self.root.verbose),
         };
         match quiet_level {


### PR DESCRIPTION
Closes #3007 

Changes default logging level for `generate` command from `info` to `warn`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
