### PR TITLE
chore(ci): allow nightly build to be manually triggered

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: nightly
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
 


### PR DESCRIPTION
Useful for testing changes to it without waiting.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>