### PR TITLE
chore: remove compat from sinks healthchecks

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -194,12 +194,9 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             Box::new(svc_sink)
         };
 
-        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed();
 
-        Ok((
-            super::VectorSink::Futures01Sink(sink),
-            Box::new(healthcheck),
-        ))
+        Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use chrono::{DateTime, SecondsFormat, Utc};
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use futures01::Sink;
 use lazy_static::lazy_static;
 use rusoto_cloudwatch::{
@@ -59,9 +59,9 @@ inventory::submit! {
 impl SinkConfig for CloudWatchMetricsSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
         let sink = CloudWatchMetricsSvc::new(self.clone(), client, cx)?;
-        Ok((sink, Box::new(healthcheck)))
+        Ok((sink, healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use futures01::{stream::iter_ok, Sink};
 use lazy_static::lazy_static;
 use rusoto_core::RusotoError;
@@ -74,11 +74,11 @@ inventory::submit! {
 impl SinkConfig for KinesisFirehoseSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
         let sink = KinesisFirehoseService::new(self.clone(), client, cx)?;
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use futures01::{stream::iter_ok, Sink};
 use lazy_static::lazy_static;
 use rand::random;
@@ -79,11 +79,11 @@ inventory::submit! {
 impl SinkConfig for KinesisSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
         let sink = KinesisService::new(self.clone(), client, cx)?;
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use bytes::Bytes;
 use chrono::Utc;
-use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use futures01::{stream::iter_ok, Sink};
 use http::StatusCode;
 use lazy_static::lazy_static;
@@ -143,9 +143,9 @@ inventory::submit! {
 impl SinkConfig for S3SinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let client = self.create_client(cx.resolver())?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed().compat();
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
         let sink = self.new(client, cx)?;
-        Ok((sink, Box::new(healthcheck)))
+        Ok((sink, healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -5,7 +5,8 @@ use crate::{
     event::{self, Event},
     internal_events::BlackholeEventReceived,
 };
-use futures01::{future, AsyncSink, Future, Poll, Sink, StartSend};
+use futures::{future, FutureExt};
+use futures01::{AsyncSink, Poll, Sink, StartSend};
 use serde::{Deserialize, Serialize};
 
 pub struct BlackholeSink {
@@ -28,7 +29,7 @@ inventory::submit! {
 impl SinkConfig for BlackholeConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = Box::new(BlackholeSink::new(self.clone(), cx.acker()));
-        let healthcheck = Box::new(healthcheck());
+        let healthcheck = future::ok(()).boxed();
 
         Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
@@ -40,10 +41,6 @@ impl SinkConfig for BlackholeConfig {
     fn sink_type(&self) -> &'static str {
         "blackhole"
     }
-}
-
-fn healthcheck() -> impl Future<Item = (), Error = crate::Error> {
-    future::ok(())
 }
 
 impl BlackholeSink {

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -10,7 +10,7 @@ use crate::{
     tls::{TlsOptions, TlsSettings},
 };
 use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, StatusCode, Uri};
 use hyper::Body;
@@ -80,11 +80,11 @@ impl SinkConfig for ClickhouseConfig {
         )
         .sink_map_err(|e| error!("Fatal clickhouse sink error: {}", e));
 
-        let healthcheck = healthcheck(client, self.clone()).boxed().compat();
+        let healthcheck = healthcheck(client, self.clone()).boxed();
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -7,9 +7,11 @@ use crate::{
     },
 };
 use async_trait::async_trait;
-use futures::pin_mut;
-use futures::stream::{Stream, StreamExt};
-use futures01::future;
+use futures::{
+    future, pin_mut,
+    stream::{Stream, StreamExt},
+    FutureExt,
+};
 use serde::{Deserialize, Serialize};
 use tokio::io::{self, AsyncWriteExt};
 
@@ -59,7 +61,7 @@ impl SinkConfig for ConsoleSinkConfig {
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(future::ok(())),
+            future::ok(()).boxed(),
         ))
     }
 

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -13,7 +13,6 @@ use crate::{
     tls::{MaybeTlsSettings, TlsConfig},
 };
 use bytes::Bytes;
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use serde::{Deserialize, Serialize};
 
@@ -63,10 +62,7 @@ impl SinkConfig for DatadogLogsConfig {
         let sink = StreamSink::new(sink, cx.acker())
             .with_flat_map(move |e| iter_ok(encode_event(e, &api_key, &encoding)));
 
-        Ok((
-            VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck.compat()),
-        ))
+        Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -14,7 +14,7 @@ use crate::{
     tls::{TlsOptions, TlsSettings},
 };
 use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{
     header::{HeaderName, HeaderValue},
@@ -104,7 +104,7 @@ impl SinkConfig for ElasticSearchConfig {
         let common = ElasticSearchCommon::parse_config(&self)?;
         let client = HttpClient::new(cx.resolver(), common.tls_settings.clone())?;
 
-        let healthcheck = healthcheck(client.clone(), common).boxed().compat();
+        let healthcheck = healthcheck(client.clone(), common).boxed();
 
         let common = ElasticSearchCommon::parse_config(&self)?;
         let compression = common.compression;
@@ -127,7 +127,7 @@ impl SinkConfig for ElasticSearchConfig {
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -602,7 +602,7 @@ mod integration_tests {
         tls::TlsOptions,
         Event,
     };
-    use futures::{compat::Future01CompatExt, future, stream, TryStreamExt};
+    use futures::{future, stream, TryStreamExt};
     use http::{Request, StatusCode};
     use hyper::Body;
     use serde_json::{json, Value};
@@ -758,7 +758,7 @@ mod integration_tests {
         let cx = SinkContext::new_test();
         let (sink, healthcheck) = config.build(cx.clone()).expect("Building config failed");
 
-        healthcheck.compat().await.expect("Health check failed");
+        healthcheck.await.expect("Health check failed");
 
         let (input, events) = random_events_with_stream(100, 100);
         match break_events {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -11,8 +11,11 @@ use crate::{
 use async_compression::tokio_02::write::GzipEncoder;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::pin_mut;
-use futures::stream::{Stream, StreamExt};
+use futures::{
+    future, pin_mut,
+    stream::{Stream, StreamExt},
+    FutureExt,
+};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use tokio::{
@@ -122,7 +125,7 @@ impl SinkConfig for FileSinkConfig {
         let sink = StreamSink::new(sink.into_futures01sink(), cx.acker());
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(futures01::future::ok(())),
+            future::ok(()).boxed(),
         ))
     }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use bytes::Bytes;
 use chrono::Utc;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::{stream::iter_ok, Sink};
 use http::{StatusCode, Uri};
 use hyper::{
@@ -157,10 +157,10 @@ impl SinkConfig for GcsSinkConfig {
 
     async fn build_async(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let sink = GcsSink::new(self, &cx).await?;
-        let healthcheck = sink.clone().healthcheck().boxed().compat();
+        let healthcheck = sink.clone().healthcheck().boxed();
         let service = sink.service(self, &cx)?;
 
-        Ok((service, Box::new(healthcheck)))
+        Ok((service, healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     tls::{TlsOptions, TlsSettings},
 };
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, Uri};
 use hyper::Body;
@@ -85,9 +85,7 @@ impl SinkConfig for PubsubConfig {
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(cx.resolver(), tls_settings)?;
 
-        let healthcheck = healthcheck(client.clone(), sink.uri("")?, sink.creds.clone())
-            .boxed()
-            .compat();
+        let healthcheck = healthcheck(client.clone(), sink.uri("")?, sink.creds.clone()).boxed();
 
         let sink = BatchedHttpSink::new(
             sink,
@@ -99,10 +97,7 @@ impl SinkConfig for PubsubConfig {
         )
         .sink_map_err(|e| error!("Fatal gcp pubsub sink error: {}", e));
 
-        Ok((
-            VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
-        ))
+        Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     tls::{TlsOptions, TlsSettings},
 };
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, Uri};
 use hyper::Body;
@@ -133,7 +133,7 @@ impl SinkConfig for StackdriverConfig {
                 .map(|key| Atom::from(key.as_str())),
         };
 
-        let healthcheck = healthcheck(client.clone(), sink.clone()).boxed().compat();
+        let healthcheck = healthcheck(client.clone(), sink.clone()).boxed();
 
         let sink = BatchedHttpSink::new(
             sink,
@@ -145,10 +145,7 @@ impl SinkConfig for StackdriverConfig {
         )
         .sink_map_err(|e| error!("Fatal stackdriver sink error: {}", e));
 
-        Ok((
-            VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
-        ))
+        Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -6,7 +6,7 @@ use crate::{
         BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, TowerRequestConfig, UriSerde,
     },
 };
-use futures::TryFutureExt;
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, StatusCode, Uri};
 use serde::{Deserialize, Serialize};
@@ -56,7 +56,7 @@ impl SinkConfig for HoneycombConfig {
         )
         .sink_map_err(|e| error!("Fatal honeycomb sink error: {}", e));
 
-        let healthcheck = Box::new(Box::pin(healthcheck(self.clone(), client)).compat());
+        let healthcheck = healthcheck(self.clone(), client).boxed();
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     tls::{TlsOptions, TlsSettings},
 };
-use futures::{FutureExt, TryFutureExt};
-use futures01::{future, Sink};
+use futures::{future, FutureExt};
+use futures01::Sink;
 use http::{
     header::{self, HeaderName, HeaderValue},
     Method, Request, StatusCode, Uri,
@@ -130,12 +130,10 @@ impl SinkConfig for HttpSinkConfig {
 
         match self.healthcheck_uri.clone() {
             Some(healthcheck_uri) => {
-                let healthcheck = healthcheck(healthcheck_uri, self.auth.clone(), client)
-                    .boxed()
-                    .compat();
-                Ok((sink, Box::new(healthcheck)))
+                let healthcheck = healthcheck(healthcheck_uri, self.auth.clone(), client).boxed();
+                Ok((sink, healthcheck))
             }
-            None => Ok((sink, Box::new(future::ok(())))),
+            None => Ok((sink, future::ok(()).boxed())),
         }
     }
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -118,10 +118,7 @@ impl SinkConfig for InfluxDBLogsConfig {
         )
         .sink_map_err(|e| error!("Fatal influxdb_logs sink error: {}", e));
 
-        Ok((
-            VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
-        ))
+        Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }
 
     fn input_type(&self) -> DataType {
@@ -195,7 +192,7 @@ impl InfluxDBLogsConfig {
             client,
         )?;
 
-        Ok(Box::new(healthcheck))
+        Ok(healthcheck)
     }
 }
 

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -716,7 +716,6 @@ mod integration_tests {
         },
         sinks::util::http::HttpClient,
     };
-    use futures::compat::Future01CompatExt;
 
     #[tokio::test]
     async fn influxdb2_healthchecks_ok() {
@@ -734,7 +733,6 @@ mod integration_tests {
 
         healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client)
             .unwrap()
-            .compat()
             .await
             .unwrap();
     }
@@ -755,7 +753,6 @@ mod integration_tests {
 
         healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client)
             .unwrap()
-            .compat()
             .await
             .unwrap_err();
     }
@@ -776,7 +773,6 @@ mod integration_tests {
 
         healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client)
             .unwrap()
-            .compat()
             .await
             .unwrap();
     }
@@ -797,7 +793,6 @@ mod integration_tests {
 
         healthcheck(endpoint, influxdb1_settings, influxdb2_settings, client)
             .unwrap()
-            .compat()
             .await
             .unwrap_err();
     }

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -3,8 +3,7 @@ pub mod metrics;
 
 use crate::sinks::util::{encode_namespace, http::HttpClient};
 use chrono::{DateTime, Utc};
-use futures::TryFutureExt;
-use futures01::Future;
+use futures::FutureExt;
 use http::{StatusCode, Uri};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -154,17 +153,18 @@ fn healthcheck(
 
     let request = hyper::Request::get(uri).body(hyper::Body::empty()).unwrap();
 
-    let healthcheck = client
-        .call(request)
-        .compat()
-        .map_err(|err| err.into())
-        .and_then(|response| match response.status() {
-            StatusCode::OK => Ok(()),
-            StatusCode::NO_CONTENT => Ok(()),
-            other => Err(super::HealthcheckError::UnexpectedStatus { status: other }.into()),
-        });
-
-    Ok(Box::new(healthcheck))
+    Ok(async move {
+        client
+            .call(request)
+            .await
+            .map_err(|err| err.into())
+            .and_then(|response| match response.status() {
+                StatusCode::OK => Ok(()),
+                StatusCode::NO_CONTENT => Ok(()),
+                other => Err(super::HealthcheckError::UnexpectedStatus { status: other }.into()),
+            })
+    }
+    .boxed())
 }
 
 // https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::util::encoding::{EncodingConfig, EncodingConfigWithDefault, EncodingConfiguration},
     template::{Template, TemplateError},
 };
-use futures::{compat::Compat, FutureExt, TryFutureExt};
+use futures::{compat::Compat, FutureExt};
 use futures01::{
     future as future01, stream::FuturesUnordered, Async, AsyncSink, Future, Poll, Sink, StartSend,
     Stream,
@@ -88,11 +88,8 @@ inventory::submit! {
 impl SinkConfig for KafkaSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = KafkaSink::new(self.clone(), cx.acker())?;
-        let hc = healthcheck(self.clone()).boxed().compat();
-        Ok((
-            super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(hc),
-        ))
+        let hc = healthcheck(self.clone()).boxed();
+        Ok((super::VectorSink::Futures01Sink(Box::new(sink)), hc))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -7,7 +7,7 @@ use crate::{
         BatchConfig, BatchSettings, BoxedRawValue, JsonArrayBuffer, TowerRequestConfig, UriSerde,
     },
 };
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, StatusCode, Uri};
 use serde::{Deserialize, Serialize};
@@ -79,11 +79,11 @@ impl SinkConfig for LogdnaConfig {
         )
         .sink_map_err(|e| error!("Fatal logdna sink error: {}", e));
 
-        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed();
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -25,7 +25,7 @@ use crate::{
     tls::{TlsOptions, TlsSettings},
 };
 use derivative::Derivative;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -95,11 +95,11 @@ impl SinkConfig for LokiConfig {
         )
         .sink_map_err(|e| error!("Fatal loki sink error: {}", e));
 
-        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed();
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -1,6 +1,7 @@
 use crate::Event;
 use futures::{
     compat::{Compat, Future01CompatExt},
+    future::BoxFuture,
     StreamExt, TryFutureExt,
 };
 use snafu::Snafu;
@@ -70,7 +71,7 @@ pub enum VectorSink {
     Futures01Sink(Box<dyn futures01::Sink<SinkItem = Event, SinkError = ()> + 'static + Send>),
 }
 
-pub type Healthcheck = Box<dyn futures01::Future<Item = (), Error = crate::Error> + Send>;
+pub type Healthcheck = BoxFuture<'static, crate::Result<()>>;
 
 /// Common build errors
 #[derive(Debug, Snafu)]

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -9,7 +9,6 @@ use crate::{
     tls::{MaybeTlsSettings, TlsSettings},
 };
 use bytes::Bytes;
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use serde::{Deserialize, Serialize};
 use syslog::{Facility, Formatter3164, LogFormat, Severity};
@@ -55,7 +54,7 @@ impl SinkConfig for PapertrailConfig {
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck.compat()),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -6,8 +6,8 @@ use crate::{
     Event,
 };
 use chrono::Utc;
-use futures::{compat::Future01CompatExt, future::FutureExt, TryFutureExt};
-use futures01::{future, Async, AsyncSink, Future, Sink};
+use futures::{compat::Future01CompatExt, future, FutureExt, TryFutureExt};
+use futures01::{Async, AsyncSink, Future, Sink};
 use hyper::{
     header::HeaderValue,
     service::{make_service_fn, service_fn},
@@ -74,7 +74,7 @@ impl SinkConfig for PrometheusSinkConfig {
         }
 
         let sink = Box::new(PrometheusSink::new(self.clone(), cx.acker()));
-        let healthcheck = Box::new(future::ok(()));
+        let healthcheck = future::ok(()).boxed();
 
         Ok((super::VectorSink::Futures01Sink(sink), healthcheck))
     }
@@ -307,7 +307,7 @@ fn handle(
         message = "Request complete",
         response_code = field::debug(response.status())
     );
-    Box::new(future::ok(response))
+    Box::new(futures01::future::ok(response))
 }
 
 impl PrometheusSink {

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -87,10 +87,10 @@ impl SinkConfig for PulsarSinkConfig {
             .create_pulsar_producer()
             .await
             .context(CreatePulsarSink)?;
-        let hc = healthcheck(producer);
+        let healthcheck = healthcheck(producer).boxed();
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(hc.boxed().compat()),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -13,7 +13,7 @@ use crate::{
     template::Template,
     tls::{TlsOptions, TlsSettings},
 };
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use futures01::Sink;
 use http::{Request, StatusCode, Uri};
 use hyper::Body;
@@ -106,11 +106,11 @@ impl SinkConfig for HecSinkConfig {
         )
         .sink_map_err(|e| error!("Fatal splunk_hec sink error: {}", e));
 
-        let healthcheck = healthcheck(self.clone(), client).boxed().compat();
+        let healthcheck = healthcheck(self.clone(), client).boxed();
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck,
         ))
     }
 

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -11,9 +11,7 @@ use crate::{
     tls::{MaybeTlsSettings, MaybeTlsStream, TlsConfig, TlsError},
 };
 use bytes::Bytes;
-use futures::{
-    compat::CompatSink, future::BoxFuture, task::noop_waker_ref, FutureExt, TryFutureExt,
-};
+use futures::{compat::CompatSink, task::noop_waker_ref, FutureExt, TryFutureExt};
 use futures01::{
     stream::iter_ok, try_ready, Async, AsyncSink, Future, Poll as Poll01, Sink, StartSend,
 };
@@ -67,10 +65,7 @@ impl TcpSinkConfig {
                 .with_flat_map(move |event| iter_ok(encode_event(event, &encoding))),
         );
 
-        Ok((
-            VectorSink::Futures01Sink(sink),
-            Box::new(healthcheck.compat()),
-        ))
+        Ok((VectorSink::Futures01Sink(sink), healthcheck))
     }
 }
 
@@ -108,7 +103,7 @@ impl TcpSink {
         }
     }
 
-    pub fn healthcheck(&self) -> BoxFuture<'static, crate::Result<()>> {
+    pub fn healthcheck(&self) -> Healthcheck {
         tcp_healthcheck(
             self.host.clone(),
             self.port,

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -5,8 +5,8 @@ use crate::{
     sinks::{Healthcheck, VectorSink},
 };
 use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
-use futures01::{future, stream::iter_ok, Async, AsyncSink, Future, Poll, Sink, StartSend};
+use futures::{future, FutureExt, TryFutureExt};
+use futures01::{stream::iter_ok, Async, AsyncSink, Future, Poll, Sink, StartSend};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::io;
@@ -61,7 +61,7 @@ pub fn raw_udp(
 }
 
 fn udp_healthcheck() -> Healthcheck {
-    Box::new(future::ok(()))
+    future::ok(()).boxed()
 }
 
 pub struct UdpSink {

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -41,9 +41,9 @@ impl UnixSinkConfig {
         let sink = Box::new(
             sink.with_flat_map(move |event| stream::iter_ok(encode_event(event, &encoding))),
         );
-        let healthcheck = healthcheck(self.path.clone()).boxed().compat();
+        let healthcheck = healthcheck(self.path.clone()).boxed();
 
-        Ok((VectorSink::Futures01Sink(sink), Box::new(healthcheck)))
+        Ok((VectorSink::Futures01Sink(sink), healthcheck))
     }
 }
 

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -7,7 +7,6 @@ use crate::{
     Event,
 };
 use bytes::{BufMut, Bytes, BytesMut};
-use futures::TryFutureExt;
 use futures01::{stream::iter_ok, Sink};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -55,7 +54,7 @@ impl SinkConfig for VectorSinkConfig {
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck.compat()),
+            healthcheck,
         ))
     }
 

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -834,7 +834,7 @@ mod tests {
     ) -> (VectorSink, mpsc::Receiver<Event>) {
         let (source, address) = source().await;
         let (sink, health) = sink(address, encoding, compression);
-        assert!(health.compat().await.is_ok());
+        assert!(health.await.is_ok());
         (sink, source)
     }
 
@@ -1093,7 +1093,7 @@ mod tests {
         let message = "no_authorization";
         let (source, address) = source_with(None).await;
         let (sink, health) = sink(address, Encoding::Text, Compression::Gzip);
-        assert!(health.compat().await.is_ok());
+        assert!(health.await.is_ok());
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -164,7 +164,7 @@ pub async fn build_pieces(
         let healthcheck_task = async move {
             if enable_healthcheck {
                 let duration = Duration::from_secs(10);
-                timeout(duration, healthcheck.compat())
+                timeout(duration, healthcheck)
                     .map(|result| match result {
                         Ok(Ok(_)) => {
                             info!("Healthcheck: Passed.");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,7 +3,8 @@
 // all over the place.
 #![allow(dead_code)]
 
-use futures01::{future, sink::Sink, stream, sync::mpsc::Receiver, Async, Future, Stream};
+use futures::{future, FutureExt};
+use futures01::{sink::Sink, stream, sync::mpsc::Receiver, Async, Future, Stream};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::sync::{
@@ -106,7 +107,7 @@ impl SourceConfig for MockSourceConfig {
         let mut recv = wrapped.lock().unwrap().take().unwrap();
         let mut shutdown = Some(shutdown);
         let mut _token = None;
-        let source = future::lazy(move || {
+        let source = futures01::future::lazy(move || {
             stream::poll_fn(move || {
                 if let Some(until) = shutdown.as_mut() {
                     match until.poll() {
@@ -285,7 +286,7 @@ where
         };
         Ok((
             VectorSink::Futures01Sink(Box::new(sink)),
-            Box::new(healthcheck),
+            healthcheck.boxed(),
         ))
     }
 


### PR DESCRIPTION
Each sink already uses new futures but adds an extra compatibility layer for nothing. This PR removes compat layer from sinks healthchecks.