### PR TITLE
enhancement(humio_logs sink): Add source configuration to Humio sink

### DIFF
--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -54,6 +54,16 @@ examples = ["${HUMIO_TOKEN}", "A94A8FE5CCB19BA61C4C08"]
 required = true
 description = "Your Humio ingestion token."
 
+[sinks.splunk_hec.options.source]
+type = "string"
+common = false
+examples = ["/var/log/syslog", "UDP:514"]
+required = false
+description = """\
+The source of events sent to this sink. Typically the filename the logs \
+originated from. Maps to @source in Humio.
+"""
+
 [sinks.humio_logs.options.host]
 type = "string"
 default = "https://cloud.humio.com"

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -59,6 +59,7 @@ type = "string"
 common = false
 examples = ["/var/log/syslog", "UDP:514"]
 required = false
+templateable = true
 description = """\
 The source of events sent to this sink. Typically the filename the logs \
 originated from. Maps to @source in Humio.

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -57,7 +57,7 @@ description = "Your Humio ingestion token."
 [sinks.splunk_hec.options.source]
 type = "string"
 common = false
-examples = ["/var/log/syslog", "UDP:514"]
+examples = ["{{file}}", "/var/log/syslog", "UDP:514"]
 required = false
 templateable = true
 description = """\

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -54,7 +54,7 @@ examples = ["${HUMIO_TOKEN}", "A94A8FE5CCB19BA61C4C08"]
 required = true
 description = "Your Humio ingestion token."
 
-[sinks.splunk_hec.options.source]
+[sinks.humio_logs.options.source]
 type = "string"
 common = false
 examples = ["{{file}}", "/var/log/syslog", "UDP:514"]

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -3,6 +3,7 @@ use crate::{
     sinks::util::{
         encoding::EncodingConfigWithDefault, service2::TowerRequestConfig, BatchConfig, Compression,
     },
+    template::Template,
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ const HOST: &str = "https://cloud.humio.com";
 pub struct HumioLogsConfig {
     token: String,
     host: Option<String>,
-    source: Option<String>,
+    source: Option<Template>,
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
@@ -136,6 +137,7 @@ mod integration_tests {
     use serde_json::json;
     use serde_json::Value as JsonValue;
     use std::collections::HashMap;
+    use std::convert::TryFrom;
 
     // matches humio container address
     const HOST: &str = "http://localhost:8080";
@@ -185,7 +187,7 @@ mod integration_tests {
             let repo = create_repository().await;
 
             let mut config = config(&repo.default_ingest_token);
-            config.source = Some("/var/log/syslog".to_string());
+            config.source = Template::try_from("/var/log/syslog".to_string()).ok();
 
             let (sink, _) = config.build(cx).unwrap();
 


### PR DESCRIPTION
Targeting https://github.com/timberio/vector/pull/3327

This exposes the added `source` config from the Splunk HEC sink to the
Humio sink. It maps to `@source` in Humio. If unset, it is simply empty
in Humio.

https://docs.humio.com/integrations/data-shippers/hec/

Related to https://github.com/timberio/vector/issues/3251

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>