### PR TITLE
chore(aws_s3 sink): Fix flakey s3_gzip test

### DIFF
--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -617,7 +617,7 @@ mod integration_tests {
 
         let config = S3SinkConfig {
             compression: Compression::Gzip,
-            filename_time_format: Some("%S%f".into()),
+            filename_time_format: Some("%s%f".into()),
             ..config(10000).await
         };
 


### PR DESCRIPTION
The test was using `%S%f` for the time format for the object name, where
`%S` is "Second number (00--60), zero-padded to 2 digits."
(https://docs.rs/chrono/0.4.11/chrono/format/strftime/index.html#specifiers).
When the test ran close to the minute mark, this caused it write later
batches as objects that appear _earlier_ in the ListObjectsV2 call than
objects written before it.

This changes the filename_time_format to be `%s%f` where `%s` is the unix
timestamp so objects written later should always appear after.

Supersedes https://github.com/timberio/vector/pull/4222
Closes #4223