### PR TITLE
chore: Run clippy on all tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,7 +409,7 @@ sinks-pulsar = ["pulsar"]
 nightly = []
 
 # Testing-related features
-docker = [
+all-integration-tests = [
   "aws-integration-tests",
   "clickhouse-integration-tests",
   "docker-integration-tests",

--- a/Makefile
+++ b/Makefile
@@ -744,7 +744,7 @@ check-component-features: ## Check that all component features are setup properl
 
 .PHONY: check-clippy
 check-clippy: ## Check code with Clippy
-	${MAYBE_ENVIRONMENT_EXEC} cargo clippy --workspace --all-targets -- -D warnings
+	${MAYBE_ENVIRONMENT_EXEC} cargo clippy --workspace --all-targets --features all-integration-tests -- -D warnings
 
 .PHONY: check-fmt
 check-fmt: ## Check that all files are formatted properly


### PR DESCRIPTION
The default `make check-clippy` target did not include the necessary features to check all the integration tests. This renames the appropriate feature flag (`docker` did not really mean a Docker-related feature) and adds the new `all-integration-tests` feature flag to the clippy command line.

Note: This will break CI until #4006 is resolved.