### PR TITLE
chore: Do not copy in init.d to rpmbuild process as it is no longer used by the RPM

### DIFF
--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -67,9 +67,7 @@ done
 
 # Init support data
 mkdir -p \
-  "$RPMBUILD_DIR/SOURCES/init.d" \
   "$RPMBUILD_DIR/SOURCES/systemd"
-cp -av distribution/init.d/. "$RPMBUILD_DIR/SOURCES/init.d"
 cp -av distribution/systemd/. "$RPMBUILD_DIR/SOURCES/systemd"
 
 # Copy the archive into the sources dir


### PR DESCRIPTION
Our RPM uses systemd - the init script is not consumed by this RPM any longer and does not need to be copied into the environment.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
