### PR TITLE
fix(reload): Wait on Windows after components shutdown

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -220,6 +220,14 @@ impl RunningTopology {
         // Checks passed so let's shutdown the difference.
         self.shutdown_diff(&diff).await;
 
+        // Gives windows some time to make available any port
+        // released by shutdown componenets.
+        // Issue: https://github.com/timberio/vector/issues/3035
+        if cfg!(windows){
+            // This value is guess work.
+            tokio::time::delay_for(Duration::from_millis(200)).await;
+        }
+
         // Now let's actually build the new pieces.
         if let Some(mut new_pieces) = build_or_log_errors(&new_config, &diff).await {
             if self

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -223,7 +223,7 @@ impl RunningTopology {
         // Gives windows some time to make available any port
         // released by shutdown componenets.
         // Issue: https://github.com/timberio/vector/issues/3035
-        if cfg!(windows){
+        if cfg!(windows) {
             // This value is guess work.
             tokio::time::delay_for(Duration::from_millis(200)).await;
         }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -660,9 +660,6 @@ mod reload_tests {
     use crate::sources::splunk_hec::SplunkConfig;
     use crate::test_util::{next_addr, start_topology};
 
-    // TODO: Run it only on Linux and Mac since it fails on Windows.
-    // TODO: Issue: https://github.com/timberio/vector/issues/3035
-    #[cfg(unix)]
     #[tokio::test]
     async fn topology_reuse_old_port() {
         let address = next_addr();


### PR DESCRIPTION
Closes #3035 

Adds a 200ms delay on windows during reload.

### Alternatives
Maybe there is some Windows function we could call to check for this. 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
