### PR TITLE
chore(tests): Retry_until

### DIFF
--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -372,6 +372,7 @@ mod tests {
         time::Duration,
     };
 
+    #[allow(clippy::never_loop)]
     async fn retry_until_helper(count: Arc<RwLock<i32>>) -> Result<(), ()> {
         while *count.read().unwrap() < 3 {
             let mut c = count.write().unwrap();

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -372,9 +372,9 @@ mod tests {
         time::Duration,
     };
 
-    #[allow(clippy::never_loop)]
+    // helper which errors the first 3x, and succeeds on the 4th
     async fn retry_until_helper(count: Arc<RwLock<i32>>) -> Result<(), ()> {
-        while *count.read().unwrap() < 3 {
+        if *count.read().unwrap() < 3 {
             let mut c = count.write().unwrap();
             *c += 1;
             return Err(());

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -348,6 +348,63 @@ where
     .await
 }
 
+// Retries a func every `retry` duration until given an Ok(T); panics after `until` elapses
+pub async fn retry_until<F, Fut, T, E>(mut f: F, retry: Duration, until: Duration) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>> + Send + 'static,
+{
+    let started = Instant::now();
+    while started.elapsed() < until {
+        match f().await {
+            Ok(res) => return res,
+            Err(_) => tokio::time::delay_for(retry).await,
+        }
+    }
+    panic!("Timeout")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retry_until;
+    use std::{
+        sync::{Arc, RwLock},
+        time::Duration,
+    };
+
+    async fn retry_until_helper(count: Arc<RwLock<i32>>) -> Result<(), ()> {
+        while *count.read().unwrap() < 3 {
+            let mut c = count.write().unwrap();
+            *c += 1;
+            return Err(());
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_until_before_timeout() {
+        let count = Arc::new(RwLock::new(0));
+        let func = || {
+            let count = Arc::clone(&count);
+            retry_until_helper(count)
+        };
+
+        retry_until(func, Duration::from_millis(10), Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn retry_until_after_timeout() {
+        let count: Arc<RwLock<i32>> = Arc::new(RwLock::new(0));
+        let func = || {
+            let count = Arc::clone(&count);
+            retry_until_helper(count)
+        };
+
+        retry_until(func, Duration::from_millis(50), Duration::from_millis(100)).await;
+    }
+}
+
 pub struct CountReceiver<T> {
     count: Arc<AtomicUsize>,
     trigger: Option<oneshot::Sender<()>>,


### PR DESCRIPTION
Adds a `test_util::retry_until` helper, for retrying an async block until an `Ok(T)` is returned per `retry: Duration` - or until `until: Duration` has elapsed, whichever comes first. The latter panics.

Updates the Splunk integration test to use this approach vs. checking for openness of port 8089, which could occasionally result in a race condition where the port was open but the service wasn't fully initialised.

This could be used in other places where `wait_for_tcp` is currently employed, but for the sake of limiting scope, I've avoided touching other code paths.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
