### PR TITLE
enhancement(aws_s3 sink): Add additional canned ACLs

### DIFF
--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -92,6 +92,8 @@ enum S3CannedAcl {
     PublicReadWrite,
     AwsExecRead,
     AuthenticatedRead,
+    BucketOwnerRead,
+    BucketOwnerFullControl,
     LogDeliveryWrite,
 }
 


### PR DESCRIPTION
These two ACLs appeared to be missing.

A user in gitter was asking about them:
https://gitter.im/timberio-vector/community?at=5f3527942376a9317f17a39e

Reference https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>