### PR TITLE
chore: Re-enable all integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,6 +258,24 @@ jobs:
       - run: make slim-builds
       - run: make test-integration-gcp
 
+  test-integration-humio:
+    name: Integration - Linux, Humio
+    runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: make slim-builds
+      - run: make test-integration-humio
+
   test-integration-influxdb:
     name: Integration - Linux, Influx
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,8 @@ ifeq ($(AUTOSPAWN), true)
 	$(MAKE) start-integration-gcp
 	sleep 10 # Many services are very slow... Give them a sec..
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features gcp-integration-tests --lib ::gcp:: -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-default-features --features "gcp-integration-tests gcp-pubsub-integration-tests gcp-cloud-storage-integration-tests" \
+	 --lib ::gcp:: -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	$(MAKE) -k stop-integration-gcp
 endif

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -219,10 +219,6 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::test_util::{random_events_with_stream, random_string, trace_init};
-    use futures::{
-        compat::{Future01CompatExt, Sink01CompatExt},
-        SinkExt,
-    };
     use reqwest::{Client, Method, Response};
     use serde_json::{json, Value};
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -275,9 +275,7 @@ mod integration_tests {
         let (topic, _subscription) = create_topic_subscription().await;
         let topic = format!("BAD{}", topic);
         let (_sink, healthcheck) = config_build(&topic).await;
-        healthcheck
-            .await
-            .expect_err("Health check did not fail");
+        healthcheck.await.expect_err("Health check did not fail");
     }
 
     async fn create_topic_subscription() -> (String, String) {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -249,14 +249,10 @@ mod integration_tests {
         let (topic, subscription) = create_topic_subscription().await;
         let (sink, healthcheck) = config_build(&topic).await;
 
-        healthcheck.compat().await.expect("Health check failed");
+        healthcheck.await.expect("Health check failed");
 
-        let (input, mut events) = random_events_with_stream(100, 100);
-        let _ = sink
-            .sink_compat()
-            .send_all(&mut events)
-            .await
-            .expect("Sending events failed");
+        let (input, events) = random_events_with_stream(100, 100);
+        sink.run(events).await.expect("Sending events failed");
 
         let response = pull_messages(&subscription, 1000).await;
         let messages = response
@@ -280,7 +276,6 @@ mod integration_tests {
         let topic = format!("BAD{}", topic);
         let (_sink, healthcheck) = config_build(&topic).await;
         healthcheck
-            .compat()
             .await
             .expect_err("Health check did not fail");
     }

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -139,8 +139,6 @@ mod integration_tests {
         Event,
     };
     use chrono::Utc;
-    use futures::compat::Future01CompatExt;
-    use futures01::Sink;
     use serde_json::{json, Value as JsonValue};
     use std::{collections::HashMap, convert::TryFrom};
 

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -139,6 +139,7 @@ mod integration_tests {
         Event,
     };
     use chrono::Utc;
+    use futures::{future, stream};
     use serde_json::{json, Value as JsonValue};
     use std::{collections::HashMap, convert::TryFrom};
 
@@ -158,7 +159,7 @@ mod integration_tests {
         let message = random_string(100);
         let event = Event::from(message.clone());
 
-        sink.send(event).compat().await.unwrap();
+        sink.run(stream::once(future::ready(event))).await.unwrap();
 
         let entry = find_entry(repo.name.as_str(), message.as_str()).await;
 
@@ -191,7 +192,7 @@ mod integration_tests {
 
         let message = random_string(100);
         let event = Event::from(message.clone());
-        sink.send(event).compat().await.unwrap();
+        sink.run(stream::once(future::ready(event))).await.unwrap();
 
         let entry = find_entry(repo.name.as_str(), message.as_str()).await;
 
@@ -222,7 +223,7 @@ mod integration_tests {
                 .as_mut_log()
                 .insert("@timestamp", Utc::now().to_rfc3339());
 
-            sink.send(event).compat().await.unwrap();
+            sink.run(stream::once(future::ready(event))).await.unwrap();
 
             let entry = find_entry(repo.name.as_str(), message.as_str()).await;
 
@@ -243,7 +244,7 @@ mod integration_tests {
             let message = random_string(100);
             let event = Event::from(message.clone());
 
-            sink.send(event).compat().await.unwrap();
+            sink.run(stream::once(future::ready(event))).await.unwrap();
 
             let entry = find_entry(repo.name.as_str(), message.as_str()).await;
 


### PR DESCRIPTION
This PR re-enables the Humio and GCP tests and fixes some warnings and failures in the GCP tests.

@bruceg I am unsure how to address the humio tests as I am not quite sure I understand the relationship between the Spunk and Humio sinks.