### PR TITLE
chore(tests): Re add fixed `sources::file::tests::remove_file` test

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1513,7 +1513,7 @@ mod tests {
             // Wait for remove grace period to end.
             delay_for(Duration::from_secs(remove_after + 1)).await;
 
-            if let Err(_) = File::open(&path) {
+            if File::open(&path).is_err() {
                 break;
             }
         }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1477,6 +1477,9 @@ mod tests {
         );
     }
 
+    // TODO: Renable test for Mac after https://github.com/timberio/vector/issues/4196 has been resolved
+    // TODO: and check if the original issue has been resolved https://github.com/timberio/vector/issues/3780.
+    #[cfg(not(target_os = "macos"))]
     #[tokio::test]
     async fn remove_file() {
         let n = 5;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1476,4 +1476,53 @@ mod tests {
             ]
         );
     }
+
+    #[tokio::test]
+    async fn remove_file() {
+        let n = 5;
+        let remove_after = 1;
+
+        let (tx, rx) = Pipeline::new_test();
+        let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
+
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            include: vec![dir.path().join("*")],
+            remove_after: Some(remove_after),
+            glob_minimum_cooldown: 100,
+            ..test_default_file_config(&dir)
+        };
+
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
+        tokio::spawn(source.compat());
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+
+        sleep_500_millis().await; // The files must be observed at their original lengths before writing to them
+
+        for i in 0..n {
+            writeln!(&mut file, "{}", i).unwrap();
+        }
+        std::mem::drop(file);
+
+        for _ in 0..10 {
+            // Wait for remove grace period to end.
+            delay_for(Duration::from_secs(remove_after + 1)).await;
+
+            if let Err(_) = File::open(&path) {
+                break;
+            }
+        }
+
+        drop(trigger_shutdown);
+
+        let received = wait_with_timeout(rx.collect().compat()).await;
+        assert_eq!(received.len(), n);
+
+        match File::open(&path) {
+            Ok(_) => panic!("File wasn't removed"),
+            Err(error) => assert_eq!(error.kind(), std::io::ErrorKind::NotFound),
+        }
+    }
 }


### PR DESCRIPTION
Ref #3780 

Test now periodically checks if the file has been removed with max total wait of 20sec.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
