### PR TITLE
chore(deps): Remove some From implemementations from Event

### DIFF
--- a/benches/event.rs
+++ b/benches/event.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use criterion::{criterion_group, Criterion};
 use serde_json::{json, Value};
 use vector::{
@@ -12,9 +13,9 @@ fn benchmark_event(c: &mut Criterion) {
     c.bench_function("create and insert single-level", |b| {
         b.iter(|| {
             let mut log = Event::new_empty_log().into_log();
-            log.insert("key1", "value1");
-            log.insert("key2", "value2");
-            log.insert("key3", "value3");
+            log.insert("key1", Bytes::from("value1"));
+            log.insert("key2", Bytes::from("value2"));
+            log.insert("key3", Bytes::from("value3"));
         })
     });
 
@@ -34,9 +35,9 @@ fn benchmark_event(c: &mut Criterion) {
     c.bench_function("create and insert nested-keys", |b| {
         b.iter(|| {
             let mut log = Event::new_empty_log().into_log();
-            log.insert("key1.nested1.nested2", "value1");
-            log.insert("key1.nested1.nested3", "value4");
-            log.insert("key3", "value3");
+            log.insert("key1.nested1.nested2", Bytes::from("value1"));
+            log.insert("key1.nested1.nested3", Bytes::from("value4"));
+            log.insert("key3", Bytes::from("value3"));
         })
     });
 
@@ -60,8 +61,8 @@ fn benchmark_event(c: &mut Criterion) {
     c.bench_function("create and insert array", |b| {
         b.iter(|| {
             let mut log = Event::new_empty_log().into_log();
-            log.insert("key1.nested1[0]", "value1");
-            log.insert("key1.nested1[1]", "value2");
+            log.insert("key1.nested1[0]", Bytes::from("value1"));
+            log.insert("key1.nested1[1]", Bytes::from("value2"));
         })
     });
 

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use criterion::{criterion_group, Benchmark, Criterion};
 use indexmap::IndexMap;
 use transforms::lua::v2::LuaConfig;
@@ -14,11 +15,11 @@ fn add_fields(c: &mut Criterion) {
     let value = "this is the value";
 
     let key_atom_native = key.into();
-    let value_bytes_native = value.into();
+    let value_bytes_native = Bytes::from(value).into();
     let key_atom_v1 = key.into();
-    let value_bytes_v1 = value.into();
+    let value_bytes_v1 = Bytes::from(value).into();
     let key_atom_v2 = key.into();
-    let value_bytes_v2 = value.into();
+    let value_bytes_v2 = Bytes::from(value).into();
 
     c.bench(
         "lua_add_fields",
@@ -26,7 +27,10 @@ fn add_fields(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let mut map = IndexMap::new();
-                    map.insert(key.into(), toml::value::Value::String(value.to_owned()));
+                    map.insert(
+                        key.to_string().into(),
+                        toml::value::Value::String(value.to_string()),
+                    );
                     transforms::add_fields::AddFields::new(map, true)
                 },
                 |mut transform| {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -307,6 +307,10 @@ impl From<String> for Value {
     }
 }
 
+// We only enable this in testing for convenience, since `"foo"` is a `&str`.
+// In normal operation, it's better to let the caller decide where to clone and when, rather than
+// hiding this from them.
+#[cfg(test)]
 impl From<&str> for Value {
     fn from(s: &str) -> Self {
         Value::Bytes(Vec::from(s.as_bytes()).into())

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -301,12 +301,6 @@ impl From<Vec<u8>> for Value {
     }
 }
 
-impl From<&[u8]> for Value {
-    fn from(bytes: &[u8]) -> Self {
-        Value::Bytes(Vec::from(bytes).into())
-    }
-}
-
 impl From<String> for Value {
     fn from(string: String) -> Self {
         Value::Bytes(string.into())

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -307,12 +307,6 @@ impl From<String> for Value {
     }
 }
 
-impl From<&String> for Value {
-    fn from(string: &String) -> Self {
-        string.as_str().into()
-    }
-}
-
 impl From<&str> for Value {
     fn from(s: &str) -> Self {
         Value::Bytes(Vec::from(s.as_bytes()).into())

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -101,7 +101,7 @@ impl HttpSink for LogdnaConfig {
 
         let line = log
             .remove(&event::log_schema().message_key())
-            .unwrap_or_else(|| "".into());
+            .unwrap_or_else(|| String::from("").into());
         let timestamp = log
             .remove(&event::log_schema().timestamp_key())
             .unwrap_or_else(|| chrono::Utc::now().into());

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -908,7 +908,7 @@ impl ContainerMetadata {
         Ok(ContainerMetadata {
             labels,
             name: name.as_str().trim_start_matches('/').to_owned().into(),
-            image: config.image.unwrap().to_owned().into(),
+            image: config.image.unwrap().into(),
             created_at: DateTime::parse_from_rfc3339(created.as_str())?.with_timezone(&Utc),
         })
     }

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -895,7 +895,12 @@ impl ContainerMetadata {
             .as_ref()
             .map(|map| {
                 map.iter()
-                    .map(|(key, value)| (("label.".to_owned() + key).into(), value.as_bytes().to_owned().into()))
+                    .map(|(key, value)| {
+                        (
+                            ("label.".to_owned() + key).into(),
+                            value.as_bytes().to_owned().into(),
+                        )
+                    })
                     .collect()
             })
             .unwrap_or_default();

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -781,7 +781,7 @@ impl ContainerLogInfo {
             let mut log_event = LogEvent::default();
 
             // Source type
-            log_event.insert(event::log_schema().source_type_key(), "docker");
+            log_event.insert(event::log_schema().source_type_key(), Bytes::from("docker"));
 
             // The log message.
             log_event.insert(event::log_schema().message_key().clone(), bytes_message);
@@ -895,15 +895,15 @@ impl ContainerMetadata {
             .as_ref()
             .map(|map| {
                 map.iter()
-                    .map(|(key, value)| (("label.".to_owned() + key).into(), value.as_str().into()))
+                    .map(|(key, value)| (("label.".to_owned() + key).into(), value.as_bytes().to_owned().into()))
                     .collect()
             })
             .unwrap_or_default();
 
         Ok(ContainerMetadata {
             labels,
-            name: name.as_str().trim_start_matches('/').into(),
-            image: config.image.unwrap().as_str().into(),
+            name: name.as_str().trim_start_matches('/').to_owned().into(),
+            image: config.image.unwrap().to_owned().into(),
             created_at: DateTime::parse_from_rfc3339(created.as_str())?.with_timezone(&Utc),
         })
     }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -293,7 +293,7 @@ fn create_event(
     // Add source type
     event
         .as_mut_log()
-        .insert(event::log_schema().source_type_key(), "file");
+        .insert(event::log_schema().source_type_key(), Bytes::from("file"));
 
     if let Some(file_key) = &file_key {
         event.as_mut_log().insert(file_key.clone(), file);

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -108,7 +108,7 @@ fn add_headers(
             .map(HeaderValue::as_bytes)
             .unwrap_or_default();
         for event in events.iter_mut() {
-            event.as_mut_log().insert(header_name as &str, value);
+            event.as_mut_log().insert(header_name as &str, value.to_vec());
         }
     }
 

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -54,7 +54,7 @@ impl HttpSource for SimpleHttpSource {
                 // Add source type
                 let key = event::log_schema().source_type_key();
                 for event in events.iter_mut() {
-                    event.as_mut_log().try_insert(key, "http");
+                    event.as_mut_log().try_insert(key, Bytes::from("http"));
                 }
                 events
             })

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -108,7 +108,9 @@ fn add_headers(
             .map(HeaderValue::as_bytes)
             .unwrap_or_default();
         for event in events.iter_mut() {
-            event.as_mut_log().insert(header_name as &str, value.to_vec());
+            event
+                .as_mut_log()
+                .insert(header_name as &str, value.to_vec());
         }
     }
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -6,6 +6,7 @@ use crate::{
     shutdown::ShutdownSignal,
     Pipeline,
 };
+use bytes::Bytes;
 use chrono::TimeZone;
 use futures::{
     compat::Future01CompatExt,
@@ -223,7 +224,7 @@ fn create_event(record: Record) -> Event {
         }
     }
     // Add source type
-    log.try_insert(event::log_schema().source_type_key(), "journald");
+    log.try_insert(event::log_schema().source_type_key(), Bytes::from("journald"));
 
     log.into()
 }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -224,7 +224,10 @@ fn create_event(record: Record) -> Event {
         }
     }
     // Add source type
-    log.try_insert(event::log_schema().source_type_key(), Bytes::from("journald"));
+    log.try_insert(
+        event::log_schema().source_type_key(),
+        Bytes::from("journald"),
+    );
 
     log.into()
 }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -6,6 +6,7 @@ use crate::{
     shutdown::ShutdownSignal,
     Pipeline,
 };
+use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use futures::{
     compat::{Compat, Future01CompatExt},
@@ -141,7 +142,7 @@ fn kafka_source(
                             log.insert(event::log_schema().timestamp_key().clone(), timestamp);
 
                             // Add source type
-                            log.insert(event::log_schema().source_type_key(), "kafka");
+                            log.insert(event::log_schema().source_type_key(), Bytes::from("kafka"));
 
                             if let Some(key_field) = &key_field {
                                 match msg.key() {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -130,7 +130,7 @@ fn kafka_source(
                             let mut event = Event::new_empty_log();
                             let log = event.as_mut_log();
 
-                            log.insert(event::log_schema().message_key().clone(), payload);
+                            log.insert(event::log_schema().message_key().clone(), payload.to_vec());
 
                             // Extract timestamp from kafka message
                             let timestamp = msg
@@ -147,7 +147,7 @@ fn kafka_source(
                                 match msg.key() {
                                     None => (),
                                     Some(key) => {
-                                        log.insert(key_field.clone(), key);
+                                        log.insert(key_field.clone(), key.to_vec());
                                     }
                                 }
                             }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -290,10 +290,10 @@ fn create_event(line: Bytes, file: &str) -> Event {
     // Add source type.
     event
         .as_mut_log()
-        .insert(event::log_schema().source_type_key(), COMPONENT_NAME);
+        .insert(event::log_schema().source_type_key(), COMPONENT_NAME.to_owned());
 
     // Add file.
-    event.as_mut_log().insert(FILE_KEY, file);
+    event.as_mut_log().insert(FILE_KEY, file.to_owned());
 
     event
 }
@@ -301,5 +301,5 @@ fn create_event(line: Bytes, file: &str) -> Event {
 /// This function returns the default value for `self_node_name` variable
 /// as it should be at the generated config file.
 fn default_self_node_name_env_template() -> String {
-    format!("${{{}}}", SELF_NODE_NAME_ENV_KEY)
+    format!("${{{}}}", SELF_NODE_NAME_ENV_KEY.to_owned())
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -288,9 +288,10 @@ fn create_event(line: Bytes, file: &str) -> Event {
     let mut event = Event::from(line);
 
     // Add source type.
-    event
-        .as_mut_log()
-        .insert(event::log_schema().source_type_key(), COMPONENT_NAME.to_owned());
+    event.as_mut_log().insert(
+        event::log_schema().source_type_key(),
+        COMPONENT_NAME.to_owned(),
+    );
 
     // Add file.
     event.as_mut_log().insert(FILE_KEY, file.to_owned());

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -89,7 +89,7 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
     .iter()
     {
         if let Some(val) = val {
-            log.insert(key, val);
+            log.insert(key, val.to_owned());
         }
     }
 
@@ -103,7 +103,7 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
             } else {
                 path.extend(PathIter::new(key));
             }
-            log.insert_path(path, val);
+            log.insert_path(path, val.to_owned());
         }
     }
 }

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -71,13 +71,13 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
     .iter()
     {
         if let Some(val) = val {
-            log.insert(key, val);
+            log.insert(key, val.clone());
         }
     }
 
     if let Some(labels) = &metadata.labels {
         for (key, val) in labels.iter() {
-            log.insert(format!("{}.{}", fields_spec.pod_labels, key), val);
+            log.insert(format!("{}.{}", fields_spec.pod_labels, key), val.clone());
         }
     }
 }

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -162,9 +162,10 @@ fn line_to_event(line: String) -> Event {
     };
 
     // Add source type
-    event
-        .as_mut_log()
-        .try_insert(event::log_schema().source_type_key(), Bytes::from("logplex"));
+    event.as_mut_log().try_insert(
+        event::log_schema().source_type_key(),
+        Bytes::from("logplex"),
+    );
 
     event
 }

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -146,10 +146,10 @@ fn line_to_event(line: String) -> Event {
             log.insert(event::log_schema().timestamp_key().clone(), ts);
         }
 
-        log.insert(event::log_schema().host_key().clone(), hostname);
+        log.insert(event::log_schema().host_key().clone(), hostname.to_owned());
 
-        log.insert("app_name", app_name);
-        log.insert("proc_id", proc_id);
+        log.insert("app_name", app_name.to_owned());
+        log.insert("proc_id", proc_id.to_owned());
 
         event
     } else {
@@ -164,7 +164,7 @@ fn line_to_event(line: String) -> Event {
     // Add source type
     event
         .as_mut_log()
-        .try_insert(event::log_schema().source_type_key(), "logplex");
+        .try_insert(event::log_schema().source_type_key(), Bytes::from("logplex"));
 
     event
 }

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -60,7 +60,7 @@ impl TcpSource for RawTcpSource {
 
         event
             .as_mut_log()
-            .insert(event::log_schema().source_type_key(), "socket");
+            .insert(event::log_schema().source_type_key(), Bytes::from("socket"));
 
         let host_key = (self.config.host_key.as_ref()).unwrap_or(&event::log_schema().host_key());
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -5,7 +5,7 @@ use crate::{
     sources::Source,
     Pipeline,
 };
-use bytes::{BytesMut, Bytes};
+use bytes::{Bytes, BytesMut};
 use codec::BytesDelimitedCodec;
 use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use futures01::Sink;

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -5,7 +5,7 @@ use crate::{
     sources::Source,
     Pipeline,
 };
-use bytes::BytesMut;
+use bytes::{BytesMut, Bytes};
 use codec::BytesDelimitedCodec;
 use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use futures01::Sink;
@@ -78,7 +78,7 @@ pub fn udp(
 
                             event
                                 .as_mut_log()
-                                .insert(event::log_schema().source_type_key(), "socket");
+                                .insert(event::log_schema().source_type_key(), Bytes::from("socket"));
                             event
                                 .as_mut_log()
                                 .insert(host_key.clone(), address.to_string());

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -42,7 +42,7 @@ fn build_event(host_key: &str, received_from: Option<Bytes>, line: &str) -> Opti
     let mut event = Event::from(line);
     event
         .as_mut_log()
-        .insert(event::log_schema().source_type_key(), "socket");
+        .insert(event::log_schema().source_type_key(), Bytes::from("socket"));
     if let Some(host) = received_from {
         event.as_mut_log().insert(host_key, host);
     }

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -343,13 +343,13 @@ impl<R: Read> EventStream<R> {
         EventStream {
             data,
             events: 0,
-            channel: channel.map(|value| value.as_bytes().into()),
+            channel: channel.map(|value| value.into_bytes().into()),
             time: Time::Now(Utc::now()),
             extractors: [
                 DefaultExtractor::new_with(
                     "host",
                     &event::log_schema().host_key(),
-                    host.map(|value| value.as_bytes().into()),
+                    host.map(|value| value.into_bytes().into()),
                 ),
                 DefaultExtractor::new("index", &INDEX),
                 DefaultExtractor::new("source", &SOURCE),
@@ -608,11 +608,11 @@ fn raw_event(
     log.insert(event::log_schema().message_key().clone(), message);
 
     // Add channel
-    log.insert(CHANNEL.clone(), channel.as_bytes());
+    log.insert(CHANNEL.clone(), channel.into_bytes());
 
     // Add host
     if let Some(host) = host {
-        log.insert(event::log_schema().host_key().clone(), host.as_bytes());
+        log.insert(event::log_schema().host_key().clone(), host.into_bytes());
     }
 
     // Add timestamp

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -400,7 +400,7 @@ impl<R: Read> Stream for EventStream<R> {
         let log = event.as_mut_log();
 
         // Add source type
-        log.insert(event::log_schema().source_type_key(), "splunk_hec");
+        log.insert(event::log_schema().source_type_key(), Bytes::from("splunk_hec"));
 
         // Process event field
         match json.get_mut("event") {
@@ -621,7 +621,7 @@ fn raw_event(
     // Add source type
     event
         .as_mut_log()
-        .try_insert(event::log_schema().source_type_key(), "splunk_hec");
+        .try_insert(event::log_schema().source_type_key(), Bytes::from("splunk_hec"));
 
     emit!(SplunkHECEventReceived);
 

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -400,7 +400,10 @@ impl<R: Read> Stream for EventStream<R> {
         let log = event.as_mut_log();
 
         // Add source type
-        log.insert(event::log_schema().source_type_key(), Bytes::from("splunk_hec"));
+        log.insert(
+            event::log_schema().source_type_key(),
+            Bytes::from("splunk_hec"),
+        );
 
         // Process event field
         match json.get_mut("event") {
@@ -619,9 +622,10 @@ fn raw_event(
     log.insert(event::log_schema().timestamp_key().clone(), Utc::now());
 
     // Add source type
-    event
-        .as_mut_log()
-        .try_insert(event::log_schema().source_type_key(), Bytes::from("splunk_hec"));
+    event.as_mut_log().try_insert(
+        event::log_schema().source_type_key(),
+        Bytes::from("splunk_hec"),
+    );
 
     emit!(SplunkHECEventReceived);
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -187,7 +187,7 @@ fn create_event(line: Bytes, host_key: &str, hostname: &Option<String>) -> Event
     // Add source type
     event
         .as_mut_log()
-        .insert(event::log_schema().source_type_key(), "stdin");
+        .insert(event::log_schema().source_type_key(), Bytes::from("stdin"));
 
     if let Some(hostname) = &hostname {
         event.as_mut_log().insert(host_key, hostname.clone());

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -324,7 +324,7 @@ fn event_from_str(host_key: &str, default_host: Option<Bytes>, line: &str) -> Op
     // Add source type
     event
         .as_mut_log()
-        .insert(event::log_schema().source_type_key(), "syslog");
+        .insert(event::log_schema().source_type_key(), Bytes::from("syslog"));
 
     if let Some(default_host) = default_host.clone() {
         event.as_mut_log().insert("source_ip", default_host);
@@ -361,35 +361,35 @@ fn insert_fields_from_syslog(event: &mut Event, parsed: Message<&str>) {
     let log = event.as_mut_log();
 
     if let Some(host) = parsed.hostname {
-        log.insert("hostname", host);
+        log.insert("hostname", host.to_string());
     }
     if let Some(severity) = parsed.severity {
-        log.insert("severity", severity.as_str());
+        log.insert("severity", severity.as_str().to_owned());
     }
     if let Some(facility) = parsed.facility {
-        log.insert("facility", facility.as_str());
+        log.insert("facility", facility.as_str().to_owned());
     }
     if let Protocol::RFC5424(version) = parsed.protocol {
         log.insert("version", version as i64);
     }
     if let Some(app_name) = parsed.appname {
-        log.insert("appname", app_name);
+        log.insert("appname", app_name.to_owned());
     }
     if let Some(msg_id) = parsed.msgid {
-        log.insert("msgid", msg_id);
+        log.insert("msgid", msg_id.to_owned());
     }
     if let Some(procid) = parsed.procid {
         let value: Value = match procid {
             ProcId::PID(pid) => pid.into(),
-            ProcId::Name(name) => name.into(),
+            ProcId::Name(name) => name.to_string().into(),
         };
         log.insert("procid", value);
     }
 
-    for element in parsed.structured_data.iter() {
-        for (name, value) in element.params.iter() {
+    for element in parsed.structured_data.into_iter() {
+        for (name, value) in element.params.into_iter() {
             let key = format!("{}.{}", element.id, name);
-            log.insert(key, *value);
+            log.insert(key, value.to_string());
         }
     }
 }

--- a/src/topology/unit_test.rs
+++ b/src/topology/unit_test.rs
@@ -252,7 +252,7 @@ fn build_input(
                 let mut event = Event::from("");
                 for (path, value) in log_fields {
                     let value: Value = match value {
-                        TestInputValue::String(s) => s.as_bytes().into(),
+                        TestInputValue::String(s) => s.as_bytes().to_vec().into(),
                         TestInputValue::Boolean(b) => (*b).into(),
                         TestInputValue::Integer(i) => (*i).into(),
                         TestInputValue::Float(f) => (*f).into(),

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -94,10 +94,10 @@ impl Transform for GrokParser {
                 let drop_field = self.drop_field && matches.get(&self.field).is_none();
                 for (name, value) in matches.iter() {
                     let conv = self.types.get(name).unwrap_or(&Conversion::Bytes);
-                    match conv.convert(value.into()) {
+                    match conv.convert(value.to_string().into()) {
                         Ok(value) => {
                             if let Some(path) = self.paths.get(name) {
-                                event.insert_path(path.to_vec(), value);
+                                event.insert_path(path.to_vec(), value.clone());
                             } else {
                                 let path = PathIter::new(name).collect::<Vec<_>>();
                                 self.paths.insert(name.to_string(), path.clone());

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -73,7 +73,7 @@ impl Transform for Logfmt {
                 }
 
                 if let Some(conv) = self.conversions.get(&key) {
-                    match conv.convert(val.as_bytes().into()) {
+                    match conv.convert(val.into_bytes().into()) {
                         Ok(value) => {
                             event.as_mut_log().insert(key, value);
                         }

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -147,7 +147,7 @@ impl rlua::UserData for LuaEvent {
             |_ctx, this, (key, value): (String, Option<rlua::Value<'lua>>)| {
                 match value {
                     Some(rlua::Value::String(string)) => {
-                        this.inner.as_mut_log().insert(key, string.as_bytes());
+                        this.inner.as_mut_log().insert(key, string.as_bytes().to_vec());
                     }
                     Some(rlua::Value::Integer(integer)) => {
                         this.inner.as_mut_log().insert(key, Value::Integer(integer));

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -147,7 +147,9 @@ impl rlua::UserData for LuaEvent {
             |_ctx, this, (key, value): (String, Option<rlua::Value<'lua>>)| {
                 match value {
                     Some(rlua::Value::String(string)) => {
-                        this.inner.as_mut_log().insert(key, string.as_bytes().to_vec());
+                        this.inner
+                            .as_mut_log()
+                            .insert(key, string.as_bytes().to_vec());
                     }
                     Some(rlua::Value::Integer(integer)) => {
                         this.inner.as_mut_log().insert(key, Value::Integer(integer));

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -110,7 +110,7 @@ impl CompiledRegex {
                         .iter()
                         .filter_map(move |(idx, name, conversion)| {
                             capture_locs.get(*idx).and_then(|(start, end)| {
-                                let capture: Value = value[start..end].into();
+                                let capture: Value = value[start..end].to_vec().into();
 
                                 match conversion.convert(capture) {
                                     Ok(value) => Some((name.clone(), value)),

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -102,7 +102,7 @@ impl Transform for Split {
                 .iter()
                 .zip(split(value, self.separator.clone()).into_iter())
             {
-                match conversion.convert(value.as_bytes().into()) {
+                match conversion.convert(value.as_bytes().to_vec().into()) {
                     Ok(value) => {
                         event.as_mut_log().insert(name.clone(), value);
                     }

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -102,7 +102,7 @@ impl Transform for Tokenizer {
             for ((name, path, conversion), value) in
                 self.field_names.iter().zip(parse(value).into_iter())
             {
-                match conversion.convert(value.as_bytes().into()) {
+                match conversion.convert(value.as_bytes().to_vec().into()) {
                     Ok(value) => {
                         event.as_mut_log().insert_path(path.clone(), value);
                     }

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -88,7 +88,7 @@ async fn topology_shutdown_while_active() {
     for event in processed_events {
         assert_eq!(
             event.as_log()[&event::log_schema().message_key()],
-            "test transformed".into()
+            "test transformed".to_owned().into()
         );
     }
 


### PR DESCRIPTION
Part of #2841 


This removes a few extra implementations of these which are kind of not idiomatic since we should encourage the caller to choose the allocation time of the values.

I allowed this in tests on `&str` since it's just so, so usable.