### PR TITLE
chore(tests): Do not run the auto-concurrency tests on macos

### DIFF
--- a/src/sinks/util/auto_concurrency/tests.rs
+++ b/src/sinks/util/auto_concurrency/tests.rs
@@ -1,6 +1,6 @@
 // Only run the test suite on unix systems, as the timings on especially
 // MacOS are too variable to produce reliable results in these tests.
-#![cfg(all(test, unix, feature = "sources-generator"))]
+#![cfg(all(test, not(target_os = "macos"), feature = "sources-generator"))]
 
 use super::controller::ControllerStatistics;
 use super::MAX_CONCURRENCY;


### PR DESCRIPTION
These were supposed to be excluded by `#[cfg(unix)]` but apparently that is turned on for macos. Solve it instead with `#[cfg(note(target_os = "macos"))]`

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #3429 