### PR TITLE
chore: simplify validate subcommand behavior

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -53,7 +53,11 @@ pub fn process_paths(config_paths: &[PathBuf]) -> Option<Vec<PathBuf>> {
     Some(paths)
 }
 
-pub fn read_configs(config_paths: &[PathBuf]) -> Result<Config, Vec<String>> {
+pub fn from_paths(
+    config_paths: &[PathBuf],
+    old: impl Into<Option<Config>>,
+) -> Result<Config, Vec<String>> {
+    let old = old.into();
     let mut config = Config::empty();
     let mut errors = Vec::new();
 
@@ -74,6 +78,11 @@ pub fn read_configs(config_paths: &[PathBuf]) -> Result<Config, Vec<String>> {
     }
 
     if errors.is_empty() {
+        if old.is_none() {
+            crate::event::LOG_SCHEMA
+                .set(config.global.log_schema.clone())
+                .expect("Couldn't set schema");
+        }
         Ok(config)
     } else {
         Err(errors)

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -86,7 +86,7 @@ fn load_from_inputs(
     for input in inputs {
         if let Err(errs) = load(input).and_then(|n| config.append(n)) {
             // TODO: add back paths
-            errors.extend(errs.iter().map(|e| format!("{}", e)));
+            errors.extend(errs.iter().map(|e| e.to_string()));
         }
     }
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -54,11 +54,7 @@ pub fn process_paths(config_paths: &[PathBuf]) -> Option<Vec<PathBuf>> {
     Some(paths)
 }
 
-pub fn load_from_paths(
-    config_paths: &[PathBuf],
-    old: impl Into<Option<Config>>,
-) -> Result<Config, Vec<String>> {
-    let old = old.into();
+pub fn load_from_paths(config_paths: &[PathBuf]) -> Result<Config, Vec<String>> {
     let mut config = Config::empty();
     let mut errors = Vec::new();
 
@@ -79,11 +75,6 @@ pub fn load_from_paths(
     }
 
     if errors.is_empty() {
-        if old.is_none() {
-            crate::event::LOG_SCHEMA
-                .set(config.global.log_schema.clone())
-                .expect("Couldn't set schema");
-        }
         Ok(config)
     } else {
         Err(errors)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -372,7 +372,7 @@ impl Config {
     pub fn get_inputs(&self, identifier: &str) -> Vec<String> {
         self.expansions
             .get(identifier)
-            .map(|v| v.clone())
+            .cloned()
             .unwrap_or_else(|| vec![String::from(identifier)])
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,7 @@ mod vars;
 pub mod watcher;
 
 pub use diff::ConfigDiff;
-pub use loading::{load_from_paths, process_paths, CONFIG_PATHS};
+pub use loading::{load_from_paths, load_from_str, process_paths, CONFIG_PATHS};
 pub use validation::check;
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,7 @@ mod vars;
 pub mod watcher;
 
 pub use diff::ConfigDiff;
-pub use loading::{process_paths, read_configs, CONFIG_PATHS};
+pub use loading::{from_paths, process_paths, CONFIG_PATHS};
 pub use validation::check;
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,7 @@ mod vars;
 pub mod watcher;
 
 pub use diff::ConfigDiff;
-pub use loading::*;
+pub use loading::{process_paths, read_configs, CONFIG_PATHS};
 pub use validation::check;
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use futures01::Future;
 use std::cmp::max;
 use tokio::select;
 use vector::{
-    config::{self, Config, ConfigDiff},
-    event, generate, heartbeat,
+    config::{self, ConfigDiff},
+    generate, heartbeat,
     internal_events::{VectorReloaded, VectorStarted, VectorStopped},
     list, metrics, runtime,
     signal::{self, SignalTo},
@@ -105,21 +105,19 @@ fn main() {
             path = ?config_paths
         );
 
-        let read_config = config::read_configs(&config_paths);
-        let maybe_config = handle_config_errors(read_config);
-        let config = maybe_config.unwrap_or_else(|| {
-            std::process::exit(exitcode::CONFIG);
-        });
-        event::LOG_SCHEMA
-            .set(config.global.log_schema.clone())
-            .expect("Couldn't set schema");
+        let config = config::from_paths(&config_paths, None)
+            .map_err(handle_config_errors)
+            .unwrap_or_else(|()| {
+                std::process::exit(exitcode::CONFIG);
+            });
 
         let diff = ConfigDiff::initial(&config);
         let pieces = topology::validate(&config, &diff).await.unwrap_or_else(|| {
             std::process::exit(exitcode::CONFIG);
         });
 
-        let result = topology::start_validated(config, diff, pieces, opts.require_healthy).await;
+        let result =
+            topology::start_validated(config.clone(), diff, pieces, opts.require_healthy).await;
         let (mut topology, graceful_crash) = result.unwrap_or_else(|| {
             std::process::exit(exitcode::CONFIG);
         });
@@ -136,10 +134,8 @@ fn main() {
                 Some(signal) = signals.next() => {
                     if signal == SignalTo::Reload {
                         // Reload config
-                        let new_config = config::read_configs(&config_paths);
+                        let new_config = config::from_paths(&config_paths, config.clone()).map_err(handle_config_errors).ok();
 
-                        trace!("Parsing config");
-                        let new_config = handle_config_errors(new_config);
                         if let Some(new_config) = new_config {
                             match topology
                                 .reload_config_and_respawn(new_config, opts.require_healthy)
@@ -186,14 +182,8 @@ fn main() {
     rt.shutdown_now().wait().unwrap();
 }
 
-fn handle_config_errors(config: Result<Config, Vec<String>>) -> Option<Config> {
-    match config {
-        Err(errors) => {
-            for error in errors {
-                error!("Configuration error: {}", error);
-            }
-            None
-        }
-        Ok(config) => Some(config),
+fn handle_config_errors(errors: Vec<String>) {
+    for error in errors {
+        error!("Configuration error: {}", error);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,11 +105,15 @@ fn main() {
             path = ?config_paths
         );
 
-        let config = config::load_from_paths(&config_paths, None)
+        let config = config::load_from_paths(&config_paths)
             .map_err(handle_config_errors)
             .unwrap_or_else(|()| {
                 std::process::exit(exitcode::CONFIG);
             });
+
+        vector::event::LOG_SCHEMA
+            .set(config.global.log_schema.clone())
+            .expect("Couldn't set schema");
 
         let diff = ConfigDiff::initial(&config);
         let pieces = topology::validate(&config, &diff).await.unwrap_or_else(|| {
@@ -134,7 +138,7 @@ fn main() {
                 Some(signal) = signals.next() => {
                     if signal == SignalTo::Reload {
                         // Reload config
-                        let new_config = config::load_from_paths(&config_paths, config.clone()).map_err(handle_config_errors).ok();
+                        let new_config = config::load_from_paths(&config_paths).map_err(handle_config_errors).ok();
 
                         if let Some(new_config) = new_config {
                             match topology

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
         });
 
         let result =
-            topology::start_validated(config.clone(), diff, pieces, opts.require_healthy).await;
+            topology::start_validated(config, diff, pieces, opts.require_healthy).await;
         let (mut topology, graceful_crash) = result.unwrap_or_else(|| {
             std::process::exit(exitcode::CONFIG);
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
             path = ?config_paths
         );
 
-        let config = config::from_paths(&config_paths, None)
+        let config = config::load_from_paths(&config_paths, None)
             .map_err(handle_config_errors)
             .unwrap_or_else(|()| {
                 std::process::exit(exitcode::CONFIG);
@@ -134,7 +134,7 @@ fn main() {
                 Some(signal) = signals.next() => {
                     if signal == SignalTo::Reload {
                         // Reload config
-                        let new_config = config::from_paths(&config_paths, config.clone()).map_err(handle_config_errors).ok();
+                        let new_config = config::load_from_paths(&config_paths, config.clone()).map_err(handle_config_errors).ok();
 
                         if let Some(new_config) = new_config {
                             match topology

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -510,11 +510,11 @@ pub fn build_unit_tests(config: &mut super::Config) -> Result<Vec<UnitTest>, Vec
 ))]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config;
 
     #[test]
     fn parse_no_input() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.bar]
   inputs = ["foo"]
@@ -545,7 +545,7 @@ mod tests {
                 .to_owned(),]
         );
 
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.bar]
   inputs = ["foo"]
@@ -583,7 +583,7 @@ mod tests {
 
     #[test]
     fn parse_no_test_input() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.bar]
   inputs = ["foo"]
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn parse_no_outputs() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -642,7 +642,7 @@ mod tests {
 
     #[test]
     fn parse_broken_topology() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["something"]
@@ -747,7 +747,7 @@ mod tests {
 
     #[test]
     fn parse_bad_input_event() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -782,7 +782,7 @@ mod tests {
 
     #[test]
     fn test_success_multi_inputs() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -870,7 +870,7 @@ mod tests {
 
     #[test]
     fn test_success() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -930,7 +930,7 @@ mod tests {
 
     #[test]
     fn test_swimlanes() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -990,7 +990,7 @@ mod tests {
 
     #[test]
     fn test_fail_no_outputs() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = [ "TODO" ]
@@ -1020,7 +1020,7 @@ mod tests {
 
     #[test]
     fn test_fail_two_output_events() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = [ "TODO" ]
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn test_no_outputs_from() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = [ "ignored" ]
@@ -1127,7 +1127,7 @@ mod tests {
 
     #[test]
     fn test_no_outputs_from_chained() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = [ "ignored" ]
@@ -1169,7 +1169,7 @@ mod tests {
 
     #[test]
     fn test_log_input() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -1206,7 +1206,7 @@ mod tests {
 
     #[test]
     fn test_metric_input() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -1244,7 +1244,7 @@ mod tests {
 
     #[test]
     fn test_success_over_gap() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]
@@ -1289,7 +1289,7 @@ mod tests {
 
     #[test]
     fn test_success_tree() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.ignored]
   inputs = ["also_ignored"]
@@ -1347,7 +1347,7 @@ mod tests {
 
     #[test]
     fn test_fails() {
-        let mut config: Config = toml::from_str(
+        let mut config = config::load_from_str(
             r#"
 [transforms.foo]
   inputs = ["ignored"]

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,7 +1,4 @@
-use crate::{
-    config::{self, Config},
-    topology::unit_test::UnitTest,
-};
+use crate::{config, topology::unit_test::UnitTest};
 use colored::*;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -15,13 +12,12 @@ pub struct Opts {
 }
 
 fn build_tests(path: PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
-    // pass an empty config as the previous to avoid trying to reset globals
-    let mut config = match config::load_from_paths(&[path], Config::empty()) {
-        Err(load_errs) => {
-            return Err(load_errs);
-        }
-        Ok(c) => c,
-    };
+    let mut config = config::load_from_paths(&[path])?;
+
+    // Ignore failures on calls other than the first
+    crate::event::LOG_SCHEMA
+        .set(config.global.log_schema.clone())
+        .ok();
 
     crate::topology::unit_test::build_unit_tests(&mut config)
 }

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,10 +1,9 @@
 use crate::{
     config::{self, Config},
-    event,
     topology::unit_test::UnitTest,
 };
 use colored::*;
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -15,36 +14,14 @@ pub struct Opts {
     paths: Vec<PathBuf>,
 }
 
-fn build_tests(i: usize, path: &PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
-    let file = match File::open(path) {
-        Ok(f) => f,
-        Err(error) => {
-            if let std::io::ErrorKind::NotFound = error.kind() {
-                return Err(vec![format!(
-                    "Config file not found in path '{}'",
-                    path.to_str().unwrap_or("")
-                )]);
-            } else {
-                return Err(vec![format!(
-                    "Could not open file '{}': {}",
-                    path.to_str().unwrap_or(""),
-                    error
-                )]);
-            }
-        }
-    };
-
-    let mut config = match Config::load(file) {
+fn build_tests(path: PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
+    // pass an empty config as the previous to avoid trying to reset globals
+    let mut config = match config::load_from_paths(&[path], Config::empty()) {
         Err(load_errs) => {
             return Err(load_errs);
         }
         Ok(c) => c,
     };
-    if i == 0 {
-        event::LOG_SCHEMA
-            .set(config.global.log_schema.clone())
-            .expect("Couldn't set schema");
-    }
 
     crate::topology::unit_test::build_unit_tests(&mut config)
 }
@@ -57,13 +34,13 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
         std::process::exit(exitcode::CONFIG);
     });
 
-    for (i, p) in paths.iter().enumerate() {
-        let path_str = p.to_str().unwrap_or("");
+    for (i, path) in paths.iter().enumerate() {
+        let path_str = path.to_str().unwrap_or("");
         if i > 0 {
             println!();
         }
         println!("Running {} tests", path_str);
-        match build_tests(i, p) {
+        match build_tests(path.clone()) {
             Ok(mut tests) => {
                 let mut aggregated_test_errors = Vec::new();
                 let mut aggregated_test_inspections = Vec::new();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use colored::*;
 use exitcode::ExitCode;
-use std::{fmt, fs::File, path::PathBuf};
+use std::{fmt, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -97,32 +97,12 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Result<Config, Option<Co
     let mut validated = 0;
     let mut full_config = Config::empty();
     for config_path in paths {
-        let file = match File::open(&config_path) {
-            Ok(file) => file,
-            Err(error) => {
-                if let std::io::ErrorKind::NotFound = error.kind() {
-                    fmt.error(format!("File {:?} not found", config_path));
-                } else {
-                    fmt.error(format!(
-                        "Failed opening file {:?} with error {:?}",
-                        config_path, error
-                    ));
-                }
-                continue;
-            }
-        };
-
-        trace!(
-            message = "Parsing config.",
-            path = ?config_path
-        );
-
         let mut sub_failed = |title: String, errors| {
             fmt.title(title);
             fmt.sub_error(errors);
         };
 
-        let mut config = match Config::load(file) {
+        let mut config = match config::load_from_paths(&[config_path.clone()], None) {
             Ok(config) => config,
             Err(errors) => {
                 sub_failed(format!("Failed to parse {:?}", config_path), errors);

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -92,7 +92,7 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Result<Config, Option<Co
         return Err(None);
     };
 
-    match config::load_from_paths(&paths, None) {
+    match config::load_from_paths(&paths) {
         Ok(config) => {
             fmt.success(format!("Loaded {:?}", &paths));
             Ok(config)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -57,12 +57,8 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
     let mut validated = true;
 
     let config = match validate_config(opts, &mut fmt) {
-        Ok(config) => config,
-        Err(Some(config)) => {
-            validated &= false;
-            config
-        }
-        Err(None) => return exitcode::CONFIG,
+        Some(config) => config,
+        None => return exitcode::CONFIG,
     };
 
     if !(opts.no_topology || opts.no.topology) {
@@ -83,24 +79,24 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
 
 /// Ok if all configs were succesfully validated.
 /// Err Some contains only succesfully validated configs.
-fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Result<Config, Option<Config>> {
+fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
     // Prepare paths
     let paths = if let Some(paths) = config::process_paths(&opts.paths) {
         paths
     } else {
         fmt.error("No config file paths");
-        return Err(None);
+        return None;
     };
 
     match config::load_from_paths(&paths) {
         Ok(config) => {
             fmt.success(format!("Loaded {:?}", &paths));
-            Ok(config)
+            Some(config)
         }
         Err(errors) => {
             fmt.title(format!("Failed to load {:?}", paths));
             fmt.sub_error(errors);
-            Err(None)
+            None
         }
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,10 +1,10 @@
 use vector::{
-    config::{self, Config, ConfigDiff},
+    config::{self, ConfigDiff},
     topology,
 };
 
 async fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
-    match Config::load(config.as_bytes()) {
+    match config::load_from_str(config) {
         Ok(c) => {
             let diff = ConfigDiff::initial(&c);
             match (


### PR DESCRIPTION
I've pulled this out of my larger set of changes because I think it warrants a review of its own.

The basic issue is that the current `validate` subcommand tries to be very fine-grained about where in the config loading process errors occur. It also attempts to validate config files one-by-one, which is not the way that we do it when running vector normally (they're combined and the result is validated). This is making it very difficult to consolidate and make that loading process more extensible, so I've opted here to simplify it and bring it more in line with how configs get validated at runtime.

The main differences in behavior here are:

1. There are no more distinct subsections of config errors in the `validate` output (e.g. file loading vs deserialization vs macro expansion)
2. Instead of validating files independently one-by-one, we behave the same as running vector normally and combine them into one config that's validated as a whole

We may want to make another pass after this to ensure the `validate` output is still as pretty as it was intended to be, but my priority is to unblock the rest of my own work right now.

There's also probably some similar simplifications to be made around the unit testing subcommand because it also treats files independently, but that wasn't on the critical path for my own changes.

