### PR TITLE
feat(aws service): Add support for `use_eks_web_identity` to all AWS sinks

### DIFF
--- a/.meta/_partials/fields/_aws_options.toml.erb
+++ b/.meta/_partials/fields/_aws_options.toml.erb
@@ -19,3 +19,10 @@ examples = ["us-east-1"]
 relevant_when = {endpoint = ""}
 required = true
 description = "The [AWS region][urls.aws_regions] of the target service. If `endpoint` is provided it will override this value since the endpoint includes the region."
+
+[<%= namespace %>.use_eks_web_identity]
+type = "bool"
+common = true
+default = false
+required = false
+description = "Enables/disables usage of IAM Roles for EKS Service Accounts."

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -164,7 +164,7 @@ impl CloudwatchLogsSinkConfig {
         let creds = rusoto::AwsCredentialsProvider::new(
             &region,
             self.assume_role.clone(),
-            self.use_eks_web_identity.clone(),
+            self.use_eks_web_identity,
         )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -881,6 +881,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -1256,7 +1257,7 @@ mod integration_tests {
         };
 
         let client = rusoto::client(Resolver).unwrap();
-        let creds = rusoto::AwsCredentialsProvider::new(&region, None).unwrap();
+        let creds = rusoto::AwsCredentialsProvider::new(&region, None, None).unwrap();
         CloudWatchLogsClient::new_with(client, creds, region)
     }
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -79,6 +79,7 @@ pub struct CloudwatchLogsSinkConfig {
     #[serde(default)]
     pub request: TowerRequestConfig<Option<usize>>,
     pub assume_role: Option<String>,
+    pub use_eks_web_identity: Option<bool>,
 }
 
 inventory::submit! {
@@ -98,6 +99,7 @@ fn default_config(e: Encoding) -> CloudwatchLogsSinkConfig {
         batch: Default::default(),
         request: Default::default(),
         assume_role: Default::default(),
+        use_eks_web_identity: Default::default(),
     }
 }
 
@@ -159,7 +161,11 @@ impl CloudwatchLogsSinkConfig {
         let region = (&self.region).try_into()?;
 
         let client = rusoto::client(resolver)?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = rusoto::AwsCredentialsProvider::new(
+            &region,
+            self.assume_role.clone(),
+            self.use_eks_web_identity.clone(),
+        )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(CloudWatchLogsClient::new_with_client(client, region))
@@ -919,6 +925,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -982,6 +989,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -1051,6 +1059,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -1100,6 +1109,7 @@ mod integration_tests {
             },
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -1150,6 +1160,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).unwrap();
@@ -1231,6 +1242,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let client = config.create_client(Resolver).unwrap();

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -108,7 +108,7 @@ impl CloudWatchMetricsSinkConfig {
         let creds = rusoto::AwsCredentialsProvider::new(
             &region,
             self.assume_role.clone(),
-            self.use_eks_web_identity.clone(),
+            self.use_eks_web_identity,
         )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -41,6 +41,7 @@ pub struct CloudWatchMetricsSinkConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub assume_role: Option<String>,
+    pub use_eks_web_identity: Option<bool>,
 }
 
 lazy_static! {
@@ -104,7 +105,11 @@ impl CloudWatchMetricsSinkConfig {
         };
 
         let client = rusoto::client(resolver)?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = rusoto::AwsCredentialsProvider::new(
+            &region,
+            self.assume_role.clone(),
+            self.use_eks_web_identity.clone(),
+        )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(CloudWatchClient::new_with_client(client, region))

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -122,7 +122,7 @@ impl KinesisFirehoseSinkConfig {
         let creds = rusoto::AwsCredentialsProvider::new(
             &region,
             self.assume_role.clone(),
-            self.use_eks_web_identity.clone(),
+            self.use_eks_web_identity,
         )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -55,6 +55,7 @@ pub struct KinesisSinkConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub assume_role: Option<String>,
+    pub use_eks_web_identity: Option<bool>,
 }
 
 lazy_static! {
@@ -123,7 +124,11 @@ impl KinesisSinkConfig {
         let region = (&self.region).try_into()?;
 
         let client = rusoto::client(resolver)?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = rusoto::AwsCredentialsProvider::new(
+            &region,
+            self.assume_role.clone(),
+            self.use_eks_web_identity.clone(),
+        )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(KinesisClient::new_with_client(client, region))
@@ -404,6 +409,7 @@ mod integration_tests {
             },
             request: Default::default(),
             assume_role: None,
+            use_eks_web_identity: None,
         };
 
         let cx = SinkContext::new_test();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -127,7 +127,7 @@ impl KinesisSinkConfig {
         let creds = rusoto::AwsCredentialsProvider::new(
             &region,
             self.assume_role.clone(),
-            self.use_eks_web_identity.clone(),
+            self.use_eks_web_identity,
         )?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -245,7 +245,7 @@ impl S3SinkConfig {
         let creds = rusoto::AwsCredentialsProvider::new(
             &region,
             self.assume_role.clone(),
-            self.use_eks_web_identity.clone(),
+            self.use_eks_web_identity,
         )?;
 
         Ok(S3Client::new_with(client, creds, region))

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -64,6 +64,7 @@ pub struct S3SinkConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub assume_role: Option<String>,
+    pub use_eks_web_identity: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -241,7 +242,11 @@ impl S3SinkConfig {
         let region = (&self.region).try_into()?;
         let client = rusoto::client(resolver)?;
 
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = rusoto::AwsCredentialsProvider::new(
+            &region,
+            self.assume_role.clone(),
+            self.use_eks_web_identity.clone(),
+        )?;
 
         Ok(S3Client::new_with(client, creds, region))
     }

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -377,7 +377,7 @@ impl ElasticSearchCommon {
             }) => Some(rusoto::AwsCredentialsProvider::new(
                 &region,
                 assume_role.clone(),
-                use_eks_web_identity.clone(),
+                *use_eks_web_identity,
             )?),
         };
 


### PR DESCRIPTION
Hopefully closes #2881 

Hi! I've taken a little stab at fixing #2881 as it would be really useful for us. 

This is my first time writing any Rust, so I've tried to base off of #1772 which seems to be a similar feature and looking at rusoto/rusoto#1497, rusoto/rusoto#1577 as recommended in #2881.

