### PR TITLE
chore: revert tokio in tls update (#3188)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5606,8 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.4"
-source = "git+https://github.com/seanmonstar/warp?rev=6777564d18b04c3d5b616a79907cfa175663c350#6777564d18b04c3d5b616a79907cfa175663c350"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
@@ -5624,8 +5625,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio 0.2.21",
  "tower-service 0.3.0",
- "tracing",
- "tracing-futures 0.2.1",
  "urlencoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -465,6 +465,3 @@ required-features = ["kubernetes-e2e-tests"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
-
-[patch.crates-io]
-warp = { git = "https://github.com/seanmonstar/warp", rev = "6777564d18b04c3d5b616a79907cfa175663c350" }

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -10,7 +10,6 @@ use crate::{
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
 use bytes::Bytes;
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use serde::{Deserialize, Serialize};
 
@@ -60,7 +59,7 @@ impl SinkConfig for DatadogLogsConfig {
         let sink =
             sink.with_flat_map(move |e| iter_ok(encode_event(e, api_key.clone(), &encoding)));
 
-        Ok((Box::new(sink), Box::new(healthcheck.compat())))
+        Ok((Box::new(sink), Box::new(healthcheck)))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -9,7 +9,6 @@ use crate::{
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
 use bytes::Bytes;
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use serde::{Deserialize, Serialize};
 use syslog::{Facility, Formatter3164, LogFormat, Severity};
@@ -52,7 +51,7 @@ impl SinkConfig for PapertrailConfig {
 
         let sink = sink.with_flat_map(move |e| iter_ok(encode_event(e, pid, &encoding)));
 
-        Ok((Box::new(sink), Box::new(healthcheck.compat())))
+        Ok((Box::new(sink), Box::new(healthcheck)))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -175,19 +175,14 @@ mod test {
     #[cfg(feature = "sources-tls")]
     #[test]
     fn tcp_stream_detects_disconnect() {
-        use crate::tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};
-        use futures::{future, FutureExt, StreamExt};
-        use std::{
-            future::Future,
-            net::Shutdown,
-            pin::Pin,
-            sync::{
-                atomic::{AtomicUsize, Ordering},
-                Arc,
-            },
-            task::Poll,
+        use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
+        use futures01::{Async, Stream};
+        use std::io::{ErrorKind, Read};
+        use std::net::Shutdown;
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
         };
-        use tokio::{io::AsyncRead, net::TcpStream};
 
         crate::test_util::trace_init();
 
@@ -216,8 +211,7 @@ mod test {
         let conn_counter = Arc::new(AtomicUsize::new(0));
         let conn_counter1 = Arc::clone(&conn_counter);
 
-        let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
-        let mut close_rx = Some(close_rx.map(|x| x.unwrap()));
+        let (mut close_tx, mut close_rx) = tokio01::sync::mpsc::unbounded_channel::<()>();
 
         let config = Some(TlsConfig {
             enabled: Some(true),
@@ -227,45 +221,37 @@ mod test {
                 ..Default::default()
             },
         });
+        let stream = MaybeTlsSettings::from_config(&config, true).unwrap();
 
         // Only accept two connections.
-        let jh = rt.spawn_handle_std(async move {
-            let tls = MaybeTlsSettings::from_config(&config, true).unwrap();
-            let mut listener = tls.bind(&addr).await.unwrap();
-            listener
-                .incoming()
-                .take(2)
-                .for_each(|connection| {
-                    let mut close_rx = close_rx.take();
+        let fut = stream
+            .bind(&addr)
+            .unwrap()
+            .incoming()
+            .take(2)
+            .for_each(move |mut socket| {
+                conn_counter1.fetch_add(1, Ordering::SeqCst);
+                loop {
+                    if let Ok(Async::Ready(_)) = close_rx.poll() {
+                        socket.get_ref().unwrap().shutdown(Shutdown::Write).unwrap();
+                    }
 
-                    conn_counter1.fetch_add(1, Ordering::SeqCst);
-                    let msg_counter1 = Arc::clone(&msg_counter1);
-
-                    let mut stream: MaybeTlsIncomingStream<TcpStream> = connection.unwrap();
-                    future::poll_fn(move |cx| loop {
-                        if let Some(fut) = close_rx.as_mut() {
-                            if let Poll::Ready(()) = Pin::new(fut).poll(cx) {
-                                stream.get_ref().unwrap().shutdown(Shutdown::Write).unwrap();
-                                close_rx = None;
+                    let mut buf = vec![0u8; 11];
+                    match socket.read(&mut buf) {
+                        Err(error) if error.kind() == ErrorKind::WouldBlock => {}
+                        Err(error) => panic!("{}", error),
+                        Ok(n) => {
+                            if n == 0 {
+                                break;
+                            } else {
+                                msg_counter1.fetch_add(1, Ordering::SeqCst);
                             }
                         }
-
-                        return match Pin::new(&mut stream).poll_read(cx, &mut [0u8; 11]) {
-                            Poll::Ready(Ok(n)) => {
-                                if n == 0 {
-                                    Poll::Ready(())
-                                } else {
-                                    msg_counter1.fetch_add(1, Ordering::SeqCst);
-                                    continue;
-                                }
-                            }
-                            Poll::Ready(Err(error)) => panic!("{}", error),
-                            Poll::Pending => Poll::Pending,
-                        };
-                    })
-                })
-                .await;
-        });
+                    };
+                }
+                Ok(())
+            });
+        let jh = rt.spawn_handle_std(fut.compat());
 
         let (_, events) = random_lines_with_stream(10, 10);
         let pump = sink.send_all(events);
@@ -278,7 +264,7 @@ mod test {
             let amnt = msg_counter.load(Ordering::SeqCst);
 
             if amnt == 10 {
-                close_tx.send(()).unwrap();
+                close_tx.try_send(()).unwrap();
                 break;
             }
 

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -7,31 +7,31 @@ use crate::{
     },
     sinks::util::{encode_event, encoding::EncodingConfig, Encoding, SinkBuildError, StreamSink},
     sinks::{Healthcheck, RouterSink},
-    tls::{MaybeTlsSettings, MaybeTlsStream, TlsConfig, TlsError},
+    tls::{MaybeTlsConnector, MaybeTlsSettings, MaybeTlsStream, TlsConfig},
     topology::config::SinkContext,
 };
 use bytes05::Bytes;
 use futures::{
-    compat::CompatSink, future::BoxFuture, task::noop_waker_ref, FutureExt, TryFutureExt,
+    compat::{Compat01As03, CompatSink},
+    FutureExt, TryFutureExt,
 };
 use futures01::{
-    stream::iter_ok, try_ready, Async, AsyncSink, Future, Poll as Poll01, Sink, StartSend,
+    future, stream::iter_ok, try_ready, Async, AsyncSink, Future, Poll, Sink, StartSend,
 };
 use serde::{Deserialize, Serialize};
-use snafu::{ResultExt, Snafu};
+use snafu::Snafu;
 use std::{
+    io::{ErrorKind, Read},
     net::SocketAddr,
-    pin::Pin,
-    task::{Context, Poll},
     time::Duration,
 };
-use tokio::{
-    io::AsyncRead,
-    net::TcpStream,
-    time::{delay_for, Delay},
-};
+use tokio::time::{delay_for, Delay};
+use tokio01::net::tcp::TcpStream;
 use tokio_retry::strategy::ExponentialBackoff;
-use tokio_util::codec::{BytesCodec, FramedWrite};
+use tokio_util::{
+    codec::{BytesCodec, FramedWrite},
+    compat::{Compat, FuturesAsyncWriteCompatExt},
+};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -67,7 +67,7 @@ impl TcpSinkConfig {
                 .with_flat_map(move |event| iter_ok(encode_event(event, &encoding))),
         );
 
-        Ok((sink, Box::new(healthcheck.compat())))
+        Ok((sink, healthcheck))
     }
 }
 
@@ -84,12 +84,13 @@ pub struct TcpSink {
 enum TcpSinkState {
     Disconnected,
     ResolvingDns(crate::dns::ResolverFuture),
-    Connecting(Box<dyn Future<Item = MaybeTlsStream<TcpStream>, Error = TlsError> + Send>),
+    Connecting(MaybeTlsConnector),
     Connected(TcpOrTlsStream),
     Backoff(Box<dyn Future<Item = (), Error = ()> + Send>),
 }
 
-type TcpOrTlsStream = CompatSink<FramedWrite<MaybeTlsStream<TcpStream>, BytesCodec>, Bytes>;
+type TcpOrTlsStream =
+    CompatSink<FramedWrite<Compat<Compat01As03<MaybeTlsStream<TcpStream>>>, BytesCodec>, Bytes>;
 
 impl TcpSink {
     pub fn new(host: String, port: u16, resolver: Resolver, tls: MaybeTlsSettings) -> Self {
@@ -100,20 +101,18 @@ impl TcpSink {
             resolver,
             tls,
             state: TcpSinkState::Disconnected,
-            // state2: TcpSinkState2::Disconnected,
             backoff: Self::fresh_backoff(),
             span,
         }
     }
 
-    pub fn healthcheck(&self) -> BoxFuture<'static, crate::Result<()>> {
+    pub fn healthcheck(&self) -> Healthcheck {
         tcp_healthcheck(
             self.host.clone(),
             self.port,
             self.resolver,
             self.tls.clone(),
         )
-        .boxed()
     }
 
     fn fresh_backoff() -> ExponentialBackoff {
@@ -132,7 +131,7 @@ impl TcpSink {
         Box::new(async move { Ok(delay.await) }.boxed().compat())
     }
 
-    fn poll_connection(&mut self) -> Poll01<&mut TcpOrTlsStream, ()> {
+    fn poll_connection(&mut self) -> Poll<&mut TcpOrTlsStream, ()> {
         loop {
             self.state = match self.state {
                 TcpSinkState::Disconnected => {
@@ -147,9 +146,13 @@ impl TcpSink {
                             let addr = SocketAddr::new(ip, self.port);
 
                             debug!(message = "connecting", %addr);
-                            let fut = self.tls.clone().connect(self.host.clone(), addr);
-                            let fut = Box::new(fut.boxed().compat());
-                            TcpSinkState::Connecting(fut)
+                            match self.tls.connect(self.host.clone(), addr) {
+                                Ok(connector) => TcpSinkState::Connecting(connector),
+                                Err(error) => {
+                                    error!(message = "unable to connect", %error);
+                                    TcpSinkState::Backoff(self.next_delay01())
+                                }
+                            }
                         } else {
                             error!("DNS resolved but there were no IP addresses.");
                             TcpSinkState::Backoff(self.next_delay01())
@@ -161,12 +164,22 @@ impl TcpSink {
                         TcpSinkState::Backoff(self.next_delay01())
                     }
                 },
+                TcpSinkState::Backoff(ref mut delay) => match delay.poll() {
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    // Err can only occur if the tokio runtime has been shutdown or if more than 2^63 timers have been created
+                    Err(()) => unreachable!(),
+                    Ok(Async::Ready(())) => {
+                        debug!(message = "disconnected.");
+                        TcpSinkState::Disconnected
+                    }
+                },
                 TcpSinkState::Connecting(ref mut connect_future) => match connect_future.poll() {
                     Ok(Async::Ready(stream)) => {
                         emit!(TcpConnectionEstablished {
                             peer_addr: stream.peer_addr().ok(),
                         });
                         self.backoff = Self::fresh_backoff();
+                        let stream = Compat01As03::new(stream).compat_write();
                         let out = FramedWrite::new(stream, BytesCodec::new());
                         TcpSinkState::Connected(CompatSink::new(out))
                     }
@@ -177,21 +190,11 @@ impl TcpSink {
                     }
                 },
                 TcpSinkState::Connected(ref mut connection) => return Ok(Async::Ready(connection)),
-                TcpSinkState::Backoff(ref mut delay) => match delay.poll() {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    // Err can only occur if the tokio runtime has been shutdown or if more than 2^63 timers have been created
-                    Err(()) => unreachable!(),
-                    Ok(Async::Ready(())) => {
-                        debug!(message = "disconnected.");
-                        TcpSinkState::Disconnected
-                    }
-                },
             };
         }
     }
 }
 
-// New Sink trait implemented in PR#3188: https://github.com/timberio/vector/pull/3188#discussion_r463843208
 impl Sink for TcpSink {
     type SinkItem = bytes::Bytes;
     type SinkError = ();
@@ -208,18 +211,17 @@ impl Sink for TcpSink {
                 // This can return a proper disconnect error or `Ok(0)`
                 // which means the pipe is broken and we should try to reconnect.
                 //
-                // If this returns `Poll::Pending` we know the connection is still
+                // If this returns `WouldBlock` we know the connection is still
                 // valid and the write will most likely succeed.
-
-                let stream: &mut MaybeTlsStream<TcpStream> = connection.get_mut().get_mut();
-                let mut cx = Context::from_waker(noop_waker_ref());
-                match Pin::new(stream).poll_read(&mut cx, &mut [0u8; 1]) {
-                    Poll::Ready(Err(error)) => {
+                let stream: &mut MaybeTlsStream<TcpStream> =
+                    connection.get_mut().get_mut().get_mut().get_mut();
+                match stream.read(&mut [0u8; 1]) {
+                    Err(error) if error.kind() != ErrorKind::WouldBlock => {
                         emit!(TcpConnectionDisconnected { error });
                         self.state = TcpSinkState::Disconnected;
                         Ok(AsyncSink::NotReady(line))
                     }
-                    Poll::Ready(Ok(0)) => {
+                    Ok(0) => {
                         // Maybe this is only a sign to close the channel,
                         // in which case we should try to flush our buffers
                         // before disconnecting.
@@ -289,30 +291,41 @@ impl Sink for TcpSink {
 #[derive(Debug, Snafu)]
 enum HealthcheckError {
     #[snafu(display("Connect error: {}", source))]
-    ConnectError { source: TlsError },
+    ConnectError { source: crate::tls::TlsError },
     #[snafu(display("Unable to resolve DNS: {}", source))]
     DnsError { source: crate::dns::DnsError },
     #[snafu(display("No addresses returned."))]
     NoAddresses,
 }
 
-pub async fn tcp_healthcheck(
+pub fn tcp_healthcheck(
     host: String,
     port: u16,
     resolver: Resolver,
     tls: MaybeTlsSettings,
-) -> crate::Result<()> {
-    let ip = resolver
-        .lookup_ip(host.clone())
-        .await
-        .context(DnsError)?
-        .next()
-        .ok_or_else(|| HealthcheckError::NoAddresses)?;
+) -> Healthcheck {
+    // Lazy to avoid immediately connecting
+    let check = future::lazy(move || {
+        resolver
+            .lookup_ip_01(host.clone())
+            .map_err(|source| HealthcheckError::DnsError { source }.into())
+            .and_then(|mut ip| {
+                ip.next()
+                    .ok_or_else(|| HealthcheckError::NoAddresses.into())
+            })
+            .and_then(move |ip| {
+                let addr = SocketAddr::new(ip, port);
+                future::result(
+                    tls.connect(host, addr)
+                        .map_err(|source| HealthcheckError::ConnectError { source }.into()),
+                )
+            })
+            .and_then(|maybe| {
+                maybe
+                    .map(|_| ())
+                    .map_err(|source| HealthcheckError::ConnectError { source }.into())
+            })
+    });
 
-    let _ = tls
-        .connect(host, SocketAddr::new(ip, port))
-        .await
-        .context(ConnectError)?;
-
-    Ok(())
+    Box::new(check)
 }

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use bytes::Bytes;
 use bytes05::{BufMut, BytesMut};
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -54,7 +53,7 @@ impl SinkConfig for VectorSinkConfig {
         let sink = StreamSink::new(sink, cx.acker())
             .with_flat_map(move |event| iter_ok(encode_event(event)));
 
-        Ok((Box::new(sink), Box::new(healthcheck.compat())))
+        Ok((Box::new(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -6,7 +6,6 @@ use crate::{
     topology::config::{DataType, GlobalOptions, SourceConfig},
     Pipeline,
 };
-use async_trait::async_trait;
 use bytes05::{buf::BufExt, Bytes};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -33,19 +32,8 @@ impl HttpSource for LogplexSource {
 }
 
 #[typetag::serde(name = "logplex")]
-#[async_trait]
 impl SourceConfig for LogplexConfig {
     fn build(
-        &self,
-        _name: &str,
-        _globals: &GlobalOptions,
-        _shutdown: ShutdownSignal,
-        _out: Pipeline,
-    ) -> crate::Result<super::Source> {
-        unimplemented!()
-    }
-
-    async fn build_async(
         &self,
         _: &str,
         _: &GlobalOptions,
@@ -185,20 +173,16 @@ mod tests {
         test_util::trace_init();
         let (sender, recv) = Pipeline::new_test();
         let address = test_util::next_addr();
-        rt.spawn_std(async move {
+        rt.spawn(
             LogplexConfig { address, tls: None }
-                .build_async(
+                .build(
                     "default",
                     &GlobalOptions::default(),
                     ShutdownSignal::noop(),
                     sender,
                 )
-                .await
-                .unwrap()
-                .compat()
-                .await
-                .unwrap()
-        });
+                .unwrap(),
+        );
         (recv, address)
     }
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -141,20 +141,15 @@ mod test {
     use crate::shutdown::{ShutdownSignal, SourceShutdownCoordinator};
     use crate::sinks::util::tcp::TcpSink;
     use crate::test_util::{
-        block_on, collect_n, next_addr, random_string, runtime, send_lines, send_lines_tls,
-        trace_init, wait_for_tcp, CollectN,
+        block_on, collect_n, next_addr, runtime, send_lines, send_lines_tls, wait_for_tcp, CollectN,
     };
     use crate::tls::{MaybeTlsSettings, TlsConfig, TlsOptions};
     use crate::topology::config::{GlobalOptions, SourceConfig};
     use crate::Pipeline;
     use bytes::Bytes;
     #[cfg(unix)]
-    use futures::SinkExt;
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        stream, StreamExt,
-    };
-    use futures01::{sync::oneshot, Stream};
+    use futures::{compat::Future01CompatExt, stream, SinkExt};
+    use futures01::{sync::oneshot, Future, Stream};
     #[cfg(unix)]
     use std::path::PathBuf;
     use std::{
@@ -361,8 +356,6 @@ mod test {
 
     #[test]
     fn tcp_shutdown_infinite_stream() {
-        trace_init();
-
         // It's important that the buffer be large enough that the TCP source doesn't have
         // to block trying to forward its input into the Sender because the channel is full,
         // otherwise even sending the signal to shut down won't wake it up.
@@ -382,7 +375,7 @@ mod test {
         .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
         .unwrap();
         let mut rt = Runtime::with_thread_count(2).unwrap();
-        let source_handle = rt.spawn_handle_std(server.compat());
+        let source_handle = oneshot::spawn(server, &rt.executor());
         wait_for_tcp(addr);
 
         // Spawn future that keeps sending lines to the TCP source forever.
@@ -392,15 +385,13 @@ mod test {
             Resolver,
             MaybeTlsSettings::Raw(()),
         );
-        let message = random_string(512);
-        let message_event = Bytes::from(message.clone() + "\n");
-        rt.spawn_std(async move {
-            let _ = stream::repeat(())
-                .map(move |_| Ok(message_event.clone()))
-                .forward(sink.sink_compat())
-                .await
-                .unwrap();
-        });
+        rt.spawn(
+            futures01::stream::iter_ok::<_, ()>(std::iter::repeat(()))
+                .map(|_| Bytes::from("test\n"))
+                .map_err(|_| ())
+                .forward(sink)
+                .map(|_| ()),
+        );
 
         // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.
         let (_rx, events) = rt.block_on(CollectN::new(rx, 100)).ok().unwrap();
@@ -408,7 +399,7 @@ mod test {
         for event in events {
             assert_eq!(
                 event.as_log()[&event::log_schema().message_key()],
-                message.clone().into()
+                "test".into()
             );
         }
 
@@ -418,9 +409,7 @@ mod test {
         assert_eq!(true, shutdown_success);
 
         // Ensure that the source has actually shut down.
-        rt.block_on_std(async move {
-            let _ = source_handle.await.unwrap();
-        })
+        rt.block_on(source_handle).unwrap();
     }
 
     //////// UDP TESTS ////////

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -1,25 +1,61 @@
 use super::{
-    CreateAcceptor, Handshake, MaybeTls, MaybeTlsSettings, MaybeTlsStream, PeerAddress, TcpBind,
-    TlsError, TlsSettings,
+    CreateAcceptor, IncomingListener, MaybeTlsSettings, MaybeTlsStream, PeerAddress, Result,
+    TcpBind, TlsError, TlsSettings,
 };
-use bytes05::{Buf, BufMut};
-use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
-use openssl::ssl::{SslAcceptor, SslMethod};
+use futures01::{try_ready, Async, Future, Stream};
+use openssl::ssl::{HandshakeError, SslAcceptor, SslMethod};
 use snafu::ResultExt;
 use std::{
-    mem::MaybeUninit,
+    fmt::{self, Debug, Formatter},
+    io::{self, ErrorKind, Read, Write},
     net::SocketAddr,
-    pin::Pin,
-    task::{Context, Poll},
 };
-use tokio::{
-    io::{self, AsyncRead, AsyncWrite},
-    net::{TcpListener, TcpStream},
+use tokio01::{
+    io::{AsyncRead, AsyncWrite},
+    net::{tcp::Incoming, TcpListener, TcpStream},
 };
-use tokio_openssl::{HandshakeError, SslStream};
+use tokio_openssl03::{AcceptAsync, SslAcceptorExt};
+
+pub(crate) struct MaybeTlsIncoming<I: Stream> {
+    incoming: I,
+    acceptor: Option<SslAcceptor>,
+}
+
+impl<I: Stream> MaybeTlsIncoming<I> {
+    pub(crate) fn new(incoming: I, acceptor: Option<SslAcceptor>) -> Self {
+        Self { incoming, acceptor }
+    }
+}
+
+impl Stream for MaybeTlsIncoming<Incoming> {
+    type Item = MaybeTlsIncomingStream<TcpStream>;
+    type Error = TlsError;
+
+    fn poll(&mut self) -> Result<Async<Option<Self::Item>>> {
+        Ok(Async::Ready(
+            match try_ready!(self
+                .incoming
+                .poll()
+                .map_err(Into::into)
+                .context(IncomingListener))
+            {
+                Some(stream) => Some(MaybeTlsIncomingStream::new(stream, &self.acceptor)?),
+                None => None,
+            },
+        ))
+    }
+}
+
+impl<I: Stream + Debug> Debug for MaybeTlsIncoming<I> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("MaybeTlsIncoming")
+            .field("incoming", &self.incoming)
+            .finish()
+    }
+}
 
 impl TlsSettings {
-    pub(crate) fn acceptor(&self) -> crate::tls::Result<SslAcceptor> {
+    pub(crate) fn acceptor(&self) -> Result<SslAcceptor> {
         match self.identity {
             None => Err(TlsError::MissingRequiredIdentity),
             Some(_) => {
@@ -33,8 +69,8 @@ impl TlsSettings {
 }
 
 impl MaybeTlsSettings {
-    pub(crate) async fn bind(&self, addr: &SocketAddr) -> crate::tls::Result<MaybeTlsListener> {
-        let listener = TcpListener::bind(addr).await.context(TcpBind)?;
+    pub(crate) fn bind(&self, addr: &SocketAddr) -> Result<MaybeTlsListener> {
+        let listener = TcpListener::bind(addr).context(TcpBind)?;
 
         let acceptor = match self {
             Self::Tls(tls) => Some(tls.acceptor()?),
@@ -51,19 +87,12 @@ pub(crate) struct MaybeTlsListener {
 }
 
 impl MaybeTlsListener {
-    pub(crate) fn incoming(
-        &mut self,
-    ) -> impl Stream<Item = crate::tls::Result<MaybeTlsIncomingStream<TcpStream>>> + '_ {
-        let acceptor = self.acceptor.clone();
-        self.listener
-            .incoming()
-            .map(move |connection| match connection {
-                Ok(stream) => MaybeTlsIncomingStream::new(stream, acceptor.clone()),
-                Err(source) => Err(TlsError::IncomingListener { source }),
-            })
+    pub(crate) fn incoming(self) -> MaybeTlsIncoming<Incoming> {
+        let incoming = self.listener.incoming();
+        MaybeTlsIncoming::new(incoming, self.acceptor)
     }
 
-    pub(crate) fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
+    pub(crate) fn local_addr(&self) -> std::result::Result<SocketAddr, std::io::Error> {
         self.listener.local_addr()
     }
 }
@@ -79,7 +108,7 @@ impl From<TcpListener> for MaybeTlsListener {
 
 pub struct MaybeTlsIncomingStream<S> {
     state: StreamState<S>,
-    // BoxFuture doesn't allow access to the inner stream, but users
+    // AcceptAsync doesn't allow access to the inner stream, but users
     // of MaybeTlsIncomingStream want access to the peer address while
     // still handshaking, so we have to cache it here.
     peer_addr: SocketAddr,
@@ -87,7 +116,7 @@ pub struct MaybeTlsIncomingStream<S> {
 
 enum StreamState<S> {
     Accepted(MaybeTlsStream<S>),
-    Accepting(BoxFuture<'static, Result<SslStream<S>, HandshakeError<S>>>),
+    Accepting(AcceptAsync<S>),
 }
 
 impl<S> MaybeTlsIncomingStream<S> {
@@ -98,105 +127,99 @@ impl<S> MaybeTlsIncomingStream<S> {
     /// None if connection still hasen't been established.
     pub fn get_ref(&self) -> Option<&S> {
         match &self.state {
-            StreamState::Accepted(stream) => Some(match stream {
-                MaybeTls::Raw(s) => s,
-                MaybeTls::Tls(s) => s.get_ref(),
-            }),
+            StreamState::Accepted(stream) => {
+                if let Some(raw) = stream.raw() {
+                    Some(raw)
+                } else {
+                    Some(
+                        stream
+                            .tls()
+                            .expect("Stream not raw nor tls")
+                            .get_ref()
+                            .get_ref(),
+                    )
+                }
+            }
             StreamState::Accepting(_) => None,
         }
     }
 }
 
 impl MaybeTlsIncomingStream<TcpStream> {
-    pub(super) fn new(
-        stream: TcpStream,
-        acceptor: Option<SslAcceptor>,
-    ) -> crate::tls::Result<Self> {
+    pub(super) fn new(stream: TcpStream, acceptor: &Option<SslAcceptor>) -> Result<Self> {
         let peer_addr = stream.peer_addr().context(PeerAddress)?;
         let state = match acceptor {
-            Some(acceptor) => StreamState::Accepting(
-                async move { tokio_openssl::accept(&acceptor, stream).await }.boxed(),
-            ),
+            Some(acceptor) => StreamState::Accepting(acceptor.accept_async(stream)),
             None => StreamState::Accepted(MaybeTlsStream::Raw(stream)),
         };
         Ok(Self { peer_addr, state })
     }
+}
 
-    // Explicit handshake method
-    pub(crate) async fn handshake(&mut self) -> crate::tls::Result<()> {
-        if let StreamState::Accepting(fut) = &mut self.state {
-            let stream = fut.await.context(Handshake)?;
-            self.state = StreamState::Accepted(MaybeTlsStream::Tls(stream));
-        }
-
-        Ok(())
-    }
-
-    fn poll_io<T, F>(self: Pin<&mut Self>, cx: &mut Context, poll_fn: F) -> Poll<io::Result<T>>
-    where
-        F: FnOnce(Pin<&mut MaybeTlsStream<TcpStream>>, &mut Context) -> Poll<io::Result<T>>,
-    {
-        let mut this = self.get_mut();
-        loop {
-            return match &mut this.state {
-                StreamState::Accepted(stream) => poll_fn(Pin::new(stream), cx),
-                StreamState::Accepting(fut) => match futures::ready!(fut.as_mut().poll(cx)) {
-                    Ok(stream) => {
-                        this.state = StreamState::Accepted(MaybeTlsStream::Tls(stream));
-                        continue;
-                    }
-                    Err(error) => {
-                        let error = io::Error::new(io::ErrorKind::Other, error);
-                        Poll::Ready(Err(error))
-                    }
+fn poll_handshake<S: Read + Write>(acceptor: &mut AcceptAsync<S>) -> io::Result<StreamState<S>> {
+    match acceptor.poll() {
+        Err(error) => match error {
+            HandshakeError::WouldBlock(_) => Err(io::Error::new(
+                ErrorKind::WouldBlock,
+                TlsError::HandshakeNotReady,
+            )),
+            HandshakeError::Failure(stream) => Err(io::Error::new(
+                ErrorKind::Other,
+                TlsError::Handshake {
+                    source: stream.into_error(),
                 },
-            };
+            )),
+            HandshakeError::SetupFailure(source) => Err(io::Error::new(
+                ErrorKind::Other,
+                TlsError::HandshakeSetup { source },
+            )),
+        },
+        Ok(Async::Ready(stream)) => Ok(StreamState::Accepted(MaybeTlsStream::Tls(stream))),
+        Ok(Async::NotReady) => Err(io::Error::new(
+            ErrorKind::WouldBlock,
+            TlsError::HandshakeNotReady,
+        )),
+    }
+}
+
+impl<S: Read + Write> Read for MaybeTlsIncomingStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.state {
+            StreamState::Accepted(stream) => stream.read(buf),
+            StreamState::Accepting(acceptor) => {
+                self.state = poll_handshake(acceptor)?;
+                self.read(buf)
+            }
         }
     }
 }
 
-impl AsyncRead for MaybeTlsIncomingStream<TcpStream> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        self.poll_io(cx, |s, cx| s.poll_read(cx, buf))
+impl<S: Read + Write> Write for MaybeTlsIncomingStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match &mut self.state {
+            StreamState::Accepted(stream) => stream.write(buf),
+            StreamState::Accepting(acceptor) => {
+                self.state = poll_handshake(acceptor)?;
+                self.write(buf)
+            }
+        }
     }
 
-    unsafe fn prepare_uninitialized_buffer(&self, _buf: &mut [MaybeUninit<u8>]) -> bool {
-        // Both, TcpStream & SslStream return false
-        // We can not use `poll_io` here, because need Context for polling handshake
-        false
-    }
-
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.poll_io(cx, |s, cx| s.poll_read_buf(cx, buf))
+    fn flush(&mut self) -> io::Result<()> {
+        match &mut self.state {
+            StreamState::Accepted(stream) => stream.flush(),
+            StreamState::Accepting(_) => Ok(()),
+        }
     }
 }
 
-impl AsyncWrite for MaybeTlsIncomingStream<TcpStream> {
-    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        self.poll_io(cx, |s, cx| s.poll_write(cx, buf))
-    }
+impl<S: Read + Write> AsyncRead for MaybeTlsIncomingStream<S> {}
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        self.poll_io(cx, |s, cx| s.poll_flush(cx))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        self.poll_io(cx, |s, cx| s.poll_shutdown(cx))
-    }
-
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.poll_io(cx, |s, cx| s.poll_write_buf(cx, buf))
+impl<S: AsyncRead + AsyncWrite> AsyncWrite for MaybeTlsIncomingStream<S> {
+    fn shutdown(&mut self) -> io::Result<Async<()>> {
+        match &mut self.state {
+            StreamState::Accepted(stream) => stream.shutdown(),
+            StreamState::Accepting(_) => Ok(Async::Ready(())),
+        }
     }
 }

--- a/src/tls/maybe_tls.rs
+++ b/src/tls/maybe_tls.rs
@@ -1,19 +1,13 @@
-use bytes05::{Buf, BufMut};
-use pin_project::pin_project;
-use std::{
-    fmt,
-    mem::MaybeUninit,
-    pin::Pin,
-    task::{Context, Poll},
-};
-use tokio::io::{self, AsyncRead, AsyncWrite};
+use futures01::Poll;
+use std::fmt::{self, Debug, Formatter};
+use std::io::{self, Read, Write};
+use tokio01::io::{AsyncRead, AsyncWrite};
 
 /// A type wrapper for objects that can exist in either a raw state or
 /// wrapped by TLS handling.
-#[pin_project(project = MaybeTlsProj)]
 pub enum MaybeTls<R, T> {
-    Raw(#[pin] R),
-    Tls(#[pin] T),
+    Raw(R),
+    Tls(T),
 }
 
 impl<R, T> MaybeTls<R, T> {
@@ -60,8 +54,8 @@ impl<R: Clone, T: Clone> Clone for MaybeTls<R, T> {
 }
 
 // Conditionally implement Debug for Debugable types
-impl<R: fmt::Debug, T: fmt::Debug> fmt::Debug for MaybeTls<R, T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<R: Debug, T: Debug> Debug for MaybeTls<R, T> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         match self {
             Self::Raw(raw) => write!(fmt, "MaybeTls::Raw({:?})", raw),
             Self::Tls(tls) => write!(fmt, "MaybeTls::Tls({:?})", tls),
@@ -69,67 +63,38 @@ impl<R: fmt::Debug, T: fmt::Debug> fmt::Debug for MaybeTls<R, T> {
     }
 }
 
-impl<R: AsyncRead, T: AsyncRead> AsyncRead for MaybeTls<R, T> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_read(cx, buf),
-            MaybeTlsProj::Raw(s) => s.poll_read(cx, buf),
-        }
-    }
-
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [MaybeUninit<u8>]) -> bool {
+impl<R: Read, T: Read> Read for MaybeTls<R, T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            MaybeTls::Tls(s) => s.prepare_uninitialized_buffer(buf),
-            MaybeTls::Raw(s) => s.prepare_uninitialized_buffer(buf),
+            Self::Tls(s) => s.read(buf),
+            Self::Raw(s) => s.read(buf),
+        }
+    }
+}
+
+impl<R: AsyncRead, T: AsyncRead> AsyncRead for MaybeTls<R, T> {}
+
+impl<R: Write, T: Write> Write for MaybeTls<R, T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Tls(s) => s.write(buf),
+            Self::Raw(s) => s.write(buf),
         }
     }
 
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_read_buf(cx, buf),
-            MaybeTlsProj::Raw(s) => s.poll_read_buf(cx, buf),
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Tls(s) => s.flush(),
+            Self::Raw(s) => s.flush(),
         }
     }
 }
 
 impl<R: AsyncWrite, T: AsyncWrite> AsyncWrite for MaybeTls<R, T> {
-    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_write(cx, buf),
-            MaybeTlsProj::Raw(s) => s.poll_write(cx, buf),
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_flush(cx),
-            MaybeTlsProj::Raw(s) => s.poll_flush(cx),
-        }
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_shutdown(cx),
-            MaybeTlsProj::Raw(s) => s.poll_shutdown(cx),
-        }
-    }
-
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        match self.project() {
-            MaybeTlsProj::Tls(s) => s.poll_write_buf(cx, buf),
-            MaybeTlsProj::Raw(s) => s.poll_write_buf(cx, buf),
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        match self {
+            Self::Tls(s) => s.shutdown(),
+            Self::Raw(s) => s.shutdown(),
         }
     }
 }

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -11,12 +11,10 @@ use openssl::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
-use std::{
-    fmt,
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-};
+use std::fmt::{self, Debug, Formatter};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 const PEM_START_MARKER: &str = "-----BEGIN ";
 
@@ -300,8 +298,8 @@ fn load_mac_certs(builder: &mut SslContextBuilder) -> Result<()> {
     Ok(())
 }
 
-impl fmt::Debug for TlsSettings {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Debug for TlsSettings {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("TlsSettings")
             .field("verify_certificate", &self.verify_certificate)
             .field("verify_hostname", &self.verify_hostname)

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -121,7 +121,7 @@ fn test_unix_stream_syslog() {
         stream.shutdown(std::net::Shutdown::Both).unwrap();
 
         // Otherwise some lines will be lost
-        tokio::time::delay_for(std::time::Duration::from_millis(1000)).await;
+        tokio::time::delay_for(std::time::Duration::from_millis(100)).await;
 
         // Shut down server
         topology.stop().compat().await.unwrap();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -307,7 +307,7 @@ async fn healthcheck() {
         None.into(),
     );
 
-    assert!(healthcheck.await.is_ok());
+    assert!(healthcheck.compat().await.is_ok());
 
     let bad_addr = next_addr();
     let bad_healthcheck = vector::sinks::util::tcp::tcp_healthcheck(
@@ -317,5 +317,5 @@ async fn healthcheck() {
         None.into(),
     );
 
-    assert!(bad_healthcheck.await.is_err());
+    assert!(bad_healthcheck.compat().await.is_err());
 }


### PR DESCRIPTION
Looks like #3188 hang up some tests in CI, I can not figure out right now what's wrong, so decide revert changes.

Part of CI pass in my fork: https://github.com/fanatid/vector/runs/946240422?check_suite_focus=true

Need green CI before merge.