### PR TITLE
docs(http sink): Fix default for rate_limit_num

### DIFF
--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -6873,9 +6873,9 @@ require('custom_module')
     # time window.
     #
     # * optional
-    # * default: 1000
+    # * default: 10
     # * type: uint
-    rate_limit_num = 1000
+    rate_limit_num = 10
 
     # The maximum number of retries to make for failed requests. The default, for
     # all intents and purposes, represents an infinite number of retries.


### PR DESCRIPTION
The actual default is 10, not 1000.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

@binarylogic how might I back port this so it is reflected in our live documentation on vector.dev?