### PR TITLE
feat(observability): Update log levels for transforms

### DIFF
--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -20,7 +20,7 @@ pub struct AddTagsTagOverwritten<'a> {
 
 impl<'a> InternalEvent for AddTagsTagOverwritten<'a> {
     fn emit_logs(&self) {
-        error!(message = "Tag overwritten.", %self.tag, rate_limit_secs = 30);
+        debug!(message = "Tag overwritten.", %self.tag, rate_limit_secs = 30);
     }
 }
 
@@ -31,6 +31,6 @@ pub struct AddTagsTagNotOverwritten<'a> {
 
 impl<'a> InternalEvent for AddTagsTagNotOverwritten<'a> {
     fn emit_logs(&self) {
-        error!(message = "Tag not overwritten.", %self.tag, rate_limit_secs = 30);
+        debug!(message = "Tag not overwritten.", %self.tag, rate_limit_secs = 30);
     }
 }

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -47,7 +47,7 @@ pub(crate) struct GrokParserMissingField<'a> {
 
 impl InternalEvent for GrokParserMissingField<'_> {
     fn emit_logs(&self) {
-        debug!(message = "Field does not exist.", field = %self.field);
+        warn!(message = "Field does not exist.", field = %self.field);
     }
 
     fn emit_metrics(&self) {
@@ -67,7 +67,7 @@ pub(crate) struct GrokParserConversionFailed<'a> {
 
 impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
     fn emit_logs(&self) {
-        debug!(
+        warn!(
             message = "Could not convert types.",
             name = %self.name,
             error = %self.error,

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -48,7 +48,7 @@ pub(crate) struct RegexParserMissingField<'a> {
 
 impl InternalEvent for RegexParserMissingField<'_> {
     fn emit_logs(&self) {
-        debug!(message = "Field does not exist.", field = %self.field);
+        warn!(message = "Field does not exist.", field = %self.field);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/remove_fields.rs
+++ b/src/internal_events/remove_fields.rs
@@ -20,6 +20,6 @@ pub struct RemoveFieldsFieldMissing<'a> {
 
 impl<'a> InternalEvent for RemoveFieldsFieldMissing<'a> {
     fn emit_logs(&self) {
-        error!(message = "Field did not exist.", %self.field, rate_limit_secs = 30);
+        debug!(message = "Field did not exist.", %self.field, rate_limit_secs = 30);
     }
 }

--- a/src/internal_events/rename_fields.rs
+++ b/src/internal_events/rename_fields.rs
@@ -20,7 +20,7 @@ pub struct RenameFieldsFieldOverwritten<'a> {
 
 impl<'a> InternalEvent for RenameFieldsFieldOverwritten<'a> {
     fn emit_logs(&self) {
-        error!(message = "Field overwritten.", %self.field, rate_limit_secs = 30);
+        debug!(message = "Field overwritten.", %self.field, rate_limit_secs = 30);
     }
 }
 
@@ -31,6 +31,6 @@ pub struct RenameFieldsFieldDoesNotExist<'a> {
 
 impl<'a> InternalEvent for RenameFieldsFieldDoesNotExist<'a> {
     fn emit_logs(&self) {
-        error!(message = "Field did not exist.", %self.field, rate_limit_secs = 30);
+        warn!(message = "Field did not exist.", %self.field, rate_limit_secs = 30);
     }
 }

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -21,7 +21,7 @@ pub struct SplitFieldMissing<'a> {
 
 impl<'a> InternalEvent for SplitFieldMissing<'a> {
     fn emit_logs(&self) {
-        debug!(
+        warn!(
             message = "Field does not exist.",
             field = %self.field,
             rate_limit_secs = 10
@@ -45,7 +45,7 @@ pub struct SplitConvertFailed<'a> {
 
 impl<'a> InternalEvent for SplitConvertFailed<'a> {
     fn emit_logs(&self) {
-        debug!(
+        warn!(
             message = "Could not convert types.",
             field = %self.field,
             error = %self.error,

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -23,7 +23,7 @@ pub(crate) struct TagCardinalityLimitRejectingEvent<'a> {
 
 impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
     fn emit_logs(&self) {
-        error!(
+        debug!(
             message = "Event containing tag with new value after hitting configured 'value_limit'; discarding event.",
             tag_key = self.tag_key,
             tag_value = self.tag_value,
@@ -46,7 +46,7 @@ pub(crate) struct TagCardinalityLimitRejectingTag<'a> {
 
 impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
     fn emit_logs(&self) {
-        warn!(
+        debug!(
             message = "Rejecting tag after hitting configured 'value_limit'.",
             tag_key = self.tag_key,
             tag_value = self.tag_value,
@@ -68,7 +68,7 @@ pub(crate) struct TagCardinalityValueLimitReached<'a> {
 
 impl<'a> InternalEvent for TagCardinalityValueLimitReached<'a> {
     fn emit_logs(&self) {
-        warn!(
+        debug!(
             "Value_limit reached for key {}. New values for this key will be rejected.",
             key = self.key,
         );

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -21,7 +21,7 @@ pub(crate) struct TokenizerFieldMissing<'a> {
 
 impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
     fn emit_logs(&self) {
-        debug!(
+        warn!(
             message = "Field does not exist.",
             field = %self.field,
             rate_limit_secs = 10
@@ -45,7 +45,7 @@ pub(crate) struct TokenizerConvertFailed<'a> {
 
 impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
     fn emit_logs(&self) {
-        debug!(
+        warn!(
             message = "Could not convert types.",
             field = %self.field,
             error = %self.error,


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

I've updated the log levels of several transforms to better match why it's being logged.

 - add_tags: both of these logs are emitted when Vector takes the action as configured (only emits overwritten message when overwrite = true)
 - grok_parser: set missing field log to warn based on a [quick chat](https://discordapp.com/channels/742820443487993987/746070604192415834/761038283655872532) with @binarylogic, conversion failure seems like a warning or maybe even an error?
 - regex_parser: matched behaviour with grok_parser
 - remove_fields: also discussed with @binarylogic - if you're trying to remove a field and it already isn't there, that seems _ok_
 - rename_events: overwritten is again the configured behaviour like add_tags, warn on missing field as above
 - split: warn on missing again, and another log for converting which I set to warn but could be error?
 - tag_cardinality_limit: these all appear to be logging when the transform is carrying out its task, maybe it could be info though?
 - tokenizer: warn on missing again, and another log for converting which I set to warn but could be error?