### PR TITLE
docs(file sink): Add `compression` option to the `file` source

### DIFF
--- a/.meta/sinks/file.toml.erb
+++ b/.meta/sinks/file.toml.erb
@@ -15,7 +15,16 @@ input_types = ["log"]
 requirements = {}
 write_to_description = "a file"
 
-<%= render("_partials/fields/_component_options.toml", type: "sink", name: "file") %>
+<%= render("_partials/fields/_component_options.toml",
+  type: "sink",
+  name: "file") %>
+
+<%= render("_partials/fields/_compression_options.toml",
+  namespace: "sinks.file.options",
+  options: {
+    "default" => "none"
+  }
+) %>
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.file.options",


### PR DESCRIPTION
Following up on https://github.com/timberio/vector/pull/3373#issuecomment-678809146