### PR TITLE
feat(humio_logs sink): Allow configuration of type field

### DIFF
--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -54,6 +54,17 @@ examples = ["${HUMIO_TOKEN}", "A94A8FE5CCB19BA61C4C08"]
 required = true
 description = "Your Humio ingestion token."
 
+[sinks.humio_logs.options.type]
+type = "string"
+common = false
+examples = ["json", "none"]
+required = false
+description = """\
+The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
+
+If unset, Humio will default it to none.
+"""
+
 [sinks.humio_logs.options.host]
 type = "string"
 default = "https://cloud.humio.com"

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -18,6 +18,10 @@ pub struct HumioLogsConfig {
         default
     )]
     encoding: EncodingConfigWithDefault<Encoding>,
+
+    #[serde(rename = "type")]
+    sourcetype: Option<String>,
+
     #[serde(default)]
     pub compression: Compression,
 
@@ -72,6 +76,7 @@ impl HumioLogsConfig {
         HecSinkConfig {
             token: self.token.clone(),
             host,
+            sourcetype: self.sourcetype.clone(),
             encoding: self.encoding.clone().transmute(),
             compression: self.compression,
             batch: self.batch,
@@ -129,6 +134,7 @@ mod integration_tests {
         topology::config::{SinkConfig, SinkContext},
         Event,
     };
+    use chrono::Utc;
     use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use serde_json::json;
@@ -171,6 +177,58 @@ mod integration_tests {
                 "Humio encountered an error parsing this message: {}",
                 entry.error_msg.unwrap_or("no error message".to_string())
             );
+        });
+    }
+
+    #[test]
+    fn humio_type() {
+        let mut rt = runtime();
+
+        rt.block_on_std(async move {
+            let repo = create_repository().await;
+
+            // sets type
+            {
+                let mut config = config(&repo.default_ingest_token);
+                config.sourcetype = Some("json".to_string());
+
+                let (sink, _) = config.build(SinkContext::new_test()).unwrap();
+
+                let message = random_string(100);
+                let mut event = Event::from(message.clone());
+                // Humio expects to find an @timestamp field for JSON lines
+                // https://docs.humio.com/ingesting-data/parsers/built-in-parsers/#json
+                event
+                    .as_mut_log()
+                    .insert("@timestamp", Utc::now().to_rfc3339());
+
+                sink.send(event).compat().await.unwrap();
+
+                let entry = find_entry(repo.name.as_str(), message.as_str()).await;
+
+                assert_eq!(entry.humio_type, "json");
+                assert!(
+                    entry.error.is_none(),
+                    "Humio encountered an error parsing this message: {}",
+                    entry.error_msg.unwrap_or("no error message".to_string())
+                );
+            }
+
+            // defaults to none
+            {
+                let config = config(&repo.default_ingest_token);
+
+                let (sink, _) = config.build(SinkContext::new_test()).unwrap();
+
+                let message = random_string(100);
+                let event = Event::from(message.clone());
+
+                sink.send(event).compat().await.unwrap();
+
+                let entry = find_entry(repo.name.as_str(), message.as_str()).await;
+
+                assert_eq!(entry.humio_type, "none");
+            }
         });
     }
 
@@ -287,7 +345,7 @@ mutation {{
         humio_type: String,
 
         #[serde(rename = "@error")]
-        error: Option<bool>,
+        error: Option<String>,
 
         #[serde(rename = "@error_msg")]
         error_msg: Option<String>,


### PR DESCRIPTION
Targeting #3297  

This adds a configuration option to tell Humio what the type is of the
events so that it can parse them accordingly.

I think this usually won't be needed, but could be useful if the `text`
encoding is used.

Closes https://github.com/timberio/vector/issues/3082

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>