### PR TITLE
chore(transforms): add TransformConfig::build_async

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -177,7 +177,7 @@ pub async fn build_pieces(
         let cx = TransformContext { resolver };
 
         let input_type = transform.inner.input_type();
-        let transform = match transform.inner.build(cx) {
+        let transform = match transform.inner.build_async(cx).await {
             Err(error) => {
                 errors.push(format!("Transform \"{}\": {}", name, error));
                 continue;

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -204,9 +204,17 @@ pub struct TransformOuter {
     pub inner: Box<dyn TransformConfig>,
 }
 
+#[async_trait::async_trait]
 #[typetag::serde(tag = "type")]
 pub trait TransformConfig: core::fmt::Debug + Send + Sync {
     fn build(&self, cx: TransformContext) -> crate::Result<Box<dyn transforms::Transform>>;
+
+    async fn build_async(
+        &self,
+        cx: TransformContext,
+    ) -> crate::Result<Box<dyn transforms::Transform>> {
+        self.build(cx)
+    }
 
     fn input_type(&self) -> DataType;
 


### PR DESCRIPTION
Closes #2932 
Closes #2639 

Pretty straightforward! This was the only transform off the top of my head that needed an async build, but we can shift others if needed as well.