### PR TITLE
chore(topology): Wait for detached sink to finish 

### DIFF
--- a/src/sinks/streaming_sink/compat.rs
+++ b/src/sinks/streaming_sink/compat.rs
@@ -60,7 +60,12 @@ pub fn adapt_to_topology(mut streaming_sink: impl StreamingSink + 'static) -> si
     let synched = SynchedSink {
         sink,
         synching: false,
-        sync: Box::new(handle.compat().map(|res| res.unwrap())),
+        sync: Box::new(handle.compat().map_err(|res| {
+            if res.is_panic() {
+                // We are propagating panic as if this spawn indirection isn't here.
+                panic!(res);
+            }
+        })),
     };
 
     Box::new(synched)

--- a/src/sinks/streaming_sink/compat.rs
+++ b/src/sinks/streaming_sink/compat.rs
@@ -60,7 +60,7 @@ pub fn adapt_to_topology(mut streaming_sink: impl StreamingSink + 'static) -> si
     let synched = SynchedSink {
         sink,
         synching: false,
-        sync: Box::new(handle.compat().map_err(|_| ())),
+        sync: Box::new(handle.compat().map(|res| res.unwrap())),
     };
 
     Box::new(synched)

--- a/src/sinks/streaming_sink/compat.rs
+++ b/src/sinks/streaming_sink/compat.rs
@@ -3,7 +3,8 @@ use crate::sinks;
 use crate::Event;
 use futures::channel::mpsc;
 use futures::compat::CompatSink;
-use futures01::sink::Sink;
+use futures::future::TryFutureExt;
+use futures01::{future::Future, sink::Sink, Async, AsyncSink, Poll};
 
 /// This function provides the compatibility with our old interfaces.
 ///
@@ -49,12 +50,48 @@ pub type OldSink = Box<dyn Sink<SinkItem = Event, SinkError = ()> + 'static + Se
 pub fn adapt_to_topology(mut streaming_sink: impl StreamingSink + 'static) -> sinks::RouterSink {
     let (stream, sink) = sink_interface_compat();
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         streaming_sink
             .run(stream)
             .await
             .expect("streaming sink error")
     });
 
-    sink
+    let synched = SynchedSink {
+        sink,
+        synching: false,
+        sync: Box::new(handle.compat().map_err(|_| ())),
+    };
+
+    Box::new(synched)
+}
+
+/// Behaves in all regards like the underlying sink, except that on close
+/// it synchronizes on sync.
+struct SynchedSink {
+    sink: OldSink,
+    sync: Box<dyn Future<Item = (), Error = ()> + 'static + Send>,
+    synching: bool,
+}
+
+impl Sink for SynchedSink {
+    type SinkItem = Event;
+    type SinkError = ();
+    fn start_send(&mut self, item: Self::SinkItem) -> Result<AsyncSink<Event>, ()> {
+        self.sink.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        if !self.synching {
+            if let Async::NotReady = self.sink.close()? {
+                return Ok(Async::NotReady);
+            }
+            self.synching = true;
+        }
+        self.sync.poll()
+    }
 }

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -68,6 +68,7 @@ pub struct StreamSink<T> {
     inner: T,
     acker: Acker,
     pending: usize,
+    closing_inner: bool,
 }
 
 impl<T> StreamSink<T> {
@@ -76,6 +77,7 @@ impl<T> StreamSink<T> {
             inner,
             acker,
             pending: 0,
+            closing_inner: false,
         }
     }
 }
@@ -113,6 +115,16 @@ impl<T: Sink> Sink for StreamSink<T> {
         self.pending = 0;
 
         Ok(().into())
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        if !self.closing_inner {
+            if let Async::NotReady = self.poll_complete()? {
+                return Ok(Async::NotReady);
+            }
+            self.closing_inner = true;
+        }
+        self.inner.close()
     }
 }
 


### PR DESCRIPTION
Closes #3438 

On `close` of the `Sink` it also wait's for the `sink` future to finish. Also adds implementation of `close` for `StreamSink` because it is wrapping the `Sink`.

The issue is affecting only `file` and `console` sinks since they are the only ones using `adapt_to_topology` at the moment.
 
Tested with #3373 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
