### PR TITLE
feat(platforms): rough draft of "service" deployment for vector

### DIFF
--- a/distribution/helm/vector-service/.helmignore
+++ b/distribution/helm/vector-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/distribution/helm/vector-service/Chart.yaml
+++ b/distribution/helm/vector-service/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: nightly-2020-09-10
+description: A Helm chart to collect Kubernetes logs with Vector
+home: https://vector.dev/
+icon: https://vector.dev/press/vector-icon.svg
+maintainers:
+- email: vector@timber.io
+  name: Vector Contributors
+name: vector-service
+sources:
+- https://github.com/timberio/vector/
+type: application
+version: 0.11.0-nightly-2020-09-10

--- a/distribution/helm/vector-service/templates/_helpers.tpl
+++ b/distribution/helm/vector-service/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vector.labels" -}}
+helm.sh/chart: {{ include "vector.chart" . }}
+{{ include "vector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the name of the ConfigMap
+*/}}
+{{- define "vector.configMapName" -}}
+{{- if (empty .Values.existingConfigMap) }}
+{{- include "vector.fullname" . }}
+{{- else }}
+{{- .Values.existingConfigMap }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the actual image tag to use.
+*/}}
+{{- define "vector.imageTag" -}}
+{{- if .Values.image.tag }}
+{{- .Values.image.tag }}
+{{- else }}
+{{- $version := default .Chart.AppVersion .Values.image.version }}
+{{- printf "%s-%s" $version .Values.image.base }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-service/templates/configmap.yaml
+++ b/distribution/helm/vector-service/templates/configmap.yaml
@@ -1,0 +1,49 @@
+{{- if (empty .Values.existingConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vector.configMapName" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+data:
+  vector.toml: |
+    data_dir = "{{ .Values.globalOptions.dataDir }}"
+
+    {{- with .Values.logSchema }}
+    [log_schema]
+      host_key = "{{ .hostKey }}"
+      message_key = "{{ .messageKey }}"
+      source_type_key = "{{ .sourceTypeKey }}"
+      timestamp_key = "{{ .timestampKey }}"
+    {{- end }}
+
+    {{- range $sourceId, $source := .Values.sources }}
+    [sources.{{ $sourceId }}]
+      type = "{{ $source.type }}"
+
+      {{- with $source.rawConfig }}
+      {{- . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $transformId, $transform := .Values.transforms }}
+    [transforms.{{ $transformId }}]
+      type = "{{ $transform.type }}"
+      inputs = {{ $transform.inputs | toJson }}
+
+      {{- with $transform.rawConfig }}
+      {{- . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- range $sinkId, $sink := .Values.sinks }}
+    [sinks.{{ $sinkId }}]
+      type = "{{ $sink.type }}"
+      inputs = {{ $sink.inputs | toJson }}
+
+      {{- with $sink.rawConfig }}
+      {{- . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+
+{{- end }}

--- a/distribution/helm/vector-service/templates/podsecuritypolicy.yaml
+++ b/distribution/helm/vector-service/templates/podsecuritypolicy.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "vector.fullname" . }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'hostPath'
+    - 'configMap'
+    - 'secret'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+      readOnly: true
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+    {{- range .Values.extraVolumes }}
+    {{- if .hostPath }}
+    - pathPrefix: {{ .hostPath.path }}
+    {{- end }}
+    {{- end }}
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+{{- end }}

--- a/distribution/helm/vector-service/templates/rbac.yaml
+++ b/distribution/helm/vector-service/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vector.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - watch
+{{- if .Values.psp.enabled }}
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - {{ include "vector.fullname" . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vector.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/distribution/helm/vector-service/templates/service.yaml
+++ b/distribution/helm/vector-service/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: metrics
+      port: 9598
+      protocol: TCP
+      targetPort: 9598
+  selector:
+    {{- include "vector.selectorLabels" . | nindent 4 }}

--- a/distribution/helm/vector-service/templates/serviceaccount.yaml
+++ b/distribution/helm/vector-service/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vector.serviceAccountName" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/distribution/helm/vector-service/templates/statefulset.yaml
+++ b/distribution/helm/vector-service/templates/statefulset.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+spec:
+  podManagementPolicy: "{{ .Values.podManagementPolicy }}"
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "vector.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "vector.fullname" . }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "vector.selectorLabels" . | nindent 8 }}
+        vector.dev/exclude: "true"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vector.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: vector
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "vector.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # Vector data dir mount.
+            - name: data-dir
+              mountPath: "{{ .Values.globalOptions.dataDir }}"
+            # Vector config dir mount.
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            # Extra volumes.
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      terminationGracePeriodSeconds: 60
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        # Vector will store it's data here.
+        - name: data-dir
+        {{- if .Values.storage.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: datadir
+        {{- else if .Values.storage.hostPath }}
+          hostPath:
+            path: {{ .Values.storage.hostPath | quote }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        # Vector config dir with a managed config map.
+        - name: config-dir
+          configMap:
+            name: {{ include "vector.configMapName" . }}
+        # Extra volumes.
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- if .Values.storage.persistentVolume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data-dir
+        labels:
+          app.kubernetes.io/name: {{ template "vector.name" . }}
+          app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- with .Values.storage.persistentVolume.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.storage.persistentVolume.annotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+      {{- end }}
+      spec:
+        accessModes: ["ReadWriteOnce"]
+      {{- if .Values.storage.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.storage.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: {{ .Values.storage.persistentVolume.storageClass | quote}}
+      {{- end }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.persistentVolume.size | quote }}
+{{- end }}

--- a/distribution/helm/vector-service/values.yaml
+++ b/distribution/helm/vector-service/values.yaml
@@ -1,0 +1,147 @@
+# Default values for vector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: timberio/vector
+  pullPolicy: IfNotPresent
+  # Overrides the image tag, the default is `{image.version}-{image.base}`.
+  tag: ""
+  # Overrides the image version, the default is the Chart appVersion.
+  version: ""
+  base: "debian"
+
+# Image pull secrets to use at the `Pod`s managed by `StatefulSet`.
+imagePullSecrets: []
+
+# Override the chart name used in templates.
+nameOverride: ""
+# Override the full chart name (name prefixed with release name) used in
+# templates.
+fullnameOverride: ""
+
+podManagementPolicy: Parallel
+
+replicas: 1
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and `create` is true, a name is generated using the `fullname`
+  # template.
+  name: ""
+
+# Annotations to add to the `Pod`s managed by `StatefulSet`.
+podAnnotations: {}
+
+# Labels to add to the `Pod`s managed by `StatefulSet`.
+podLabels: {}
+
+# PodSecurityContext to set at the `Pod`s managed by `StatefulSet`.
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Security context to set at the `vector` container at the `Pod`s managed by
+# `StatefulSet`.
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Extra env vars to pass to the `vector` container.
+env: []
+  # - name: VAR
+  #    valueFrom:
+  #      secretKeyRef:
+  #        name: secret
+  #        key: password
+
+# Various tweakables for the `Pod`s managed by `StatefulSet`.
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Additional volumes to pass to the `Pod`s managed by `StatefulSet`.
+extraVolumes: []
+
+# Additional volume mounts to pass to the `vector` container of the `Pod`s
+# managed by `StatefulSet`.
+extraVolumeMounts: []
+
+rbac:
+  # Whether to create rbac resources or not. Disable for non-rbac clusters.
+  enabled: false
+
+psp:
+  # Whether to create `PodSecurityPolicy` or not.
+  enabled: false
+
+# Set this to non-empty value to use existing `ConfigMap` for `vector`, instead
+# of using a generated one.
+existingConfigMap: ""
+
+# Global parts of the generated `vector` config.
+globalOptions:
+  # Specifies the (in-container) data dir used by `vector`.
+  dataDir: "/vector-data-dir"
+
+# Schema part of the generated `vector` config.
+logSchema:
+  hostKey: "host"
+  messageKey: "message"
+  sourceTypeKey: "source_type"
+  timestampKey: "timestamp"
+
+
+# Sources to add to the generated `vector` config
+sources: {}
+  # source_name:
+  #   type: "source_type"
+  #   rawConfig: |
+  #     option = "value"
+
+# Transforms to add to the generated `vector` config.
+transforms: {}
+  # transform_name:
+  #   type: "transform_type"
+  #   inputs: ["input1", "input2"]
+  #   rawConfig: |
+  #     option = "value"
+
+# Sinks to add to the generated `vector` config.
+sinks: {}
+  # sink_name:
+  #   type: "sink_type"
+  #   inputs: ["input1", "input2"]
+  #   rawConfig: |
+  #     option = "value"
+
+storage:
+  # Absolute path on host to store CockroachDB's data.
+  # If specified, but `persistentVolume.enabled` is `true`, then has no effect.
+  hostPath: ""
+
+  # If `enabled` is `true` then a PersistentVolumeClaim will be created and
+  # used to store Vector's data, otherwise `hostPath` is used.
+  persistentVolume:
+    enabled: false
+    size: 10Gi
+    # If defined, then `storageClassName: <storageClass>`.
+    # If set to "-", then `storageClassName: ""`, which disables dynamic
+    # provisioning.
+    # If undefined or empty (default), then no `storageClassName` spec is set,
+    # so the default provisioner will be chosen (gp2 on AWS, standard on
+    # GKE, AWS & OpenStack).
+    storageClass: ""
+
+    # Additional labels to apply to the created PersistentVolumeClaims.
+    labels: {}
+    # Additional annotations to apply to the created PersistentVolumeClaims.
+    annotations: {}


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
As I'm drafting an internal proposal to migrate our existing logging pipeline to use vector I needed a deployment method that would replace Logstash for doing transformations across all events and index them appropriately into Elasticsearch.

Currently Vector provides a chart for a "daemon" installation with a DaemonSet resource, and I converted those resources to use a StatefulSet to handle the "service" strategy described [here](https://vector.dev/docs/setup/deployment/strategies/#service).

This is still a WIP, but is currently working in my current experiments.

Related: #3227
