### PR TITLE
fix(statsd sink): Sink should emit event on invalid metric

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -56,8 +56,10 @@ mod socket;
 mod split;
 #[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
 mod splunk_hec;
-#[cfg(any(feature = "sources-statsd", feature = "sinks-statsd"))]
-mod statsd;
+#[cfg(feature = "sinks-statsd")]
+mod statsd_sink;
+#[cfg(feature = "sources-statsd")]
+mod statsd_source;
 mod stdin;
 #[cfg(feature = "transforms-swimlanes")]
 mod swimlanes;
@@ -127,8 +129,10 @@ pub(crate) use self::socket::*;
 pub use self::split::*;
 #[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
 pub(crate) use self::splunk_hec::*;
-#[cfg(any(feature = "sources-statsd", feature = "sinks-statsd"))]
-pub use self::statsd::*;
+#[cfg(feature = "sinks-statsd")]
+pub use self::statsd_sink::*;
+#[cfg(feature = "sources-statsd")]
+pub use self::statsd_source::*;
 pub use self::stdin::*;
 #[cfg(feature = "transforms-swimlanes")]
 pub use self::swimlanes::*;

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -56,7 +56,7 @@ mod socket;
 mod split;
 #[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
 mod splunk_hec;
-#[cfg(feature = "sources-statsd")]
+#[cfg(any(feature = "sources-statsd", feature = "sinks-statsd"))]
 mod statsd;
 mod stdin;
 #[cfg(feature = "transforms-swimlanes")]
@@ -127,7 +127,7 @@ pub(crate) use self::socket::*;
 pub use self::split::*;
 #[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
 pub(crate) use self::splunk_hec::*;
-#[cfg(feature = "sources-statsd")]
+#[cfg(any(feature = "sources-statsd", feature = "sinks-statsd"))]
 pub use self::statsd::*;
 pub use self::stdin::*;
 #[cfg(feature = "transforms-swimlanes")]

--- a/src/internal_events/statsd.rs
+++ b/src/internal_events/statsd.rs
@@ -26,12 +26,14 @@ impl InternalEvent for StatsdEventReceived {
     }
 }
 
+#[cfg(feature = "sources-statsd")]
 #[derive(Debug)]
 pub struct StatsdInvalidRecord<'a> {
     pub error: crate::sources::statsd::parser::ParseError,
     pub text: &'a str,
 }
 
+#[cfg(feature = "sources-statsd")]
 impl InternalEvent for StatsdInvalidRecord<'_> {
     fn emit_logs(&self) {
         error!(message = "Invalid packet from statsd, discarding.", error = %self.error, text = %self.text);

--- a/src/internal_events/statsd.rs
+++ b/src/internal_events/statsd.rs
@@ -117,7 +117,7 @@ impl<'a> InternalEvent for StatsdInvalidMetric<'a> {
         counter!(
             "processing_errors", 1,
             "component_kind" => "sink",
-            "component_type" => "statsd_metrics",
+            "component_type" => "statsd",
             "error_type" => "invalid_metric",
         );
     }

--- a/src/internal_events/statsd.rs
+++ b/src/internal_events/statsd.rs
@@ -96,12 +96,12 @@ impl<T: std::fmt::Debug + std::fmt::Display> InternalEvent for StatsdSocketError
 }
 
 #[derive(Debug)]
-pub struct StatsdInvalidMetric {
-    pub value: MetricValue,
-    pub kind: MetricKind,
+pub struct StatsdInvalidMetric<'a> {
+    pub value: &'a MetricValue,
+    pub kind: &'a MetricKind,
 }
 
-impl InternalEvent for StatsdInvalidMetric {
+impl<'a> InternalEvent for StatsdInvalidMetric<'a> {
     fn emit_logs(&self) {
         warn!(
             message = "Invalid metric sent; dropping event.",

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -1,0 +1,29 @@
+use super::InternalEvent;
+use crate::event::metric::{MetricKind, MetricValue};
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct StatsdInvalidMetricReceived<'a> {
+    pub value: &'a MetricValue,
+    pub kind: &'a MetricKind,
+}
+
+impl<'a> InternalEvent for StatsdInvalidMetricReceived<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Invalid metric received; dropping event.",
+            value = ?self.value,
+            kind = ?self.kind,
+            rate_limit_secs = 30,
+        )
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "processing_errors", 1,
+            "component_kind" => "sink",
+            "component_type" => "statsd",
+            "error_type" => "invalid_metric",
+        );
+    }
+}

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -1,5 +1,4 @@
 use super::InternalEvent;
-use crate::event::metric::{MetricKind, MetricValue};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -26,14 +25,12 @@ impl InternalEvent for StatsdEventReceived {
     }
 }
 
-#[cfg(feature = "sources-statsd")]
 #[derive(Debug)]
 pub struct StatsdInvalidRecord<'a> {
     pub error: crate::sources::statsd::parser::ParseError,
     pub text: &'a str,
 }
 
-#[cfg(feature = "sources-statsd")]
 impl InternalEvent for StatsdInvalidRecord<'_> {
     fn emit_logs(&self) {
         error!(message = "Invalid packet from statsd, discarding.", error = %self.error, text = %self.text);
@@ -93,32 +90,6 @@ impl<T: std::fmt::Debug + std::fmt::Display> InternalEvent for StatsdSocketError
             "socket_errors", 1,
             "component_kind" => "source",
             "component_type" => "statsd",
-        );
-    }
-}
-
-#[derive(Debug)]
-pub struct StatsdInvalidMetric<'a> {
-    pub value: &'a MetricValue,
-    pub kind: &'a MetricKind,
-}
-
-impl<'a> InternalEvent for StatsdInvalidMetric<'a> {
-    fn emit_logs(&self) {
-        warn!(
-            message = "Invalid metric sent; dropping event.",
-            value = ?self.value,
-            kind = ?self.kind,
-            rate_limit_secs = 30,
-        )
-    }
-
-    fn emit_metrics(&self) {
-        counter!(
-            "processing_errors", 1,
-            "component_kind" => "sink",
-            "component_type" => "statsd",
-            "error_type" => "invalid_metric",
         );
     }
 }

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
     event::Event,
-    internal_events::StatsdInvalidMetric,
+    internal_events::StatsdInvalidMetricReceived,
     sinks::util::{encode_namespace, BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
 };
 use futures::{future, FutureExt};
@@ -182,7 +182,7 @@ fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
             }
         }
         _ => {
-            emit!(StatsdInvalidMetric {
+            emit!(StatsdInvalidMetricReceived {
                 value: &metric.value,
                 kind: &metric.kind,
             });

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,9 +3,8 @@ use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
     event::Event,
-    sinks::util::{encode_namespace, BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
     internal_events::StatsdInvalidMetric,
-    sinks::util::{BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
+    sinks::util::{encode_namespace, BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
 };
 use futures::{future, FutureExt};
 use futures01::{stream, Sink};

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -184,8 +184,8 @@ fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
         }
         _ => {
             emit!(StatsdInvalidMetric {
-                value: metric.value.clone(),
-                kind: metric.kind.clone(),
+                value: &metric.value,
+                kind: &metric.kind,
             });
         }
     };

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -187,6 +187,8 @@ fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
                 value: &metric.value,
                 kind: &metric.kind,
             });
+
+            return None;
         }
     };
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -4,6 +4,8 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
     event::Event,
     sinks::util::{encode_namespace, BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
+    internal_events::StatsdInvalidMetric,
+    sinks::util::{BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
 };
 use futures::{future, FutureExt};
 use futures01::{stream, Sink};
@@ -181,10 +183,10 @@ fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
             }
         }
         _ => {
-            warn!(
-                "invalid metric sent to statsd sink ({:?}) ({:?})",
-                metric.kind, metric.value
-            );
+            emit!(StatsdInvalidMetric {
+                value: metric.value.clone(),
+                kind: metric.kind.clone(),
+            });
         }
     };
 


### PR DESCRIPTION
On receiving an invalid event, the StatsD sink should emit an internal event rather than a warning.

This fixed #3635 

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
