### PR TITLE
chore: Extract line_agg from file source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /src/tls.rs @bruceg
 /src/trace.rs @LucioFranco
 /src/types.rs @bruceg
+/src/line_agg.rs @MOZGIII
 
 /src/sinks/*_metrics.rs @lukesteensen
 /src/sinks/aws_kinesis_streams.rs @LucioFranco
@@ -45,8 +46,7 @@
 /src/sinks/util/auto_concurrency @bruceg
 
 /src/sources/docker.rs @LucioFranco
-/src/sources/file/mod.rs @LucioFranco
-/src/sources/file/line_agg.rs @MOZGIII
+/src/sources/file.rs @LucioFranco
 /src/sources/generator.rs @bruceg
 /src/sources/journald.rs @bruceg
 /src/sources/kafka.rs @a-rodin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod hyper;
 #[cfg(feature = "rdkafka")]
 pub mod kafka;
 pub mod kubernetes;
+pub mod line_agg;
 pub mod list;
 pub mod metrics;
 pub(crate) mod pipeline;

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -1,3 +1,5 @@
+//! A reusable line aggregation implementation.
+
 #![deny(missing_docs)]
 
 use bytes05::{Bytes, BytesMut};

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2,6 +2,7 @@ use crate::{
     config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
     event::{self, Event},
     internal_events::{FileEventReceived, FileSourceInternalEventsEmitter},
+    line_agg::{self, LineAgg},
     shutdown::ShutdownSignal,
     trace::{current_span, Instrument},
     Pipeline,
@@ -24,9 +25,6 @@ use std::convert::{TryFrom, TryInto};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use tokio::task::spawn_blocking;
-
-mod line_agg;
-use line_agg::LineAgg;
 
 #[derive(Debug, Snafu)]
 enum BuildError {


### PR DESCRIPTION
This PR extracts the `line_agg` module from the `file` source, and renames the standalone `file/mod.rs` into `file.rs`.

Pretty trivial change.