### PR TITLE
fix: Avoid calling `peer_addr`

### DIFF
--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -242,7 +242,7 @@ mod test {
         // Only accept two connections.
         let jh = tokio::spawn(async move {
             let tls = MaybeTlsSettings::from_config(&config, true).unwrap();
-            let mut listener = tls.bind(&addr).await.unwrap();
+            let listener = tls.bind(&addr).await.unwrap();
             listener
                 .accept_stream()
                 .take(2)

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -244,7 +244,7 @@ mod test {
             let tls = MaybeTlsSettings::from_config(&config, true).unwrap();
             let mut listener = tls.bind(&addr).await.unwrap();
             listener
-                .incoming()
+                .accept_stream()
                 .take(2)
                 .for_each(|connection| {
                     let mut close_rx = close_rx.take();

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -120,12 +120,12 @@ impl SourceConfig for SplunkConfig {
             .or_else(finish_err);
 
         let tls = MaybeTlsSettings::from_config(&self.tls, true)?;
-        let mut listener = tls.bind(&self.address).await?;
+        let listener = tls.bind(&self.address).await?;
 
         let fut = async move {
             let _ = warp::serve(services)
                 .serve_incoming_with_graceful_shutdown(
-                    listener.incoming(),
+                    listener.accept_stream(),
                     shutdown.clone().compat().map(|_| ()),
                 )
                 .await;

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -126,10 +126,10 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
 
         let tls = MaybeTlsSettings::from_config(tls, true)?;
         let fut = async move {
-            let mut listener = tls.bind(&address).await.unwrap();
+            let listener = tls.bind(&address).await.unwrap();
             let _ = warp::serve(routes)
                 .serve_incoming_with_graceful_shutdown(
-                    listener.incoming(),
+                    listener.accept_stream(),
                     shutdown.clone().compat().map(|_| ()),
                 )
                 .await;

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -78,7 +78,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
         let listenfd = ListenFd::from_env();
 
         let fut = async move {
-            let mut listener = match make_listener(addr, listenfd, &tls).await {
+            let listener = match make_listener(addr, listenfd, &tls).await {
                 None => return Err(()),
                 Some(listener) => listener,
             };
@@ -101,7 +101,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
             .shared();
 
             listener
-                .incoming()
+                .accept_stream()
                 .take_until(shutdown.clone().compat())
                 .for_each(|connection| {
                     let shutdown = shutdown.clone();

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -1,11 +1,15 @@
-use super::{CreateAcceptor, MaybeTlsSettings, MaybeTlsStream, TcpBind, TlsError, TlsSettings};
+use super::{
+    CreateAcceptor, IncomingListener, MaybeTlsSettings, MaybeTlsStream, TcpBind, TlsError,
+    TlsSettings,
+};
 #[cfg(feature = "listenfd")]
-use super::{Handshake, MaybeTls, PeerAddress};
+use super::{Handshake, MaybeTls};
 use bytes::{Buf, BufMut};
-use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, stream, FutureExt, Stream};
 use openssl::ssl::{SslAcceptor, SslMethod};
 use snafu::ResultExt;
 use std::{
+    future::Future,
     mem::MaybeUninit,
     net::SocketAddr,
     pin::Pin,
@@ -50,16 +54,33 @@ pub(crate) struct MaybeTlsListener {
 }
 
 impl MaybeTlsListener {
-    pub(crate) fn incoming(
-        &mut self,
-    ) -> impl Stream<Item = crate::tls::Result<MaybeTlsIncomingStream<TcpStream>>> + '_ {
-        let acceptor = self.acceptor.clone();
+    pub(crate) async fn accept(&mut self) -> crate::tls::Result<MaybeTlsIncomingStream<TcpStream>> {
         self.listener
-            .incoming()
-            .map(move |connection| match connection {
-                Ok(stream) => MaybeTlsIncomingStream::new(stream, acceptor.clone()),
-                Err(source) => Err(TlsError::IncomingListener { source }),
+            .accept()
+            .await
+            .map(|(stream, peer_addr)| {
+                MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
             })
+            .context(IncomingListener)
+    }
+
+    async fn into_accept(
+        mut self,
+    ) -> (crate::tls::Result<MaybeTlsIncomingStream<TcpStream>>, Self) {
+        (self.accept().await, self)
+    }
+
+    pub(crate) fn accept_stream(
+        self,
+    ) -> impl Stream<Item = crate::tls::Result<MaybeTlsIncomingStream<TcpStream>>> {
+        let mut accept = Box::pin(self.into_accept());
+        stream::poll_fn(move |context| match accept.as_mut().poll(context) {
+            Poll::Ready((item, this)) => {
+                accept.set(this.into_accept());
+                Poll::Ready(Some(item))
+            }
+            Poll::Pending => Poll::Pending,
+        })
     }
 
     #[cfg(feature = "listenfd")]
@@ -115,16 +136,16 @@ impl MaybeTlsIncomingStream<TcpStream> {
     #[cfg(feature = "listenfd")]
     pub(super) fn new(
         stream: TcpStream,
+        peer_addr: SocketAddr,
         acceptor: Option<SslAcceptor>,
-    ) -> crate::tls::Result<Self> {
-        let peer_addr = stream.peer_addr().context(PeerAddress)?;
+    ) -> Self {
         let state = match acceptor {
             Some(acceptor) => StreamState::Accepting(
                 async move { tokio_openssl::accept(&acceptor, stream).await }.boxed(),
             ),
             None => StreamState::Accepted(MaybeTlsStream::Raw(stream)),
         };
-        Ok(Self { peer_addr, state })
+        Self { peer_addr, state }
     }
 
     #[cfg(not(feature = "listenfd"))]

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -149,18 +149,14 @@ impl MaybeTlsIncomingStream<TcpStream> {
     }
 
     #[cfg(not(feature = "listenfd"))]
-    pub(super) fn new(
-        stream: TcpStream,
-        _: SocketAddr,
-        acceptor: Option<SslAcceptor>,
-    ) -> crate::tls::Result<Self> {
+    pub(super) fn new(stream: TcpStream, _: SocketAddr, acceptor: Option<SslAcceptor>) -> Self {
         let state = match acceptor {
             Some(acceptor) => StreamState::Accepting(
                 async move { tokio_openssl::accept(&acceptor, stream).await }.boxed(),
             ),
             None => StreamState::Accepted(MaybeTlsStream::Raw(stream)),
         };
-        Ok(Self { state })
+        Self { state }
     }
 
     // Explicit handshake method

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -151,6 +151,7 @@ impl MaybeTlsIncomingStream<TcpStream> {
     #[cfg(not(feature = "listenfd"))]
     pub(super) fn new(
         stream: TcpStream,
+        _: SocketAddr,
         acceptor: Option<SslAcceptor>,
     ) -> crate::tls::Result<Self> {
         let state = match acceptor {


### PR DESCRIPTION
Ref #2731.

The issue with vector shutting down when we fail to accept `tcp` connenction was fixed with #3449. This PR addresses the source of the error which was a call to `peer_addr`. There was probably a race, between us receiving the socket and calling `peer_addr`, and other side closing the channel. Although I wasn't able to trigger this race, the PR adds a fix which completely eliminates the need for calling `peer_addr` and so eliminates any race that we can avoid.

The bug was effecting multiple sources and sinks  

### Todo

- [x] Ask for original reporters to verify that this PR fixes the issue.    


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
