### PR TITLE
chore: Refactor line_agg

### DIFF
--- a/src/sources/file/line_agg.rs
+++ b/src/sources/file/line_agg.rs
@@ -1,12 +1,20 @@
+#![deny(missing_docs)]
+
 use bytes05::{Bytes, BytesMut};
-use futures01::{Async, Poll, Stream};
+use futures::{Stream, StreamExt};
+use pin_project::pin_project;
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use std::hash::Hash;
 use std::time::Duration;
-use tokio01::timer::DelayQueue;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::time::DelayQueue;
 
+/// The mode of operation of the line aggregator.
 #[derive(Debug, Hash, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
@@ -38,8 +46,9 @@ pub enum Mode {
     HaltWith,
 }
 
+/// Configuration parameters of the line aggregator.
 #[derive(Debug, Clone)]
-pub(super) struct Config {
+pub struct Config {
     /// Start pattern to look for as a beginning of the message.
     pub start_pattern: Regex,
     /// Condition pattern to look for. Exact behavior is configured via `mode`.
@@ -53,7 +62,9 @@ pub(super) struct Config {
 }
 
 impl Config {
-    pub(super) fn for_legacy(marker: Regex, timeout_ms: u64) -> Self {
+    /// Build `Config` from legacy `file` source line aggragator configurtion
+    /// params.
+    pub fn for_legacy(marker: Regex, timeout_ms: u64) -> Self {
         let start_pattern = marker;
         let condition_pattern = start_pattern.clone();
         let mode = Mode::HaltBefore;
@@ -68,16 +79,18 @@ impl Config {
     }
 }
 
-pub(super) struct LineAgg<T, K> {
+/// Line aggregator.
+///
+/// Provides a `Stream` implementation that reads lines from the `inner` stream
+/// and yields aggraged lines.
+#[pin_project(project = LineAggProj)]
+pub struct LineAgg<T, K> {
     /// The stream from which we read the lines.
+    #[pin]
     inner: T,
 
-    /// Configuration parameters to use.
-    config: Config,
-
-    /// Line per key.
-    /// Key is usually a filename or other line source identifier.
-    buffers: HashMap<K, BytesMut>,
+    /// The core line aggregation logic.
+    logic: Logic<K>,
 
     /// Stashed lines. When line aggreation results in more than one line being
     /// emitted, we have to stash lines and return them into the stream after
@@ -89,27 +102,50 @@ pub(super) struct LineAgg<T, K> {
     /// and just flush all the buffered data.
     draining: Option<Vec<(Bytes, K)>>,
 
-    /// A queue of key timeouts.
-    timeouts: DelayQueue<K>,
-
     /// A queue of keys with expired timeouts.
     expired: VecDeque<K>,
 }
 
-impl<T, K> LineAgg<T, K>
-where
-    K: Hash + Eq + Clone,
-{
-    pub(super) fn new(inner: T, config: Config) -> Self {
+/// Core line aggregation logic.
+///
+/// Encapsulates the essential state and the core logic for the line
+/// aggregation algorithm.
+pub struct Logic<K> {
+    /// Configuration parameters to use.
+    config: Config,
+
+    /// Line per key.
+    /// Key is usually a filename or other line source identifier.
+    buffers: HashMap<K, BytesMut>,
+
+    /// A queue of key timeouts.
+    timeouts: DelayQueue<K>,
+}
+
+impl<K> Logic<K> {
+    /// Create a new `Logic` using the specified `Config`.
+    pub fn new(config: Config) -> Self {
         Self {
-            inner,
-
             config,
-
-            draining: None,
-            stashed: None,
             buffers: HashMap::new(),
             timeouts: DelayQueue::new(),
+        }
+    }
+}
+
+impl<T, K> LineAgg<T, K>
+where
+    T: Stream<Item = (Bytes, K)> + Unpin,
+    K: Hash + Eq + Clone,
+{
+    /// Create a new `LineAgg` using the specified `inner` stream and
+    /// preconfigured `logic`.
+    pub fn new(inner: T, logic: Logic<K>) -> Self {
+        Self {
+            inner,
+            logic,
+            draining: None,
+            stashed: None,
             expired: VecDeque::new(),
         }
     }
@@ -117,89 +153,127 @@ where
 
 impl<T, K> Stream for LineAgg<T, K>
 where
-    T: Stream<Item = (Bytes, K), Error = ()>,
+    T: Stream<Item = (Bytes, K)> + Unpin,
     K: Hash + Eq + Clone,
 {
     /// `Bytes` - the line data; `K` - file name, or other line source.
     type Item = (Bytes, K);
-    type Error = ();
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
         loop {
             // If we have a stashed line, process it before doing anything else.
-            if let Some((line, src)) = self.stashed.take() {
+            if let Some((line, src)) = this.stashed.take() {
                 // Handle the stashed line. If the handler gave us something -
                 // return it, otherwise restart the loop iteration to start
                 // anew. Handler could've stashed another value, continuing to
                 // the new loop iteration handles that.
-                if let Some(val) = self.handle_line_and_stashing(line, src) {
-                    return Ok(Async::Ready(Some(val)));
+                if let Some(val) = Self::handle_line_and_stashing(&mut this, line, src) {
+                    return Poll::Ready(Some(val));
                 }
                 continue;
             }
 
             // If we're in draining mode, short circut here.
-            if let Some(to_drain) = &mut self.draining {
-                if let Some((line, src)) = to_drain.pop() {
-                    return Ok(Async::Ready(Some((line, src))));
+            if let Some(to_drain) = &mut this.draining {
+                if let Some(val) = to_drain.pop() {
+                    return Poll::Ready(Some(val));
                 } else {
-                    return Ok(Async::Ready(None));
+                    return Poll::Ready(None);
                 }
             }
 
             // Check for keys that have hit their timeout.
-            while let Ok(Async::Ready(Some(expired_key))) = self.timeouts.poll() {
-                self.expired.push_back(expired_key.into_inner());
+            while let Poll::Ready(Some(Ok(expired_key))) = this.logic.timeouts.poll_expired(cx) {
+                this.expired.push_back(expired_key.into_inner());
             }
 
-            match self.inner.poll() {
-                Ok(Async::Ready(Some((line, src)))) => {
+            match this.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some((line, src))) => {
                     // Handle the incoming line we got from `inner`. If the
                     // handler gave us something - return it, otherwise continue
                     // with the flow.
-                    if let Some(val) = self.handle_line_and_stashing(line, src) {
-                        return Ok(Async::Ready(Some(val)));
+                    if let Some(val) = Self::handle_line_and_stashing(&mut this, line, src) {
+                        return Poll::Ready(Some(val));
                     }
                 }
-                Ok(Async::Ready(None)) => {
+                Poll::Ready(None) => {
                     // We got `None`, this means the `inner` stream has ended.
                     // Start flushing all existing data, stop polling `inner`.
-                    self.draining =
-                        Some(self.buffers.drain().map(|(k, v)| (v.into(), k)).collect());
+                    *this.draining = Some(
+                        this.logic
+                            .buffers
+                            .drain()
+                            .map(|(k, v)| (v.into(), k))
+                            .collect(),
+                    );
                 }
-                Ok(Async::NotReady) => {
+                Poll::Pending => {
                     // We didn't get any lines from `inner`, so we just give
                     // a line from the expired lines queue.
-                    if let Some(key) = self.expired.pop_front() {
-                        if let Some(buffered) = self.buffers.remove(&key) {
-                            return Ok(Async::Ready(Some((buffered.freeze(), key))));
+                    if let Some(key) = this.expired.pop_front() {
+                        if let Some(buffered) = this.logic.buffers.remove(&key) {
+                            return Poll::Ready(Some((buffered.freeze(), key)));
                         }
                     }
 
-                    return Ok(Async::NotReady);
+                    return Poll::Pending;
                 }
-                Err(()) => return Err(()),
             };
         }
     }
 }
 
+impl<T, K> LineAgg<T, K>
+where
+    T: Stream<Item = (Bytes, K)> + Unpin,
+    K: Hash + Eq + Clone,
+{
+    /// Handle line and do stashing of extra emitted lines.
+    /// Requires that the `stashed` item is empty (i.e. entry is vacant). This
+    /// invariant has to be taken care of by the caller.
+    fn handle_line_and_stashing(
+        this: &mut LineAggProj<'_, T, K>,
+        line: Bytes,
+        src: K,
+    ) -> Option<(Bytes, K)> {
+        // Stashed line is always consumed at the start of the `poll`
+        // loop before entering this line processing logic. If it's
+        // non-empty here - it's a bug.
+        debug_assert!(this.stashed.is_none());
+        let val = this.logic.handle_line(line, src)?;
+        let val = match val {
+            // If we have to emit just one line - that's easy,
+            // we just return it.
+            (Emit::One(line), src) => (line, src),
+            // If we have to emit two lines - take the second
+            // one and stash it, then return the first one.
+            // This way, the stashed line will be returned
+            // on the next stream poll.
+            (Emit::Two(line, to_stash), src) => {
+                *this.stashed = Some((to_stash, src.clone()));
+                (line, src)
+            }
+        };
+        Some(val)
+    }
+}
+
 /// Specifies the amount of lines to emit in response to a single input line.
 /// We have to emit either one or two lines.
-enum Emit {
+pub enum Emit {
     /// Emit one line.
     One(Bytes),
     /// Emit two lines, in the order they're specified.
     Two(Bytes, Bytes),
 }
 
-impl<T, K> LineAgg<T, K>
+impl<K> Logic<K>
 where
-    T: Stream<Item = (Bytes, K), Error = ()>,
     K: Hash + Eq + Clone,
 {
     /// Handle line, if we have something to output - return it.
-    fn handle_line(&mut self, line: Bytes, src: K) -> Option<(Emit, K)> {
+    pub fn handle_line(&mut self, line: Bytes, src: K) -> Option<(Emit, K)> {
         // Check if we already have the buffered data for the source.
         match self.buffers.entry(src) {
             Entry::Occupied(mut entry) => {
@@ -273,31 +347,6 @@ where
             }
         }
     }
-
-    /// Handle line and do stashing of extra emitted lines.
-    /// Requires that the `stashed` item is empty (i.e. entry is vacant). This
-    /// invariant has to be taken care of by the caller.
-    fn handle_line_and_stashing(&mut self, line: Bytes, src: K) -> Option<(Bytes, K)> {
-        // Stashed line is always consumed at the start of the `poll`
-        // loop before entering this line processing logic. If it's
-        // non-empty here - it's a bug.
-        debug_assert!(self.stashed.is_none());
-        let val = self.handle_line(line, src)?;
-        let val = match val {
-            // If we have to emit just one line - that's easy,
-            // we just return it.
-            (Emit::One(line), src) => (line, src),
-            // If we have to emit two lines - take the second
-            // one and stash it, then return the first one.
-            // This way, the stashed line will be returned
-            // on the next stream poll.
-            (Emit::Two(line, to_stash), src) => {
-                self.stashed = Some((to_stash, src.clone()));
-                (line, src)
-            }
-        };
-        Some(val)
-    }
 }
 
 fn add_next_line(buffered: &mut BytesMut, line: Bytes) {
@@ -310,8 +359,8 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
-    #[test]
-    fn mode_continue_through_1() {
+    #[tokio::test]
+    async fn mode_continue_through_1() {
         let lines = vec![
             "some usual line",
             "some other usual line",
@@ -338,11 +387,11 @@ mod tests {
                 " last part of the incomplete finishing message"
             ),
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn mode_continue_past_1() {
+    #[tokio::test]
+    async fn mode_continue_past_1() {
         let lines = vec![
             "some usual line",
             "some other usual line",
@@ -369,11 +418,11 @@ mod tests {
                 "last part of the incomplete finishing message \\"
             ),
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn mode_halt_before_1() {
+    #[tokio::test]
+    async fn mode_halt_before_1() {
         let lines = vec![
             "INFO some usual line",
             "INFO some other usual line",
@@ -400,11 +449,11 @@ mod tests {
                 "last part of the incomplete finishing message"
             ),
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn mode_halt_with_1() {
+    #[tokio::test]
+    async fn mode_halt_with_1() {
         let lines = vec![
             "some usual line;",
             "some other usual line;",
@@ -431,11 +480,11 @@ mod tests {
                 "last part of the incomplete finishing message"
             ),
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn use_case_java_exception() {
+    #[tokio::test]
+    async fn use_case_java_exception() {
         let lines = vec![
             "java.lang.Exception",
             "    at com.foo.bar(bar.java:123)",
@@ -452,11 +501,11 @@ mod tests {
             "    at com.foo.bar(bar.java:123)\n",
             "    at com.foo.baz(baz.java:456)",
         )];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn use_case_ruby_exception() {
+    #[tokio::test]
+    async fn use_case_ruby_exception() {
         let lines = vec![
             "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)",
             "\tfrom foobar.rb:6:in `bar'",
@@ -475,12 +524,12 @@ mod tests {
             "\tfrom foobar.rb:2:in `foo'\n",
             "\tfrom foobar.rb:9:in `<main>'",
         )];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
     /// https://github.com/timberio/vector/issues/3237
-    #[test]
-    fn two_lines_emit_with_continue_through() {
+    #[tokio::test]
+    async fn two_lines_emit_with_continue_through() {
         let lines = vec![
             "not merged 1", // will NOT be stashed, but passthroughed
             " merged 1",
@@ -515,11 +564,11 @@ mod tests {
             " merged 6\n merged 7\n merged 8",
             "not merged 6",
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn two_lines_emit_with_halt_before() {
+    #[tokio::test]
+    async fn two_lines_emit_with_halt_before() {
         let lines = vec![
             "part 0.1",
             "part 0.2",
@@ -549,11 +598,11 @@ mod tests {
             "START msg 4\npart 4.1\npart 4.2\npart 4.3",
             "START msg 5",
         ];
-        run_and_assert(&lines, config, &expected);
+        run_and_assert(&lines, config, &expected).await;
     }
 
-    #[test]
-    fn legacy() {
+    #[tokio::test]
+    async fn legacy() {
         let lines = vec![
             "INFO some usual line",
             "INFO some other usual line",
@@ -578,12 +627,12 @@ mod tests {
         let stream = stream_from_lines(&lines);
         let line_agg = LineAgg::new(
             stream,
-            Config::for_legacy(
+            Logic::new(Config::for_legacy(
                 Regex::new("^(INFO|ERROR)").unwrap(), // example from the docs
                 10,
-            ),
+            )),
         );
-        let results = collect_results(line_agg);
+        let results = line_agg.collect().await;
         assert_results(results, &expected);
     }
 
@@ -594,21 +643,12 @@ mod tests {
 
     fn stream_from_lines<'a>(
         lines: &'a [&'static str],
-    ) -> impl Stream<Item = (Bytes, Filename), Error = ()> + 'a {
-        futures01::stream::iter_ok::<_, ()>(
+    ) -> impl Stream<Item = (Bytes, Filename)> + 'a {
+        futures::stream::iter(
             lines
                 .iter()
                 .map(|line| (Bytes::from_static(line.as_bytes()), "test.log".to_owned())),
         )
-    }
-
-    fn collect_results<T, K>(line_agg: LineAgg<T, K>) -> Vec<(Bytes, K)>
-    where
-        T: Stream<Item = (Bytes, K), Error = ()>,
-        K: Hash + Eq + Clone,
-    {
-        futures01::future::Future::wait(futures01::stream::Stream::collect(line_agg))
-            .expect("Failed to collect test results")
     }
 
     fn assert_results(actual: Vec<(Bytes, Filename)>, expected: &[&'static str]) {
@@ -623,10 +663,11 @@ mod tests {
         );
     }
 
-    fn run_and_assert(lines: &[&'static str], config: Config, expected: &[&'static str]) {
+    async fn run_and_assert(lines: &[&'static str], config: Config, expected: &[&'static str]) {
         let stream = stream_from_lines(lines);
-        let line_agg = LineAgg::new(stream, config);
-        let results = collect_results(line_agg);
+        let logic = Logic::new(config);
+        let line_agg = LineAgg::new(stream, logic);
+        let results = line_agg.collect().await;
         assert_results(results, expected);
     }
 }

--- a/src/sources/file/line_agg.rs
+++ b/src/sources/file/line_agg.rs
@@ -62,7 +62,7 @@ pub struct Config {
 }
 
 impl Config {
-    /// Build `Config` from legacy `file` source line aggragator configurtion
+    /// Build `Config` from legacy `file` source line aggregator configuration
     /// params.
     pub fn for_legacy(marker: Regex, timeout_ms: u64) -> Self {
         let start_pattern = marker;
@@ -82,7 +82,7 @@ impl Config {
 /// Line aggregator.
 ///
 /// Provides a `Stream` implementation that reads lines from the `inner` stream
-/// and yields aggraged lines.
+/// and yields aggregated lines.
 #[pin_project(project = LineAggProj)]
 pub struct LineAgg<T, K> {
     /// The stream from which we read the lines.


### PR DESCRIPTION
This is a minor refactoring of the `sources::file::line_agg`, in preparation to extract it for reuse among other sources.

- Extracted logic into a reusable piece (experiments have shown that this will be very useful for some implementation variants).
- Switched to futures 0.3; an attempt to rewrite the implementation to `async_stream` was made, but it turned out to be more complicated than the raw poll-based implementation. The poll-based approach is easier to reason about. This isn't definite though, and possibly another attempt will be more successful.
