### PR TITLE
fix(startup): init script / rm output option

### DIFF
--- a/distribution/init.d/vector
+++ b/distribution/init.d/vector
@@ -35,7 +35,7 @@ RETVAL=0
 # Start
 start() {
   echo -n $"Starting $prog: "
-  daemon --pidfile=${pidfile} --output=/var/log/vector.log $vector $OPTIONS
+  daemon --pidfile=${pidfile} $vector $OPTIONS
   RETVAL=$?
   echo
   return $RETVAL


### PR DESCRIPTION
function daemon does not have an output option, so delete it.

I couldn't find the init.d processor that has the output option, so I just want to delete it.
https://github.com/fedora-sysv/initscripts/blob/master/etc/rc.d/init.d/functions#L239-L272
