### PR TITLE
fix(gcp_cloud_storage sink): apply encoding rules after key prefix

### DIFF
--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -402,7 +402,6 @@ fn encode_event(
     key_prefix: &Template,
     encoding: &EncodingConfig<Encoding>,
 ) -> Option<PartitionInnerBuffer<Vec<u8>, Bytes>> {
-    encoding.apply_rules(&mut event);
     let key = key_prefix
         .render_string(&event)
         .map_err(|missing_keys| {
@@ -413,6 +412,7 @@ fn encode_event(
             );
         })
         .ok()?;
+    encoding.apply_rules(&mut event);
     let log = event.into_log();
     let bytes = match encoding.codec() {
         Encoding::Ndjson => serde_json::to_vec(&log)

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -503,6 +503,21 @@ mod tests {
         assert_eq!(map["key"], "value".to_string());
     }
 
+    #[test]
+    fn gcs_encode_event_apply_rules() {
+        crate::test_util::trace_init();
+
+        let message = "hello world".to_string();
+        let mut event = Event::from(message);
+        event.as_mut_log().insert("key", "value");
+
+        let key_format = Template::try_from("key: {{ key }}").unwrap();
+        let bytes = encode_event(event, &key_format, &Encoding::Text.into()).unwrap();
+
+        let (_, key) = bytes.into_parts();
+        assert_eq!(key, "key: value");
+    }
+
     fn request_settings(
         extension: Option<&str>,
         uuid: bool,


### PR DESCRIPTION
Closes #3769 

Simple fix but the open a bigger question (related with #3766): how we can validate all sinks that encoding rules applied and when we should apply them.. extra documentation about encoding? Integrate encoding into the stream?