### PR TITLE
feat(splunk_hec sink): Make sourcetype templatable

### DIFF
--- a/.meta/sinks/splunk_hec.toml.erb
+++ b/.meta/sinks/splunk_hec.toml.erb
@@ -79,6 +79,7 @@ type = "string"
 common = false
 examples = ["_json", "httpevent"]
 required = false
+templateable = true
 description = """\
 The sourcetype of events sent to this sink. If unset, Splunk will default to httpevent.
 """

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -1,6 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 use serde_json::Error;
+use string_cache::DefaultAtom as Atom;
 
 #[derive(Debug)]
 pub struct SplunkEventSent {
@@ -39,6 +40,29 @@ impl InternalEvent for SplunkEventEncodeError {
     fn emit_metrics(&self) {
         counter!(
             "encode_errors", 1,
+            "component_kind" => "sink",
+            "component_type" => "splunk_hec",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SplunkSourceTypeMissingKeys {
+    pub keys: Vec<Atom>,
+}
+
+impl InternalEvent for SplunkSourceTypeMissingKeys {
+    fn emit_logs(&self) {
+        warn!(
+            message = "failed to render template for sourcetype, leaving empty",
+            missing_keys = ?self.keys,
+            rate_limit_secs = 30,
+        )
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "sourcetype_missing_keys", 1,
             "component_kind" => "sink",
             "component_type" => "splunk_hec",
         );

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -1,12 +1,13 @@
 use crate::{
     event::{self, Event, LogEvent, Value},
-    internal_events::{SplunkEventEncodeError, SplunkEventSent},
+    internal_events::{SplunkEventEncodeError, SplunkEventSent, SplunkSourceTypeMissingKeys},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpClient, HttpSink},
         service2::TowerRequestConfig,
         BatchConfig, BatchSettings, Buffer, Compression,
     },
+    template::Template,
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -37,7 +38,7 @@ pub struct HecSinkConfig {
     #[serde(default)]
     pub indexed_fields: Vec<Atom>,
     pub index: Option<String>,
-    pub sourcetype: Option<String>,
+    pub sourcetype: Option<Template>,
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
@@ -122,6 +123,19 @@ impl HttpSink for HecSinkConfig {
     fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
         self.encoding.apply_rules(&mut event);
 
+        let sourcetype = self
+            .sourcetype
+            .as_ref()
+            .map(|sourcetype| {
+                sourcetype
+                    .render_string(&event)
+                    .map_err(|missing_keys| {
+                        emit!(SplunkSourceTypeMissingKeys { keys: missing_keys });
+                    })
+                    .ok()
+            })
+            .unwrap_or(None);
+
         let mut event = event.into_log();
 
         let host = event.get(&self.host_key).cloned();
@@ -161,7 +175,7 @@ impl HttpSink for HecSinkConfig {
             body["index"] = json!(index);
         }
 
-        if let Some(sourcetype) = &self.sourcetype {
+        if let Some(sourcetype) = sourcetype {
             body["sourcetype"] = json!(sourcetype);
         }
 
@@ -525,7 +539,7 @@ mod integration_tests {
         rt.block_on_std(async move {
             let indexed_fields = vec![Atom::from("asdf")];
             let mut config = config(Encoding::Json, indexed_fields).await;
-            config.sourcetype = Some("_json".to_string());
+            config.sourcetype = Template::try_from("_json".to_string()).ok();
 
             let (sink, _) = config.build(cx).unwrap();
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -123,18 +123,14 @@ impl HttpSink for HecSinkConfig {
     fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
         self.encoding.apply_rules(&mut event);
 
-        let sourcetype = self
-            .sourcetype
-            .as_ref()
-            .map(|sourcetype| {
-                sourcetype
-                    .render_string(&event)
-                    .map_err(|missing_keys| {
-                        emit!(SplunkSourceTypeMissingKeys { keys: missing_keys });
-                    })
-                    .ok()
-            })
-            .unwrap_or(None);
+        let sourcetype = self.sourcetype.as_ref().and_then(|sourcetype| {
+            sourcetype
+                .render_string(&event)
+                .map_err(|missing_keys| {
+                    emit!(SplunkSourceTypeMissingKeys { keys: missing_keys });
+                })
+                .ok()
+        });
 
         let mut event = event.into_log();
 


### PR DESCRIPTION
Allows for setting the sourcetype dynamically based on an event field.

Related: #3251 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>