### PR TITLE
chore: Add .rustfmt.toml to assist IDE formatters.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+# Using defaults.
+indent_style = "Block"
+reorder_imports = true


### PR DESCRIPTION
Using default values because the base rustfmt should be used. The perceived advantage is that
auto code formatters in contributors IDEs would more readily recognize that rustfmt should be
used over some alternative formatter.

Resolves #507

Signed-off-by: Harold Dost <h.dost@criteo.com>