### PR TITLE
chore(ci): Add workflow_dispatch to E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,7 @@ on:
       - "rust-toolchain"
   schedule:
     - cron: "0 4 * * *"
+  workflow_dispatch:
 
 env:
   VERBOSE: true


### PR DESCRIPTION
This will help re-running tests after enabling the `ci-condition: k8s e2e all targets` without asking people to force-push the code at PRs.