### PR TITLE
chore: Hand format `main`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
         let signal = loop {
             select! {
                 Some(signal) = signals.next() => {
-                    if signal == SignalTo::Reload{
+                    if signal == SignalTo::Reload {
                         // Reload config
                         info!(
                             message = "Reloading configs.",
@@ -166,7 +166,7 @@ fn main() {
                         } else {
                             error!("Reload aborted.");
                         }
-                    }else{
+                    } else {
                         break signal;
                     }
                 }


### PR DESCRIPTION
Spotted by @lukesteensen in #3185 `cargo fmt` is confused in `select` macro so this PR hand formats it. 

I'll merge this immediately. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
