### PR TITLE
enhancement(platforms): Setup cross compiling to mips with cross (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,6 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
-
-[[package]]
-name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
@@ -134,6 +128,15 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.2",
  "syn 1.0.33",
+]
+
+[[package]]
+name = "atomic-shim"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20fdac7156779a1a30d970e838195558b4810dd06aa69e7c7461bdc518edf9b"
+dependencies = [
+ "crossbeam",
 ]
 
 [[package]]
@@ -263,6 +266,15 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "blake2b_simd"
@@ -790,6 +802,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils 0.7.0",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.12"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
+checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
  "quote 1.0.2",
  "syn 1.0.33",
@@ -1803,13 +1839,16 @@ dependencies = [
 
 [[package]]
 name = "im"
-version = "12.3.4"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de38d1511a0ce7677538acb1e31b5df605147c458e061b2cdb89858afb1cd182"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
 dependencies = [
- "rustc_version",
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
  "sized-chunks",
  "typenum",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -2123,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
 ]
@@ -2470,12 +2509,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-runtime"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb3035626782c533953bcc1a349467543b7f0e9d7b0c92edc61ee2bda7033d6"
+checksum = "ce0e4f69639ccc0c6b2f0612164f9817349eb25545ed1ffb5ef3e1e1c1d220b4"
 dependencies = [
- "arc-swap 0.3.11",
- "crossbeam-utils 0.6.6",
+ "arc-swap",
+ "atomic-shim",
+ "crossbeam-utils 0.7.0",
  "im",
  "metrics",
  "metrics-core",
@@ -2485,7 +2525,7 @@ dependencies = [
  "metrics-observer-prometheus",
  "metrics-observer-yaml",
  "metrics-util",
- "parking_lot",
+ "parking_lot 0.10.2",
  "quanta",
 ]
 
@@ -2927,8 +2967,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -2943,6 +2993,20 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.2.0",
  "winapi 0.3.9",
 ]
 
@@ -3267,10 +3331,12 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
+checksum = "21484fda3d8ad7affee37755c77a5d0da527543f0af0c7f731c14e2215645d39"
 dependencies = [
+ "atomic-shim",
+ "ctor",
  "libc",
  "winapi 0.3.9",
 ]
@@ -3487,6 +3553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4251,7 +4326,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
- "arc-swap 0.4.4",
+ "arc-swap",
  "libc",
 ]
 
@@ -4269,10 +4344,11 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "sized-chunks"
-version = "0.1.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
 dependencies = [
+ "bitmaps",
  "typenum",
 ]
 
@@ -4848,7 +4924,7 @@ dependencies = [
  "log",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.9.0",
  "slab",
  "tokio-executor",
  "tokio-io",
@@ -5371,6 +5447,7 @@ dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
+ "atomic-shim",
  "atty",
  "base64 0.10.1",
  "bloom",
@@ -5437,6 +5514,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "pulsar",
+ "quanta",
  "rand 0.5.6",
  "rdkafka",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ tracing-tower = { git = "https://github.com/tokio-rs/tracing", rev = "65547d8809
 # Metrics
 metrics = "0.12.1"
 metrics-core = "0.5.2"
-metrics-runtime = "0.13.0"
+metrics-runtime = "0.13.1"
+quanta = "0.3.2"
 
 # Aws
 rusoto_core = { version = "0.45.0", features = ["encoding"], optional = true }
@@ -92,6 +93,7 @@ goauth = { version = "0.7.1", optional = true }
 smpl_jwt = { version = "0.5.0", optional = true }
 
 # External libs
+atomic-shim = "0.1.0"
 derivative = "1.0"
 chrono = { version = "0.4.6", features = ["serde"] }
 rand = "0.5.5"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTFLAGS"
+]

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -9,6 +9,7 @@ use crate::{
         BatchConfig, BatchSettings, MetricBuffer, TowerRequestConfig,
     },
 };
+use atomic_shim::AtomicI64;
 use chrono::{DateTime, Utc};
 use futures::{FutureExt, TryFutureExt};
 use futures01::Sink;
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicI64, Ordering::SeqCst};
+use std::sync::atomic::Ordering::SeqCst;
 
 #[derive(Debug, Snafu)]
 enum BuildError {


### PR DESCRIPTION
Build with

```bash
RUSTFLAGS="-C target-feature=+xgot -C target-feature=+crt-static \
-L /usr/local/lib/gcc/mipsel-linux-muslsf/6.4.0 -L /usr/local/mipsel-linux-muslsf/lib \
-C link-arg=-Wl,-Bstatic -C link-arg=-lstdc++ -C link-arg=-lc -C link-arg=-latomic -C link-arg=-lgcc -C link-arg=-Wl,-Bdynamic \
" \
cross build --target mipsel-unknown-linux-musl --no-default-features --features "$(cat features)"
```

`features` are same as `default-musl`, except `vendor-sasl` and `sources-docker`
```
sources-file sources-generator sources-http sources-internal_metrics sources-journald sources-kafka sources-logplex sources-prometheus sources-socket sources-splunk_hec sources-statsd sources-stdin sources-syslog sources-tls sources-vector sources-kubernetes-logs transforms sinks vendor-openssl vendor-libz unix leveldb-cmake rdkafka-cmake
```

vendor-sasl: fails to build due to some unknown error, most likely it uses wrong linker (need to try setting TARGET_LD and add it to Cross.toml)

```
  = note: /usr/local/bin/../lib/gcc/mipsel-linux-muslsf/6.4.0/../../../../mipsel-linux-muslsf/bin/ld: /target/mipsel-unknown-linux-musl/debug/deps/libsasl2_sys-4a6f0408e9c9649d.rlib(client.o): Relocations in generic ELF (EM: 62)                                                                                                                                                        
          /usr/local/bin/../lib/gcc/mipsel-linux-muslsf/6.4.0/../../../../mipsel-linux-muslsf/bin/ld: /target/mipsel-unknown-linux-musl/debug/deps/libsasl2_sys-4a6f0408e9c9649d.rlib(client.o): Relocations in generic ELF (EM: 62)                                                                                                                                                        
          /target/mipsel-unknown-linux-musl/debug/deps/libsasl2_sys-4a6f0408e9c9649d.rlib: error adding symbols: File in wrong format                                                         
          collect2: error: ld returned 1 exit status
```
		 
`sources-docker`: depends on rustls & ring, fails on ring's build.rs (missing assembly crypto primitives for MIPS)

If we need to build a static binary we need `-C target-feature=+xgot`
otherwise we get errors like:
```
relocation truncated to fit: R_MIPS_GOT16 against `memcpy'
```
https://gcc.gnu.org/onlinedocs/gcc-3.4.6/gcc/MIPS-Options.html

Dynamic build links (remove `-C link-arg=-Wl,-Bstatic` and `C link-arg=-Wl,-Bdynamic`, `-C target-feature=+crt-static`)
Currently final static linking fails most likely due to https://github.com/rust-lang/rust/issues/36710
```
  = note: /usr/local/mipsel-linux-muslsf/lib/libstdc++.a(system_error.o): In function `__static_initialization_and_destruction_0':
          /tmp/tmp.YeBfj1Eiss/build/local/mipsel-linux-muslsf/obj_gcc/mipsel-linux-muslsf/libstdc++-v3/src/c++11/../../../../../src_gcc/libstdc++-v3/src/c++11/system_error.cc:70: undefined reference to `__dso_handle'
          /tmp/tmp.YeBfj1Eiss/build/local/mipsel-linux-muslsf/obj_gcc/mipsel-linux-muslsf/libstdc++-v3/src/c++11/../../../../../src_gcc/libstdc++-v3/src/c++11/system_error.cc:71: undefined reference to `__dso_handle'
          /rust/lib/rustlib/mipsel-unknown-linux-musl/lib/libstd-04d242cd37db4ff6.rlib(std-04d242cd37db4ff6.std.bp0ve1o5-cgu.0.rcgu.o):(.data._rust_extern_with_linkage___dso_handle+0x0): undefined reference to `__dso_handle'
          collect2: error: ld returned 1 exit status
```
