### PR TITLE
chore(deps): update warp 0.2.4 (git) to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5612,8 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.4"
-source = "git+https://github.com/seanmonstar/warp?rev=6777564d18b04c3d5b616a79907cfa175663c350#6777564d18b04c3d5b616a79907cfa175663c350"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ inventory = "0.1"
 maxminddb = { version = "0.14.0", optional = true }
 strip-ansi-escapes = { version = "0.1.0"}
 colored = "1.9"
-warp = { version = "0.2.4", default-features = false, optional = true }
+warp = { version = "0.2.5", default-features = false, optional = true }
 evmap = { version = "10.0.2", features = ["bytes"], optional = true }
 logfmt = { version = "0.0.2", optional = true }
 notify = "4.0.14"
@@ -460,6 +460,3 @@ required-features = ["kubernetes-e2e-tests"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
-
-[patch.crates-io]
-warp = { git = "https://github.com/seanmonstar/warp", rev = "6777564d18b04c3d5b616a79907cfa175663c350" }


### PR DESCRIPTION
Remove `[patch.crates-io]` from `Cargo.toml`.