### PR TITLE
chore(ci): Update the Kubernetes versions we test against at CI (1.19.2)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,7 +99,7 @@ jobs:
               { version: "v1.19.2", is_essential: true },
               { version: "v1.18.9" },
               { version: "v1.17.12" },
-              { version: "v1.16.15" }, // v1.16.13 is broken, see https://github.com/kubernetes/minikube/issues/8840
+              { version: "v1.16.15" }, // v1.16.13 is broken, see https://github.com/kubernetes/kubernetes/issues/93194
               { version: "v1.15.12" },
               { version: "v1.14.10" },
             ]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,9 +96,10 @@ jobs:
               "v1.11.0", // https://github.com/kubernetes/minikube/issues/8799
             ]
             const kubernetes_version = [
-              { version: "v1.18.6", is_essential: true },
-              { version: "v1.17.9" },
-              { version: "v1.16.12" }, // v1.16.13 is broken, see https://github.com/kubernetes/minikube/issues/8840
+              { version: "v1.19.2", is_essential: true },
+              { version: "v1.18.9" },
+              { version: "v1.17.12" },
+              { version: "v1.16.15" }, // v1.16.13 is broken, see https://github.com/kubernetes/minikube/issues/8840
               { version: "v1.15.12" },
               { version: "v1.14.10" },
             ]


### PR DESCRIPTION
Manually started E2E run: https://github.com/timberio/vector/runs/1146238453?check_suite_focus=true