### PR TITLE
feat(remap transform): Add new remap functions

### DIFF
--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -59,7 +59,8 @@ query_function = {
     sha1 |
     md5 |
     now |
-    strip_whitespace 
+    strip_whitespace |
+    truncate
 }
 
 to_string = { "to_string(" ~ query_arithmetic ~ ("," ~ (string | null) )? ~ ")"}
@@ -75,6 +76,7 @@ sha1 = { "sha1(" ~ query_arithmetic ~ ")" }
 md5 = { "md5(" ~ query_arithmetic ~ ")" }
 now = { "now(" ~ query_arithmetic ~ ")" }
 strip_whitespace = { "strip_whitespace(" ~ query_arithmetic ~ ")"}
+truncate = { "truncate(" ~ query_arithmetic ~ "," ~ query_arithmetic ~ ("," ~ boolean)? ~ ")" }
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -58,7 +58,8 @@ query_function = {
     uuid_v4 |
     sha1 |
     md5 |
-    now
+    now |
+    strip_whitespace 
 }
 
 to_string = { "to_string(" ~ query_arithmetic ~ ("," ~ (string | null) )? ~ ")"}
@@ -73,6 +74,7 @@ uuid_v4 = { "uuid_v4()" }
 sha1 = { "sha1(" ~ query_arithmetic ~ ")" }
 md5 = { "md5(" ~ query_arithmetic ~ ")" }
 now = { "now(" ~ query_arithmetic ~ ")" }
+strip_whitespace = { "strip_whitespace(" ~ query_arithmetic ~ ")"}
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -60,7 +60,8 @@ query_function = {
     md5 |
     now |
     strip_whitespace |
-    truncate
+    truncate |
+    parse_json
 }
 
 to_string = { "to_string(" ~ query_arithmetic ~ ("," ~ (string | null) )? ~ ")"}
@@ -77,6 +78,7 @@ md5 = { "md5(" ~ query_arithmetic ~ ")" }
 now = { "now(" ~ query_arithmetic ~ ")" }
 strip_whitespace = { "strip_whitespace(" ~ query_arithmetic ~ ")"}
 truncate = { "truncate(" ~ query_arithmetic ~ "," ~ query_arithmetic ~ ("," ~ boolean)? ~ ")" }
+parse_json = { "parse_json(" ~ query_arithmetic ~ ")" }
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -63,7 +63,8 @@ query_function = {
     now |
     strip_whitespace |
     truncate |
-    parse_json
+    parse_json |
+    flatten
 }
 
 to_string = { "to_string(" ~ query_arithmetic ~ ("," ~ (string | null) )? ~ ")"}
@@ -81,6 +82,7 @@ now = { "now(" ~ query_arithmetic ~ ")" }
 strip_whitespace = { "strip_whitespace(" ~ query_arithmetic ~ ")"}
 truncate = { "truncate(" ~ query_arithmetic ~ "," ~ query_arithmetic ~ ("," ~ boolean)? ~ ")" }
 parse_json = { "parse_json(" ~ query_arithmetic ~ ")" }
+flatten = { "flatten(" ~ query_arithmetic ~ ")" }
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -22,11 +22,13 @@ target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }
 // Functions
 function = {
     deletion |
-    only_fields
+    only_fields |
+    merge
 }
 
 deletion = { "del(" ~ target_paths ~ ")" }
 only_fields = { "only_fields(" ~ target_paths ~ ")" }
+merge = { "merge(" ~ target_path ~ "," ~ query_arithmetic ~ ("," ~ query_arithmetic)? ~ ")" }
 
 // One or more path arguments for a given function.
 //

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -8,9 +8,9 @@ use crate::{
             arithmetic::Arithmetic,
             arithmetic::Operator,
             functions::{
-                DowncaseFn, Md5Fn, NotFn, NowFn, ParseTimestampFn, Sha1Fn, StripWhitespaceFn,
-                ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn, TruncateFn,
-                UpcaseFn, UuidV4Fn,
+                DowncaseFn, Md5Fn, NotFn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn,
+                StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
+                TruncateFn, UpcaseFn, UuidV4Fn,
             },
             path::Path as QueryPath,
             Literal,
@@ -336,6 +336,12 @@ fn query_function_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>
 
             Ok(Box::new(TruncateFn::new(query, limit, ellipsis)))
         }
+        Rule::parse_json => {
+            let param = pair.into_inner().next().ok_or(TOKEN_ERR)?;
+            let query = query_arithmetic_from_pair(param)?;
+            Ok(Box::new(ParseJsonFn::new(query)))
+        }
+
         _ => unreachable!("parser should not allow other query_function child rules here"),
     }
 }
@@ -1050,6 +1056,13 @@ mod tests {
                         Box::new(Literal::from(Value::Float(5.0))),
                         Some(Value::Boolean(true)),
                     )),
+                ))]),
+            ),
+            (
+                ".foo = parse_json(.foo)",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(ParseJsonFn::new(Box::new(QueryPath::from("foo")))),
                 ))]),
             ),
         ];

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -1000,6 +1000,13 @@ mod tests {
                     Box::new(DowncaseFn::new(Box::new(QueryPath::from("foo")))),
                 ))]),
             ),
+            (
+                ".foo = strip_whitespace(.foo)",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(StripWhitespaceFn::new(Box::new(QueryPath::from("foo")))),
+                ))]),
+            ),
         ];
 
         for (mapping, exp) in cases {

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -8,8 +8,8 @@ use crate::{
             arithmetic::Arithmetic,
             arithmetic::Operator,
             functions::{
-                DowncaseFn, Md5Fn, NotFn, NowFn, ParseTimestampFn, Sha1Fn, ToBooleanFn, ToFloatFn,
-                ToIntegerFn, ToStringFn, ToTimestampFn, UpcaseFn, UuidV4Fn,
+                DowncaseFn, Md5Fn, NotFn, NowFn, ParseTimestampFn, Sha1Fn, StripWhitespaceFn,
+                ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn, UpcaseFn, UuidV4Fn,
             },
             path::Path as QueryPath,
             Literal,
@@ -314,6 +314,11 @@ fn query_function_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>
             let pair = pair.into_inner().next().ok_or(TOKEN_ERR)?;
             let query = query_arithmetic_from_pair(pair)?;
             Ok(Box::new(NowFn::new(query)))
+        }
+        Rule::strip_whitespace => {
+            let param = pair.into_inner().next().ok_or(TOKEN_ERR)?;
+            let query = query_arithmetic_from_pair(param)?;
+            Ok(Box::new(StripWhitespaceFn::new(query)))
         }
         _ => unreachable!("parser should not allow other query_function child rules here"),
     }

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -8,7 +8,7 @@ use crate::{
             arithmetic::Arithmetic,
             arithmetic::Operator,
             functions::{
-                DowncaseFn, Md5Fn, NotFn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn,
+                DowncaseFn, FlattenFn, Md5Fn, NotFn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn,
                 StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
                 TruncateFn, UpcaseFn, UuidV4Fn,
             },
@@ -340,6 +340,11 @@ fn query_function_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>
             let param = pair.into_inner().next().ok_or(TOKEN_ERR)?;
             let query = query_arithmetic_from_pair(param)?;
             Ok(Box::new(ParseJsonFn::new(query)))
+        }
+        Rule::flatten => {
+            let param = pair.into_inner().next().ok_or(TOKEN_ERR)?;
+            let query = query_arithmetic_from_pair(param)?;
+            Ok(Box::new(FlattenFn::new(query)))
         }
 
         _ => unreachable!("parser should not allow other query_function child rules here"),
@@ -1076,6 +1081,13 @@ mod tests {
                 Mapping::new(vec![Box::new(Assignment::new(
                     "foo".to_string(),
                     Box::new(ParseJsonFn::new(Box::new(QueryPath::from("foo")))),
+                ))]),
+            ),
+            (
+                ".foo = flatten(.foo)",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(FlattenFn::new(Box::new(QueryPath::from("foo")))),
                 ))]),
             ),
             (

--- a/src/mapping/query/functions.rs
+++ b/src/mapping/query/functions.rs
@@ -274,7 +274,7 @@ impl Function for StripWhitespaceFn {
                 return Ok(Value::Bytes(bytes.slice_ref(s.trim().as_bytes())));
             } else {
                 // Not a valid unicode string.
-                return Ok(Value::Bytes(bytes));
+                Err("unable to strip white_space from non-unicode string types".to_string())
             }
         } else {
             Err("unable to strip white_space from non-string types".to_string())
@@ -501,7 +501,7 @@ impl Function for TruncateFn {
                 }
             } else {
                 // Not a valid utf8 string.
-                Ok(Value::Bytes(bytes))
+                Err("unable to truncate from non-unicode string types".to_string())
             }
         } else {
             Err("unable to truncate non-string types".to_string())

--- a/src/mapping/query/functions.rs
+++ b/src/mapping/query/functions.rs
@@ -989,11 +989,11 @@ mod tests {
                     let mut event = Event::from("");
                     event.as_mut_log().insert(
                         "foo",
-                        Value::from(" \u{3000}\u{205F}\u{202F}\u{A0}\u{9} ❤❤hi there ❤❤  \u{9}\u{A0}\u{202F}\u{205F}\u{3000} "),
+                        Value::from(" \u{3000}\u{205F}\u{202F}\u{A0}\u{9} ❤❤ hi there ❤❤  \u{9}\u{A0}\u{202F}\u{205F}\u{3000} "),
                     );
                     event
                 },
-                Ok(Value::Bytes("❤❤hi there ❤❤".into())),
+                Ok(Value::Bytes("❤❤ hi there ❤❤".into())),
                 StripWhitespaceFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
             ),
         ];

--- a/src/mapping/query/functions.rs
+++ b/src/mapping/query/functions.rs
@@ -276,9 +276,9 @@ impl Function for StripWhitespaceFn {
                 // Not a valid unicode string.
                 return Ok(Value::Bytes(bytes));
             }
+        } else {
+            Err("unable to strip white_space from non-string types".to_string())
         }
-
-        Ok(value)
     }
 }
 

--- a/src/mapping/query/functions.rs
+++ b/src/mapping/query/functions.rs
@@ -271,7 +271,7 @@ impl Function for StripWhitespaceFn {
             // and will give us a trim function.
             // This does not need to allocate any additional memory.
             if let Ok(s) = std::str::from_utf8(&bytes) {
-                return Ok(Value::Bytes(bytes.slice_ref(s.trim().as_bytes())));
+                Ok(Value::Bytes(bytes.slice_ref(s.trim().as_bytes())))
             } else {
                 // Not a valid unicode string.
                 Err("unable to strip white_space from non-unicode string types".to_string())


### PR DESCRIPTION
Adding the following remap functions.

- [ ] Add `flatten` remap function. Closes #3752 
- [ ] Add `replace` remap function. Closes #3750 
- [ ] Add `split` remap function. Closes #3745 

(Note this branch is currently based on #3767 so it currently looks like there are way more commits that there really are!)