### PR TITLE
chore: checkout full repo for lint checks

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          # check-version needs tags
+          fetch-depth: 0 # fetch everything
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
`make check-version` requires git history.

Appears to have broken by https://github.com/timberio/vector/pull/3348
when the CI checks were condensed as the old `make check-version` check
used actions/checkout@v1

Example failure:

```
Run make check-version
./scripts/check-version.rb
/var/lib/gems/2.7.0/gems/git-1.7.0/lib/git/lib.rb:989:in `command': git '--git-dir=/home/runner/work/vector/vector/.git' '--work-tree=/home/runner/work/vector/vector' '-c' 'color.ui=false' describe '--tags' '--abbrev=0' 'HEAD'  2>&1:fatal: No names found, cannot describe anything. (Git::GitExecuteError)
	from /var/lib/gems/2.7.0/gems/git-1.7.0/lib/git/lib.rb:126:in `describe'
	from /var/lib/gems/2.7.0/gems/git-1.7.0/lib/git/base.rb:271:in `describe'
	from ./scripts/check-version.rb:41:in `<main>'
make: *** [Makefile:366: check-version] Error 1
```

https://github.com/timberio/vector/runs/949426583