### PR TITLE
chore(operations): Debian buster is stable, not sid

### DIFF
--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:stretch-slim AS builder
+FROM debian:buster-slim AS builder
 
 COPY vector-*.deb ./
 RUN dpkg -i vector-$(dpkg --print-architecture).deb
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
 

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:sid-slim AS builder
+FROM debian:stretch-slim AS builder
 
 COPY vector-*.deb ./
 RUN dpkg -i vector-$(dpkg --print-architecture).deb
 
-FROM debian:sid-slim
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix my mistake in #3129

Buster is stable, not sid.