### PR TITLE
chore(tests): Run nightly builds at 4 AM UTC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: nightly
 
 on:
   schedule:
-    - cron: "0 14 * * *"
+    - cron: "0 4 * * *"
 
 env:
   CHANNEL: nightly


### PR DESCRIPTION
To cause less build contention during peak hours.

Borrowed time from recent dependabot PR:
https://github.com/timberio/vector/pull/3299

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>