### PR TITLE
fix(file source): more robust handling of split reads

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -71,7 +71,6 @@ where
         C: Sink<(Bytes, String)> + Unpin,
         <C as Sink<(Bytes, String)>>::Error: std::error::Error,
     {
-        let mut line_buffer = Vec::new();
         let mut fingerprint_buffer = Vec::new();
 
         let mut fp_map: IndexMap<FileFingerprint, FileWatcher> = Default::default();
@@ -204,52 +203,53 @@ where
                 }
 
                 let mut bytes_read: usize = 0;
-                while let Ok(sz) = watcher.read_line(&mut line_buffer) {
-                    if sz > 0 {
-                        trace!(
-                            message = "read bytes.",
-                            path = field::debug(&watcher.path),
-                            bytes = field::debug(sz)
-                        );
-
-                        bytes_read += sz;
-
-                        if !line_buffer.is_empty() {
-                            lines.push((
-                                line_buffer.clone().into(),
-                                watcher.path.to_str().expect("not a valid path").to_owned(),
-                            ));
-                            line_buffer.clear();
-                        }
-                    } else {
-                        // Should the file be removed
-                        if let Some(grace_period) = self.remove_after {
-                            if watcher.last_read_success().elapsed() >= grace_period {
-                                // Try to remove
-                                match remove_file(&watcher.path) {
-                                    Ok(()) => {
-                                        self.emitter.emit_file_deleted(&watcher.path);
-                                        watcher.set_dead();
-                                    }
-                                    Err(error) => {
-                                        // We will try again after some time.
-                                        self.emitter.emit_file_delete_failed(&watcher.path, error);
-                                    }
-                                }
-                            }
-                        }
-
+                while let Ok(line) = watcher.read_line() {
+                    if line.is_empty() {
                         break;
                     }
+
+                    let sz = line.len();
+                    trace!(
+                        message = "read bytes.",
+                        path = field::debug(&watcher.path),
+                        bytes = field::debug(sz)
+                    );
+
+                    bytes_read += sz;
+
+                    lines.push((
+                        line,
+                        watcher.path.to_str().expect("not a valid path").to_owned(),
+                    ));
+
                     if bytes_read > self.max_read_bytes {
                         maxed_out_reading_single_file = true;
                         break;
                     }
                 }
+
                 if bytes_read > 0 {
                     global_bytes_read = global_bytes_read.saturating_add(bytes_read);
                     checkpointer.set_checkpoint(file_id, watcher.get_file_position());
+                } else {
+                    // Should the file be removed
+                    if let Some(grace_period) = self.remove_after {
+                        if watcher.last_read_success().elapsed() >= grace_period {
+                            // Try to remove
+                            match remove_file(&watcher.path) {
+                                Ok(()) => {
+                                    self.emitter.emit_file_deleted(&watcher.path);
+                                    watcher.set_dead();
+                                }
+                                Err(error) => {
+                                    // We will try again after some time.
+                                    self.emitter.emit_file_delete_failed(&watcher.path, error);
+                                }
+                            }
+                        }
+                    }
                 }
+
                 // Do not move on to newer files if we are behind on an older file
                 if self.oldest_first && maxed_out_reading_single_file {
                     break;

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -204,7 +204,7 @@ where
                 }
 
                 let mut bytes_read: usize = 0;
-                while let Ok(sz) = watcher.read_line(&mut line_buffer, self.max_line_bytes) {
+                while let Ok(sz) = watcher.read_line(&mut line_buffer) {
                     if sz > 0 {
                         trace!(
                             message = "read bytes.",
@@ -321,7 +321,12 @@ where
         } else {
             checkpointer.get_checkpoint(file_id).unwrap_or(0)
         };
-        match FileWatcher::new(path.clone(), file_position, self.ignore_before) {
+        match FileWatcher::new(
+            path.clone(),
+            file_position,
+            self.ignore_before,
+            self.max_line_bytes,
+        ) {
             Ok(mut watcher) => {
                 if file_position == 0 {
                     self.emitter.emit_file_added(&path);

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -203,7 +203,7 @@ where
                 }
 
                 let mut bytes_read: usize = 0;
-                while let Ok(line) = watcher.read_line() {
+                while let Ok(Some(line)) = watcher.read_line() {
                     if line.is_empty() {
                         break;
                     }

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -203,7 +203,8 @@ mod test {
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");
         let mut rotation_count = 0;
-        let mut fw = FileWatcher::new(path.clone(), 0, None).expect("must be able to create");
+        let mut fw =
+            FileWatcher::new(path.clone(), 0, None, 100_000).expect("must be able to create");
 
         let mut writes = 0;
         let mut sut_reads = 0;
@@ -259,7 +260,7 @@ mod test {
                     let mut buf = Vec::new();
                     let mut attempts = 10;
                     while attempts > 0 {
-                        match fw.read_line(&mut buf, 100_000) {
+                        match fw.read_line(&mut buf) {
                             Err(_) => {
                                 unreachable!();
                             }
@@ -295,7 +296,8 @@ mod test {
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");
         let mut rotation_count = 0;
-        let mut fw = FileWatcher::new(path.clone(), 0, None).expect("must be able to create");
+        let mut fw =
+            FileWatcher::new(path.clone(), 0, None, 100_000).expect("must be able to create");
 
         let mut fwfiles: Vec<FWFile> = vec![];
         fwfiles.push(FWFile::new());
@@ -330,7 +332,7 @@ mod test {
                     let mut buf = Vec::new();
                     let mut attempts = 10;
                     while attempts > 0 {
-                        match fw.read_line(&mut buf, 100_000) {
+                        match fw.read_line(&mut buf) {
                             Err(_) => {
                                 unreachable!();
                             }

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -263,7 +263,11 @@ mod test {
                             Err(_) => {
                                 unreachable!();
                             }
-                            Ok(line) if line.is_empty() => {
+                            Ok(Some(line)) if line.is_empty() => {
+                                attempts -= 1;
+                                continue;
+                            }
+                            Ok(None) => {
                                 attempts -= 1;
                                 continue;
                             }
@@ -334,12 +338,17 @@ mod test {
                             Err(_) => {
                                 unreachable!();
                             }
-                            Ok(line) if line.is_empty() => {
+                            Ok(Some(line)) if line.is_empty() => {
                                 attempts -= 1;
                                 assert!(fwfiles[read_index].read_line().is_none());
                                 continue;
                             }
-                            Ok(line) => {
+                            Ok(None) => {
+                                attempts -= 1;
+                                assert!(fwfiles[read_index].read_line().is_none());
+                                continue;
+                            }
+                            Ok(Some(line)) => {
                                 let exp =
                                     fwfiles[read_index].read_line().expect("could not readline");
                                 assert_eq!(exp.into_bytes(), line);

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -257,14 +257,13 @@ mod test {
                     read_index += 1;
                 }
                 FWAction::Read => {
-                    let mut buf = Vec::new();
                     let mut attempts = 10;
                     while attempts > 0 {
-                        match fw.read_line(&mut buf) {
+                        match fw.read_line() {
                             Err(_) => {
                                 unreachable!();
                             }
-                            Ok(0) => {
+                            Ok(line) if line.is_empty() => {
                                 attempts -= 1;
                                 continue;
                             }
@@ -329,24 +328,22 @@ mod test {
                     read_index += 1;
                 }
                 FWAction::Read => {
-                    let mut buf = Vec::new();
                     let mut attempts = 10;
                     while attempts > 0 {
-                        match fw.read_line(&mut buf) {
+                        match fw.read_line() {
                             Err(_) => {
                                 unreachable!();
                             }
-                            Ok(0) => {
+                            Ok(line) if line.is_empty() => {
                                 attempts -= 1;
                                 assert!(fwfiles[read_index].read_line().is_none());
                                 continue;
                             }
-                            Ok(sz) => {
+                            Ok(line) => {
                                 let exp =
                                     fwfiles[read_index].read_line().expect("could not readline");
-                                assert_eq!(exp.into_bytes(), buf);
-                                assert_eq!(sz, buf.len() + 1);
-                                buf.clear();
+                                assert_eq!(exp.into_bytes(), line);
+                                // assert_eq!(sz, buf.len() + 1);
                                 break;
                             }
                         }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1367,6 +1367,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_split_reads() {
+        let (tx, rx) = Pipeline::new_test();
+        let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
+
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            include: vec![dir.path().join("*")],
+            start_at_beginning: true,
+            max_read_bytes: 1,
+            ..test_default_file_config(&dir)
+        };
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+
+        writeln!(&mut file, "hello i am a normal line").unwrap();
+
+        sleep_500_millis().await;
+
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
+        tokio::spawn(source.compat());
+
+        sleep_500_millis().await;
+
+        write!(&mut file, "i am not a full line").unwrap();
+
+        // Longer than the EOF timeout
+        sleep_500_millis().await;
+
+        writeln!(&mut file, " until now").unwrap();
+
+        sleep_500_millis().await;
+
+        drop(trigger_shutdown);
+
+        let received = wait_with_timeout(
+            rx.map(|event| {
+                event
+                    .as_log()
+                    .get(&log_schema().message_key())
+                    .unwrap()
+                    .clone()
+            })
+            .collect()
+            .compat(),
+        )
+        .await;
+
+        assert_eq!(
+            received,
+            vec![
+                "hello i am a normal line".into(),
+                "i am not a full line until now".into(),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn test_gzipped_file() {
         let (tx, rx) = Pipeline::new_test();
         let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();


### PR DESCRIPTION
Fixes #2992 

This is an initial minimal-ish fix for the file source being too willing to return lines that did not end in a newline. Our original fix in #1236 was to wait up to a millisecond for the rest of a line to show up before considering it complete and returning it anyway. It turns out that in high-throughput situations, it's not uncommon for partial log lines to be visible for periods of time longer than this. This causes Vector to return a single logical line split across multiple events, which obviously breaks many kinds of downstream processing.

The problem with the sleep approach is that we can't know how long we need to sleep to see the rest of the line, and any amount of time we sleep is time we're not doing useful work, potentially lowering our overall throughput. This PR eliminates the sleep, instead opting to make a single logical line read operation able to be suspended and resumed across calls. The core of that change is to switch from a single line buffer to one that's specific to each file watcher. This means the intermediate state won't get overwritten between calls and we're safe to return control to the main loop.

This opens up a couple of edge cases that will require a larger change to handle, but they generally seem very unlikely to cause issues. Mostly, we are less likely to return legitimately interrupted writes as their own event. These are likely _extremely_ uncommon, and will now be prepended to the following line, just as they appear if you read the file normally. If there is no following line, we won't flush the partial message until the file is deleted, which may not happen. If Vector is shut down before it sees another newline, it doesn't have a mechanism to flush this intermediate state.

There's some further refactoring here that should happen, but I cut it short in favor of getting the fix out sooner:

1. We should read directly into the `BytesMut` instead of double buffering via `BufReader`
2. `read_until_with_max_size` should be inlined into `read_line` because the boundary doesn't really make sense anymore

Both these refactoring and plugging any edge cases can happen as part of the larger file source cleanup that should be coming up soon.