### PR TITLE
chore: Remove tokio 0.1 from shutdown

### DIFF
--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,9 +1,10 @@
+use futures::{FutureExt, TryFutureExt};
 use futures01::{future, Async, Future};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 use stream_cancel::{Trigger, Tripwire};
-use tokio01::timer;
+use tokio::time;
 
 /// When this struct goes out of scope and its internal refcount goes to 0 it is a signal that its
 /// corresponding Source has completed executing and may be cleaned up.  It is the responsibility
@@ -283,17 +284,15 @@ impl SourceShutdownCoordinator {
     ) -> impl Future<Item = bool, Error = ()> {
         let success = shutdown_complete_tripwire.map(move |_| true);
 
-        let timeout = timer::Delay::new(deadline)
-            .map(move |_| {
-                error!(
-                    "Source '{}' failed to shutdown before deadline. Forcing shutdown.",
-                    name,
-                );
-                false
-            })
-            .map_err(|err| panic!("Timer error: {:?}", err));
+        let timeout = time::delay_until(deadline.into()).map(move |_| {
+            error!(
+                "Source '{}' failed to shutdown before deadline. Forcing shutdown.",
+                name,
+            );
+            false
+        });
 
-        let union = success.select(timeout);
+        let union = success.select(timeout.map(Ok).compat());
         union
             .map(|(success, _)| {
                 if success {

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -282,7 +282,7 @@ impl SourceShutdownCoordinator {
         name: String,
         deadline: Instant,
     ) -> impl Future<Item = bool, Error = ()> {
-        let done = async move {
+        async move {
             select! {
                 _ = shutdown_complete_tripwire.compat() => {
                     shutdown_force_trigger.disable();
@@ -297,9 +297,10 @@ impl SourceShutdownCoordinator {
                     false
                 }
             }
-        };
-
-        Box::pin(done.map(Ok)).compat()
+        }
+        .map(Ok)
+        .boxed()
+        .compat()
     }
 }
 


### PR DESCRIPTION
Ref.  #2945.

Removes direct dependency on `tokio01` in `src/shutdown.rs`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
