### PR TITLE
chore: Add back .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# .PHONY: $(MAKECMDGOALS) all
+.PHONY: $(MAKECMDGOALS)
 .DEFAULT_GOAL := help
 RUN := $(shell realpath $(shell dirname $(firstword $(MAKEFILE_LIST)))/scripts/docker-compose-run.sh)
 


### PR DESCRIPTION
I have local scripts named `build`, `test`, `check`, etc. which need these targets to be phony.

Signed-off-by: Duy Do <juchiast@gmail.com>