### PR TITLE
fix: remove unused imports

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -110,11 +110,7 @@ pub use self::remove_tags::*;
 #[cfg(feature = "transforms-rename_fields")]
 pub use self::rename_fields::*;
 pub use self::sampler::*;
-#[cfg(any(
-    feature = "sources-socket",
-    feature = "sources-syslog",
-    feature = "sources-vector"
-))]
+#[cfg(any(feature = "sources-socket", feature = "sources-syslog"))]
 pub(crate) use self::socket::*;
 pub use self::split::*;
 #[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -243,7 +243,7 @@ mod integration_tests {
         sinks::util::encoding::TimestampFormat,
         test_util::{random_string, trace_init},
     };
-    use futures::{compat::Future01CompatExt, future, stream};
+    use futures::{future, stream};
     use serde_json::Value;
     use tokio::time::{timeout, Duration};
 

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -91,7 +91,7 @@ mod test {
         event::Event,
         test_util::{next_addr, next_addr_v6, random_lines_with_stream, trace_init, CountReceiver},
     };
-    use futures::{compat::Sink01CompatExt, future, stream, SinkExt};
+    use futures::{future, stream};
     use serde_json::Value;
     use std::net::{SocketAddr, UdpSocket};
 
@@ -183,7 +183,7 @@ mod test {
     #[tokio::test]
     async fn tcp_stream_detects_disconnect() {
         use crate::tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};
-        use futures::{future, FutureExt, StreamExt};
+        use futures::{compat::Sink01CompatExt, future, FutureExt, SinkExt, StreamExt};
         use std::{
             net::Shutdown,
             pin::Pin,


### PR DESCRIPTION
Fix `unused_imports` warnings (introduced in https://github.com/timberio/vector/pull/3743) in `clickhouse.rs`.
Also fixes `unused_imports` in `socket.rs`.