### PR TITLE
fix(observability)!: Remove forwarding to syslog from distributed systemd unit

### DIFF
--- a/distribution/systemd/vector.service
+++ b/distribution/systemd/vector.service
@@ -10,9 +10,6 @@ Group=vector
 ExecStart=/usr/bin/vector
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=no
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=vector
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Instead, just rely on the default configuration the operator has
configured systemd with (typically journald). I think this is less
suprising than automatically forwarding via syslog not the least of
which because the host system may not be running a syslog daemon.

Users can still configure this via
a /etc/systemd/system/vector/override.conf file. I think the base
configuration should be as simple as possible.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

Related to https://github.com/timberio/vector/issues/3414