### PR TITLE
chore(tests): Re add `topology_reuse_old_port` test for `unix`

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -763,6 +763,47 @@ mod reload_tests {
     use crate::topology;
     use crate::topology::config::Config;
 
+    // TODO: Run it only on Linux and Mac since it fails on Windows.
+    // TODO: Issue: https://github.com/timberio/vector/issues/3035
+    #[cfg(unix)]
+    #[test]
+    fn topology_reuse_old_port() {
+        let address = next_addr();
+
+        let mut rt = runtime();
+
+        let mut old_config = Config::empty();
+        old_config.add_source("in1", SplunkConfig::on(address));
+        old_config.add_sink(
+            "out",
+            &[&"in1"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        let mut new_config = Config::empty();
+        new_config.add_source("in2", SplunkConfig::on(address));
+        new_config.add_sink(
+            "out",
+            &[&"in2"],
+            ConsoleSinkConfig {
+                target: Target::Stdout,
+                encoding: Encoding::Text.into(),
+            },
+        );
+
+        rt.block_on_std(async move {
+            let (mut topology, _crash) = topology::start(old_config, false).await.unwrap();
+
+            assert!(topology
+                .reload_config_and_respawn(new_config, false)
+                .await
+                .unwrap());
+        });
+    }
+
     #[test]
     fn topology_rebuild_old() {
         let address = next_addr();


### PR DESCRIPTION
Ref. #3035

Test is only failing on Windows, so we can re introduce it and enable it for the rest.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
