### PR TITLE
docs(regex_parser transform): Fix quoting of patterns in example

### DIFF
--- a/.meta/transforms/regex_parser.toml.erb
+++ b/.meta/transforms/regex_parser.toml.erb
@@ -39,12 +39,10 @@ as the target, it will only be overwritten if this is set to `true`.\
 """
 
 [transforms.regex_parser.options.patterns]
-type = "string"
+type = "[string]"
 common = true
 examples = [
-"""\
-['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']\
-"""
+['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']
 ]
 required = true
 description = """\

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2482,8 +2482,8 @@ require('custom_module')
   # in any of the expressions.
   #
   # * required
-  # * type: string
-  patterns = "['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']"
+  # * type: [string]
+  patterns = ["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"]
 
   # If this setting is present, the parsed fields will be inserted into the log
   # as a sub-object with this name. If a field with the same name already exists,

--- a/website/docs/reference/transforms/regex_parser.md
+++ b/website/docs/reference/transforms/regex_parser.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-07-13"
+last_modified_on: "2020-07-30"
 component_title: "Regex Parser"
 description: "The Vector `regex_parser` transform accepts and outputs `log` events, allowing you to parse a log field's value with a Regular Expression."
 event_types: ["log"]
@@ -45,7 +45,7 @@ a log field's value with a [Regular Expression][urls.regex].
   inputs = ["my-source-or-transform-id"] # required
   drop_field = true # optional, default
   field = "message" # optional, default
-  patterns = "['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']" # required
+  patterns = ["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"] # required
 
   # Types
   types.status = "int" # example
@@ -67,7 +67,7 @@ a log field's value with a [Regular Expression][urls.regex].
   drop_field = true # optional, default
   field = "message" # optional, default
   overwrite_target = true # optional, default
-  patterns = "['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']" # required
+  patterns = ["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"] # required
   target_field = "root_field" # optional, no default
 
   # Types
@@ -157,14 +157,14 @@ target, it will only be overwritten if this is set to `true`.
   common={true}
   defaultValue={null}
   enumValues={null}
-  examples={["['^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$']"]}
+  examples={[["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"]]}
   groups={[]}
   name={"patterns"}
   path={null}
   relevantWhen={null}
   required={true}
   templateable={false}
-  type={"string"}
+  type={"[string]"}
   unit={null}
   warnings={[]}
   >

--- a/website/metadata.js
+++ b/website/metadata.js
@@ -45737,7 +45737,7 @@ module.exports = {
     "regex_parser": {
       "beta": false,
       "config_examples": {
-        "toml": "[transforms.out]\n  inputs = [\"in\"] # required\n  patterns = \"['^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$']\" # required\n  type = \"regex_parser\" # required"
+        "toml": "[transforms.out]\n  inputs = [\"in\"] # required\n  patterns = [\"^(?P<timestamp>[\\\\\\\\w\\\\\\\\-:\\\\\\\\+]+) (?P<level>\\\\\\\\w+) (?P<message>.*)$\"] # required\n  type = \"regex_parser\" # required"
       },
       "delivery_guarantee": null,
       "description": null,


### PR DESCRIPTION
It was being rendered in the docs as having "s around the list.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

Discovered this while looking at https://gitter.im/timberio-vector/community?at=5f2214f625cae90e6d8c6f67