### PR TITLE
chore(operations): Fixup clippy issues from 1.44 rollback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::approx_constant)]
-#![allow(clippy::blocks_in_if_conditions)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]
 #![allow(clippy::new_ret_no_self)]
@@ -8,6 +7,7 @@
 #![allow(clippy::trivial_regex)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
+#![allow(clippy::block_in_if_condition_stmt)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
In #3141 we were too fast and clippy lints were failing. This fixes them.