### PR TITLE
chore(sources): introduce Pipeline type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod kafka;
 pub mod kubernetes;
 pub mod list;
 pub mod metrics;
+pub(crate) mod pipeline;
 pub mod region;
 pub mod runtime;
 pub mod serde;
@@ -57,6 +58,7 @@ pub mod unit_test;
 pub mod validate;
 
 pub use event::Event;
+pub use pipeline::Pipeline;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,45 @@
+use crate::Event;
+use futures01::{
+    sync::mpsc::{channel, Receiver, SendError, Sender},
+    AsyncSink, Poll, Sink,
+};
+
+#[derive(Debug, Clone)]
+pub struct Pipeline {
+    inner: Sender<Event>,
+}
+
+impl Sink for Pipeline {
+    type SinkItem = Event;
+    type SinkError = SendError<Self::SinkItem>;
+
+    fn start_send(
+        &mut self,
+        item: Self::SinkItem,
+    ) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
+        self.inner.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.poll_complete()
+    }
+}
+
+impl Pipeline {
+    pub fn new_test() -> (Self, Receiver<Event>) {
+        Self::new_with_buffer(100)
+    }
+
+    pub fn new_with_buffer(n: usize) -> (Self, Receiver<Event>) {
+        let (tx, rx) = channel(n);
+        (Self::from_sender(tx), rx)
+    }
+
+    pub fn from_sender(inner: Sender<Event>) -> Self {
+        Self { inner }
+    }
+
+    pub fn poll_ready(&mut self) -> Poll<(), SendError<()>> {
+        self.inner.poll_ready()
+    }
+}

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -893,6 +893,7 @@ mod tests {
     use super::*;
     use crate::runtime::Runtime;
     use crate::test_util::{collect_n, runtime, trace_init};
+    use crate::Pipeline;
     use bollard::{
         container::{
             Config as ContainerConfig, CreateContainerOptions, KillContainerOptions,
@@ -901,7 +902,7 @@ mod tests {
         image::{CreateImageOptions, CreateImageResults, ListImagesOptions},
     };
     use futures::{compat::Future01CompatExt, stream::TryStreamExt};
-    use futures01::{Async, Stream as Stream01};
+    use futures01::{sync::mpsc as mpsc01, Async, Stream as Stream01};
 
     /// None if docker is not present on the system
     fn source_with<'a, L: Into<Option<&'a str>>>(
@@ -922,7 +923,7 @@ mod tests {
     /// None if docker is not present on the system
     fn source_with_config(config: DockerConfig, rt: &mut Runtime) -> mpsc01::Receiver<Event> {
         // trace_init();
-        let (sender, recv) = mpsc01::channel(100);
+        let (sender, recv) = Pipeline::new_test();
         rt.spawn(
             config
                 .build(

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -4,11 +4,11 @@ use crate::{
     sources::util::{ErrorMessage, HttpSource},
     tls::TlsConfig,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    Pipeline,
 };
 use bytes05::{Bytes, BytesMut};
 use chrono::Utc;
 use codec::BytesDelimitedCodec;
-use futures01::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::net::SocketAddr;
@@ -67,7 +67,7 @@ impl SourceConfig for SimpleHttpConfig {
         _: &str,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         let source = SimpleHttpSource {
             encoding: self.encoding,
@@ -205,6 +205,7 @@ mod tests {
         runtime::Runtime,
         test_util::{self, collect_n, runtime},
         topology::config::{GlobalOptions, SourceConfig},
+        Pipeline,
     };
     use futures::compat::Future01CompatExt;
     use futures01::sync::mpsc;
@@ -219,7 +220,7 @@ mod tests {
         headers: Vec<String>,
     ) -> (mpsc::Receiver<Event>, SocketAddr) {
         test_util::trace_init();
-        let (sender, recv) = mpsc::channel(100);
+        let (sender, recv) = Pipeline::new_test();
         let address = test_util::next_addr();
         rt.spawn(
             SimpleHttpConfig {

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -2,7 +2,7 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     shutdown::ShutdownSignal,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
-    Event,
+    Event, Pipeline,
 };
 use chrono::Utc;
 use futures::{
@@ -10,7 +10,7 @@ use futures::{
     future::{FutureExt, TryFutureExt},
     stream::StreamExt,
 };
-use futures01::{sync::mpsc, Future, Sink};
+use futures01::{Future, Sink};
 use metrics_core::Key;
 use metrics_runtime::{Controller, Measurement};
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ impl SourceConfig for InternalMetricsConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         let fut = run(get_controller()?, out, shutdown).boxed().compat();
         Ok(Box::new(fut))
@@ -55,7 +55,7 @@ fn get_controller() -> crate::Result<Controller> {
 
 async fn run(
     controller: Controller,
-    mut out: mpsc::Sender<Event>,
+    mut out: Pipeline,
     mut shutdown: ShutdownSignal,
 ) -> Result<(), ()> {
     let mut interval = interval(Duration::from_secs(2)).map(|_| ());

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -3,6 +3,7 @@ use crate::{
     kafka::KafkaAuthConfig,
     shutdown::ShutdownSignal,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    Pipeline,
 };
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
@@ -10,7 +11,7 @@ use futures::{
     compat::{Compat, Future01CompatExt},
     FutureExt, StreamExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use rdkafka::{
     config::ClientConfig,
     consumer::{Consumer, StreamConsumer},
@@ -81,7 +82,7 @@ impl SourceConfig for KafkaSourceConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         kafka_source(self, shutdown, out)
     }
@@ -98,7 +99,7 @@ impl SourceConfig for KafkaSourceConfig {
 fn kafka_source(
     config: &KafkaSourceConfig,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> crate::Result<super::Source> {
     let key_field = config.key_field.clone();
     let consumer = Arc::new(create_consumer(config)?);
@@ -221,8 +222,7 @@ fn create_consumer(config: &KafkaSourceConfig) -> crate::Result<StreamConsumer> 
 #[cfg(test)]
 mod test {
     use super::{kafka_source, KafkaSourceConfig};
-    use crate::shutdown::ShutdownSignal;
-    use futures01::sync::mpsc;
+    use crate::{shutdown::ShutdownSignal, Pipeline};
 
     fn make_config() -> KafkaSourceConfig {
         KafkaSourceConfig {
@@ -242,7 +242,7 @@ mod test {
     #[test]
     fn kafka_source_create_ok() {
         let config = make_config();
-        assert!(kafka_source(&config, ShutdownSignal::noop(), mpsc::channel(1).0).is_ok());
+        assert!(kafka_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_ok());
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod test {
             auto_offset_reset: "incorrect-auto-offset-reset".to_string(),
             ..make_config()
         };
-        assert!(kafka_source(&config, ShutdownSignal::noop(), mpsc::channel(1).0).is_err());
+        assert!(kafka_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_err());
     }
 }
 
@@ -263,9 +263,9 @@ mod integration_test {
         event,
         shutdown::ShutdownSignal,
         test_util::{collect_n, random_string, runtime},
+        Pipeline,
     };
     use chrono::Utc;
-    use futures01::sync::mpsc;
     use rdkafka::{
         config::ClientConfig,
         producer::{FutureProducer, FutureRecord},
@@ -323,7 +323,7 @@ mod integration_test {
             now.timestamp_millis(),
         ));
         println!("Receiving event...");
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = Pipeline::new_test();
         rt.spawn(kafka_source(&config, ShutdownSignal::noop(), tx).unwrap());
         let events = rt.block_on(collect_n(rx, 1)).ok().unwrap();
         assert_eq!(

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -14,12 +14,12 @@ use crate::{
     sources,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
     transforms::Transform,
+    Pipeline,
 };
 use bytes05::Bytes;
 use evmap10::{self as evmap};
 use file_source::{FileServer, FileServerShutdown, Fingerprinter};
 use futures::{future::FutureExt, sink::Sink, stream::StreamExt};
-use futures01::sync::mpsc;
 use k8s_openapi::api::core::v1::Pod;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -75,7 +75,7 @@ impl SourceConfig for Config {
         name: &str,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<sources::Source> {
         let source = Source::new(self, Resolver, globals, name)?;
 

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -4,10 +4,10 @@ use crate::{
     sources::util::{ErrorMessage, HttpSource},
     tls::TlsConfig,
     topology::config::{DataType, GlobalOptions, SourceConfig},
+    Pipeline,
 };
 use bytes05::{buf::BufExt, Bytes};
 use chrono::{DateTime, Utc};
-use futures01::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use std::{
     io::{BufRead, BufReader},
@@ -38,7 +38,7 @@ impl SourceConfig for LogplexConfig {
         _: &str,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         let source = LogplexSource::default();
         source.run(self.address, "events", &self.tls, out, shutdown)
@@ -161,6 +161,7 @@ mod tests {
         runtime::Runtime,
         test_util::{self, collect_n, runtime},
         topology::config::{GlobalOptions, SourceConfig},
+        Pipeline,
     };
     use chrono::{DateTime, Utc};
     use futures::compat::Future01CompatExt;
@@ -170,7 +171,7 @@ mod tests {
 
     fn source(rt: &mut Runtime) -> (mpsc::Receiver<Event>, SocketAddr) {
         test_util::trace_init();
-        let (sender, recv) = mpsc::channel(100);
+        let (sender, recv) = Pipeline::new_test();
         let address = test_util::next_addr();
         rt.spawn(
             LogplexConfig { address, tls: None }

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -3,13 +3,13 @@ use crate::{
     internal_events::{PrometheusHttpError, PrometheusParseError, PrometheusRequestCompleted},
     shutdown::ShutdownSignal,
     topology::config::GlobalOptions,
-    Event,
+    Event, Pipeline,
 };
 use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     future, stream, FutureExt, StreamExt, TryFutureExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use hyper::{Body, Client, Request};
 use hyper_openssl::HttpsConnector;
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ impl crate::topology::config::SourceConfig for PrometheusConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         let mut urls = Vec::new();
         for host in self.hosts.iter() {
@@ -59,7 +59,7 @@ fn prometheus(
     urls: Vec<String>,
     interval: u64,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> super::Source {
     let task = tokio::time::interval(Duration::from_secs(interval))
         .take_until(shutdown.compat())

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -3,11 +3,12 @@ use crate::{
     internal_events::{UdpEventReceived, UdpSocketError},
     shutdown::ShutdownSignal,
     sources::Source,
+    Pipeline,
 };
 use bytes05::BytesMut;
 use codec::BytesDelimitedCodec;
 use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use string_cache::DefaultAtom as Atom;
@@ -43,7 +44,7 @@ pub fn udp(
     max_length: usize,
     host_key: Atom,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> Source {
     let mut out = out.sink_map_err(|e| error!("error sending event: {:?}", e));
 

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -3,9 +3,9 @@ use crate::{
     internal_events::UnixSocketEventReceived,
     shutdown::ShutdownSignal,
     sources::{util::build_unix_source, Source},
+    Pipeline,
 };
 use bytes05::Bytes;
-use futures01::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio_util::codec::LinesCodec;
@@ -55,7 +55,7 @@ pub fn unix(
     max_length: usize,
     host_key: String,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> Source {
     build_unix_source(
         path,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,9 +1,9 @@
-use crate::{shutdown::ShutdownSignal, topology::config::GlobalOptions, Event};
+use crate::{shutdown::ShutdownSignal, topology::config::GlobalOptions, Event, Pipeline};
 use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     stream, FutureExt, StreamExt, TryFutureExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use parser::parse;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -25,7 +25,7 @@ impl crate::topology::config::SourceConfig for StatsdConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         Ok(statsd(self.address, shutdown, out))
     }
@@ -39,7 +39,7 @@ impl crate::topology::config::SourceConfig for StatsdConfig {
     }
 }
 
-fn statsd(addr: SocketAddr, shutdown: ShutdownSignal, out: mpsc::Sender<Event>) -> super::Source {
+fn statsd(addr: SocketAddr, shutdown: ShutdownSignal, out: Pipeline) -> super::Source {
     let out = out.sink_map_err(|e| error!("error sending metric: {:?}", e));
 
     Box::new(

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -3,13 +3,14 @@ use crate::{
     internal_events::{StdinEventReceived, StdinReadFailed},
     shutdown::ShutdownSignal,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    Pipeline,
 };
 use bytes::Bytes;
 use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     FutureExt, StreamExt, TryFutureExt, TryStreamExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -58,7 +59,7 @@ impl SourceConfig for StdinConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         stdin_source(io::BufReader::new(io::stdin()), self.clone(), shutdown, out)
     }
@@ -76,7 +77,7 @@ pub fn stdin_source<R>(
     stdin: R,
     config: StdinConfig,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> crate::Result<super::Source>
 where
     R: Send + io::BufRead + 'static,
@@ -198,8 +199,8 @@ fn create_event(line: Bytes, host_key: &str, hostname: &Option<String>) -> Event
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{event, test_util::runtime};
-    use futures01::{sync::mpsc, Async::*, Stream};
+    use crate::{event, test_util::runtime, Pipeline};
+    use futures01::{Async::*, Stream};
     use std::io::Cursor;
 
     #[test]
@@ -222,7 +223,7 @@ mod tests {
     #[test]
     fn stdin_decodes_line() {
         crate::test_util::trace_init();
-        let (tx, mut rx) = mpsc::channel(10);
+        let (tx, mut rx) = Pipeline::new_test();
         let config = StdinConfig::default();
         let buf = Cursor::new("hello world\nhello world again");
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -7,6 +7,7 @@ use crate::{
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    Pipeline,
 };
 use bytes05::{Buf, Bytes, BytesMut};
 use chrono::{Datelike, Utc};
@@ -15,7 +16,7 @@ use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     FutureExt, StreamExt, TryFutureExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::net::SocketAddr;
@@ -82,7 +83,7 @@ impl SourceConfig for SyslogConfig {
         _name: &str,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<super::Source> {
         let host_key = self
             .host_key
@@ -254,7 +255,7 @@ pub fn udp(
     _max_length: usize,
     host_key: String,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
 ) -> super::Source {
     let out = out.sink_map_err(|e| error!("error sending line: {:?}", e));
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -2,14 +2,14 @@ use crate::{
     internal_events::TcpConnectionError,
     shutdown::ShutdownSignal,
     tls::{MaybeTlsIncomingStream, MaybeTlsListener, MaybeTlsSettings},
-    Event,
+    Event, Pipeline,
 };
 use bytes05::Bytes;
 use futures::{
     compat::{Compat, Compat01As03, Future01CompatExt, Stream01CompatExt},
     StreamExt, TryStreamExt,
 };
-use futures01::{future, stream, sync::mpsc, Async, Future, Sink, Stream};
+use futures01::{future, stream, Async, Future, Sink, Stream};
 use listenfd::ListenFd;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{
@@ -78,7 +78,7 @@ pub trait TcpSource: Clone + Send + 'static {
         shutdown_timeout_secs: u64,
         tls: MaybeTlsSettings,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<crate::sources::Source> {
         let out = out.sink_map_err(|e| error!("error sending event: {:?}", e));
 

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,13 +1,13 @@
 use crate::{
     async_read::VecAsyncReadExt, emit, event::Event, internal_events::UnixSocketError,
-    shutdown::ShutdownSignal, sources::Source,
+    shutdown::ShutdownSignal, sources::Source, Pipeline,
 };
 use bytes05::Bytes;
 use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     future, FutureExt, SinkExt, StreamExt, TryFutureExt,
 };
-use futures01::{sync::mpsc, Sink};
+use futures01::Sink;
 use std::path::PathBuf;
 use tokio::net::{UnixListener, UnixStream};
 use tokio_util::codec::{Decoder, FramedRead};
@@ -24,7 +24,7 @@ pub fn build_unix_source<D, E>(
     decoder: D,
     host_key: String,
     shutdown: ShutdownSignal,
-    out: mpsc::Sender<Event>,
+    out: Pipeline,
     build_event: impl Fn(&str, Option<Bytes>, &str) -> Option<Event> + Clone + Send + Sync + 'static,
 ) -> Source
 where

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -2,12 +2,11 @@ use crate::{
     buffers::Acker,
     conditions,
     dns::Resolver,
-    event::{self, Event, Metric},
+    event::{self, Metric},
     shutdown::ShutdownSignal,
-    sinks, sources, transforms,
+    sinks, sources, transforms, Pipeline,
 };
 use component::ComponentDescription;
-use futures01::sync::mpsc;
 use indexmap::IndexMap; // IndexMap preserves insertion order, allowing us to output errors in the same order they are present in the file
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -130,7 +129,7 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
         name: &str,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<sources::Source>;
 
     async fn build_async(
@@ -138,7 +137,7 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
         name: &str,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
-        out: mpsc::Sender<Event>,
+        out: Pipeline,
     ) -> crate::Result<sources::Source> {
         self.build(name, globals, shutdown, out)
     }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -870,7 +870,6 @@ mod source_finished_tests {
     feature = "transforms-json_parser"
 ))]
 mod transient_state_tests {
-    use crate::event::Event;
     use crate::shutdown::ShutdownSignal;
     use crate::sinks::blackhole::BlackholeConfig;
     use crate::sources::stdin::StdinConfig;
@@ -878,9 +877,10 @@ mod transient_state_tests {
     use crate::test_util::runtime;
     use crate::topology::config::{Config, DataType, GlobalOptions, SourceConfig};
     use crate::transforms::json_parser::JsonParserConfig;
+    use crate::Pipeline;
     use crate::{topology, Error};
     use futures::compat::Future01CompatExt;
-    use futures01::{sync::mpsc::Sender, Future};
+    use futures01::Future;
     use serde::{Deserialize, Serialize};
     use stream_cancel::{Trigger, Tripwire};
 
@@ -909,7 +909,7 @@ mod transient_state_tests {
             _name: &str,
             _globals: &GlobalOptions,
             shutdown: ShutdownSignal,
-            out: Sender<Event>,
+            out: Pipeline,
         ) -> Result<Source, Error> {
             let source = shutdown
                 .map(|_| ())

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "sources-socket", feature = "sinks-socket"))]
 
 use futures::compat::Future01CompatExt;
-use futures01::{future, sync::mpsc, Async, AsyncSink, Sink, Stream};
+use futures01::{future, Async, AsyncSink, Sink, Stream};
 use serde::{Deserialize, Serialize};
 use vector::{
     shutdown::ShutdownSignal,
@@ -12,7 +12,7 @@ use vector::{
         self,
         config::{self, GlobalOptions, SinkContext},
     },
-    Event, {sinks, sources},
+    Event, Pipeline, {sinks, sources},
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -187,7 +187,7 @@ impl config::SourceConfig for ErrorSourceConfig {
         _name: &str,
         _globals: &GlobalOptions,
         _shutdown: ShutdownSignal,
-        _out: mpsc::Sender<Event>,
+        _out: Pipeline,
     ) -> Result<sources::Source, vector::Error> {
         Ok(Box::new(future::err(())))
     }
@@ -254,7 +254,7 @@ impl config::SourceConfig for PanicSourceConfig {
         _name: &str,
         _globals: &GlobalOptions,
         _shutdown: ShutdownSignal,
-        _out: mpsc::Sender<Event>,
+        _out: Pipeline,
     ) -> Result<sources::Source, vector::Error> {
         Ok(Box::new(future::lazy::<_, future::FutureResult<(), ()>>(
             || panic!(),


### PR DESCRIPTION
Closes #2935

This is just a mechanical change to introduce pipelines first as a wrapper around the old `Sender`s. Now that we have the wrapper in place, we can get going on some more interesting changes:

1. Embed transforms in pipelines
2. Add APIs for partitioning
3. Replace old channels with new ones
4. etc, etc