### PR TITLE
chore: Define macros for most of the "events_processed" internal events

### DIFF
--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -1,17 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct AddFieldsEventProcessed;
-
-impl InternalEvent for AddFieldsEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "add_fields",
-        );
-    }
-}
+define_events_processed!(AddFieldsEventProcessed, "transform", "add_fields");
 
 #[derive(Debug)]
 pub struct AddFieldsTemplateRenderingError<'a> {

--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -1,17 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct AddTagsEventProcessed;
-
-impl InternalEvent for AddTagsEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "add_tags",
-        );
-    }
-}
+define_events_processed!(AddTagsEventProcessed, "transform", "add_tags");
 
 #[derive(Debug)]
 pub struct AddTagsTagOverwritten<'a> {

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -2,17 +2,7 @@ use super::InternalEvent;
 use metrics::counter;
 use string_cache::DefaultAtom as Atom;
 
-#[derive(Debug)]
-pub struct ANSIStripperEventProcessed;
-
-impl InternalEvent for ANSIStripperEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "ansi_stripper",
-        );
-    }
-}
+define_events_processed!(ANSIStripperEventProcessed, "transform", "ansi_stripper");
 
 #[derive(Debug)]
 pub struct ANSIStripperFieldMissing<'a> {

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -1,22 +1,3 @@
-use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct AwsKinesisStreamsEventSent {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for AwsKinesisStreamsEventSent {
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "sink",
-            "component_type" => "aws_kinesis_streams",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "sink",
-            "component_type" => "aws_kinesis_streams",
-        );
-    }
-}
+define_events_processed_bytes!(AwsKinesisStreamsEventSent, "sink", "aws_kinesis_streams");

--- a/src/internal_events/blackhole.rs
+++ b/src/internal_events/blackhole.rs
@@ -1,22 +1,3 @@
-use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct BlackholeEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for BlackholeEventReceived {
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "sink",
-            "component_type" => "blackhole",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "sink",
-            "component_type" => "blackhole",
-        );
-    }
-}
+define_events_processed_bytes!(BlackholeEventReceived, "sink", "blackhole");

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -1,21 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub(crate) struct GrokParserEventProcessed;
-
-impl InternalEvent for GrokParserEventProcessed {
-    fn emit_logs(&self) {
-        trace!(message = "Processed one event.");
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "grok_parser",
-        );
-    }
-}
+define_events_processed!(GrokParserEventProcessed, "transform", "grok_parser");
 
 #[derive(Debug)]
 pub(crate) struct GrokParserFailedMatch<'a> {

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -1,27 +1,12 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub(crate) struct JournaldEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for JournaldEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "Received line.", byte_size = %self.byte_size);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-                 "component_kind" => "source",
-                 "component_name" => "journald",
-        );
-        counter!("bytes_processed", self.byte_size as u64,
-                 "component_kind" => "source",
-                 "component_name" => "journald",
-        );
-    }
-}
+define_events_processed_bytes!(
+    JournaldEventReceived,
+    "source",
+    "journald",
+    "Received line."
+);
 
 #[derive(Debug)]
 pub(crate) struct JournaldInvalidRecord {

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -3,21 +3,7 @@ use metrics::counter;
 use serde_json::Error;
 use string_cache::DefaultAtom as Atom;
 
-#[derive(Debug)]
-pub(crate) struct JsonParserEventProcessed;
-
-impl InternalEvent for JsonParserEventProcessed {
-    fn emit_logs(&self) {
-        trace!(message = "Received one event.");
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "json_parser",
-        );
-    }
-}
+define_events_processed!(JsonParserEventProcessed, "transform", "json_parser");
 
 #[derive(Debug)]
 pub(crate) struct JsonParserFailedParse<'a> {

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -1,29 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct KafkaEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for KafkaEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "Received one event.", rate_limit_secs = 10);
-    }
-
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "source",
-            "component_type" => "kafka",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "source",
-            "component_type" => "kafka",
-        );
-    }
-}
+define_events_processed_bytes!(KafkaEventReceived, "source", "kafka");
 
 #[derive(Debug)]
 pub struct KafkaOffsetUpdateFailed {

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -2,17 +2,7 @@ use super::InternalEvent;
 use crate::transforms::lua::v1::format_error;
 use metrics::{counter, gauge};
 
-#[derive(Debug)]
-pub struct LuaEventProcessed;
-
-impl InternalEvent for LuaEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "lua",
-        );
-    }
-}
+define_events_processed!(LuaEventProcessed, "transform", "lua");
 
 #[derive(Debug)]
 pub struct LuaGcTriggered {

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -2,21 +2,7 @@ use super::InternalEvent;
 use metrics::counter;
 use string_cache::DefaultAtom as Atom;
 
-#[derive(Debug)]
-pub(crate) struct RegexParserEventProcessed;
-
-impl InternalEvent for RegexParserEventProcessed {
-    fn emit_logs(&self) {
-        trace!(message = "Processed one event.");
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "regex_parser",
-        );
-    }
-}
+define_events_processed!(RegexParserEventProcessed, "transform", "regex_parser");
 
 #[derive(Debug)]
 pub(crate) struct RegexParserFailedMatch<'a> {

--- a/src/internal_events/sampler.rs
+++ b/src/internal_events/sampler.rs
@@ -1,17 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct SamplerEventProcessed;
-
-impl InternalEvent for SamplerEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "sampler",
-        );
-    }
-}
+define_events_processed!(SamplerEventProcessed, "transform", "sampler");
 
 #[derive(Debug)]
 pub struct SamplerEventDiscarded;

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -2,17 +2,7 @@ use super::InternalEvent;
 use metrics::counter;
 use string_cache::DefaultAtom as Atom;
 
-#[derive(Debug)]
-pub struct SplitEventProcessed;
-
-impl InternalEvent for SplitEventProcessed {
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "transform",
-            "component_type" => "split",
-        );
-    }
-}
+define_events_processed!(SplitEventProcessed, "transform", "split");
 
 #[derive(Debug)]
 pub struct SplitFieldMissing<'a> {

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -6,25 +6,7 @@ use string_cache::DefaultAtom as Atom;
 #[cfg(feature = "sources-splunk_hec")]
 pub(crate) use self::source::*;
 
-#[derive(Debug)]
-pub(crate) struct SplunkEventSent {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for SplunkEventSent {
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "sink",
-            "component_type" => "splunk_hec",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "sink",
-            "component_type" => "splunk_hec",
-        );
-    }
-}
+define_events_processed_bytes!(SplunkEventSent, "sink", "splunk_hec", "Sent one event.");
 
 #[derive(Debug)]
 pub(crate) struct SplunkEventEncodeError {

--- a/src/internal_events/statsd.rs
+++ b/src/internal_events/statsd.rs
@@ -1,29 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct StatsdEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for StatsdEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "received packet.", byte_size = %self.byte_size);
-    }
-
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "source",
-            "component_name" => "statsd",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "source",
-            "component_name" => "statsd",
-        );
-    }
-}
+define_events_processed_bytes!(StatsdEventReceived, "source", "statsd", "Received packet.");
 
 #[derive(Debug)]
 pub struct StatsdInvalidRecord<'a> {

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -1,29 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct StdinEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for StdinEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "Received one event.");
-    }
-
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "source",
-            "component_type" => "stdin",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "source",
-            "component_type" => "stdin",
-        );
-    }
-}
+define_events_processed_bytes!(StdinEventReceived, "source", "stdin");
 
 #[derive(Debug)]
 pub struct StdinReadFailed {

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -1,27 +1,7 @@
 use super::InternalEvent;
 use metrics::counter;
 
-#[derive(Debug)]
-pub struct SyslogEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for SyslogEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "received line.", byte_size = %self.byte_size);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_processed", 1,
-            "component_kind" => "source",
-            "component_type" => "syslog",
-        );
-        counter!("bytes_processed", self.byte_size as u64,
-            "component_kind" => "source",
-            "component_type" => "syslog",
-        );
-    }
-}
+define_events_processed_bytes!(SyslogEventReceived, "source", "syslog");
 
 #[derive(Debug)]
 pub struct SyslogUdpReadError {

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -2,49 +2,9 @@ use super::InternalEvent;
 use metrics::counter;
 use prost::DecodeError;
 
-#[derive(Debug)]
-pub struct VectorEventSent {
-    pub byte_size: usize,
-}
+define_events_processed_bytes!(VectorEventReceived, "sink", "vector");
 
-impl InternalEvent for VectorEventSent {
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "sink",
-            "component_type" => "vector",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "sink",
-            "component_type" => "vector",
-        );
-    }
-}
-
-#[derive(Debug)]
-pub struct VectorEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for VectorEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "Received one event.",);
-    }
-
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "source",
-            "component_type" => "vector",
-        );
-        counter!(
-            "bytes_processed", self.byte_size as u64,
-            "component_kind" => "source",
-            "component_type" => "vector",
-        );
-    }
-}
+define_events_processed_bytes!(VectorEventSent, "sink", "vector", "Events sent.");
 
 #[derive(Debug)]
 pub struct VectorProtoDecodeError {


### PR DESCRIPTION
As discussed in Slack. Is there another easy target for DRY?

Signed-off-by: Bruce Guenter <bruce@timber.io>