### PR TITLE
chore: replace tokio::test by own macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -118,9 +118,9 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -226,8 +226,8 @@ dependencies = [
  "clang-sys",
  "lazy_static 1.4.0",
  "peeking_take_while",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "regex",
  "rustc-hash",
  "shlex",
@@ -320,7 +320,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-util",
  "url",
  "winapi 0.3.8",
@@ -864,8 +864,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.33",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -906,9 +906,9 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1025,9 +1025,9 @@ checksum = "1676e1daadfd216bda88d3a6fedd1bf53b829a085f5cc4d81c6f3054f50ef983"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1121,9 +1121,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "synstructure",
 ]
 
@@ -1147,7 +1147,7 @@ dependencies = [
  "quickcheck",
  "scan_fmt",
  "tempfile",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tracing",
  "winapi 0.3.8",
 ]
@@ -1311,9 +1311,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1387,9 +1387,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f62a139c59ae846c3964c392f12aac68f1997d1a40e9d3b40a89a4ab553e04a0"
 dependencies = [
  "proc-macro-error 0.4.9",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1398,9 +1398,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a36606a68532b5640dc86bb1f33c64b45c4682aad4c50f3937b317ea387f3d6"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1453,7 +1453,7 @@ dependencies = [
  "simpl",
  "smpl_jwt",
  "time 0.2.16",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1481,7 +1481,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-util",
 ]
 
@@ -1652,7 +1652,7 @@ dependencies = [
  "pin-project",
  "socket2",
  "time 0.1.42",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tower-service 0.3.0",
  "want",
 ]
@@ -1671,7 +1671,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-openssl 0.4.0",
 ]
 
@@ -1684,7 +1684,7 @@ dependencies = [
  "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-tls",
 ]
 
@@ -1699,7 +1699,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1771,9 +1771,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99a4111304bade76468d05beab3487c226e4fe4c4de1c4e8f006e815762db73"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1873,7 +1873,7 @@ dependencies = [
  "once_cell",
  "serde_json",
  "tempfile",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2144,8 +2144,8 @@ name = "lucet-runtime-macros"
 version = "0.7.0-dev"
 source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac83173d27fddf1aca48412a86#d4fc14a03bdb99ac83173d27fddf1aca48412a86"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.33",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2186,9 +2186,9 @@ version = "0.7.0-dev"
 source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac83173d27fddf1aca48412a86#d4fc14a03bdb99ac83173d27fddf1aca48412a86"
 dependencies = [
  "lucet-wiggle",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasi-common",
  "wiggle-generate",
 ]
@@ -2211,9 +2211,9 @@ source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac
 dependencies = [
  "heck",
  "lucet-module",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wiggle-generate",
  "witx",
 ]
@@ -2224,8 +2224,8 @@ version = "0.7.0-dev"
 source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac83173d27fddf1aca48412a86#d4fc14a03bdb99ac83173d27fddf1aca48412a86"
 dependencies = [
  "lucet-wiggle-generate",
- "quote 1.0.2",
- "syn 1.0.33",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wiggle-generate",
  "witx",
 ]
@@ -2356,7 +2356,7 @@ checksum = "f3fc63816bd5f8bde5eb31ce471f9633adc69ba1c55b44191b4d5fc7e263e8ab"
 dependencies = [
  "log 0.4.8",
  "metrics-core",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2660,9 +2660,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2711,9 +2711,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9f19dafa80d8af21ede328f2c4ed836604a2eb1c309d688f89a7cc40568923"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2943,9 +2943,9 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3044,10 +3044,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 dependencies = [
  "proc-macro-error-attr 0.4.9",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "rustversion",
- "syn 1.0.33",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3057,9 +3057,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr 1.0.2",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "version_check 0.9.1",
 ]
 
@@ -3069,10 +3069,10 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "rustversion",
- "syn 1.0.33",
+ "syn 1.0.38",
  "syn-mid",
 ]
 
@@ -3082,9 +3082,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -3095,9 +3095,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3117,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -3160,9 +3160,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools 0.8.2",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3197,7 +3197,7 @@ dependencies = [
  "prost-derive",
  "rand 0.7.3",
  "regex",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-native-tls",
  "tokio-util",
  "url",
@@ -3247,11 +3247,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
 ]
 
 [[package]]
@@ -3486,7 +3486,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3606,7 +3606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-tls",
  "url",
  "wasm-bindgen",
@@ -3677,7 +3677,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "xml-rs",
 ]
 
@@ -3697,7 +3697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "zeroize",
 ]
 
@@ -3778,7 +3778,7 @@ dependencies = [
  "serde",
  "sha2",
  "time 0.2.16",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3836,9 +3836,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3993,9 +3993,9 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4037,9 +4037,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4196,9 +4196,9 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec32ba84a7a86aeb0bc32fd0c46d31b0285599f68ea72e87eff6127889d99e1"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4251,11 +4251,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.33",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4265,13 +4265,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.33",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4312,8 +4312,8 @@ checksum = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "string_cache_shared",
 ]
 
@@ -4357,9 +4357,9 @@ checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
  "heck",
  "proc-macro-error 1.0.2",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4392,12 +4392,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "unicode-xid 0.2.0",
 ]
 
@@ -4407,9 +4407,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4427,9 +4427,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "unicode-xid 0.2.0",
 ]
 
@@ -4495,6 +4495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-util-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4518,9 +4527,9 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4575,10 +4584,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "standback",
- "syn 1.0.33",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4614,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -4646,7 +4655,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-current-thread",
  "tokio-executor",
  "tokio-reactor",
@@ -4690,9 +4699,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4702,7 +4711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4723,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4805,7 +4814,7 @@ checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
  "bytes 0.5.6",
  "futures-core",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4844,7 +4853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4859,7 +4868,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.21",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4917,7 +4926,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tower-layer 0.3.0",
  "tower-service 0.3.0",
  "tracing",
@@ -5034,7 +5043,7 @@ checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
 dependencies = [
  "futures-util",
  "pin-project",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-test",
  "tower-layer 0.3.0",
  "tower-service 0.3.0",
@@ -5082,9 +5091,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -5222,9 +5231,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc232cda3b1d82664153e6c95d1071809aa0f1011f306c3d6989f33d8c6ede17"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -5472,8 +5481,9 @@ dependencies = [
  "syslog_loose",
  "task-compat",
  "tempfile",
+ "test-util-macros",
  "tokio 0.1.22",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tokio-compat",
  "tokio-openssl 0.3.0",
  "tokio-openssl 0.4.0",
@@ -5610,7 +5620,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.21",
+ "tokio 0.2.22",
  "tower-service 0.3.0",
  "urlencoding",
 ]
@@ -5657,9 +5667,9 @@ dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log 0.4.8",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -5681,7 +5691,7 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5691,9 +5701,9 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5713,9 +5723,9 @@ dependencies = [
  "anyhow",
  "heck",
  "log 0.4.8",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wasm-bindgen-backend",
  "weedle",
 ]
@@ -5784,8 +5794,8 @@ version = "0.17.0"
 source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac83173d27fddf1aca48412a86#d4fc14a03bdb99ac83173d27fddf1aca48412a86"
 dependencies = [
  "heck",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
  "witx",
 ]
 
@@ -5807,9 +5817,9 @@ source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac
 dependencies = [
  "anyhow",
  "heck",
- "proc-macro2 1.0.18",
- "quote 1.0.2",
- "syn 1.0.33",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "witx",
 ]
 
@@ -5818,8 +5828,8 @@ name = "wiggle-macro"
 version = "0.17.0"
 source = "git+https://github.com/bytecodealliance/lucet.git?rev=d4fc14a03bdb99ac83173d27fddf1aca48412a86#d4fc14a03bdb99ac83173d27fddf1aca48412a86"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.33",
+ "quote 1.0.7",
+ "syn 1.0.38",
  "wiggle-generate",
  "witx",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,19 @@ extended-description-file = "target/debian-extended-description.txt"
 [workspace]
 members = [
   ".",
+  "lib/codec",
   "lib/file-source",
+  "lib/k8s-test-framework",
+  "lib/test-util-macros",
   "lib/tracing-limit",
   "lib/vector-wasm",
-  "lib/k8s-test-framework",
 ]
 
 [dependencies]
 # Internal libs
 codec = { path = "lib/codec" }
 file-source = { path = "lib/file-source" }
+test-util-macros = { path = "lib/test-util-macros" }
 tracing-limit = { path = "lib/tracing-limit" }
 
 # Tokio / Futures

--- a/lib/test-util-macros/Cargo.toml
+++ b/lib/test-util-macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-util-macros"
+version = "0.1.0"
+authors = ["Vector Contributors <vector@timber.io>"]
+edition = "2018"
+description = "Test util proc macros."
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.19"
+quote = "1.0.7"
+syn = { version = "1.0.38" }

--- a/lib/test-util-macros/src/lib.rs
+++ b/lib/test-util-macros/src/lib.rs
@@ -1,0 +1,143 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 Tokio Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use std::num::NonZeroUsize;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Scheduler {
+    Basic,
+    Threaded,
+}
+
+#[proc_macro_attribute]
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    parse(args, input).unwrap_or_else(|e| e.to_compile_error().into())
+}
+
+fn parse(args: syn::AttributeArgs, mut input: syn::ItemFn) -> Result<TokenStream, syn::Error> {
+    let sig = &mut input.sig;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = input.vis;
+
+    for attr in attrs {
+        if attr.path.is_ident("test") {
+            let msg = "second test attribute is supplied";
+            return Err(syn::Error::new_spanned(&attr, msg));
+        }
+    }
+
+    if !sig.inputs.is_empty() {
+        let msg = "the test function cannot accept arguments";
+        return Err(syn::Error::new_spanned(&sig.inputs, msg));
+    }
+
+    if sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return Err(syn::Error::new_spanned(sig.fn_token, msg));
+    }
+
+    sig.asyncness = None;
+
+    let mut scheduler = None;
+    let mut core_threads = None;
+
+    for arg in args {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
+                let ident = namevalue.path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(namevalue, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "core_threads" => match &namevalue.lit {
+                        syn::Lit::Int(expr) => {
+                            let num = expr.base10_parse::<NonZeroUsize>().unwrap();
+                            core_threads = Some(num);
+                        }
+                        _ => {
+                            return Err(syn::Error::new_spanned(
+                                namevalue,
+                                "core_threads argument must be an int",
+                            ))
+                        }
+                    },
+                    name => {
+                        let msg = format!("Unknown attribute pair {} is specified; expected one of: `core_threads`", name);
+                        return Err(syn::Error::new_spanned(namevalue, msg));
+                    }
+                }
+            }
+            syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
+                let ident = path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(path, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "threaded_scheduler" => scheduler = Some(Scheduler::Threaded),
+                    "basic_scheduler" => scheduler = Some(Scheduler::Basic),
+                    name => {
+                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                        return Err(syn::Error::new_spanned(path, msg));
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "Unknown attribute inside the macro",
+                ));
+            }
+        }
+    }
+
+    let mut rt = quote! { tokio::runtime::Builder::new().threaded_scheduler() };
+    if scheduler == Some(Scheduler::Basic) {
+        rt = quote! { #rt.basic_scheduler() };
+    }
+    if let Some(v) = core_threads.map(|v| v.get()) {
+        rt = quote! { #rt.core_threads(#v) };
+    }
+
+    let result = quote! {
+        #[::core::prelude::v1::test]
+        #(#attrs)*
+        #vis #sig {
+            #rt
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    crate::test_util::trace_init();
+                    #body
+                })
+        }
+    };
+
+    Ok(result.into())
+}

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -121,11 +121,13 @@ fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &[PathBuf]) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::temp_file;
+    use crate::test_util::{self, temp_file};
     use futures::compat::Future01CompatExt;
     use futures01::{Future, Stream};
-    use std::time::Duration;
-    use std::{fs::File, io::Write};
+    use std::{
+        time::Duration,
+        {fs::File, io::Write},
+    };
     #[cfg(unix)]
     use tokio_signal::unix::{Signal, SIGHUP};
 
@@ -139,9 +141,8 @@ mod tests {
         tokio::time::timeout(timeout, fut).await.is_ok()
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_update() {
-        crate::test_util::trace_init();
         let delay = Duration::from_secs(3);
         let file_path = temp_file();
         let mut file = File::create(&file_path).unwrap();
@@ -153,9 +154,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn sym_file_update() {
-        crate::test_util::trace_init();
         let delay = Duration::from_secs(3);
         let file_path = temp_file();
         let sym_file = temp_file();

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -203,6 +203,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util;
     use std::task::Poll;
     use tokio_test::{assert_pending, assert_ready, task};
 
@@ -221,7 +222,7 @@ mod tests {
         assert!(unwrap_ready(fut.poll()).is_none());
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn next_expired_is_pending_with_a_non_empty_map() {
         let mut map = ExpiringHashMap::<String, String>::default();
 
@@ -232,7 +233,7 @@ mod tests {
         assert_pending!(fut.poll());
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn next_expired_does_not_wake_when_the_value_is_available_upfront() {
         let mut map = ExpiringHashMap::<String, String>::default();
 
@@ -249,7 +250,7 @@ mod tests {
     // In theory, this is only possible when the runtime timer used in the
     // underlying delay queue and the means by which we fresse/adjust time are
     // working together.
-    #[tokio::test]
+    #[test_util::test]
     async fn next_expired_wakes_and_becomes_ready_when_value_ttl_expires() {
         let mut map = ExpiringHashMap::<String, String>::default();
 
@@ -273,7 +274,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn next_expired_api_allows_inserting_items() {
         let mut map = ExpiringHashMap::<String, String>::default();
 

--- a/src/kubernetes/debounce.rs
+++ b/src/kubernetes/debounce.rs
@@ -55,12 +55,13 @@ impl Debounce {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util;
     use futures::{pin_mut, poll};
 
     const TEST_DELAY_FRACTION: Duration = Duration::from_secs(60 * 60); // one hour
     const TEST_DELAY: Duration = Duration::from_secs(24 * 60 * 60); // one day
 
-    #[tokio::test]
+    #[test_util::test]
     async fn one_signal() {
         tokio::time::pause();
 
@@ -98,7 +99,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn late_request() {
         tokio::time::pause();
 
@@ -127,7 +128,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn multiple_signals() {
         tokio::time::pause();
 
@@ -167,7 +168,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn sequence() {
         tokio::time::pause();
 
@@ -222,7 +223,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn is_debouncing() {
         tokio::time::pause();
 

--- a/src/kubernetes/state/evmap.rs
+++ b/src/kubernetes/state/evmap.rs
@@ -128,7 +128,10 @@ fn kv<T: Metadata<Ty = ObjectMeta>>(object: T) -> Option<(String, Value<T>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kubernetes::state::{MaintainedWrite, Write};
+    use crate::{
+        kubernetes::state::{MaintainedWrite, Write},
+        test_util,
+    };
     use k8s_openapi::api::core::v1::Pod;
 
     fn make_pod(uid: &str) -> Pod {
@@ -149,7 +152,7 @@ mod tests {
         assert_eq!(val, Box::new(HashValue::new(pod)));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_without_debounce() {
         let (state_reader, state_writer) = evmap::new();
         let mut state_writer = Writer::new(state_writer, None);
@@ -165,7 +168,7 @@ mod tests {
         drop(state_writer);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_with_debounce() {
         // Due to https://github.com/tokio-rs/tokio/issues/2090 we're not
         // pausing the time.

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -359,9 +359,10 @@ fn add_next_line(buffered: &mut BytesMut, line: Bytes) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util;
     use pretty_assertions::assert_eq;
 
-    #[tokio::test]
+    #[test_util::test]
     async fn mode_continue_through_1() {
         let lines = vec![
             "some usual line",
@@ -392,7 +393,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn mode_continue_past_1() {
         let lines = vec![
             "some usual line",
@@ -423,7 +424,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn mode_halt_before_1() {
         let lines = vec![
             "INFO some usual line",
@@ -454,7 +455,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn mode_halt_with_1() {
         let lines = vec![
             "some usual line;",
@@ -485,7 +486,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn use_case_java_exception() {
         let lines = vec![
             "java.lang.Exception",
@@ -506,7 +507,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn use_case_ruby_exception() {
         let lines = vec![
             "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)",
@@ -530,7 +531,7 @@ mod tests {
     }
 
     /// https://github.com/timberio/vector/issues/3237
-    #[tokio::test]
+    #[test_util::test]
     async fn two_lines_emit_with_continue_through() {
         let lines = vec![
             "not merged 1", // will NOT be stashed, but passthroughed
@@ -569,7 +570,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn two_lines_emit_with_halt_before() {
         let lines = vec![
             "part 0.1",
@@ -603,7 +604,7 @@ mod tests {
         run_and_assert(&lines, config, &expected).await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn legacy() {
         let lines = vec![
             "INFO some usual line",

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -303,12 +303,12 @@ impl SourceShutdownCoordinator {
 
 #[cfg(test)]
 mod test {
-    use crate::shutdown::SourceShutdownCoordinator;
+    use crate::{shutdown::SourceShutdownCoordinator, test_util};
     use futures::compat::Future01CompatExt;
     use futures01::future::Future;
     use tokio::time::{Duration, Instant};
 
-    #[tokio::test]
+    #[test_util::test]
     async fn shutdown_coordinator_shutdown_source_clean() {
         let mut shutdown = SourceShutdownCoordinator::default();
         let name = "test";
@@ -324,7 +324,7 @@ mod test {
         assert_eq!(true, success);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn shutdown_coordinator_shutdown_source_force() {
         let mut shutdown = SourceShutdownCoordinator::default();
         let name = "test";

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -366,11 +366,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn reopening() {
         use pretty_assertions::assert_eq;
-
-        test_util::trace_init();
 
         let template = temp_file();
 

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -182,9 +182,9 @@ pub fn healthcheck_response(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_downcast_matches;
+    use crate::{assert_downcast_matches, test_util};
 
-    #[tokio::test]
+    #[test_util::test]
     #[ignore]
     async fn fails_missing_creds() {
         let config: GcpAuthConfig = toml::from_str("").unwrap();

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -194,8 +194,9 @@ async fn healthcheck(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util;
 
-    #[tokio::test]
+    #[test_util::test]
     async fn fails_missing_creds() {
         let config: PubsubConfig = toml::from_str(
             r#"

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -270,7 +270,7 @@ mod tests {
     use super::*;
     use crate::{
         event::{LogEvent, Value},
-        test_util::runtime,
+        test_util::{self, runtime},
     };
     use serde_json::value::RawValue;
     use std::iter::FromIterator;
@@ -405,7 +405,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn fails_missing_creds() {
         let config: StackdriverConfig = toml::from_str(
             r#"

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -294,7 +294,7 @@ mod tests {
         sinks::http::HttpSinkConfig,
         sinks::util::http::HttpSink,
         sinks::util::test::build_test_server,
-        test_util::{next_addr, random_lines_with_stream},
+        test_util::{self, next_addr, random_lines_with_stream},
     };
     use bytes::buf::BufExt;
     use futures::compat::Future01CompatExt;
@@ -388,7 +388,7 @@ mod tests {
         let _ = config.build(cx).unwrap();
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn http_happy_path_post() {
         let num_lines = 1000;
 
@@ -446,7 +446,7 @@ mod tests {
         assert_eq!(input_lines, output_lines);
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn http_happy_path_put() {
         let num_lines = 1000;
 
@@ -505,7 +505,7 @@ mod tests {
         assert_eq!(input_lines, output_lines);
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn http_passes_custom_headers() {
         let num_lines = 1000;
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -212,13 +212,14 @@ impl Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::Event;
-    use crate::sinks::influxdb::test_util::{assert_fields, split_line_protocol, ts};
-    use crate::sinks::util::http::HttpSink;
-    use crate::sinks::util::test::build_test_server;
-    use crate::test_util;
-    use chrono::offset::TimeZone;
-    use chrono::Utc;
+    use crate::{
+        event::Event,
+        sinks::influxdb::test_util::{assert_fields, split_line_protocol, ts},
+        sinks::util::http::HttpSink,
+        sinks::util::test::build_test_server,
+        test_util,
+    };
+    use chrono::{offset::TimeZone, Utc};
     use futures::compat::Future01CompatExt;
     use futures01::{Sink, Stream};
 
@@ -426,7 +427,7 @@ mod tests {
         assert_eq!("1542182950000000011\n", line_protocol.3);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn smoke_v1() {
         let (mut config, cx) = crate::sinks::util::test::load_sink::<InfluxDBLogsConfig>(
             r#"
@@ -488,7 +489,7 @@ mod tests {
         assert_line_protocol(0, lines.next());
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn smoke_v2() {
         let (mut config, cx) = crate::sinks::util::test::load_sink::<InfluxDBLogsConfig>(
             r#"

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -218,10 +218,12 @@ async fn healthcheck(config: LogdnaConfig, mut client: HttpClient) -> crate::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::SinkConfig;
-    use crate::event::Event;
-    use crate::sinks::util::test::{build_test_server, load_sink};
-    use crate::test_util;
+    use crate::{
+        config::SinkConfig,
+        event::Event,
+        sinks::util::test::{build_test_server, load_sink},
+        test_util,
+    };
     use futures::compat::Future01CompatExt;
     use futures01::{Sink, Stream};
     use serde_json::json;
@@ -256,9 +258,8 @@ mod tests {
         assert_eq!(event3_out.get("app").unwrap(), &json!("vector"));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn smoke() {
-        crate::test_util::trace_init();
         let (mut config, cx) = load_sink::<LogdnaConfig>(
             r#"
             api_key = "mylogtoken"

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -249,16 +249,15 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use crate::config::SinkConfig;
-    use crate::sinks::util::test::load_sink;
-    use crate::template::Template;
-    use crate::Event;
+    use crate::{
+        config::SinkConfig, sinks::util::test::load_sink, template::Template, test_util, Event,
+    };
     use bytes::Bytes;
     use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use std::convert::TryFrom;
 
-    #[tokio::test]
+    #[test_util::test]
     async fn text() {
         let stream = uuid::Uuid::new_v4();
 
@@ -295,7 +294,7 @@ mod integration_tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn json() {
         let stream = uuid::Uuid::new_v4();
 
@@ -333,7 +332,7 @@ mod integration_tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn many_streams() {
         let stream1 = uuid::Uuid::new_v4();
         let stream2 = uuid::Uuid::new_v4();

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -147,7 +147,7 @@ mod tests {
         config::SinkConfig,
         event::Event,
         sinks::util::{service2::InFlightLimit, test::build_test_server},
-        test_util::next_addr,
+        test_util::{self, next_addr},
     };
     use bytes::buf::BufExt;
     use futures::compat::Future01CompatExt;
@@ -271,7 +271,7 @@ mod tests {
         assert!(http_config.auth.is_none());
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn new_relic_logs_happy_path() {
         let in_addr = next_addr();
 

--- a/src/sinks/sematext_logs.rs
+++ b/src/sinks/sematext_logs.rs
@@ -99,14 +99,16 @@ fn map_timestamp(mut event: Event) -> impl Future<Item = Event, Error = ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::SinkConfig;
-    use crate::event::Event;
-    use crate::sinks::util::test::{build_test_server, load_sink};
-    use crate::test_util;
+    use crate::{
+        config::SinkConfig,
+        event::Event,
+        sinks::util::test::{build_test_server, load_sink},
+        test_util,
+    };
     use futures::compat::Future01CompatExt;
     use futures01::{Sink, Stream};
 
-    #[tokio::test]
+    #[test_util::test]
     async fn smoke() {
         let (mut config, cx) = load_sink::<SematextLogsConfig>(
             r#"

--- a/src/sinks/util/auto_concurrency/service.rs
+++ b/src/sinks/util/auto_concurrency/service.rs
@@ -112,13 +112,17 @@ impl fmt::Debug for State {
 
 #[cfg(test)]
 mod tests {
-    use super::super::controller::{ControllerStatistics, Inner};
-    use super::super::AutoConcurrencyLimitLayer;
+    use super::super::{
+        controller::{ControllerStatistics, Inner},
+        AutoConcurrencyLimitLayer,
+    };
     use super::*;
-    use crate::assert_downcast_matches;
+    use crate::{assert_downcast_matches, test_util};
     use snafu::Snafu;
-    use std::sync::{Mutex, MutexGuard};
-    use std::time::Duration;
+    use std::{
+        sync::{Mutex, MutexGuard},
+        time::Duration,
+    };
     use tokio::time::{advance, pause};
     use tokio_test::{assert_pending, assert_ready_ok};
     use tower_test03::{
@@ -228,7 +232,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn startup_conditions() {
         TestService::run(|mut svc| async move {
             // Concurrency starts at 1
@@ -238,7 +242,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn increases_limit() {
         let stats = TestService::run(|mut svc| async move {
             // Concurrency starts at 1
@@ -266,7 +270,7 @@ mod tests {
         assert_eq!(observed_rtt.mean, 1.0);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn handles_deferral() {
         TestService::run(|mut svc| async move {
             assert_eq!(svc.inner().current_limit, 1);
@@ -290,7 +294,7 @@ mod tests {
     }
 
     #[allow(clippy::needless_range_loop)]
-    #[tokio::test]
+    #[test_util::test]
     async fn rapid_decrease() {
         TestService::run(|mut svc| async move {
             let mut reqs = [None, None, None];

--- a/src/sinks/util/auto_concurrency/tests.rs
+++ b/src/sinks/util/auto_concurrency/tests.rs
@@ -18,19 +18,23 @@ use crate::{
         Healthcheck, RouterSink,
     },
     sources::generator::GeneratorConfig,
-    test_util::{start_topology, stats::LevelTimeHistogram},
+    test_util::{self, start_topology, stats::LevelTimeHistogram},
 };
 use core::task::Context;
-use futures::compat::Future01CompatExt;
-use futures::future::{pending, BoxFuture};
+use futures::{
+    compat::Future01CompatExt,
+    future::{pending, BoxFuture},
+};
 use futures01::{future, Sink};
 use rand::{distributions::Exp1, prelude::*};
 use serde::Serialize;
 use snafu::Snafu;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::task::Poll;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    task::Poll,
+    time::{Duration, Instant},
+};
 use tokio::time::{delay_for, delay_until};
 use tower03::Service;
 
@@ -306,7 +310,7 @@ async fn run_test4(
     TestData { stats, cstats }
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn fixed_concurrency() {
     // Simulate a very jittery link, but with a fixed concurrency
     let results = run_test4(
@@ -334,7 +338,7 @@ async fn fixed_concurrency() {
     assert_eq!(in_flight.mode, 10, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn constant_link() {
     let results = run_test(
         500,
@@ -386,7 +390,7 @@ async fn constant_link() {
     );
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn defers_at_high_concurrency() {
     let results = run_test(
         500,
@@ -429,7 +433,7 @@ async fn defers_at_high_concurrency() {
     assert_within!(c_in_flight.mean, 2.0, 4.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn drops_at_high_concurrency() {
     let results = run_test(
         500,
@@ -466,7 +470,7 @@ async fn drops_at_high_concurrency() {
     assert_within!(c_in_flight.mean, 3.0, 5.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn slow_link() {
     let results = run_test(
         200,
@@ -503,7 +507,7 @@ async fn slow_link() {
     assert_within!(c_in_flight.mean, 1.0, 2.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn slow_send_1() {
     let results = run_test(
         100,
@@ -537,7 +541,7 @@ async fn slow_send_1() {
     assert_within!(c_in_flight.mean, 0.5, 1.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn slow_send_2() {
     let results = run_test(
         100,
@@ -571,7 +575,7 @@ async fn slow_send_2() {
     assert_within!(c_in_flight.mean, 1.0, 2.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn medium_send() {
     let results = run_test(
         500,
@@ -604,7 +608,7 @@ async fn medium_send() {
     assert_within!(c_in_flight.mean, 4.0, 5.0, "{:#?}", results);
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn jittery_link_small() {
     let results = run_test(
         500,

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -288,7 +288,7 @@ mod test {
     use crate::{
         buffers::Acker,
         event::metric::{Metric, MetricValue, StatisticKind},
-        Event,
+        test_util, Event,
     };
     use futures01::{future, Future, Sink};
     use pretty_assertions::assert_eq;
@@ -334,7 +334,7 @@ mod test {
         (buffered, sent_requests)
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_counters() {
         let (sink, sent_batches) = sink();
 
@@ -453,7 +453,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_aggregated_counters() {
         let (sink, sent_batches) = sink();
 
@@ -528,7 +528,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_gauges() {
         let (sink, sent_batches) = sink();
 
@@ -601,7 +601,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_aggregated_gauges() {
         let (sink, sent_batches) = sink();
 
@@ -696,7 +696,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_sets() {
         let (sink, sent_batches) = sink();
 
@@ -753,7 +753,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_distributions() {
         let (sink, sent_batches) = sink();
 
@@ -860,7 +860,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_aggregated_histograms_absolute() {
         let (sink, sent_batches) = sink();
 
@@ -950,7 +950,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_aggregated_histograms_incremental() {
         let (sink, sent_batches) = sink();
 
@@ -1028,7 +1028,7 @@ mod test {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn metric_buffer_aggregated_summaries() {
         let (sink, sent_batches) = sink();
 

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -171,8 +171,11 @@ impl Batch for Buffer {
 #[cfg(test)]
 mod test {
     use super::{Buffer, Compression};
-    use crate::buffers::Acker;
-    use crate::sinks::util::{BatchSettings, BatchSink};
+    use crate::{
+        buffers::Acker,
+        sinks::util::{BatchSettings, BatchSink},
+        test_util,
+    };
     use futures01::{future, Future, Sink};
     use std::{
         io::Read,
@@ -180,7 +183,7 @@ mod test {
     };
     use tokio::time::Duration;
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn gzip() {
         use flate2::read::GzDecoder;
 

--- a/src/sinks/util/retries2.rs
+++ b/src/sinks/util/retries2.rs
@@ -175,17 +175,16 @@ impl RetryAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::trace_init;
+    use crate::test_util;
     use std::{fmt, time::Duration};
     use tokio::time;
     use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok, task};
     use tower03::retry::RetryLayer;
     use tower_test03::{assert_request_eq, mock};
 
-    #[tokio::test]
+    #[test_util::test(basic_scheduler)]
     async fn service_error_retry() {
         time::pause();
-        trace_init();
 
         let policy = FixedRetryPolicy::new(
             5,
@@ -212,10 +211,8 @@ mod tests {
         assert_eq!(fut.await.unwrap(), "world");
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn service_error_no_retry() {
-        trace_init();
-
         let policy = FixedRetryPolicy::new(
             5,
             Duration::from_secs(1),
@@ -232,10 +229,9 @@ mod tests {
         assert_ready_err!(fut.poll());
     }
 
-    #[tokio::test]
+    #[test_util::test(basic_scheduler)]
     async fn timeout_error() {
         time::pause();
-        trace_init();
 
         let policy = FixedRetryPolicy::new(
             5,

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -737,7 +737,7 @@ mod tests {
     use crate::sinks::util::{
         buffer::partition::Partition, BatchSettings, EncodedLength, VecBuffer,
     };
-    use crate::test_util::{basic_scheduler_block_on_std, runtime};
+    use crate::test_util::{self, basic_scheduler_block_on_std, runtime};
     use bytes::Bytes;
     use futures01::{future, Sink};
     use std::sync::{atomic::Ordering::Relaxed, Arc, Mutex};
@@ -757,7 +757,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn batch_sink_acking_sequential() {
         let (acker, ack_counter) = Acker::new_for_testing();
 
@@ -845,7 +845,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn batch_sink_buffers_messages_until_limit() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -877,7 +877,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn batch_sink_flushes_below_min_on_close() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -930,7 +930,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn partition_batch_sink_buffers_messages_until_limit() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -961,7 +961,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn partition_batch_sink_buffers_by_partition_buffer_size_one() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -987,7 +987,7 @@ mod tests {
         assert_eq!(&*output, &vec![vec![Partitions::A], vec![Partitions::B]]);
     }
 
-    #[tokio::test(core_threads = 2)]
+    #[test_util::test]
     async fn partition_batch_sink_buffers_by_partition_buffer_size_two() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -195,7 +195,7 @@ impl Sink for UnixSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::{random_lines_with_stream, CountReceiver};
+    use crate::test_util::{self, random_lines_with_stream, CountReceiver};
     use futures::compat::Future01CompatExt;
     use futures01::Sink;
     use tokio::net::UnixListener;
@@ -204,7 +204,7 @@ mod tests {
         tempfile::tempdir().unwrap().into_path().join(name)
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn unix_sink_healthcheck() {
         let good_path = temp_uds_path("valid_uds");
         let _listener = UnixListener::bind(&good_path).unwrap();
@@ -214,7 +214,7 @@ mod tests {
         assert!(healthcheck(bad_path).await.is_err());
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn basic_unix_sink() {
         let num_lines = 1000;
         let out_path = temp_uds_path("unix_test");

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -362,9 +362,7 @@ fn create_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        config::Config, event, shutdown::ShutdownSignal, sources::file, test_util::trace_init,
-    };
+    use crate::{config::Config, event, shutdown::ShutdownSignal, sources::file, test_util};
     use futures01::Stream;
     use pretty_assertions::assert_eq;
     use std::{
@@ -489,7 +487,7 @@ mod tests {
         assert_eq!(log[event::log_schema().source_type_key()], "file".into());
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_happy_path() {
         let n = 5;
         let (tx, rx) = Pipeline::new_test();
@@ -547,7 +545,7 @@ mod tests {
         assert_eq!(goodbye_i, n);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_truncate() {
         let n = 5;
         let (tx, rx) = Pipeline::new_test();
@@ -612,7 +610,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_rotate() {
         let n = 5;
         let (tx, rx) = Pipeline::new_test();
@@ -678,7 +676,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_multiple_paths() {
         let n = 5;
         let (tx, rx) = Pipeline::new_test();
@@ -734,7 +732,7 @@ mod tests {
         assert_eq!(is, [n as usize; 3]);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_file_key() {
         // Default
         {
@@ -854,7 +852,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_start_position_server_restart() {
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -940,7 +938,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_start_position_server_restart_with_file_rotation() {
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
@@ -1000,7 +998,7 @@ mod tests {
     }
 
     #[cfg(unix)] // this test uses unix-specific function `futimes` during test time
-    #[tokio::test]
+    #[test_util::test]
     async fn file_start_position_ignore_old_files() {
         use std::os::unix::io::AsRawFd;
         use std::time::{Duration, SystemTime};
@@ -1086,7 +1084,7 @@ mod tests {
         assert_eq!(after_lines, vec!["_first line", "_second line"]);
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn file_max_line_bytes() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1144,7 +1142,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_multi_line_aggregation_legacy() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1215,7 +1213,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_multi_line_aggregation() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1290,7 +1288,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_fair_reads() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1355,7 +1353,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_oldest_first() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1420,7 +1418,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_gzipped_file() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
@@ -1463,10 +1461,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn remove_file() {
-        trace_init();
-
         let n = 5;
         let remove_after = 2;
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -556,7 +556,7 @@ mod checkpointer_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Pipeline;
+    use crate::{test_util, Pipeline};
     use futures01::stream::Stream;
     use std::{
         io::{self, BufReader, Cursor},
@@ -648,7 +648,7 @@ mod tests {
             .unwrap()
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn reads_journal() {
         let received = run_journal(&[], &[], None).await;
         assert_eq!(received.len(), 5);
@@ -667,7 +667,7 @@ mod tests {
         assert_eq!(priority(&received[1]), Value::Bytes("DEBUG".into()));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn includes_units() {
         let received = run_journal(&["unit.service"], &[], None).await;
         assert_eq!(received.len(), 1);
@@ -675,7 +675,7 @@ mod tests {
         assert_eq!(timestamp(&received[0]), value_ts(1578529839, 140002000));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn excludes_units() {
         let received = run_journal(&[], &["unit.service", "badunit.service"], None).await;
         assert_eq!(received.len(), 3);
@@ -693,7 +693,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn handles_checkpoint() {
         let received = run_journal(&[], &[], Some("1")).await;
         assert_eq!(received.len(), 4);
@@ -701,14 +701,14 @@ mod tests {
         assert_eq!(timestamp(&received[0]), value_ts(1578529839, 140002000));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn parses_array_messages() {
         let received = run_journal(&["badunit.service"], &[], None).await;
         assert_eq!(received.len(), 1);
         assert_eq!(message(&received[0]), Value::Bytes("¿Hello?".into()));
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn handles_missing_timestamp() {
         let received = run_journal(&["stdout"], &[], None).await;
         assert_eq!(received.len(), 2);

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -130,7 +130,7 @@ mod test {
     use crate::{
         config,
         sinks::prometheus::PrometheusSinkConfig,
-        test_util::{next_addr, start_topology},
+        test_util::{self, next_addr, start_topology},
         Error,
     };
     use futures::compat::Future01CompatExt;
@@ -139,7 +139,7 @@ mod test {
     use pretty_assertions::assert_eq;
     use tokio::time::{delay_for, Duration};
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_prometheus_routing() {
         let in_addr = next_addr();
         let out_addr = next_addr();

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -107,7 +107,7 @@ mod test {
     use crate::{
         config,
         sinks::prometheus::PrometheusSinkConfig,
-        test_util::{next_addr, start_topology},
+        test_util::{self, next_addr, start_topology},
     };
     use futures::{compat::Future01CompatExt, TryStreamExt};
     use futures01::Stream;
@@ -123,7 +123,7 @@ mod test {
             .unwrap()
     }
 
-    #[tokio::test]
+    #[test_util::test]
     async fn test_statsd() {
         let in_addr = next_addr();
         let out_addr = next_addr();

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -25,6 +25,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     sync::Arc,
 };
+pub use test_util_macros::test;
 use tokio::{
     io::{AsyncRead, AsyncWrite, Result as IoResult},
     net::{TcpListener, TcpStream},

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -786,14 +786,16 @@ mod reload_tests {
 
 #[cfg(all(test, feature = "sinks-console", feature = "sources-generator"))]
 mod source_finished_tests {
-    use crate::config::Config;
-    use crate::sinks::console::{ConsoleSinkConfig, Encoding, Target};
-    use crate::sources::generator::GeneratorConfig;
-    use crate::test_util::start_topology;
+    use crate::{
+        config::Config,
+        sinks::console::{ConsoleSinkConfig, Encoding, Target},
+        sources::generator::GeneratorConfig,
+        test_util::{self, start_topology},
+    };
     use futures::compat::Future01CompatExt;
     use tokio::time::{timeout, Duration};
 
-    #[tokio::test]
+    #[test_util::test]
     async fn sources_finished() {
         let mut old_config = Config::empty();
         let generator = GeneratorConfig::repeat(vec!["text".to_owned()], 1, None);

--- a/tests/kubernetes-e2e.rs
+++ b/tests/kubernetes-e2e.rs
@@ -11,6 +11,7 @@ use k8s_test_framework::{
     lock, test_pod, wait_for_resource::WaitFor, Framework, Interface, Reader,
 };
 use std::collections::HashSet;
+use vector::test_util;
 
 const VECTOR_CONFIG: &str = r#"
 apiVersion: v1
@@ -155,7 +156,7 @@ where
 /// This test validates that vector picks up logs at the simplest case
 /// possible - a new pod is deployed and prints to stdout, and we assert that
 /// vector picks that up.
-#[tokio::test]
+#[test_util::test]
 async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -223,7 +224,7 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector properly merges a log message that
 /// kubernetes has internally split into multiple partial log lines.
-#[tokio::test]
+#[test_util::test]
 async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -292,7 +293,7 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector picks up preexisting logs - logs that
 /// existed before vector was deployed.
-#[tokio::test]
+#[test_util::test]
 async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -363,7 +364,7 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector picks up multiple log lines, and that they
 /// arrive at the proper order.
-#[tokio::test]
+#[test_util::test]
 async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -433,7 +434,7 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector properly annotates log events with pod
 /// metadata obtained from the k8s API.
-#[tokio::test]
+#[test_util::test]
 async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -509,7 +510,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector properly filters out the logs that are
 /// requested to be excluded from collection, based on k8s API `Pod` labels.
-#[tokio::test]
+#[test_util::test]
 async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
@@ -649,7 +650,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
 
 /// This test validates that vector properly collects logs from multiple
 /// `Namespace`s and `Pod`s.
-#[tokio::test]
+#[test_util::test]
 async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -12,8 +12,8 @@ use vector::{
     runtime::Runtime,
     sinks, sources,
     test_util::{
-        next_addr, random_lines, runtime, send_lines, start_topology, trace_init, wait_for_tcp,
-        CountReceiver,
+        self, next_addr, random_lines, runtime, send_lines, start_topology, trace_init,
+        wait_for_tcp, CountReceiver,
     },
     transforms,
 };
@@ -288,7 +288,7 @@ fn reconnect() {
     });
 }
 
-#[tokio::test]
+#[test_util::test]
 async fn healthcheck() {
     let addr = next_addr();
     let resolver = vector::dns::Resolver;


### PR DESCRIPTION
Closes #3360.

New macros add `crate::test_util::trace_init()` in tests, we can not do this with `tokio::test`.