### PR TITLE
chore: Make the `namespace` option on metrics sinks optional

### DIFF
--- a/.meta/sinks/datadog_metrics.toml.erb
+++ b/.meta/sinks/datadog_metrics.toml.erb
@@ -51,5 +51,5 @@ description = "Datadog endpoint to send metrics to."
 type = "string"
 common = true
 examples = ["service"]
-required = true
+required = false
 description = "A prefix that will be added to all metric names."

--- a/.meta/sinks/influxdb_metrics.toml.erb
+++ b/.meta/sinks/influxdb_metrics.toml.erb
@@ -140,6 +140,6 @@ type = "string"
 common = true
 examples = ["service"]
 groups = ["v1", "v2"]
-required = true
+required = false
 sort = 1
 description = "A prefix that will be added to all metric names."

--- a/.meta/sinks/prometheus.toml.erb
+++ b/.meta/sinks/prometheus.toml.erb
@@ -34,7 +34,7 @@ description = "The address to expose for scraping."
 type = "string"
 common = true
 examples = ["service"]
-required = true
+required = false
 description = """\
 A prefix that will be added to all metric names.
 It should follow Prometheus [naming conventions][urls.prometheus_metric_naming].\

--- a/.meta/sinks/statsd.toml.erb
+++ b/.meta/sinks/statsd.toml.erb
@@ -29,7 +29,7 @@ description = "The UDP socket address to send stats to."
 type = "string"
 common = true
 examples = ["service"]
-required = true
+required = false
 description = "A prefix that will be added to all metric names."
 
 [[sinks.statsd.examples]]

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -37,7 +37,7 @@ struct DatadogState {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DatadogConfig {
-    pub namespace: String,
+    pub namespace: Option<String>,
     // Deprecated name
     #[serde(alias = "host", default = "default_endpoint")]
     pub endpoint: String,
@@ -166,7 +166,11 @@ impl HttpSink for DatadogSink {
         let interval = now - self.last_sent_timestamp.load(SeqCst);
         self.last_sent_timestamp.store(now, SeqCst);
 
-        let input = encode_events(events, interval, &self.config.namespace);
+        let input = encode_events(
+            events,
+            interval,
+            self.config.namespace.as_ref().map(|s| s.as_str()),
+        );
         let body = serde_json::to_vec(&input).unwrap();
 
         Request::post(self.uri.clone())
@@ -220,11 +224,10 @@ fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> i64 {
     }
 }
 
-fn encode_namespace(namespace: &str, name: &str) -> String {
-    if !namespace.is_empty() {
-        format!("{}.{}", namespace, name)
-    } else {
-        name.to_string()
+fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, name),
+        _ => name.to_string(),
     }
 }
 
@@ -280,7 +283,7 @@ fn stats(values: &[f64], counts: &[u32]) -> Option<DatadogStats> {
     })
 }
 
-fn encode_events(events: Vec<Metric>, interval: i64, namespace: &str) -> DatadogRequest {
+fn encode_events(events: Vec<Metric>, interval: i64, namespace: Option<&str>) -> DatadogRequest {
     let series = events
         .into_iter()
         .filter_map(|event| {
@@ -501,7 +504,7 @@ mod tests {
                 value: MetricValue::Counter { value: 1.0 },
             },
         ];
-        let input = encode_events(events, interval, "ns");
+        let input = encode_events(events, interval, Some("ns"));
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -528,7 +531,7 @@ mod tests {
                 value: MetricValue::Gauge { value: -1.1 },
             },
         ];
-        let input = encode_events(events, 60, "");
+        let input = encode_events(events, 60, Some(""));
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -548,7 +551,7 @@ mod tests {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
             },
         }];
-        let input = encode_events(events, 60, "");
+        let input = encode_events(events, 60, Some(""));
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -656,7 +659,7 @@ mod tests {
                 statistic: StatisticKind::Histogram,
             },
         }];
-        let input = encode_events(events, 60, "");
+        let input = encode_events(events, 60, Some(""));
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -5,6 +5,7 @@ use crate::{
         Event,
     },
     sinks::{
+        encode_namespace,
         util::{
             http::{BatchedHttpSink, HttpClient, HttpSink},
             BatchConfig, BatchSettings, MetricBuffer, TowerRequestConfig,
@@ -224,13 +225,6 @@ fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> i64 {
     }
 }
 
-fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
-    match namespace {
-        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, name),
-        _ => name.to_string(),
-    }
-}
-
 fn stats(values: &[f64], counts: &[u32]) -> Option<DatadogStats> {
     if values.len() != counts.len() {
         return None;
@@ -287,7 +281,7 @@ fn encode_events(events: Vec<Metric>, interval: i64, namespace: Option<&str>) ->
     let series = events
         .into_iter()
         .filter_map(|event| {
-            let fullname = encode_namespace(namespace, &event.name);
+            let fullname = encode_namespace(namespace, '.', &event.name);
             let ts = encode_timestamp(event.timestamp);
             let tags = event.tags.clone().map(encode_tags);
             match event.kind {

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -5,8 +5,8 @@ use crate::{
         Event,
     },
     sinks::{
-        encode_namespace,
         util::{
+            encode_namespace,
             http::{BatchedHttpSink, HttpClient, HttpSink},
             BatchConfig, BatchSettings, MetricBuffer, TowerRequestConfig,
         },
@@ -167,11 +167,7 @@ impl HttpSink for DatadogSink {
         let interval = now - self.last_sent_timestamp.load(SeqCst);
         self.last_sent_timestamp.store(now, SeqCst);
 
-        let input = encode_events(
-            events,
-            interval,
-            self.config.namespace.as_ref().map(|s| s.as_str()),
-        );
+        let input = encode_events(events, interval, self.config.namespace.as_deref());
         let body = serde_json::to_vec(&input).unwrap();
 
         Request::post(self.uri.clone())

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -143,7 +143,7 @@ impl HttpSink for InfluxDBLogsSink {
         let mut event = event.into_log();
 
         // Measurement
-        let measurement = encode_namespace(&self.namespace, &"vector");
+        let measurement = encode_namespace(Some(&self.namespace), &"vector");
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -143,7 +143,7 @@ impl HttpSink for InfluxDBLogsSink {
         let mut event = event.into_log();
 
         // Measurement
-        let measurement = encode_namespace(Some(&self.namespace), &"vector");
+        let measurement = encode_namespace(Some(&self.namespace), '.', "vector");
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -33,7 +33,7 @@ struct InfluxDBSvc {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InfluxDBConfig {
-    pub namespace: String,
+    pub namespace: Option<String>,
     pub endpoint: String,
     #[serde(flatten)]
     pub influxdb1_settings: Option<InfluxDB1Settings>,
@@ -140,7 +140,11 @@ impl Service<Vec<Metric>> for InfluxDBSvc {
     }
 
     fn call(&mut self, items: Vec<Metric>) -> Self::Future {
-        let input = encode_events(self.protocol_version, items, &self.config.namespace);
+        let input = encode_events(
+            self.protocol_version,
+            items,
+            self.config.namespace.as_ref().map(|s| s.as_str()),
+        );
         let body: Vec<u8> = input.into_bytes();
 
         self.inner.call(body)
@@ -167,7 +171,7 @@ fn create_build_request(
 fn encode_events(
     protocol_version: ProtocolVersion,
     events: Vec<Metric>,
-    namespace: &str,
+    namespace: Option<&str>,
 ) -> String {
     let mut output = String::new();
     for event in events.into_iter() {
@@ -380,7 +384,7 @@ mod tests {
             },
         ];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(
             line_protocols,
             "ns.total,metric_type=counter value=1.5 1542182950000000011\n\
@@ -398,7 +402,7 @@ mod tests {
             value: MetricValue::Gauge { value: -1.5 },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(
             line_protocols,
             "ns.meter,metric_type=gauge,normal_tag=value,true_tag=true value=-1.5 1542182950000000011"
@@ -417,7 +421,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(
             line_protocols,
             "ns.users,metric_type=set,normal_tag=value,true_tag=true value=2 1542182950000000011"
@@ -439,7 +443,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V1, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V1, events, Some("ns"));
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 1);
 
@@ -478,7 +482,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 1);
 
@@ -517,7 +521,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V1, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V1, events, Some("ns"));
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 1);
 
@@ -556,7 +560,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 1);
 
@@ -618,7 +622,7 @@ mod tests {
             },
         ];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 3);
 
@@ -694,7 +698,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(line_protocols.len(), 0);
     }
 
@@ -712,7 +716,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(line_protocols.len(), 0);
     }
 
@@ -730,7 +734,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, events, "ns");
+        let line_protocols = encode_events(ProtocolVersion::V2, events, Some("ns"));
         assert_eq!(line_protocols.len(), 0);
     }
 }

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -175,7 +175,7 @@ fn encode_events(
 ) -> String {
     let mut output = String::new();
     for event in events.into_iter() {
-        let fullname = encode_namespace(namespace, &event.name);
+        let fullname = encode_namespace(namespace, '.', &event.name);
         let ts = encode_timestamp(event.timestamp);
         let tags = event.tags.clone();
         match event.value {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -143,7 +143,7 @@ impl Service<Vec<Metric>> for InfluxDBSvc {
         let input = encode_events(
             self.protocol_version,
             items,
-            self.config.namespace.as_ref().map(|s| s.as_str()),
+            self.config.namespace.as_deref(),
         );
         let body: Vec<u8> = input.into_bytes();
 
@@ -785,7 +785,7 @@ mod integration_tests {
         let cx = SinkContext::new_test();
 
         let config = InfluxDBConfig {
-            namespace: "ns".to_string(),
+            namespace: Some("ns".to_string()),
             endpoint: "http://localhost:9999".to_string(),
             influxdb1_settings: None,
             influxdb2_settings: Some(InfluxDB2Settings {

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -282,11 +282,10 @@ fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> i64 {
     }
 }
 
-fn encode_namespace(namespace: &str, name: &str) -> String {
-    if !namespace.is_empty() {
-        format!("{}.{}", namespace, name)
-    } else {
-        name.to_string()
+fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, name),
+        _ => name.to_string(),
     }
 }
 
@@ -653,8 +652,11 @@ mod tests {
 
     #[test]
     fn test_encode_namespace() {
-        assert_eq!(encode_namespace("services", "status"), "services.status");
-        assert_eq!(encode_namespace("", "status"), "status")
+        assert_eq!(
+            encode_namespace(Some("services"), "status"),
+            "services.status"
+        );
+        assert_eq!(encode_namespace(None, "status"), "status")
     }
 
     #[test]

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -1,7 +1,7 @@
 pub mod logs;
 pub mod metrics;
 
-use crate::sinks::util::http::HttpClient;
+use crate::sinks::util::{encode_namespace, http::HttpClient};
 use chrono::{DateTime, Utc};
 use futures::TryFutureExt;
 use futures01::Future;
@@ -279,13 +279,6 @@ fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> i64 {
         ts.timestamp_nanos()
     } else {
         encode_timestamp(Some(Utc::now()))
-    }
-}
-
-fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
-    match namespace {
-        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, name),
-        _ => name.to_string(),
     }
 }
 
@@ -648,15 +641,6 @@ mod tests {
         let start = Utc::now().timestamp_nanos();
         assert_eq!(encode_timestamp(Some(ts())), 1542182950000000011);
         assert!(encode_timestamp(None) >= start)
-    }
-
-    #[test]
-    fn test_encode_namespace() {
-        assert_eq!(
-            encode_namespace(Some("services"), "status"),
-            "services.status"
-        );
-        assert_eq!(encode_namespace(None, "status"), "status")
     }
 
     #[test]

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -35,7 +35,7 @@ enum BuildError {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusSinkConfig {
-    pub namespace: String,
+    pub namespace: Option<String>,
     #[serde(default = "default_address")]
     pub address: SocketAddr,
     #[serde(default = "default_histogram_buckets")]
@@ -96,11 +96,11 @@ struct PrometheusSink {
     acker: Acker,
 }
 
-fn encode_namespace(namespace: &str, name: &str) -> String {
-    if !namespace.is_empty() {
-        format!("{}_{}", namespace, name)
-    } else {
-        name.to_string()
+fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(namespace) if namespace.is_empty() => name.to_string(),
+        Some(namespace) => format!("{}_{}", namespace, name),
+        None => name.to_string(),
     }
 }
 
@@ -136,7 +136,7 @@ fn encode_tags_with_extra(
     format!("{{{}}}", parts.join(","))
 }
 
-fn encode_metric_header(namespace: &str, metric: &Metric) -> String {
+fn encode_metric_header(namespace: Option<&str>, metric: &Metric) -> String {
     let mut s = String::new();
     let name = &metric.name;
     let fullname = encode_namespace(namespace, name);
@@ -155,7 +155,12 @@ fn encode_metric_header(namespace: &str, metric: &Metric) -> String {
     s
 }
 
-fn encode_metric_datum(namespace: &str, buckets: &[f64], expired: bool, metric: &Metric) -> String {
+fn encode_metric_datum(
+    namespace: Option<&str>,
+    buckets: &[f64],
+    expired: bool,
+    metric: &Metric,
+) -> String {
     let mut s = String::new();
     let fullname = encode_namespace(namespace, &metric.name);
 
@@ -267,7 +272,7 @@ fn encode_metric_datum(namespace: &str, buckets: &[f64], expired: bool, metric: 
 
 fn handle(
     req: Request<Body>,
-    namespace: &str,
+    namespace: Option<&str>,
     buckets: &[f64],
     expired: bool,
     metrics: &IndexSet<MetricEntry>,
@@ -283,10 +288,10 @@ fn handle(
 
             for metric in metrics {
                 let name = &metric.0.name;
-                let frame = encode_metric_datum(&namespace, &buckets, expired, &metric.0);
+                let frame = encode_metric_datum(namespace, &buckets, expired, &metric.0);
 
                 if !processed_headers.contains(&name) {
-                    let header = encode_metric_header(&namespace, &metric.0);
+                    let header = encode_metric_header(namespace, &metric.0);
                     s.push_str(&header);
                     processed_headers.insert(name);
                 };
@@ -353,7 +358,15 @@ impl PrometheusSink {
                         method = field::debug(req.method()),
                         path = field::debug(req.uri().path()),
                     )
-                    .in_scope(|| handle(req, &namespace, &buckets, expired, &metrics))
+                    .in_scope(|| {
+                        handle(
+                            req,
+                            namespace.as_ref().map(|s| s.as_str()),
+                            &buckets,
+                            expired,
+                            &metrics,
+                        )
+                    })
                     .compat()
                 }))
             }
@@ -444,8 +457,8 @@ mod tests {
             value: MetricValue::Counter { value: 10.0 },
         };
 
-        let header = encode_metric_header("vector", &metric);
-        let frame = encode_metric_datum("vector", &[], false, &metric);
+        let header = encode_metric_header(Some("vector"), &metric);
+        let frame = encode_metric_datum(Some("vector"), &[], false, &metric);
 
         assert_eq!(
             header,
@@ -464,8 +477,8 @@ mod tests {
             value: MetricValue::Gauge { value: -1.1 },
         };
 
-        let header = encode_metric_header("vector", &metric);
-        let frame = encode_metric_datum("vector", &[], false, &metric);
+        let header = encode_metric_header(Some("vector"), &metric);
+        let frame = encode_metric_datum(Some("vector"), &[], false, &metric);
 
         assert_eq!(
             header,
@@ -486,8 +499,8 @@ mod tests {
             },
         };
 
-        let header = encode_metric_header("", &metric);
-        let frame = encode_metric_datum("", &[], false, &metric);
+        let header = encode_metric_header(None, &metric);
+        let frame = encode_metric_datum(None, &[], false, &metric);
 
         assert_eq!(
             header,
@@ -508,8 +521,8 @@ mod tests {
             },
         };
 
-        let header = encode_metric_header("", &metric);
-        let frame = encode_metric_datum("", &[], true, &metric);
+        let header = encode_metric_header(None, &metric);
+        let frame = encode_metric_datum(None, &[], true, &metric);
 
         assert_eq!(
             header,
@@ -532,8 +545,8 @@ mod tests {
             },
         };
 
-        let header = encode_metric_header("", &metric);
-        let frame = encode_metric_datum("", &[0.0, 2.5, 5.0], false, &metric);
+        let header = encode_metric_header(None, &metric);
+        let frame = encode_metric_datum(None, &[0.0, 2.5, 5.0], false, &metric);
 
         assert_eq!(
             header,
@@ -557,8 +570,8 @@ mod tests {
             },
         };
 
-        let header = encode_metric_header("", &metric);
-        let frame = encode_metric_datum("", &[], false, &metric);
+        let header = encode_metric_header(None, &metric);
+        let frame = encode_metric_datum(None, &[], false, &metric);
 
         assert_eq!(
             header,
@@ -582,8 +595,8 @@ mod tests {
             },
         };
 
-        let header = encode_metric_header("", &metric);
-        let frame = encode_metric_datum("", &[], false, &metric);
+        let header = encode_metric_header(None, &metric);
+        let frame = encode_metric_datum(None, &[], false, &metric);
 
         assert_eq!(
             header,

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -98,9 +98,8 @@ struct PrometheusSink {
 
 fn encode_namespace(namespace: Option<&str>, name: &str) -> String {
     match namespace {
-        Some(namespace) if namespace.is_empty() => name.to_string(),
-        Some(namespace) => format!("{}_{}", namespace, name),
-        None => name.to_string(),
+        Some(namespace) if !namespace.is_empty() => format!("{}_{}", namespace, name),
+        _ => name.to_string(),
     }
 }
 

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -350,15 +350,7 @@ impl PrometheusSink {
                         method = field::debug(req.method()),
                         path = field::debug(req.uri().path()),
                     )
-                    .in_scope(|| {
-                        handle(
-                            req,
-                            namespace.as_ref().map(|s| s.as_str()),
-                            &buckets,
-                            expired,
-                            &metrics,
-                        )
-                    })
+                    .in_scope(|| handle(req, namespace.as_deref(), &buckets, expired, &metrics))
                     .compat()
                 }))
             }

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,7 +3,7 @@ use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
     event::Event,
-    sinks::util::{BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
+    sinks::util::{encode_namespace, BatchConfig, BatchSettings, BatchSink, Buffer, Compression},
 };
 use futures::{future, FutureExt, TryFutureExt};
 use futures01::{stream, Sink};
@@ -195,11 +195,7 @@ fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
         }
     };
 
-    let mut message: String = buf.join("|");
-    message = match namespace {
-        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, message),
-        _ => message,
-    };
+    let message = encode_namespace(namespace, '.', buf.join("|"));
 
     let mut body: Vec<u8> = message.into_bytes();
     body.push(b'\n');

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -48,7 +48,7 @@ impl Client {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct StatsdSinkConfig {
-    pub namespace: String,
+    pub namespace: Option<String>,
     #[serde(default = "default_address")]
     pub address: SocketAddr,
     #[serde(default)]
@@ -106,7 +106,9 @@ impl StatsdSvc {
             acker,
         )
         .sink_map_err(|e| error!("Fatal statsd sink error: {}", e))
-        .with_flat_map(move |event| stream::iter_ok(encode_event(event, &namespace)));
+        .with_flat_map(move |event| {
+            stream::iter_ok(encode_event(event, namespace.as_ref().map(|s| s.as_str())))
+        });
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }
@@ -151,7 +153,7 @@ fn push_event<V: Display>(
     };
 }
 
-fn encode_event(event: Event, namespace: &str) -> Option<Vec<u8>> {
+fn encode_event(event: Event, namespace: Option<&str>) -> Option<Vec<u8>> {
     let mut buf = Vec::new();
 
     let metric = event.as_metric();
@@ -194,8 +196,9 @@ fn encode_event(event: Event, namespace: &str) -> Option<Vec<u8>> {
     };
 
     let mut message: String = buf.join("|");
-    if !namespace.is_empty() {
-        message = format!("{}.{}", namespace, message);
+    message = match namespace {
+        Some(namespace) if !namespace.is_empty() => format!("{}.{}", namespace, message),
+        _ => message,
     };
 
     let mut body: Vec<u8> = message.into_bytes();
@@ -269,7 +272,7 @@ mod test {
             value: MetricValue::Counter { value: 1.5 },
         };
         let event = Event::Metric(metric1.clone());
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         let metric2 = parse(from_utf8(&frame).unwrap().trim()).unwrap();
         assert_eq!(metric1, metric2);
     }
@@ -285,7 +288,7 @@ mod test {
             value: MetricValue::Counter { value: 1.5 },
         };
         let event = Event::Metric(metric1);
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         // The statsd parser will parse the counter as Incremental,
         // so we can't compare it with the parsed value.
         assert_eq!("counter:1.5|c\n", from_utf8(&frame).unwrap());
@@ -302,7 +305,7 @@ mod test {
             value: MetricValue::Gauge { value: -1.5 },
         };
         let event = Event::Metric(metric1.clone());
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         let metric2 = parse(from_utf8(&frame).unwrap().trim()).unwrap();
         assert_eq!(metric1, metric2);
     }
@@ -318,7 +321,7 @@ mod test {
             value: MetricValue::Gauge { value: 1.5 },
         };
         let event = Event::Metric(metric1.clone());
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         let metric2 = parse(from_utf8(&frame).unwrap().trim()).unwrap();
         assert_eq!(metric1, metric2);
     }
@@ -338,7 +341,7 @@ mod test {
             },
         };
         let event = Event::Metric(metric1.clone());
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         let metric2 = parse(from_utf8(&frame).unwrap().trim()).unwrap();
         assert_eq!(metric1, metric2);
     }
@@ -356,7 +359,7 @@ mod test {
             },
         };
         let event = Event::Metric(metric1.clone());
-        let frame = &encode_event(event, "").unwrap();
+        let frame = &encode_event(event, None).unwrap();
         let metric2 = parse(from_utf8(&frame).unwrap().trim()).unwrap();
         assert_eq!(metric1, metric2);
     }
@@ -366,7 +369,7 @@ mod test {
         trace_init();
 
         let config = StatsdSinkConfig {
-            namespace: "vector".into(),
+            namespace: Some("vector".into()),
             address: default_address(),
             batch: BatchConfig {
                 max_bytes: Some(512),

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -106,9 +106,7 @@ impl StatsdSvc {
             acker,
         )
         .sink_map_err(|e| error!("Fatal statsd sink error: {}", e))
-        .with_flat_map(move |event| {
-            stream::iter_ok(encode_event(event, namespace.as_ref().map(|s| s.as_str())))
-        });
+        .with_flat_map(move |event| stream::iter_ok(encode_event(event, namespace.as_deref())));
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -21,6 +21,7 @@ use bytes::Bytes;
 use encoding::{EncodingConfig, EncodingConfiguration};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
+use std::borrow::Cow;
 
 pub use batch::{Batch, BatchConfig, BatchSettings, BatchSize, PushResult};
 pub use buffer::json::{BoxedRawValue, JsonArrayBuffer};
@@ -79,4 +80,17 @@ pub fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Op
     })
     .map_err(|error| error!(message = "Unable to encode.", %error))
     .ok()
+}
+
+/// Joins namespace with name via delimiter if namespace is present and not empty.
+pub fn encode_namespace<'a>(
+    namespace: Option<&str>,
+    delimiter: char,
+    name: impl Into<Cow<'a, str>>,
+) -> String {
+    let name = name.into();
+    match namespace {
+        Some(namespace) if !namespace.is_empty() => format!("{}{}{}", namespace, delimiter, name),
+        _ => name.into_owned(),
+    }
 }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -90,7 +90,11 @@ pub fn encode_namespace<'a>(
 ) -> String {
     let name = name.into();
     match namespace {
-        Some(namespace) if !namespace.is_empty() => format!("{}{}{}", namespace, delimiter, name),
+        Some(namespace) if namespace.is_empty() => {
+            warn!("Dropping empty namespace. This feature has been deprecated, and could be removed in the future.");
+            name.into_owned()
+        }
+        Some(namespace) => format!("{}{}{}", namespace, delimiter, name),
         _ => name.into_owned(),
     }
 }

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -220,7 +220,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                namespace: "vector".into(),
+                namespace: Some("vector".into()),
                 buckets: vec![1.0, 2.0, 4.0],
                 flush_period_secs: 1,
             },

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -135,7 +135,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                namespace: "vector".into(),
+                namespace: Some("vector".into()),
                 buckets: vec![1.0, 2.0, 4.0],
                 flush_period_secs: 1,
             },


### PR DESCRIPTION
Closes #3609 

Changes all of the sinks from #3609 except for `aws_cloudwatch_metrics`, reason being that the underlying library `rusoto_cloudwatch` requires namespace.

### Open questions

- [x] All of the changed sinks interpret empty string as no namespace. This behavior is currently preserved so to avoid breaking change, but, by making namespace optional, it seems strange from the point of the user for a specified empty namespace to be ignored, so we should consider removing it. (EDIT: added deprecation warning for using empty namespace.)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
