### PR TITLE
chore: Added support for the ci-condition: skip label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,6 +60,8 @@ jobs:
   build-deb-package:
     name: Build .deb package
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - run: make package-deb-x86_64
@@ -77,6 +79,8 @@ jobs:
   compute-k8s-test-plan:
     name: Compute K8s test plan
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -127,6 +131,8 @@ jobs:
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     needs:
       - build-deb-package
       - compute-k8s-test-plan

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -28,6 +28,8 @@ jobs:
   checks:
     name: Checks
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,6 +57,8 @@ jobs:
   check-component-features:
     name: Component Features - Linux
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
   test-linux:
     name: Unit - Linux
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -75,6 +77,8 @@ jobs:
     # Some failures are permitted until we can properly correct them.
     continue-on-error: true
     runs-on: macos-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -94,6 +98,8 @@ jobs:
     # Some failures are permitted until we can properly correct them.
     continue-on-error: true
     runs-on: windows-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v1
       - env:
@@ -104,6 +110,8 @@ jobs:
   test-misc:
     name: Shutdown - Linux
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -122,6 +130,8 @@ jobs:
   test-integration-aws:
     name: Integration - Linux, AWS
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -138,6 +148,8 @@ jobs:
   test-integration-clickhouse:
     name: Integration - Linux, Clickhouse
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -154,6 +166,8 @@ jobs:
   test-integration-docker:
     name: Integration - Linux, Docker
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -170,6 +184,8 @@ jobs:
   test-integration-elasticsearch:
     name: Integration - Linux, ES
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -186,6 +202,8 @@ jobs:
   test-integration-gcp:
     name: Integration - Linux, GCP
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -202,6 +220,8 @@ jobs:
   test-integration-influxdb:
     name: Integration - Linux, Influx
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -218,6 +238,8 @@ jobs:
   test-integration-kafka:
     name: Integration - Linux, Kafka
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -234,6 +256,8 @@ jobs:
   test-integration-loki:
     name: Integration - Linux, Loki
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -250,6 +274,8 @@ jobs:
   test-integration-pulsar:
     name: Integration - Linux, Pulsar
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -266,6 +292,8 @@ jobs:
   test-integration-splunk:
     name: Integration - Linux, Splunk
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,8 +170,14 @@ aligns better with our process.
 Currently Vector uses Github Actions to run tests. The workflows are defined in
 `.github/workflows`.
 
-Tests are run for all changes, and Github Actions is responsible for releasing
-updated versions of Vector through various channels.
+Tests are run for all changes except those that have the label:
+
+```
+ci-condition: skip
+```
+
+Github Actions is responsible for releasing updated versions of Vector through
+various channels.
 
 Some long running tests are only run daily, rather than on every pull request.
 If needed, an administrator can kick off these tests manually via:


### PR DESCRIPTION
As GitHub Actions doesn't support skipping whole workflows and you can't set
job defaults we need to specify the skip on every job.

Signed-off-by: James Turnbull <james@lovedthanlost.net>