### PR TITLE
chore(operations): Enforce paths for pull requests in the test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,20 @@ on:
       - "docker-compose.yml"
       - "Makefile"
       - "rust-toolchain"
-  pull_request: {}
+  pull_request:
+    paths:
+      - ".github/workflows/tests.yml"
+      - "lib/**"
+      - "proto/**"
+      - "scripts/**"
+      - "skaffold/**"
+      - "src/**"
+      - "tests/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "docker-compose.yml"
+      - "Makefile"
+      - "rust-toolchain"
 
 env:
   VERBOSE: true


### PR DESCRIPTION
It turns out the paths were not being honored for pull requests. We must specify paths for both triggers. Unfortunately, Github Actions does not support YAML anchors.