### PR TITLE
chore(kafka source): remove owning_ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.2",
+ "syn 1.0.33",
+]
+
+[[package]]
 name = "derive_is_enum_variant"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +987,18 @@ name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+
+[[package]]
+name = "duct"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90a9c3a25aafbd538c7d40a53f83c4487ee8216c12d1c8ef2c01eb2f6ea1553"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
 
 [[package]]
 name = "either"
@@ -2042,7 +2065,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "cranelift-entity",
- "derivative",
+ "derivative 1.0.3",
  "memoffset",
  "minisign",
  "object",
@@ -2649,19 +2672,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be601e38e20a6f3d01049d85801cb9b7a34a8da7a0da70df507bbde7735058c8"
+checksum = "5f1e2d7c9c4282839fc56f549bc006a54e6f28a851a7de7adcf3f50575751760"
 dependencies = [
- "derivative",
+ "derivative 2.1.1",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59f30f6a043f2606adbd0addbf1eef6f2e28e8c4968918b63b7ff97ac0db2a7"
+checksum = "4a9f19dafa80d8af21ede328f2c4ed836604a2eb1c309d688f89a7cc40568923"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.18",
@@ -2763,6 +2786,16 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3424,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d455ac2a07a27d87b4f0e321dfd8d9a5b574bd96f55e42e6c594712a08051222"
+checksum = "db594dc221933be6f2ad804b997b48a57a63436c26ab924222c28e9a36ad210a"
 dependencies = [
  "futures 0.3.5",
  "libc",
@@ -3435,13 +3468,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio 0.2.21",
 ]
 
 [[package]]
 name = "rdkafka-sys"
-version = "1.3.1"
+version = "2.0.0+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d770343fbbc6089c750000711a17a906e8b3f7831afcd752d9667d38833e578"
+checksum = "d2c31c649704b732bb27e47748ff8a288b4f72eccc08b777b1a442b52152b11c"
 dependencies = [
  "cmake",
  "libc",
@@ -3449,6 +3483,7 @@ dependencies = [
  "num_enum",
  "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
  "zstd-sys",
 ]
 
@@ -3804,6 +3839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b82548e259466e09971e8b1d1adfffba6005c83a2ca2aca5b5d00a61f6b8058"
+dependencies = [
+ "cc",
+ "duct",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "scan_fmt"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
 dependencies = [
  "lazy_static 1.4.0",
+]
+
+[[package]]
+name = "shared_child"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cebcf3a403e4deafaf34dc882c4a1b6a648b43e5670aa2e4bb985914eaeb2d2"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -5392,7 +5449,7 @@ dependencies = [
  "colored",
  "criterion",
  "db-key",
- "derivative",
+ "derivative 1.0.3",
  "derive_is_enum_variant",
  "dirs",
  "elastic_responses",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,15 +2808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,12 +4192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-
-[[package]]
 name = "standback"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,7 +5478,6 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-probe",
- "owning_ref",
  "pretty_assertions",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ snafu = { version = "0.6", features = ["futures-01", "futures"] }
 url = "1.7"
 base64 = { version = "0.10.1", optional = true }
 bollard = { version = "0.7", default-features = false, features = ["tls"], optional = true }
-owning_ref = { version = "0.4.0", optional = true }
 listenfd = { version = "0.3.3", optional = true }
 inventory = "0.1"
 maxminddb = { version = "0.14.0", optional = true }
@@ -252,7 +251,7 @@ sources-generator = []
 sources-http = ["warp", "sources-tls"]
 sources-internal_metrics = []
 sources-journald = []
-sources-kafka = ["owning_ref"]
+sources-kafka = []
 sources-logplex = ["warp", "sources-tls"]
 sources-prometheus = []
 sources-socket = ["bytesize", "listenfd", "tokio-uds", "sources-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ derive_is_enum_variant = "0.1.1"
 leveldb = { git = "https://github.com/timberio/leveldb", optional = true, default-features = false }
 db-key = "0.0.5"
 headers = "0.3"
-rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.24.0", features = ["libz", "ssl", "zstd"], optional = true }
 hostname = "0.1.5"
 seahash = { version = "3.0.6", optional = true }
 jemallocator = { version = "0.3.0", optional = true }
@@ -420,7 +420,7 @@ gcp-integration-tests = ["sinks-gcp"]
 gcp-pubsub-integration-tests = ["sinks-gcp"]
 gcp-cloud-storage-integration-tests = ["sinks-gcp"]
 influxdb-integration-tests = ["sinks-influxdb"]
-kafka-integration-tests = ["sinks-kafka"]
+kafka-integration-tests = ["sources-kafka", "sinks-kafka"]
 loki-integration-tests = ["sinks-loki"]
 pulsar-integration-tests = ["sinks-pulsar"]
 splunk-integration-tests = ["sinks-splunk_hec", "warp"]

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -162,7 +162,8 @@ fn kafka_source(
                     }
                 }
             })
-            // Not work =\
+            // Try `forward` after removing old futures.
+            // Error: implementation of `futures_core::stream::Stream` is not general enough
             // .forward(
             //     out.sink_compat()
             //         .sink_map_err(|e| error!(message = "Error sending to sink", error = ?e)),


### PR DESCRIPTION
Close #2972 

- update `rdkafka` crate
- remove `owning_ref` crate
- remove extra clones
- add more async code
- fix `kafka-integration-tests` feature (before part of tests was not compiled for integration tests)