### PR TITLE
chore(administration): Remove some more armv7 bits

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -169,10 +169,6 @@ jobs:
         with:
           name: vector-arm64.deb
           path: target/artifacts
-      - uses: actions/download-artifact@v1
-        with:
-          name: vector-armhf.deb
-          path: target/artifacts
       - env:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
@@ -212,10 +208,6 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: vector-arm64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v1
-        with:
-          name: vector-armhf.deb
           path: target/artifacts
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,6 @@ jobs:
         with:
           name: vector-arm64.deb
           path: target/artifacts
-      - uses: actions/download-artifact@v1
-        with:
-          name: vector-armhf.deb
-          path: target/artifacts
       - env:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
@@ -177,10 +173,6 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: vector-arm64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v1
-        with:
-          name: vector-armhf.deb
           path: target/artifacts
       - uses: actions/download-artifact@v1
         with:
@@ -295,10 +287,6 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: vector-arm64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v1
-        with:
-          name: vector-armhf.deb
           path: target/artifacts
       - uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
The armhf assets were still being referred to in the nightly build, but
are no longer being built.