### PR TITLE
chore(docker source): Provision a /var/lib/vector in docker releases

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
+VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -r
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
+VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]


### PR DESCRIPTION
Fixes #2718 by declaring `/var/lib/vector/` as a volume mountpoint.

```bash
ana@autonoma:~/git/timberio/vector$ make package-x86_64-unknown-linux-musl-all 
# ...
ana@autonoma:~/git/timberio/vector$ ./scripts/build-docker.sh 
# ...
ana@autonoma:~/git/timberio/vector$ docker run -ti -v $PWD/test.toml:/etc/vector/vector.toml:ro  timberio/vector:nightly-debian
Aug 18 21:51:46.343  INFO vector: Log level "info" is enabled.
Aug 18 21:51:46.347  INFO vector: Loading configs. path=["/etc/vector/vector.toml"]
Aug 18 21:51:46.356  INFO vector: Vector is starting. version="0.11.0" git_version="v0.9.0-535-g8658b60" released="Tue, 18 Aug 2020 21:38:44 +0000" arch="x86_64"
Aug 18 21:51:46.358  INFO vector::sources::stdin: Capturing STDIN.
Aug 18 21:51:46.360  INFO vector::topology: Running healthchecks.
Aug 18 21:51:46.360  INFO vector::topology: Starting source "source0"
Aug 18 21:51:46.360  INFO vector::topology: Starting sink "sink0"
Aug 18 21:51:46.360  INFO vector::topology::builder: Healthcheck: Passed.
^CAug 18 21:51:53.205  INFO vector: Shutting down.
Aug 18 21:51:53.206  INFO source{name=source0 type=stdin}: vector::sources::stdin: Finished sending
Aug 18 21:51:53.206  INFO vector::topology: Shutting down... Waiting on: sink0. 59 seconds left

ana@autonoma:~/git/timberio/vector$ docker run -ti -v $PWD/test.toml:/etc/vector/vector.toml:ro  timberio/vector:nightly-alpine
Aug 18 21:54:29.515  INFO vector: Log level "info" is enabled.
Aug 18 21:54:29.520  INFO vector: Loading configs. path=["/etc/vector/vector.toml"]
Aug 18 21:54:29.525  INFO vector: Vector is starting. version="0.11.0" git_version="v0.9.0-535-g8658b60" released="Tue, 18 Aug 2020 21:32:48 +0000" arch="x86_64"
Aug 18 21:54:29.526  INFO vector::sources::stdin: Capturing STDIN.
Aug 18 21:54:29.529  INFO vector::topology: Running healthchecks.
Aug 18 21:54:29.529  INFO vector::topology: Starting source "source0"
Aug 18 21:54:29.529  INFO vector::topology: Starting sink "sink0"
Aug 18 21:54:29.530  INFO vector::topology::builder: Healthcheck: Passed.
^CAug 18 21:54:31.845  INFO vector: Shutting down.
Aug 18 21:54:31.845  INFO source{name=source0 type=stdin}: vector::sources::stdin: Finished sending
Aug 18 21:54:31.846  INFO vector::topology: Shutting down... Waiting on: sink0, source0. 59 seconds left

ana@autonoma:~/git/timberio/vector$ cat test.toml 
data_dir = "/var/lib/vector/"

[sources.source0]
max_length = 102400
type = "stdin"

[sinks.sink0]
healthcheck = true
inputs = ["source0"]
type = "console"
encoding = "json"
buffer.type = "disk"
buffer.max_size = 500
buffer.when_full = "block"
```