### PR TITLE
chore(tests): Disable flaky tests on MacOS

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -117,8 +117,7 @@ fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &[PathBuf]) -> Resu
     Ok(())
 }
 
-#[cfg(unix)]
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::test_util::{temp_file, trace_init};

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -136,6 +136,7 @@ mod tests {
         tokio::time::timeout(timeout, signal.recv()).await.is_ok()
     }
 
+    #[cfg(not(macos))] // Issue https://github.com/timberio/vector/issues/2978
     #[tokio::test]
     async fn file_update() {
         trace_init();

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -188,6 +188,7 @@ mod test {
     // If this test hangs that means somewhere we are not collecting the correct
     // events.
     #[cfg(all(feature = "sources-tls", feature = "listenfd"))]
+    #[cfg(not(macos))] // Issue https://github.com/timberio/vector/issues/2978
     #[tokio::test]
     async fn tcp_stream_detects_disconnect() {
         use crate::tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -187,8 +187,9 @@ mod test {
     //
     // If this test hangs that means somewhere we are not collecting the correct
     // events.
-    #[cfg(all(feature = "sources-tls", feature = "listenfd"))]
-    #[cfg(not(macos))] // Issue https://github.com/timberio/vector/issues/2978
+    //
+    // not(macos) // Issue https://github.com/timberio/vector/issues/2978
+    #[cfg(all(feature = "sources-tls", feature = "listenfd", not(macos)))]
     #[tokio::test]
     async fn tcp_stream_detects_disconnect() {
         use crate::tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -1,3 +1,4 @@
+#![cfg(not(macos))]
 mod support;
 
 use crate::support::{sink, sink_failing_healthcheck, source, transform, MockSourceConfig};


### PR DESCRIPTION
Ref. #2978, #4056

I'll just keep disabling tests for Mac in this PR until we get a consistently passing check, and after that make a triage of them. This to avoid accumulation of broken tests behind a couple, hopefully, of them at moment 

Tests disabled on Mac:
* `tcp_stream_detects_disconnect`
* `file_update`
* `topology` tests


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
