### PR TITLE
chore(tests): Increase wait in `test_reclaim_disk_space`

### DIFF
--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -265,7 +265,7 @@ fn test_reclaim_disk_space() {
     // to file. We need for the events to be written to the file before `terminate_abruptly`.
     // We can't know when exactly all of the events have been written, so we have to guess.
     // But it should be shortly after source processing all of the events.
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    std::thread::sleep(std::time::Duration::from_secs(4));
     // Simulate a crash.
     terminate_abruptly(rt, topology);
 


### PR DESCRIPTION
Should fix `test_reclaim_disk_space` flakiness. 

It doesn't fail on my computer, but does start to fail in vm setup, like CI, and seams to be OS sensitive, so I'm guessing the cause is the known race with writing to file/hard drive, while OS caching/paging is interfering.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
