### PR TITLE
chore(ci): Update the target Ubuntu distros for package verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,9 @@ verify-rpm-amazonlinux-2: package-rpm-x86_64 ## Verify the rpm package on Amazon
 verify-rpm-centos-7: package-rpm-x86_64 ## Verify the rpm package on CentOS 7
 	$(RUN) verify-rpm-centos-7
 
-verify-deb: verify-deb-artifact-on-deb-8 verify-deb-artifact-on-deb-9 verify-deb-artifact-on-deb-10 verify-deb-artifact-on-ubuntu-16-04 verify-deb-artifact-on-ubuntu-18-04 verify-deb-artifact-on-ubuntu-19-04 ## Verify all deb packages
+verify-deb: ## Verify all deb packages
+verify-deb: verify-deb-artifact-on-deb-8 verify-deb-artifact-on-deb-9 verify-deb-artifact-on-deb-10
+verify-deb: verify-deb-artifact-on-ubuntu-14-04 verify-deb-artifact-on-ubuntu-16-04 verify-deb-artifact-on-ubuntu-18-04 verify-deb-artifact-on-ubuntu-20-04
 
 verify-deb-artifact-on-deb-8: package-deb-x86_64 ## Verify the deb package on Debian 8
 	$(RUN) verify-deb-artifact-on-deb-8
@@ -483,14 +485,17 @@ verify-deb-artifact-on-deb-9: package-deb-x86_64 ## Verify the deb package on De
 verify-deb-artifact-on-deb-10: package-deb-x86_64 ## Verify the deb package on Debian 10
 	$(RUN) verify-deb-artifact-on-deb-10
 
+verify-deb-artifact-on-ubuntu-14-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 14.04
+	$(RUN) verify-deb-artifact-on-ubuntu-14-04
+
 verify-deb-artifact-on-ubuntu-16-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 16.04
 	$(RUN) verify-deb-artifact-on-ubuntu-16-04
 
 verify-deb-artifact-on-ubuntu-18-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 18.04
 	$(RUN) verify-deb-artifact-on-ubuntu-18-04
 
-verify-deb-artifact-on-ubuntu-19-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 19.04
-	$(RUN) verify-deb-artifact-on-ubuntu-19-04
+verify-deb-artifact-on-ubuntu-20-04: package-deb-x86_64 ## Verify the deb package on Ubuntu 20.04
+	$(RUN) verify-deb-artifact-on-ubuntu-20-04
 
 verify-nixos:  ## Verify that Vector can be built on NixOS
 	$(RUN) verify-nixos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,6 +232,16 @@ services:
     command:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
+  verify-deb-artifact-on-ubuntu-14-04:
+    build:
+      context: .
+      dockerfile: scripts/ci-docker-images/verifier-ubuntu-14-04/Dockerfile
+    volumes:
+      - $PWD:$PWD
+    working_dir: $PWD
+    command:
+      ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
+
   verify-deb-artifact-on-ubuntu-16-04:
     build:
       context: .
@@ -252,10 +262,10 @@ services:
     command:
       ["sh", "-ec", "dpkg -i target/artifacts/*-amd64.deb && vector --version"]
 
-  verify-deb-artifact-on-ubuntu-19-04:
+  verify-deb-artifact-on-ubuntu-20-04:
     build:
       context: .
-      dockerfile: scripts/ci-docker-images/verifier-ubuntu-19-04/Dockerfile
+      dockerfile: scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
     volumes:
       - $PWD:$PWD
     working_dir: $PWD

--- a/scripts/ci-docker-images/verifier-ubuntu-14-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-14-04/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:19.04
+FROM ubuntu:14.04
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
   apt-get install -y \

--- a/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-16-04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
   apt-get install -y \
   ca-certificates \

--- a/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
+++ b/scripts/ci-docker-images/verifier-ubuntu-20-04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This removes the no-longer-supported 19.04; replacing it with 20.04.
I also added 14.04 which is still supported.

Fixes #3290

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>