### PR TITLE
chore(tests): Fix `splunk_hec` source tests

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -746,13 +746,11 @@ mod tests {
     };
     use chrono::{TimeZone, Utc};
     use futures::compat::Future01CompatExt;
-    use futures01::{stream, sync::mpsc, Sink};
+    use futures01::{stream, sync::mpsc, Future, Sink};
     use std::net::SocketAddr;
 
     /// Splunk token
     const TOKEN: &str = "token";
-
-    const CHANNEL_CAPACITY: usize = 1000;
 
     fn source(rt: &mut Runtime) -> (mpsc::Receiver<Event>, SocketAddr) {
         source_with(rt, Some(TOKEN.to_owned()))
@@ -813,12 +811,8 @@ mod tests {
         rt: &mut Runtime,
     ) -> Vec<Event> {
         let n = messages.len();
-        assert!(
-            n <= CHANNEL_CAPACITY,
-            "To much messages for the sink channel"
-        );
         let pump = sink.send_all(stream::iter_ok(messages.into_iter().map(Into::into)));
-        let _ = rt.block_on(pump).unwrap();
+        rt.spawn(pump.map(|_| ()));
         let events = rt.block_on(collect_n(source, n)).unwrap();
 
         assert_eq!(n, events.len());

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -812,7 +812,7 @@ mod tests {
     ) -> Vec<Event> {
         let n = messages.len();
         let pump = sink.send_all(stream::iter_ok(messages.into_iter().map(Into::into)));
-        rt.spawn(pump.map(|_| ()));
+        rt.spawn(pump.map(|_| ()).map_err(|()| panic!()));
         let events = rt.block_on(collect_n(source, n)).unwrap();
 
         assert_eq!(n, events.len());


### PR DESCRIPTION
#3275 introduced `Pipeline` which has less of a capacity than the previously used channel which caused a deadlock in tests that were depending on that capacity being larger than a certain size.

This PR removes this dependency. 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
