### PR TITLE
fix(prometheus sink): Ensure server starts immediately

### DIFF
--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -377,9 +377,8 @@ impl PrometheusSink {
 #[async_trait]
 impl StreamSink for PrometheusSink {
     async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        self.start_server_if_needed();
         while let Some(event) = input.next().await {
-            self.start_server_if_needed();
-
             let item = event.into_metric();
             let mut metrics = self.metrics.write().unwrap();
 


### PR DESCRIPTION
This addresses #4238 

This assumes that the server will run forever (until shutdown) so the function only needs to be run once (but it won't hurt if it's run multiple times) 

