### PR TITLE
chore: Add Kirill to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
       day: "saturday"
       time: "04:00" # UTC
     reviewers:
+      - "fanatid"
       - "hoverbear"
     assignees:
+      - "fanatid"
       - "hoverbear"
     labels:
       - "domain: deps"


### PR DESCRIPTION
Since Kirill has been involved in our dependencies I thought it would help to add him to Depdendabot. This should help push those PRs through faster.