### PR TITLE
chore: Added back add index after Docker image fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,7 +444,7 @@ services:
       [
         "sh",
         "-c",
-        "./bin/splunk remove index custom_index; ./bin/splunk set minfreemb 5 && ./entrypoint.sh",
+        "./bin/splunk add index custom_index && ./bin/splunk set minfreemb 5 && ./entrypoint.sh",
       ]
   elasticsearch:
     image: elasticsearch:6.6.2


### PR DESCRIPTION
I worked out what was wrong with the Docker image that was making the add index duplicated and fixed that. Now adding the index is the right step in the docker-compose file.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
