### PR TITLE
chore(operations): teach dependabot the right label

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,7 +8,7 @@ update_configs:
     default_assignees:
       - "hoverbear"
     default_labels:
-      - "domain: dependencies"
+      - "domain: deps"
     # https://dependabot.com/docs/config-file/#version_requirement_updates
     version_requirement_updates: "off" # We should consider switching this to "auto"
     commit_message:


### PR DESCRIPTION
Dependabot complains a lot about this so it's simple to fix: https://github.com/timberio/vector/pull/3116#issuecomment-660954930