### PR TITLE
chore: use _unpin methods

### DIFF
--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -179,7 +179,6 @@ mod test {
         use crate::tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};
         use futures::{future, FutureExt, StreamExt};
         use std::{
-            future::Future,
             net::Shutdown,
             pin::Pin,
             sync::{
@@ -250,7 +249,7 @@ mod test {
                     let mut stream: MaybeTlsIncomingStream<TcpStream> = connection.unwrap();
                     future::poll_fn(move |cx| loop {
                         if let Some(fut) = close_rx.as_mut() {
-                            if let Poll::Ready(()) = Pin::new(fut).poll(cx) {
+                            if let Poll::Ready(()) = fut.poll_unpin(cx) {
                                 stream.get_ref().unwrap().shutdown(Shutdown::Write).unwrap();
                                 close_rx = None;
                             }

--- a/src/sources/kubernetes_logs/lifecycle.rs
+++ b/src/sources/kubernetes_logs/lifecycle.rs
@@ -1,8 +1,12 @@
 use crate::shutdown::{ShutdownSignal, ShutdownSignalToken};
-use futures::channel::oneshot;
-use futures::future::{select, BoxFuture, Either};
-use futures::StreamExt;
-use futures::{compat::Compat01As03, pin_mut, ready, stream::FuturesUnordered};
+use futures::{
+    channel::oneshot,
+    compat::Compat01As03,
+    future::{select, BoxFuture, Either},
+    pin_mut, ready,
+    stream::FuturesUnordered,
+    FutureExt, StreamExt,
+};
 use std::{
     future::Future,
     pin::Pin,
@@ -128,7 +132,7 @@ impl Future for ShutdownHandle {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let _ = ready!(Pin::new(&mut self.0).poll(cx));
+        let _ = ready!(self.0.poll_unpin(cx));
         Poll::Ready(())
     }
 }

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -8,12 +8,12 @@ use bytes::Bytes;
 use futures::{
     compat::{Future01CompatExt, Sink01CompatExt},
     future::{self, BoxFuture},
-    stream, FutureExt, Stream, StreamExt, TryFutureExt,
+    stream, FutureExt, StreamExt, TryFutureExt,
 };
 use futures01::Sink;
 use listenfd::ListenFd;
 use serde::{de, Deserialize, Deserializer, Serialize};
-use std::{fmt, future::Future, io, net::SocketAddr, pin::Pin, task::Poll, time::Duration};
+use std::{fmt, io, net::SocketAddr, task::Poll, time::Duration};
 use tokio::{
     net::{TcpListener, TcpStream},
     time::delay_for,
@@ -177,7 +177,7 @@ async fn handle_stream(
     let mut reader = FramedRead::new(socket, source.decoder());
     stream::poll_fn(move |cx| {
         if let Some(fut) = shutdown.as_mut() {
-            match Pin::new(fut).poll(cx) {
+            match fut.poll_unpin(cx) {
                 Poll::Ready(Ok(token)) => {
                     debug!("Start gracefull shutdown");
                     // Close our write part of TCP socket to signal the other side
@@ -203,7 +203,7 @@ async fn handle_stream(
             }
         }
 
-        Pin::new(&mut reader).poll_next(cx)
+        reader.poll_next_unpin(cx)
     })
     .take_until(tripwire)
     .filter_map(move |frame| future::ready(match frame {


### PR DESCRIPTION
[FutureExt](https://docs.rs/futures/0.3.5/futures/future/trait.FutureExt.html) / [StreamExt](https://docs.rs/futures/0.3.5/futures/stream/trait.StreamExt.html) have `_unpin` methods as a shortcut which pin object for us, so we do not need construct Pin before poll.