### PR TITLE
fix(reduce transform): improve array handling

### DIFF
--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -375,9 +375,7 @@ pub fn get_value_merger(v: Value, m: &MergeStrategy) -> Result<Box<dyn ReduceVal
                 v.to_string_lossy()
             )),
         },
-        MergeStrategy::Array => match v {
-            _ => Ok(Box::new(ArrayMerger::new(v))),
-        },
+        MergeStrategy::Array => Ok(Box::new(ArrayMerger::new(v))),
         MergeStrategy::Discard => Ok(Box::new(DiscardMerger::new(v))),
     }
 }

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -79,8 +79,8 @@ struct ArrayMerger {
 }
 
 impl ArrayMerger {
-    fn new(v: Vec<Value>) -> Self {
-        Self { v }
+    fn new(v: Value) -> Self {
+        Self { v: vec![v] }
     }
 }
 
@@ -376,8 +376,7 @@ pub fn get_value_merger(v: Value, m: &MergeStrategy) -> Result<Box<dyn ReduceVal
             )),
         },
         MergeStrategy::Array => match v {
-            Value::Array(a) => Ok(Box::new(ArrayMerger::new(a))),
-            _ => Ok(Box::new(ArrayMerger::new(vec![v]))),
+            _ => Ok(Box::new(ArrayMerger::new(v))),
         },
         MergeStrategy::Discard => Ok(Box::new(DiscardMerger::new(v))),
     }

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -74,6 +74,35 @@ impl ReduceValueMerger for ConcatMerger {
 //------------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
+struct ConcatArrayMerger {
+    v: Vec<Value>,
+}
+
+impl ConcatArrayMerger {
+    fn new(v: Vec<Value>) -> Self {
+        Self { v }
+    }
+}
+
+impl ReduceValueMerger for ConcatArrayMerger {
+    fn add(&mut self, v: Value) -> Result<(), String> {
+        if let Value::Array(a) = v {
+            self.v.extend_from_slice(&a);
+        } else {
+            self.v.push(v);
+        }
+        Ok(())
+    }
+
+    fn insert_into(self: Box<Self>, k: String, v: &mut LogEvent) -> Result<(), String> {
+        v.insert(k, Value::Array(self.v));
+        Ok(())
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
 struct ArrayMerger {
     v: Vec<Value>,
 }
@@ -370,8 +399,9 @@ pub fn get_value_merger(v: Value, m: &MergeStrategy) -> Result<Box<dyn ReduceVal
         },
         MergeStrategy::Concat => match v {
             Value::Bytes(b) => Ok(Box::new(ConcatMerger::new(b))),
+            Value::Array(a) => Ok(Box::new(ConcatArrayMerger::new(a))),
             _ => Err(format!(
-                "expected string value, found: '{}'",
+                "expected string or array value, found: '{}'",
                 v.to_string_lossy()
             )),
         },
@@ -429,7 +459,7 @@ mod test {
         assert!(get_value_merger(json!([]).into(), &MergeStrategy::Max).is_err());
         assert!(get_value_merger(json!([]).into(), &MergeStrategy::Min).is_err());
         assert!(get_value_merger(json!([]).into(), &MergeStrategy::Array).is_ok());
-        assert!(get_value_merger(json!([]).into(), &MergeStrategy::Concat).is_err());
+        assert!(get_value_merger(json!([]).into(), &MergeStrategy::Concat).is_ok());
 
         assert!(get_value_merger(json!({}).into(), &MergeStrategy::Discard).is_ok());
         assert!(get_value_merger(json!({}).into(), &MergeStrategy::Sum).is_err());
@@ -508,6 +538,15 @@ mod test {
         assert_eq!(
             merge(4.3.into(), 4.2.into(), &MergeStrategy::Min),
             Ok(4.2.into())
+        );
+
+        assert_eq!(
+            merge(json!([4]).into(), json!([2]).into(), &MergeStrategy::Concat),
+            Ok(json!([4, 2]).into())
+        );
+        assert_eq!(
+            merge(json!([]).into(), 42.into(), &MergeStrategy::Concat),
+            Ok(json!([42]).into())
         );
     }
 

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -77,12 +77,11 @@ impl ReduceState {
     fn new(e: LogEvent, strategies: &IndexMap<String, MergeStrategy>) -> Self {
         Self {
             stale_since: Instant::now(),
-            // TODO: all_fields alternative that consumes
             fields: e
-                .all_fields()
+                .into_iter()
                 .filter_map(|(k, v)| {
                     if let Some(strat) = strategies.get(&k) {
-                        match get_value_merger(v.clone(), strat) {
+                        match get_value_merger(v, strat) {
                             Ok(m) => Some((k, m)),
                             Err(err) => {
                                 warn!("failed to create merger for field '{}': {}", k, err);
@@ -98,12 +97,12 @@ impl ReduceState {
     }
 
     fn add_event(&mut self, e: LogEvent, strategies: &IndexMap<String, MergeStrategy>) {
-        for (k, v) in e.all_fields() {
+        for (k, v) in e.into_iter() {
             let strategy = strategies.get(&k);
             match self.fields.entry(k) {
                 hash_map::Entry::Vacant(entry) => {
                     if let Some(strat) = strategy {
-                        match get_value_merger(v.clone(), strat) {
+                        match get_value_merger(v, strat) {
                             Ok(m) => {
                                 entry.insert(m);
                             }
@@ -291,6 +290,7 @@ mod test {
         topology::config::{TransformConfig, TransformContext},
         Event,
     };
+    use serde_json::json;
 
     #[test]
     fn reduce_from_condition() {
@@ -491,6 +491,61 @@ identifier_fields = [ "request_id" ]
         assert_eq!(
             outputs.first().unwrap().as_log()[&"counter".into()],
             Value::from(7)
+        );
+    }
+
+    #[test]
+    fn arrays() {
+        let mut reduce = toml::from_str::<ReduceConfig>(
+            r#"
+identifier_fields = [ "request_id" ]
+
+merge_strategies.foo = "array"
+
+[ends_when]
+  "test_end.exists" = true
+"#,
+        )
+        .unwrap()
+        .build(TransformContext::new_test())
+        .unwrap();
+
+        let mut outputs = Vec::new();
+
+        let mut e = Event::from("test message 1");
+        e.as_mut_log().insert("foo", json!([1, 3]));
+        e.as_mut_log().insert("request_id", "1");
+        reduce.transform_into(&mut outputs, e);
+
+        let mut e = Event::from("test message 2");
+        e.as_mut_log().insert("foo", json!([2, 4]));
+        e.as_mut_log().insert("request_id", "2");
+        reduce.transform_into(&mut outputs, e);
+
+        let mut e = Event::from("test message 3");
+        e.as_mut_log().insert("foo", json!([5, 7]));
+        e.as_mut_log().insert("request_id", "1");
+        e.as_mut_log().insert("test_end", "yep");
+        reduce.transform_into(&mut outputs, e);
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs.first().unwrap().as_log()[&"foo".into()],
+            json!([[1, 3], [5, 7]]).into()
+        );
+
+        outputs.clear();
+
+        let mut e = Event::from("test message 4");
+        e.as_mut_log().insert("foo", json!([6, 8]));
+        e.as_mut_log().insert("request_id", "2");
+        e.as_mut_log().insert("test_end", "yep");
+        reduce.transform_into(&mut outputs, e);
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs.first().unwrap().as_log()[&"foo".into()],
+            json!([[2, 4], [6, 8]]).into()
         );
     }
 }

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -89,7 +89,7 @@ impl ReduceState {
                             }
                         }
                     } else {
-                        Some((k, v.clone().into()))
+                        Some((k, v.into()))
                     }
                 })
                 .collect(),


### PR DESCRIPTION
Closes #3074 

Two bugs fixed here:

1. Using `all_fields` instead of `into_iter` gaves us paths instead of keys, so thing like arrays and objects would not get strategized correctly.
2. Special casing arrays when constructing the `ArrayMerger` meant that the initial array would be flattened in the result but subsequent additions would not.