### PR TITLE
fix(humio_logs sink): Set host key correctly

### DIFF
--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -95,4 +95,16 @@ description = "The optional endpoint to send Humio logs to."
   namespace: "sinks.humio_logs.options",
   encodings: ["json", "text"],
   default: "json"
-) %>
+          ) %>
+
+[sinks.humio_logs.options.host_key]
+type = "string"
+common = true
+examples = ["hostname"]
+required = false
+description = """\
+The name of the log field to be used as the hostname sent to Humio. This \
+overrides the \ [global `host_key` \
+option][docs.reference.global-options#host_key].\
+"""
+

--- a/.meta/sinks/humio_logs.toml.erb
+++ b/.meta/sinks/humio_logs.toml.erb
@@ -104,7 +104,5 @@ examples = ["hostname"]
 required = false
 description = """\
 The name of the log field to be used as the hostname sent to Humio. This \
-overrides the \ [global `host_key` \
-option][docs.reference.global-options#host_key].\
+overrides the [global `host_key` option][docs.reference.global-options#host_key].\
 """
-

--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ ifeq ($(AUTOSPAWN), true)
 	$(MAKE) start-integration-humio
 	sleep 10 # Many services are very slow... Give them a sec..
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features humio-integration-tests --lib ::humio:: -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features humio-integration-tests --lib ::humio_logs::integration_tests:: -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	$(MAKE) -k stop-integration-humio
 endif

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -7,6 +7,7 @@ use crate::{
     template::Template,
 };
 use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
 
 const HOST: &str = "https://cloud.humio.com";
 
@@ -25,6 +26,9 @@ pub struct HumioLogsConfig {
 
     event_type: Option<Template>,
 
+    #[serde(default = "default_host_key")]
+    pub host_key: Atom,
+
     #[serde(default)]
     pub compression: Compression,
 
@@ -33,6 +37,10 @@ pub struct HumioLogsConfig {
 
     #[serde(default)]
     batch: BatchConfig,
+}
+
+fn default_host_key() -> Atom {
+    crate::config::LogSchema::default().host_key().clone()
 }
 
 inventory::submit! {
@@ -85,6 +93,7 @@ impl HumioLogsConfig {
             compression: self.compression,
             batch: self.batch,
             request: self.request,
+            host_key: self.host_key.clone(),
             ..Default::default()
         }
     }
@@ -133,7 +142,7 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::{
-        config::{SinkConfig, SinkContext},
+        config::{log_schema, SinkConfig, SinkContext},
         sinks::util::Compression,
         test_util::random_string,
         Event,
@@ -157,7 +166,10 @@ mod integration_tests {
         let (sink, _) = config.build(cx).unwrap();
 
         let message = random_string(100);
-        let event = Event::from(message.clone());
+        let host = "192.168.1.1".to_string();
+        let mut event = Event::from(message.clone());
+        let log = event.as_mut_log();
+        log.insert(log_schema().host_key(), host.clone());
 
         sink.run(stream::once(future::ready(event))).await.unwrap();
 
@@ -179,6 +191,7 @@ mod integration_tests {
                 .error_msg
                 .unwrap_or_else(|| "no error message".to_string())
         );
+        assert_eq!(Some(host), entry.host);
     }
 
     #[tokio::test]
@@ -269,6 +282,7 @@ mod integration_tests {
                 max_events: Some(1),
                 ..Default::default()
             },
+            host_key: log_schema().host_key().clone(),
             ..Default::default()
         }
     }
@@ -390,6 +404,9 @@ mutation {{
 
         #[serde(rename = "@source")]
         source: Option<String>,
+
+        #[serde(rename = "@host")]
+        host: Option<String>,
 
         // fields parsed from ingested log
         #[serde(flatten)]


### PR DESCRIPTION
This sink was previously not setting the `host` key of the Splunk HEC
format
(https://docs.humio.com/integrations/ingest-logs-with-a-data-shipper/hec/)
as the `host_key` field on the `SinkHecConfig` was defaulting `host_key`
to `''`.

I opted to expose the `host_key` as a config option on the Humio sink to
parallel its existence on the Splunk HEC sink.

Fixes #4228

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>