### PR TITLE
chore: correct linger misbehavior

### DIFF
--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -273,6 +273,9 @@ where
                         trace!("Polling batch linger.");
                         self.service.poll_complete()?;
                         try_ready!(linger.poll());
+                        // If the linger is ready, we've done it.
+                        // Reset the state so we don't get UB later.
+                        self.linger.take();
                     } else {
                         try_ready!(self.service.poll_complete());
                     }


### PR DESCRIPTION
It's my hope this will resolve #3830, but I have no proof of it.

Regardless, this corrects a misbehavior I found with @LucioFranco and @fanatid during debugging. 

You can see in #3830 @spencergilbert hit:

```rust
  12:          0x1f193b7 - <futures_util::future::future::NeverError<Fut> as core::future::future::Future>::poll::h7fb471e0dc82775f
  13:          0x2203da9 - <futures_util::compat::compat03as01::Compat<Fut> as futures::future::Future>::poll::hd3a935b220d64df3
  14:          0x1c1510a - <vector::sinks::util::sink::BatchSink<S,B,Request> as futures::sink::Sink>::poll_complete::h2ae3a9d473642464
```

Which leads us to here:

https://github.com/timberio/vector/blob/4d139851e441cac846414fe604c039d98461c7ff/src/sinks/util/sink.rs#L231-L232

As you can see, below, we use it here:

https://github.com/timberio/vector/blob/4d139851e441cac846414fe604c039d98461c7ff/src/sinks/util/sink.rs#L274-L277

But in the case where it returns a `Ready` (such that we are not allowed to poll it again) it is not reset.

This probably started due to the 0.1 to 0.2 migration of Tokio, since delay changed:

https://github.com/timberio/vector/blob/1b270eb591fbc08743c466164d36ba7879bdd21a/src/sinks/util/batch.rs#L132-L134