### PR TITLE
chore: Install Ruby on OSX CI runner

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -180,6 +180,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: make slim-builds
       - run: make check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: make slim-builds
       - run: make test

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+set -e -o verbose
+
+brew install ruby
+
+echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"
+
+if [ -n "${CI-}" ] ; then
+  echo "::add-path::/usr/local/opt/ruby/bin"
+fi


### PR DESCRIPTION
It comes preinstalled with 2.6 which is below our Gemfile requirement in
scripts/.

https://github.com/actions/virtual-environments/blob/3d7f73608f6c438ef990a591dee574e90de9dce1/images/macos/macos-10.15-Readme.md

This fixes the mac related GH Actions checks.

Fixes #3167 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>