### PR TITLE
chore(sources): add SourceConfig::build_async

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -136,7 +136,10 @@ pub async fn build_pieces(
 
         let (shutdown_signal, force_shutdown_tripwire) = shutdown_coordinator.register_source(name);
 
-        let server = match source.build(&name, &config.global, shutdown_signal, tx) {
+        let server = match source
+            .build_async(&name, &config.global, shutdown_signal, tx)
+            .await
+        {
             Err(error) => {
                 errors.push(format!("Source \"{}\": {}", name, error));
                 continue;

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -122,6 +122,7 @@ pub enum DataType {
     Metric,
 }
 
+#[async_trait::async_trait]
 #[typetag::serde(tag = "type")]
 pub trait SourceConfig: core::fmt::Debug + Send + Sync {
     fn build(
@@ -131,6 +132,16 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
         shutdown: ShutdownSignal,
         out: mpsc::Sender<Event>,
     ) -> crate::Result<sources::Source>;
+
+    async fn build_async(
+        &self,
+        name: &str,
+        globals: &GlobalOptions,
+        shutdown: ShutdownSignal,
+        out: mpsc::Sender<Event>,
+    ) -> crate::Result<sources::Source> {
+        self.build(name, globals, shutdown, out)
+    }
 
     fn output_type(&self) -> DataType;
 


### PR DESCRIPTION
Closes #2933 

This one is unused for the time being, but added for consistency. I'll open an issue to align all of these once we're further along.
