### PR TITLE
chore(ci): Helm lint

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -43,6 +43,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
+      - run: scripts/ci-setup-helm.sh
       - run: make slim-builds
       - run: make check-markdown
       - run: make check-meta

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -50,6 +50,7 @@ jobs:
       - run: make check-clippy
       - run: make check-version
       - run: make check-scripts
+      - run: make check-helm
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check advisories

--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,9 @@ check-examples: ## Check that the config/examples files are valid
 check-scripts: ## Check that scipts do not have common mistakes
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-scripts.sh
 
+check-helm: ## Check that the Helm Chart passes helm lint
+	${MAYBE_ENVIRONMENT_EXEC} helm lint distribution/helm/vector
+
 ##@ Packaging
 
 package-all: package-archive-all package-deb-all package-rpm-all ## Build all packages

--- a/distribution/helm/vector/Chart.yaml
+++ b/distribution/helm/vector/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: vector
 type: application
 icon: https://vector.dev/press/vector-icon.svg


### PR DESCRIPTION
This PR adds running `helm lint` at CI.

It is very simple, yet it poses an important question - is this the right way to manage Helm installation? Should we, maybe, keep it as part of our environment? If so, how is should look like?
CC @Hoverbear 

We'll also use Helm to generate YAML for Kubernetes - there's an upcoming PR.