### PR TITLE
chore: Fix issue templates front-matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,10 @@
 ---
 name: Bug Report
 about: Let us know about an unexpected error, a crash, or an incorrect behavior.
-labels: Type: Bug
+labels: 'type: bug'
+assignees: ''
+title: ''
+
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,10 @@
 ---
 name: Feature Request
 about: Suggest a new feature or other enhancement.
-labels: Type: Enhancement
+labels: 'type: enhancement'
+assignees: ''
+title: ''
+
 ---
 
 <!--


### PR DESCRIPTION
I noticed that it wasn't providing the issue templates when creating
a new issue. I think this is probably because the front-matter was not
valid YAML.

I also added in the additional config options that appear when using the
Github UI to create an issue template.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>