### PR TITLE
enhancement(tokenizer transform): add internal events

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -61,6 +61,8 @@ mod syslog;
 #[cfg(feature = "transforms-tag_cardinality_limit")]
 mod tag_cardinality_limit;
 mod tcp;
+#[cfg(feature = "transforms-tokenizer")]
+mod tokenizer;
 mod unix;
 mod vector;
 #[cfg(feature = "wasm")]
@@ -126,6 +128,8 @@ pub use self::syslog::*;
 #[cfg(feature = "transforms-tag_cardinality_limit")]
 pub(crate) use self::tag_cardinality_limit::*;
 pub use self::tcp::*;
+#[cfg(feature = "transforms-tokenizer")]
+pub use self::tokenizer::*;
 pub use self::unix::*;
 pub use self::vector::*;
 #[cfg(feature = "wasm")]

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -129,7 +129,7 @@ pub use self::syslog::*;
 pub(crate) use self::tag_cardinality_limit::*;
 pub use self::tcp::*;
 #[cfg(feature = "transforms-tokenizer")]
-pub use self::tokenizer::*;
+pub(crate) use self::tokenizer::*;
 pub use self::unix::*;
 pub use self::vector::*;
 #[cfg(feature = "wasm")]

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -3,7 +3,7 @@ use metrics::counter;
 use string_cache::DefaultAtom as Atom;
 
 #[derive(Debug)]
-pub struct TokenizerEventProcessed;
+pub(crate) struct TokenizerEventProcessed;
 
 impl InternalEvent for TokenizerEventProcessed {
     fn emit_metrics(&self) {
@@ -15,7 +15,7 @@ impl InternalEvent for TokenizerEventProcessed {
 }
 
 #[derive(Debug)]
-pub struct TokenizerFieldMissing<'a> {
+pub(crate) struct TokenizerFieldMissing<'a> {
     pub field: &'a Atom,
 }
 
@@ -38,7 +38,7 @@ impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
 }
 
 #[derive(Debug)]
-pub struct TokenizerConvertFailed<'a> {
+pub(crate) struct TokenizerConvertFailed<'a> {
     pub field: &'a Atom,
     pub error: crate::types::Error,
 }

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -1,0 +1,63 @@
+use super::InternalEvent;
+use metrics::counter;
+use string_cache::DefaultAtom as Atom;
+
+#[derive(Debug)]
+pub struct TokenizerEventProcessed;
+
+impl InternalEvent for TokenizerEventProcessed {
+    fn emit_metrics(&self) {
+        counter!("events_processed", 1,
+            "component_kind" => "transform",
+            "component_type" => "tokenizer",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct TokenizerFieldMissing<'a> {
+    pub field: &'a Atom,
+}
+
+impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
+    fn emit_logs(&self) {
+        debug!(
+            message = "Field does not exist.",
+            field = %self.field,
+            rate_limit_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processing_errors", 1,
+            "component_kind" => "transform",
+            "component_type" => "tokenizer",
+            "error_type" => "field_missing",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct TokenizerConvertFailed<'a> {
+    pub field: &'a Atom,
+    pub error: crate::types::Error,
+}
+
+impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
+    fn emit_logs(&self) {
+        debug!(
+            message = "Could not convert types.",
+            field = %self.field,
+            error = %self.error,
+            rate_limit_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processing_errors", 1,
+            "component_kind" => "transform",
+            "component_type" => "tokenizer",
+            "error_type" => "convert_failed",
+        );
+    }
+}

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -2,6 +2,7 @@ use super::Transform;
 use crate::{
     config::{DataType, TransformConfig, TransformContext, TransformDescription},
     event::{self, Event, PathComponent, PathIter},
+    internal_events::{TokenizerConvertFailed, TokenizerEventProcessed, TokenizerFieldMissing},
     types::{parse_check_conversion_map, Conversion},
 };
 use nom::{
@@ -65,7 +66,7 @@ impl TransformConfig for TokenizerConfig {
 }
 
 pub struct Tokenizer {
-    field_names: Vec<(String, Vec<PathComponent>, Conversion)>,
+    field_names: Vec<(Atom, Vec<PathComponent>, Conversion)>,
     field: Atom,
     drop_field: bool,
 }
@@ -82,7 +83,7 @@ impl Tokenizer {
             .map(|name| {
                 let conversion = types.get(&name).unwrap_or(&Conversion::Bytes).clone();
                 let path: Vec<PathComponent> = PathIter::new(&name).collect();
-                (name.to_string(), path, conversion)
+                (name, path, conversion)
             })
             .collect();
 
@@ -107,12 +108,7 @@ impl Transform for Tokenizer {
                         event.as_mut_log().insert_path(path.clone(), value);
                     }
                     Err(error) => {
-                        debug!(
-                            message = "Could not convert types.",
-                            path = &name[..],
-                            %error,
-                            rate_limit_secs = 30
-                        );
+                        emit!(TokenizerConvertFailed { field: name, error });
                     }
                 }
             }
@@ -120,11 +116,10 @@ impl Transform for Tokenizer {
                 event.as_mut_log().remove(&self.field);
             }
         } else {
-            debug!(
-                message = "Field does not exist.",
-                field = self.field.as_ref(),
-            );
+            emit!(TokenizerFieldMissing { field: &self.field });
         };
+
+        emit!(TokenizerEventProcessed);
 
         Some(event)
     }


### PR DESCRIPTION
Closes #3410

Pretty straightfoward. Snuck in one small cleanup to get rid of an unnecessary conversion and align better with other `MissingField` errors.