### PR TITLE
chore: consolidate config compilation

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -56,7 +56,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
         Benchmark::new("pipe", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -72,7 +72,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -107,7 +107,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
         Benchmark::new("pipe_with_tiny_lines", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -123,7 +123,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -158,7 +158,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
         Benchmark::new("pipe_with_huge_lines", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -174,7 +174,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -210,7 +210,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
         Benchmark::new("pipe_with_many_writers", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -226,7 +226,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -274,7 +274,7 @@ fn benchmark_interconnected(c: &mut Criterion) {
         Benchmark::new("interconnected", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in1",
                         sources::socket::SocketConfig::make_tcp_config(in_addr1),
@@ -302,7 +302,7 @@ fn benchmark_interconnected(c: &mut Criterion) {
                     let (output_lines1, output_lines2, topology) = rt.block_on(async move {
                         let output_lines1 = CountReceiver::receive_lines(out_addr1);
                         let output_lines2 = CountReceiver::receive_lines(out_addr2);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (output_lines1, output_lines2, topology)
@@ -341,7 +341,7 @@ fn benchmark_transforms(c: &mut Criterion) {
         Benchmark::new("transforms", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -374,7 +374,7 @@ fn benchmark_transforms(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -453,7 +453,7 @@ fn benchmark_complex(c: &mut Criterion) {
         Benchmark::new("complex", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in1",
                         sources::socket::SocketConfig::make_tcp_config(in_addr1),
@@ -552,7 +552,7 @@ fn benchmark_complex(c: &mut Criterion) {
                         let output_lines_sampled = CountReceiver::receive_lines(out_addr_sampled);
                         let output_lines_200 = CountReceiver::receive_lines(out_addr_200);
                         let output_lines_404 = CountReceiver::receive_lines(out_addr_404);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -72,7 +72,8 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -123,7 +124,8 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -174,7 +176,8 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -226,7 +229,8 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -302,7 +306,8 @@ fn benchmark_interconnected(c: &mut Criterion) {
                     let (output_lines1, output_lines2, topology) = rt.block_on(async move {
                         let output_lines1 = CountReceiver::receive_lines(out_addr1);
                         let output_lines2 = CountReceiver::receive_lines(out_addr2);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (output_lines1, output_lines2, topology)
@@ -374,7 +379,8 @@ fn benchmark_transforms(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -552,7 +558,8 @@ fn benchmark_complex(c: &mut Criterion) {
                         let output_lines_sampled = CountReceiver::receive_lines(out_addr_sampled);
                         let output_lines_200 = CountReceiver::receive_lines(out_addr_200);
                         let output_lines_404 = CountReceiver::receive_lines(out_addr_404);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -72,7 +72,7 @@ fn benchmark_simple_pipe(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -123,7 +123,7 @@ fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -174,7 +174,7 @@ fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -226,7 +226,7 @@ fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -302,7 +302,7 @@ fn benchmark_interconnected(c: &mut Criterion) {
                     let (output_lines1, output_lines2, topology) = rt.block_on(async move {
                         let output_lines1 = CountReceiver::receive_lines(out_addr1);
                         let output_lines2 = CountReceiver::receive_lines(out_addr2);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (output_lines1, output_lines2, topology)
@@ -374,7 +374,7 @@ fn benchmark_transforms(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -552,7 +552,7 @@ fn benchmark_complex(c: &mut Criterion) {
                         let output_lines_sampled = CountReceiver::receive_lines(out_addr_sampled);
                         let output_lines_200 = CountReceiver::receive_lines(out_addr_200);
                         let output_lines_404 = CountReceiver::receive_lines(out_addr_404);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr1).await;
                         wait_for_tcp(in_addr2).await;
                         (

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -24,7 +24,7 @@ fn benchmark_buffers(c: &mut Criterion) {
         Benchmark::new("in-memory", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -44,7 +44,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -64,7 +64,7 @@ fn benchmark_buffers(c: &mut Criterion) {
         .with_function("on-disk", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -84,7 +84,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -106,7 +106,7 @@ fn benchmark_buffers(c: &mut Criterion) {
         .with_function("low-limit-on-disk", move |b| {
             b.iter_with_setup(
                 || {
-                    let mut config = config::Config::empty();
+                    let mut config = config::Config::builder();
                     config.add_source(
                         "in",
                         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -126,7 +126,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config, false).await;
+                        let (topology, _crash) = start_topology(config.build(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -44,7 +44,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -84,7 +84,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -126,7 +126,7 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build(), false).await;
+                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -44,7 +44,8 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -84,7 +85,8 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });
@@ -126,7 +128,8 @@ fn benchmark_buffers(c: &mut Criterion) {
                     let mut rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {
                         let output_lines = CountReceiver::receive_lines(out_addr);
-                        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                        let (topology, _crash) =
+                            start_topology(config.build().unwrap(), false).await;
                         wait_for_tcp(in_addr).await;
                         (output_lines, topology)
                     });

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -57,7 +57,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let (topology, input) = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config.build(), false).await;
+                    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
                     let mut options = OpenOptions::new();
                     options.create(true).write(true);

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -42,7 +42,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
                 source.include.push(input.clone());
                 source.data_dir = Some(data_dir);
 
-                let mut config = config::Config::empty();
+                let mut config = config::Config::builder();
                 config.add_source("in", source);
                 config.add_sink(
                     "out",
@@ -57,7 +57,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let (topology, input) = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config, false).await;
+                    let (topology, _crash) = start_topology(config.build(), false).await;
 
                     let mut options = OpenOptions::new();
                     options.create(true).write(true);

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -24,7 +24,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
     let bench = Benchmark::new("http_no_compression", move |b| {
         b.iter_with_setup(
             || {
-                let mut config = config::Config::empty();
+                let mut config = config::Config::builder();
                 config.add_source(
                     "in",
                     sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -48,7 +48,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let topology = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config, false).await;
+                    let (topology, _crash) = start_topology(config.build(), false).await;
                     wait_for_tcp(in_addr).await;
                     topology
                 });
@@ -82,7 +82,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
     let bench = Benchmark::new("http_gzip", move |b| {
         b.iter_with_setup(
             || {
-                let mut config = config::Config::empty();
+                let mut config = config::Config::builder();
                 config.add_source(
                     "in",
                     sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -106,7 +106,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let topology = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config, false).await;
+                    let (topology, _crash) = start_topology(config.build(), false).await;
                     wait_for_tcp(in_addr).await;
                     topology
                 });

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -48,7 +48,7 @@ fn benchmark_http_no_compression(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let topology = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config.build(), false).await;
+                    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                     wait_for_tcp(in_addr).await;
                     topology
                 });
@@ -106,7 +106,7 @@ fn benchmark_http_gzip(c: &mut Criterion) {
 
                 let mut rt = runtime();
                 let topology = rt.block_on(async move {
-                    let (topology, _crash) = start_topology(config.build(), false).await;
+                    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
                     wait_for_tcp(in_addr).await;
                     topology
                 });

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,6 +1,6 @@
 use super::{
-    default_data_dir, Config, GlobalOptions, SinkConfig, SinkOuter, SourceConfig, TestDefinition,
-    TransformConfig, TransformOuter,
+    compiler, default_data_dir, Config, GlobalOptions, SinkConfig, SinkOuter, SourceConfig,
+    TestDefinition, TransformConfig, TransformOuter,
 };
 use crate::event;
 use indexmap::IndexMap;
@@ -34,16 +34,8 @@ impl Clone for ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    // TODO: compilation here
-    pub fn build(self) -> Config {
-        Config {
-            global: self.global,
-            sources: self.sources,
-            sinks: self.sinks,
-            transforms: self.transforms,
-            tests: self.tests,
-            expansions: Default::default(),
-        }
+    pub fn build(self) -> Result<Config, Vec<String>> {
+        compiler::compile(self)
     }
 
     pub fn add_source<S: SourceConfig + 'static>(&mut self, name: &str, source: S) {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -37,11 +37,16 @@ impl ConfigBuilder {
         compiler::compile(self)
     }
 
-    pub fn add_source<S: SourceConfig + 'static>(&mut self, name: &str, source: S) {
-        self.sources.insert(name.to_string(), Box::new(source));
+    pub fn add_source<S: SourceConfig + 'static, T: Into<String>>(&mut self, name: T, source: S) {
+        self.sources.insert(name.into(), Box::new(source));
     }
 
-    pub fn add_sink<S: SinkConfig + 'static>(&mut self, name: &str, inputs: &[&str], sink: S) {
+    pub fn add_sink<S: SinkConfig + 'static, T: Into<String>>(
+        &mut self,
+        name: T,
+        inputs: &[&str],
+        sink: S,
+    ) {
         let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
         let sink = SinkOuter {
             buffer: Default::default(),
@@ -50,12 +55,12 @@ impl ConfigBuilder {
             inputs,
         };
 
-        self.sinks.insert(name.to_string(), sink);
+        self.sinks.insert(name.into(), sink);
     }
 
-    pub fn add_transform<T: TransformConfig + 'static>(
+    pub fn add_transform<T: TransformConfig + 'static, S: Into<String>>(
         &mut self,
-        name: &str,
+        name: S,
         inputs: &[&str],
         transform: T,
     ) {
@@ -65,7 +70,7 @@ impl ConfigBuilder {
             inputs,
         };
 
-        self.transforms.insert(name.to_string(), transform);
+        self.transforms.insert(name.into(), transform);
     }
 
     pub fn append(&mut self, with: Self) -> Result<(), Vec<String>> {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -27,8 +27,8 @@ impl Clone for ConfigBuilder {
         // we first serialize it into JSON, then back from
         // JSON. Originally we used TOML here but TOML does not
         // support serializing `None`.
-        let json = serde_json::to_vec(self).unwrap();
-        serde_json::from_slice(&json[..]).unwrap()
+        let json = serde_json::to_value(self).unwrap();
+        serde_json::from_value(json).unwrap()
     }
 }
 

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,0 +1,158 @@
+use super::{
+    default_data_dir, Config, GlobalOptions, SinkConfig, SinkOuter, SourceConfig, TestDefinition,
+    TransformConfig, TransformOuter,
+};
+use crate::event;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigBuilder {
+    #[serde(flatten)]
+    pub global: GlobalOptions,
+    #[serde(default)]
+    pub sources: IndexMap<String, Box<dyn SourceConfig>>,
+    #[serde(default)]
+    pub sinks: IndexMap<String, SinkOuter>,
+    #[serde(default)]
+    pub transforms: IndexMap<String, TransformOuter>,
+    #[serde(default)]
+    pub tests: Vec<TestDefinition>,
+}
+
+impl Clone for ConfigBuilder {
+    fn clone(&self) -> Self {
+        // This is a hack around the issue of cloning
+        // trait objects. So instead to clone the config
+        // we first serialize it into JSON, then back from
+        // JSON. Originally we used TOML here but TOML does not
+        // support serializing `None`.
+        let json = serde_json::to_vec(self).unwrap();
+        serde_json::from_slice(&json[..]).unwrap()
+    }
+}
+
+impl ConfigBuilder {
+    // TODO: compilation here
+    pub fn build(self) -> Config {
+        Config {
+            global: self.global,
+            sources: self.sources,
+            sinks: self.sinks,
+            transforms: self.transforms,
+            tests: self.tests,
+            expansions: Default::default(),
+        }
+    }
+
+    pub fn add_source<S: SourceConfig + 'static>(&mut self, name: &str, source: S) {
+        self.sources.insert(name.to_string(), Box::new(source));
+    }
+
+    pub fn add_sink<S: SinkConfig + 'static>(&mut self, name: &str, inputs: &[&str], sink: S) {
+        let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
+        let sink = SinkOuter {
+            buffer: Default::default(),
+            healthcheck: true,
+            inner: Box::new(sink),
+            inputs,
+        };
+
+        self.sinks.insert(name.to_string(), sink);
+    }
+
+    pub fn add_transform<T: TransformConfig + 'static>(
+        &mut self,
+        name: &str,
+        inputs: &[&str],
+        transform: T,
+    ) {
+        let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
+        let transform = TransformOuter {
+            inner: Box::new(transform),
+            inputs,
+        };
+
+        self.transforms.insert(name.to_string(), transform);
+    }
+
+    pub fn append(&mut self, with: Self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if self.global.data_dir.is_none() || self.global.data_dir == default_data_dir() {
+            self.global.data_dir = with.global.data_dir;
+        } else if with.global.data_dir != default_data_dir()
+            && self.global.data_dir != with.global.data_dir
+        {
+            // If two configs both set 'data_dir' and have conflicting values
+            // we consider this an error.
+            errors.push("conflicting values for 'data_dir' found".to_owned());
+        }
+
+        // If the user has multiple config files, we must *merge* log schemas until we meet a
+        // conflict, then we are allowed to error.
+        let default_schema = event::LogSchema::default();
+        if with.global.log_schema != default_schema {
+            // If the set value is the default, override it. If it's already overridden, error.
+            if self.global.log_schema.host_key() != default_schema.host_key()
+                && self.global.log_schema.host_key() != with.global.log_schema.host_key()
+            {
+                errors.push("conflicting values for 'log_schema.host_key' found".to_owned());
+            } else {
+                self.global
+                    .log_schema
+                    .set_host_key(with.global.log_schema.host_key().clone());
+            }
+            if self.global.log_schema.message_key() != default_schema.message_key()
+                && self.global.log_schema.message_key() != with.global.log_schema.message_key()
+            {
+                errors.push("conflicting values for 'log_schema.message_key' found".to_owned());
+            } else {
+                self.global
+                    .log_schema
+                    .set_message_key(with.global.log_schema.message_key().clone());
+            }
+            if self.global.log_schema.timestamp_key() != default_schema.timestamp_key()
+                && self.global.log_schema.timestamp_key() != with.global.log_schema.timestamp_key()
+            {
+                errors.push("conflicting values for 'log_schema.timestamp_key' found".to_owned());
+            } else {
+                self.global
+                    .log_schema
+                    .set_timestamp_key(with.global.log_schema.timestamp_key().clone());
+            }
+        }
+
+        with.sources.keys().for_each(|k| {
+            if self.sources.contains_key(k) {
+                errors.push(format!("duplicate source name found: {}", k));
+            }
+        });
+        with.sinks.keys().for_each(|k| {
+            if self.sinks.contains_key(k) {
+                errors.push(format!("duplicate sink name found: {}", k));
+            }
+        });
+        with.transforms.keys().for_each(|k| {
+            if self.transforms.contains_key(k) {
+                errors.push(format!("duplicate transform name found: {}", k));
+            }
+        });
+        with.tests.iter().for_each(|wt| {
+            if self.tests.iter().any(|t| t.name == wt.name) {
+                errors.push(format!("duplicate test name found: {}", wt.name));
+            }
+        });
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        self.sources.extend(with.sources);
+        self.sinks.extend(with.sinks);
+        self.transforms.extend(with.transforms);
+        self.tests.extend(with.tests);
+
+        Ok(())
+    }
+}

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,0 +1,13 @@
+use super::{builder::ConfigBuilder, Config};
+
+pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
+    let initial = Config {
+        global: raw.global,
+        sources: raw.sources,
+        sinks: raw.sinks,
+        transforms: raw.transforms,
+        tests: raw.tests,
+        expansions: Default::default(),
+    };
+    Ok(initial)
+}

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -36,9 +36,8 @@ pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
     }
 }
 
-/// Some component configs can act like macros and expand themselves into
-/// multiple replacement configs. Returns a map of components to their
-/// expanded child names.
+/// Some component configs can act like macros and expand themselves into multiple replacement
+/// configs. Performs those expansions and records the relevant metadata.
 pub(super) fn expand_macros(config: &mut Config) -> Result<(), Vec<String>> {
     let mut expanded_transforms = IndexMap::new();
     let mut expansions = IndexMap::new();

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,7 +1,8 @@
-use super::{builder::ConfigBuilder, Config};
+use super::{builder::ConfigBuilder, validation, Config, TransformOuter};
+use indexmap::IndexMap;
 
 pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
-    let initial = Config {
+    let mut config = Config {
         global: raw.global,
         sources: raw.sources,
         sinks: raw.sinks,
@@ -9,5 +10,71 @@ pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
         tests: raw.tests,
         expansions: Default::default(),
     };
-    Ok(initial)
+
+    let mut errors = Vec::new();
+
+    if let Some(warnings) = validation::warnings(&config) {
+        for warning in warnings {
+            warn!(message = %warning)
+        }
+    }
+
+    if let Err(type_errors) = validation::check_shape(&config) {
+        errors.extend(type_errors);
+    }
+
+    if let Err(type_errors) = validation::typecheck(&config) {
+        errors.extend(type_errors);
+    }
+
+    expand_macros(&mut config)?;
+
+    if errors.is_empty() {
+        Ok(config)
+    } else {
+        Err(errors)
+    }
+}
+
+/// Some component configs can act like macros and expand themselves into
+/// multiple replacement configs. Returns a map of components to their
+/// expanded child names.
+pub(super) fn expand_macros(config: &mut Config) -> Result<(), Vec<String>> {
+    let mut expanded_transforms = IndexMap::new();
+    let mut expansions = IndexMap::new();
+    let mut errors = Vec::new();
+
+    while let Some((k, mut t)) = config.transforms.pop() {
+        if let Some(expanded) = match t.inner.expand() {
+            Ok(e) => e,
+            Err(err) => {
+                errors.push(format!("failed to expand transform '{}': {}", k, err));
+                continue;
+            }
+        } {
+            let mut children = Vec::new();
+            for (name, child) in expanded {
+                let full_name = format!("{}.{}", k, name);
+                expanded_transforms.insert(
+                    full_name.clone(),
+                    TransformOuter {
+                        inputs: t.inputs.clone(),
+                        inner: child,
+                    },
+                );
+                children.push(full_name);
+            }
+            expansions.insert(k.clone(), children);
+        } else {
+            expanded_transforms.insert(k, t);
+        }
+    }
+    config.transforms = expanded_transforms;
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        config.expansions = expansions;
+        Ok(())
+    }
 }

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -10,7 +10,7 @@ pub struct ConfigDiff {
 
 impl ConfigDiff {
     pub fn initial(initial: &Config) -> Self {
-        Self::new(&Config::empty(), initial)
+        Self::new(&Config::default(), initial)
     }
 
     pub fn new(old: &Config, new: &Config) -> Self {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1,4 +1,4 @@
-use super::{vars, Config};
+use super::{builder::ConfigBuilder, vars, Config};
 use glob::glob;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
@@ -80,7 +80,7 @@ pub fn load_from_str(input: &str) -> Result<Config, Vec<String>> {
 fn load_from_inputs(
     inputs: impl IntoIterator<Item = impl std::io::Read>,
 ) -> Result<Config, Vec<String>> {
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     let mut errors = Vec::new();
 
     for input in inputs {
@@ -89,6 +89,9 @@ fn load_from_inputs(
             errors.extend(errs.iter().map(|e| e.to_string()));
         }
     }
+
+    // TODO: this should be the last step
+    let mut config = config.build();
 
     if let Err(mut errs) = config.expand_macros() {
         errors.append(&mut errs);
@@ -116,7 +119,7 @@ fn open_config(path: &Path) -> Option<File> {
     }
 }
 
-fn load(mut input: impl std::io::Read) -> Result<Config, Vec<String>> {
+fn load(mut input: impl std::io::Read) -> Result<ConfigBuilder, Vec<String>> {
     let mut source_string = String::new();
     input
         .read_to_string(&mut source_string)

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -91,7 +91,7 @@ fn load_from_inputs(
     }
 
     // TODO: this should be the last step
-    let mut config = config.build();
+    let mut config = config.build()?;
 
     if let Err(mut errs) = config.expand_macros() {
         errors.append(&mut errs);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,13 +18,16 @@ mod compiler;
 pub mod component;
 mod diff;
 mod loading;
+mod unit_test;
 mod validation;
 mod vars;
 pub mod watcher;
 
+pub use builder::ConfigBuilder;
 pub use diff::ConfigDiff;
 pub use loading::{load_from_paths, load_from_str, process_paths, CONFIG_PATHS};
-pub use validation::check;
+pub use unit_test::build_unit_tests_main as build_unit_tests;
+pub use validation::warnings;
 
 #[derive(Debug, Default)]
 pub struct Config {
@@ -327,52 +330,6 @@ impl Config {
             .get(identifier)
             .cloned()
             .unwrap_or_else(|| vec![String::from(identifier)])
-    }
-
-    /// Some component configs can act like macros and expand themselves into
-    /// multiple replacement configs. Returns a map of components to their
-    /// expanded child names.
-    pub fn expand_macros(&mut self) -> Result<(), Vec<String>> {
-        let mut expanded_transforms = IndexMap::new();
-        let mut expansions = IndexMap::new();
-        let mut errors = Vec::new();
-
-        while let Some((k, mut t)) = self.transforms.pop() {
-            if let Some(expanded) = match t.inner.expand() {
-                Ok(e) => e,
-                Err(err) => {
-                    errors.push(format!("failed to expand transform '{}': {}", k, err));
-                    continue;
-                }
-            } {
-                let mut children = Vec::new();
-                for (name, child) in expanded {
-                    let full_name = format!("{}.{}", k, name);
-                    expanded_transforms.insert(
-                        full_name.clone(),
-                        TransformOuter {
-                            inputs: t.inputs.clone(),
-                            inner: child,
-                        },
-                    );
-                    children.push(full_name);
-                }
-                expansions.insert(k.clone(), children);
-            } else {
-                expanded_transforms.insert(k, t);
-            }
-        }
-        self.transforms = expanded_transforms;
-
-        if !errors.is_empty() {
-            Err(errors)
-        } else {
-            self.expansions = expansions;
-            Ok(())
-        }
-    }
-    pub fn typecheck(&self) -> Result<(), Vec<String>> {
-        validation::typecheck(self)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,6 +14,7 @@ use std::fs::DirBuilder;
 use std::path::PathBuf;
 
 mod builder;
+mod compiler;
 pub mod component;
 mod diff;
 mod loading;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,6 +13,7 @@ use snafu::{ResultExt, Snafu};
 use std::fs::DirBuilder;
 use std::path::PathBuf;
 
+mod builder;
 pub mod component;
 mod diff;
 mod loading;
@@ -24,20 +25,13 @@ pub use diff::ConfigDiff;
 pub use loading::{load_from_paths, load_from_str, process_paths, CONFIG_PATHS};
 pub use validation::check;
 
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Default)]
 pub struct Config {
-    #[serde(flatten)]
     pub global: GlobalOptions,
-    #[serde(default)]
     pub sources: IndexMap<String, Box<dyn SourceConfig>>,
-    #[serde(default)]
     pub sinks: IndexMap<String, SinkOuter>,
-    #[serde(default)]
     pub transforms: IndexMap<String, TransformOuter>,
-    #[serde(default)]
     pub tests: Vec<TestDefinition>,
-    #[serde(skip)]
     expansions: IndexMap<String, Vec<String>>,
 }
 
@@ -319,51 +313,9 @@ pub enum TestCondition {
     String(String),
 }
 
-// Helper methods for programming construction during tests
 impl Config {
-    pub fn empty() -> Self {
-        Self {
-            global: GlobalOptions {
-                data_dir: None,
-                log_schema: event::LogSchema::default(),
-            },
-            sources: IndexMap::new(),
-            sinks: IndexMap::new(),
-            transforms: IndexMap::new(),
-            tests: Vec::new(),
-            expansions: IndexMap::new(),
-        }
-    }
-
-    pub fn add_source<S: SourceConfig + 'static>(&mut self, name: &str, source: S) {
-        self.sources.insert(name.to_string(), Box::new(source));
-    }
-
-    pub fn add_sink<S: SinkConfig + 'static>(&mut self, name: &str, inputs: &[&str], sink: S) {
-        let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
-        let sink = SinkOuter {
-            buffer: Default::default(),
-            healthcheck: true,
-            inner: Box::new(sink),
-            inputs,
-        };
-
-        self.sinks.insert(name.to_string(), sink);
-    }
-
-    pub fn add_transform<T: TransformConfig + 'static>(
-        &mut self,
-        name: &str,
-        inputs: &[&str],
-        transform: T,
-    ) {
-        let inputs = inputs.iter().map(|&s| s.to_owned()).collect::<Vec<_>>();
-        let transform = TransformOuter {
-            inner: Box::new(transform),
-            inputs,
-        };
-
-        self.transforms.insert(name.to_string(), transform);
+    pub fn builder() -> builder::ConfigBuilder {
+        Default::default()
     }
 
     /// Expand a logical component name (i.e. from the config file) into the names of the
@@ -418,100 +370,8 @@ impl Config {
             Ok(())
         }
     }
-
-    pub fn append(&mut self, with: Self) -> Result<(), Vec<String>> {
-        let mut errors = Vec::new();
-
-        if self.global.data_dir.is_none() || self.global.data_dir == default_data_dir() {
-            self.global.data_dir = with.global.data_dir;
-        } else if with.global.data_dir != default_data_dir()
-            && self.global.data_dir != with.global.data_dir
-        {
-            // If two configs both set 'data_dir' and have conflicting values
-            // we consider this an error.
-            errors.push("conflicting values for 'data_dir' found".to_owned());
-        }
-
-        // If the user has multiple config files, we must *merge* log schemas until we meet a
-        // conflict, then we are allowed to error.
-        let default_schema = event::LogSchema::default();
-        if with.global.log_schema != default_schema {
-            // If the set value is the default, override it. If it's already overridden, error.
-            if self.global.log_schema.host_key() != default_schema.host_key()
-                && self.global.log_schema.host_key() != with.global.log_schema.host_key()
-            {
-                errors.push("conflicting values for 'log_schema.host_key' found".to_owned());
-            } else {
-                self.global
-                    .log_schema
-                    .set_host_key(with.global.log_schema.host_key().clone());
-            }
-            if self.global.log_schema.message_key() != default_schema.message_key()
-                && self.global.log_schema.message_key() != with.global.log_schema.message_key()
-            {
-                errors.push("conflicting values for 'log_schema.message_key' found".to_owned());
-            } else {
-                self.global
-                    .log_schema
-                    .set_message_key(with.global.log_schema.message_key().clone());
-            }
-            if self.global.log_schema.timestamp_key() != default_schema.timestamp_key()
-                && self.global.log_schema.timestamp_key() != with.global.log_schema.timestamp_key()
-            {
-                errors.push("conflicting values for 'log_schema.timestamp_key' found".to_owned());
-            } else {
-                self.global
-                    .log_schema
-                    .set_timestamp_key(with.global.log_schema.timestamp_key().clone());
-            }
-        }
-
-        with.sources.keys().for_each(|k| {
-            if self.sources.contains_key(k) {
-                errors.push(format!("duplicate source name found: {}", k));
-            }
-        });
-        with.sinks.keys().for_each(|k| {
-            if self.sinks.contains_key(k) {
-                errors.push(format!("duplicate sink name found: {}", k));
-            }
-        });
-        with.transforms.keys().for_each(|k| {
-            if self.transforms.contains_key(k) {
-                errors.push(format!("duplicate transform name found: {}", k));
-            }
-        });
-        with.tests.iter().for_each(|wt| {
-            if self.tests.iter().any(|t| t.name == wt.name) {
-                errors.push(format!("duplicate test name found: {}", wt.name));
-            }
-        });
-        if !errors.is_empty() {
-            return Err(errors);
-        }
-
-        self.sources.extend(with.sources);
-        self.sinks.extend(with.sinks);
-        self.transforms.extend(with.transforms);
-        self.tests.extend(with.tests);
-
-        Ok(())
-    }
-
     pub fn typecheck(&self) -> Result<(), Vec<String>> {
         validation::typecheck(self)
-    }
-}
-
-impl Clone for Config {
-    fn clone(&self) -> Self {
-        // This is a hack around the issue of cloning
-        // trait objects. So instead to clone the config
-        // we first serialize it into JSON, then back from
-        // JSON. Originally we used TOML here but TOML does not
-        // support serializing `None`.
-        let json = serde_json::to_vec(self).unwrap();
-        serde_json::from_slice(&json[..]).unwrap()
     }
 }
 
@@ -526,12 +386,12 @@ fn healthcheck_default() -> bool {
     feature = "transforms-json_parser"
 ))]
 mod test {
-    use super::Config;
+    use super::{builder::ConfigBuilder, load_from_str};
     use std::path::PathBuf;
 
     #[test]
     fn default_data_dir() {
-        let config: Config = toml::from_str(
+        let config = load_from_str(
             r#"
       [sources.in]
       type = "file"
@@ -553,7 +413,7 @@ mod test {
 
     #[test]
     fn default_schema() {
-        let config: Config = toml::from_str(
+        let config = load_from_str(
             r#"
       [sources.in]
       type = "file"
@@ -580,7 +440,7 @@ mod test {
 
     #[test]
     fn custom_schema() {
-        let config: Config = toml::from_str(
+        let config = load_from_str(
             r#"
       [log_schema]
       host_key = "this"
@@ -606,7 +466,7 @@ mod test {
 
     #[test]
     fn config_append() {
-        let mut config: Config = toml::from_str(
+        let mut config: ConfigBuilder = toml::from_str(
             r#"
       [sources.in]
       type = "file"
@@ -657,7 +517,7 @@ mod test {
 
     #[test]
     fn config_append_collisions() {
-        let mut config: Config = toml::from_str(
+        let mut config: ConfigBuilder = toml::from_str(
             r#"
       [sources.in]
       type = "file"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,7 +35,7 @@ pub struct Config {
     pub sources: IndexMap<String, Box<dyn SourceConfig>>,
     pub sinks: IndexMap<String, SinkOuter>,
     pub transforms: IndexMap<String, TransformOuter>,
-    pub tests: Vec<TestDefinition>,
+    tests: Vec<TestDefinition>,
     expansions: IndexMap<String, Vec<String>>,
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,9 +1,8 @@
 use super::{Config, DataType};
 use std::collections::HashMap;
 
-pub fn check(config: &Config) -> Result<Vec<String>, Vec<String>> {
+pub fn check_shape(config: &Config) -> Result<(), Vec<String>> {
     let mut errors = vec![];
-    let mut warnings = vec![];
 
     if config.sources.is_empty() {
         errors.push("No sources defined in the config.".to_owned());
@@ -40,6 +39,16 @@ pub fn check(config: &Config) -> Result<Vec<String>, Vec<String>> {
         }
     }
 
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+pub fn warnings(config: &Config) -> Option<Vec<String>> {
+    let mut warnings = vec![];
+
     let source_names = config.sources.keys().map(|name| ("source", name.clone()));
     let transform_names = config
         .transforms
@@ -63,14 +72,10 @@ pub fn check(config: &Config) -> Result<Vec<String>, Vec<String>> {
         }
     }
 
-    if let Err(type_errors) = config.typecheck() {
-        errors.extend(type_errors);
-    }
-
-    if errors.is_empty() {
-        Ok(warnings)
+    if warnings.is_empty() {
+        None
     } else {
-        Err(errors)
+        Some(warnings)
     }
 }
 

--- a/src/event/log_schema.rs
+++ b/src/event/log_schema.rs
@@ -1,0 +1,66 @@
+use getset::{Getters, Setters};
+use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
+
+pub static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
+
+lazy_static! {
+    static ref LOG_SCHEMA_DEFAULT: LogSchema = LogSchema {
+        message_key: Atom::from("message"),
+        timestamp_key: Atom::from("timestamp"),
+        host_key: Atom::from("host"),
+        source_type_key: Atom::from("source_type"),
+    };
+}
+
+pub fn log_schema() -> &'static LogSchema {
+    LOG_SCHEMA.get().unwrap_or(&LOG_SCHEMA_DEFAULT)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Getters, Setters)]
+#[serde(default)]
+pub struct LogSchema {
+    #[serde(default = "LogSchema::default_message_key")]
+    #[getset(get = "pub", set = "pub(crate)")]
+    message_key: Atom,
+    #[serde(default = "LogSchema::default_timestamp_key")]
+    #[getset(get = "pub", set = "pub(crate)")]
+    timestamp_key: Atom,
+    #[serde(default = "LogSchema::default_host_key")]
+    #[getset(get = "pub", set = "pub(crate)")]
+    host_key: Atom,
+    #[serde(default = "LogSchema::default_source_type_key")]
+    #[getset(get = "pub", set = "pub(crate)")]
+    source_type_key: Atom,
+}
+
+impl Default for LogSchema {
+    fn default() -> Self {
+        LogSchema {
+            message_key: Atom::from("message"),
+            timestamp_key: Atom::from("timestamp"),
+            host_key: Atom::from("host"),
+            source_type_key: Atom::from("source_type"),
+        }
+    }
+}
+
+impl LogSchema {
+    fn default_message_key() -> Atom {
+        Atom::from("message")
+    }
+
+    fn default_timestamp_key() -> Atom {
+        Atom::from("timestamp")
+    }
+
+    fn default_host_key() -> Atom {
+        Atom::from("host")
+    }
+
+    fn default_source_type_key() -> Atom {
+        Atom::from("source_type")
+    }
+}

--- a/src/event/log_schema.rs
+++ b/src/event/log_schema.rs
@@ -7,12 +7,7 @@ use string_cache::DefaultAtom as Atom;
 pub static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
 
 lazy_static! {
-    static ref LOG_SCHEMA_DEFAULT: LogSchema = LogSchema {
-        message_key: Atom::from("message"),
-        timestamp_key: Atom::from("timestamp"),
-        host_key: Atom::from("host"),
-        source_type_key: Atom::from("source_type"),
-    };
+    static ref LOG_SCHEMA_DEFAULT: LogSchema = LogSchema::default();
 }
 
 pub fn log_schema() -> &'static LogSchema {
@@ -39,10 +34,10 @@ pub struct LogSchema {
 impl Default for LogSchema {
     fn default() -> Self {
         LogSchema {
-            message_key: Atom::from("message"),
-            timestamp_key: Atom::from("timestamp"),
-            host_key: Atom::from("host"),
-            source_type_key: Atom::from("source_type"),
+            message_key: Self::default_message_key(),
+            timestamp_key: Self::default_timestamp_key(),
+            host_key: Self::default_host_key(),
+            source_type_key: Self::default_source_type_key(),
         }
     }
 }
@@ -62,5 +57,40 @@ impl LogSchema {
 
     fn default_source_type_key() -> Atom {
         Atom::from("source_type")
+    }
+
+    pub fn merge(&mut self, other: LogSchema) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if other != *LOG_SCHEMA_DEFAULT {
+            // If the set value is the default, override it. If it's already overridden, error.
+            if self.host_key() != LOG_SCHEMA_DEFAULT.host_key()
+                && self.host_key() != other.host_key()
+            {
+                errors.push("conflicting values for 'log_schema.host_key' found".to_owned());
+            } else {
+                self.set_host_key(other.host_key().clone());
+            }
+            if self.message_key() != LOG_SCHEMA_DEFAULT.message_key()
+                && self.message_key() != other.message_key()
+            {
+                errors.push("conflicting values for 'log_schema.message_key' found".to_owned());
+            } else {
+                self.set_message_key(other.message_key().clone());
+            }
+            if self.timestamp_key() != LOG_SCHEMA_DEFAULT.timestamp_key()
+                && self.timestamp_key() != other.timestamp_key()
+            {
+                errors.push("conflicting values for 'log_schema.timestamp_key' found".to_owned());
+            } else {
+                self.set_timestamp_key(other.timestamp_key().clone());
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
             .expect("Couldn't set schema");
 
         let diff = ConfigDiff::initial(&config);
-        let pieces = topology::validate(&config, &diff).await.unwrap_or_else(|| {
+        let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap_or_else(|| {
             std::process::exit(exitcode::CONFIG);
         });
 

--- a/src/sinks/util/auto_concurrency/tests.rs
+++ b/src/sinks/util/auto_concurrency/tests.rs
@@ -250,12 +250,12 @@ async fn run_test4(
     let stats = Arc::clone(&test_config.stats);
     let cstats = Arc::clone(&test_config.controller_stats);
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     let generator = GeneratorConfig::repeat(vec!["line 1".into()], lines, interval);
     config.add_source("in", generator);
     config.add_sink("out", &["in"], test_config);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let controller = get_controller().unwrap();
 

--- a/src/sinks/util/auto_concurrency/tests.rs
+++ b/src/sinks/util/auto_concurrency/tests.rs
@@ -255,7 +255,7 @@ async fn run_test4(
     config.add_source("in", generator);
     config.add_sink("out", &["in"], test_config);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let controller = get_controller().unwrap();
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -405,7 +405,7 @@ mod tests {
         let global_dir = tempdir().unwrap();
         let local_dir = tempdir().unwrap();
 
-        let mut config = Config::empty();
+        let mut config = Config::default();
         config.global.data_dir = global_dir.into_path().into();
 
         // local path given -- local should win

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -226,7 +226,7 @@ mod test {
             },
         );
 
-        let (topology, _crash) = start_topology(config.build(), false).await;
+        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
         delay_for(Duration::from_secs(1)).await;
 
         let response = Client::new()

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -207,7 +207,7 @@ mod test {
             }
         });
 
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source(
             "in",
             PrometheusConfig {
@@ -226,7 +226,7 @@ mod test {
             },
         );
 
-        let (topology, _crash) = start_topology(config, false).await;
+        let (topology, _crash) = start_topology(config.build(), false).await;
         delay_for(Duration::from_secs(1)).await;
 
         let response = Client::new()

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -141,7 +141,7 @@ mod test {
             },
         );
 
-        let (topology, _crash) = start_topology(config.build(), false).await;
+        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
         let bind_addr = next_addr();
         let socket = std::net::UdpSocket::bind(&bind_addr).unwrap();

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -128,7 +128,7 @@ mod test {
         let in_addr = next_addr();
         let out_addr = next_addr();
 
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source("in", StatsdConfig { address: in_addr });
         config.add_sink(
             "out",
@@ -141,7 +141,7 @@ mod test {
             },
         );
 
-        let (topology, _crash) = start_topology(config, false).await;
+        let (topology, _crash) = start_topology(config.build(), false).await;
 
         let bind_addr = next_addr();
         let socket = std::net::UdpSocket::bind(&bind_addr).unwrap();

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -463,7 +463,7 @@ pub async fn start_topology(
     require_healthy: bool,
 ) -> (RunningTopology, mpsc::UnboundedReceiver<()>) {
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::validate(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
     topology::start_validated(config, diff, pieces, require_healthy)
         .await
         .unwrap()

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -704,7 +704,7 @@ mod reload_tests {
         );
 
         let mut new_config = Config::builder();
-        old_config.add_source("in1", SplunkConfig::on(address));
+        new_config.add_source("in1", SplunkConfig::on(address));
         new_config.add_source("in2", SplunkConfig::on(address));
         new_config.add_sink(
             "out",
@@ -716,7 +716,10 @@ mod reload_tests {
         );
 
         let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
-        assert!(new_config.build().is_err());
+        assert!(!topology
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
+            .await
+            .unwrap());
     }
 
     #[tokio::test]

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -650,12 +650,12 @@ mod tests {
         old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());
         let mut new_config = old_config.clone();
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
 
         new_config.global.data_dir = Some(Path::new("/qwerty").to_path_buf());
 
         topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap();
 
@@ -702,9 +702,9 @@ mod reload_tests {
             },
         );
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
         assert!(topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap());
     }
@@ -736,9 +736,9 @@ mod reload_tests {
             },
         );
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
         assert!(!topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap());
     }
@@ -758,9 +758,9 @@ mod reload_tests {
             },
         );
 
-        let (mut topology, _crash) = start_topology(old_config.clone().build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.clone().build().unwrap(), false).await;
         assert!(topology
-            .reload_config_and_respawn(old_config.build(), false)
+            .reload_config_and_respawn(old_config.build().unwrap(), false)
             .await
             .unwrap());
     }
@@ -791,7 +791,7 @@ mod source_finished_tests {
             },
         );
 
-        let (topology, _crash) = start_topology(old_config.build(), false).await;
+        let (topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
 
         timeout(Duration::from_secs(2), topology.sources_finished().compat())
             .await
@@ -895,7 +895,7 @@ mod transient_state_tests {
         );
         new_config.add_sink("out1", &["trans"], BlackholeConfig { print_amount: 1000 });
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
 
         trigger_old.cancel();
 
@@ -903,7 +903,7 @@ mod transient_state_tests {
         finished.compat().await.unwrap();
 
         assert!(topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap());
     }
@@ -937,9 +937,9 @@ mod transient_state_tests {
         );
         new_config.add_sink("out1", &["trans"], BlackholeConfig { print_amount: 1000 });
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
         assert!(topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap());
     }
@@ -981,9 +981,9 @@ mod transient_state_tests {
         );
         new_config.add_sink("out1", &["trans1"], BlackholeConfig { print_amount: 1000 });
 
-        let (mut topology, _crash) = start_topology(old_config.build(), false).await;
+        let (mut topology, _crash) = start_topology(old_config.build().unwrap(), false).await;
         assert!(topology
-            .reload_config_and_respawn(new_config.build(), false)
+            .reload_config_and_respawn(new_config.build().unwrap(), false)
             .await
             .unwrap());
     }

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,4 +1,4 @@
-use crate::{config, topology::unit_test::UnitTest};
+use crate::config;
 use colored::*;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -9,17 +9,6 @@ pub struct Opts {
     /// Any number of Vector config files to test. If none are specified the
     /// default config path `/etc/vector/vector.toml` will be targeted.
     paths: Vec<PathBuf>,
-}
-
-fn build_tests(path: PathBuf) -> Result<Vec<UnitTest>, Vec<String>> {
-    let mut config = config::load_from_paths(&[path])?;
-
-    // Ignore failures on calls other than the first
-    crate::event::LOG_SCHEMA
-        .set(config.global.log_schema.clone())
-        .ok();
-
-    crate::topology::unit_test::build_unit_tests(&mut config)
 }
 
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
@@ -36,7 +25,7 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             println!();
         }
         println!("Running {} tests", path_str);
-        match build_tests(path.clone()) {
+        match config::build_unit_tests(path.clone()) {
             Ok(mut tests) => {
                 let mut aggregated_test_errors = Vec::new();
                 let mut aggregated_test_inspections = Vec::new();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -11,20 +11,9 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
-    /// Disables topology check
-    #[structopt(long)]
-    no_topology: bool,
-
     /// Disables environment checks. That includes component checks and health checks.
     #[structopt(long)]
     no_environment: bool,
-
-    /// Shorthand for `--no-topology` and `--no-environment` flags. Just `-n` won't disable anything,
-    /// it needs to be used with `t` for `--no-topology`, and or `e` for `--no-environment` in any order.
-    /// Example:
-    /// `-nte` and `-net` both mean `--no-topology` and `--no-environment`
-    #[structopt(short, parse(from_str = NoCheck::from_str), possible_values = &["","t", "e","et","te"], default_value="")]
-    no: NoCheck,
 
     /// Fail validation on warnings
     #[structopt(short, long)]
@@ -33,21 +22,6 @@ pub struct Opts {
     /// Any number of Vector config files to validate. If none are specified the
     /// default config path `/etc/vector/vector.toml` will be targeted.
     paths: Vec<PathBuf>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct NoCheck {
-    topology: bool,
-    environment: bool,
-}
-
-impl NoCheck {
-    fn from_str(s: &str) -> Self {
-        Self {
-            topology: s.find('t').is_some(),
-            environment: s.find('e').is_some(),
-        }
-    }
 }
 
 /// Performs topology, component, and health checks.
@@ -61,7 +35,7 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
         None => return exitcode::CONFIG,
     };
 
-    if !(opts.no_environment || opts.no.environment) {
+    if !opts.no_environment {
         validated &= validate_environment(&config, &mut fmt).await;
     }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -61,10 +61,6 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
         None => return exitcode::CONFIG,
     };
 
-    if !(opts.no_topology || opts.no.topology) {
-        validated &= validate_topology(opts, &config, &mut fmt);
-    }
-
     if !(opts.no_environment || opts.no.environment) {
         validated &= validate_environment(&config, &mut fmt).await;
     }
@@ -97,31 +93,6 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
             fmt.title(format!("Failed to load {:?}", paths));
             fmt.sub_error(errors);
             None
-        }
-    }
-}
-
-fn validate_topology(opts: &Opts, config: &Config, fmt: &mut Formatter) -> bool {
-    match config::check(config) {
-        Ok(warnings) => {
-            if warnings.is_empty() {
-                fmt.success("Configuration topology");
-                true
-            } else if opts.deny_warnings {
-                fmt.title("Topology errors");
-                fmt.sub_error(warnings);
-                false
-            } else {
-                fmt.title("Topology warnings");
-                fmt.sub_warning(warnings);
-                fmt.success("Configuration topology");
-                true
-            }
-        }
-        Err(errors) => {
-            fmt.title("Topology errors");
-            fmt.sub_error(errors);
-            false
         }
     }
 }
@@ -287,14 +258,6 @@ impl Formatter {
         I::Item: fmt::Display,
     {
         self.sub(self.error_intro.clone(), errors)
-    }
-
-    /// A list of warnings that go with a title.
-    fn sub_warning<I: IntoIterator>(&mut self, warnings: I)
-    where
-        I::Item: fmt::Display,
-    {
-        self.sub(self.warning_intro.clone(), warnings)
     }
 
     fn sub<I: IntoIterator>(&mut self, intro: impl AsRef<str>, msgs: I)

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -49,7 +49,7 @@ fn test_buffering() {
     let (in_tx, source_config, source_event_counter) = support::source_with_event_counter();
     let sink_config = support::sink_dead();
     let config = {
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source("in", source_config);
         config.add_sink("out", &["in"], sink_config);
         config.sinks["out"].buffer = BufferConfig::Disk {
@@ -57,7 +57,7 @@ fn test_buffering() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir.clone());
-        config
+        config.build()
     };
 
     let mut rt = runtime();
@@ -98,7 +98,7 @@ fn test_buffering() {
     let (in_tx, source_config) = support::source();
     let (out_rx, sink_config) = support::sink(10);
     let config = {
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source("in", source_config);
         config.add_sink("out", &["in"], sink_config);
         config.sinks["out"].buffer = BufferConfig::Disk {
@@ -106,7 +106,7 @@ fn test_buffering() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir);
-        config
+        config.build()
     };
 
     let mut rt = runtime();
@@ -160,7 +160,7 @@ fn test_max_size() {
     let (in_tx, source_config, source_event_counter) = support::source_with_event_counter();
     let sink_config = support::sink_dead();
     let config = {
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source("in", source_config);
         config.add_sink("out", &["in"], sink_config);
         config.sinks["out"].buffer = BufferConfig::Disk {
@@ -168,7 +168,7 @@ fn test_max_size() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir.clone());
-        config
+        config.build()
     };
 
     let mut rt = runtime();
@@ -208,7 +208,7 @@ fn test_max_size() {
     let (_in_tx, source_config) = support::source();
     let (out_rx, sink_config) = support::sink(10);
     let config = {
-        let mut config = config::Config::empty();
+        let mut config = config::Config::builder();
         config.add_source("in", source_config);
         config.add_sink("out", &["in"], sink_config);
         config.sinks["out"].buffer = BufferConfig::Disk {
@@ -216,7 +216,7 @@ fn test_max_size() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir);
-        config
+        config.build()
     };
 
     let mut rt = runtime();

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -57,7 +57,7 @@ fn test_buffering() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir.clone());
-        config.build()
+        config.build().unwrap()
     };
 
     let mut rt = runtime();
@@ -106,7 +106,7 @@ fn test_buffering() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir);
-        config.build()
+        config.build().unwrap()
     };
 
     let mut rt = runtime();
@@ -168,7 +168,7 @@ fn test_max_size() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir.clone());
-        config.build()
+        config.build().unwrap()
     };
 
     let mut rt = runtime();
@@ -216,7 +216,7 @@ fn test_max_size() {
             when_full: Default::default(),
         };
         config.global.data_dir = Some(data_dir);
-        config.build()
+        config.build().unwrap()
     };
 
     let mut rt = runtime();

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -8,14 +8,12 @@ async fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
         Ok(c) => {
             let diff = ConfigDiff::initial(&c);
             match (
-                config::check(&c),
+                config::warnings(&c),
                 topology::builder::build_pieces(&c, &diff).await,
             ) {
-                (Ok(warnings), Ok(_new_pieces)) => Ok(warnings),
-                (Err(t_errors), Err(p_errors)) => {
-                    Err(t_errors.into_iter().chain(p_errors).collect())
-                }
-                (Err(errors), Ok(_)) | (Ok(_), Err(errors)) => Err(errors),
+                (Some(warnings), Ok(_pieces)) => Ok(warnings),
+                (None, Ok(_pieces)) => Ok(vec![]),
+                (_, Err(errors)) => Err(errors),
             }
         }
         Err(error) => Err(error),

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -70,7 +70,7 @@ async fn test_sink_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = start_topology(config.build(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -150,7 +150,7 @@ async fn test_sink_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, crash) = start_topology(config.build(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -216,7 +216,7 @@ async fn test_source_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, crash) = start_topology(config.build(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -285,7 +285,7 @@ async fn test_source_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = start_topology(config.build(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -55,7 +55,7 @@ async fn test_sink_panic() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -70,7 +70,7 @@ async fn test_sink_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = start_topology(config, false).await;
+    let (topology, crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -136,7 +136,7 @@ async fn test_sink_error() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -150,7 +150,7 @@ async fn test_sink_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, crash) = start_topology(config, false).await;
+    let (topology, crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -202,7 +202,7 @@ async fn test_source_error() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -216,7 +216,7 @@ async fn test_source_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, crash) = start_topology(config, false).await;
+    let (topology, crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;
@@ -270,7 +270,7 @@ async fn test_source_panic() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -285,7 +285,7 @@ async fn test_source_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, crash) = start_topology(config, false).await;
+    let (topology, crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
     delay_for(Duration::from_millis(100)).await;

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -39,7 +39,7 @@ async fn test_tcp_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -92,7 +92,7 @@ async fn test_unix_stream_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     // Wait for server to accept traffic
     while std::os::unix::net::UnixStream::connect(&in_path).is_err() {
@@ -155,7 +155,7 @@ async fn test_octet_counting_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -27,7 +27,7 @@ async fn test_tcp_syslog() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         SyslogConfig::new(Mode::Tcp {
@@ -39,7 +39,7 @@ async fn test_tcp_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -81,7 +81,7 @@ async fn test_unix_stream_syslog() {
     let in_path = tempfile::tempdir().unwrap().into_path().join("stream_test");
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         SyslogConfig::new(Mode::Unix {
@@ -92,7 +92,7 @@ async fn test_unix_stream_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     // Wait for server to accept traffic
     while std::os::unix::net::UnixStream::connect(&in_path).is_err() {
@@ -143,7 +143,7 @@ async fn test_octet_counting_syslog() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         SyslogConfig::new(Mode::Tcp {
@@ -155,7 +155,7 @@ async fn test_octet_counting_syslog() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -23,7 +23,7 @@ async fn pipe() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -36,7 +36,7 @@ async fn pipe() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -61,7 +61,7 @@ async fn sample() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -83,7 +83,7 @@ async fn sample() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -118,7 +118,7 @@ async fn fork() {
     let out_addr1 = next_addr();
     let out_addr2 = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -137,7 +137,7 @@ async fn fork() {
     let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
     let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -172,7 +172,7 @@ async fn merge_and_fork() {
 
     // out1 receives both in1 and in2
     // out2 receives in2 only
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in1",
         sources::socket::SocketConfig::make_tcp_config(in_addr1),
@@ -195,7 +195,7 @@ async fn merge_and_fork() {
     let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
     let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr1).await;
     wait_for_tcp(in_addr2).await;
@@ -245,7 +245,7 @@ async fn reconnect() {
     let in_addr = next_addr();
     let out_addr = next_addr();
 
-    let mut config = config::Config::empty();
+    let mut config = config::Config::builder();
     config.add_source(
         "in",
         sources::socket::SocketConfig::make_tcp_config(in_addr),
@@ -258,7 +258,7 @@ async fn reconnect() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -36,7 +36,7 @@ async fn pipe() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -83,7 +83,7 @@ async fn sample() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -137,7 +137,7 @@ async fn fork() {
     let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
     let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 
@@ -195,7 +195,7 @@ async fn merge_and_fork() {
     let mut output_lines1 = CountReceiver::receive_lines(out_addr1);
     let mut output_lines2 = CountReceiver::receive_lines(out_addr2);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr1).await;
     wait_for_tcp(in_addr2).await;
@@ -258,7 +258,7 @@ async fn reconnect() {
 
     let output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
     // Wait for server to accept traffic
     wait_for_tcp(in_addr).await;
 

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -496,7 +496,7 @@ async fn topology_swap_transform_is_atomic() {
 async fn topology_required_healthcheck_fails_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::validate(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
     assert!(topology::start_validated(config, diff, pieces, true)
         .await
         .is_none());
@@ -506,7 +506,7 @@ async fn topology_required_healthcheck_fails_start() {
 async fn topology_optional_healthcheck_does_not_fail_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::validate(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
     assert!(topology::start_validated(config, diff, pieces, false)
         .await
         .is_some());

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -21,17 +21,17 @@ use vector::{
 };
 
 fn basic_config() -> Config {
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink(10).1);
-    config
+    config.build()
 }
 
 fn basic_config_with_sink_failing_healthcheck() -> Config {
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink_failing_healthcheck(10).1);
-    config
+    config.build()
 }
 
 fn into_message(event: Event) -> String {
@@ -53,12 +53,12 @@ async fn topology_shutdown_while_active() {
     let transform1 = transform(" transformed", 0.0);
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_transform("t1", &["in1"], transform1);
     config.add_sink("out1", &["t1"], sink1);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let pump_handle = tokio::spawn(async move {
         iter_ok::<_, SendError<vector::event::Event>>(iter::from_fn(move || {
@@ -104,11 +104,11 @@ async fn topology_source_and_sink() {
     let (in1, source1) = source();
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let event = Event::from("this");
     in1.send(event.clone()).compat().await.unwrap();
@@ -126,12 +126,12 @@ async fn topology_multiple_sources() {
     let (in2, source2) = source();
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_source("in2", source2);
     config.add_sink("out1", &["in1", "in2"], sink1);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let event1 = Event::from("this");
     let event2 = Event::from("that");
@@ -156,12 +156,12 @@ async fn topology_multiple_sinks() {
     let (out1, sink1) = sink(10);
     let (out2, sink2) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
     config.add_sink("out2", &["in1"], sink2);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let event = Event::from("this");
 
@@ -183,13 +183,13 @@ async fn topology_transform_chain() {
     let transform2 = transform(" second", 0.0);
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_transform("t1", &["in1"], transform1);
     config.add_transform("t2", &["t1"], transform2);
     config.add_sink("out1", &["t2"], sink1);
 
-    let (topology, _crash) = start_topology(config, false).await;
+    let (topology, _crash) = start_topology(config.build(), false).await;
 
     let event = Event::from("this");
 
@@ -208,21 +208,21 @@ async fn topology_remove_one_source() {
     let (in2, source2) = source();
     let (_out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_source("in2", source2);
     config.add_sink("out1", &["in1", "in2"], sink1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink1);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -245,19 +245,19 @@ async fn topology_remove_one_sink() {
     let (out1, sink1) = sink(10);
     let (out2, sink2) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
     config.add_sink("out2", &["in1"], sink2);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -281,23 +281,23 @@ async fn topology_remove_one_transform() {
     let transform2 = transform(" transformed", 0.0);
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_transform("t1", &["in1"], transform1);
     config.add_transform("t2", &["t1"], transform2);
     config.add_sink("out1", &["t2"], sink1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
     let transform2 = transform(" transformed", 0.0);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_transform("t2", &["in1"], transform2);
     config.add_sink("out1", &["t2"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -315,21 +315,21 @@ async fn topology_swap_source() {
     let (in1, source1) = source();
     let (out1v1, sink1v1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1v1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
     let (in2, source2) = source();
     let (out1v2, sink1v2) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in2", source2);
     config.add_sink("out1", &["in2"], sink1v2);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -355,20 +355,20 @@ async fn topology_swap_sink() {
     let (in1, source1) = source();
     let (out1, sink1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
     let (out2, sink2) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out2", &["in1"], sink2);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -392,23 +392,23 @@ async fn topology_swap_transform() {
     let transform1 = transform(" transformed", 0.0);
     let (out1v1, sink1v1) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_transform("t1", &["in1"], transform1);
     config.add_sink("out1", &["t1"], sink1v1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
     let transform2 = transform(" replaced", 0.0);
     let (out1v2, sink1v2) = sink(10);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_transform("t2", &["in1"], transform2);
     config.add_sink("out1", &["t2"], sink1v2);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
 
@@ -460,23 +460,23 @@ async fn topology_swap_transform_is_atomic() {
     let h_out = tokio::spawn(output.compat());
     let h_in = tokio::spawn(input.compat());
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source1);
     config.add_transform("t1", &["in1"], transform1v1);
     config.add_sink("out1", &["t1"], sink1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
     delay_for(Duration::from_millis(10)).await;
 
     let transform1v2 = transform(" replaced", 0.0);
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_transform("t1", &["in1"], transform1v2);
     config.add_sink("out1", &["t1"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config, false)
+        .reload_config_and_respawn(config.build(), false)
         .await
         .unwrap());
     delay_for(Duration::from_millis(10)).await;
@@ -537,22 +537,22 @@ async fn topology_healthcheck_not_run_on_unchanged_reload() {
 
 #[tokio::test]
 async fn topology_healthcheck_run_for_changes_on_reload() {
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     // We can't just drop the sender side since that will close the source.
     let (_ch0, src) = source();
     config.add_source("in1", src);
     config.add_sink("out1", &["in1"], sink(10).1);
 
-    let (mut topology, _crash) = start_topology(config, false).await;
+    let (mut topology, _crash) = start_topology(config.build(), false).await;
 
-    let mut config = Config::empty();
+    let mut config = Config::builder();
     // We can't just drop the sender side since that will close the source.
     let (_ch1, src) = source();
     config.add_source("in1", src);
     config.add_sink("out2", &["in1"], sink_failing_healthcheck(10).1);
 
     assert!(!topology
-        .reload_config_and_respawn(config, true)
+        .reload_config_and_respawn(config.build(), true)
         .await
         .unwrap());
 }

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -24,14 +24,14 @@ fn basic_config() -> Config {
     let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink(10).1);
-    config.build()
+    config.build().unwrap()
 }
 
 fn basic_config_with_sink_failing_healthcheck() -> Config {
     let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink_failing_healthcheck(10).1);
-    config.build()
+    config.build().unwrap()
 }
 
 fn into_message(event: Event) -> String {
@@ -58,7 +58,7 @@ async fn topology_shutdown_while_active() {
     config.add_transform("t1", &["in1"], transform1);
     config.add_sink("out1", &["t1"], sink1);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let pump_handle = tokio::spawn(async move {
         iter_ok::<_, SendError<vector::event::Event>>(iter::from_fn(move || {
@@ -108,7 +108,7 @@ async fn topology_source_and_sink() {
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let event = Event::from("this");
     in1.send(event.clone()).compat().await.unwrap();
@@ -131,7 +131,7 @@ async fn topology_multiple_sources() {
     config.add_source("in2", source2);
     config.add_sink("out1", &["in1", "in2"], sink1);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let event1 = Event::from("this");
     let event2 = Event::from("that");
@@ -161,7 +161,7 @@ async fn topology_multiple_sinks() {
     config.add_sink("out1", &["in1"], sink1);
     config.add_sink("out2", &["in1"], sink2);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let event = Event::from("this");
 
@@ -189,7 +189,7 @@ async fn topology_transform_chain() {
     config.add_transform("t2", &["t1"], transform2);
     config.add_sink("out1", &["t2"], sink1);
 
-    let (topology, _crash) = start_topology(config.build(), false).await;
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let event = Event::from("this");
 
@@ -213,7 +213,7 @@ async fn topology_remove_one_source() {
     config.add_source("in2", source2);
     config.add_sink("out1", &["in1", "in2"], sink1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let (out1, sink1) = sink(10);
 
@@ -222,7 +222,7 @@ async fn topology_remove_one_source() {
     config.add_sink("out1", &["in1"], sink1);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -250,14 +250,14 @@ async fn topology_remove_one_sink() {
     config.add_sink("out1", &["in1"], sink1);
     config.add_sink("out2", &["in1"], sink2);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let mut config = Config::builder();
     config.add_source("in1", source().1);
     config.add_sink("out1", &["in1"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -287,7 +287,7 @@ async fn topology_remove_one_transform() {
     config.add_transform("t2", &["t1"], transform2);
     config.add_sink("out1", &["t2"], sink1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let transform2 = transform(" transformed", 0.0);
 
@@ -297,7 +297,7 @@ async fn topology_remove_one_transform() {
     config.add_sink("out1", &["t2"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -319,7 +319,7 @@ async fn topology_swap_source() {
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1v1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let (in2, source2) = source();
     let (out1v2, sink1v2) = sink(10);
@@ -329,7 +329,7 @@ async fn topology_swap_source() {
     config.add_sink("out1", &["in2"], sink1v2);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -359,7 +359,7 @@ async fn topology_swap_sink() {
     config.add_source("in1", source1);
     config.add_sink("out1", &["in1"], sink1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let (out2, sink2) = sink(10);
 
@@ -368,7 +368,7 @@ async fn topology_swap_sink() {
     config.add_sink("out2", &["in1"], sink2);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -397,7 +397,7 @@ async fn topology_swap_transform() {
     config.add_transform("t1", &["in1"], transform1);
     config.add_sink("out1", &["t1"], sink1v1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let transform2 = transform(" replaced", 0.0);
     let (out1v2, sink1v2) = sink(10);
@@ -408,7 +408,7 @@ async fn topology_swap_transform() {
     config.add_sink("out1", &["t2"], sink1v2);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
 
@@ -465,7 +465,7 @@ async fn topology_swap_transform_is_atomic() {
     config.add_transform("t1", &["in1"], transform1v1);
     config.add_sink("out1", &["t1"], sink1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
     delay_for(Duration::from_millis(10)).await;
 
     let transform1v2 = transform(" replaced", 0.0);
@@ -476,7 +476,7 @@ async fn topology_swap_transform_is_atomic() {
     config.add_sink("out1", &["t1"], sink(10).1);
 
     assert!(topology
-        .reload_config_and_respawn(config.build(), false)
+        .reload_config_and_respawn(config.build().unwrap(), false)
         .await
         .unwrap());
     delay_for(Duration::from_millis(10)).await;
@@ -543,7 +543,7 @@ async fn topology_healthcheck_run_for_changes_on_reload() {
     config.add_source("in1", src);
     config.add_sink("out1", &["in1"], sink(10).1);
 
-    let (mut topology, _crash) = start_topology(config.build(), false).await;
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
     let mut config = Config::builder();
     // We can't just drop the sender side since that will close the source.
@@ -552,7 +552,7 @@ async fn topology_healthcheck_run_for_changes_on_reload() {
     config.add_sink("out2", &["in1"], sink_failing_healthcheck(10).1);
 
     assert!(!topology
-        .reload_config_and_respawn(config.build(), true)
+        .reload_config_and_respawn(config.build().unwrap(), true)
         .await
         .unwrap());
 }


### PR DESCRIPTION
Closes #2936 

The overall goal here is to ensure that every `Config` instance is always valid and fully constructed. This means going through type checking, DAG validation, macro expansion, etc.

To do this, we bring all of those stages together in the `config` module and lock things down such that an invalid or incomplete `Config` can never escape the `config` module. This gives us the ability to add new stages (e.g. transform inlining) in one place, knowing they will be applied consistently.

More specifically, this PR introduces a new `ConfigBuilder` struct that takes over being {,de}serializable, clonable, test-friendly, etc, allowing us to lock down the actual `Config` struct significantly, making it harder to misuse.

There are definitely a lot of compromises here, mostly around the way that subcommands like `validate` and `test` expect to be able to use configs that would normally be invalid. I tried to make the changes relatively minimal, which means there are definitely areas that we can revisit and improve as needed in the future.