### PR TITLE
enhancement(templating): adds new Helm DaemonSet template variable for pods labels

### DIFF
--- a/distribution/helm/vector/templates/daemonset.yaml
+++ b/distribution/helm/vector/templates/daemonset.yaml
@@ -18,6 +18,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "vector.selectorLabels" . | nindent 8 }}
         vector.dev/exclude: "true"
     spec:

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -35,6 +35,9 @@ serviceAccount:
 # Annotations to add to the `Pod`s managed by `DaemonSet`.
 podAnnotations: {}
 
+# Labels to add to the `Pod`s managed by `DaemonSet`.
+podLabels: {}
+
 # PodSecurityContext to set at the `Pod`s managed by `DaemonSet`.
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
The small PR add the ability for a user of the Helm template to add arbitrary pod labels to the DaemonSet spec template via a values.yaml file when deploying the package.

Resolves #3568.