### PR TITLE
chore: Fix grub to work in both CI and Docker containers

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -3,10 +3,20 @@ set -e -o verbose
 
 export DEBIAN_FRONTEND=noninteractive
 
+apt update --yes
+
+# This is a workaround for GH https://github.com/actions/virtual-environments/issues/1605
+# This fix will be removed when GH addresses the issue.
+# What's happening here? Well we use this script inside CI and Docker containers.
+# It'll run fine in CI because update-grub can find a root parition.
+# Inside a container it'll fail. Either way we don't care about the outcome of the command
+# so we ignore its exit.
+
+set +e
 apt-get install --yes grub-efi
 update-grub
+set -e
 
-apt update --yes
 apt upgrade --yes
 
 # Deps


### PR DESCRIPTION
This is a workaround for GH https://github.com/actions/virtual-environments/issues/1605
This fix will be removed when GH addresses the issue.
What's happening here? Well, we use this script inside CI and Docker containers.
It'll run fine in CI because update-grub can find a root partition.
Inside a container, it'll fail. Either way, we don't care about the outcome of the command
so we ignore its exit.

This will fix our currently failing `environment-prepare` Make task.

Signed-off-by: James Turnbull <james@lovedthanlost.net>

