### PR TITLE
fix(config): expand macros before validation

### DIFF
--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -13,6 +13,8 @@ pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
 
     let mut errors = Vec::new();
 
+    expand_macros(&mut config)?;
+
     if let Some(warnings) = validation::warnings(&config) {
         for warning in warnings {
             warn!(message = %warning)
@@ -26,8 +28,6 @@ pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
     if let Err(type_errors) = validation::typecheck(&config) {
         errors.extend(type_errors);
     }
-
-    expand_macros(&mut config)?;
 
     if errors.is_empty() {
         Ok(config)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -706,3 +706,43 @@ async fn parses_sink_full_es_aws() {
     .await
     .unwrap();
 }
+
+#[cfg(all(
+    feature = "sources-socket",
+    feature = "transforms-swimlanes",
+    feature = "sinks-socket"
+))]
+#[tokio::test]
+async fn swimlanes() {
+    let warnings = load(
+        r#"
+        [sources.in]
+        type = "socket"
+        mode = "tcp"
+        address = "127.0.0.1:1235"
+
+        [transforms.splitting_gerrys]
+        type = "swimlanes"
+        inputs = ["in"]
+
+        [transforms.splitting_gerrys.lanes.only_gerrys]
+        type = "check_fields"
+        "host.eq" = "gerry"
+
+        [transforms.splitting_gerrys.lanes.no_gerrys]
+        type = "check_fields"
+        "host.neq" = "gerry"
+
+        [sinks.out]
+        type = "socket"
+        mode = "tcp"
+        inputs = ["splitting_gerrys.only_gerrys", "splitting_gerrys.no_gerrys"]
+        encoding = "text"
+        address = "127.0.0.1:9999"
+      "#,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(0, warnings.len());
+}


### PR DESCRIPTION
Fixes #3889

This was me immediately getting bit by allowing unit tests to use invalid configs in #3672. The fix is simple and I added a test that would have caught it, but it's a reminder that we should try to go further in that refactoring for correctness.