### PR TITLE
chore(deps): Upgrade base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,15 +202,6 @@ checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -5465,7 +5456,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atty",
- "base64 0.10.1",
+ "base64 0.12.3",
  "bloom",
  "bollard",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ uuid = { version = "0.7", features = ["serde", "v4"], optional = true }
 exitcode = "1.1.2"
 snafu = { version = "0.6", features = ["futures-01", "futures"] }
 url = "2.1.1"
-base64 = { version = "0.10.1", optional = true }
+base64 = { version = "0.12.3", optional = true }
 bollard = { version = "0.8.0", optional = true }
 listenfd = { version = "0.3.3", optional = true }
 inventory = "0.1"


### PR DESCRIPTION
Noticed a feature was missing as I was working on the AWS Kinesis
Firehose source.  It's not required, I can use the older API, but
I didn't see a reason not to upgrade.

@Hoverbear should there have been a dependabot PR for this? I didn't see one.

Changelog:
https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md