### PR TITLE
enhancement(docker platform): Added distroless-libc and distroless-static docker container bases

### DIFF
--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -81,6 +81,16 @@ which is a smaller, more compact variant of the [`debian` image][urls.docker_deb
 docker run timberio/vector:0.10.0-debian
 ```
 
+#### distroless-*
+
+[Distroless][urls.distroless] is a base docker image based on either stripping down an OS, or building
+the key parts from scratch. It contains only the barest of essentials for running
+a static or dynamically linked binary.
+
+distroless-static uses the statically linked musl x86 build
+distroless-libc uses a dynamically linked build which leverages
+libc provided by distroless/base/cc
+
 ### Architectures
 
 Vector's images are multi-arch and support the
@@ -125,3 +135,4 @@ Vector's Docker source files are located
 [urls.vector_docker_source_files]: https://github.com/timberio/vector/tree/master/distribution/docker
 [urls.vector_releases]: https://vector.dev/releases/latest/
 [urls.vector_repo]: https://github.com/timberio/vector
+[urls.distroless]: https://github.com/GoogleContainerTools/distroless

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:buster-slim AS builder
+
+COPY vector-*.deb ./
+RUN dpkg -i vector-$(dpkg --print-architecture).deb
+
+FROM gcr.io/distroless/cc-debian10
+
+COPY --from=builder /usr/bin/vector /usr/bin/vector
+COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
+COPY --from=builder /etc/vector /etc/vector
+VOLUME /var/lib/vector/
+
+# Smoke test
+RUN ["vector", "--version"]
+
+ENTRYPOINT ["/usr/bin/vector"]
+

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:buster-slim AS builder
+
+WORKDIR /vector
+
+COPY vector-x86_64-unknown-linux-musl*.tar.gz ./
+RUN tar -xvf vector-x86_64-unknown-linux-musl*.tar.gz --strip-components=2
+
+FROM gcr.io/distroless/static
+
+COPY --from=builder /vector/bin/* /usr/local/bin/
+COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
+VOLUME /var/lib/vector/
+
+# Smoke test
+RUN ["vector", "--version"]
+
+ENTRYPOINT ["/usr/local/bin/vector"]

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -68,9 +68,15 @@ if [[ "$CHANNEL" == "latest" ]]; then
   for VERSION_TAG in "$VERSION_EXACT" "$VERSION_MINOR_X" "$VERSION_MAJOR_X" latest; do
     build alpine "$VERSION_TAG"
     build debian "$VERSION_TAG"
+    build distroless-static "$VERSION_TAG"
+    build distroless-libc "$VERSION_TAG"
   done
 elif [[ "$CHANNEL" == "nightly" ]]; then
     build alpine nightly
+    build distroless-static nightly
+    build distroless-libc nightly
 elif [[ "$CHANNEL" == "test" ]]; then
   build "${BASE:-"alpine"}" "${TAG:-"test"}"
+  build "${BASE:-"distroless-libc"}" "${TAG:-"test"}"
+  build "${BASE:-"distroless-static"}" "${TAG:-"test"}"
 fi


### PR DESCRIPTION

This is a simple PR which adds 2 docker container targets that use the [distroless](https://github.com/GoogleContainerTools/distroless) Container base.  

distroless/static is basically `FROM scratch` plus CA certificates.  
distroless/cc is distroless/static plus libc and related dependencies, so that dynamic binaries may run.  

I've successfully tested the musl build within the distroless/static,  and tested the debian package binary using the distroless/cc platform.  

The final containers are 86MB and 89MB respectively. 