### PR TITLE
chore(tests)!: Use Helm chart at the K8s E2E tests

### DIFF
--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -55,10 +55,16 @@ securityContext: {}
 # Extra env vars to pass to the `vector` container.
 env: []
 
+# Tolerations to set for the `Pod`s managed by `DaemonSet`.
+tolerations:
+  # This toleration is to have the `DaemonSet` runnable on master nodes.
+  # Remove it if your masters can't run pods.
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+
 # Various tweakables for the `Pod`s managed by `DaemonSet`.
 resources: {}
 nodeSelector: {}
-tolerations: []
 affinity: {}
 
 # Additional volumes to pass to the `Pod`s managed by `DaemonSet`.

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -23,7 +23,7 @@ impl Framework {
         &self,
         namespace: &str,
         custom_resource: &str,
-        custom_helm_values: Option<&str>,
+        custom_helm_values: &str,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
         let mut manager = vector::manager(
             self.interface.deploy_vector_command.as_str(),

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -23,11 +23,13 @@ impl Framework {
         &self,
         namespace: &str,
         custom_resource: &str,
+        custom_helm_values: Option<&str>,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
         let mut manager = vector::manager(
             self.interface.deploy_vector_command.as_str(),
             namespace,
             custom_resource,
+            custom_helm_values,
         )?;
         manager.up().await?;
         Ok(manager)

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -22,14 +22,14 @@ impl Framework {
     pub async fn vector(
         &self,
         namespace: &str,
-        custom_resource: &str,
         custom_helm_values: &str,
+        custom_resource: &str,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
         let mut manager = vector::manager(
             self.interface.deploy_vector_command.as_str(),
             namespace,
-            custom_resource,
             custom_helm_values,
+            custom_resource,
         )?;
         manager.up().await?;
         Ok(manager)

--- a/lib/k8s-test-framework/src/helm_values_file.rs
+++ b/lib/k8s-test-framework/src/helm_values_file.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+use crate::temp_file::TempFile;
+
+#[derive(Debug)]
+pub struct HelmValuesFile(TempFile);
+
+impl HelmValuesFile {
+    pub fn new(data: &str) -> std::io::Result<Self> {
+        Ok(Self(TempFile::new("values.yml", data)?))
+    }
+
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+}

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -23,6 +23,7 @@ mod log_lookup;
 pub mod namespace;
 mod reader;
 mod resource_file;
+mod temp_file;
 pub mod test_pod;
 mod up_down;
 mod util;

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -17,6 +17,7 @@
 
 mod exec_tail;
 pub mod framework;
+mod helm_values_file;
 pub mod interface;
 mod lock;
 mod log_lookup;

--- a/lib/k8s-test-framework/src/resource_file.rs
+++ b/lib/k8s-test-framework/src/resource_file.rs
@@ -1,21 +1,16 @@
-use std::path::{Path, PathBuf};
-use tempfile::{tempdir, TempDir};
+use std::path::Path;
+
+use crate::temp_file::TempFile;
 
 #[derive(Debug)]
-pub struct ResourceFile {
-    dir: TempDir,
-    path: PathBuf,
-}
+pub struct ResourceFile(TempFile);
 
 impl ResourceFile {
     pub fn new(data: &str) -> std::io::Result<Self> {
-        let dir = tempdir()?;
-        let path = dir.path().join("custom.yaml");
-        std::fs::write(&path, data)?;
-        Ok(Self { dir, path })
+        Ok(Self(TempFile::new("custom.yaml", data)?))
     }
 
     pub fn path(&self) -> &Path {
-        self.path.as_path()
+        self.0.path()
     }
 }

--- a/lib/k8s-test-framework/src/temp_file.rs
+++ b/lib/k8s-test-framework/src/temp_file.rs
@@ -1,0 +1,21 @@
+use std::path::{Path, PathBuf};
+use tempfile::{tempdir, TempDir};
+
+#[derive(Debug)]
+pub struct TempFile {
+    dir: TempDir,
+    path: PathBuf,
+}
+
+impl TempFile {
+    pub fn new(file_name: &str, data: &str) -> std::io::Result<Self> {
+        let dir = tempdir()?;
+        let path = dir.path().join(file_name);
+        std::fs::write(&path, data)?;
+        Ok(Self { dir, path })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+}

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -9,8 +9,8 @@ use std::process::{Command, Stdio};
 pub struct CommandBuilder {
     interface_command: String,
     namespace: String,
-    custom_resource_file: Option<ResourceFile>,
     custom_helm_values_file: Option<HelmValuesFile>,
+    custom_resource_file: Option<ResourceFile>,
 }
 
 impl up_down::CommandBuilder for CommandBuilder {
@@ -24,12 +24,12 @@ impl up_down::CommandBuilder for CommandBuilder {
             .arg(&self.namespace)
             .stdin(Stdio::null());
 
-        if let Some(ref custom_resource_file) = self.custom_resource_file {
-            command.env("CUSTOM_RESOURCE_CONFIGS_FILE", custom_resource_file.path());
-        }
-
         if let Some(ref custom_helm_values_file) = self.custom_helm_values_file {
             command.env("CUSTOM_HELM_VALUES_FILE", custom_helm_values_file.path());
+        }
+
+        if let Some(ref custom_resource_file) = self.custom_resource_file {
+            command.env("CUSTOM_RESOURCE_CONFIGS_FILE", custom_resource_file.path());
         }
 
         command
@@ -42,23 +42,23 @@ impl up_down::CommandBuilder for CommandBuilder {
 pub fn manager(
     interface_command: &str,
     namespace: &str,
-    custom_resource: &str,
     custom_helm_values: &str,
+    custom_resource: &str,
 ) -> Result<up_down::Manager<CommandBuilder>> {
-    let custom_resource_file = if custom_resource.is_empty() {
-        None
-    } else {
-        Some(ResourceFile::new(custom_resource)?)
-    };
     let custom_helm_values_file = if custom_helm_values.is_empty() {
         None
     } else {
         Some(HelmValuesFile::new(custom_helm_values)?)
     };
+    let custom_resource_file = if custom_resource.is_empty() {
+        None
+    } else {
+        Some(ResourceFile::new(custom_resource)?)
+    };
     Ok(up_down::Manager::new(CommandBuilder {
         interface_command: interface_command.to_owned(),
         namespace: namespace.to_owned(),
-        custom_resource_file,
         custom_helm_values_file,
+        custom_resource_file,
     }))
 }

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -43,12 +43,13 @@ pub fn manager(
     interface_command: &str,
     namespace: &str,
     custom_resource: &str,
-    custom_helm_values: Option<&str>,
+    custom_helm_values: &str,
 ) -> Result<up_down::Manager<CommandBuilder>> {
     let custom_resource_file = ResourceFile::new(custom_resource)?;
-    let custom_helm_values_file = match custom_helm_values {
-        Some(data) => Some(HelmValuesFile::new(data)?),
-        None => None,
+    let custom_helm_values_file = if custom_helm_values.is_empty() {
+        None
+    } else {
+        Some(HelmValuesFile::new(custom_helm_values)?)
     };
     Ok(up_down::Manager::new(CommandBuilder {
         interface_command: interface_command.to_owned(),

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -1,7 +1,6 @@
 //! Manage Vector.
 
-use super::{resource_file::ResourceFile, Result};
-use crate::up_down;
+use crate::{helm_values_file::HelmValuesFile, resource_file::ResourceFile, up_down, Result};
 use std::process::{Command, Stdio};
 
 /// Parameters required to build a `kubectl` command to manage Vector in the
@@ -11,6 +10,7 @@ pub struct CommandBuilder {
     interface_command: String,
     namespace: String,
     custom_resource_file: ResourceFile,
+    custom_helm_values_file: Option<HelmValuesFile>,
 }
 
 impl up_down::CommandBuilder for CommandBuilder {
@@ -27,6 +27,11 @@ impl up_down::CommandBuilder for CommandBuilder {
                 self.custom_resource_file.path(),
             )
             .stdin(Stdio::null());
+
+        if let Some(ref custom_helm_values_file) = self.custom_helm_values_file {
+            command.env("CUSTOM_HELM_VALUES_FILE", custom_helm_values_file.path());
+        }
+
         command
     }
 }
@@ -38,11 +43,17 @@ pub fn manager(
     interface_command: &str,
     namespace: &str,
     custom_resource: &str,
+    custom_helm_values: Option<&str>,
 ) -> Result<up_down::Manager<CommandBuilder>> {
     let custom_resource_file = ResourceFile::new(custom_resource)?;
+    let custom_helm_values_file = match custom_helm_values {
+        Some(data) => Some(HelmValuesFile::new(data)?),
+        None => None,
+    };
     Ok(up_down::Manager::new(CommandBuilder {
         interface_command: interface_command.to_owned(),
         namespace: namespace.to_owned(),
         custom_resource_file,
+        custom_helm_values_file,
     }))
 }

--- a/scripts/deploy-kubernetes-test.sh
+++ b/scripts/deploy-kubernetes-test.sh
@@ -58,6 +58,12 @@ up() {
 
   HELM_VALUES=()
 
+  HELM_VALUES+=(
+    # Set a reasonable log level to avoid issues with internal logs
+    # overwriting console output.
+    --set "env[0].name=LOG,env[0].value=info"
+  )
+
   if [[ -n "$CUSTOM_HELM_VALUES_FILE" ]]; then
     HELM_VALUES+=(
       --values "$CUSTOM_HELM_VALUES_FILE"

--- a/scripts/deploy-kubernetes-test.sh
+++ b/scripts/deploy-kubernetes-test.sh
@@ -76,12 +76,14 @@ up() {
     --set "image.tag=$CONTAINER_IMAGE_TAG"
   )
 
+  set -x
   $VECTOR_TEST_HELM install \
     --atomic \
     --namespace "$NAMESPACE" \
     "${HELM_VALUES[@]}" \
     "vector" \
     "./distribution/helm/vector"
+  { set +x; } &>/dev/null
 }
 
 down() {

--- a/scripts/deploy-kubernetes-test.sh
+++ b/scripts/deploy-kubernetes-test.sh
@@ -31,16 +31,19 @@ NAMESPACE="${2:?"Specify the namespace as the second argument"}"
 # Allow overriding kubectl with something like `minikube kubectl --`.
 VECTOR_TEST_KUBECTL="${VECTOR_TEST_KUBECTL:-"kubectl"}"
 
+# Allow overriding helm with a custom command.
+VECTOR_TEST_HELM="${VECTOR_TEST_HELM:-"helm"}"
+
 # Allow optionally installing custom resource configs.
 CUSTOM_RESOURCE_CONFIGS_FILE="${CUSTOM_RESOURCE_CONFIGS_FILE:-""}"
 
+# Allow optionally passing custom Helm values.
+CUSTOM_HELM_VALUES_FILE="${CUSTOM_HELM_VALUES_FILE:-""}"
 
-# TODO: replace with `helm template | kubectl apply -f -` when Helm Chart is
-# available.
-
-templated-config() {
-  cat < "distribution/kubernetes/vector.yaml" \
-    | sed "s|^    namespace: vector|    namespace: $NAMESPACE|"
+split-container-image() {
+  local INPUT="$1"
+  CONTAINER_IMAGE_REPOSITORY="${INPUT%:*}"
+  CONTAINER_IMAGE_TAG="${INPUT#*:}"
 }
 
 up() {
@@ -53,9 +56,26 @@ up() {
     $VECTOR_TEST_KUBECTL create --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
   fi
 
-  templated-config \
-    | sed -E 's|image: "?timberio/vector:[^$]*$'"|image: $CONTAINER_IMAGE|" \
-    | $VECTOR_TEST_KUBECTL create --namespace "$NAMESPACE" -f -
+  HELM_VALUES=()
+
+  if [[ -n "$CUSTOM_HELM_VALUES_FILE" ]]; then
+    HELM_VALUES+=(
+      --values "$CUSTOM_HELM_VALUES_FILE"
+    )
+  fi
+
+  split-container-image "$CONTAINER_IMAGE"
+  HELM_VALUES+=(
+    --set "image.repository=$CONTAINER_IMAGE_REPOSITORY"
+    --set "image.tag=$CONTAINER_IMAGE_TAG"
+  )
+
+  $VECTOR_TEST_HELM install \
+    --atomic \
+    --namespace "$NAMESPACE" \
+    "${HELM_VALUES[@]}" \
+    "vector" \
+    "./distribution/helm/vector"
 }
 
 down() {
@@ -63,13 +83,13 @@ down() {
     $VECTOR_TEST_KUBECTL delete --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
   fi
 
-  templated-config | $VECTOR_TEST_KUBECTL delete --namespace "$NAMESPACE" -f -
+  $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "vector"
 
   $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"
 }
 
 case "$COMMAND" in
-  up|down|templated-config)
+  up|down)
     "$COMMAND" "$@"
     ;;
   *)

--- a/scripts/kubernetes-yaml/values.yaml
+++ b/scripts/kubernetes-yaml/values.yaml
@@ -5,8 +5,6 @@ image:
   base: alpine
 
 env:
-  # Set a reasonable log level to avoid issues with internal logs
-  # overwriting console output at E2E tests. Feel free to change at
-  # a real deployment.
+  # Set the log level reasonably high.
   - name: LOG
     value: info

--- a/scripts/kubernetes-yaml/values.yaml
+++ b/scripts/kubernetes-yaml/values.yaml
@@ -10,9 +10,3 @@ env:
   # a real deployment.
   - name: LOG
     value: info
-
-tolerations:
-  # This toleration is to have the daemonset runnable on master nodes.
-  # Remove it if your masters can't run pods.
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule

--- a/tests/kubernetes-e2e.rs
+++ b/tests/kubernetes-e2e.rs
@@ -755,3 +755,74 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     drop(vector);
     Ok(())
 }
+
+/// This test validates that vector helm chart properly allows configuration via
+/// an additional config file, i.e. it can combine the managed and custom config
+/// files.
+#[tokio::test]
+async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let framework = make_framework();
+
+    let vector = framework
+        .vector("test-vector", "", CUSTOM_RESOURCE_VECTOR_CONFIG)
+        .await?;
+    framework
+        .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
+        .await?;
+
+    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod(
+            "test-vector-test-pod",
+            "test-pod",
+            "echo MARKER",
+            vec![],
+        ))?)
+        .await?;
+    framework
+        .wait(
+            "test-vector-test-pod",
+            vec!["pods/test-pod"],
+            WaitFor::Condition("initialized"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let mut log_reader = framework.logs("test-vector", "daemonset/vector")?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the rest of the log lines.
+    let mut got_marker = false;
+    look_for_log_line(&mut log_reader, |val| {
+        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+            // A log from something other than our test pod, pretend we don't
+            // see it.
+            return FlowControlCommand::GoOn;
+        }
+
+        // Ensure we got the marker.
+        assert_eq!(val["message"], "MARKER");
+
+        if got_marker {
+            // We've already seen one marker! This is not good, we only emitted
+            // one.
+            panic!("Marker seen more than once");
+        }
+
+        // If we did, remember it.
+        got_marker = true;
+
+        // Request to stop the flow.
+        FlowControlCommand::Terminate
+    })
+    .await?;
+
+    assert!(got_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(vector);
+    Ok(())
+}

--- a/tests/kubernetes-e2e.rs
+++ b/tests/kubernetes-e2e.rs
@@ -12,7 +12,17 @@ use k8s_test_framework::{
 };
 use std::collections::HashSet;
 
-const VECTOR_CONFIG: &str = r#"
+const HELM_VALUES_STDOUT_SINK: &str = r#"
+sinks:
+  stdout:
+    type: "console"
+    inputs: ["kubernetes_logs"]
+    rawConfig: |
+      target = "stdout"
+      encoding = "json"
+"#;
+
+const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = r#"
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -160,7 +170,9 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -228,7 +240,9 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -319,7 +333,9 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     // Wait for some extra time to ensure pod completes.
     tokio::time::delay_for(std::time::Duration::from_secs(10)).await;
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -368,7 +384,9 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -438,7 +456,9 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -515,7 +535,9 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;
@@ -655,7 +677,9 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let vector = framework.vector("test-vector", VECTOR_CONFIG).await?;
+    let vector = framework
+        .vector("test-vector", HELM_VALUES_STDOUT_SINK, "")
+        .await?;
     framework
         .wait_for_rollout("test-vector", "daemonset/vector", vec!["--timeout=60s"])
         .await?;


### PR DESCRIPTION
This PR switches the E2E tests to using Helm chart instead of YAML config for greater configurability.

It also changes some of the Helm chart defaults, hence the `!`:
- moves master node toleration to the chart default, previously it was a YAML config-specific setting

Closes #3097.

It also unlocks writing more advanced tests, as now we can pass Helm values instead of just custom resources. This gives more possibilities to tweak the deployed Helm chart, and thus, to test more code paths.