### PR TITLE
chore: Update minikube to 1.15.1

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -94,7 +94,7 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.13.1",
+              "v1.14.0",
             ]
             const kubernetes_version = [
               { version: "v1.19.2", is_essential: true },

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -94,7 +94,7 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.11.0", // https://github.com/kubernetes/minikube/issues/8799
+              "v1.13.1",
             ]
             const kubernetes_version = [
               { version: "v1.19.2", is_essential: true },

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -94,7 +94,7 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.14.0",
+              "v1.15.1",
             ]
             const kubernetes_version = [
               { version: "v1.19.2", is_essential: true },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -844,9 +844,9 @@ E2E (end-to-end) tests.
 Vector release artifacts are prepared for E2E tests, so the ability to do that
 is required too, see Vector [docs](https://vector.dev) for more details.
 
-> Note: `minikube` has a bug in the latest versions that affects our test
+> Note: `minikube` had a bug in the versions `1.12.x` that affected our test
 > process - see https://github.com/kubernetes/minikube/issues/8799.
-> Use version `1.11.0` for now.
+> Use version `1.13.0+` that has this bug fixed.
 
 Also:
 


### PR DESCRIPTION
1.13.1 update seems problematic at the moment, this PR exists to gather some data through our CI runs.
1.40 was also problematic.
We're looking into updating to 1.15.1 now.

Upstream tracking issue: https://github.com/kubernetes/minikube/issues/9304