### PR TITLE
fix(elasticsearch sink): stop logging every received event

### DIFF
--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -5,9 +5,14 @@ use string_cache::DefaultAtom as Atom;
 #[derive(Debug)]
 pub struct ElasticSearchEventReceived {
     pub byte_size: usize,
+    pub index: String,
 }
 
 impl InternalEvent for ElasticSearchEventReceived {
+    fn emit_logs(&self) {
+        trace!(message = "inserting event", index = %self.index);
+    }
+
     fn emit_metrics(&self) {
         counter!(
             "events_processed", 1,

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -186,7 +186,6 @@ impl HttpSink for ElasticSearchCommon {
                 emit!(ElasticSearchMissingKeys { keys: missing_keys });
             })
             .ok()?;
-        info!("inserting into index: {}", index);
 
         let mut action = json!({
             "index": {
@@ -207,7 +206,8 @@ impl HttpSink for ElasticSearchCommon {
         body.push(b'\n');
 
         emit!(ElasticSearchEventReceived {
-            byte_size: body.len()
+            byte_size: body.len(),
+            index
         });
 
         Some(body)


### PR DESCRIPTION
It was pointed out in #2973 that we're logging an awful lot in the ES sink. The current setup issues an `info` log every time it encodes an event, which very much seems like overkill.

This moves that log down to trace level, puts it behind the event emit, and cleans it up a bit.