### PR TITLE
chore: Moves platform-specific signal code out of `main`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod region;
 pub mod runtime;
 pub mod serde;
 pub mod shutdown;
+pub mod signal;
 pub mod sinks;
 pub mod sources;
 pub mod stream;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,18 @@ extern crate tracing;
 mod cli;
 
 use cli::{Color, LogFormat, Opts, SubCommand};
-use futures::compat::Future01CompatExt;
+use futures::{compat::Future01CompatExt, StreamExt, TryStreamExt};
 use futures01::{future, Future, Stream};
 use std::{
     cmp::max,
     fs::File,
     path::{Path, PathBuf},
 };
-#[cfg(unix)]
-use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use topology::Config;
 use vector::{
-    config_paths, event, generate, list, metrics, runtime, topology, trace, unit_test, validate,
+    config_paths, event, generate, list, metrics, runtime,
+    signal::{self, SignalTo},
+    topology, trace, unit_test, validate,
 };
 
 fn main() {
@@ -132,69 +132,62 @@ fn main() {
             std::process::exit(exitcode::CONFIG);
         });
 
-        #[cfg(unix)]
-        {
-            let mut topology = topology;
-            let sigint = Signal::new(SIGINT).flatten_stream();
-            let sigterm = Signal::new(SIGTERM).flatten_stream();
-            let sigquit = Signal::new(SIGQUIT).flatten_stream();
-            let sighup = Signal::new(SIGHUP).flatten_stream();
+        let mut topology = topology;
 
-            let mut signals = sigint.select(sigterm.select(sigquit.select(sighup)));
+        let mut signals = signal::signals().map(Result::<_, ()>::Ok).boxed().compat();
 
-            let signal = loop {
-                let signal = future::poll_fn(|| signals.poll());
-                let to_shutdown = future::poll_fn(|| graceful_crash.poll())
-                    .map(|_| ())
-                    .select(topology.sources_finished());
+        let signal = loop {
+            let signal = future::poll_fn(|| signals.poll());
+            let to_shutdown = future::poll_fn(|| graceful_crash.poll())
+                .map(|_| ())
+                .select(topology.sources_finished());
 
-                let next = signal
-                    .select2(to_shutdown)
-                    .compat()
-                    .await
-                    .map_err(|_| ())
-                    .expect("Neither stream errors");
+            let next = signal
+                .select2(to_shutdown)
+                .compat()
+                .await
+                .map_err(|_| ())
+                .expect("Neither stream errors");
 
-                let signal = match next {
-                    future::Either::A((signal, _)) => signal.expect("Signal streams never end"),
-                    // Trigger graceful shutdown if a component crashed, or all sources have ended.
-                    future::Either::B((_to_shutdown, _)) => SIGINT,
-                };
-
-                if signal != SIGHUP {
-                    break signal;
-                }
-
-                // Reload config
-                info!(
-                    message = "Reloading configs.",
-                    path = ?config_paths
-                );
-                let new_config = read_configs(&config_paths);
-
-                trace!("Parsing config");
-                let new_config = handle_config_errors(new_config);
-                if let Some(new_config) = new_config {
-                    match topology
-                        .reload_config_and_respawn(new_config, opts.require_healthy)
-                        .await
-                    {
-                        Ok(true) => (),
-                        Ok(false) => error!("Reload was not successful."),
-                        // Trigger graceful shutdown for what remains of the topology
-                        Err(()) => break SIGINT,
-                    }
-                } else {
-                    error!("Reload aborted.");
-                }
+            let signal = match next {
+                future::Either::A((signal, _)) => signal.expect("Signal streams never end"),
+                // Trigger graceful shutdown if a component crashed, or all sources have ended.
+                future::Either::B((_to_shutdown, _)) => SignalTo::Shutdown,
             };
 
-            if signal == SIGINT || signal == SIGTERM {
-                use futures01::future::Either;
+            if signal != SignalTo::Reload {
+                break signal;
+            }
 
+            // Reload config
+            info!(
+                message = "Reloading configs.",
+                path = ?config_paths
+            );
+            let new_config = read_configs(&config_paths);
+
+            trace!("Parsing config");
+            let new_config = handle_config_errors(new_config);
+            if let Some(new_config) = new_config {
+                match topology
+                    .reload_config_and_respawn(new_config, opts.require_healthy)
+                    .await
+                {
+                    Ok(true) => (),
+                    Ok(false) => error!("Reload was not successful."),
+                    // Trigger graceful shutdown for what remains of the topology
+                    Err(()) => break SignalTo::Shutdown,
+                }
+            } else {
+                error!("Reload aborted.");
+            }
+        };
+
+        match signal {
+            SignalTo::Shutdown => {
+                use futures01::future::Either;
                 info!("Shutting down.");
                 let shutdown = topology.stop();
-
                 match shutdown.select2(signals.into_future()).compat().await {
                     Ok(Either::A(_)) => { /* Graceful shutdown finished */ }
                     Ok(Either::B(_)) => {
@@ -203,45 +196,12 @@ fn main() {
                     }
                     Err(_) => unreachable!(),
                 }
-            } else if signal == SIGQUIT {
+            }
+            SignalTo::Quit => {
                 info!("Shutting down immediately");
                 drop(topology);
-            } else {
-                unreachable!();
             }
-        }
-        #[cfg(windows)]
-        {
-            let ctrl_c = tokio_signal::ctrl_c().flatten_stream().into_future();
-            let to_shutdown = future::poll_fn(move || graceful_crash.poll())
-                .map(|_| ())
-                .select(topology.sources_finished());
-
-            let interruption = ctrl_c
-                .select2(to_shutdown)
-                .compat()
-                .await
-                .map_err(|_| ())
-                .expect("Neither stream errors");
-
-            use futures01::future::Either;
-
-            let ctrl_c = match interruption {
-                Either::A(((_, ctrl_c_stream), _)) => ctrl_c_stream.into_future(),
-                Either::B((_, ctrl_c)) => ctrl_c,
-            };
-
-            info!("Shutting down.");
-            let shutdown = topology.stop();
-
-            match shutdown.select2(ctrl_c).compat().await {
-                Ok(Either::A(_)) => { /* Graceful shutdown finished */ }
-                Ok(Either::B(_)) => {
-                    info!("Shutting down immediately.");
-                    // Dropping the shutdown future will immediately shut the server down
-                }
-                Err(_) => unreachable!(),
-            }
+            SignalTo::Reload => unreachable!(),
         }
     });
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -38,7 +38,7 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
 /// Signals from OS/user.
 #[cfg(windows)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
-    let ctrl_c = tokio_signal::ctrl_c().flatten_stream().into_future();
+    let ctrl_c = tokio_signal::ctrl_c().flatten_stream();
 
     ctrl_c
         .map(|_| SignalTo::Shutdown)

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,48 @@
+use futures::{compat::Stream01CompatExt, Stream, StreamExt, TryStreamExt};
+use futures01::{Future as Future01, Stream as Stream01};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SignalTo {
+    /// Signal to reload config.
+    Reload,
+    /// Signal to shutdown process.
+    Shutdown,
+    /// Shutdown process immediately.
+    Quit,
+}
+
+/// Signals from OS/user.
+#[cfg(unix)]
+pub fn signals() -> impl Stream<Item = SignalTo> {
+    use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+
+    let sigint = Signal::new(SIGINT).flatten_stream();
+    let sigterm = Signal::new(SIGTERM).flatten_stream();
+    let sigquit = Signal::new(SIGQUIT).flatten_stream();
+    let sighup = Signal::new(SIGHUP).flatten_stream();
+
+    let signals = sigint.select(sigterm.select(sigquit.select(sighup)));
+
+    signals
+        .map(|signal| match signal {
+            SIGHUP => SignalTo::Reload,
+            SIGINT | SIGTERM => SignalTo::Shutdown,
+            SIGQUIT => SignalTo::Quit,
+            _ => unreachable!(),
+        })
+        .compat()
+        .into_stream()
+        .map(|result| result.expect("Neither stream errors"))
+}
+
+/// Signals from OS/user.
+#[cfg(windows)]
+pub fn signals() -> impl Stream<Item = SignalTo> {
+    let ctrl_c = tokio_signal::ctrl_c().flatten_stream().into_future();
+
+    ctrl_c
+        .map(|_| SignalTo::Shutdown)
+        .compat()
+        .into_stream()
+        .map(|result| result.expect("Shouldn't error"))
+}


### PR DESCRIPTION
Closes #1383 

With moving signal code "slight" updates to usage of `futures01` in handling code was applied. We can split this update out to a separate PR if needed, it was too tempting not to collapse all of the `select`,`compat`,`match`, etc., into a simpler form.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
