### PR TITLE
fix(sinks): instrument and guard against double poll

### DIFF
--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -160,8 +160,9 @@ pub struct BatchSink<S, B, Request> {
     service: ServiceSink<S, Request>,
     batch: StatefulBatch<B>,
     timeout: Duration,
-    linger: Option<Box<dyn Future<Item = (), Error = Infallible> + Send>>,
+    linger: Option<SafeLinger>,
     closing: bool,
+    service_was_not_ready: bool,
     _pd: PhantomData<Request>,
 }
 
@@ -182,6 +183,7 @@ where
             timeout,
             linger: None,
             closing: false,
+            service_was_not_ready: false,
             _pd: PhantomData,
         }
     }
@@ -191,9 +193,19 @@ where
     }
 
     fn linger_elapsed(&mut self) -> bool {
+        let clue = self.capture_clue();
         match &mut self.linger {
-            Some(delay) => delay.poll().expect("timer error").is_ready(),
+            Some(delay) => delay.poll_with_clue(clue).expect("timer error").is_ready(),
             None => false,
+        }
+    }
+
+    fn capture_clue(&self) -> Clue {
+        Clue {
+            closing: self.closing,
+            batch_was_full: self.batch.was_full(),
+            batch_is_empty: self.batch.is_empty(),
+            service_was_not_ready: self.service_was_not_ready,
         }
     }
 }
@@ -237,7 +249,7 @@ where
             trace!("Starting new batch timer.");
             // We just inserted the first item of a new batch, so set our delay to the longest time
             // we want to allow that item to linger in the batch before being flushed.
-            let delay = Box::new(delay_for(self.timeout).never_error().boxed().compat());
+            let delay = SafeLinger::new(self.timeout);
             self.linger = Some(delay);
         }
 
@@ -261,7 +273,13 @@ where
                 // or return that we're not ready to send. If we send and it works, loop to poll or
                 // close inner instead of prematurely returning Ready
                 if self.should_send() {
+                    // If we have a non-full batch that hits linger while the inner service is not
+                    // ready, should_send will poll linger and get Ready, then this try_ready will
+                    // return, then poll_complete gets called again, causing a double-poll of
+                    // linger via should_send.
+                    self.service_was_not_ready = true;
                     try_ready!(self.service.poll_ready());
+                    self.service_was_not_ready = false;
 
                     trace!("Service ready; Sending batch.");
                     let batch = self.batch.fresh_replace();
@@ -272,21 +290,35 @@ where
                     let fut = self.service.call(request, batch_size).compat();
                     tokio::spawn(fut);
 
-                    // Disable linger timeout
-                    self.linger.take();
+                    // Remove the now-sent batch's linger timeout
+                    self.linger = None;
                 } else {
-                    // We have a batch but we can't send any items
-                    // most likely because we have not hit either
-                    // our batch size or the timeout. Here we want
-                    // to poll the inner futures but still return
-                    // NotReady if the linger timeout is not complete yet.
+                    // We have data but not a full batch and the linger time has not elapsed, so do
+                    // not sent a request yet. Instead, poll the inner service to drive progress
+                    // and defer readiness to the linger timeout if present.
+                    let clue = self.capture_clue();
                     if let Some(linger) = &mut self.linger {
-                        trace!("Polling batch linger.");
                         self.service.poll_complete()?;
-                        try_ready!(linger.poll());
-                        // If the linger is ready, we've done it.
-                        // Reset the state so we don't get UB later.
-                        self.linger.take();
+
+                        // It's unlikely that we get past `try_ready` here because there's no way
+                        // for `should_send` to return false without polling a present `linger`. If
+                        // we do get past it, that means the timer expired within the tiny window
+                        // between the two `poll` calls and we should loop again because it's
+                        // probably time to send a batch.
+                        //
+                        // But then things get tricky. As noted above, `should_send` calls `poll` on
+                        // `linger`. But we just called `poll` on `linger` ourselves and it
+                        // returned `Ready`. Normally, it's a contract violation to re-poll
+                        // a future that has returned `Ready`. But we also can't reset `linger`,
+                        // because then `should_send` would not know that it had expired and we
+                        // might not send a batch when we should.
+                        //
+                        // Our (temporary) solution here is the SafeLinger wrapper type, which
+                        // quacks like a future but doesn't mind being polled again after it
+                        // returns `Ready`. It's also instrumented to collect some clues as to the
+                        // circumstances of the double poll.
+                        trace!("Polling batch linger.");
+                        try_ready!(linger.poll_with_clue(clue));
                     } else {
                         try_ready!(self.service.poll_complete());
                     }
@@ -314,6 +346,47 @@ where
             .field("timeout", &self.timeout)
             .finish()
     }
+}
+
+struct SafeLinger {
+    inner: Box<dyn Future<Item = (), Error = Infallible> + Send>,
+    finished: bool,
+    clues: Vec<Clue>,
+}
+
+impl SafeLinger {
+    fn new(timeout: Duration) -> Self {
+        SafeLinger {
+            inner: Box::new(delay_for(timeout).never_error().boxed().compat()),
+            finished: false,
+            clues: Vec::new(),
+        }
+    }
+
+    fn poll_with_clue(&mut self, clue: Clue) -> Poll<(), Infallible> {
+        if self.finished {
+            self.clues.push(clue);
+            warn!(message = "Linger polled after ready.", clues = ?self.clues);
+            Ok(Async::Ready(()))
+        } else {
+            match self.inner.poll() {
+                Ok(Async::Ready(())) => {
+                    self.finished = true;
+                    self.clues.push(clue);
+                    Ok(Async::Ready(()))
+                }
+                anything_else => anything_else,
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Clue {
+    closing: bool,
+    batch_was_full: bool,
+    batch_is_empty: bool,
+    service_was_not_ready: bool,
 }
 
 // === PartitionBatchSink ===


### PR DESCRIPTION
Ref #3830

It's still not clear to me how we could be getting a double-poll after #3869, but this should plug the gap rather thoroughly and give us some instrumentation to help explain. It also addresses a (very slight, likely never hit) behavior issue introduced there, along with a few small cleanups and explanatory comments.

The clue system can likely be removed once we figure out what is going on, but it should help us continue to track down the proble while mitigating user impact in the meantime.