### PR TITLE
chore(observability): Make counters naming consistent

### DIFF
--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -30,7 +30,7 @@ impl<'a> InternalEvent for CoercerConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "coercer",
             "error_type" => "type_conversion_failed",

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -32,7 +32,7 @@ impl InternalEvent for GrokParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "grok_parser",
             "error_type" => "failed_match",
@@ -51,7 +51,7 @@ impl InternalEvent for GrokParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "grok_parser",
             "error_type" => "missing_field",
@@ -76,7 +76,7 @@ impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "grok_parser",
             "error_type" => "type_conversion_failed",

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -36,7 +36,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "json_parser",
             "error_type" => "failed_parse",
@@ -59,7 +59,7 @@ impl<'a> InternalEvent for JsonParserTargetExists<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "json_parser",
             "error_type" => "target_field_exists",

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -33,7 +33,7 @@ impl InternalEvent for RegexParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "regex_parser",
             "error_type" => "failed_match",
@@ -52,7 +52,7 @@ impl InternalEvent for RegexParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "regex_parser",
             "error_type" => "missing_field",
@@ -75,7 +75,7 @@ impl<'a> InternalEvent for RegexParserTargetExists<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "regex_parser",
             "error_type" => "target_field_exists",
@@ -100,7 +100,7 @@ impl<'a> InternalEvent for RegexParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_error", 1,
+        counter!("processing_errors", 1,
             "component_kind" => "transform",
             "component_type" => "regex_parser",
             "error_type" => "type_conversion_failed",


### PR DESCRIPTION
We are using both "processing_error" and "processing_errors" in counters.

This PR renames all to "processing_error**s**".

Signed-off-by: Duy Do <juchiast@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
