### PR TITLE
chore(operations): Resolve newest release issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,7 +342,8 @@ jobs:
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: |
-          export PASS_VERSION=$(make version)
+          export VERSION=$(make version)
+          export SHA1="${{ github.sha }}"
           export GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           make release-github
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
         run: make release-s3
 
   release-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
@@ -339,6 +339,8 @@ jobs:
         with:
           name: vector-aarch64.rpm
           path: target/artifacts
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
       - run: |
           export PASS_VERSION=$(make version)
           export GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
@@ -408,6 +410,6 @@ jobs:
           name: vector-aarch64.rpm
           path: target/artifacts
       - run: |
-          export PASS_VERSION=$(make version)
+          export VERSION=$(make version)
           export GITHUB_TOKEN="${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}"
           make release-homebrew


### PR DESCRIPTION
Resolve the newest issues present in https://github.com/timberio/vector/actions/runs/178842534.

![image](https://user-images.githubusercontent.com/130903/88230422-42849f00-cc27-11ea-9033-fd9c4ab55870.png)

This is resolved by using a newer version of ubuntu that is bootstraped with our env.

![image](https://user-images.githubusercontent.com/130903/88230464-55976f00-cc27-11ea-8c3c-1312c3529c57.png)

This is solved by renaming `PASS_VERSION` to `VERSION`.

(Reminder we can't test these very well outside of actually trying to do a release)