### PR TITLE
fix(splunk_hec sink)!: Make sourcetype explicit on Splunk sink

### DIFF
--- a/.meta/sinks/splunk_hec.toml.erb
+++ b/.meta/sinks/splunk_hec.toml.erb
@@ -74,6 +74,15 @@ description = """\
 The name of the index where send the events to. If not specified, the default index is used.
 """
 
+[sinks.splunk_hec.options.sourcetype]
+type = "string"
+common = false
+examples = ["_json", "httpevent"]
+required = false
+description = """\
+The sourcetype of events sent to this sink. If unset, Splunk will default to httpevent.
+"""
+
 [sinks.splunk_hec.options.token]
 type = "string"
 common = true

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ ifeq ($(AUTOSPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose up -d dependencies-splunk
 	sleep 5 # Many services are very lazy... Give them a sec...
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features splunk-integration-tests ::splunk:: -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features splunk-integration-tests ::splunk_hec:: -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	${MAYBE_ENVIRONMENT_EXEC} $(CONTAINER_TOOL)-compose stop
 endif

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -37,6 +37,7 @@ pub struct HecSinkConfig {
     #[serde(default)]
     pub indexed_fields: Vec<Atom>,
     pub index: Option<String>,
+    pub sourcetype: Option<String>,
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
@@ -131,8 +132,6 @@ impl HttpSink for HecSinkConfig {
         };
         let timestamp = (timestamp.timestamp_millis() as f64) / 1000f64;
 
-        let sourcetype = event.get(&event::log_schema().source_type_key()).cloned();
-
         let fields = self
             .indexed_fields
             .iter()
@@ -162,8 +161,7 @@ impl HttpSink for HecSinkConfig {
             body["index"] = json!(index);
         }
 
-        if let Some(sourcetype) = sourcetype {
-            let sourcetype = sourcetype.to_string_lossy();
+        if let Some(sourcetype) = &self.sourcetype {
             body["sourcetype"] = json!(sourcetype);
         }
 
@@ -526,15 +524,14 @@ mod integration_tests {
 
         rt.block_on_std(async move {
             let indexed_fields = vec![Atom::from("asdf")];
-            let config = config(Encoding::Json, indexed_fields).await;
+            let mut config = config(Encoding::Json, indexed_fields).await;
+            config.sourcetype = Some("_json".to_string());
+
             let (sink, _) = config.build(cx).unwrap();
 
             let message = random_string(100);
             let mut event = Event::from(message.clone());
             event.as_mut_log().insert("asdf", "hello");
-            event
-                .as_mut_log()
-                .insert(event::log_schema().source_type_key(), "file");
             sink.send(event).compat().await.unwrap();
 
             let entry = find_entry(message.as_str()).await;
@@ -543,7 +540,7 @@ mod integration_tests {
             let asdf = entry["asdf"].as_array().unwrap()[0].as_str().unwrap();
             assert_eq!("hello", asdf);
             let sourcetype = entry["sourcetype"].as_str().unwrap();
-            assert_eq!("file", sourcetype);
+            assert_eq!("_json", sourcetype);
         });
     }
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -384,12 +384,11 @@ mod integration_tests {
     // It usually takes ~1 second for the event to show up in search, so poll until
     // we see it.
     async fn find_entry(message: &str) -> serde_json::value::Value {
-        let value = Some(message);
         for _ in 0..20usize {
             match recent_entries(None)
                 .await
                 .into_iter()
-                .find(|entry| entry["message"].as_str() == value)
+                .find(|entry| entry["_raw"].as_str().unwrap_or("").contains(&message))
             {
                 Some(value) => return value,
                 None => std::thread::sleep(std::time::Duration::from_millis(100)),


### PR DESCRIPTION
This change removes the logic introduced in #2318 as we discovered it was causing issues with the `humio` sink as `humio` uses the sent source type to parse the incoming message. For example, if we send `syslog` as the `sourcetype` it attempts to parse our JSON payload as a syslog formatted message (details https://github.com/timberio/vector/issues/3082#issuecomment-665148156).

The first commit is just getting the splunk tests running again. The second commit is the change.

I'll open a follow up to add this configuration to the `humio` sink as well.

Fixes https://github.com/timberio/vector/issues/3250