### PR TITLE
chore(tests): Fix race in `CountReceiver`

### DIFF
--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -145,13 +145,13 @@ mod test {
             let context = SinkContext::new_test();
             let (sink, _healthcheck) = config.build(context).unwrap();
 
-            let receiver = CountReceiver::receive_lines(addr);
+            let mut receiver = CountReceiver::receive_lines(addr);
 
             let (lines, events) = random_lines_with_stream(10, 100);
             let _ = sink.send_all(events).compat().await.unwrap();
 
-            // Some CI machines are very slow, be generous.
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            // Wait for output to connect
+            receiver.connected().await;
 
             let output = receiver.wait().await;
             assert_eq!(lines.len(), output.len());

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -231,7 +231,7 @@ mod tests {
             let out_path = temp_uds_path("unix_test");
 
             // Set up server to receive events from the Sink.
-            let receiver = CountReceiver::receive_lines_unix(out_path.clone());
+            let mut receiver = CountReceiver::receive_lines_unix(out_path.clone());
 
             // Set up Sink
             let config = UnixSinkConfig::new(out_path, Encoding::Text.into());
@@ -241,6 +241,9 @@ mod tests {
             // Send the test data
             let (input_lines, events) = random_lines_with_stream(100, num_lines);
             let _ = sink.send_all(events).compat().await.unwrap();
+
+            // Wait for output to connect
+            receiver.connected().await;
 
             // Receive the data sent by the Sink to the receiver
             assert_eq!(input_lines, receiver.wait().await);

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -201,7 +201,7 @@ impl Sink for UnixSink {
     }
 }
 
-#[cfg(all(feature = "tokio/uds", test))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_util::{random_lines_with_stream, runtime, shutdown_on_idle, CountReceiver};

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -412,7 +412,7 @@ impl CountReceiver<String> {
         })
     }
 
-    #[cfg(all(feature = "tokio/uds", unix))]
+    #[cfg(unix)]
     pub fn receive_lines_unix<P>(path: P) -> CountReceiver<String>
     where
         P: AsRef<Path> + Send + 'static,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -360,12 +360,19 @@ where
 pub struct CountReceiver<T> {
     count: Arc<AtomicUsize>,
     trigger: oneshot::Sender<()>,
+    connected: Option<oneshot::Receiver<()>>,
     handle: JoinHandle<Vec<T>>,
 }
 
 impl<T: Send + 'static> CountReceiver<T> {
     pub fn count(&self) -> usize {
         self.count.load(Ordering::Relaxed)
+    }
+
+    pub async fn connected(&mut self) {
+        if let Some(tripwire) = self.connected.take() {
+            tripwire.await.unwrap();
+        }
     }
 
     pub async fn wait(self) -> Vec<T> {
@@ -375,25 +382,33 @@ impl<T: Send + 'static> CountReceiver<T> {
 
     fn new<F, Fut>(make_fut: F) -> CountReceiver<T>
     where
-        F: FnOnce(Arc<AtomicUsize>, oneshot::Receiver<()>) -> Fut,
+        F: FnOnce(Arc<AtomicUsize>, oneshot::Receiver<()>, oneshot::Sender<()>) -> Fut,
         Fut: std::future::Future<Output = Vec<T>> + Send + 'static,
     {
         let count = Arc::new(AtomicUsize::new(0));
         let (trigger, tripwire) = oneshot::channel();
+        let (trigger_connected, connected) = oneshot::channel();
 
         CountReceiver {
             count: Arc::clone(&count),
             trigger,
-            handle: tokio::spawn(make_fut(count, tripwire)),
+            connected: Some(connected),
+            handle: tokio::spawn(make_fut(count, tripwire, trigger_connected)),
         }
     }
 }
 
 impl CountReceiver<String> {
     pub fn receive_lines(addr: SocketAddr) -> CountReceiver<String> {
-        CountReceiver::new(|count, tripwire| async move {
+        CountReceiver::new(|count, tripwire, connected| async move {
             let mut listener = TcpListener::bind(addr).await.unwrap();
-            CountReceiver::receive_lines_stream(listener.incoming(), count, tripwire).await
+            CountReceiver::receive_lines_stream(
+                listener.incoming(),
+                count,
+                tripwire,
+                Some(connected),
+            )
+            .await
         })
     }
 
@@ -402,9 +417,15 @@ impl CountReceiver<String> {
     where
         P: AsRef<Path> + Send + 'static,
     {
-        CountReceiver::new(|count, tripwire| async move {
+        CountReceiver::new(|count, tripwire, connected| async move {
             let mut listener = tokio::net::UnixListener::bind(path).unwrap();
-            CountReceiver::receive_lines_stream(listener.incoming(), count, tripwire).await
+            CountReceiver::receive_lines_stream(
+                listener.incoming(),
+                count,
+                tripwire,
+                Some(connected),
+            )
+            .await
         })
     }
 
@@ -412,15 +433,21 @@ impl CountReceiver<String> {
         stream: S,
         count: Arc<AtomicUsize>,
         tripwire: oneshot::Receiver<()>,
+        mut connected: Option<oneshot::Sender<()>>,
     ) -> Vec<String>
     where
         S: Stream<Item = IoResult<T>>,
         T: AsyncWrite + AsyncRead,
     {
+        tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+
         stream
             .take_until(tripwire)
             .map_ok(|socket| FramedRead::new(socket, LinesCodec::new()))
-            .map(|x| x.unwrap())
+            .map(|x| {
+                connected.take().map(|trigger| trigger.send(()));
+                x.unwrap()
+            })
             .flatten()
             .map(|x| x.unwrap())
             .inspect(move |_| {
@@ -437,7 +464,8 @@ impl CountReceiver<Event> {
         S: Stream01<Item = Event> + Send + 'static,
         <S as Stream01>::Error: std::fmt::Debug,
     {
-        CountReceiver::new(|count, tripwire| async move {
+        CountReceiver::new(|count, tripwire, connected| async move {
+            connected.send(()).unwrap();
             stream
                 .compat()
                 .take_until(tripwire)

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -369,6 +369,7 @@ impl<T: Send + 'static> CountReceiver<T> {
         self.count.load(Ordering::Relaxed)
     }
 
+    /// Succeds once first connection has been maid.
     pub async fn connected(&mut self) {
         if let Some(tripwire) = self.connected.take() {
             tripwire.await.unwrap();
@@ -439,8 +440,6 @@ impl CountReceiver<String> {
         S: Stream<Item = IoResult<T>>,
         T: AsyncWrite + AsyncRead,
     {
-        tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-
         stream
             .take_until(tripwire)
             .map_ok(|socket| FramedRead::new(socket, LinesCodec::new()))

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -369,7 +369,7 @@ impl<T: Send + 'static> CountReceiver<T> {
         self.count.load(Ordering::Relaxed)
     }
 
-    /// Succeds once first connection has been maid.
+    /// Succeds once first connection has been made.
     pub async fn connected(&mut self) {
         if let Some(tripwire) = self.connected.take() {
             tripwire.await.unwrap();

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -73,13 +73,16 @@ fn test_sink_panic() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
         let (topology, crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
         std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -155,12 +158,15 @@ fn test_sink_error() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         let (topology, crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
         std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -222,12 +228,15 @@ fn test_source_error() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         let (topology, crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
         std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -291,13 +300,16 @@ fn test_source_panic() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
         let (topology, crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
         std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -36,11 +36,14 @@ fn pipe() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         let (topology, _crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -84,11 +87,14 @@ fn sample() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines = CountReceiver::receive_lines(out_addr);
+        let mut output_lines = CountReceiver::receive_lines(out_addr);
 
         let (topology, _crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
+
+        // Wait for output to connect
+        output_lines.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -138,12 +144,16 @@ fn fork() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines1 = CountReceiver::receive_lines(out_addr1);
-        let output_lines2 = CountReceiver::receive_lines(out_addr2);
+        let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
+        let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
         let (topology, _crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr);
+
+        // Wait for output to connect
+        output_lines1.connected().await;
+        output_lines2.connected().await;
 
         let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
         send_lines(in_addr, input_lines.clone()).await.unwrap();
@@ -194,13 +204,17 @@ fn merge_and_fork() {
 
     let mut rt = runtime();
     rt.block_on_std(async move {
-        let output_lines1 = CountReceiver::receive_lines(out_addr1);
-        let output_lines2 = CountReceiver::receive_lines(out_addr2);
+        let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
+        let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
         let (topology, _crash) = topology::start(config, false).await.unwrap();
         // Wait for server to accept traffic
         wait_for_tcp(in_addr1);
         wait_for_tcp(in_addr2);
+
+        // Wait for output to connect
+        output_lines1.connected().await;
+        output_lines2.connected().await;
 
         let input_lines1 = random_lines(100).take(num_lines).collect::<Vec<_>>();
         let input_lines2 = random_lines(100).take(num_lines).collect::<Vec<_>>();


### PR DESCRIPTION
### Problem

There was a race in some of our usages of `CountReceiver`, and there still is (explained later). The race was happening between `CountReceiver` establishing first connection and:
* waiting on it
* shutting down `topology`

If connection is established before both of them, everything is fine, if not, the events weren't being collected so the tests failed.

### Solution

 `CountReceiver` now exposes a way to wait for the first connection which tests can use to avoid the race. This theoretically doesn't remove the race entirely since we don't sync for other connections, but our usage of it is for one connection only so this fixes the race in practice. This behavior is commented in code.

### Affected

First found while examining flaky `merge_and_fork` test, but was affecting dozens of tests. They were determined to be affected by ,well, first using the `CountReceiver` and second they started to fail once an artificial delay was introduced [here](https://github.com/timberio/vector/blob/6244e68d206eb614311ab950634850d0d36ab69a/src/test_util.rs#L441), to amplify the race. So with `merge_and_fork`, all other affected tests were also preemptively modified:
* `tcp_stream`
* `basic_unix_sink`, which is also now enabled
* `crash` tests
* `tcp` tests

Other tests and benches weren't failing so they weren't changed.

Some of before removed flaky tests were also using this code so they probably had this race:
* #3043 
* #3041 
* #3039 

- [ ] It will be nice to check if those tests were really affected and if this fixes them completely.

Ref. #2978 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
