### PR TITLE
chore(rpm platform): Fixup rpm builds to support new tarballs

### DIFF
--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -22,7 +22,7 @@ URL: %{_url}
 
 %prep
 # We are currently in the BUILD dir
-tar -xvf %{_sourcedir}/%{_source} --strip-components=1
+tar -xvf %{_sourcedir}/%{_source} --strip-components=2
 cp -a %{_sourcedir}/systemd/. systemd
 
 %install


### PR DESCRIPTION
In #3657 we changed the tarball layout a bit and so the `--strip-components=` flag had to be updated.