### PR TITLE
chore(operations): Use curl to get grease

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -25,7 +25,7 @@ apt install --yes \
     libsasl2-dev \
     gnupg2
 
-curl -O https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
+curl -LO https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
 tar -xvf grease-1.0.1-linux-amd64.tar.gz
 cp grease/bin/grease /usr/bin/grease
 

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -25,7 +25,7 @@ apt install --yes \
     libsasl2-dev \
     gnupg2
 
-wget https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
+curl -O https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
 tar -xvf grease-1.0.1-linux-amd64.tar.gz
 cp grease/bin/grease /usr/bin/grease
 


### PR DESCRIPTION
We didn't catch this on CI because the docker images we're using differ slightly from the CI base images. (#3125 will improve this!)