### PR TITLE
enhancement(kubernetes_logs source): Allow using custom selectors

### DIFF
--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -62,6 +62,10 @@ pub struct Config {
 
     /// Specifies the field names for metadata annotation.
     annotation_fields: pod_metadata_annotator::FieldsSpec,
+
+    /// Specifies the label selector to filter `Pod`s with.
+    #[serde(default = "default_label_selector")]
+    label_selector: String,
 }
 
 inventory::submit! {
@@ -73,6 +77,7 @@ impl GenerateConfig for Config {
         toml::Value::try_from(&Self {
             self_node_name: default_self_node_name_env_template(),
             auto_partial_merge: true,
+            label_selector: default_label_selector(),
             ..Default::default()
         })
         .unwrap()
@@ -153,7 +158,6 @@ impl Source {
         );
 
         let field_selector = format!("spec.nodeName={}", self_node_name);
-        let label_selector = "vector.dev/exclude!=true".to_owned();
 
         let k8s_config = k8s::client::config::Config::in_cluster()?;
         let client = k8s::client::Client::new(k8s_config, resolver)?;
@@ -166,7 +170,7 @@ impl Source {
             auto_partial_merge: config.auto_partial_merge,
             fields_spec: config.annotation_fields.clone(),
             field_selector,
-            label_selector,
+            label_selector: config.label_selector.clone(),
         })
     }
 
@@ -354,6 +358,11 @@ fn create_event(line: Bytes, file: &str) -> Event {
 /// as it should be at the generated config file.
 fn default_self_node_name_env_template() -> String {
     format!("${{{}}}", SELF_NODE_NAME_ENV_KEY.to_owned())
+}
+
+/// This function returns the default value for `label_selector`.
+fn default_label_selector() -> String {
+    "vector.dev/exclude!=true".to_string()
 }
 
 #[cfg(test)]

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -392,7 +392,7 @@ fn prepare_label_selector(config: &Config) -> String {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<super::Config>();

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -367,14 +367,16 @@ fn prepare_field_selector(config: &Config) -> crate::Result<String> {
         ?self_node_name
     );
 
-    let mut field_selector = format!("spec.nodeName={}", self_node_name);
+    let field_selector = format!("spec.nodeName={}", self_node_name);
 
-    if !config.extra_field_selector.is_empty() {
-        field_selector.push(',');
-        field_selector.push_str(config.extra_field_selector.as_str());
+    if config.extra_field_selector.is_empty() {
+        return Ok(field_selector);
     }
 
-    Ok(field_selector)
+    Ok(format!(
+        "{},{}",
+        field_selector, config.extra_field_selector
+    ))
 }
 
 /// This function construct the effective label selector to use, based on


### PR DESCRIPTION
This PR adds the ability to pass additional [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) and [fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/) selectors.


Closes #3412
Closes #3413

~Blocked by #4176, the test has to be added after it's merged.~

To do:
- [x] test
- [ ] docs