### PR TITLE
chore(socket source): Update `udp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tokio-openssl = "0.3.0"
 tokio-retry = "0.2.0"
 tokio-signal = "0.2.7"
 tokio-compat = { version = "0.1", features = ["rt-full"] }
-tokio-util = { version = "0.3.1", features = ["compat"] }
+tokio-util = { version = "0.3.1", features = ["compat", "codec", "udp"] }
 async-trait = "0.1"
 
 # Tracing

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -142,8 +142,7 @@ mod test {
     use crate::shutdown::{ShutdownSignal, SourceShutdownCoordinator};
     use crate::sinks::util::tcp::TcpSink;
     use crate::test_util::{
-        block_on, collect_n, next_addr, runtime, send_lines, send_lines_tls, trace_init,
-        wait_for_tcp, CollectN,
+        block_on, collect_n, next_addr, runtime, send_lines, send_lines_tls, wait_for_tcp, CollectN,
     };
     use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
     use crate::topology::config::{GlobalOptions, SourceConfig};
@@ -702,7 +701,6 @@ mod test {
 
     #[test]
     fn udp_shutdown_infinite_stream() {
-        trace_init();
         let (tx, rx) = mpsc::channel(10);
         let source_name = "udp_shutdown_infinite_stream";
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -2,16 +2,17 @@ use crate::{
     event::{self, Event},
     internal_events::{UdpEventReceived, UdpSocketError},
     shutdown::ShutdownSignal,
-    sources::Source,
-    stream::StreamExt,
 };
-use bytes::Bytes;
+use bytes::BytesMut;
 use codec::BytesDelimitedCodec;
-use futures01::{future, sync::mpsc, Future, Sink, Stream};
+use futures::compat::Future01CompatExt;
+use futures01::{sync::mpsc, Sink};
 use serde::{Deserialize, Serialize};
 use std::{io, net::SocketAddr};
 use string_cache::DefaultAtom as Atom;
-use tokio01::net::udp::{UdpFramed, UdpSocket};
+use tokio::net::UdpSocket;
+use tokio::select;
+use tokio_codec::Decoder;
 
 /// UDP processes messages per packet, where messages are separated by newline.
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -19,6 +20,8 @@ use tokio01::net::udp::{UdpFramed, UdpSocket};
 pub struct UdpConfig {
     pub address: SocketAddr,
     pub host_key: Option<Atom>,
+    #[serde(default = "default_max_length")]
+    pub max_length: usize,
 }
 
 impl UdpConfig {
@@ -26,54 +29,73 @@ impl UdpConfig {
         Self {
             address,
             host_key: None,
+            max_length: default_max_length(),
         }
     }
 }
 
-pub fn udp(
+fn default_max_length() -> usize {
+    bytesize::kib(100u64) as usize
+}
+
+pub async fn udp(
     address: SocketAddr,
+    max_length: usize,
     host_key: Atom,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
-) -> Source {
-    let out = out.sink_map_err(|e| error!("error sending event: {:?}", e));
+    mut out: mpsc::Sender<Event>,
+) -> Result<(), ()> {
+    let mut socket = UdpSocket::bind(&address)
+        .await
+        .map_err(|error| error!(message = "Failed to bind to udp listener socket.",%error))?;
 
-    Box::new(
-        future::lazy(move || {
-            let socket = UdpSocket::bind(&address).expect("failed to bind to udp listener socket");
+    info!(message = "listening.", %address);
 
-            info!(message = "listening.", %address);
+    let host_key = host_key.clone();
 
-            Ok(socket)
-        })
-        .and_then(move |socket| {
-            let host_key = host_key.clone();
-            // UDP processes messages per packet, where messages are separated by newline.
-            // And stretch to end of packet.
-            UdpFramed::with_decode(socket, BytesDelimitedCodec::new(b'\n'), true)
-                .take_until(shutdown)
-                .map(move |(line, addr): (Bytes, _)| {
-                    let byte_size = line.len();
+    // Buffer for accepting udp payload.
+    let mut buffer = BytesMut::with_capacity(max_length);
+    buffer.resize(max_length, 0);
+
+    let mut shutdown = shutdown.compat();
+    'main: loop {
+        select! {
+            udp_result = socket.recv_from(&mut buffer) => {
+                let (byte_size, address) = udp_result.map_err(|error: io::Error| {
+                    emit!(UdpSocketError { error });
+                })?;
+
+                let mut payload = buffer.split_to(byte_size);
+
+                // UDP processes messages per payload, where messages are separated by newline
+                // and stretch to end of payload.
+                let mut decoder = BytesDelimitedCodec::new(b'\n');
+                while let Ok(Some(line)) = decoder.decode_eof(&mut payload) {
                     let mut event = Event::from(line);
 
                     event
                         .as_mut_log()
                         .insert(event::log_schema().source_type_key(), "socket");
-
                     event
                         .as_mut_log()
-                        .insert(host_key.clone(), addr.to_string());
+                        .insert(host_key.clone(), address.to_string());
 
                     emit!(UdpEventReceived { byte_size });
-                    event
-                })
-                // Error from Decoder or UdpSocket
-                .map_err(|error: io::Error| {
-                    emit!(UdpSocketError { error });
-                })
-                .forward(out)
-                // Done with listening and sending
-                .map(|_| ())
-        }),
-    )
+
+                    select!{
+                        result = out.send(event).compat() => {
+                            out=result.map_err(|error| error!(message = "Error sending event.", %error))?;
+                        }
+                        _ = &mut shutdown => break 'main,
+                    }
+                }
+
+                buffer.reserve(byte_size);
+                buffer.resize(max_length, 0);
+            }
+            _ = &mut shutdown => break,
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Ref. #2945

In `src/sources/socket/udp.rs `
 - Removes direct dependency on `tokio 0.1`
 - New `UdpFramed` wasn't usable, mostly because of crate `bytes` version mismatch, so we are now directly managing buffer for reading the data from socket. 
 - Bonus of not using `UdpFramed` is that now we accept `max_length` configuration for `udp` mod which is documented as available, but in reality wasn't implemented.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
