### PR TITLE
feat(remap transform): add `split` function

### DIFF
--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -56,11 +56,25 @@ argument_list = _{ argument ~ ("," ~ argument)* }
 
 argument = { positional_item | keyword_item }
 
-positional_item = { query_arithmetic }
+positional_item = { argument_item }
 
-keyword_item = { ident ~ "=" ~ query_arithmetic }
+keyword_item = { ident ~ "=" ~ argument_item }
+
+argument_item = { query_arithmetic | regex }
 
 // end: Functions
+
+// Regex
+
+regex = ${ "/" ~ inner_regex_string ~ "/" ~ regex_flags }
+inner_regex_string = @{ regex_char* }
+regex_char = {
+    !("/" | "\\") ~ ANY
+    | "\\" ~ ANY
+}
+regex_flags = @{ ("i" | "g" | "m")* }
+
+// end: Regex
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/query/function/contains.rs
+++ b/src/mapping/query/function/contains.rs
@@ -71,9 +71,12 @@ impl TryFrom<ArgumentList> for ContainsFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let substring = arguments.required("substring")?;
-        let case_sensitive = arguments.optional("case_sensitive");
+        let query = arguments.required("value")?.into_value()?;
+        let substring = arguments.required("substring")?.into_value()?;
+        let case_sensitive = arguments
+            .optional("case_sensitive")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self {
             query,

--- a/src/mapping/query/function/downcase.rs
+++ b/src/mapping/query/function/downcase.rs
@@ -35,7 +35,7 @@ impl TryFrom<ArgumentList> for DowncaseFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/format_timestamp.rs
+++ b/src/mapping/query/function/format_timestamp.rs
@@ -54,8 +54,8 @@ impl TryFrom<ArgumentList> for FormatTimestampFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let format = arguments.required("format")?;
+        let query = arguments.required("value")?.into_value()?;
+        let format = arguments.required("format")?.into_value()?;
 
         Ok(Self { query, format })
     }

--- a/src/mapping/query/function/md5.rs
+++ b/src/mapping/query/function/md5.rs
@@ -38,7 +38,7 @@ impl TryFrom<ArgumentList> for Md5Fn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/parse_json.rs
+++ b/src/mapping/query/function/parse_json.rs
@@ -35,7 +35,7 @@ impl TryFrom<ArgumentList> for ParseJsonFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/parse_timestamp.rs
+++ b/src/mapping/query/function/parse_timestamp.rs
@@ -81,9 +81,12 @@ impl TryFrom<ArgumentList> for ParseTimestampFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let format = arguments.required("format")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let format = arguments.required("format")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self {
             query,

--- a/src/mapping/query/function/sha1.rs
+++ b/src/mapping/query/function/sha1.rs
@@ -38,7 +38,7 @@ impl TryFrom<ArgumentList> for Sha1Fn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -81,9 +81,12 @@ impl TryFrom<ArgumentList> for SliceFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let start = arguments.required("start")?;
-        let end = arguments.optional("end");
+        let query = arguments.required("value")?.into_value()?;
+        let start = arguments.required("start")?.into_value()?;
+        let end = arguments
+            .optional("end")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, start, end })
     }

--- a/src/mapping/query/function/split.rs
+++ b/src/mapping/query/function/split.rs
@@ -1,0 +1,183 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct SplitFn {
+    path: Box<dyn Function>,
+    pattern: ArgumentKind,
+    limit: Option<Box<dyn Function>>,
+}
+
+impl SplitFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        path: Box<dyn Function>,
+        pattern: ArgumentKind,
+        limit: Option<Box<dyn Function>>,
+    ) -> Self {
+        Self {
+            path,
+            pattern,
+            limit,
+        }
+    }
+}
+
+impl Function for SplitFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let string = {
+            let bytes = required!(ctx, self.path, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let limit = optional!(ctx, self.limit, Value::Integer(i) => i)
+            .map(|limit| {
+                if limit < 0 {
+                    Err("limit is not a positive number".to_string())
+                } else {
+                    Ok(limit as usize)
+                }
+            })
+            .transpose()?;
+
+        match &self.pattern {
+            ArgumentKind::Value(path) => {
+                let pattern = required!(ctx, path, Value::Bytes(v) => v);
+                let pattern = String::from_utf8_lossy(&pattern).into_owned();
+
+                let iter: Box<dyn Iterator<Item = _>> = match limit {
+                    Some(limit) => Box::new(string.splitn(limit, &pattern)),
+                    None => Box::new(string.split(&pattern)),
+                };
+
+                Ok(Value::Array(
+                    iter.map(|sub| Value::Bytes(sub.to_string().into()))
+                        .collect(),
+                ))
+            }
+            ArgumentKind::Regex(regex) => {
+                // The global flag has no meaning here.
+                // Should we error or just ignore?
+                let iter: Box<dyn Iterator<Item = _>> = match &limit {
+                    Some(ref limit) => Box::new(regex.regex.splitn(&string, *limit)),
+                    None => Box::new(regex.regex.split(&string)),
+                };
+
+                Ok(Value::Array(
+                    iter.map(|sub| Value::Bytes(sub.to_string().into()))
+                        .collect(),
+                ))
+            }
+        }
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "pattern",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "limit",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for SplitFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let path = arguments.required("value")?.into_value()?;
+        let pattern = arguments.required("pattern")?;
+
+        let limit = arguments
+            .optional("limit")
+            .map(|v| v.into_value())
+            .transpose()?;
+
+        Ok(Self {
+            path,
+            pattern,
+            limit,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn check_split() {
+        let cases = vec![
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from(""));
+                    event
+                },
+                Ok(Value::from(vec![Value::from("")])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    ArgumentKind::Value(Box::new(Literal::from(Value::from(" ")))),
+                    None,
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("This is a long string."));
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from("This"),
+                    Value::from("is"),
+                    Value::from("a"),
+                    Value::from("long"),
+                    Value::from("string."),
+                ])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    ArgumentKind::Value(Box::new(Literal::from(Value::from(" ")))),
+                    None,
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("This is a long string."));
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from("This"),
+                    Value::from("is a long string."),
+                ])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    ArgumentKind::Regex(RemapRegex {
+                        regex: regex::Regex::new(" ").unwrap(),
+                        global: true,
+                    }),
+                    Some(Box::new(Literal::from(Value::from(2)))),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/strip_whitespace.rs
+++ b/src/mapping/query/function/strip_whitespace.rs
@@ -37,7 +37,7 @@ impl TryFrom<ArgumentList> for StripWhitespaceFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/to_bool.rs
+++ b/src/mapping/query/function/to_bool.rs
@@ -52,8 +52,11 @@ impl TryFrom<ArgumentList> for ToBooleanFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, default })
     }

--- a/src/mapping/query/function/to_float.rs
+++ b/src/mapping/query/function/to_float.rs
@@ -53,8 +53,11 @@ impl TryFrom<ArgumentList> for ToFloatFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, default })
     }

--- a/src/mapping/query/function/to_int.rs
+++ b/src/mapping/query/function/to_int.rs
@@ -53,8 +53,11 @@ impl TryFrom<ArgumentList> for ToIntegerFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, default })
     }

--- a/src/mapping/query/function/to_string.rs
+++ b/src/mapping/query/function/to_string.rs
@@ -48,8 +48,11 @@ impl TryFrom<ArgumentList> for ToStringFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, default })
     }

--- a/src/mapping/query/function/to_timestamp.rs
+++ b/src/mapping/query/function/to_timestamp.rs
@@ -49,8 +49,11 @@ impl TryFrom<ArgumentList> for ToTimestampFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let default = arguments.optional("default");
+        let query = arguments.required("value")?.into_value()?;
+        let default = arguments
+            .optional("default")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self { query, default })
     }

--- a/src/mapping/query/function/tokenize.rs
+++ b/src/mapping/query/function/tokenize.rs
@@ -42,7 +42,7 @@ impl TryFrom<ArgumentList> for TokenizeFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }

--- a/src/mapping/query/function/truncate.rs
+++ b/src/mapping/query/function/truncate.rs
@@ -99,9 +99,12 @@ impl TryFrom<ArgumentList> for TruncateFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
-        let limit = arguments.required("limit")?;
-        let ellipsis = arguments.optional("ellipsis");
+        let query = arguments.required("value")?.into_value()?;
+        let limit = arguments.required("limit")?.into_value()?;
+        let ellipsis = arguments
+            .optional("ellipsis")
+            .map(|v| v.into_value())
+            .transpose()?;
 
         Ok(Self {
             query,

--- a/src/mapping/query/function/upcase.rs
+++ b/src/mapping/query/function/upcase.rs
@@ -35,7 +35,7 @@ impl TryFrom<ArgumentList> for UpcaseFn {
     type Error = String;
 
     fn try_from(mut arguments: ArgumentList) -> Result<Self> {
-        let query = arguments.required("value")?;
+        let query = arguments.required("value")?.into_value()?;
 
         Ok(Self { query })
     }


### PR DESCRIPTION
Fixes #3745 
Closes #4091 

This adds the `split` remap function. Since split takes a regex parameter it also adds in the ability for remap functions to handle regexes.

It's very possible this needs some tidy up, I want to post it here to get some feedback on the approach taken to implement regex parameters. I just have this vague notion in my head that this can be improved.

I have created an `ArgumentKind` struct that can either be a query or a regex. The `Argument` then stores this rather than the query directly.

Now, because the `Argument` is not necessarily a function, it can no longer implement `Function` in order to ensure that the result resolves to the type specified by `Parameter`. Instead, I have created a new struct, `TypedArgument` that does. It is a little bit unsatisfying because now both `Argument` and `TypedArgument` contains a `Parameter` field - `Argument` because it needs the `Parameter` name and `TypedArgument` because it needs the `Parameters` type. 


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
