### PR TITLE
chore(operations): Bump vector to 0.11.0 to fix make check-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,8 +341,7 @@ jobs:
           path: target/artifacts
       - run: |
           export PASS_VERSION=$(make version)
-          export PASS_CIRCLE_SHA1="${{ github.sha }}"
-          export PASS_GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           make release-github
 
   release-homebrew:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,7 +5477,7 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "vector"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Fixed the `make check-version` check failing