### PR TITLE
chore(dev): Add missing codeblock language to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Currently Vector uses Github Actions to run tests. The workflows are defined in
 
 Tests are run for all changes except those that have the label:
 
-```
+```text
 ci-condition: skip
 ```
 


### PR DESCRIPTION
Introduced by https://github.com/timberio/vector/pull/3539 but
presumably not noticed as that PR was also testing the label :smile: 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>