### PR TITLE
chore(operations): Fix release-github and release-homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,7 +348,7 @@ jobs:
           make release-github
 
   release-homebrew:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
@@ -410,6 +410,8 @@ jobs:
         with:
           name: vector-aarch64.rpm
           path: target/artifacts
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
       - run: |
           export VERSION=$(make version)
           export GITHUB_TOKEN="${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}"

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -25,6 +25,10 @@ apt install --yes \
     libsasl2-dev \
     gnupg2
 
+wget https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
+tar -xvf grease-1.0.1-linux-amd64.tar.gz
+cp grease/bin/grease /usr/bin/grease
+
 # Locales
 locale-gen en_US.UTF-8
 dpkg-reconfigure locales

--- a/scripts/release-github.rb
+++ b/scripts/release-github.rb
@@ -13,7 +13,7 @@ require_relative "setup"
 #
 
 VERSION = ENV.fetch("VERSION")
-SHA1 = ENV.fetch("CIRCLE_SHA1")
+SHA1 = ENV.fetch("SHA1")
 
 #
 # Setup


### PR DESCRIPTION
This didn't slip into the other PR #3165 :(

Also provisions the https://github.com/timberio/grease tool in our bootstrappers and updates the `release-homebrew` task to use it.