### PR TITLE
chore: more async functions in tests

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -83,7 +83,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -134,7 +134,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -185,7 +185,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -244,7 +244,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
                         std::thread::sleep(std::time::Duration::from_millis(100));
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines * num_writers, output_lines.wait().await.len());
+                        assert_eq!(num_lines * num_writers, output_lines.await.len());
                     });
                 },
             );
@@ -314,8 +314,8 @@ fn benchmark_interconnected(c: &mut Criterion) {
                         send_lines(in_addr2, lines2).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines * 2, output_lines1.wait().await.len());
-                        assert_eq!(num_lines * 2, output_lines2.wait().await.len());
+                        assert_eq!(num_lines * 2, output_lines1.await.len());
+                        assert_eq!(num_lines * 2, output_lines2.await.len());
                     });
                 },
             );
@@ -385,7 +385,7 @@ fn benchmark_transforms(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -596,10 +596,10 @@ fn benchmark_complex(c: &mut Criterion) {
 
                         topology.stop().compat().await.unwrap();
 
-                        let output_lines_all = output_lines_all.wait().await.len();
-                        let output_lines_sampled = output_lines_sampled.wait().await.len();
-                        let output_lines_200 = output_lines_200.wait().await.len();
-                        let output_lines_404 = output_lines_404.wait().await.len();
+                        let output_lines_all = output_lines_all.await.len();
+                        let output_lines_sampled = output_lines_sampled.await.len();
+                        let output_lines_200 = output_lines_200.await.len();
+                        let output_lines_404 = output_lines_404.await.len();
 
                         assert_eq!(output_lines_all, num_lines * 2);
                         assert_relative_eq!(

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -56,7 +56,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
 
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -96,7 +96,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
                         tokio::time::delay_for(std::time::Duration::from_secs(100)).await;
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );
@@ -136,7 +136,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                         send_lines(in_addr, lines).await.unwrap();
                         tokio::time::delay_for(std::time::Duration::from_secs(100)).await;
                         topology.stop().compat().await.unwrap();
-                        assert_eq!(num_lines, output_lines.wait().await.len());
+                        assert_eq!(num_lines, output_lines.await.len());
                     });
                 },
             );

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -359,7 +359,10 @@ mod integration_tests {
         region::RegionOrEndpoint,
         test_util::{random_lines_with_stream, random_string},
     };
-    use futures::compat::Future01CompatExt;
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        SinkExt,
+    };
     use futures01::Sink;
     use rusoto_core::Region;
     use rusoto_kinesis::{Kinesis, KinesisClient};
@@ -398,9 +401,9 @@ mod integration_tests {
 
         let timestamp = chrono::Utc::now().timestamp_millis();
 
-        let (mut input_lines, events) = random_lines_with_stream(100, 11);
+        let (mut input_lines, mut events) = random_lines_with_stream(100, 11);
 
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         delay_for(Duration::from_secs(1)).await;
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -359,11 +359,7 @@ mod integration_tests {
         region::RegionOrEndpoint,
         test_util::{random_lines_with_stream, random_string},
     };
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        SinkExt,
-    };
-    use futures01::Sink;
+    use futures::{compat::Sink01CompatExt, SinkExt};
     use rusoto_core::Region;
     use rusoto_kinesis::{Kinesis, KinesisClient};
     use std::sync::Arc;

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -534,8 +534,8 @@ mod integration_tests {
     use bytes::{buf::BufExt, BytesMut};
     use flate2::read::GzDecoder;
     use futures::{
-        compat::Future01CompatExt,
-        stream::{self, StreamExt},
+        compat::{Future01CompatExt, Sink01CompatExt},
+        stream, SinkExt, StreamExt,
     };
     use futures01::Sink;
     use pretty_assertions::assert_eq;
@@ -554,9 +554,9 @@ mod integration_tests {
         let client = config.create_client(cx.resolver()).unwrap();
         let sink = config.new(client, cx).unwrap();
 
-        let (lines, events) = random_lines_with_stream(100, 10);
+        let (lines, mut events) = random_lines_with_stream(100, 10);
 
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         let keys = get_keys(prefix.unwrap()).await;
         assert_eq!(keys.len(), 1);
@@ -635,9 +635,9 @@ mod integration_tests {
         let client = config.create_client(cx.resolver()).unwrap();
         let sink = config.new(client, cx).unwrap();
 
-        let (lines, events) = random_lines_with_stream(100, 500);
+        let (lines, mut events) = random_lines_with_stream(100, 500);
 
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         let keys = get_keys(prefix.unwrap()).await;
         assert_eq!(keys.len(), 6);

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -97,16 +97,16 @@ impl Sink for BlackholeSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::buffers::Acker;
-    use crate::test_util::random_events_with_stream;
+    use crate::{buffers::Acker, test_util::random_events_with_stream};
+    use futures::{compat::Sink01CompatExt, SinkExt};
 
-    #[test]
-    fn blackhole() {
+    #[tokio::test]
+    async fn blackhole() {
         let config = BlackholeConfig { print_amount: 10 };
         let sink = BlackholeSink::new(config, Acker::Null);
 
-        let (_input_lines, events) = random_events_with_stream(100, 10);
+        let (_input_lines, mut events) = random_events_with_stream(100, 10);
 
-        let _ = sink.send_all(events).wait().unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
     }
 }

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -571,7 +571,10 @@ mod integration_tests {
         tls::TlsOptions,
         Event,
     };
-    use futures::compat::Future01CompatExt;
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        SinkExt,
+    };
     use futures01::{Sink, Stream};
     use http::{Request, StatusCode};
     use hyper::Body;
@@ -728,27 +731,27 @@ mod integration_tests {
 
         healthcheck.compat().await.expect("Health check failed");
 
-        let (input, events) = random_events_with_stream(100, 100);
+        let (input, mut events) = random_events_with_stream(100, 100);
         match break_events {
             true => {
                 // Break all but the first event to simulate some kind of partial failure
                 let mut doit = false;
                 let _ = sink
-                    .send_all(events.map(move |mut event| {
+                    .sink_compat()
+                    .send_all(&mut events.map(move |mut event| {
                         if doit {
                             event.as_mut_log().insert("_type", 1);
                         }
                         doit = true;
                         event
                     }))
-                    .compat()
                     .await
                     .expect("Sending events failed");
             }
             false => {
                 let _ = sink
-                    .send_all(events)
-                    .compat()
+                    .sink_compat()
+                    .send_all(&mut events)
                     .await
                     .expect("Sending events failed");
             }

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -573,9 +573,9 @@ mod integration_tests {
     };
     use futures::{
         compat::{Future01CompatExt, Sink01CompatExt},
-        SinkExt,
+        SinkExt, TryStreamExt,
     };
-    use futures01::{Sink, Stream};
+    use futures01::Sink;
     use http::{Request, StatusCode};
     use hyper::Body;
     use serde_json::{json, Value};
@@ -738,7 +738,7 @@ mod integration_tests {
                 let mut doit = false;
                 let _ = sink
                     .sink_compat()
-                    .send_all(&mut events.map(move |mut event| {
+                    .send_all(&mut events.map_ok(move |mut event| {
                         if doit {
                             event.as_mut_log().insert("_type", 1);
                         }

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -343,7 +343,7 @@ mod tests {
         };
 
         let mut sink = FileSink::new(&config);
-        let (input, _) = random_lines_with_stream(100, 64);
+        let (input, _events) = random_lines_with_stream(100, 64);
 
         let events = stream::iter(input.clone().into_iter().map(Event::from));
         sink.run(events).await.unwrap();
@@ -480,7 +480,7 @@ mod tests {
         };
 
         let mut sink = FileSink::new(&config);
-        let (mut input, _) = random_lines_with_stream(10, 64);
+        let (mut input, _events) = random_lines_with_stream(10, 64);
 
         let (mut tx, rx) = tokio::sync::mpsc::channel(1);
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -400,7 +400,7 @@ mod tests {
 
         let mut sink = FileSink::new(&config);
 
-        let (mut input, _) = random_events_with_stream(32, 8);
+        let (mut input, _events) = random_events_with_stream(32, 8);
         input[0].as_mut_log().insert("date", "2019-26-07");
         input[0].as_mut_log().insert("level", "warning");
         input[1].as_mut_log().insert("date", "2019-26-07");

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -214,8 +214,10 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::test_util::{random_events_with_stream, random_string, trace_init};
-    use futures::compat::Future01CompatExt;
-    use futures01::Sink;
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        SinkExt,
+    };
     use reqwest::{Client, Method, Response};
     use serde_json::{json, Value};
 
@@ -248,10 +250,10 @@ mod integration_tests {
 
         healthcheck.compat().await.expect("Health check failed");
 
-        let (input, events) = random_events_with_stream(100, 100);
+        let (input, mut events) = random_events_with_stream(100, 100);
         let _ = sink
-            .send_all(events)
-            .compat()
+            .sink_compat()
+            .send_all(&mut events)
             .await
             .expect("Sending events failed");
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -291,14 +291,15 @@ mod tests {
     use crate::{
         assert_downcast_matches,
         config::SinkContext,
-        sinks::http::HttpSinkConfig,
-        sinks::util::http::HttpSink,
-        sinks::util::test::build_test_server,
+        sinks::{
+            http::HttpSinkConfig,
+            util::{http::HttpSink, test::build_test_server},
+        },
         test_util::{next_addr, random_lines_with_stream},
     };
     use bytes::buf::BufExt;
-    use futures::{compat::Sink01CompatExt, SinkExt};
-    use futures01::Stream;
+    use flate2::read::GzDecoder;
+    use futures::{compat::Sink01CompatExt, stream, SinkExt, StreamExt};
     use headers::{Authorization, HeaderMapExt};
     use hyper::Method;
     use serde::Deserialize;
@@ -388,7 +389,7 @@ mod tests {
         let _ = config.build(cx).unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn http_happy_path_post() {
         let num_lines = 1000;
 
@@ -422,32 +423,28 @@ mod tests {
         drop(trigger);
 
         let output_lines = rx
-            .wait()
-            .map(Result::unwrap)
-            .map(|(parts, body)| {
+            .flat_map(|(parts, body)| {
                 assert_eq!(Method::POST, parts.method);
                 assert_eq!("/frames", parts.uri.path());
                 assert_eq!(
                     Some(Authorization::basic("waldo", "hunter2")),
                     parts.headers.typed_get()
                 );
-                body.reader()
+                stream::iter(BufReader::new(GzDecoder::new(body.reader())).lines())
             })
-            .map(flate2::read::GzDecoder::new)
-            .map(BufReader::new)
-            .flat_map(BufRead::lines)
             .map(Result::unwrap)
-            .map(|s| {
-                let val: serde_json::Value = serde_json::from_str(&s).unwrap();
+            .map(|line| {
+                let val: serde_json::Value = serde_json::from_str(&line).unwrap();
                 val.get("message").unwrap().as_str().unwrap().to_owned()
             })
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .await;
 
         assert_eq!(num_lines, output_lines.len());
         assert_eq!(input_lines, output_lines);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn http_happy_path_put() {
         let num_lines = 1000;
 
@@ -482,32 +479,28 @@ mod tests {
         drop(trigger);
 
         let output_lines = rx
-            .wait()
-            .map(Result::unwrap)
-            .map(|(parts, body)| {
+            .flat_map(|(parts, body)| {
                 assert_eq!(Method::PUT, parts.method);
                 assert_eq!("/frames", parts.uri.path());
                 assert_eq!(
                     Some(Authorization::basic("waldo", "hunter2")),
                     parts.headers.typed_get()
                 );
-                body.reader()
+                stream::iter(BufReader::new(GzDecoder::new(body.reader())).lines())
             })
-            .map(flate2::read::GzDecoder::new)
-            .map(BufReader::new)
-            .flat_map(BufRead::lines)
             .map(Result::unwrap)
-            .map(|s| {
-                let val: serde_json::Value = serde_json::from_str(&s).unwrap();
+            .map(|line| {
+                let val: serde_json::Value = serde_json::from_str(&line).unwrap();
                 val.get("message").unwrap().as_str().unwrap().to_owned()
             })
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .await;
 
         assert_eq!(num_lines, output_lines.len());
         assert_eq!(input_lines, output_lines);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn http_passes_custom_headers() {
         let num_lines = 1000;
 
@@ -539,9 +532,7 @@ mod tests {
         drop(trigger);
 
         let output_lines = rx
-            .wait()
-            .map(Result::unwrap)
-            .map(|(parts, body)| {
+            .flat_map(|(parts, body)| {
                 assert_eq!(Method::POST, parts.method);
                 assert_eq!("/frames", parts.uri.path());
                 assert_eq!(
@@ -552,17 +543,15 @@ mod tests {
                     Some("quux"),
                     parts.headers.get("baz").map(|v| v.to_str().unwrap())
                 );
-                body.reader()
+                stream::iter(BufReader::new(GzDecoder::new(body.reader())).lines())
             })
-            .map(flate2::read::GzDecoder::new)
-            .map(BufReader::new)
-            .flat_map(BufRead::lines)
             .map(Result::unwrap)
-            .map(|s| {
-                let val: serde_json::Value = serde_json::from_str(&s).unwrap();
+            .map(|line| {
+                let val: serde_json::Value = serde_json::from_str(&line).unwrap();
                 val.get("message").unwrap().as_str().unwrap().to_owned()
             })
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .await;
 
         assert_eq!(num_lines, output_lines.len());
         assert_eq!(input_lines, output_lines);

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -297,8 +297,8 @@ mod tests {
         test_util::{next_addr, random_lines_with_stream},
     };
     use bytes::buf::BufExt;
-    use futures::compat::Future01CompatExt;
-    use futures01::{Sink, Stream};
+    use futures::{compat::Sink01CompatExt, SinkExt};
+    use futures01::Stream;
     use headers::{Authorization, HeaderMapExt};
     use hyper::Method;
     use serde::Deserialize;
@@ -410,14 +410,15 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
+        let mut sink = sink.sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(events);
+        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.send_all(&mut events);
 
         tokio::spawn(server);
 
-        let _ = pump.compat().await.unwrap();
+        let _ = pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx
@@ -469,14 +470,15 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
+        let mut sink = sink.sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(events);
+        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.send_all(&mut events);
 
         tokio::spawn(server);
 
-        let _ = pump.compat().await.unwrap();
+        let _ = pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx
@@ -525,14 +527,15 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
+        let mut sink = sink.sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(events);
+        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.send_all(&mut events);
 
         tokio::spawn(server);
 
-        let _ = pump.compat().await.unwrap();
+        let _ = pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -329,7 +329,10 @@ mod integration_test {
         test_util::{random_lines_with_stream, random_string, wait_for},
         tls::TlsOptions,
     };
-    use futures::{compat::Future01CompatExt, future};
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        future, SinkExt,
+    };
     use futures01::Sink;
     use rdkafka::{
         consumer::{BaseConsumer, Consumer},
@@ -462,9 +465,9 @@ mod integration_test {
         let sink = KafkaSink::new(config, acker).unwrap();
 
         let num_events = 1000;
-        let (input, events) = random_lines_with_stream(100, num_events);
+        let (input, mut events) = random_lines_with_stream(100, num_events);
 
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         // read back everything from the beginning
         let mut client_config = rdkafka::ClientConfig::new();

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -333,7 +333,6 @@ mod integration_test {
         compat::{Future01CompatExt, Sink01CompatExt},
         future, SinkExt,
     };
-    use futures01::Sink;
     use rdkafka::{
         consumer::{BaseConsumer, Consumer},
         Message, Offset, TopicPartitionList,

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -227,10 +227,7 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        SinkExt, StreamExt,
-    };
+    use futures::{compat::Sink01CompatExt, SinkExt, StreamExt};
     use pulsar::SubType;
 
     #[tokio::test]
@@ -265,7 +262,7 @@ mod integration_tests {
         let (acker, ack_counter) = Acker::new_for_testing();
         let producer = cnf.create_pulsar_producer().await.unwrap();
         let sink = cnf.new_sink(producer, acker).unwrap();
-        let _ = sink.sink_compat().send_all(events).await.unwrap();
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
         assert_eq!(
             ack_counter.load(std::sync::atomic::Ordering::Relaxed),
             num_events

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -227,7 +227,10 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
-    use futures::{compat::Future01CompatExt, StreamExt};
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        SinkExt, StreamExt,
+    };
     use pulsar::SubType;
 
     #[tokio::test]
@@ -235,7 +238,7 @@ mod integration_tests {
         trace_init();
 
         let num_events = 1_000;
-        let (_input, events) = random_lines_with_stream(100, num_events);
+        let (_input, mut events) = random_lines_with_stream(100, num_events);
 
         let topic = format!("test-{}", random_string(10));
         let cnf = PulsarSinkConfig {
@@ -262,7 +265,7 @@ mod integration_tests {
         let (acker, ack_counter) = Acker::new_for_testing();
         let producer = cnf.create_pulsar_producer().await.unwrap();
         let sink = cnf.new_sink(producer, acker).unwrap();
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let _ = sink.sink_compat().send_all(events).await.unwrap();
         assert_eq!(
             ack_counter.load(std::sync::atomic::Ordering::Relaxed),
             num_events

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -91,7 +91,10 @@ mod test {
         event::Event,
         test_util::{next_addr, random_lines_with_stream, trace_init, CountReceiver},
     };
-    use futures::compat::Future01CompatExt;
+    use futures::{
+        compat::{Future01CompatExt, Sink01CompatExt},
+        SinkExt,
+    };
     use futures01::Sink;
     use serde_json::Value;
     use std::net::UdpSocket;
@@ -146,8 +149,8 @@ mod test {
 
         let mut receiver = CountReceiver::receive_lines(addr);
 
-        let (lines, events) = random_lines_with_stream(10, 100);
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let (lines, mut events) = random_lines_with_stream(10, 100);
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         // Wait for output to connect
         receiver.connected().await;
@@ -211,6 +214,7 @@ mod test {
         };
         let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
+        let mut sink = sink.sink_compat();
 
         let msg_counter = Arc::new(AtomicUsize::new(0));
         let msg_counter1 = Arc::clone(&msg_counter);
@@ -268,8 +272,8 @@ mod test {
                 .await;
         });
 
-        let (_, events) = random_lines_with_stream(10, 10);
-        let (sink, _) = sink.send_all(events).compat().await.unwrap();
+        let (_, mut events) = random_lines_with_stream(10, 10);
+        let _ = sink.send_all(&mut events).await.unwrap();
 
         // Loop and check for 10 events, we should always get 10 events. Once,
         // we have 10 events we can tell the server to shutdown to simulate the
@@ -289,15 +293,15 @@ mod test {
         assert_eq!(conn_counter.load(Ordering::SeqCst), 1);
 
         // Send another 10 events
-        let (_, events) = random_lines_with_stream(10, 10);
-        let pump = sink.send_all(events).compat().await.unwrap();
+        let (_, mut events) = random_lines_with_stream(10, 10);
+        let _ = sink.send_all(&mut events).await.unwrap();
 
         // Some CI machines are very slow, be generous.
         delay_for(Duration::from_secs(2)).await;
 
         // Drop the connection to allow the server to fully read from the buffer
         // and exit.
-        drop(pump);
+        drop(sink);
 
         // Wait for server task to be complete.
         let _ = jh.await.unwrap();

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -155,7 +155,7 @@ mod test {
         // Wait for output to connect
         receiver.connected().await;
 
-        let output = receiver.wait().await;
+        let output = receiver.await;
         assert_eq!(lines.len(), output.len());
         for (source, received) in lines.iter().zip(output) {
             let json = serde_json::from_str::<Value>(&received).expect("Invalid JSON");

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -417,7 +417,7 @@ mod test {
         let stream = stream::iter_ok(events);
         let _ = sink.send_all(stream).compat().await.unwrap();
 
-        let messages = collect_n(rx, 1).compat().await.ok().unwrap();
+        let messages = collect_n(rx, 1).await.unwrap();
         assert_eq!(
             messages[0],
             Bytes::from("vector.counter:1.5|c|#empty_tag:,normal_tag:value,true_tag\nvector.histogram:2|h|@0.01"),

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -290,8 +290,8 @@ mod test {
         event::metric::{Metric, MetricValue, StatisticKind},
         Event,
     };
-    use futures::future;
-    use futures01::{Future, Sink};
+    use futures::{compat::Future01CompatExt, future};
+    use futures01::Sink;
     use pretty_assertions::assert_eq;
     use std::{
         collections::BTreeMap,
@@ -335,7 +335,7 @@ mod test {
         (buffered, sent_requests)
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_counters() {
         let (sink, sent_batches) = sink();
 
@@ -376,7 +376,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -454,7 +455,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_aggregated_counters() {
         let (sink, sent_batches) = sink();
 
@@ -486,7 +487,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -529,7 +531,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_gauges() {
         let (sink, sent_batches) = sink();
 
@@ -559,7 +561,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -602,7 +605,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_aggregated_gauges() {
         let (sink, sent_batches) = sink();
 
@@ -647,7 +650,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -697,7 +701,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_sets() {
         let (sink, sent_batches) = sink();
 
@@ -731,7 +735,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -754,7 +759,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_distributions() {
         let (sink, sent_batches) = sink();
 
@@ -792,7 +797,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -861,7 +867,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_aggregated_histograms_absolute() {
         let (sink, sent_batches) = sink();
 
@@ -901,7 +907,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -951,7 +958,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_aggregated_histograms_incremental() {
         let (sink, sent_batches) = sink();
 
@@ -991,7 +998,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();
@@ -1029,7 +1037,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn metric_buffer_aggregated_summaries() {
         let (sink, sent_batches) = sink();
 
@@ -1055,7 +1063,8 @@ mod test {
         let _ = sink
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(events.into_iter()))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let buffer = Arc::try_unwrap(sent_batches).unwrap().into_inner().unwrap();

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -173,15 +173,15 @@ mod test {
     use super::{Buffer, Compression};
     use crate::buffers::Acker;
     use crate::sinks::util::{BatchSettings, BatchSink};
-    use futures::future;
-    use futures01::{Future, Sink};
+    use futures::{compat::Future01CompatExt, future};
+    use futures01::Sink;
     use std::{
         io::Read,
         sync::{Arc, Mutex},
     };
     use tokio::time::Duration;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn gzip() {
         use flate2::read::GzDecoder;
 
@@ -211,7 +211,8 @@ mod test {
         let _ = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(input))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let output = Arc::try_unwrap(sent_requests)

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -40,10 +40,8 @@ use futures::{
     FutureExt, TryFutureExt,
 };
 use futures01::{
-    future::Either,
-    stream::FuturesUnordered,
-    sync::oneshot::{self, Receiver},
-    try_ready, Async, AsyncSink, Future, Poll, Sink, StartSend, Stream,
+    future::Either, stream::FuturesUnordered, sync::oneshot, try_ready, Async, AsyncSink, Future,
+    Poll, Sink, StartSend, Stream,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -616,7 +614,7 @@ where
 
 struct ServiceSink<S, Request> {
     service: S,
-    in_flight: FuturesUnordered<Receiver<(usize, usize)>>,
+    in_flight: FuturesUnordered<oneshot::Receiver<(usize, usize)>>,
     acker: Acker,
     seq_head: usize,
     seq_tail: usize,

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -754,7 +754,7 @@ mod tests {
         test_util::{basic_scheduler_block_on_std, runtime},
     };
     use bytes::Bytes;
-    use futures::future;
+    use futures::{compat::Future01CompatExt, future};
     use futures01::Sink;
     use std::sync::{atomic::Ordering::Relaxed, Arc, Mutex};
     use tokio::task::yield_now;
@@ -773,7 +773,7 @@ mod tests {
         tokio::time::resume();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn batch_sink_acking_sequential() {
         let (acker, ack_counter) = Acker::new_for_testing();
 
@@ -784,7 +784,8 @@ mod tests {
         let _ = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(0..22))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         assert_eq!(ack_counter.load(Relaxed), 22);
@@ -863,7 +864,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn batch_sink_buffers_messages_until_limit() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -881,7 +882,8 @@ mod tests {
         let _ = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(0..22))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let output = sent_requests.lock().unwrap();
@@ -895,7 +897,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn batch_sink_flushes_below_min_on_close() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -913,7 +915,8 @@ mod tests {
         assert!(buffered.start_send(1).unwrap().is_ready());
 
         futures01::future::poll_fn(|| buffered.close())
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let output = sent_requests.lock().unwrap();
@@ -950,7 +953,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn partition_batch_sink_buffers_messages_until_limit() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -967,7 +970,8 @@ mod tests {
         let (_buffered, _) = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(0..22))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let output = sent_requests.lock().unwrap();
@@ -981,7 +985,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn partition_batch_sink_buffers_by_partition_buffer_size_one() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -999,7 +1003,8 @@ mod tests {
         let (_buffered, _) = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(input))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let mut output = sent_requests.lock().unwrap();
@@ -1007,7 +1012,7 @@ mod tests {
         assert_eq!(&*output, &vec![vec![Partitions::A], vec![Partitions::B]]);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test]
     async fn partition_batch_sink_buffers_by_partition_buffer_size_two() {
         let (acker, _) = Acker::new_for_testing();
         let sent_requests = Arc::new(Mutex::new(Vec::new()));
@@ -1025,7 +1030,8 @@ mod tests {
         let (_buffered, _) = buffered
             .sink_map_err(drop)
             .send_all(futures01::stream::iter_ok(input))
-            .wait()
+            .compat()
+            .await
             .unwrap();
 
         let mut output = sent_requests.lock().unwrap();

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -196,8 +196,7 @@ impl Sink for UnixSink {
 mod tests {
     use super::*;
     use crate::test_util::{random_lines_with_stream, CountReceiver};
-    use futures::compat::Future01CompatExt;
-    use futures01::Sink;
+    use futures::{compat::Sink01CompatExt, SinkExt};
     use tokio::net::UnixListener;
 
     fn temp_uds_path(name: &str) -> PathBuf {
@@ -228,8 +227,8 @@ mod tests {
         let (sink, _healthcheck) = config.build(cx).unwrap();
 
         // Send the test data
-        let (input_lines, events) = random_lines_with_stream(100, num_lines);
-        let _ = sink.send_all(events).compat().await.unwrap();
+        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
+        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
 
         // Wait for output to connect
         receiver.connected().await;

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -234,6 +234,6 @@ mod tests {
         receiver.connected().await;
 
         // Receive the data sent by the Sink to the receiver
-        assert_eq!(input_lines, receiver.wait().await);
+        assert_eq!(input_lines, receiver.await);
     }
 }

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -1152,7 +1152,7 @@ mod tests {
         }
 
         // Wait for before message
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],
             "before".into()
@@ -1180,7 +1180,7 @@ mod tests {
         let docker = docker().unwrap();
 
         let id = container_log_n(1, name, Some(label), message, &docker).await;
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         container_remove(&id, &docker).await;
 
         let log = events[0].as_log();
@@ -1208,7 +1208,7 @@ mod tests {
         let docker = docker().unwrap();
 
         let id = container_log_n(2, name, None, message, &docker).await;
-        let events = collect_n(out, 2).compat().await.ok().unwrap();
+        let events = collect_n(out, 2).await.unwrap();
         container_remove(&id, &docker).await;
 
         assert_eq!(
@@ -1235,7 +1235,7 @@ mod tests {
 
         let id0 = container_log_n(1, name0, None, "13", &docker).await;
         let id1 = container_log_n(1, name1, None, message, &docker).await;
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         container_remove(&id0, &docker).await;
         container_remove(&id1, &docker).await;
 
@@ -1260,7 +1260,7 @@ mod tests {
 
         let id0 = container_log_n(1, name0, None, "13", &docker).await;
         let id1 = container_log_n(1, name1, Some(label), message, &docker).await;
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         container_remove(&id0, &docker).await;
         container_remove(&id1, &docker).await;
 
@@ -1282,7 +1282,7 @@ mod tests {
         let id = running_container(name, Some(label), message, &docker).await;
         let out = source_with(&[name], None);
 
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         let _ = container_kill(&id, &docker).await;
         container_remove(&id, &docker).await;
 
@@ -1316,7 +1316,7 @@ mod tests {
         let docker = docker().unwrap();
 
         let id = container_log_n(1, name, None, message, &docker).await;
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         container_remove(&id, &docker).await;
 
         assert_eq!(
@@ -1368,7 +1368,7 @@ mod tests {
         let exclude_out = source_with_config(config_ex);
         let include_out = source_with_config(config_in);
 
-        let _ = collect_n(include_out, 1).compat().await.ok().unwrap();
+        let _ = collect_n(include_out, 1).await.unwrap();
         let _ = container_kill(&id, &docker).await;
         container_remove(&id, &docker).await;
 
@@ -1390,7 +1390,7 @@ mod tests {
         let docker = docker().unwrap();
 
         let id = container_log_n(1, name, None, message.as_str(), &docker).await;
-        let events = collect_n(out, 1).compat().await.ok().unwrap();
+        let events = collect_n(out, 1).await.unwrap();
         container_remove(&id, &docker).await;
 
         let log = events[0].as_log();

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -287,7 +287,7 @@ mod tests {
 
         assert_eq!(200, send(addr, body).await);
 
-        let mut events = collect_n(rx, 2).compat().await.unwrap();
+        let mut events = collect_n(rx, 2).await.unwrap();
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -318,7 +318,7 @@ mod tests {
 
         assert_eq!(200, send(addr, body).await);
 
-        let mut events = collect_n(rx, 2).compat().await.unwrap();
+        let mut events = collect_n(rx, 2).await.unwrap();
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(200, send(addr, "{}").await); //can be one object or array of objects
         assert_eq!(200, send(addr, "[{},{},{}]").await);
 
-        let mut events = collect_n(rx, 2).compat().await.unwrap();
+        let mut events = collect_n(rx, 2).await.unwrap();
         assert!(events
             .remove(1)
             .as_log()
@@ -372,7 +372,7 @@ mod tests {
         assert_eq!(200, send(addr, r#"[{"key":"value"}]"#).await);
         assert_eq!(200, send(addr, r#"{"key2":"value2"}"#).await);
 
-        let mut events = collect_n(rx, 2).compat().await.unwrap();
+        let mut events = collect_n(rx, 2).await.unwrap();
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -402,7 +402,7 @@ mod tests {
             send(addr, "{\"key1\":\"value1\"}\n\n{\"key2\":\"value2\"}").await
         );
 
-        let mut events = collect_n(rx, 2).compat().await.unwrap();
+        let mut events = collect_n(rx, 2).await.unwrap();
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -442,7 +442,7 @@ mod tests {
             send_with_headers(addr, "{\"key1\":\"value1\"}", headers).await
         );
 
-        let mut events = collect_n(rx, 1).compat().await.unwrap();
+        let mut events = collect_n(rx, 1).await.unwrap();
         {
             let event = events.remove(0);
             let log = event.as_log();

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -329,7 +329,7 @@ mod integration_test {
                 .unwrap()
                 .compat(),
         );
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -231,7 +231,7 @@ mod tests {
 
         assert_eq!(200, send(addr, body).await);
 
-        let mut events = collect_n(rx, body.lines().count()).compat().await.unwrap();
+        let mut events = collect_n(rx, body.lines().count()).await.unwrap();
         let event = events.remove(0);
         let log = event.as_log();
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -491,7 +491,7 @@ mod test {
         let address = init_udp(tx);
 
         send_lines_udp(address, vec!["test".to_string()]);
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],
@@ -505,7 +505,7 @@ mod test {
         let address = init_udp(tx);
 
         send_lines_udp(address, vec!["test\ntest2".to_string()]);
-        let events = collect_n(rx, 2).compat().await.ok().unwrap();
+        let events = collect_n(rx, 2).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],
@@ -523,7 +523,7 @@ mod test {
         let address = init_udp(tx);
 
         send_lines_udp(address, vec!["test".to_string(), "test2".to_string()]);
-        let events = collect_n(rx, 2).compat().await.ok().unwrap();
+        let events = collect_n(rx, 2).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],
@@ -541,7 +541,7 @@ mod test {
         let address = init_udp(tx);
 
         let from = send_lines_udp(address, vec!["test".to_string()]);
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().host_key()],
@@ -555,7 +555,7 @@ mod test {
         let address = init_udp(tx);
 
         let _ = send_lines_udp(address, vec!["test".to_string()]);
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[event::log_schema().source_type_key()],
@@ -572,7 +572,7 @@ mod test {
         let (address, source_handle) = init_udp_with_shutdown(tx, source_name, &mut shutdown);
 
         send_lines_udp(address, vec!["test".to_string()]);
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],
@@ -674,7 +674,7 @@ mod test {
 
         send_lines_unix(path, vec!["test"]).await;
 
-        let events = collect_n(rx, 1).compat().await.ok().unwrap();
+        let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(1, events.len());
         assert_eq!(
@@ -694,7 +694,7 @@ mod test {
         let path = init_unix(tx);
 
         send_lines_unix(path, vec!["test\ntest2"]).await;
-        let events = collect_n(rx, 2).compat().await.ok().unwrap();
+        let events = collect_n(rx, 2).await.unwrap();
 
         assert_eq!(2, events.len());
         assert_eq!(
@@ -714,7 +714,7 @@ mod test {
         let path = init_unix(tx);
 
         send_lines_unix(path, vec!["test", "test2"]).await;
-        let events = collect_n(rx, 2).compat().await.ok().unwrap();
+        let events = collect_n(rx, 2).await.unwrap();
 
         assert_eq!(2, events.len());
         assert_eq!(

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -140,7 +140,7 @@ mod test {
         shutdown::{ShutdownSignal, SourceShutdownCoordinator},
         sinks::util::tcp::TcpSink,
         test_util::{
-            collect_n, next_addr, random_string, send_lines, send_lines_tls, wait_for_tcp, CollectN,
+            collect_n, next_addr, random_string, send_lines, send_lines_tls, wait_for_tcp,
         },
         tls::{MaybeTlsSettings, TlsConfig, TlsOptions},
         Pipeline,
@@ -401,7 +401,7 @@ mod test {
         });
 
         // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.
-        let (_rx, events) = CollectN::new(rx, 100).compat().await.ok().unwrap();
+        let events = collect_n(rx, 100).await.unwrap();
         assert_eq!(100, events.len());
         for event in events {
             assert_eq!(
@@ -609,7 +609,7 @@ mod test {
         });
 
         // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.
-        let (_rx, events) = CollectN::new(rx, 100).compat().await.ok().unwrap();
+        let events = collect_n(rx, 100).await.unwrap();
         assert_eq!(100, events.len());
         for event in events {
             assert_eq!(

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -842,7 +842,7 @@ mod tests {
         let n = messages.len();
         let pump = sink.send_all(stream::iter_ok(messages.into_iter().map(Into::into)));
         tokio::spawn(pump.map(|_| ()).map_err(|()| panic!()).compat());
-        let events = collect_n(source, n).compat().await.unwrap();
+        let events = collect_n(source, n).await.unwrap();
 
         assert_eq!(n, events.len());
 
@@ -1002,7 +1002,7 @@ mod tests {
         event.as_mut_log().insert("name", "bob");
 
         let _ = sink.send(event).compat().await.unwrap();
-        let event = collect_n(source, 1).compat().await.unwrap().remove(0);
+        let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(event.as_log()[&"greeting".into()], "hello".into());
         assert_eq!(event.as_log()[&"name".into()], "bob".into());
@@ -1026,7 +1026,7 @@ mod tests {
         event.as_mut_log().insert("line", "hello");
 
         let _ = sink.send(event).compat().await.unwrap();
-        let event = collect_n(source, 1).compat().await.unwrap().remove(0);
+        let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(
             event.as_log()[&event::log_schema().message_key()],
@@ -1043,7 +1043,7 @@ mod tests {
 
         assert_eq!(200, post(address, "services/collector/raw", message).await);
 
-        let event = collect_n(source, 1).compat().await.unwrap().remove(0);
+        let event = collect_n(source, 1).await.unwrap().remove(0);
         assert_eq!(
             event.as_log()[&event::log_schema().message_key()],
             message.into()
@@ -1109,7 +1109,7 @@ mod tests {
             post(address, "services/collector/event", message).await
         );
 
-        let event = collect_n(source, 1).compat().await.unwrap().remove(0);
+        let event = collect_n(source, 1).await.unwrap().remove(0);
         assert_eq!(
             event.as_log()[&event::log_schema().message_key()],
             "first".into()
@@ -1136,7 +1136,7 @@ mod tests {
             post(address, "services/collector/event", message).await
         );
 
-        let events = collect_n(source, 3).compat().await.unwrap();
+        let events = collect_n(source, 3).await.unwrap();
 
         assert_eq!(
             events[0].as_log()[&event::log_schema().message_key()],

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -101,12 +101,12 @@ mod test {
             Metric,
         },
         sinks::vector::VectorSinkConfig,
-        test_util::{next_addr, wait_for_tcp, CollectCurrent},
+        test_util::{collect_ready, next_addr, wait_for_tcp},
         tls::{TlsConfig, TlsOptions},
         Event, Pipeline,
     };
     use futures::compat::Future01CompatExt;
-    use futures01::{stream, Future, Sink};
+    use futures01::{stream, Sink};
     use std::net::SocketAddr;
     use tokio::time::{delay_for, Duration};
 
@@ -154,7 +154,7 @@ mod test {
 
         delay_for(Duration::from_millis(50)).await;
 
-        let (_, output) = CollectCurrent::new(rx).wait().unwrap();
+        let output = collect_ready(rx).await.unwrap();
         assert_eq!(events, output);
     }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -383,7 +383,7 @@ impl<T> Future for CountReceiver<T> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         if let Some(trigger) = this.trigger.take() {
-            trigger.send(()).unwrap();
+            let _ = trigger.send(());
         }
 
         let result = futures::ready!(Pin::new(&mut this.handle).poll(cx));

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -127,7 +127,7 @@ fn test_buffering() {
 
         topology.stop().compat().await.unwrap();
 
-        let output_events = output_events.wait().await;
+        let output_events = output_events.await;
         assert_eq!(expected_events_count, output_events.len());
         assert_eq!(input_events, &output_events[..num_events]);
         assert_eq!(input_events2, &output_events[num_events..]);
@@ -227,7 +227,7 @@ fn test_max_size() {
 
         topology.stop().compat().await.unwrap();
 
-        let output_events = output_events.wait().await;
+        let output_events = output_events.await;
         assert_eq!(num_events / 2, output_events.len());
         assert_eq!(&input_events[..num_events / 2], &output_events[..]);
     });

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "leveldb")]
 
-use futures::compat::Future01CompatExt;
-use futures01::{Future, Sink};
+use futures::{
+    compat::{Future01CompatExt, Sink01CompatExt},
+    SinkExt,
+};
+use futures01::Future;
 use prost::Message;
 use tempfile::tempdir;
 use tracing::trace;
@@ -60,13 +63,13 @@ fn test_buffering() {
     let mut rt = runtime();
     let (topology, input_events) = rt.block_on_std(async move {
         let (topology, _crash) = start_topology(config, false).await;
-        let (input_events, input_events_stream) =
+        let (input_events, mut input_events_stream) =
             random_events_with_stream(line_length, num_events);
 
         let _ = in_tx
+            .sink_compat()
             .sink_map_err(|err| panic!(err))
-            .send_all(input_events_stream)
-            .compat()
+            .send_all(&mut input_events_stream)
             .await
             .unwrap();
 
@@ -110,13 +113,13 @@ fn test_buffering() {
     rt.block_on_std(async move {
         let (topology, _crash) = start_topology(config, false).await;
 
-        let (input_events2, input_events_stream) =
+        let (input_events2, mut input_events_stream) =
             random_events_with_stream(line_length, num_events);
 
         let _ = in_tx
+            .sink_compat()
             .sink_map_err(|err| panic!(err))
-            .send_all(input_events_stream)
-            .compat()
+            .send_all(&mut input_events_stream)
             .await
             .unwrap();
 
@@ -141,7 +144,8 @@ fn test_max_size() {
 
     let num_events: usize = 1000;
     let line_length = 1000;
-    let (input_events, input_events_stream) = random_events_with_stream(line_length, num_events);
+    let (input_events, mut input_events_stream) =
+        random_events_with_stream(line_length, num_events);
 
     let max_size = input_events
         .clone()
@@ -172,9 +176,9 @@ fn test_max_size() {
         let (topology, _crash) = start_topology(config, false).await;
 
         let _ = in_tx
+            .sink_compat()
             .sink_map_err(|err| panic!(err))
-            .send_all(input_events_stream)
-            .compat()
+            .send_all(&mut input_events_stream)
             .await
             .unwrap();
 

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -87,7 +87,7 @@ async fn test_sink_panic() {
     topology.stop().compat().await.unwrap();
     delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(num_lines, output_lines.len());
     assert_eq!(input_lines, output_lines);
 }
@@ -166,7 +166,7 @@ async fn test_sink_error() {
     topology.stop().compat().await.unwrap();
     delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(num_lines, output_lines.len());
     assert_eq!(input_lines, output_lines);
 }
@@ -232,7 +232,7 @@ async fn test_source_error() {
     topology.stop().compat().await.unwrap();
     delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(num_lines, output_lines.len());
     assert_eq!(input_lines, output_lines);
 }
@@ -302,7 +302,7 @@ async fn test_source_panic() {
     topology.stop().compat().await.unwrap();
     delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(num_lines, output_lines.len());
     assert_eq!(input_lines, output_lines);
 }

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -2,8 +2,6 @@
 
 use bytes::Bytes;
 use futures::compat::Future01CompatExt;
-#[cfg(unix)]
-use futures::{stream, SinkExt, StreamExt};
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
 use serde_json::Value;
@@ -12,13 +10,7 @@ use sinks::{
     util::{encoding::EncodingConfig, Encoding},
 };
 use std::{collections::HashMap, fmt, str::FromStr};
-#[cfg(unix)]
-use tokio::net::UnixStream;
 use tokio_util::codec::BytesCodec;
-#[cfg(unix)]
-use tokio_util::codec::{FramedWrite, LinesCodec};
-#[cfg(unix)]
-use vector::test_util::runtime;
 use vector::{
     config, sinks,
     sources::syslog::{Mode, SyslogConfig},
@@ -80,6 +72,11 @@ async fn test_tcp_syslog() {
 #[cfg(unix)]
 #[test]
 fn test_unix_stream_syslog() {
+    use futures::{stream, SinkExt, StreamExt};
+    use tokio::net::UnixStream;
+    use tokio_util::codec::{FramedWrite, LinesCodec};
+    use vector::test_util::runtime;
+
     let num_messages: usize = 10000;
 
     let in_path = tempfile::tempdir().unwrap().into_path().join("stream_test");

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -54,7 +54,7 @@ async fn test_tcp_syslog() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(output_lines.len(), num_messages);
 
     let output_messages: Vec<SyslogMessageRFC5424> = output_lines
@@ -119,7 +119,7 @@ fn test_unix_stream_syslog() {
         // Shut down server
         topology.stop().compat().await.unwrap();
 
-        let output_lines = output_lines.wait().await;
+        let output_lines = output_lines.await;
         assert_eq!(output_lines.len(), num_messages);
 
         let output_messages: Vec<SyslogMessageRFC5424> = output_lines
@@ -183,7 +183,7 @@ async fn test_octet_counting_syslog() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(output_lines.len(), num_messages);
 
     let output_messages: Vec<SyslogMessageRFC5424> = output_lines

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -49,7 +49,7 @@ async fn pipe() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert_eq!(num_lines, output_lines.len());
     assert_eq!(input_lines, output_lines);
 }
@@ -96,7 +96,7 @@ async fn sample() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     let num_output_lines = output_lines.len();
 
     let output_lines_ratio = num_output_lines as f32 / num_lines as f32;
@@ -151,8 +151,8 @@ async fn fork() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines1 = output_lines1.wait().await;
-    let output_lines2 = output_lines2.wait().await;
+    let output_lines1 = output_lines1.await;
+    let output_lines2 = output_lines2.await;
     assert_eq!(num_lines, output_lines1.len());
     assert_eq!(num_lines, output_lines2.len());
     assert_eq!(input_lines, output_lines1);
@@ -212,8 +212,8 @@ async fn merge_and_fork() {
     // Shut down server
     topology.stop().compat().await.unwrap();
 
-    let output_lines1 = output_lines1.wait().await;
-    let output_lines2 = output_lines2.wait().await;
+    let output_lines1 = output_lines1.await;
+    let output_lines2 = output_lines2.await;
 
     assert_eq!(num_lines, output_lines2.len());
 
@@ -266,7 +266,7 @@ async fn reconnect() {
     // Shut down server and wait for it to fully flush
     topology.stop().compat().await.unwrap();
 
-    let output_lines = output_lines.wait().await;
+    let output_lines = output_lines.await;
     assert!(num_lines >= 2);
     assert!(output_lines.iter().all(|line| input_lines.contains(line)))
 }


### PR DESCRIPTION
- Part of #3478. Remove `threaded_scheduler` attribute from part of the tests (come from #3505).
- Add more async functions.
- Replace futures:0.1 to futures:0.3 in some tests.