### PR TITLE
fix(docs): Spelling fix on field path docs

### DIFF
--- a/website/docs/reference/field-path-notation.md
+++ b/website/docs/reference/field-path-notation.md
@@ -7,7 +7,7 @@ description: "Vector's field path notation allows you to reference field values 
 Throughout Vector's configuration you'll notice that certain options take field
 paths as values, such as the
 [`rename_fields` transform][docs.transforms.rename_fields]. In order to
-referenxe nested, or array, values you can use Vector's field path notation.
+reference nested or array values, you can use Vector's field path notation.
 This notation is not anything special, it simply uses `.` and `[<index>]` to
 access nested and array values, respectively.
 


### PR DESCRIPTION
Quick spelling fix on the field path notation docs page.