### PR TITLE
chore(sinks): Batch buffer size rework

### DIFF
--- a/benches/batch.rs
+++ b/benches/batch.rs
@@ -5,7 +5,8 @@ use std::convert::Infallible;
 use std::time::Duration;
 use vector::buffers::Acker;
 use vector::sinks::util::{
-    Batch, BatchSink, BatchSize, Buffer, Compression, Partition, PartitionBatchSink, PushResult,
+    batch::{Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult},
+    BatchSink, Buffer, Compression, Partition, PartitionBatchSink,
 };
 use vector::test_util::random_lines;
 
@@ -179,6 +180,13 @@ impl PartitionedBuffer {
 impl Batch for PartitionedBuffer {
     type Input = InnerBuffer;
     type Output = InnerBuffer;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Buffer::get_settings_defaults(config, defaults)
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         let key = item.key;

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -164,7 +164,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             .bytes(1_048_576)
             .events(10_000)
             .timeout(1)
-            .parse_config::<VecBuffer2<InputLogEvent>>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let log_group = self.group_name.clone();

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::{FixedRetryPolicy, RetryLogic},
-        rusoto, Batch, BatchConfig, BatchSettings, Compression, Length, PartitionBatchSink,
+        rusoto, BatchConfig, BatchSettings, Compression, Length, PartitionBatchSink,
         PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig, TowerRequestSettings,
         VecBuffer2,
     },
@@ -160,13 +160,11 @@ impl CloudwatchLogsSinkConfig {
 #[typetag::serde(name = "aws_cloudwatch_logs")]
 impl SinkConfig for CloudwatchLogsSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let batch = VecBuffer2::<InputLogEvent>::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(1_048_576)
-                .events(10_000)
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(1_048_576)
+            .events(10_000)
+            .timeout(1)
+            .parse_config::<VecBuffer2<InputLogEvent>>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let log_group = self.group_name.clone();

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -3,8 +3,8 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     region::RegionOrEndpoint,
     sinks::util::{
-        retries2::RetryLogic, rusoto, service2::TowerRequestConfig, BatchConfig, BatchSettings,
-        Compression, MetricBuffer,
+        retries2::RetryLogic, rusoto, service2::TowerRequestConfig, Batch, BatchConfig,
+        BatchSettings, Compression, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -117,11 +117,10 @@ impl CloudWatchMetricsSvc {
         client: CloudWatchClient,
         cx: SinkContext,
     ) -> crate::Result<super::RouterSink> {
-        let batch = config
-            .batch
-            .disallow_max_bytes()?
-            .use_size_as_events()?
-            .get_settings_or_default(BatchSettings::default().events(20).timeout(1));
+        let batch = MetricBuffer::get_settings_defaults(
+            config.batch,
+            BatchSettings::default().events(20).timeout(1),
+        )?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -3,8 +3,8 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     region::RegionOrEndpoint,
     sinks::util::{
-        retries2::RetryLogic, rusoto, service2::TowerRequestConfig, Batch, BatchConfig,
-        BatchSettings, Compression, MetricBuffer,
+        retries2::RetryLogic, rusoto, service2::TowerRequestConfig, BatchConfig, BatchSettings,
+        Compression, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -117,10 +117,10 @@ impl CloudWatchMetricsSvc {
         client: CloudWatchClient,
         cx: SinkContext,
     ) -> crate::Result<super::RouterSink> {
-        let batch = MetricBuffer::get_settings_defaults(
-            config.batch,
-            BatchSettings::default().events(20).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .events(20)
+            .timeout(1)
+            .parse_config::<MetricBuffer>(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -120,7 +120,7 @@ impl CloudWatchMetricsSvc {
         let batch = BatchSettings::default()
             .events(20)
             .timeout(1)
-            .parse_config::<MetricBuffer>(config.batch)?;
+            .parse_config(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -8,7 +8,7 @@ use crate::{
         rusoto,
         service2::TowerRequestConfig,
         sink::Response,
-        Batch, BatchConfig, BatchSettings, Compression, VecBuffer,
+        BatchConfig, BatchSettings, Compression, VecBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -129,10 +129,10 @@ impl KinesisFirehoseService {
         client: KinesisFirehoseClient,
         cx: SinkContext,
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
-        let batch = VecBuffer::<String>::get_settings_defaults(
-            config.batch,
-            BatchSettings::default().events(500).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .events(500)
+            .timeout(1)
+            .parse_config::<VecBuffer<String>>(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -132,7 +132,7 @@ impl KinesisFirehoseService {
         let batch = BatchSettings::default()
             .events(500)
             .timeout(1)
-            .parse_config::<VecBuffer<String>>(config.batch)?;
+            .parse_config(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -8,7 +8,7 @@ use crate::{
         rusoto,
         service2::TowerRequestConfig,
         sink::Response,
-        BatchConfig, BatchSettings, Compression, VecBuffer,
+        Batch, BatchConfig, BatchSettings, Compression, VecBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -129,11 +129,10 @@ impl KinesisFirehoseService {
         client: KinesisFirehoseClient,
         cx: SinkContext,
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
-        let batch = config
-            .batch
-            .disallow_max_bytes()?
-            .use_size_as_events()?
-            .get_settings_or_default(BatchSettings::default().events(500).timeout(1));
+        let batch = VecBuffer::<String>::get_settings_defaults(
+            config.batch,
+            BatchSettings::default().events(500).timeout(1),
+        )?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -9,7 +9,7 @@ use crate::{
         rusoto,
         service2::TowerRequestConfig,
         sink::Response,
-        Batch, BatchConfig, BatchSettings, Compression, VecBuffer,
+        BatchConfig, BatchSettings, Compression, VecBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -136,10 +136,10 @@ impl KinesisService {
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
         let client = Arc::new(client);
 
-        let batch = VecBuffer::<String>::get_settings_defaults(
-            config.batch,
-            BatchSettings::default().events(500).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .events(500)
+            .timeout(1)
+            .parse_config::<VecBuffer<String>>(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -9,7 +9,7 @@ use crate::{
         rusoto,
         service2::TowerRequestConfig,
         sink::Response,
-        BatchConfig, BatchSettings, Compression, VecBuffer,
+        Batch, BatchConfig, BatchSettings, Compression, VecBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -136,11 +136,10 @@ impl KinesisService {
     ) -> crate::Result<impl Sink<SinkItem = Event, SinkError = ()>> {
         let client = Arc::new(client);
 
-        let batch = config
-            .batch
-            .disallow_max_bytes()?
-            .use_size_as_events()?
-            .get_settings_or_default(BatchSettings::default().events(500).timeout(1));
+        let batch = VecBuffer::<String>::get_settings_defaults(
+            config.batch,
+            BatchSettings::default().events(500).timeout(1),
+        )?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -139,7 +139,7 @@ impl KinesisService {
         let batch = BatchSettings::default()
             .events(500)
             .timeout(1)
-            .parse_config::<VecBuffer<String>>(config.batch)?;
+            .parse_config(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -9,8 +9,8 @@ use crate::{
         rusoto,
         service2::{ServiceBuilderExt, TowerCompat, TowerRequestConfig},
         sink::Response,
-        BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
-        PartitionInnerBuffer,
+        Batch, BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink,
+        PartitionBuffer, PartitionInnerBuffer,
     },
     template::Template,
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -177,10 +177,10 @@ impl S3SinkConfig {
             .clone()
             .unwrap_or_else(|| "%s".into());
         let filename_append_uuid = self.filename_append_uuid.unwrap_or(true);
-        let batch = self
-            .batch
-            .use_size_as_bytes()?
-            .get_settings_or_default(BatchSettings::default().bytes(10_000_000).timeout(300));
+        let batch = Buffer::get_settings_defaults(
+            self.batch,
+            BatchSettings::default().bytes(10_000_000).timeout(300),
+        )?;
 
         let key_prefix = self.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix)?;

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -9,8 +9,8 @@ use crate::{
         rusoto,
         service2::{ServiceBuilderExt, TowerCompat, TowerRequestConfig},
         sink::Response,
-        Batch, BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink,
-        PartitionBuffer, PartitionInnerBuffer,
+        BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
+        PartitionInnerBuffer,
     },
     template::Template,
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -177,10 +177,10 @@ impl S3SinkConfig {
             .clone()
             .unwrap_or_else(|| "%s".into());
         let filename_append_uuid = self.filename_append_uuid.unwrap_or(true);
-        let batch = Buffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default().bytes(10_000_000).timeout(300),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(10_000_000)
+            .timeout(300)
+            .parse_config::<Buffer>(self.batch)?;
 
         let key_prefix = self.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix)?;

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -180,7 +180,7 @@ impl S3SinkConfig {
         let batch = BatchSettings::default()
             .bytes(10_000_000)
             .timeout(300)
-            .parse_config::<Buffer>(self.batch)?;
+            .parse_config(self.batch)?;
 
         let key_prefix = self.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix)?;

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -5,7 +5,7 @@ use crate::{
         http::{Auth, BatchedHttpSink, HttpClient, HttpRetryLogic, HttpSink},
         retries2::{RetryAction, RetryLogic},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, Buffer, Compression,
+        BatchConfig, BatchSettings, Buffer, Compression,
     },
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -60,12 +60,10 @@ pub enum Encoding {
 #[typetag::serde(name = "clickhouse")]
 impl SinkConfig for ClickhouseConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let batch = Buffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .timeout(1)
+            .parse_config::<Buffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -63,7 +63,7 @@ impl SinkConfig for ClickhouseConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
-            .parse_config::<Buffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -6,7 +6,7 @@ use crate::{
     sinks::util::{
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, MetricBuffer,
+        Batch, BatchConfig, BatchSettings, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -109,11 +109,10 @@ impl SinkConfig for DatadogConfig {
         let client = HttpClient::new(cx.resolver(), None)?;
         let healthcheck = healthcheck(self.clone(), client.clone()).boxed().compat();
 
-        let batch = self
-            .batch
-            .disallow_max_bytes()?
-            .use_size_as_events()?
-            .get_settings_or_default(BatchSettings::default().events(20).timeout(1));
+        let batch = MetricBuffer::get_settings_defaults(
+            self.batch,
+            BatchSettings::default().events(20).timeout(1),
+        )?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = build_uri(&self.host)?;

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -112,7 +112,7 @@ impl SinkConfig for DatadogConfig {
         let batch = BatchSettings::default()
             .events(20)
             .timeout(1)
-            .parse_config::<MetricBuffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = build_uri(&self.host)?;

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -6,7 +6,7 @@ use crate::{
     sinks::util::{
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, MetricBuffer,
+        BatchConfig, BatchSettings, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -109,10 +109,10 @@ impl SinkConfig for DatadogConfig {
         let client = HttpClient::new(cx.resolver(), None)?;
         let healthcheck = healthcheck(self.clone(), client.clone()).boxed().compat();
 
-        let batch = MetricBuffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default().events(20).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .events(20)
+            .timeout(1)
+            .parse_config::<MetricBuffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = build_uri(&self.host)?;

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -9,7 +9,7 @@ use crate::{
         retries2::{RetryAction, RetryLogic},
         rusoto,
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, Buffer, Compression,
+        BatchConfig, BatchSettings, Buffer, Compression,
     },
     template::{Template, TemplateError},
     tls::{TlsOptions, TlsSettings},
@@ -108,12 +108,10 @@ impl SinkConfig for ElasticSearchConfig {
 
         let common = ElasticSearchCommon::parse_config(&self)?;
         let compression = common.compression;
-        let batch = Buffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .timeout(1)
+            .parse_config::<Buffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::with_retry_logic(

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -9,7 +9,7 @@ use crate::{
         retries2::{RetryAction, RetryLogic},
         rusoto,
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, Buffer, Compression,
+        Batch, BatchConfig, BatchSettings, Buffer, Compression,
     },
     template::{Template, TemplateError},
     tls::{TlsOptions, TlsSettings},
@@ -108,15 +108,12 @@ impl SinkConfig for ElasticSearchConfig {
 
         let common = ElasticSearchCommon::parse_config(&self)?;
         let compression = common.compression;
-        let batch = self
-            .batch
-            .clone()
-            .use_size_as_bytes()?
-            .get_settings_or_default(
-                BatchSettings::default()
-                    .bytes(bytesize::mib(10u64))
-                    .timeout(1),
-            );
+        let batch = Buffer::get_settings_defaults(
+            self.batch,
+            BatchSettings::default()
+                .bytes(bytesize::mib(10u64))
+                .timeout(1),
+        )?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::with_retry_logic(

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -111,7 +111,7 @@ impl SinkConfig for ElasticSearchConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
-            .parse_config::<Buffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::with_retry_logic(

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -8,8 +8,8 @@ use crate::{
             http::{HttpClient, HttpClientFuture},
             retries2::{RetryAction, RetryLogic},
             service2::{ServiceBuilderExt, TowerCompat, TowerRequestConfig},
-            BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
-            PartitionInnerBuffer,
+            Batch, BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink,
+            PartitionBuffer, PartitionInnerBuffer,
         },
         Healthcheck, RouterSink,
     },
@@ -207,11 +207,12 @@ impl GcsSink {
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 
-        let batch = config.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch = Buffer::get_settings_defaults(
+            config.batch,
             BatchSettings::default()
                 .bytes(bytesize::mib(10u64))
                 .timeout(300),
-        );
+        )?;
 
         let key_prefix = config.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix).context(KeyPrefixTemplate)?;

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -210,7 +210,7 @@ impl GcsSink {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(300)
-            .parse_config::<Buffer>(config.batch)?;
+            .parse_config(config.batch)?;
 
         let key_prefix = config.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix).context(KeyPrefixTemplate)?;

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -8,8 +8,8 @@ use crate::{
             http::{HttpClient, HttpClientFuture},
             retries2::{RetryAction, RetryLogic},
             service2::{ServiceBuilderExt, TowerCompat, TowerRequestConfig},
-            Batch, BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink,
-            PartitionBuffer, PartitionInnerBuffer,
+            BatchConfig, BatchSettings, Buffer, Compression, PartitionBatchSink, PartitionBuffer,
+            PartitionInnerBuffer,
         },
         Healthcheck, RouterSink,
     },
@@ -207,12 +207,10 @@ impl GcsSink {
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
         let encoding = config.encoding.clone();
 
-        let batch = Buffer::get_settings_defaults(
-            config.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .timeout(300),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .timeout(300)
+            .parse_config::<Buffer>(config.batch)?;
 
         let key_prefix = config.key_prefix.as_deref().unwrap_or("date=%F/");
         let key_prefix = Template::try_from(key_prefix).context(KeyPrefixTemplate)?;

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -6,7 +6,7 @@ use crate::{
             encoding::{EncodingConfigWithDefault, EncodingConfiguration},
             http::{BatchedHttpSink, HttpClient, HttpSink},
             service2::TowerRequestConfig,
-            Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer,
+            BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer,
         },
         Healthcheck, RouterSink, UriParseError,
     },
@@ -70,13 +70,11 @@ impl SinkConfig for PubsubConfig {
 
     async fn build_async(&self, cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
         let sink = PubsubSink::from_config(self).await?;
-        let batch_settings = JsonArrayBuffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .events(1000)
-                .timeout(1),
-        )?;
+        let batch_settings = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .events(1000)
+            .timeout(1)
+            .parse_config::<JsonArrayBuffer>(self.batch)?;
         let request_settings = self.request.unwrap_with(&Default::default());
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -74,7 +74,7 @@ impl SinkConfig for PubsubConfig {
             .bytes(bytesize::mib(10u64))
             .events(1000)
             .timeout(1)
-            .parse_config::<JsonArrayBuffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request_settings = self.request.unwrap_with(&Default::default());
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -6,7 +6,7 @@ use crate::{
             encoding::{EncodingConfigWithDefault, EncodingConfiguration},
             http::{BatchedHttpSink, HttpClient, HttpSink},
             service2::TowerRequestConfig,
-            Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer,
+            BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer,
         },
         Healthcheck, RouterSink,
     },
@@ -117,12 +117,10 @@ impl SinkConfig for StackdriverConfig {
     async fn build_async(&self, cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
         let creds = self.auth.make_credentials(Scope::LoggingWrite).await?;
 
-        let batch = JsonArrayBuffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::kib(5000u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::kib(5000u64))
+            .timeout(1)
+            .parse_config::<JsonArrayBuffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -120,7 +120,7 @@ impl SinkConfig for StackdriverConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::kib(5000u64))
             .timeout(1)
-            .parse_config::<JsonArrayBuffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -43,7 +43,7 @@ impl SinkConfig for HoneycombConfig {
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::kib(100u64))
             .timeout(1)
-            .parse_config::<JsonArrayBuffer>(self.batch)?;
+            .parse_config(self.batch)?;
 
         let client = HttpClient::new(cx.resolver(), None)?;
 

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -3,7 +3,7 @@ use crate::{
     sinks::util::{
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
+        BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -40,12 +40,10 @@ inventory::submit! {
 impl SinkConfig for HoneycombConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = JsonArrayBuffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::kib(100u64))
-                .timeout(1),
-        )?;
+        let batch_settings = BatchSettings::default()
+            .bytes(bytesize::kib(100u64))
+            .timeout(1)
+            .parse_config::<JsonArrayBuffer>(self.batch)?;
 
         let client = HttpClient::new(cx.resolver(), None)?;
 

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -3,7 +3,7 @@ use crate::{
     sinks::util::{
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
+        Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -40,11 +40,12 @@ inventory::submit! {
 impl SinkConfig for HoneycombConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = self.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch_settings = JsonArrayBuffer::get_settings_defaults(
+            self.batch,
             BatchSettings::default()
                 .bytes(bytesize::kib(100u64))
                 .timeout(1),
-        );
+        )?;
 
         let client = HttpClient::new(cx.resolver(), None)?;
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -4,7 +4,7 @@ use crate::{
         encoding::{EncodingConfig, EncodingConfiguration},
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, Buffer, Compression, UriSerde,
+        Batch, BatchConfig, BatchSettings, Buffer, Compression, UriSerde,
     },
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -110,11 +110,12 @@ impl SinkConfig for HttpSinkConfig {
         config.uri = build_uri(config.uri.clone()).into();
 
         let compression = config.compression;
-        let batch = config.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch = Buffer::get_settings_defaults(
+            config.batch,
             BatchSettings::default()
                 .bytes(bytesize::mib(10u64))
                 .timeout(1),
-        );
+        )?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -113,7 +113,7 @@ impl SinkConfig for HttpSinkConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
-            .parse_config::<Buffer>(config.batch)?;
+            .parse_config(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -4,7 +4,7 @@ use crate::{
         encoding::{EncodingConfig, EncodingConfiguration},
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, Buffer, Compression, UriSerde,
+        BatchConfig, BatchSettings, Buffer, Compression, UriSerde,
     },
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -110,12 +110,10 @@ impl SinkConfig for HttpSinkConfig {
         config.uri = build_uri(config.uri.clone()).into();
 
         let compression = config.compression;
-        let batch = Buffer::get_settings_defaults(
-            config.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .timeout(1)
+            .parse_config::<Buffer>(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -83,7 +83,7 @@ impl SinkConfig for InfluxDBLogsConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(1u64))
             .timeout(1)
-            .parse_config::<Buffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let settings = influxdb_settings(

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -6,7 +6,7 @@ use crate::sinks::influxdb::{
 use crate::sinks::util::encoding::EncodingConfigWithDefault;
 use crate::sinks::util::http::{BatchedHttpSink, HttpClient, HttpSink};
 use crate::sinks::util::{
-    service2::TowerRequestConfig, BatchConfig, BatchSettings, Buffer, Compression,
+    service2::TowerRequestConfig, Batch, BatchConfig, BatchSettings, Buffer, Compression,
 };
 use crate::sinks::Healthcheck;
 use crate::{
@@ -80,11 +80,12 @@ impl SinkConfig for InfluxDBLogsConfig {
         let client = HttpClient::new(cx.resolver(), None)?;
         let healthcheck = self.healthcheck(client.clone())?;
 
-        let batch = self.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch = Buffer::get_settings_defaults(
+            self.batch,
             BatchSettings::default()
                 .bytes(bytesize::mib(1u64))
                 .timeout(1),
-        );
+        )?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let settings = influxdb_settings(

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -6,7 +6,7 @@ use crate::sinks::influxdb::{
 use crate::sinks::util::encoding::EncodingConfigWithDefault;
 use crate::sinks::util::http::{BatchedHttpSink, HttpClient, HttpSink};
 use crate::sinks::util::{
-    service2::TowerRequestConfig, Batch, BatchConfig, BatchSettings, Buffer, Compression,
+    service2::TowerRequestConfig, BatchConfig, BatchSettings, Buffer, Compression,
 };
 use crate::sinks::Healthcheck;
 use crate::{
@@ -80,12 +80,10 @@ impl SinkConfig for InfluxDBLogsConfig {
         let client = HttpClient::new(cx.resolver(), None)?;
         let healthcheck = self.healthcheck(client.clone())?;
 
-        let batch = Buffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(1u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(1u64))
+            .timeout(1)
+            .parse_config::<Buffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let settings = influxdb_settings(

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::util::{
         http::{HttpBatchService, HttpClient, HttpRetryLogic},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, MetricBuffer,
+        Batch, BatchConfig, BatchSettings, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -97,11 +97,10 @@ impl InfluxDBSvc {
         let token = settings.token();
         let protocol_version = settings.protocol_version();
 
-        let batch = config
-            .batch
-            .disallow_max_bytes()?
-            .use_size_as_events()?
-            .get_settings_or_default(BatchSettings::default().events(20).timeout(1));
+        let batch = MetricBuffer::get_settings_defaults(
+            config.batch,
+            BatchSettings::default().events(20).timeout(1),
+        )?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = settings.write_uri(endpoint)?;

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -100,7 +100,7 @@ impl InfluxDBSvc {
         let batch = BatchSettings::default()
             .events(20)
             .timeout(1)
-            .parse_config::<MetricBuffer>(config.batch)?;
+            .parse_config(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = settings.write_uri(endpoint)?;

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::util::{
         http::{HttpBatchService, HttpClient, HttpRetryLogic},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, MetricBuffer,
+        BatchConfig, BatchSettings, MetricBuffer,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -97,10 +97,10 @@ impl InfluxDBSvc {
         let token = settings.token();
         let protocol_version = settings.protocol_version();
 
-        let batch = MetricBuffer::get_settings_defaults(
-            config.batch,
-            BatchSettings::default().events(20).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .events(20)
+            .timeout(1)
+            .parse_config::<MetricBuffer>(config.batch)?;
         let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
 
         let uri = settings.write_uri(endpoint)?;

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -4,7 +4,7 @@ use crate::{
         encoding::EncodingConfigWithDefault,
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
+        BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -62,12 +62,10 @@ pub enum Encoding {
 impl SinkConfig for LogdnaConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = JsonArrayBuffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .timeout(1),
-        )?;
+        let batch_settings = BatchSettings::default()
+            .bytes(bytesize::mib(10u64))
+            .timeout(1)
+            .parse_config::<JsonArrayBuffer>(self.batch)?;
         let client = HttpClient::new(cx.resolver(), None)?;
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -65,7 +65,7 @@ impl SinkConfig for LogdnaConfig {
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
-            .parse_config::<JsonArrayBuffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let client = HttpClient::new(cx.resolver(), None)?;
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -4,7 +4,7 @@ use crate::{
         encoding::EncodingConfigWithDefault,
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
+        Batch, BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, UriSerde,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -62,11 +62,12 @@ pub enum Encoding {
 impl SinkConfig for LogdnaConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = self.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch_settings = JsonArrayBuffer::get_settings_defaults(
+            self.batch,
             BatchSettings::default()
                 .bytes(bytesize::mib(10u64))
                 .timeout(1),
-        );
+        )?;
         let client = HttpClient::new(cx.resolver(), None)?;
 
         let sink = BatchedHttpSink::new(

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -19,7 +19,7 @@ use crate::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, UriSerde, VecBuffer,
+        BatchConfig, BatchSettings, UriSerde, VecBuffer,
     },
     template::Template,
     tls::{TlsOptions, TlsSettings},
@@ -80,10 +80,10 @@ impl SinkConfig for LokiConfig {
         }
 
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = VecBuffer::<String>::get_settings_defaults(
-            self.batch,
-            BatchSettings::default().events(100_000).timeout(1),
-        )?;
+        let batch_settings = BatchSettings::default()
+            .events(100_000)
+            .timeout(1)
+            .parse_config::<VecBuffer<String>>(self.batch)?;
         let tls = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls)?;
 

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -19,7 +19,7 @@ use crate::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{Auth, BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, UriSerde, VecBuffer,
+        Batch, BatchConfig, BatchSettings, UriSerde, VecBuffer,
     },
     template::Template,
     tls::{TlsOptions, TlsSettings},
@@ -80,10 +80,10 @@ impl SinkConfig for LokiConfig {
         }
 
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = self
-            .batch
-            .use_size_as_bytes()?
-            .get_settings_or_default(BatchSettings::default().events(100_000).timeout(1));
+        let batch_settings = VecBuffer::<String>::get_settings_defaults(
+            self.batch,
+            BatchSettings::default().events(100_000).timeout(1),
+        )?;
         let tls = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls)?;
 

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -83,7 +83,7 @@ impl SinkConfig for LokiConfig {
         let batch_settings = BatchSettings::default()
             .events(100_000)
             .timeout(1)
-            .parse_config::<VecBuffer<String>>(self.batch)?;
+            .parse_config(self.batch)?;
         let tls = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls)?;
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -5,7 +5,7 @@ use crate::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        Batch, BatchConfig, BatchSettings, Buffer, Compression,
+        BatchConfig, BatchSettings, Buffer, Compression,
     },
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -81,12 +81,10 @@ impl SinkConfig for HecSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         validate_host(&self.host)?;
 
-        let batch = Buffer::get_settings_defaults(
-            self.batch,
-            BatchSettings::default()
-                .bytes(bytesize::mib(1u64))
-                .timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(bytesize::mib(1u64))
+            .timeout(1)
+            .parse_config::<Buffer>(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -5,7 +5,7 @@ use crate::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
-        BatchConfig, BatchSettings, Buffer, Compression,
+        Batch, BatchConfig, BatchSettings, Buffer, Compression,
     },
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
@@ -81,11 +81,12 @@ impl SinkConfig for HecSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         validate_host(&self.host)?;
 
-        let batch = self.batch.use_size_as_bytes()?.get_settings_or_default(
+        let batch = Buffer::get_settings_defaults(
+            self.batch,
             BatchSettings::default()
                 .bytes(bytesize::mib(1u64))
                 .timeout(1),
-        );
+        )?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -84,7 +84,7 @@ impl SinkConfig for HecSinkConfig {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(1u64))
             .timeout(1)
-            .parse_config::<Buffer>(self.batch)?;
+            .parse_config(self.batch)?;
         let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,7 +3,7 @@ use crate::{
     event::metric::{MetricKind, MetricValue},
     event::Event,
     sinks::util::{
-        service2::TowerCompat, Batch, BatchConfig, BatchSettings, BatchSink, Buffer, Compression,
+        service2::TowerCompat, BatchConfig, BatchSettings, BatchSink, Buffer, Compression,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -88,10 +88,11 @@ impl StatsdSvc {
         // However we need to leave some space for +1 extra trailing event in the buffer.
         // Also one might keep an eye on server side limitations, like
         // mentioned here https://github.com/DataDog/dd-agent/issues/2638
-        let batch = Buffer::get_settings_defaults(
-            config.batch,
-            BatchSettings::default().bytes(1300).events(1000).timeout(1),
-        )?;
+        let batch = BatchSettings::default()
+            .bytes(1300)
+            .events(1000)
+            .timeout(1)
+            .parse_config::<Buffer>(config.batch)?;
         let namespace = config.namespace.clone();
 
         let client = Client::new(config.address)?;

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -92,7 +92,7 @@ impl StatsdSvc {
             .bytes(1300)
             .events(1000)
             .timeout(1)
-            .parse_config::<Buffer>(config.batch)?;
+            .parse_config(config.batch)?;
         let namespace = config.namespace.clone();
 
         let client = Client::new(config.address)?;

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,7 +3,7 @@ use crate::{
     event::metric::{MetricKind, MetricValue},
     event::Event,
     sinks::util::{
-        service2::TowerCompat, BatchConfig, BatchSettings, BatchSink, Buffer, Compression,
+        service2::TowerCompat, Batch, BatchConfig, BatchSettings, BatchSink, Buffer, Compression,
     },
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -88,10 +88,10 @@ impl StatsdSvc {
         // However we need to leave some space for +1 extra trailing event in the buffer.
         // Also one might keep an eye on server side limitations, like
         // mentioned here https://github.com/DataDog/dd-agent/issues/2638
-        let batch = config
-            .batch
-            .use_size_as_bytes()?
-            .get_settings_or_default(BatchSettings::default().bytes(1300).events(1000).timeout(1));
+        let batch = Buffer::get_settings_defaults(
+            config.batch,
+            BatchSettings::default().bytes(1300).events(1000).timeout(1),
+        )?;
         let namespace = config.namespace.clone();
 
         let client = Client::new(config.address)?;

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -24,6 +24,7 @@ pub struct BatchConfig {
 }
 
 impl BatchConfig {
+    // This is used internally by new_relic_logs sink, else it could be pub(super) too
     pub fn use_size_as_bytes(&self) -> Result<Self, BatchError> {
         let max_bytes = match (self.max_bytes, self.max_size) {
             (Some(_), Some(_)) => return Err(BatchError::BytesAndSize),
@@ -38,7 +39,7 @@ impl BatchConfig {
         })
     }
 
-    pub fn disallow_max_bytes(&self) -> Result<Self, BatchError> {
+    pub(super) fn disallow_max_bytes(&self) -> Result<Self, BatchError> {
         // Sinks that used `max_size` for an event count cannot count
         // bytes, so err if `max_bytes` is set.
         match self.max_bytes {
@@ -47,7 +48,7 @@ impl BatchConfig {
         }
     }
 
-    pub fn use_size_as_events(&self) -> Result<Self, BatchError> {
+    pub(super) fn use_size_as_events(&self) -> Result<Self, BatchError> {
         let max_events = match (self.max_events, self.max_size) {
             (Some(_), Some(_)) => return Err(BatchError::EventsAndSize),
             (Some(events), None) => Some(events),
@@ -61,7 +62,7 @@ impl BatchConfig {
         })
     }
 
-    pub fn get_settings_or_default(&self, defaults: BatchSettings) -> BatchSettings {
+    pub(super) fn get_settings_or_default(&self, defaults: BatchSettings) -> BatchSettings {
         BatchSettings {
             size: BatchSize {
                 bytes: self.max_bytes.unwrap_or(defaults.size.bytes),

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -92,6 +92,10 @@ pub struct BatchSettings {
 }
 
 impl BatchSettings {
+    pub fn parse_config<B: Batch>(self, config: BatchConfig) -> Result<BatchSettings, BatchError> {
+        B::get_settings_defaults(config, self)
+    }
+
     // Fake the builder pattern
     pub const fn bytes(self, bytes: u64) -> Self {
         Self {

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -140,6 +140,15 @@ pub trait Batch {
     type Input;
     type Output;
 
+    /// Turn the batch configuration into an actualized set of settings,
+    /// and deal with the proper behavior of `max_size` and if
+    /// `max_bytes` may be set. This is in the trait to ensure all batch
+    /// buffers implement it.
+    fn get_settings_defaults(
+        _config: BatchConfig,
+        _defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError>;
+
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input>;
     fn is_empty(&self) -> bool;
     fn fresh(&self) -> Self;
@@ -187,6 +196,13 @@ where
 {
     type Input = B::Input;
     type Output = B::Output;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        B::get_settings_defaults(config, defaults)
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         if self.was_full {

--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -11,11 +11,11 @@ pub type BoxedRawValue = Box<RawValue>;
 pub struct JsonArrayBuffer {
     buffer: Vec<BoxedRawValue>,
     total_bytes: usize,
-    settings: BatchSize,
+    settings: BatchSize<Self>,
 }
 
 impl JsonArrayBuffer {
-    pub fn new(settings: BatchSize) -> Self {
+    pub fn new(settings: BatchSize<Self>) -> Self {
         Self {
             buffer: Vec::new(),
             total_bytes: 0,
@@ -30,8 +30,8 @@ impl Batch for JsonArrayBuffer {
 
     fn get_settings_defaults(
         config: BatchConfig,
-        defaults: BatchSettings,
-    ) -> Result<BatchSettings, BatchError> {
+        defaults: BatchSettings<Self>,
+    ) -> Result<BatchSettings<Self>, BatchError> {
         Ok(config
             .use_size_as_bytes()?
             .get_settings_or_default(defaults))
@@ -78,10 +78,7 @@ mod tests {
 
     #[test]
     fn multi_object_array() {
-        let batch = BatchSize {
-            bytes: 9999,
-            events: 2,
-        };
+        let batch = BatchSettings::default().bytes(9999).events(2).size;
         let mut buffer = JsonArrayBuffer::new(batch);
 
         assert_eq!(

--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -1,4 +1,6 @@
-use crate::sinks::util::{batch::err_event_too_large, Batch, BatchSize, PushResult};
+use super::super::batch::{
+    err_event_too_large, Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+};
 use serde_json::value::{to_raw_value, RawValue, Value};
 
 pub type BoxedRawValue = Box<RawValue>;
@@ -25,6 +27,15 @@ impl JsonArrayBuffer {
 impl Batch for JsonArrayBuffer {
     type Input = Value;
     type Output = Vec<BoxedRawValue>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Ok(config
+            .use_size_as_bytes()?
+            .get_settings_or_default(defaults))
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         let raw_item = to_raw_value(&item).expect("Value should be valid json");

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -1,6 +1,8 @@
 use crate::event::metric::{Metric, MetricKind, MetricValue};
 use crate::event::Event;
-use crate::sinks::util::{Batch, BatchSize, PushResult};
+use crate::sinks::util::batch::{
+    Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+};
 use std::cmp::Ordering;
 use std::collections::{hash_map::DefaultHasher, HashSet};
 use std::hash::{Hash, Hasher};
@@ -113,6 +115,16 @@ impl MetricBuffer {
 impl Batch for MetricBuffer {
     type Input = Event;
     type Output = Vec<Metric>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Ok(config
+            .disallow_max_bytes()?
+            .use_size_as_events()?
+            .get_settings_or_default(defaults))
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         if self.num_items() >= self.max_events {

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -58,7 +58,7 @@ pub struct Buffer {
     inner: InnerBuffer,
     num_items: usize,
     num_bytes: usize,
-    settings: BatchSize,
+    settings: BatchSize<Self>,
     compression: Compression,
 }
 
@@ -69,7 +69,7 @@ pub enum InnerBuffer {
 }
 
 impl Buffer {
-    pub fn new(settings: BatchSize, compression: Compression) -> Self {
+    pub fn new(settings: BatchSize<Self>, compression: Compression) -> Self {
         let buffer = Vec::with_capacity(settings.bytes);
         let inner = match compression {
             Compression::None => InnerBuffer::Plain(buffer),
@@ -121,8 +121,8 @@ impl Batch for Buffer {
 
     fn get_settings_defaults(
         config: BatchConfig,
-        defaults: BatchSettings,
-    ) -> Result<BatchSettings, BatchError> {
+        defaults: BatchSettings<Self>,
+    ) -> Result<BatchSettings<Self>, BatchError> {
         Ok(config
             .use_size_as_bytes()?
             .get_settings_or_default(defaults))
@@ -172,7 +172,7 @@ impl Batch for Buffer {
 mod test {
     use super::{Buffer, Compression};
     use crate::buffers::Acker;
-    use crate::sinks::util::{BatchSink, BatchSize};
+    use crate::sinks::util::{BatchSettings, BatchSink};
     use crate::test_util::runtime;
     use futures01::{future, Future, Sink};
     use std::io::Read;
@@ -197,10 +197,7 @@ mod test {
 
             future::ok::<_, std::io::Error>(())
         });
-        let batch_size = BatchSize {
-            bytes: 100_000,
-            events: 1_000,
-        };
+        let batch_size = BatchSettings::default().bytes(100_000).events(1_000).size;
         let timeout = Duration::from_secs(0);
 
         let buffered = BatchSink::with_executor(

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -1,4 +1,6 @@
-use super::batch::{err_event_too_large, Batch, BatchSize, PushResult};
+use super::batch::{
+    err_event_too_large, Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+};
 use flate2::write::GzEncoder;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -116,6 +118,15 @@ impl Buffer {
 impl Batch for Buffer {
     type Input = Vec<u8>;
     type Output = Vec<u8>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Ok(config
+            .use_size_as_bytes()?
+            .get_settings_or_default(defaults))
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         // The compressed encoders don't flush bytes immediately, so we

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -1,4 +1,4 @@
-use crate::sinks::util::{Batch, PushResult};
+use super::super::batch::{Batch, BatchConfig, BatchError, BatchSettings, PushResult};
 
 pub trait Partition<K> {
     fn partition(&self) -> K;
@@ -28,6 +28,13 @@ where
 {
     type Input = PartitionInnerBuffer<T::Input, K>;
     type Output = PartitionInnerBuffer<T::Output, K>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        T::get_settings_defaults(config, defaults)
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         let key = item.key;

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -31,9 +31,9 @@ where
 
     fn get_settings_defaults(
         config: BatchConfig,
-        defaults: BatchSettings,
-    ) -> Result<BatchSettings, BatchError> {
-        T::get_settings_defaults(config, defaults)
+        defaults: BatchSettings<Self>,
+    ) -> Result<BatchSettings<Self>, BatchError> {
+        Ok(T::get_settings_defaults(config, defaults.into())?.into())
     }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -7,7 +7,7 @@ pub struct VecBuffer<T> {
 }
 
 impl<T> VecBuffer<T> {
-    pub fn new(settings: BatchSize) -> Self {
+    pub fn new(settings: BatchSize<Self>) -> Self {
         Self::new_with_max(settings.events)
     }
 
@@ -23,8 +23,8 @@ impl<T> Batch for VecBuffer<T> {
 
     fn get_settings_defaults(
         config: BatchConfig,
-        defaults: BatchSettings,
-    ) -> Result<BatchSettings, BatchError> {
+        defaults: BatchSettings<Self>,
+    ) -> Result<BatchSettings<Self>, BatchError> {
         Ok(config
             .disallow_max_bytes()?
             .use_size_as_events()?

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -1,4 +1,4 @@
-use super::super::{Batch, BatchSize, PushResult};
+use super::super::batch::{Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult};
 
 #[derive(Clone)]
 pub struct VecBuffer<T> {
@@ -20,6 +20,16 @@ impl<T> VecBuffer<T> {
 impl<T> Batch for VecBuffer<T> {
     type Input = T;
     type Output = Vec<T>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Ok(config
+            .disallow_max_bytes()?
+            .use_size_as_events()?
+            .get_settings_or_default(defaults))
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         if self.batch.len() >= self.max_events {

--- a/src/sinks/util/buffer/vec2.rs
+++ b/src/sinks/util/buffer/vec2.rs
@@ -1,4 +1,6 @@
-use super::{err_event_too_large, Batch, BatchSize, PushResult};
+use super::{
+    err_event_too_large, Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+};
 
 pub trait Length {
     fn len(&self) -> usize;
@@ -32,6 +34,15 @@ impl<T> VecBuffer2<T> {
 impl<T: Length> Batch for VecBuffer2<T> {
     type Input = T;
     type Output = Vec<T>;
+
+    fn get_settings_defaults(
+        config: BatchConfig,
+        defaults: BatchSettings,
+    ) -> Result<BatchSettings, BatchError> {
+        Ok(config
+            .use_size_as_events()?
+            .get_settings_or_default(defaults))
+    }
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input> {
         let new_bytes = self.bytes + item.len();

--- a/src/sinks/util/buffer/vec2.rs
+++ b/src/sinks/util/buffer/vec2.rs
@@ -14,15 +14,15 @@ pub trait Length {
 pub struct VecBuffer2<T> {
     batch: Vec<T>,
     bytes: usize,
-    settings: BatchSize,
+    settings: BatchSize<Self>,
 }
 
 impl<T> VecBuffer2<T> {
-    pub fn new(settings: BatchSize) -> Self {
+    pub fn new(settings: BatchSize<Self>) -> Self {
         Self::new_with_settings(settings)
     }
 
-    fn new_with_settings(settings: BatchSize) -> Self {
+    fn new_with_settings(settings: BatchSize<Self>) -> Self {
         Self {
             batch: Vec::with_capacity(settings.events),
             bytes: 0,
@@ -37,8 +37,8 @@ impl<T: Length> Batch for VecBuffer2<T> {
 
     fn get_settings_defaults(
         config: BatchConfig,
-        defaults: BatchSettings,
-    ) -> Result<BatchSettings, BatchError> {
+        defaults: BatchSettings<Self>,
+    ) -> Result<BatchSettings<Self>, BatchError> {
         Ok(config
             .use_size_as_events()?
             .get_settings_or_default(defaults))

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -767,7 +767,7 @@ impl<'a> Response for &'a str {}
 mod tests {
     use super::*;
     use crate::buffers::Acker;
-    use crate::sinks::util::{buffer::partition::Partition, BatchSize, VecBuffer};
+    use crate::sinks::util::{buffer::partition::Partition, BatchSettings, VecBuffer};
     use crate::test_util::runtime;
     use bytes::Bytes;
     use futures01::{future, Sink};
@@ -777,10 +777,6 @@ mod tests {
     };
     use tokio01_test::clock::MockClock;
 
-    const BATCH_SIZE: BatchSize = BatchSize {
-        events: 10,
-        bytes: 9999,
-    };
     const TIMEOUT: Duration = Duration::from_secs(10);
 
     #[test]
@@ -791,10 +787,11 @@ mod tests {
 
         let (acker, ack_counter) = Acker::new_for_testing();
 
+        let batch = BatchSettings::default().events(10).bytes(9999);
         let svc = tower::service_fn(|_| future::ok::<_, std::io::Error>(()));
         let buffered = BatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -842,14 +839,11 @@ mod tests {
             Delay::new(deadline).map(drop)
         });
 
-        let batch_size = BatchSize {
-            events: 1,
-            ..BATCH_SIZE
-        };
+        let batch = BatchSettings::default().bytes(9999).events(1);
 
         let mut sink = BatchSink::with_executor(
             svc,
-            VecBuffer::new(batch_size),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             exec.clone(),
@@ -918,9 +912,10 @@ mod tests {
 
             future::ok::<_, std::io::Error>(())
         });
+        let batch = BatchSettings::default().bytes(9999).events(10);
         let buffered = BatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -960,9 +955,10 @@ mod tests {
 
             future::ok::<_, std::io::Error>(())
         });
+        let batch = BatchSettings::default().bytes(9999).events(10);
         let mut buffered = BatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -994,9 +990,10 @@ mod tests {
 
             future::ok::<_, std::io::Error>(())
         });
+        let batch = BatchSettings::default().bytes(9999).events(10);
         let mut buffered = BatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -1029,9 +1026,10 @@ mod tests {
 
             future::ok::<_, std::io::Error>(())
         });
+        let batch = BatchSettings::default().bytes(9999).events(10);
         let buffered = PartitionBatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -1068,14 +1066,11 @@ mod tests {
             future::ok::<_, std::io::Error>(())
         });
 
-        let batch_size = BatchSize {
-            events: 1,
-            ..BATCH_SIZE
-        };
+        let batch = BatchSettings::default().bytes(9999).events(1);
 
         let buffered = PartitionBatchSink::with_executor(
             svc,
-            VecBuffer::new(batch_size),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -1108,14 +1103,11 @@ mod tests {
             future::ok::<_, std::io::Error>(())
         });
 
-        let batch_size = BatchSize {
-            events: 2,
-            ..BATCH_SIZE
-        };
+        let batch = BatchSettings::default().bytes(9999).events(2);
 
         let buffered = PartitionBatchSink::with_executor(
             svc,
-            VecBuffer::new(batch_size),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),
@@ -1155,9 +1147,10 @@ mod tests {
             future::ok::<_, std::io::Error>(())
         });
 
+        let batch = BatchSettings::default().bytes(9999).events(10);
         let mut buffered = PartitionBatchSink::with_executor(
             svc,
-            VecBuffer::new(BATCH_SIZE),
+            VecBuffer::new(batch.size),
             TIMEOUT,
             acker,
             rt.executor(),


### PR DESCRIPTION
Closes #3024 

This doesn't directly merge batch settings parsing with later handling, but ties the two together using type inference, such that the correct handler is used automatically.