### PR TITLE
chore: migrate RouterSink to enum

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -173,12 +173,12 @@ pub struct SinkOuter {
 #[async_trait::async_trait]
 #[typetag::serde(tag = "type")]
 pub trait SinkConfig: core::fmt::Debug + Send + Sync {
-    fn build(&self, cx: SinkContext) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)>;
+    fn build(&self, cx: SinkContext) -> crate::Result<(sinks::VectorSink, sinks::Healthcheck)>;
 
     async fn build_async(
         &self,
         cx: SinkContext,
-    ) -> crate::Result<(sinks::RouterSink, sinks::Healthcheck)> {
+    ) -> crate::Result<(sinks::VectorSink, sinks::Healthcheck)> {
         self.build(cx)
     }
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -886,7 +886,12 @@ mod integration_tests {
 
         let (input_lines, mut events) = random_lines_with_stream(100, 11);
 
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let mut request = GetLogEventsRequest::default();
         request.log_stream_name = stream_name.clone().into();
@@ -935,6 +940,7 @@ mod integration_tests {
         // out-of-order timestamps.
         let mut doit = false;
         let _ = sink
+            .into_futures01sink()
             .sink_compat()
             .send_all(&mut events.map_ok(move |mut event| {
                 if doit {
@@ -1022,7 +1028,7 @@ mod integration_tests {
         lines.push(add_event(Duration::days(-1)));
         lines.push(add_event(Duration::days(-13)));
 
-        let pump = sink.send_all(stream::iter_ok(events));
+        let pump = sink.into_futures01sink().send_all(stream::iter_ok(events));
         let (sink, _) = pump.compat().await.unwrap();
         // drop the sink so it closes all its connections
         drop(sink);
@@ -1070,7 +1076,12 @@ mod integration_tests {
 
         let (input_lines, mut events) = random_lines_with_stream(100, 11);
 
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let mut request = GetLogEventsRequest::default();
         request.log_stream_name = stream_name.clone().into();
@@ -1120,7 +1131,12 @@ mod integration_tests {
 
         let (input_lines, mut events) = random_lines_with_stream(100, 11);
 
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let mut request = GetLogEventsRequest::default();
         request.log_stream_name = stream_name.clone().into();
@@ -1177,7 +1193,7 @@ mod integration_tests {
             })
             .collect::<Vec<_>>();
 
-        let pump = sink.send_all(iter_ok(events));
+        let pump = sink.into_futures01sink().send_all(iter_ok(events));
         let (sink, _) = pump.compat().await.unwrap();
         let sink = sink.flush().compat().await.unwrap();
         // drop the sink so it closes all its connections

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -164,7 +164,7 @@ impl CloudwatchLogsSinkConfig {
 
 #[typetag::serde(name = "aws_cloudwatch_logs")]
 impl SinkConfig for CloudwatchLogsSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let batch = BatchSettings::default()
             .bytes(1_048_576)
             .events(10_000)
@@ -196,7 +196,10 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 
         let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
-        Ok((sink, Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(sink),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -508,6 +508,11 @@ mod integration_tests {
 
         let stream = stream::iter_ok(events.clone().into_iter());
 
-        let _ = sink.send_all(stream).compat().await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .send_all(stream)
+            .compat()
+            .await
+            .unwrap();
     }
 }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -432,8 +432,7 @@ mod integration_tests {
         test_util::random_string,
     };
     use chrono::offset::TimeZone;
-    use futures::compat::Future01CompatExt;
-    use futures01::{stream, Sink};
+    use futures::{stream, StreamExt};
 
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
@@ -506,13 +505,7 @@ mod integration_tests {
             events.push(event);
         }
 
-        let stream = stream::iter_ok(events.clone().into_iter());
-
-        let _ = sink
-            .into_futures01sink()
-            .send_all(stream)
-            .compat()
-            .await
-            .unwrap();
+        let stream = stream::iter(events).map(|x| Ok(x.into()));
+        sink.run(stream).await.unwrap();
     }
 }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -57,7 +57,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "aws_cloudwatch_metrics")]
 impl SinkConfig for CloudWatchMetricsSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
         let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
         let sink = CloudWatchMetricsSvc::new(self.clone(), client, cx)?;
@@ -116,7 +116,7 @@ impl CloudWatchMetricsSvc {
         config: CloudWatchMetricsSinkConfig,
         client: CloudWatchClient,
         cx: SinkContext,
-    ) -> crate::Result<super::RouterSink> {
+    ) -> crate::Result<super::VectorSink> {
         let batch = BatchSettings::default()
             .events(20)
             .timeout(1)
@@ -135,7 +135,7 @@ impl CloudWatchMetricsSvc {
             )
             .sink_map_err(|e| error!("CloudwatchMetrics sink error: {}", e));
 
-        Ok(Box::new(sink))
+        Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }
 
     fn encode_events(&mut self, events: Vec<Metric>) -> PutMetricDataInput {

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -72,11 +72,14 @@ inventory::submit! {
 
 #[typetag::serde(name = "aws_kinesis_firehose")]
 impl SinkConfig for KinesisFirehoseSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
         let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
         let sink = KinesisFirehoseService::new(self.clone(), client, cx)?;
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -77,11 +77,14 @@ inventory::submit! {
 
 #[typetag::serde(name = "aws_kinesis_streams")]
 impl SinkConfig for KinesisSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
         let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
         let sink = KinesisService::new(self.clone(), client, cx)?;
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -556,7 +556,12 @@ mod integration_tests {
 
         let (lines, mut events) = random_lines_with_stream(100, 10);
 
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let keys = get_keys(prefix.unwrap()).await;
         assert_eq!(keys.len(), 1);
@@ -601,6 +606,7 @@ mod integration_tests {
         });
 
         let _ = sink
+            .into_futures01sink()
             .send_all(futures01::stream::iter_ok(events))
             .compat()
             .await
@@ -637,7 +643,12 @@ mod integration_tests {
 
         let (lines, mut events) = random_lines_with_stream(100, 500);
 
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let keys = get_keys(prefix.unwrap()).await;
         assert_eq!(keys.len(), 6);

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -26,11 +26,11 @@ inventory::submit! {
 
 #[typetag::serde(name = "blackhole")]
 impl SinkConfig for BlackholeConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = Box::new(BlackholeSink::new(self.clone(), cx.acker()));
         let healthcheck = Box::new(healthcheck());
 
-        Ok((sink, healthcheck))
+        Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -61,7 +61,7 @@ pub enum Encoding {
 
 #[typetag::serde(name = "clickhouse")]
 impl SinkConfig for ClickhouseConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
@@ -82,7 +82,10 @@ impl SinkConfig for ClickhouseConfig {
 
         let healthcheck = healthcheck(client, self.clone()).boxed().compat();
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -280,7 +280,11 @@ mod integration_tests {
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.send(input_event.clone()).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(input_event.clone())
+            .compat()
+            .await
+            .unwrap();
 
         let output = client.select_all(&table).await;
         assert_eq!(1, output.rows);
@@ -327,7 +331,11 @@ mod integration_tests {
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.send(input_event.clone()).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(input_event.clone())
+            .compat()
+            .await
+            .unwrap();
 
         let output = client.select_all(&table).await;
         assert_eq!(1, output.rows);
@@ -385,7 +393,11 @@ timestamp_format = "unix""#,
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.send(input_event.clone()).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(input_event.clone())
+            .compat()
+            .await
+            .unwrap();
 
         let output = client.select_all(&table).await;
         assert_eq!(1, output.rows);
@@ -442,7 +454,7 @@ timestamp_format = "unix""#,
         // this timeout should trigger.
         timeout(
             Duration::from_secs(5),
-            sink.send(input_event.clone()).compat(),
+            sink.into_futures01sink().send(input_event.clone()).compat(),
         )
         .await
         .unwrap()

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -243,8 +243,7 @@ mod integration_tests {
         sinks::util::encoding::TimestampFormat,
         test_util::{random_string, trace_init},
     };
-    use futures::compat::Future01CompatExt;
-    use futures01::Sink;
+    use futures::{compat::Future01CompatExt, future, stream};
     use serde_json::Value;
     use tokio::time::{timeout, Duration};
 
@@ -280,9 +279,7 @@ mod integration_tests {
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.into_futures01sink()
-            .send(input_event.clone())
-            .compat()
+        sink.run(stream::once(future::ok(input_event.clone())))
             .await
             .unwrap();
 
@@ -331,9 +328,7 @@ mod integration_tests {
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.into_futures01sink()
-            .send(input_event.clone())
-            .compat()
+        sink.run(stream::once(future::ok(input_event.clone())))
             .await
             .unwrap();
 
@@ -393,9 +388,7 @@ timestamp_format = "unix""#,
         let mut input_event = Event::from("raw log line");
         input_event.as_mut_log().insert("host", "example.com");
 
-        sink.into_futures01sink()
-            .send(input_event.clone())
-            .compat()
+        sink.run(stream::once(future::ok(input_event.clone())))
             .await
             .unwrap();
 
@@ -454,7 +447,7 @@ timestamp_format = "unix""#,
         // this timeout should trigger.
         timeout(
             Duration::from_secs(5),
-            sink.into_futures01sink().send(input_event.clone()).compat(),
+            sink.run(stream::once(future::ok(input_event))),
         )
         .await
         .unwrap()

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -45,7 +45,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "console")]
 impl SinkConfig for ConsoleSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let encoding = self.encoding.clone();
 
         let output: Box<dyn io::AsyncWrite + Send + Sync + Unpin> = match self.target {
@@ -55,9 +55,12 @@ impl SinkConfig for ConsoleSinkConfig {
 
         let sink = WriterSink { output, encoding };
         let sink = streaming_sink::compat::adapt_to_topology(sink);
-        let sink = StreamSink::new(sink, cx.acker());
+        let sink = StreamSink::new(sink.as_futures01sink(), cx.acker());
 
-        Ok((Box::new(sink), Box::new(future::ok(()))))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(future::ok(())),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -55,7 +55,7 @@ impl SinkConfig for ConsoleSinkConfig {
 
         let sink = WriterSink { output, encoding };
         let sink = streaming_sink::compat::adapt_to_topology(sink);
-        let sink = StreamSink::new(sink.as_futures01sink(), cx.acker());
+        let sink = StreamSink::new(sink.into_futures01sink(), cx.acker());
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -1,4 +1,2 @@
 pub mod logs;
 pub mod metrics;
-
-pub(self) use super::{Healthcheck, HealthcheckError, RouterSink, UriParseError};

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -100,7 +100,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "elasticsearch")]
 impl SinkConfig for ElasticSearchConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let common = ElasticSearchCommon::parse_config(&self)?;
         let client = HttpClient::new(cx.resolver(), common.tls_settings.clone())?;
 
@@ -125,7 +125,10 @@ impl SinkConfig for ElasticSearchConfig {
         )
         .sink_map_err(|e| error!("Fatal elasticsearch sink error: {}", e));
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -624,7 +624,11 @@ mod integration_tests {
         input_event.as_mut_log().insert("my_id", "42");
         input_event.as_mut_log().insert("foo", "bar");
 
-        sink.send(input_event.clone()).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(input_event.clone())
+            .compat()
+            .await
+            .unwrap();
 
         // make sure writes all all visible
         flush(cx.resolver(), common).await.unwrap();
@@ -742,6 +746,7 @@ mod integration_tests {
                 // Break all but the first event to simulate some kind of partial failure
                 let mut doit = false;
                 let _ = sink
+                    .into_futures01sink()
                     .sink_compat()
                     .send_all(&mut events.map_ok(move |mut event| {
                         if doit {
@@ -755,6 +760,7 @@ mod integration_tests {
             }
             false => {
                 let _ = sink
+                    .into_futures01sink()
                     .sink_compat()
                     .send_all(&mut events)
                     .await

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -116,11 +116,14 @@ impl OutFile {
 
 #[typetag::serde(name = "file")]
 impl SinkConfig for FileSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = FileSink::new(&self);
         let sink = streaming_sink::compat::adapt_to_topology(sink);
-        let sink = StreamSink::new(sink, cx.acker());
-        Ok((Box::new(sink), Box::new(futures01::future::ok(()))))
+        let sink = StreamSink::new(sink.as_futures01sink(), cx.acker());
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(futures01::future::ok(())),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -119,7 +119,7 @@ impl SinkConfig for FileSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = FileSink::new(&self);
         let sink = streaming_sink::compat::adapt_to_topology(sink);
-        let sink = StreamSink::new(sink.as_futures01sink(), cx.acker());
+        let sink = StreamSink::new(sink.into_futures01sink(), cx.acker());
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
             Box::new(futures01::future::ok(())),

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -8,7 +8,7 @@ use crate::{
             http::{BatchedHttpSink, HttpClient, HttpSink},
             BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, TowerRequestConfig,
         },
-        Healthcheck, RouterSink, UriParseError,
+        Healthcheck, UriParseError, VectorSink,
     },
     tls::{TlsOptions, TlsSettings},
 };
@@ -63,11 +63,11 @@ inventory::submit! {
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_pubsub")]
 impl SinkConfig for PubsubConfig {
-    fn build(&self, _cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
+    fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         unimplemented!()
     }
 
-    async fn build_async(&self, cx: SinkContext) -> crate::Result<(RouterSink, Healthcheck)> {
+    async fn build_async(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let sink = PubsubSink::from_config(self).await?;
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
@@ -92,7 +92,10 @@ impl SinkConfig for PubsubConfig {
         )
         .sink_map_err(|e| error!("Fatal gcp pubsub sink error: {}", e));
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {
@@ -233,7 +236,7 @@ mod integration_tests {
         }
     }
 
-    async fn config_build(topic: &str) -> (crate::sinks::RouterSink, crate::sinks::Healthcheck) {
+    async fn config_build(topic: &str) -> (VectorSink, crate::sinks::Healthcheck) {
         let cx = SinkContext::new_test();
         config(topic)
             .build_async(cx)

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -37,7 +37,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "honeycomb")]
 impl SinkConfig for HoneycombConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::kib(100u64))
@@ -58,7 +58,10 @@ impl SinkConfig for HoneycombConfig {
 
         let healthcheck = Box::new(Box::pin(healthcheck(self.clone(), client)).compat());
 
-        Ok((Box::new(sink), healthcheck))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            healthcheck,
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -299,7 +299,7 @@ mod tests {
     };
     use bytes::buf::BufExt;
     use flate2::read::GzDecoder;
-    use futures::{compat::Sink01CompatExt, stream, SinkExt, StreamExt};
+    use futures::{stream, StreamExt};
     use headers::{Authorization, HeaderMapExt};
     use hyper::Method;
     use serde::Deserialize;
@@ -411,15 +411,14 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(&mut events);
+        let (input_lines, events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.run(events);
 
         tokio::spawn(server);
 
-        let _ = pump.await.unwrap();
+        pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx
@@ -467,15 +466,14 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(&mut events);
+        let (input_lines, events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.run(events);
 
         tokio::spawn(server);
 
-        let _ = pump.await.unwrap();
+        pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx
@@ -520,15 +518,14 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
-        let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
-        let pump = sink.send_all(&mut events);
+        let (input_lines, events) = random_lines_with_stream(100, num_lines);
+        let pump = sink.run(events);
 
         tokio::spawn(server);
 
-        let _ = pump.await.unwrap();
+        pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -411,7 +411,7 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.as_futures01sink().sink_compat();
+        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
         let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
@@ -467,7 +467,7 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.as_futures01sink().sink_compat();
+        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
         let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
@@ -520,7 +520,7 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).unwrap();
-        let mut sink = sink.as_futures01sink().sink_compat();
+        let mut sink = sink.into_futures01sink().sink_compat();
         let (rx, trigger, server) = build_test_server(in_addr);
 
         let (input_lines, mut events) = random_lines_with_stream(100, num_lines);

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -59,7 +59,7 @@ impl From<Encoding> for splunk_hec::Encoding {
 
 #[typetag::serde(name = "humio_logs")]
 impl SinkConfig for HumioLogsConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         self.build_hec_config().build(cx)
     }
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -476,7 +476,7 @@ mod tests {
         }
 
         let pump = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 
@@ -542,7 +542,7 @@ mod tests {
         }
 
         let pump = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -11,7 +11,7 @@ use crate::{
             http::{BatchedHttpSink, HttpClient, HttpSink},
             BatchConfig, BatchSettings, Buffer, Compression, TowerRequestConfig,
         },
-        Healthcheck,
+        Healthcheck, VectorSink,
     },
 };
 use futures01::Sink;
@@ -72,7 +72,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "influxdb_logs")]
 impl SinkConfig for InfluxDBLogsConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         // let mut config = self.clone();
         let mut tags: HashSet<String> = self.tags.clone().into_iter().collect();
         tags.insert(log_schema().host_key().to_string());
@@ -118,7 +118,10 @@ impl SinkConfig for InfluxDBLogsConfig {
         )
         .sink_map_err(|e| error!("Fatal influxdb_logs sink error: {}", e));
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {
@@ -472,7 +475,9 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink.send_all(futures01::stream::iter_ok(events));
+        let pump = sink
+            .as_futures01sink()
+            .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 
         let output = rx.next().await.unwrap();
@@ -536,7 +541,9 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink.send_all(futures01::stream::iter_ok(events));
+        let pump = sink
+            .as_futures01sink()
+            .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 
         let output = rx.next().await.unwrap();

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -223,8 +223,7 @@ mod tests {
         test_util::next_addr,
     };
     use chrono::{offset::TimeZone, Utc};
-    use futures::{compat::Future01CompatExt, StreamExt};
-    use futures01::Sink;
+    use futures::{stream, StreamExt};
 
     #[test]
     fn test_config_without_tags() {
@@ -475,10 +474,7 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink
-            .into_futures01sink()
-            .send_all(futures01::stream::iter_ok(events));
-        let _ = pump.compat().await.unwrap();
+        sink.run(stream::iter(events).map(Ok)).await.unwrap();
 
         let output = rx.next().await.unwrap();
 
@@ -541,10 +537,7 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink
-            .into_futures01sink()
-            .send_all(futures01::stream::iter_ok(events));
-        let _ = pump.compat().await.unwrap();
+        sink.run(stream::iter(events).map(Ok)).await.unwrap();
 
         let output = rx.next().await.unwrap();
 
@@ -653,12 +646,7 @@ mod integration_tests {
         events.push(event1);
         events.push(event2);
 
-        let _ = sink
-            .into_futures01sink()
-            .send_all(futures01::stream::iter_ok(events))
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::iter(events).map(Ok)).await.unwrap();
 
         let mut body = std::collections::HashMap::new();
         body.insert("query", format!("from(bucket:\"my-bucket\") |> range(start: 0) |> filter(fn: (r) => r._measurement == \"{}.vector\")", ns.clone()));

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -605,8 +605,7 @@ mod integration_tests {
         },
     };
     use chrono::Utc;
-    use futures::compat::Future01CompatExt;
-    use futures01::Sink;
+    use futures::{stream, StreamExt};
 
     #[tokio::test]
     async fn influxdb2_logs_put_data() {

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -654,6 +654,7 @@ mod integration_tests {
         events.push(event2);
 
         let _ = sink
+            .into_futures01sink()
             .send_all(futures01::stream::iter_ok(events))
             .compat()
             .await

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -819,7 +819,12 @@ mod integration_tests {
 
         let stream = stream01::iter_ok(events.clone().into_iter());
 
-        let _ = sink.send_all(stream).compat().await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .send_all(stream)
+            .compat()
+            .await
+            .unwrap();
 
         let mut body = std::collections::HashMap::new();
         body.insert("query", format!("from(bucket:\"my-bucket\") |> range(start: 0) |> filter(fn: (r) => r._measurement == \"ns.{}\")", metric));

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -752,8 +752,7 @@ mod integration_tests {
         Event,
     };
     use chrono::Utc;
-    use futures::{compat::Future01CompatExt, stream, StreamExt};
-    use futures01::{stream as stream01, Sink};
+    use futures::{stream, StreamExt};
 
     //    fn onboarding_v1() {
     //        let client = reqwest::Client::builder()

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -1,8 +1,6 @@
 pub mod logs;
 pub mod metrics;
 
-pub(self) use super::{Healthcheck, RouterSink};
-
 use crate::sinks::util::http::HttpClient;
 use chrono::{DateTime, Utc};
 use futures::TryFutureExt;

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -86,10 +86,13 @@ inventory::submit! {
 
 #[typetag::serde(name = "kafka")]
 impl SinkConfig for KafkaSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = KafkaSink::new(self.clone(), cx.acker())?;
         let hc = healthcheck(self.clone()).boxed().compat();
-        Ok((Box::new(sink), Box::new(hc)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(hc),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -61,7 +61,7 @@ pub enum Encoding {
 
 #[typetag::serde(name = "logdna")]
 impl SinkConfig for LogdnaConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
@@ -81,7 +81,10 @@ impl SinkConfig for LogdnaConfig {
 
         let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {
@@ -305,7 +308,9 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink.send_all(futures01::stream::iter_ok(events));
+        let pump = sink
+            .as_futures01sink()
+            .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 
         let output = rx.next().await.unwrap();

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -309,7 +309,7 @@ mod tests {
         }
 
         let pump = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(futures01::stream::iter_ok(events));
         let _ = pump.compat().await.unwrap();
 

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -228,8 +228,7 @@ mod tests {
         sinks::util::test::{build_test_server, load_sink},
         test_util::{next_addr, random_lines, trace_init},
     };
-    use futures::{compat::Future01CompatExt, StreamExt};
-    use futures01::Sink;
+    use futures::{stream, StreamExt};
     use serde_json::json;
 
     #[test]
@@ -308,10 +307,7 @@ mod tests {
             events.push(event);
         }
 
-        let pump = sink
-            .into_futures01sink()
-            .send_all(futures01::stream::iter_ok(events));
-        let _ = pump.compat().await.unwrap();
+        sink.run(stream::iter(events).map(Ok)).await.unwrap();
 
         let output = rx.next().await.unwrap();
 

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -71,7 +71,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "loki")]
 impl SinkConfig for LokiConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         if self.labels.is_empty() {
             return Err("`labels` must include at least one label.".into());
         }
@@ -97,7 +97,10 @@ impl SinkConfig for LokiConfig {
 
         let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -1,6 +1,7 @@
 use crate::Event;
 use futures::{compat::Future01CompatExt, TryFutureExt};
 use snafu::Snafu;
+use std::fmt;
 
 pub mod streaming_sink;
 pub mod util;
@@ -96,5 +97,20 @@ impl VectorSink {
         match self {
             Self::Futures01Sink(sink) => input.forward(sink).compat().map_ok(|_| ()).await,
         }
+    }
+
+    pub fn as_futures01sink(
+        self,
+    ) -> Box<dyn futures01::Sink<SinkItem = Event, SinkError = ()> + 'static + Send> {
+        match self {
+            Self::Futures01Sink(sink) => sink,
+            // _ => panic!("Failed type coercion, {:?} is not a Futures01Sink", self),
+        }
+    }
+}
+
+impl fmt::Debug for VectorSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VectorSink").finish()
     }
 }

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -99,7 +99,7 @@ impl VectorSink {
         }
     }
 
-    pub fn as_futures01sink(
+    pub fn into_futures01sink(
         self,
     ) -> Box<dyn futures01::Sink<SinkItem = Event, SinkError = ()> + 'static + Send> {
         match self {

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -76,7 +76,7 @@ pub(crate) fn skip_serializing_if_default(e: &EncodingConfigWithDefault<Encoding
 
 #[typetag::serde(name = "new_relic_logs")]
 impl SinkConfig for NewRelicLogsConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let http_conf = self.create_config()?;
         http_conf.build(cx)
     }
@@ -290,7 +290,7 @@ mod tests {
         let input_lines = (0..100).map(|i| format!("msg {}", i)).collect::<Vec<_>>();
         let events = stream01::iter_ok(input_lines.clone().into_iter().map(Event::from));
 
-        let pump = sink.send_all(events);
+        let pump = sink.as_futures01sink().send_all(events);
 
         tokio::spawn(server);
 

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -290,7 +290,7 @@ mod tests {
         let input_lines = (0..100).map(|i| format!("msg {}", i)).collect::<Vec<_>>();
         let events = stream01::iter_ok(input_lines.clone().into_iter().map(Event::from));
 
-        let pump = sink.as_futures01sink().send_all(events);
+        let pump = sink.into_futures01sink().send_all(events);
 
         tokio::spawn(server);
 

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -151,8 +151,7 @@ mod tests {
         test_util::next_addr,
     };
     use bytes::buf::BufExt;
-    use futures::{compat::Future01CompatExt, stream, StreamExt};
-    use futures01::{stream as stream01, Sink};
+    use futures::{stream, StreamExt};
     use hyper::Method;
     use serde_json::Value;
     use std::io::BufRead;
@@ -288,13 +287,12 @@ mod tests {
         let (rx, trigger, server) = build_test_server(in_addr);
 
         let input_lines = (0..100).map(|i| format!("msg {}", i)).collect::<Vec<_>>();
-        let events = stream01::iter_ok(input_lines.clone().into_iter().map(Event::from));
-
-        let pump = sink.into_futures01sink().send_all(events);
+        let events = stream::iter(input_lines.clone()).map(|x| Ok(Event::from(x)));
+        let pump = sink.run(events);
 
         tokio::spawn(server);
 
-        let _ = pump.compat().await.unwrap();
+        pump.await.unwrap();
         drop(trigger);
 
         let output_lines = rx

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -27,7 +27,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "papertrail")]
 impl SinkConfig for PapertrailConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let host = self
             .endpoint
             .host()
@@ -53,7 +53,10 @@ impl SinkConfig for PapertrailConfig {
         let sink = StreamSink::new(sink, cx.acker())
             .with_flat_map(move |e| iter_ok(encode_event(e, pid, &encoding)));
 
-        Ok((Box::new(sink), Box::new(healthcheck.compat())))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck.compat()),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -66,7 +66,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "prometheus")]
 impl SinkConfig for PrometheusSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         if self.flush_period_secs < MIN_FLUSH_PERIOD_SECS {
             return Err(Box::new(BuildError::FlushPeriodTooShort {
                 min: MIN_FLUSH_PERIOD_SECS,
@@ -76,7 +76,7 @@ impl SinkConfig for PrometheusSinkConfig {
         let sink = Box::new(PrometheusSink::new(self.clone(), cx.acker()));
         let healthcheck = Box::new(future::ok(()));
 
-        Ok((sink, healthcheck))
+        Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -69,14 +69,14 @@ inventory::submit! {
 #[async_trait::async_trait]
 #[typetag::serde(name = "pulsar")]
 impl SinkConfig for PulsarSinkConfig {
-    fn build(&self, _cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, _cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         unimplemented!()
     }
 
     async fn build_async(
         &self,
         cx: SinkContext,
-    ) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let producer = self
             .create_pulsar_producer()
             .await
@@ -88,7 +88,10 @@ impl SinkConfig for PulsarSinkConfig {
             .await
             .context(CreatePulsarSink)?;
         let hc = healthcheck(producer);
-        Ok((Box::new(sink), Box::new(hc.boxed().compat())))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(hc.boxed().compat()),
+        ))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/sematext_logs.rs
+++ b/src/sinks/sematext_logs.rs
@@ -105,7 +105,7 @@ mod tests {
         sinks::util::test::{build_test_server, load_sink},
         test_util::{next_addr, random_lines_with_stream},
     };
-    use futures::{compat::Sink01CompatExt, SinkExt, StreamExt};
+    use futures::StreamExt;
 
     #[tokio::test]
     async fn smoke() {
@@ -131,13 +131,8 @@ mod tests {
         let (mut rx, _trigger, server) = build_test_server(addr);
         tokio::spawn(server);
 
-        let (expected, mut events) = random_lines_with_stream(100, 10);
-        let _ = sink
-            .into_futures01sink()
-            .sink_compat()
-            .send_all(&mut events)
-            .await
-            .unwrap();
+        let (expected, events) = random_lines_with_stream(100, 10);
+        sink.run(events).await.unwrap();
 
         let output = rx.next().await.unwrap();
 

--- a/src/sinks/sematext_logs.rs
+++ b/src/sinks/sematext_logs.rs
@@ -68,7 +68,7 @@ impl SinkConfig for SematextLogsConfig {
         }
         .build(cx)?;
 
-        let sink = Box::new(sink.as_futures01sink().with(map_timestamp));
+        let sink = Box::new(sink.into_futures01sink().with(map_timestamp));
 
         Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
@@ -133,7 +133,7 @@ mod tests {
 
         let (expected, mut events) = random_lines_with_stream(100, 10);
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .sink_compat()
             .send_all(&mut events)
             .await

--- a/src/sinks/sematext_logs.rs
+++ b/src/sinks/sematext_logs.rs
@@ -43,7 +43,7 @@ pub enum Region {
 
 #[typetag::serde(name = "sematext")]
 impl SinkConfig for SematextLogsConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let endpoint = match (&self.endpoint, &self.region) {
             (Some(host), None) => host.clone(),
             (None, Some(Region::Na)) => "https://logsene-receiver.sematext.com".to_owned(),
@@ -68,9 +68,9 @@ impl SinkConfig for SematextLogsConfig {
         }
         .build(cx)?;
 
-        let sink = Box::new(sink.with(map_timestamp));
+        let sink = Box::new(sink.as_futures01sink().with(map_timestamp));
 
-        Ok((sink, healthcheck))
+        Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {
@@ -132,7 +132,12 @@ mod tests {
         tokio::spawn(server);
 
         let (expected, mut events) = random_lines_with_stream(100, 10);
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .as_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let output = rx.next().await.unwrap();
 

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -116,7 +116,12 @@ mod test {
         let (sink, _healthcheck) = config.build(context).unwrap();
 
         let event = Event::from("raw log line");
-        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let mut buf = [0; 256];
         let (size, _src_addr) = receiver

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -116,7 +116,7 @@ mod test {
         let (sink, _healthcheck) = config.build(context).unwrap();
 
         let event = Event::from("raw log line");
-        let _ = sink.as_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let mut buf = [0; 256];
         let (size, _src_addr) = receiver
@@ -151,7 +151,7 @@ mod test {
 
         let (lines, mut events) = random_lines_with_stream(10, 100);
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .sink_compat()
             .send_all(&mut events)
             .await
@@ -219,7 +219,7 @@ mod test {
         };
         let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).unwrap();
-        let mut sink = sink.as_futures01sink().sink_compat();
+        let mut sink = sink.into_futures01sink().sink_compat();
 
         let msg_counter = Arc::new(AtomicUsize::new(0));
         let msg_counter1 = Arc::clone(&msg_counter);

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -288,7 +288,7 @@ mod test {
         assert_eq!(conn_counter.load(Ordering::SeqCst), 1);
 
         // Send another 10 events
-        let (_, events) = random_lines_with_stream(10, 10);
+        let (_, mut events) = random_lines_with_stream(10, 10);
         sink.send_all(&mut events).await.unwrap();
 
         // Wait for server task to be complete.

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -290,6 +290,7 @@ mod test {
         // Send another 10 events
         let (_, mut events) = random_lines_with_stream(10, 10);
         sink.send_all(&mut events).await.unwrap();
+        drop(sink);
 
         // Wait for server task to be complete.
         let _ = jh.await.unwrap();

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -85,7 +85,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "splunk_hec")]
 impl SinkConfig for HecSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         validate_host(&self.endpoint)?;
 
         let batch = BatchSettings::default()
@@ -108,7 +108,10 @@ impl SinkConfig for HecSinkConfig {
 
         let healthcheck = healthcheck(self.clone(), client).boxed().compat();
 
-        Ok((Box::new(sink), Box::new(healthcheck)))
+        Ok((
+            super::VectorSink::Futures01Sink(Box::new(sink)),
+            Box::new(healthcheck),
+        ))
     }
 
     fn input_type(&self) -> DataType {
@@ -439,7 +442,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -458,7 +461,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -475,7 +478,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -490,7 +493,12 @@ mod integration_tests {
         let (sink, _) = config.build(cx).unwrap();
 
         let (messages, mut events) = random_lines_with_stream(100, 10);
-        let _ = sink.sink_compat().send_all(&mut events).await.unwrap();
+        let _ = sink
+            .as_futures01sink()
+            .sink_compat()
+            .send_all(&mut events)
+            .await
+            .unwrap();
 
         let mut found_all = false;
         for _ in 0..20 {
@@ -523,7 +531,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -544,7 +552,7 @@ mod integration_tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -568,7 +576,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -583,7 +591,7 @@ mod integration_tests {
     async fn splunk_configure_hostname() {
         let cx = SinkContext::new_test();
 
-        let config = super::HecSinkConfig {
+        let config = HecSinkConfig {
             host_key: "roast".into(),
             ..config(Encoding::Json, vec![Atom::from("asdf")]).await
         };
@@ -595,7 +603,7 @@ mod integration_tests {
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
         event.as_mut_log().insert("roast", "beef.example.com:1234");
-        sink.send(event).compat().await.unwrap();
+        sink.as_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -610,7 +618,7 @@ mod integration_tests {
     async fn splunk_healthcheck() {
         let resolver = crate::dns::Resolver;
 
-        let config_to_healthcheck = move |config: super::HecSinkConfig| {
+        let config_to_healthcheck = move |config: HecSinkConfig| {
             let tls_settings = TlsSettings::from_options(&config.tls).unwrap();
             let client = HttpClient::new(resolver, tls_settings).unwrap();
             sinks::splunk_hec::healthcheck(config, client)
@@ -699,8 +707,8 @@ mod integration_tests {
     async fn config(
         encoding: impl Into<EncodingConfigWithDefault<Encoding>>,
         indexed_fields: Vec<Atom>,
-    ) -> super::HecSinkConfig {
-        super::HecSinkConfig {
+    ) -> HecSinkConfig {
+        HecSinkConfig {
             endpoint: "http://localhost:8088/".into(),
             token: get_token().await,
             host_key: "host".into(),

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -442,7 +442,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -461,7 +461,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -478,7 +478,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -494,7 +494,7 @@ mod integration_tests {
 
         let (messages, mut events) = random_lines_with_stream(100, 10);
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .sink_compat()
             .send_all(&mut events)
             .await
@@ -531,7 +531,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -552,7 +552,7 @@ mod integration_tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -576,7 +576,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -603,7 +603,7 @@ mod integration_tests {
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
         event.as_mut_log().insert("roast", "beef.example.com:1234");
-        sink.as_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink().send(event).compat().await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -442,7 +442,11 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -461,7 +465,11 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -478,7 +486,11 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -531,7 +543,11 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -552,7 +568,11 @@ mod integration_tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -576,7 +596,11 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -603,7 +627,11 @@ mod integration_tests {
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
         event.as_mut_log().insert("roast", "beef.example.com:1234");
-        sink.into_futures01sink().send(event).compat().await.unwrap();
+        sink.into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
 
         let entry = find_entry(message.as_str()).await;
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -404,11 +404,7 @@ mod integration_tests {
         test_util::{random_lines_with_stream, random_string},
         Event,
     };
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        SinkExt,
-    };
-    use futures01::Sink;
+    use futures::{future, stream};
     use serde_json::Value as JsonValue;
     use std::net::SocketAddr;
     use tokio::time::{delay_for, Duration};
@@ -442,11 +438,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -465,11 +457,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -486,11 +474,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -504,13 +488,8 @@ mod integration_tests {
         let config = config(Encoding::Text, vec![]).await;
         let (sink, _) = config.build(cx).unwrap();
 
-        let (messages, mut events) = random_lines_with_stream(100, 10);
-        let _ = sink
-            .into_futures01sink()
-            .sink_compat()
-            .send_all(&mut events)
-            .await
-            .unwrap();
+        let (messages, events) = random_lines_with_stream(100, 10);
+        sink.run(events).await.unwrap();
 
         let mut found_all = false;
         for _ in 0..20 {
@@ -543,11 +522,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -568,11 +543,7 @@ mod integration_tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -596,11 +567,7 @@ mod integration_tests {
         let message = random_string(100);
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("asdf", "hello");
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 
@@ -627,11 +594,7 @@ mod integration_tests {
         event.as_mut_log().insert("asdf", "hello");
         event.as_mut_log().insert("host", "example.com:1234");
         event.as_mut_log().insert("roast", "beef.example.com:1234");
-        sink.into_futures01sink()
-            .send(event)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::once(future::ok(event))).await.unwrap();
 
         let entry = find_entry(message.as_str()).await;
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -233,11 +233,8 @@ mod test {
         Event,
     };
     use bytes::Bytes;
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        {SinkExt, StreamExt, TryStreamExt},
-    };
-    use futures01::{sync::mpsc, Sink};
+    use futures::{compat::Sink01CompatExt, stream, SinkExt, StreamExt, TryStreamExt};
+    use futures01::sync::mpsc;
     use tokio::net::UdpSocket;
     use tokio_util::{codec::BytesCodec, udp::UdpFramed};
     #[cfg(feature = "sources-statsd")]
@@ -414,13 +411,7 @@ mod test {
                 .unwrap()
         });
 
-        let stream = stream::iter_ok(events);
-        let _ = sink
-            .into_futures01sink()
-            .send_all(stream)
-            .compat()
-            .await
-            .unwrap();
+        sink.run(stream::iter(events).map(Ok)).await.unwrap();
 
         let messages = collect_n(rx, 1).await.unwrap();
         assert_eq!(

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -65,7 +65,7 @@ inventory::submit! {
 
 #[typetag::serde(name = "statsd")]
 impl SinkConfig for StatsdSinkConfig {
-    fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
+    fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = StatsdSvc::new(self.clone(), cx.acker())?;
         let healthcheck = StatsdSvc::healthcheck(self.clone()).boxed().compat();
         Ok((sink, Box::new(healthcheck)))
@@ -81,7 +81,7 @@ impl SinkConfig for StatsdSinkConfig {
 }
 
 impl StatsdSvc {
-    pub fn new(config: StatsdSinkConfig, acker: Acker) -> crate::Result<super::RouterSink> {
+    pub fn new(config: StatsdSinkConfig, acker: Acker) -> crate::Result<super::VectorSink> {
         // 1432 bytes is a recommended packet size to fit into MTU
         // https://github.com/statsd/statsd/blob/master/docs/metric_types.md#multi-metric-packets
         // However we need to leave some space for +1 extra trailing event in the buffer.
@@ -108,7 +108,7 @@ impl StatsdSvc {
         .sink_map_err(|e| error!("Fatal statsd sink error: {}", e))
         .with_flat_map(move |event| stream::iter_ok(encode_event(event, &namespace)));
 
-        Ok(Box::new(sink))
+        Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }
 
     async fn healthcheck(_config: StatsdSinkConfig) -> crate::Result<()> {
@@ -415,7 +415,12 @@ mod test {
         });
 
         let stream = stream::iter_ok(events);
-        let _ = sink.send_all(stream).compat().await.unwrap();
+        let _ = sink
+            .as_futures01sink()
+            .send_all(stream)
+            .compat()
+            .await
+            .unwrap();
 
         let messages = collect_n(rx, 1).await.unwrap();
         assert_eq!(

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -416,7 +416,7 @@ mod test {
 
         let stream = stream::iter_ok(events);
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(stream)
             .compat()
             .await

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -229,7 +229,7 @@ mod tests {
         // Send the test data
         let (input_lines, mut events) = random_lines_with_stream(100, num_lines);
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .sink_compat()
             .send_all(&mut events)
             .await

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -845,7 +845,7 @@ mod tests {
     ) -> Vec<Event> {
         let n = messages.len();
         let pump = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(stream::iter_ok(messages.into_iter().map(Into::into)));
         tokio::spawn(pump.map(|_| ()).map_err(|()| panic!()).compat());
         let events = collect_n(source, n).await.unwrap();
@@ -1007,7 +1007,7 @@ mod tests {
         event.as_mut_log().insert("greeting", "hello");
         event.as_mut_log().insert("name", "bob");
 
-        let _ = sink.as_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
         let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(event.as_log()[&"greeting".into()], "hello".into());
@@ -1031,7 +1031,7 @@ mod tests {
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("line", "hello");
 
-        let _ = sink.as_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
         let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1007,7 +1007,12 @@ mod tests {
         event.as_mut_log().insert("greeting", "hello");
         event.as_mut_log().insert("name", "bob");
 
-        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
         let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(event.as_log()[&"greeting".into()], "hello".into());
@@ -1031,7 +1036,12 @@ mod tests {
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("line", "hello");
 
-        let _ = sink.into_futures01sink().send(event).compat().await.unwrap();
+        let _ = sink
+            .into_futures01sink()
+            .send(event)
+            .compat()
+            .await
+            .unwrap();
         let event = collect_n(source, 1).await.unwrap().remove(0);
 
         assert_eq!(

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -147,6 +147,7 @@ mod test {
         ];
 
         let _ = sink
+            .as_futures01sink()
             .send_all(stream::iter_ok(events.clone().into_iter()))
             .compat()
             .await

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -147,7 +147,7 @@ mod test {
         ];
 
         let _ = sink
-            .as_futures01sink()
+            .into_futures01sink()
             .send_all(stream::iter_ok(events.clone().into_iter()))
             .compat()
             .await

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -105,8 +105,7 @@ mod test {
         tls::{TlsConfig, TlsOptions},
         Event, Pipeline,
     };
-    use futures::compat::Future01CompatExt;
-    use futures01::{stream, Sink};
+    use futures::{compat::Future01CompatExt, stream, StreamExt};
     use std::net::SocketAddr;
     use tokio::time::{delay_for, Duration};
 
@@ -146,10 +145,7 @@ mod test {
             }),
         ];
 
-        let _ = sink
-            .into_futures01sink()
-            .send_all(stream::iter_ok(events.clone().into_iter()))
-            .compat()
+        sink.run(stream::iter(events.clone()).map(Ok))
             .await
             .unwrap();
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -157,7 +157,7 @@ pub async fn build_pieces(
         };
 
         let sink = sink
-            .run(filter_event_type(rx, input_type))
+            .run01(filter_event_type(rx, input_type))
             .inspect(|_| debug!("Finished"));
         let task = Task::new(name, typetag, sink);
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -156,10 +156,9 @@ pub async fn build_pieces(
             Ok((sink, healthcheck)) => (sink, healthcheck),
         };
 
-        let sink = filter_event_type(rx, input_type)
-            .forward(sink)
-            .map(|_| debug!("Finished"))
-            .compat();
+        let sink = sink
+            .run(filter_event_type(rx, input_type))
+            .inspect(|_| debug!("Finished"));
         let task = Task::new(name, typetag, sink);
 
         let healthcheck_task = async move {

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -1,8 +1,8 @@
-use crate::sinks::RouterSink;
 use crate::Event;
 use futures::compat::Future01CompatExt;
-use futures01::sync::mpsc;
-use futures01::{future, Async, AsyncSink, Poll, Sink, StartSend, Stream};
+use futures01::{future, sync::mpsc, Async, AsyncSink, Poll, Sink, StartSend, Stream};
+
+type RouterSink = Box<dyn Sink<SinkItem = Event, SinkError = ()> + 'static + Send>;
 
 pub struct Fanout {
     sinks: Vec<(String, RouterSink)>,

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -8,7 +8,11 @@ use vector::{
     config::{self, GlobalOptions, SinkContext},
     shutdown::ShutdownSignal,
     test_util::{next_addr, random_lines, send_lines, start_topology, wait_for_tcp, CountReceiver},
-    Event, Pipeline, {sinks, sources},
+    Event, Pipeline,
+    {
+        sinks::{self, Healthcheck, VectorSink},
+        sources,
+    },
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,11 +20,11 @@ struct PanicSink;
 
 #[typetag::serde(name = "panic")]
 impl config::SinkConfig for PanicSink {
-    fn build(
-        &self,
-        _cx: SinkContext,
-    ) -> Result<(sinks::RouterSink, sinks::Healthcheck), vector::Error> {
-        Ok((Box::new(PanicSink), Box::new(future::ok(()))))
+    fn build(&self, _cx: SinkContext) -> Result<(VectorSink, Healthcheck), vector::Error> {
+        Ok((
+            VectorSink::Futures01Sink(Box::new(PanicSink)),
+            Box::new(future::ok(())),
+        ))
     }
 
     fn input_type(&self) -> config::DataType {
@@ -97,11 +101,11 @@ struct ErrorSink;
 
 #[typetag::serde(name = "panic")]
 impl config::SinkConfig for ErrorSink {
-    fn build(
-        &self,
-        _cx: SinkContext,
-    ) -> Result<(sinks::RouterSink, sinks::Healthcheck), vector::Error> {
-        Ok((Box::new(ErrorSink), Box::new(future::ok(()))))
+    fn build(&self, _cx: SinkContext) -> Result<(VectorSink, Healthcheck), vector::Error> {
+        Ok((
+            VectorSink::Futures01Sink(Box::new(ErrorSink)),
+            Box::new(future::ok(())),
+        ))
     }
 
     fn input_type(&self) -> config::DataType {


### PR DESCRIPTION
Closes #2934.

I changed `Sink` from RFC to `VectorSink` to exclude conflicts with `futures::Sink`.
`OldAndBad` renamed to `Futures01Sink` for better understanding of what under variant (name here is not very important since this variant should be removed in the end, right?).