### PR TITLE
chore: Update Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,7 @@ Thank you for opening an issue. Please note that we try to keep the Vector issue
 -->
 
 ### Vector Version
+
 <!---
 Run `vector --version` to show the version, and paste the result between the ``` marks below.
 
@@ -25,6 +26,7 @@ If you are not running the latest version of Vector, please try upgrading becaus
 ```
 
 ### Vector Configuration File
+
 <!--
 Paste the relevant parts of your `vector.toml` configuration between the ``` marks below.
 
@@ -36,6 +38,7 @@ Paste the relevant parts of your `vector.toml` configuration between the ``` mar
 ```
 
 ### Debug Output
+
 <!--
 Full debug output can be obtained by running Vector with the following:
 
@@ -50,16 +53,19 @@ Please create a GitHub Gist containing the debug output. Please do _not_ paste t
 
 
 ### Expected Behavior
+
 <!--
 What should have happened?
 -->
 
 ### Actual Behavior
+
 <!--
 What actually happened?
 -->
 
 ### Example Data
+
 <!--
 Please provide any example data that will help debug the issue, for example:
 
@@ -69,11 +75,13 @@ Please provide any example data that will help debug the issue, for example:
 -->
 
 ### Additional Context
+
 <!--
-Are there anything atypical about your situation that we should know? For example: is Vector running in Kubernetes? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?
+Is there anything atypical about your situation that we should know? For example: is Vector running in Kubernetes? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?
 -->
 
 ### References
+
 <!--
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Chat
+    url: https://chat.vector.dev
+    about: Chat with the Vector team and other community members.
+
+  - name: Twitter
+    url: https://twitter.com/vectordotdev
+    about: Follow us and stay up to date with Vector.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Chat
     url: https://chat.vector.dev
-    about: Chat with the Vector team and other community members.
+    about: Get help! Chat with the Vector team and other community members.
 
   - name: Twitter
     url: https://twitter.com/vectordotdev

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
-about: Suggest a new feature or other enhancement.
-labels: 'type: enhancement'
+about: Suggest a new feature or enhancement.
+labels: 'type: feature'
 assignees: ''
 title: ''
 
@@ -11,13 +11,10 @@ title: ''
 Hi there,
 
 Thank you for opening an issue. Please note that we try to keep the Vector issue tracker reserved for bug reports and feature requests. For general usage questions, please see: https://chat.vector.dev.
-
-PSA: Using Vector? Let us know! Add your company here:
-
-https://github.com/timberio/vector/blob/master/.meta/companies.toml
 -->
 
 ### Current Vector Version
+
 <!---
 Run `vector --version` to show the version, and paste the result between the ``` marks below. This will record which version was current at the time of your feature request, to help manage the request backlog.
 
@@ -28,7 +25,8 @@ If you're not using the latest version, please check to see if something related
 ...
 ```
 
-### Use-cases
+### Use-cases'
+
 <!---
 In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
 
@@ -38,6 +36,7 @@ Please keep this section focused on the problem and not on the suggested solutio
 -->
 
 ### Attempted Solutions
+
 <!---
 If you've already tried to solve the problem within Vector's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
 
@@ -47,6 +46,7 @@ Please remove any sensitive information such as passwords before sharing configu
 --->
 
 ### Proposal
+
 <!---
 If you have an idea for a way to address the problem via a change to Vector features, please describe it below.
 
@@ -56,6 +56,7 @@ If you're not sure of some details, don't worry! When we evaluate the feature re
 -->
 
 ### References
+
 <!--
 Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please create a list below that mentions each of them. For example:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -25,7 +25,7 @@ If you're not using the latest version, please check to see if something related
 ...
 ```
 
-### Use-cases'
+### Use-cases
 
 <!---
 In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.


### PR DESCRIPTION
Updates a few issues with our Github issues templates:

* Removes a broken link
* Adds relevant community links
* Disables blank issues