### PR TITLE
docs: Use `ndjson` naming in sinks

### DIFF
--- a/.meta/sinks/aws_cloudwatch_logs.toml.erb
+++ b/.meta/sinks/aws_cloudwatch_logs.toml.erb
@@ -50,7 +50,7 @@ write_to_description = "[Amazon Web Service's CloudWatch Logs service][urls.aws_
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.aws_cloudwatch_logs.options",
-  encodings: ["json", "text"]
+  encodings: ["ndjson", "text"]
 ) %>
 
 <%= render("_partials/fields/_compression_options.toml",

--- a/.meta/sinks/aws_kinesis_firehose.toml.erb
+++ b/.meta/sinks/aws_kinesis_firehose.toml.erb
@@ -52,7 +52,7 @@ write_to_description = "[Amazon Web Service's Kinesis Data Firehose][urls.aws_ki
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.aws_kinesis_firehose.options",
-  encodings: ["json", "text"]
+  encodings: ["ndjson", "text"]
 ) %>
 
 <%= render("_partials/fields/_compression_options.toml",

--- a/.meta/sinks/aws_kinesis_streams.toml.erb
+++ b/.meta/sinks/aws_kinesis_streams.toml.erb
@@ -52,7 +52,7 @@ write_to_description = "[Amazon Web Service's Kinesis Data Stream service][urls.
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.aws_kinesis_streams.options",
-  encodings: ["json", "text"]
+  encodings: ["ndjson", "text"]
 ) %>
 
 <%= render("_partials/fields/_compression_options.toml",

--- a/.meta/sinks/console.toml.erb
+++ b/.meta/sinks/console.toml.erb
@@ -25,7 +25,7 @@ write_to_description = "[standard output streams][urls.standard_streams], such a
 <%= render(
   "_partials/fields/_encoding_options.toml",
   namespace: "sinks.console.options",
-  encodings: ["json", "text"]
+  encodings: ["ndjson", "text"]
 ) %>
 
 [sinks.console.options.target]

--- a/.meta/sinks/datadog_logs.toml.erb
+++ b/.meta/sinks/datadog_logs.toml.erb
@@ -27,7 +27,7 @@ requirements = {}
 <%= render(
   "_partials/fields/_encoding_options.toml",
   namespace: "sinks.datadog_logs.options",
-  encodings: ["json", "text"]
+  encodings: ["ndjson", "text"]
 ) %>
 
 [sinks.datadog_logs.options.api_key]

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -94,5 +94,5 @@ description = "The optional endpoint to send Humio logs to."
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.humio_logs.options",
   encodings: ["ndjson", "text"],
-  default: "json"
+  default: "ndjson"
 ) %>

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -93,6 +93,6 @@ description = "The optional endpoint to send Humio logs to."
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.humio_logs.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   default: "json"
 ) %>

--- a/.meta/sinks/kafka.toml.erb
+++ b/.meta/sinks/kafka.toml.erb
@@ -46,7 +46,7 @@ write_to_description = "[Apache Kafka][urls.kafka] via the [Kafka protocol][urls
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.kafka.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   default: "text"
 ) %>
 

--- a/.meta/sinks/loki.toml.erb
+++ b/.meta/sinks/loki.toml.erb
@@ -56,7 +56,7 @@ description = "The endpoint used to ship logs to."
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.loki.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   default: "json"
 ) %>
 

--- a/.meta/sinks/loki.toml.erb
+++ b/.meta/sinks/loki.toml.erb
@@ -57,7 +57,7 @@ description = "The endpoint used to ship logs to."
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.loki.options",
   encodings: ["ndjson", "text"],
-  default: "json"
+  default: "ndjson"
 ) %>
 
 [sinks.loki.options.tenant_id]

--- a/.meta/sinks/new_relic_logs.toml.erb
+++ b/.meta/sinks/new_relic_logs.toml.erb
@@ -76,6 +76,6 @@ eu = "The EU region"
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.new_relic_logs.options",
-  encodings: ["json"],
-  default: "json"
+  encodings: ["ndjson"],
+  default: "ndjson"
 ) %>

--- a/.meta/sinks/papertrail.toml.erb
+++ b/.meta/sinks/papertrail.toml.erb
@@ -28,7 +28,7 @@ write_to_description = "[Papertrail][urls.papertrail] via [Syslog][urls.papertra
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.papertrail.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
 ) %>
 
 [sinks.papertrail.options.endpoint]

--- a/.meta/sinks/pulsar.toml.erb
+++ b/.meta/sinks/pulsar.toml.erb
@@ -26,7 +26,7 @@ write_to_description = "[Apache Pulsar][urls.pulsar] via the [Pulsar protocol][u
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.pulsar.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   default: "text"
 ) %>
 

--- a/.meta/sinks/socket.toml.erb
+++ b/.meta/sinks/socket.toml.erb
@@ -31,7 +31,7 @@ write_to_description = "a [socket][urls.socket], such as a [TCP][urls.tcp], [UDP
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.socket.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   groups: ["tcp", "udp", "unix"]
 ) %>
 

--- a/.meta/sinks/splunk_hec.toml.erb
+++ b/.meta/sinks/splunk_hec.toml.erb
@@ -44,7 +44,7 @@ write_to_description = "a [Splunk's HTTP Event Collector][urls.splunk_hec]"
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.splunk_hec.options",
-  encodings: ["json", "text"],
+  encodings: ["ndjson", "text"],
   default: "text"
 ) %>
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -68,7 +68,9 @@ lazy_static! {
 #[serde(rename_all = "snake_case")]
 pub enum Encoding {
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 inventory::submit! {
@@ -274,7 +276,7 @@ fn encode_event(
 
     let log = event.into_log();
     let data = match encoding.codec() {
-        Encoding::Json => serde_json::to_vec(&log).expect("Error encoding event as json."),
+        Encoding::Ndjson => serde_json::to_vec(&log).expect("Error encoding event as json."),
         Encoding::Text => log
             .get(&log_schema().message_key())
             .map(|v| v.as_bytes().to_vec())
@@ -321,7 +323,7 @@ mod tests {
         let message = "hello world".to_string();
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("key", "value");
-        let event = encode_event(event, &None, &Encoding::Json.into()).unwrap();
+        let event = encode_event(event, &None, &Encoding::Ndjson.into()).unwrap();
 
         let map: BTreeMap<String, String> = serde_json::from_slice(&event.data[..]).unwrap();
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -38,7 +38,9 @@ pub struct ConsoleSinkConfig {
 #[serde(rename_all = "snake_case")]
 pub enum Encoding {
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 inventory::submit! {
@@ -81,7 +83,7 @@ fn encode_event(
     encoding.apply_rules(&mut event);
     match event {
         Event::Log(log) => match encoding.codec() {
-            Encoding::Json => serde_json::to_string(&log),
+            Encoding::Ndjson => serde_json::to_string(&log),
             Encoding::Text => {
                 let s = log
                     .get(&crate::config::log_schema().message_key())
@@ -91,7 +93,7 @@ fn encode_event(
             }
         },
         Event::Metric(metric) => match encoding.codec() {
-            Encoding::Json => serde_json::to_string(&metric),
+            Encoding::Ndjson => serde_json::to_string(&metric),
             Encoding::Text => Ok(format!("{}", metric)),
         },
     }
@@ -154,7 +156,7 @@ mod test {
         log.insert("z", Value::from(25));
         log.insert("a", Value::from("0"));
 
-        let encoded = encode_event(event, &EncodingConfig::from(Encoding::Json));
+        let encoded = encode_event(event, &EncodingConfig::from(Encoding::Ndjson));
         let expected = r#"{"a":"0","x":"23","z":25}"#;
         assert_eq!(encoded.unwrap(), expected);
     }
@@ -178,7 +180,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"foos","timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"Key3":"Value3","key1":"value1","key2":"value2"},"kind":"incremental","counter":{"value":100.0}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Ndjson)).unwrap()
         );
     }
 
@@ -195,7 +197,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"users","timestamp":null,"tags":null,"kind":"incremental","set":{"values":["bob"]}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Ndjson)).unwrap()
         );
     }
 
@@ -214,7 +216,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"glork","timestamp":null,"tags":null,"kind":"incremental","distribution":{"values":[10.0],"sample_rates":[1],"statistic":"histogram"}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Ndjson)).unwrap()
         );
     }
 

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -44,7 +44,8 @@ inventory::submit! {
 #[derivative(Default)]
 pub enum Encoding {
     // Deprecated name
-    #[serde(alias = "json"),derivative(Default)]
+    #[serde(alias = "json")]
+    #[derivative(Default)]
     Ndjson,
     Text,
 }

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -43,15 +43,16 @@ inventory::submit! {
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum Encoding {
-    #[derivative(Default)]
-    Json,
+    // Deprecated name
+    #[serde(alias = "json"),derivative(Default)]
+    Ndjson,
     Text,
 }
 
 impl From<Encoding> for splunk_hec::Encoding {
     fn from(v: Encoding) -> Self {
         match v {
-            Encoding::Json => splunk_hec::Encoding::Json,
+            Encoding::Ndjson => splunk_hec::Encoding::Ndjson,
             Encoding::Text => splunk_hec::Encoding::Text,
         }
     }
@@ -259,7 +260,7 @@ mod integration_tests {
             endpoint: Some(HOST.to_string()),
             token: token.to_string(),
             compression: Compression::None,
-            encoding: Encoding::Json.into(),
+            encoding: Encoding::Ndjson.into(),
             batch: BatchConfig {
                 max_events: Some(1),
                 ..Default::default()

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -64,7 +64,9 @@ fn default_message_timeout_ms() -> u64 {
 pub enum Encoding {
     #[derivative(Default)]
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 pub struct KafkaSink {
@@ -263,7 +265,7 @@ fn encode_event(
         .unwrap_or_default();
 
     let body = match encoding.codec() {
-        Encoding::Json => serde_json::to_vec(&event.as_log()).unwrap(),
+        Encoding::Ndjson => serde_json::to_vec(&event.as_log()).unwrap(),
         Encoding::Text => event
             .as_log()
             .get(&log_schema().message_key())
@@ -304,7 +306,7 @@ mod tests {
         let (key, bytes) = encode_event(
             event,
             &Some("key".into()),
-            &EncodingConfig::from(Encoding::Json),
+            &EncodingConfig::from(Encoding::Ndjson),
         );
 
         let map: BTreeMap<String, String> = serde_json::from_slice(&bytes[..]).unwrap();

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -61,7 +61,8 @@ pub struct LokiConfig {
 #[derivative(Default)]
 enum Encoding {
     // Deprecated name
-    #[serde(alias = "json"),derivative(Default)]
+    #[serde(alias = "json")]
+    #[derivative(Default)]
     Ndjson,
     Text,
 }

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -60,8 +60,9 @@ pub struct LokiConfig {
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 enum Encoding {
-    #[derivative(Default)]
-    Json,
+    // Deprecated name
+    #[serde(alias = "json"),derivative(Default)]
+    Ndjson,
     Text,
 }
 
@@ -145,7 +146,7 @@ impl HttpSink for LokiConfig {
 
         self.encoding.apply_rules(&mut event);
         let event = match &self.encoding.codec() {
-            Encoding::Json => serde_json::to_string(&event.as_log().all_fields())
+            Encoding::Ndjson => serde_json::to_string(&event.as_log().all_fields())
                 .expect("json encoding should never fail"),
 
             Encoding::Text => event

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -56,14 +56,15 @@ inventory::submit! {
 #[derivative(Default)]
 pub enum Encoding {
      // Deprecated name
-     #[serde(alias = "json"),derivative(Default)]
+     #[serde(alias = "json")]
+    #[derivative(Default)]
      Ndjson,
 }
 
 impl From<Encoding> for crate::sinks::http::Encoding {
     fn from(v: Encoding) -> crate::sinks::http::Encoding {
         match v {
-            Encoding::Ndjson => crate::sinks::http::Encoding::Ndjson,
+            Encoding::Ndjson => crate::sinks::http::Encoding::Json,
         }
     }
 }

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -55,10 +55,10 @@ inventory::submit! {
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum Encoding {
-     // Deprecated name
-     #[serde(alias = "json")]
+    // Deprecated name
+    #[serde(alias = "json")]
     #[derivative(Default)]
-     Ndjson,
+    Ndjson,
 }
 
 impl From<Encoding> for crate::sinks::http::Encoding {

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -55,14 +55,15 @@ inventory::submit! {
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum Encoding {
-    #[derivative(Default)]
-    Json,
+     // Deprecated name
+     #[serde(alias = "json"),derivative(Default)]
+     Ndjson,
 }
 
 impl From<Encoding> for crate::sinks::http::Encoding {
     fn from(v: Encoding) -> crate::sinks::http::Encoding {
         match v {
-            Encoding::Json => crate::sinks::http::Encoding::Json,
+            Encoding::Ndjson => crate::sinks::http::Encoding::Ndjson,
         }
     }
 }
@@ -179,7 +180,7 @@ mod tests {
             "https://log-api.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
-        assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
+        assert_eq!(http_config.encoding.codec(), &Encoding::Ndjson.into());
         assert_eq!(
             http_config.batch.max_bytes,
             Some(bytesize::mib(5u64) as usize)
@@ -213,7 +214,7 @@ mod tests {
             "https://log-api.eu.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
-        assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
+        assert_eq!(http_config.encoding.codec(), &Encoding::Ndjson.into());
         assert_eq!(
             http_config.batch.max_bytes,
             Some(bytesize::mib(8u64) as usize)
@@ -253,7 +254,7 @@ mod tests {
             "https://log-api.eu.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
-        assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
+        assert_eq!(http_config.encoding.codec(), &Encoding::Ndjson.into());
         assert_eq!(
             http_config.batch.max_bytes,
             Some(bytesize::mib(8u64) as usize)

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -91,7 +91,7 @@ fn encode_event(
     let log = event.into_log();
 
     let message = match encoding.codec() {
-        Encoding::Json => serde_json::to_string(&log).unwrap(),
+        Encoding::Ndjson => serde_json::to_string(&log).unwrap(),
         Encoding::Text => log
             .get(&log_schema().message_key())
             .map(|v| v.to_string_lossy())

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -46,7 +46,9 @@ pub struct AuthConfig {
 pub enum Encoding {
     #[derivative(Default)]
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 struct PulsarSink {
@@ -194,7 +196,7 @@ fn encode_event(item: Event, encoding: &EncodingConfig<Encoding>) -> crate::Resu
     let log = item.into_log();
 
     Ok(match encoding.codec() {
-        Encoding::Json => serde_json::to_vec(&log)?,
+        Encoding::Ndjson => serde_json::to_vec(&log)?,
         Encoding::Text => log
             .get(&log_schema().message_key())
             .map(|v| v.as_bytes().to_vec())
@@ -212,7 +214,7 @@ mod tests {
         let msg = "hello_world".to_owned();
         let mut evt = Event::from(msg.clone());
         evt.as_mut_log().insert("key", "value");
-        let result = encode_event(evt, &EncodingConfig::from(Encoding::Json)).unwrap();
+        let result = encode_event(evt, &EncodingConfig::from(Encoding::Ndjson)).unwrap();
         let map: HashMap<String, String> = serde_json::from_slice(&result[..]).unwrap();
         assert_eq!(msg, map[&log_schema().message_key().to_string()]);
     }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -101,7 +101,7 @@ mod test {
         let config = SocketSinkConfig {
             mode: Mode::Udp(UdpSinkConfig {
                 address: addr.to_string(),
-                encoding: Encoding::Json.into(),
+                encoding: Encoding::Ndjson.into(),
             }),
         };
         let context = SinkContext::new_test();
@@ -145,7 +145,7 @@ mod test {
         let config = SocketSinkConfig {
             mode: Mode::Tcp(TcpSinkConfig {
                 address: addr.to_string(),
-                encoding: Encoding::Json.into(),
+                encoding: Encoding::Ndjson.into(),
                 tls: None,
             }),
         };

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -72,7 +72,9 @@ lazy_static! {
 pub enum Encoding {
     #[derivative(Default)]
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 fn default_host_key() -> Atom {
@@ -166,7 +168,7 @@ impl HttpSink for HecSinkConfig {
             .collect::<LogEvent>();
 
         let event = match self.encoding.codec() {
-            Encoding::Json => json!(event),
+            Encoding::Ndjson => json!(event),
             Encoding::Text => json!(event
                 .get(&log_schema().message_key())
                 .map(|v| v.to_string_lossy())
@@ -516,7 +518,7 @@ mod integration_tests {
         let cx = SinkContext::new_test();
 
         let indexed_fields = vec![Atom::from("asdf")];
-        let config = config(Encoding::Json, indexed_fields).await;
+        let config = config(Encoding::Ndjson, indexed_fields).await;
         let (sink, _) = config.build(cx).unwrap();
 
         let message = random_string(100);
@@ -536,7 +538,7 @@ mod integration_tests {
         let cx = SinkContext::new_test();
 
         let indexed_fields = vec![Atom::from("asdf")];
-        let config = config(Encoding::Json, indexed_fields).await;
+        let config = config(Encoding::Ndjson, indexed_fields).await;
         let (sink, _) = config.build(cx).unwrap();
 
         let message = random_string(100);
@@ -559,7 +561,7 @@ mod integration_tests {
         let cx = SinkContext::new_test();
 
         let indexed_fields = vec![Atom::from("asdf")];
-        let mut config = config(Encoding::Json, indexed_fields).await;
+        let mut config = config(Encoding::Ndjson, indexed_fields).await;
         config.sourcetype = Template::try_from("_json".to_string()).ok();
 
         let (sink, _) = config.build(cx).unwrap();
@@ -584,7 +586,7 @@ mod integration_tests {
 
         let config = HecSinkConfig {
             host_key: "roast".into(),
-            ..config(Encoding::Json, vec![Atom::from("asdf")]).await
+            ..config(Encoding::Ndjson, vec![Atom::from("asdf")]).await
         };
 
         let (sink, _) = config.build(cx).unwrap();

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -51,7 +51,9 @@ enum SinkBuildError {
 #[serde(rename_all = "snake_case")]
 pub enum Encoding {
     Text,
-    Json,
+    // Deprecated name
+    #[serde(alias = "json")]
+    Ndjson,
 }
 
 /**
@@ -64,7 +66,7 @@ pub fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Op
     let log = event.into_log();
 
     let b = match encoding.codec() {
-        Encoding::Json => serde_json::to_vec(&log),
+        Encoding::Ndjson => serde_json::to_vec(&log),
         Encoding::Text => {
             let bytes = log
                 .get(&crate::config::log_schema().message_key())

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -931,7 +931,7 @@ mod tests {
         trace_init();
 
         let message = "one_simple_json_event";
-        let (sink, source) = start(Encoding::Json, Compression::Gzip).await;
+        let (sink, source) = start(Encoding::Ndjson, Compression::Gzip).await;
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
@@ -948,7 +948,7 @@ mod tests {
         trace_init();
 
         let n = 200;
-        let (sink, source) = start(Encoding::Json, Compression::Gzip).await;
+        let (sink, source) = start(Encoding::Ndjson, Compression::Gzip).await;
 
         let messages = (0..n)
             .map(|i| format!("multiple_simple_json_event{}", i))
@@ -969,7 +969,7 @@ mod tests {
     async fn json_event() {
         trace_init();
 
-        let (sink, source) = start(Encoding::Json, Compression::Gzip).await;
+        let (sink, source) = start(Encoding::Ndjson, Compression::Gzip).await;
 
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("greeting", "hello");
@@ -990,7 +990,7 @@ mod tests {
     async fn line_to_message() {
         trace_init();
 
-        let (sink, source) = start(Encoding::Json, Compression::Gzip).await;
+        let (sink, source) = start(Encoding::Ndjson, Compression::Gzip).await;
 
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("line", "hello");

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -338,5 +338,5 @@ fn encode_priority(severity: Severity, facility: Facility) -> u8 {
 }
 
 fn tcp_json_sink(address: String) -> SocketSinkConfig {
-    SocketSinkConfig::make_tcp_config(address, EncodingConfig::from(Encoding::Json), None)
+    SocketSinkConfig::make_tcp_config(address, EncodingConfig::from(Encoding::Ndjson), None)
 }


### PR DESCRIPTION
Closes #1462 

Updates docs and code to use `ndjson` while we still accept `json` to avoid breaking change.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
