### PR TITLE
enhancement: Rewrite LineAgg to allow passing context data and be more memory efficient

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -225,7 +225,11 @@ pub fn file_source(
                 futures::future::ready(val.ok())
             });
             let logic = line_agg::Logic::new(config);
-            Box::new(Compat::new(LineAgg::new(rx, logic).map(Ok)))
+            Box::new(Compat::new(
+                LineAgg::new(rx.map(|(line, src)| (src, line, ())), logic)
+                    .map(|(src, line, _context)| (line, src))
+                    .map(Ok),
+            ))
         };
         let messages: Box<dyn Stream<Item = (Bytes, String), Error = ()> + Send> =
             if let Some(ref multiline_config) = multiline_config {


### PR DESCRIPTION
This PR alters `LineAgg` such that:

- it can pass around an extra piece of data together with each `line` - the `context`; this is required for some use cases - more on this below;
- it uses `Vec<Bytes>` instead of `ByteMut` to aggregate lines, and only does `BytesMut` once when the final event is emitted; this should reduce memory pressure and allocs count;
- it has different arguments order - the way it was before was natual for `file` source, but not for the current generic implementation.


## Motivation for adding context

`LineAgg` has to keep all the data nesessary to produce the `Event` from the aggragted `Bytes`. This is because we sometimes emit more than one line from the aggregation results - and the consumers of those merged line have to somehow transfer that data through the line aggregation mechnism.

Now, for `file` source it was very convenient that the `LineAgg` implementation naturally passed around all the required data - the `line` - for the line being processed - and the `src` - which has the semantics of the "file name" for the `file` source, and the aggregation key for the `LineAgg`. Given just the `line` and the `src`, `file` source could work.

The same approach doesn't work for sources that want to pass around additional metadata together with events. For instance, `docker` source parses the raw message into

- a timestamp, 
- labels and 
- message line. 

To properly implement `LineAgg`, we need to memorize those thought the merging process. Why can't we just keep that data outside of the merging logic? Well, that's because of the case when we want to emit multiple messages from the aggregation. If not that - it would be fine, but emitting multiple messages required us to somehow persist the content for the first message - otherwise what would we use to build the event from it?

In docker case, what's interesting is that we don't need the `src` at all - the processing there is already scoped by the container, and it's enough to just consume the stream and run the `LineAgg` logic.
