### PR TITLE
chore: fix missing `wget` in `make environment`

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -23,7 +23,8 @@ apt install --yes \
     ruby-bundler \
     nodejs \
     libsasl2-dev \
-    gnupg2
+    gnupg2 \
+    wget
 
 wget https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
 tar -xvf grease-1.0.1-linux-amd64.tar.gz


### PR DESCRIPTION
Signed-off-by: Marko Karppinen <marko@richie.fi>

bootstrap-ubuntu-20.04.sh uses wget but it's missing:

```
wget https://github.com/timberio/grease/releases/download/v1.0.1/grease-1.0.1-linux-amd64.tar.gz
./scripts/environment/bootstrap-ubuntu-20.04.sh: line 28: wget: command not found
The command '/bin/sh -c ./scripts/environment/bootstrap-ubuntu-20.04.sh' returned a non-zero code: 127
make: *** [environment] Error 127
```

Add it in.

Fixes: #3231 
