### PR TITLE
chore: Remove from_lua_missing_log_and_metric as failing on Mac

### DIFF
--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -147,13 +147,4 @@ mod test {
             assert_eq!(event, expected);
         });
     }
-
-    #[test]
-    #[should_panic]
-    fn from_lua_missing_log_and_metric() {
-        let lua_event = r#"{
-            some_field: {}
-        }"#;
-        Lua::new().context(|ctx| ctx.load(lua_event).eval::<Event>().unwrap());
-    }
 }


### PR DESCRIPTION
Signed-off-by: James Turnbull <james@lovedthanlost.net>
