### PR TITLE
chore: Remove Docker nightly-date images and nightly-debian

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -173,6 +173,7 @@ jobs:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
           PLATFORM: "linux/amd64,linux/arm64"
+          REPO: "timberio:vector-nightly"
         run: |
           ./scripts/upgrade-docker.sh
           export VERSION=$(make version)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -173,7 +173,6 @@ jobs:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
           PLATFORM: "linux/amd64,linux/arm64"
-          REPO: "timberio:vector-nightly"
         run: |
           ./scripts/upgrade-docker.sh
           export VERSION=$(make version)

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -25,7 +25,11 @@ build() {
   local BASE="$1"
   local VERSION="$2"
 
+if [ -n $VERSION ]
   local TAG="$REPO:$VERSION-$BASE"
+else
+  local TAG="$REPO:$BASE"
+fi
   local DOCKERFILE="distribution/docker/$BASE/Dockerfile"
 
   if [ -n "$PLATFORM" ]; then
@@ -70,7 +74,7 @@ if [[ "$CHANNEL" == "latest" ]]; then
     build debian "$VERSION_TAG"
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  for VERSION_TAG in "nightly-$DATE" nightly; do
+  for VERSION_TAG in "$DATE" ""; do
     build alpine "$VERSION_TAG"
     build debian "$VERSION_TAG"
   done

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -70,7 +70,7 @@ if [[ "$CHANNEL" == "latest" ]]; then
     build debian "$VERSION_TAG"
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  for VERSION_TAG in "$DATE" latest; do
+  for VERSION_TAG in nightly; do
     build alpine "$VERSION_TAG"
     build debian "$VERSION_TAG"
   done

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -25,11 +25,7 @@ build() {
   local BASE="$1"
   local VERSION="$2"
 
-if [ -n $VERSION ]
   local TAG="$REPO:$VERSION-$BASE"
-else
-  local TAG="$REPO:$BASE"
-fi
   local DOCKERFILE="distribution/docker/$BASE/Dockerfile"
 
   if [ -n "$PLATFORM" ]; then
@@ -74,7 +70,7 @@ if [[ "$CHANNEL" == "latest" ]]; then
     build debian "$VERSION_TAG"
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  for VERSION_TAG in "$DATE" ""; do
+  for VERSION_TAG in "$DATE" latest; do
     build alpine "$VERSION_TAG"
     build debian "$VERSION_TAG"
   done

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -70,10 +70,7 @@ if [[ "$CHANNEL" == "latest" ]]; then
     build debian "$VERSION_TAG"
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
-  for VERSION_TAG in nightly; do
-    build alpine "$VERSION_TAG"
-    build debian "$VERSION_TAG"
-  done
+    build alpine nightly
 elif [[ "$CHANNEL" == "test" ]]; then
   build "${BASE:-"alpine"}" "${TAG:-"test"}"
 fi


### PR DESCRIPTION
This will result in the following build in https://hub.docker.com/repository/docker/timberio/vecto

- timberio/vector:nightly-alpine

See also: https://github.com/timberio/vector-website/pull/104

Signed-off-by: James Turnbull <james@lovedthanlost.net>