### PR TITLE
chore(traces): use debug/display shortcuts on trace events

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -13,7 +13,6 @@ use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::{self, Duration};
 use tokio::time::delay_for;
-use tracing::field;
 
 use crate::metadata_ext::PortableFileExt;
 use crate::paths_provider::PathsProvider;
@@ -153,22 +152,22 @@ where
                             if watcher.path == path {
                                 trace!(
                                     message = "Continue watching file.",
-                                    path = field::debug(&path),
+                                    path = ?path,
                                 );
                             } else {
                                 // matches a file with a different path
                                 if !was_found_this_cycle {
                                     info!(
                                         message = "Watched file has been renamed.",
-                                        path = field::debug(&path),
-                                        old_path = field::debug(&watcher.path)
+                                        path = ?path,
+                                        old_path = ?watcher.path
                                     );
                                     watcher.update_path(path).ok(); // ok if this fails: might fix next cycle
                                 } else {
                                     info!(
                                         message = "More than one file has the same fingerprint.",
-                                        path = field::debug(&path),
-                                        old_path = field::debug(&watcher.path)
+                                        path = ?path,
+                                        old_path = ?watcher.path
                                     );
                                     let (old_path, new_path) = (&watcher.path, &path);
                                     if let (Ok(old_modified_time), Ok(new_modified_time)) = (
@@ -178,8 +177,8 @@ where
                                         if old_modified_time < new_modified_time {
                                             info!(
                                                 message = "switching to watch most recently modified file.",
-                                                new_modified_time = field::debug(&new_modified_time),
-                                                old_modified_time = field::debug(&old_modified_time),
+                                                new_modified_time = ?new_modified_time,
+                                                old_modified_time = ?old_modified_time,
                                             );
                                             watcher.update_path(path).ok(); // ok if this fails: might fix next cycle
                                         }
@@ -211,8 +210,8 @@ where
                     let sz = line.len();
                     trace!(
                         message = "read bytes.",
-                        path = field::debug(&watcher.path),
-                        bytes = field::debug(sz)
+                        path = ?watcher.path,
+                        bytes = ?sz
                     );
 
                     bytes_read += sz;

--- a/lib/tracing-limit/benches/limit.rs
+++ b/lib/tracing-limit/benches/limit.rs
@@ -29,7 +29,7 @@ fn bench(c: &mut Criterion) {
                             foo = "foo",
                             bar = "bar",
                             baz = 3,
-                            quuux = field::debug(0.99),
+                            quuux = ?0.99,
                         )
                     }
                 })
@@ -51,7 +51,7 @@ fn bench(c: &mut Criterion) {
                             foo = "foo",
                             bar = "bar",
                             baz = 3,
-                            quuux = field::debug(0.99),
+                            quuux = ?0.99,
                             rate_limit_secs = 5
                         )
                     }

--- a/src/internal_events/wasm/compilation.rs
+++ b/src/internal_events/wasm/compilation.rs
@@ -65,7 +65,7 @@ impl InternalEvent for WasmCompilationProgress {
             State::Errored => error!(
                 state = self.state.as_const_str(),
                 role = self.role.as_const_str(),
-                error = tracing::field::display(self.error.as_ref().unwrap_or(&String::from(""))),
+                error = %self.error.as_ref().unwrap_or(&String::from("")),
                 elapsed_micros = self.elapsed.as_micros() as u64,
                 // We do not rate limit this since it should never spam, it's a oneshot at startup.
                 "WASM Compilation via `lucet`.",

--- a/src/internal_events/wasm/event_processing.rs
+++ b/src/internal_events/wasm/event_processing.rs
@@ -57,7 +57,7 @@ impl InternalEvent for EventProcessingProgress {
             State::Errored => error!(
                 state = self.state.as_const_str(),
                 role = self.role.as_const_str(),
-                error = tracing::field::display(self.error.as_ref().unwrap_or(&String::from(""))),
+                error = %self.error.as_ref().unwrap_or(&String::from("")),
                 elapsed_micros = self.elapsed.as_micros() as u64,
                 rate_limit_secs = 30,
                 "Event processing error.",

--- a/src/internal_events/wasm/hostcall.rs
+++ b/src/internal_events/wasm/hostcall.rs
@@ -62,7 +62,7 @@ impl InternalEvent for WasmHostcallProgress {
                 state = self.state.as_const_str(),
                 call = self.call,
                 role = self.role.as_const_str(),
-                error = tracing::field::display(self.error.as_ref().unwrap_or(&String::from(""))),
+                error = %self.error.as_ref().unwrap_or(&String::from("")),
                 elapsed_micros = self.elapsed.as_micros() as u64,
                 rate_limit_secs = 30,
                 "Hostcall errored.",

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -31,7 +31,6 @@ use std::convert::{TryFrom, TryInto};
 use std::task::Context;
 use std::task::Poll;
 use tower::{Service, ServiceBuilder};
-use tracing::field;
 use tracing_futures::Instrument;
 use uuid::Uuid;
 
@@ -327,9 +326,9 @@ fn build_request(
 
     debug!(
         message = "sending events.",
-        bytes = &field::debug(inner.len()),
-        bucket = &field::debug(&bucket),
-        key = &field::debug(&key)
+        bytes = ?inner.len(),
+        bucket = ?bucket,
+        key = ?key
     );
 
     Request {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -315,11 +315,7 @@ impl RequestWrapper {
             settings.extension
         );
 
-        debug!(
-            message = "sending events.",
-            bytes = ?body.len(),
-            key = ?key
-        );
+        debug!(message = "sending events.", bytes = ?body.len(), ?key);
 
         Self {
             body,

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -32,7 +32,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::task::Poll;
 use tower::{Service, ServiceBuilder};
-use tracing::field;
 use uuid::Uuid;
 
 const NAME: &str = "gcp_cloud_storage";
@@ -318,8 +317,8 @@ impl RequestWrapper {
 
         debug!(
             message = "sending events.",
-            bytes = &field::debug(body.len()),
-            key = &field::debug(&key)
+            bytes = ?body.len(),
+            key = ?key
         );
 
         Self {

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -25,7 +25,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use stream_cancel::{Trigger, Tripwire};
-use tracing::field;
 
 const MIN_FLUSH_PERIOD_SECS: u64 = 1;
 
@@ -308,7 +307,7 @@ fn handle(
 
     info!(
         message = "Request complete",
-        response_code = field::debug(response.status())
+        response_code = ?response.status()
     );
 
     response
@@ -352,8 +351,8 @@ impl PrometheusSink {
 
                     let response = info_span!(
                         "prometheus_server",
-                        method = field::debug(req.method()),
-                        path = field::debug(req.uri().path()),
+                        method = ?req.method(),
+                        path = ?req.uri().path(),
                     )
                     .in_scope(|| handle(req, namespace.as_deref(), &buckets, expired, &metrics));
 

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -13,7 +13,6 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::time::Duration;
 use tokio::time::{delay_for, Delay};
 use tokio_retry::strategy::ExponentialBackoff;
-use tracing::field;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -164,7 +163,7 @@ impl Sink for UdpSink {
             Ok(Async::Ready(socket)) => {
                 debug!(
                     message = "sending event.",
-                    bytes = &field::display(line.len())
+                    bytes = %line.len()
                 );
                 match socket.send(&line) {
                     Err(error) => {

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -19,7 +19,6 @@ use tokio::{
 };
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_util::codec::{BytesCodec, FramedWrite};
-use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -132,7 +131,7 @@ impl UnixSink {
                 UnixSinkState::Disconnected => {
                     debug!(
                         message = "Connecting",
-                        path = &field::display(self.path.to_str().unwrap())
+                        path = %self.path.to_str().unwrap()
                     );
                     let connect_future = UnixStream::connect(self.path.clone()).boxed().compat();
                     UnixSinkState::Creating(Box::new(connect_future))

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -35,7 +35,6 @@ use std::time::Duration;
 use std::{collections::HashMap, convert::TryFrom, env};
 use string_cache::DefaultAtom as Atom;
 use tokio::sync::mpsc;
-use tracing::field;
 
 /// The beginning of image names of vector docker images packaged by vector.
 const VECTOR_IMAGE_NAME: &str = "timberio/vector";
@@ -349,8 +348,8 @@ impl DockerSource {
 
                 trace!(
                     message = "found already running container.",
-                    id = field::display(&id),
-                    names = field::debug(&names)
+                    id = %id,
+                    names = ?names
                 );
 
                 if !self.exclude_vector(id.as_str(), image.as_str()) {
@@ -369,7 +368,7 @@ impl DockerSource {
                         }
                     }),
                 ) {
-                    trace!(message = "container excluded.", id = field::display(&id));
+                    trace!(message = "container excluded.", id = %id);
                     return;
                 }
 

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -346,11 +346,7 @@ impl DockerSource {
                 let names = container.names.unwrap();
                 let image = container.image.unwrap();
 
-                trace!(
-                    message = "found already running container.",
-                    id = %id,
-                    names = ?names
-                );
+                trace!(message = "found already running container.", %id, ?names);
 
                 if !self.exclude_vector(id.as_str(), image.as_str()) {
                     return;
@@ -368,7 +364,7 @@ impl DockerSource {
                         }
                     }),
                 ) {
-                    trace!(message = "container excluded.", id = %id);
+                    trace!(message = "container excluded.", %id);
                     return;
                 }
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -33,7 +33,7 @@ use tokio::{
     task::spawn_blocking,
     time::{delay_for, Duration},
 };
-use tracing::{dispatcher, field};
+use tracing::dispatcher;
 
 const DEFAULT_BATCH_SIZE: usize = 16;
 
@@ -164,7 +164,7 @@ impl JournaldConfig {
             Err(err) => {
                 error!(
                     message = "Could not retrieve saved journald checkpoint",
-                    error = field::display(&err)
+                    error = %err
                 );
                 None
             }
@@ -351,7 +351,7 @@ where
                     Some(Err(err)) => {
                         error!(
                             message = "Could not read from journald source",
-                            error = field::display(&err),
+                            error = %err,
                         );
                         break;
                     }
@@ -390,7 +390,7 @@ where
                     if let Err(err) = self.checkpointer.set(&cursor) {
                         error!(
                             message = "Could not set journald checkpoint.",
-                            error = field::display(&err),
+                            error = %err,
                             filename = ?self.checkpointer.filename,
                         );
                     }

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 use tokio_util::{codec::BytesCodec, udp::UdpFramed};
-use tracing::field;
 
 pub mod parser;
 
@@ -59,7 +58,7 @@ fn statsd(addr: SocketAddr, shutdown: ShutdownSignal, out: Pipeline) -> super::S
 
             info!(
                 message = "Listening.",
-                addr = &field::display(addr),
+                addr = %addr,
                 r#type = "udp"
             );
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -28,7 +28,6 @@ use tokio_util::{
     codec::{BytesCodec, Decoder, LinesCodec, LinesCodecError},
     udp::UdpFramed,
 };
-use tracing::field;
 
 #[derive(Deserialize, Serialize, Debug)]
 // TODO: add back when serde-rs/serde#1358 is addressed
@@ -259,7 +258,7 @@ pub fn udp(
                 .expect("Failed to bind to UDP listener socket");
             info!(
                 message = "Listening.",
-                addr = &field::display(addr),
+                addr = %addr,
                 r#type = "udp"
             );
 
@@ -351,7 +350,7 @@ fn event_from_str(host_key: &str, default_host: Option<Bytes>, line: &str) -> Op
 
     trace!(
         message = "processing one event.",
-        event = &field::debug(&event)
+        event = ?event
     );
 
     Some(event)

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -19,7 +19,6 @@ use tokio::{
     time::delay_for,
 };
 use tokio_util::codec::{Decoder, FramedRead};
-use tracing::field;
 use tracing_futures::Instrument;
 
 async fn make_listener(
@@ -85,12 +84,10 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
 
             info!(
                 message = "Listening.",
-                addr = field::display(
-                    listener
-                        .local_addr()
-                        .map(SocketListenAddr::SocketAddr)
-                        .unwrap_or(addr)
-                )
+                addr = %listener
+                    .local_addr()
+                    .map(SocketListenAddr::SocketAddr)
+                    .unwrap_or(addr)
             );
 
             let tripwire = shutdown.clone().compat();

--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -1,14 +1,11 @@
 use super::Transform;
-
 use crate::{
     config::{DataType, TransformConfig, TransformContext, TransformDescription},
     event::Event,
 };
 use serde::{Deserialize, Serialize};
-use string_cache::DefaultAtom as Atom;
-
 use std::str::FromStr;
-use tracing::field;
+use string_cache::DefaultAtom as Atom;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -157,7 +154,7 @@ impl Transform for Geoip {
             } else {
                 debug!(
                     message = "IP Address not parsed correctly.",
-                    ipaddr = &field::display(&ipaddress),
+                    ipaddr = %ipaddress,
                 );
             }
         } else {


### PR DESCRIPTION
When worked on ~#3032~ #4243  noticed that [tracing::field::debug](https://tracing.rs/tracing/field/fn.debug.html) / [tracing::field::display](https://tracing.rs/tracing/field/fn.display.html) used instead shortcuts `?`/`%` on creating trace events. This pull request replace methods by shortcuts.