### PR TITLE
chore(operations): Fixup version invocation to not have info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,7 +531,7 @@ target-graph: ## Display dependencies between targets in this Makefile
 	@cd $(shell realpath $(shell dirname $(firstword $(MAKEFILE_LIST)))) && docker-compose run --rm target-graph $(TARGET)
 
 version: ## Get the current Vector version
-	$(RUN) version
+	@scripts/version.sh
 
 git-hooks: ## Add Vector-local git hooks for commit sign-off
 	@scripts/install-git-hooks.sh


### PR DESCRIPTION
Fixes the `make version` command from outputting content that would break the release process. Closes #3152 