### PR TITLE
chore: Fix unused truncate_string_at warning

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -123,7 +123,7 @@ mod file;
 
 const ELLIPSIS: &str = "[...]";
 
-pub(self) fn truncate_string_at(s: &str, maxlen: usize) -> Cow<str> {
+pub fn truncate_string_at(s: &str, maxlen: usize) -> Cow<str> {
     if s.len() >= maxlen {
         let mut len = maxlen - ELLIPSIS.len();
         while !s.is_char_boundary(len) {


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes: #3571

This is the trivial fix, I foresee this function becoming used in more configurations, so the feature flags are likely to become unwieldy.