### PR TITLE
chore(tests): test_util::next_addr -- pick available port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "portpicker"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b497d05c16fe00939445c00a4fe2fa4f3d3dfc9c0401a3ab5c577afda2debb9"
+dependencies = [
+ "rand 0.6.5",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,6 +5469,7 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "pin-project",
+ "portpicker",
  "pretty_assertions",
  "prometheus-parser",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ task-compat = "0.1"
 cidr-utils = "0.4.2"
 pin-project = "0.4.23"
 k8s-openapi = { version = "0.9", features = ["v1_15"], optional = true }
+portpicker = "0.1.0"
 
 # For WASM
 vector-wasm = { path = "lib/vector-wasm", optional = true }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -111,12 +111,11 @@ high: `{:?}`
 
 }
 
-static NEXT_PORT: AtomicUsize = AtomicUsize::new(1234);
-
 pub fn next_addr() -> SocketAddr {
+    use portpicker::pick_unused_port;
     use std::net::{IpAddr, Ipv4Addr};
 
-    let port = NEXT_PORT.fetch_add(1, Ordering::AcqRel) as u16;
+    let port = pick_unused_port().unwrap();
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
 }
 


### PR DESCRIPTION
Replaces the static port 1234 used in `test_util::next_addr()` with [portpicker](https://github.com/Dentosal/portpicker-rs), to return an available TCP/UDP port.

I ran into a situation where I actually had a running service on 1234, and asserts of the response body were failing. This prevents that (probably quite uncommon, but hey-- it happened) scenario.

The [source](https://github.com/Dentosal/portpicker-rs/blob/master/src/lib.rs) looks fairly benign. A random port between 15000 - 25000 is tried (up to 10x) before deferring to the OS to pick a port by binding to localhost:0 and the attempting to listen on that port (again, up to 10x.) If the total 20 iterations fail, nothing is returned and the tests fail.

Should be a drop-in replacement, unless we're relying on hardcoded ports (which I'll scan for in tests.)

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
