### PR TITLE
chore(sinks): add SinkConfig::build_async

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
         );
 
         let diff = topology::ConfigDiff::initial(&config);
-        let pieces = topology::validate(&config, &diff).unwrap_or_else(|| {
+        let pieces = topology::validate(&config, &diff).await.unwrap_or_else(|| {
             std::process::exit(exitcode::CONFIG);
         });
 

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -107,10 +107,15 @@ lazy_static! {
         .unwrap();
 }
 
+#[async_trait::async_trait]
 #[typetag::serde(name = "gcp_stackdriver_logs")]
 impl SinkConfig for StackdriverConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
-        let creds = self.auth.make_credentials(Scope::LoggingWrite)?;
+    fn build(&self, _cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
+        unimplemented!()
+    }
+
+    async fn build_async(&self, cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
+        let creds = self.auth.make_credentials(Scope::LoggingWrite).await?;
 
         let batch = self.batch.use_size_as_bytes()?.get_settings_or_default(
             BatchSettings::default()

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -406,8 +406,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn fails_missing_creds() {
+    #[tokio::test]
+    async fn fails_missing_creds() {
         let config: StackdriverConfig = toml::from_str(
             r#"
            project_id = "project"
@@ -417,7 +417,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        if config.build(SinkContext::new_test()).is_ok() {
+        if config.build_async(SinkContext::new_test()).await.is_ok() {
             panic!("config.build failed to error");
         }
     }

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -47,15 +47,9 @@ pub enum Encoding {
     Json,
 }
 
-enum PulsarProducerState {
-    NotReady(PulsarSinkConfig),
-    Creating(Box<dyn Future<Item = Producer<TokioExecutor>, Error = ()> + Send>),
-    Ready(Arc<Mutex<Producer<TokioExecutor>>>),
-}
-
 struct PulsarSink {
     encoding: EncodingConfig<Encoding>,
-    producer: PulsarProducerState,
+    producer: Arc<Mutex<Producer<TokioExecutor>>>,
     in_flight: FuturesUnordered<MetadataFuture<SendFuture, usize>>,
     // ack
     seq_head: usize,
@@ -70,11 +64,28 @@ inventory::submit! {
     SinkDescription::new_without_default::<PulsarSinkConfig>("pulsar")
 }
 
+#[async_trait::async_trait]
 #[typetag::serde(name = "pulsar")]
 impl SinkConfig for PulsarSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let sink = self.clone().new_sink(cx.acker())?;
-        let hc = self.clone().healthcheck();
+    fn build(&self, _cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+        unimplemented!()
+    }
+
+    async fn build_async(
+        &self,
+        cx: SinkContext,
+    ) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+        let producer = self
+            .create_pulsar_producer()
+            .await
+            .context(CreatePulsarSink)?;
+        let sink = self.clone().new_sink(producer, cx.acker())?;
+
+        let producer = self
+            .create_pulsar_producer()
+            .await
+            .context(CreatePulsarSink)?;
+        let hc = healthcheck(producer);
         Ok((Box::new(sink), Box::new(hc.boxed().compat())))
     }
 
@@ -100,10 +111,14 @@ impl PulsarSinkConfig {
         pulsar.producer().with_topic(&self.topic).build().await
     }
 
-    fn new_sink(self, acker: Acker) -> crate::Result<PulsarSink> {
+    fn new_sink(
+        self,
+        producer: Producer<TokioExecutor>,
+        acker: Acker,
+    ) -> crate::Result<PulsarSink> {
         Ok(PulsarSink {
             encoding: self.encoding.clone().into(),
-            producer: PulsarProducerState::NotReady(self),
+            producer: Arc::new(Mutex::new(producer)),
             in_flight: FuturesUnordered::new(),
             seq_head: 0,
             seq_tail: 0,
@@ -111,41 +126,10 @@ impl PulsarSinkConfig {
             acker,
         })
     }
-
-    async fn healthcheck(self) -> crate::Result<()> {
-        let producer = self
-            .create_pulsar_producer()
-            .await
-            .context(CreatePulsarSink)?;
-        producer.check_connection().await.map_err(Into::into)
-    }
 }
 
-impl PulsarSink {
-    fn poll_producer(&mut self) -> Poll<Arc<Mutex<Producer<TokioExecutor>>>, ()> {
-        loop {
-            self.producer = match self.producer {
-                PulsarProducerState::NotReady(ref config) => {
-                    let config = config.clone();
-                    let fut = async move {
-                        let producer = config.create_pulsar_producer().await;
-                        Ok(producer.expect("fail on creating pulsar producer"))
-                    };
-                    PulsarProducerState::Creating(Box::new(fut.boxed().compat()))
-                }
-                PulsarProducerState::Creating(ref mut fut) => match fut.poll() {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Ok(Async::Ready(producer)) => {
-                        PulsarProducerState::Ready(Arc::new(Mutex::new(producer)))
-                    }
-                    Err(_) => unreachable!(),
-                },
-                PulsarProducerState::Ready(ref producer) => {
-                    return Ok(Async::Ready(Arc::clone(producer)));
-                }
-            }
-        }
-    }
+async fn healthcheck(producer: Producer<TokioExecutor>) -> crate::Result<()> {
+    producer.check_connection().await.map_err(Into::into)
 }
 
 impl Sink for PulsarSink {
@@ -153,27 +137,22 @@ impl Sink for PulsarSink {
     type SinkError = ();
 
     fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
-        match self.poll_producer() {
-            Ok(Async::NotReady) => Ok(AsyncSink::NotReady(item)),
-            Ok(Async::Ready(producer)) => {
-                let message = encode_event(item, &self.encoding).map_err(|_| ())?;
+        let message = encode_event(item, &self.encoding).map_err(|_| ())?;
 
-                let fut = async move {
-                    let mut locked = producer.lock().await;
-                    match locked.send(message.clone()).await {
-                        Ok(fut) => fut.await,
-                        Err(e) => Err(e),
-                    }
-                };
-
-                let seqno = self.seq_head;
-                self.seq_head += 1;
-                self.in_flight
-                    .push((Box::new(fut.boxed().compat()) as SendFuture).join(future::ok(seqno)));
-                Ok(AsyncSink::Ready)
+        let producer = Arc::clone(&self.producer);
+        let fut = async move {
+            let mut locked = producer.lock().await;
+            match locked.send(message.clone()).await {
+                Ok(fut) => fut.await,
+                Err(e) => Err(e),
             }
-            Err(_) => unreachable!(),
-        }
+        };
+
+        let seqno = self.seq_head;
+        self.seq_head += 1;
+        self.in_flight
+            .push((Box::new(fut.boxed().compat()) as SendFuture).join(future::ok(seqno)));
+        Ok(AsyncSink::Ready)
     }
 
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
@@ -283,7 +262,8 @@ mod integration_tests {
                 .unwrap();
 
             let (acker, ack_counter) = Acker::new_for_testing();
-            let sink = cnf.new_sink(acker).unwrap();
+            let producer = cnf.create_pulsar_producer().await.unwrap();
+            let sink = cnf.new_sink(producer, acker).unwrap();
             let _ = sink.send_all(events).compat().await.unwrap();
             assert_eq!(
                 ack_counter.load(std::sync::atomic::Ordering::Relaxed),

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -117,7 +117,7 @@ impl PulsarSinkConfig {
         acker: Acker,
     ) -> crate::Result<PulsarSink> {
         Ok(PulsarSink {
-            encoding: self.encoding.clone().into(),
+            encoding: self.encoding.into(),
             producer: Arc::new(Mutex::new(producer)),
             in_flight: FuturesUnordered::new(),
             seq_head: 0,

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -152,9 +152,17 @@ pub struct SinkOuter {
     pub inner: Box<dyn SinkConfig>,
 }
 
+#[async_trait::async_trait]
 #[typetag::serde(tag = "type")]
 pub trait SinkConfig: core::fmt::Debug + Send + Sync {
     fn build(&self, cx: SinkContext) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)>;
+
+    async fn build_async(
+        &self,
+        cx: SinkContext,
+    ) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)> {
+        self.build(cx)
+    }
 
     fn input_type(&self) -> DataType;
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -184,7 +184,7 @@ fn validate_topology(opts: &Opts, config: &Config, fmt: &mut Formatter) -> bool 
 async fn validate_environment(config: &Config, fmt: &mut Formatter) -> bool {
     let diff = ConfigDiff::initial(config);
 
-    let mut pieces = if let Some(pieces) = validate_components(config, &diff, fmt) {
+    let mut pieces = if let Some(pieces) = validate_components(config, &diff, fmt).await {
         pieces
     } else {
         return false;
@@ -193,12 +193,16 @@ async fn validate_environment(config: &Config, fmt: &mut Formatter) -> bool {
     validate_healthchecks(config, &diff, &mut pieces, fmt).await
 }
 
-fn validate_components(config: &Config, diff: &ConfigDiff, fmt: &mut Formatter) -> Option<Pieces> {
+async fn validate_components(
+    config: &Config,
+    diff: &ConfigDiff,
+    fmt: &mut Formatter,
+) -> Option<Pieces> {
     event::LOG_SCHEMA
         .set(config.global.log_schema.clone())
         .expect("Couldn't set schema");
 
-    match topology::builder::build_pieces(config, diff) {
+    match topology::builder::build_pieces(config, diff).await {
         Ok(pieces) => {
             fmt.success("Component configuration");
             Some(pieces)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,8 +1,13 @@
 use vector::topology::{self, Config, ConfigDiff};
 
 fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
+    let mut rt = vector::runtime::Runtime::new().unwrap();
     Config::load(config.as_bytes())
-        .and_then(|c| topology::builder::check_build(&c, &ConfigDiff::initial(&c)))
+        .and_then(|c| {
+            rt.block_on_std(async move {
+                topology::builder::check_build(&c, &ConfigDiff::initial(&c)).await
+            })
+        })
         .map(|(_topology, warnings)| warnings)
 }
 


### PR DESCRIPTION
Closes #2687 
Closes #3019 

This adds a new `build_async` fn to `SinkConfig` that can be used in place of `build`. This was a smaller change than making `build` itself async and has the advantage of not requiring `async-trait` anywhere it's not needed, which improves error reporting.

We can follow up this PR and either add a default implementation of `build` or split the sync version into a subtrait. I don't have a strong opinion there so decided to punt for now.