### PR TITLE
enhancement(json_parser transform): add field's value in warn message when failing to parse

### DIFF
--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -22,6 +22,7 @@ impl InternalEvent for JsonParserEventProcessed {
 #[derive(Debug)]
 pub(crate) struct JsonParserFailedParse<'a> {
     pub field: &'a Atom,
+    pub value: &'a str,
     pub error: Error,
 }
 
@@ -30,6 +31,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
         warn!(
             message = "Event failed to parse as JSON.",
             field = %self.field,
+            value = %self.value,
             %self.error,
             rate_limit_secs = 30
         )

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -32,7 +32,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
             message = "Event failed to parse as JSON.",
             field = %self.field,
             value = %self.value,
-            %self.error,
+            error = %self.error,
             rate_limit_secs = 30
         )
     }

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -73,16 +73,18 @@ impl From<JsonParserConfig> for JsonParser {
 impl Transform for JsonParser {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
         let log = event.as_mut_log();
-        let to_parse = log.get(&self.field).map(|s| s.as_bytes());
+        let value = log.get(&self.field);
 
         emit!(JsonParserEventProcessed);
 
-        let parsed = to_parse
-            .and_then(|to_parse| {
+        let parsed = value
+            .and_then(|value| {
+                let to_parse = value.as_bytes();
                 serde_json::from_slice::<Value>(to_parse.as_ref())
                     .map_err(|error| {
                         emit!(JsonParserFailedParse {
                             field: &self.field,
+                            value: value.to_string_lossy().as_str(),
                             error
                         })
                     })


### PR DESCRIPTION
When debugging json_parser transform, either in tests or classic run, it might be hard to understand why the parser fails.

The PR adds the value of the field that was attempted to be parsed in the warn message to help the user figuring out why the parsing failed.

Example of an output:

```
Sep 30 17:33:54.573  WARN vector::internal_events::json_parser: Event failed to parse as JSON. field=json_string value={this: is not: how json: looks} self.error=key must be a string at line 1 column 2 rate_limit_secs=30
```

