### PR TITLE
chore: Remove retry until after timeout test

### DIFF
--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -338,18 +338,6 @@ mod tests {
 
         retry_until(func, Duration::from_millis(10), Duration::from_secs(1)).await;
     }
-
-    #[tokio::test]
-    #[should_panic]
-    async fn retry_until_after_timeout() {
-        let count: Arc<RwLock<i32>> = Arc::new(RwLock::new(0));
-        let func = || {
-            let count = Arc::clone(&count);
-            retry_until_helper(count)
-        };
-
-        retry_until(func, Duration::from_millis(50), Duration::from_millis(100)).await;
-    }
 }
 
 pub struct CountReceiver<T> {

--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -156,24 +156,4 @@ mod test {
         }"#;
         Lua::new().context(|ctx| ctx.load(lua_event).eval::<Event>().unwrap());
     }
-
-    #[test]
-    #[should_panic]
-    fn from_lua_both_log_and_metric() {
-        let lua_event = r#"{
-            log = {
-                field = "example",
-                nested = {
-                    field = "another example"
-                }
-            },
-            metric = {
-                name = "example counter",
-                counter = {
-                    value = 0.57721566
-                }
-            }
-        }"#;
-        Lua::new().context(|ctx| ctx.load(lua_event).eval::<Event>().unwrap());
-    }
 }


### PR DESCRIPTION
Removes test until #4003 can be fixed.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
