### PR TITLE
chore: Update the Ubuntu image used in the ci-docker-image Dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ./target/aarch64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/aarch64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    user: $USER
+    user: root
     command: scripts/build.sh
 
   package-archive-x86_64-unknown-linux-musl:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ./target/aarch64-unknown-linux-musl/cargo/git:/opt/rust/cargo/git
       - ./target/aarch64-unknown-linux-musl/rustup/tmp:/opt/rust/rustup/tmp
     working_dir: $PWD
-    user: root
+    user: $USER
     command: scripts/build.sh
 
   package-archive-x86_64-unknown-linux-musl:

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -32,7 +32,7 @@ ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Libs
-FROM ubuntu:19.10 AS libs-builder
+FROM ubuntu:20.04 AS libs-builder
 
 ARG CLANG_PREFIX
 RUN apt-get update && apt-get install -y clang llvm lld
@@ -247,7 +247,7 @@ RUN echo > dummy.c && \
   rm dummy.c dummy.o
 
 # The actual builder.
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 # Install Rust using rustup.
 RUN apt-get update && apt-get install -y curl

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,5 @@
 # We use compiler-rt, libunwind, and libc++ from LLVM.
-ARG LLVM_VERSION=9.0.1
+ARG LLVM_VERSION=10.0.0
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -28,7 +28,7 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/usr/lib/llvm-9
+ARG CLANG_PREFIX=/usr/
 ARG LIBS_PREFIX=/opt/libs
 
 # Bulid non-interactively
@@ -40,7 +40,7 @@ FROM ubuntu:20.04 AS libs-builder
 ARG DEBIAN_FRONTEND
 
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang-9 llvm-9 lld-9
+RUN apt-get update && apt-get install -y clang llvm lld
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -65,7 +65,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang-9 llvm-9 lld
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
 
 ARG TARGET
 ARG LIBS_PREFIX
@@ -100,7 +100,7 @@ RUN mkdir build && \
 
 # Compile musl.
 WORKDIR $MUSL_DIR
-ENV CC=clang-9
+ENV CC=clang
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include -D_Noreturn="
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 ENV CROSS_COMPILE=$CLANG_PREFIX/bin/
@@ -117,7 +117,7 @@ RUN cd $MUSL_DIR && \
 # Install Linux headers.
 WORKDIR $LINUX_DIR
 ARG LINUX_TARGET
-ENV CC=clang-9
+ENV CC=clang
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 RUN make -j$(nproc) headers_install \
@@ -133,8 +133,8 @@ RUN make -j$(nproc) headers_install \
 
 # libunwind
 WORKDIR $LLVM_DIR/libunwind
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc"
@@ -151,8 +151,8 @@ RUN mkdir build && \
 
 # libc++abi
 WORKDIR $LLVM_DIR/libcxxabi
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lunwind -lc"
@@ -172,8 +172,8 @@ RUN mkdir build && \
 
 # libc++
 WORKDIR $LLVM_DIR/libcxx
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc++abi -lunwind -lc"
@@ -269,7 +269,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang-9 llvm-9 lld-9
+RUN apt-get update && apt-get install -y clang llvm lld
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -4,7 +4,7 @@ ARG LLVM_VERSION=10.0.0
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
 # Exampel: "1.1.22".
-ARG MUSL_VERSION=1.1.22
+ARG MUSL_VERSION=1.1.24
 
 # LLVM target triple for Linux and MUSL. Full list of supported triples
 # can be found here:
@@ -28,7 +28,7 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/usr/
+ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Bulid non-interactively
@@ -112,7 +112,7 @@ RUN cd $MUSL_DIR && \
   --prefix=$LIBS_PREFIX \
   --disable-shared \
   --disable-gcc-wrapper && \
-  make -j$(nproc) install AR=/usr/bin/ar RANLIB=/usr/bin/ranlib
+  make -j$(nproc) install
 
 # Install Linux headers.
 WORKDIR $LINUX_DIR
@@ -203,8 +203,7 @@ ENV MUSL_CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV MUSL_CXXFLAGS="$MUSL_CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 
 ENV MUSL_LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -L$LIBS_PREFIX/lib/linux -lc++ -lc++abi -lunwind -l$(basename /opt/libs/lib/linux/libclang_rt.builtins* | tail -c+4 | head -c-3) -lc"
-# ENV MUSL_STARTFILES="$(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
-ENV MUSL_STARTFILES="$LIBS_PREFIX/lib/crt1.o $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
+ENV MUSL_STARTFILES="$(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
 
 RUN mkdir -p $LIBS_PREFIX/bin
 RUN echo \
@@ -296,13 +295,6 @@ ENV LD_x86_64_unknown_linux_gnu=/usr/bin/ld
 ENV AR_x86_64_unknown_linux_gnu=/usr/bin/ar
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gnu-cc
-
-# Manually set the correct values for configure checks that libkrb5 won't be
-# able to perform because we're cross-compiling.
-# Borrowed from https://github.com/cockroachdb/cockroach/pull/48187
-ENV krb5_cv_attr_constructor_destructor=yes
-ENV ac_cv_func_regcomp=yes
-ENV ac_cv_printf_positional=yes
 
 # Set up environment variables for Rust bindgen
 # See https://github.com/rust-lang/rust-bindgen/issues/1229#issuecomment-473493753

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -262,7 +262,7 @@ ARG TARGET
 ARG RUST_PREFIX
 ENV RUSTUP_HOME=$RUST_PREFIX/rustup
 ENV CARGO_HOME=$RUST_PREFIX/cargo
-COPY rust-toolchain /tmp
+COPY rust-toolchain /tmp/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
   sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,5 @@
 # We use compiler-rt, libunwind, and libc++ from LLVM.
-ARG LLVM_VERSION=9.0.0
+ARG LLVM_VERSION=9.0.1
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
@@ -28,14 +28,19 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/usr
+ARG CLANG_PREFIX=/usr/lib/llvm-9
 ARG LIBS_PREFIX=/opt/libs
+
+# Bulid non-interactively
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Libs
 FROM ubuntu:20.04 AS libs-builder
 
+ARG DEBIAN_FRONTEND
+
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang llvm lld
+RUN apt-get update && apt-get install -y clang-9 llvm-9 lld-9
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -60,7 +65,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang-9 llvm-9 lld
 
 ARG TARGET
 ARG LIBS_PREFIX
@@ -95,7 +100,7 @@ RUN mkdir build && \
 
 # Compile musl.
 WORKDIR $MUSL_DIR
-ENV CC=clang
+ENV CC=clang-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include -D_Noreturn="
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 ENV CROSS_COMPILE=$CLANG_PREFIX/bin/
@@ -107,12 +112,12 @@ RUN cd $MUSL_DIR && \
   --prefix=$LIBS_PREFIX \
   --disable-shared \
   --disable-gcc-wrapper && \
-  make -j$(nproc) install
+  make -j$(nproc) install AR=/usr/bin/ar RANLIB=/usr/bin/ranlib
 
 # Install Linux headers.
 WORKDIR $LINUX_DIR
 ARG LINUX_TARGET
-ENV CC=clang
+ENV CC=clang-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 RUN make -j$(nproc) headers_install \
@@ -128,8 +133,8 @@ RUN make -j$(nproc) headers_install \
 
 # libunwind
 WORKDIR $LLVM_DIR/libunwind
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc"
@@ -146,8 +151,8 @@ RUN mkdir build && \
 
 # libc++abi
 WORKDIR $LLVM_DIR/libcxxabi
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lunwind -lc"
@@ -167,8 +172,8 @@ RUN mkdir build && \
 
 # libc++
 WORKDIR $LLVM_DIR/libcxx
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc++abi -lunwind -lc"
@@ -198,6 +203,7 @@ ENV MUSL_CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV MUSL_CXXFLAGS="$MUSL_CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 
 ENV MUSL_LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -L$LIBS_PREFIX/lib/linux -lc++ -lc++abi -lunwind -l$(basename /opt/libs/lib/linux/libclang_rt.builtins* | tail -c+4 | head -c-3) -lc"
+# ENV MUSL_STARTFILES="$(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
 ENV MUSL_STARTFILES="$LIBS_PREFIX/lib/crt1.o $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
 
 RUN mkdir -p $LIBS_PREFIX/bin
@@ -233,8 +239,8 @@ RUN ln -s $CLANG_PREFIX/bin/llvm-strip $LIBS_PREFIX/bin/strip
 RUN ln -s $CLANG_PREFIX/bin/llvm-ar $LIBS_PREFIX/bin/aarch64-linux-musl-ar
 
 # Use some headers provided by Clang because which are not present in musl.
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/emmintrin.h $LIBS_PREFIX/include/emmintrin.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/emmintrin.h $LIBS_PREFIX/include/emmintrin.h
 
 # Some build scripts hardcode -lstdc++ linker flag on all Linux systems.
 # Because our linker is already configured to link with libc++ instead,
@@ -249,6 +255,8 @@ RUN echo > dummy.c && \
 # The actual builder.
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND
+
 # Install Rust using rustup.
 RUN apt-get update && apt-get install -y curl
 ARG TARGET
@@ -261,7 +269,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y clang llvm lld
+RUN apt-get update && apt-get install -y clang-9 llvm-9 lld-9
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX
@@ -289,6 +297,13 @@ ENV AR_x86_64_unknown_linux_gnu=/usr/bin/ar
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gnu-cc
 
+# Manually set the correct values for configure checks that libkrb5 won't be
+# able to perform because we're cross-compiling.
+# Borrowed from https://github.com/cockroachdb/cockroach/pull/48187
+ENV krb5_cv_attr_constructor_destructor=yes
+ENV ac_cv_func_regcomp=yes
+ENV ac_cv_printf_positional=yes
+
 # Set up environment variables for Rust bindgen
 # See https://github.com/rust-lang/rust-bindgen/issues/1229#issuecomment-473493753
 ENV BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/opt/libs -target $TARGET"
@@ -301,7 +316,7 @@ RUN printf "[build]\ntarget = \"$TARGET\"\n" > ~/.cargo/config
 RUN if [ -n "$GNU_TARGET"]; then apt-get update && apt-get install -y qemu-user; fi
 
 # Add dependencies for running tests
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata ca-certificates
+RUN apt-get install -y tzdata ca-certificates
 
 ENV TARGET="$TARGET"
 

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -33,7 +33,7 @@ ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Libs
-FROM ubuntu:19.10 AS libs-builder
+FROM ubuntu:20.04 AS libs-builder
 
 ARG CLANG_PREFIX
 RUN apt-get update && apt-get install -y llvm clang lld
@@ -250,7 +250,7 @@ RUN echo > dummy.c && \
   rm dummy.c dummy.o
 
 # The actual builder.
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 # Install Rust using rustup.
 RUN apt-get update && apt-get install -y curl

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,5 @@
 # We use compiler-rt, libunwind, and libc++ from LLVM.
-ARG LLVM_VERSION=9.0.0
+ARG LLVM_VERSION=9.0.1
 ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
@@ -29,14 +29,19 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/usr
+ARG CLANG_PREFIX=/usr/lib/llvm-9
 ARG LIBS_PREFIX=/opt/libs
+
+# Bulid non-interactively
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Libs
 FROM ubuntu:20.04 AS libs-builder
 
+ARG DEBIAN_FRONTEND
+
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y llvm clang lld
+RUN apt-get update && apt-get install -y llvm-9 clang-9 lld-9
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -61,7 +66,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang-9 llvm-9 lld-9
 
 ARG TARGET
 ARG CLANG_PREFIX
@@ -96,7 +101,7 @@ RUN mkdir build && \
 
 # Compile musl.
 WORKDIR $MUSL_DIR
-ENV CC=clang
+ENV CC=clang-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include -D_Noreturn="
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 ENV CROSS_COMPILE=$CLANG_PREFIX/bin/
@@ -108,12 +113,12 @@ RUN cd $MUSL_DIR && \
   --prefix=$LIBS_PREFIX \
   --disable-shared \
   --disable-gcc-wrapper && \
-  make -j$(nproc) install
+  make -j$(nproc) install AR=/usr/bin/ar RANLIB=/usr/bin/ranlib
 
 # Install Linux headers.
 WORKDIR $LINUX_DIR
 ARG LINUX_TARGET
-ENV CC=clang
+ENV CC=clang-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 RUN make -j$(nproc) headers_install \
@@ -129,8 +134,8 @@ RUN make -j$(nproc) headers_install \
 
 # libunwind
 WORKDIR $LLVM_DIR/libunwind
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc"
@@ -147,8 +152,8 @@ RUN mkdir build && \
 
 # libc++abi
 WORKDIR $LLVM_DIR/libcxxabi
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lunwind -lc"
@@ -168,8 +173,8 @@ RUN mkdir build && \
 
 # libc++
 WORKDIR $LLVM_DIR/libcxx
-ENV CC=clang
-ENV CXX=clang++
+ENV CC=clang-9
+ENV CXX=clang++-9
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc++abi -lunwind -lc"
@@ -199,7 +204,7 @@ ENV MUSL_CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV MUSL_CXXFLAGS="$MUSL_CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 
 ENV MUSL_LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -L$LIBS_PREFIX/lib/linux -lc++ -lc++abi -lunwind -l$(basename /opt/libs/lib/linux/libclang_rt.builtins* | tail -c+4 | head -c-3) -lc"
-ENV MUSL_STARTFILES="$LIBS_PREFIX/lib/crt1.o $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
+ENV MUSL_STARTFILES="$(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtbegin*.o') $(find $LIBS_PREFIX/lib/linux -iname 'clang_rt.crtend*.o')"
 
 RUN mkdir -p $LIBS_PREFIX/bin
 RUN echo \
@@ -233,11 +238,11 @@ RUN ln -s $CLANG_PREFIX/bin/llvm-strip $LIBS_PREFIX/bin/strip
 RUN ln -s $CLANG_PREFIX/bin/ld.lld $LIBS_PREFIX/bin/ld
 
 # Use some headers provided by Clang because they are not present in musl.
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/emmintrin.h $LIBS_PREFIX/include/emmintrin.h
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/xmmintrin.h $LIBS_PREFIX/include/xmmintrin.h
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/mmintrin.h $LIBS_PREFIX/include/mmintrin.h
-RUN ln -s $CLANG_PREFIX/lib/clang/9.0.0/include/mm_malloc.h $LIBS_PREFIX/include/mm_malloc.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/stdatomic.h $LIBS_PREFIX/include/stdatomic.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/emmintrin.h $LIBS_PREFIX/include/emmintrin.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/xmmintrin.h $LIBS_PREFIX/include/xmmintrin.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/mmintrin.h $LIBS_PREFIX/include/mmintrin.h
+RUN ln -s $CLANG_PREFIX/lib/clang/$LLVM_VERSION/include/mm_malloc.h $LIBS_PREFIX/include/mm_malloc.h
 
 # Some build scripts hardcode -lstdc++ linker flag on all Linux systems.
 # Because our linker is already configured to link with libc++ instead,
@@ -252,6 +257,8 @@ RUN echo > dummy.c && \
 # The actual builder.
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND
+
 # Install Rust using rustup.
 RUN apt-get update && apt-get install -y curl
 ARG TARGET
@@ -263,7 +270,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
   sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
-RUN apt-get update && apt-get install -y llvm clang lld
+RUN apt-get update && apt-get install -y llvm-9 clang-9 lld-9
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX
@@ -303,7 +310,7 @@ RUN printf "[build]\ntarget = \"$TARGET\"\n" > ~/.cargo/config
 RUN if [ -n "$GNU_TARGET"]; then apt-get update && apt-get install -y qemu-user; fi
 
 # Add dependencies for running tests
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata ca-certificates
+RUN apt-get install -y tzdata ca-certificates
 
 ENV TARGET="$TARGET"
 

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -1,11 +1,11 @@
 # We use compiler-rt, libunwind, and libc++ from LLVM.
-ARG LLVM_VERSION=9.0.1
+ARG LLVM_VERSION=10.0.0
 ARG LLVM_GIT_COMMIT=71fe7ec06b85f612fc0e4eb4134c7a7d0f23fac5
 # The version of musl should be the same as the one Rust is compiled with.
 # This version can be found in this file:
 # https://github.com/rust-lang/rust/blob/master/src/ci/docker/scripts/musl-toolchain.sh.
 # Exampel: "1.1.22".
-ARG MUSL_VERSION=1.1.22
+ARG MUSL_VERSION=1.1.24
 
 # LLVM target triple for Linux and MUSL. Full list of supported triples
 # can be found here:
@@ -29,7 +29,7 @@ ARG LINUX_HEADERS_VERSION=5.3.10
 
 # Locations for produced tools and libraries.
 ARG RUST_PREFIX=/opt/rust
-ARG CLANG_PREFIX=/usr/lib/llvm-9
+ARG CLANG_PREFIX=/usr
 ARG LIBS_PREFIX=/opt/libs
 
 # Bulid non-interactively
@@ -41,7 +41,7 @@ FROM ubuntu:20.04 AS libs-builder
 ARG DEBIAN_FRONTEND
 
 ARG CLANG_PREFIX
-RUN apt-get update && apt-get install -y llvm-9 clang-9 lld-9
+RUN apt-get update && apt-get install -y llvm clang lld
 
 # Get all sources at first, so that changes in arguments
 # flags would not redownload them.
@@ -66,7 +66,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
 ENV LINUX_DIR $SRC_DIR/linux-$LINUX_HEADERS_VERSION
 
 # Install build dependencies.
-RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang-9 llvm-9 lld-9
+RUN apt-get update && apt-get -y install rsync ninja-build cmake python3-distutils clang llvm lld
 
 ARG TARGET
 ARG CLANG_PREFIX
@@ -101,7 +101,7 @@ RUN mkdir build && \
 
 # Compile musl.
 WORKDIR $MUSL_DIR
-ENV CC=clang-9
+ENV CC=clang
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include -D_Noreturn="
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 ENV CROSS_COMPILE=$CLANG_PREFIX/bin/
@@ -113,12 +113,12 @@ RUN cd $MUSL_DIR && \
   --prefix=$LIBS_PREFIX \
   --disable-shared \
   --disable-gcc-wrapper && \
-  make -j$(nproc) install AR=/usr/bin/ar RANLIB=/usr/bin/ranlib
+  make -j$(nproc) install
 
 # Install Linux headers.
 WORKDIR $LINUX_DIR
 ARG LINUX_TARGET
-ENV CC=clang-9
+ENV CC=clang
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles"
 RUN make -j$(nproc) headers_install \
@@ -134,8 +134,8 @@ RUN make -j$(nproc) headers_install \
 
 # libunwind
 WORKDIR $LLVM_DIR/libunwind
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc"
@@ -152,8 +152,8 @@ RUN mkdir build && \
 
 # libc++abi
 WORKDIR $LLVM_DIR/libcxxabi
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LLVM_DIR/libcxx/include"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lunwind -lc"
@@ -173,8 +173,8 @@ RUN mkdir build && \
 
 # libc++
 WORKDIR $LLVM_DIR/libcxx
-ENV CC=clang-9
-ENV CXX=clang++-9
+ENV CC=clang
+ENV CXX=clang++
 ENV CFLAGS="-target $TARGET -nostdinc -isystem $LIBS_PREFIX/include"
 ENV CXXFLAGS="$CFLAGS -nostdinc++ -I$LIBS_PREFIX/include/c++/v1"
 ENV LDFLAGS="-fuse-ld=lld -static -nostdlib -nostartfiles -L$LIBS_PREFIX/lib -lc++abi -lunwind -lc"
@@ -270,7 +270,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
   sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
-RUN apt-get update && apt-get install -y llvm-9 clang-9 lld-9
+RUN apt-get update && apt-get install -y llvm clang lld
 
 ARG LIBS_PREFIX
 COPY --from=libs-builder $LIBS_PREFIX $LIBS_PREFIX

--- a/scripts/ci-docker-images/target-graph/Dockerfile
+++ b/scripts/ci-docker-images/target-graph/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y build-essential git libgraph-easy-perl
 RUN git clone https://github.com/lindenb/makefile2graph && \


### PR DESCRIPTION
To 20.04 which seems to match what we use elsewhere.

19.10 ceases to be supported at the end of the month.

https://wiki.ubuntu.com/EoanErmine/ReleaseNotes

Stumbled upon this while debugging an issue locally with docker's DNS resolution that I thought was a result of missing package repos (which are not actually missing).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>