### PR TITLE
chore(elasticsearch sink): Fix insert_events_with_failure test

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -734,7 +734,7 @@ mod integration_tests {
                     let _ = sink
                         .send_all(events.map(move |mut event| {
                             if doit {
-                                event.as_mut_log().insert("message", 1);
+                                event.as_mut_log().insert("_type", 1);
                             }
                             doit = true;
                             event


### PR DESCRIPTION
This test fails to fail unless `request.in_flight_limit > 1`. It appears
to be caused by a weird issue with elasticsearch itself. By "breaking"
the data by adding a reserved field to the event, we can cause events to
reliably fail, making the test reliable when `in_flight_limit = 1`.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #3303 