### PR TITLE
enhancement(ci): Ship Helm Chart from release CI workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -244,19 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install Helm
-        run: |
-          set -xeuo pipefail
-
-          KUBERNETES_VERSION="v1.18.6"
-          HELM_VERSION="v3.2.4"
-
-          curl -Lo kubectl \
-            "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
-          sudo install kubectl /usr/local/bin/ && rm kubectl
-
-          curl -L "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
-            | tar -xzv --strip-components=1 --occurrence linux-amd64/helm
-          sudo install helm /usr/local/bin/ && rm helm
+        run: scripts/ci-setup-helm.sh
       - name: Release Helm Chart
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,3 +314,20 @@ jobs:
           export VERSION=$(make version)
           export GITHUB_TOKEN="${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}"
           make release-homebrew
+
+  release-helm:
+    runs-on: ubuntu-latest
+    needs:
+      # This is not strictly required, but ensures that Helm Chart doesn't
+      # appear before the image it refers to.
+      - release-docker
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Helm
+        run: scripts/ci-setup-helm.sh
+      - name: Release Helm Chart
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
+          USE_CONTAINER: none
+        run: make release-helm

--- a/scripts/ci-setup-helm.sh
+++ b/scripts/ci-setup-helm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${CI:-}" ]]; then
+  echo "Aborted: this script is for use in CI, it may alter your system in an" \
+    "unwanted way" >&2
+  exit 1
+fi
+
+set -x
+
+KUBERNETES_VERSION="v1.18.6"
+HELM_VERSION="v3.2.4"
+
+curl -Lo kubectl \
+  "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+sudo install kubectl /usr/local/bin/ && rm kubectl
+
+curl -L "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+  | tar -xzv --strip-components=1 --occurrence linux-amd64/helm
+sudo install helm /usr/local/bin/ && rm helm


### PR DESCRIPTION
This PR adds the Helm Chart release as part of the release CI workflow.
It also extracts the helm command setup into a script so it can be reused and don't clutter the workflow file.

To ensure we don't break the nightly by extracting the script (and that the release job works), I've run a nightly build manually: https://github.com/timberio/vector/actions/runs/208615012