### PR TITLE
fix(config): Allow for fields starting with '@'

### DIFF
--- a/src/event/lookup/test.rs
+++ b/src/event/lookup/test.rs
@@ -6,9 +6,9 @@ const SUFFICIENTLY_COMPLEX: &str =
 lazy_static::lazy_static! {
     static ref SUFFICIENTLY_DECOMPOSED: [Segment; 9] = [
         Segment::field(r#"regular"#.to_string()),
-        Segment::field(r#""quoted""#.to_string()),
-        Segment::field(r#""quoted but spaces""#.to_string()),
-        Segment::field(r#""quoted.but.periods""#.to_string()),
+        Segment::quoted_field(r#"quoted"#.to_string()),
+        Segment::quoted_field(r#"quoted but spaces"#.to_string()),
+        Segment::quoted_field(r#"quoted.but.periods"#.to_string()),
         Segment::field(r#"lookup"#.to_string()),
         Segment::index(0),
         Segment::field(r#"nested_lookup"#.to_string()),
@@ -151,7 +151,9 @@ fn parse_artifact(path: impl AsRef<Path>) -> std::io::Result<String> {
     let mut buf = Vec::new();
     test_file.read_to_end(&mut buf)?;
     let string = String::from_utf8(buf).unwrap();
-    Ok(string)
+
+    // Trim newlines at end, as most editors add them automatically.
+    Ok(string.trim_end().to_owned())
 }
 
 // This test iterates over the `tests/data/fixtures/lookup` folder and ensures the lookup parsed,

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -20,7 +20,8 @@ lookup = { (path_segment | quoted_path_segment) ~ ("." ~ (path_segment | quoted_
 path_index =$ { "[" ~ inner_path_index ~ "]" }
 inner_path_index = { '0'..'9'+ }
 path_segment = ${ path_field_name ~ path_index* }
-path_field_name = { (ASCII_ALPHA | "_" | "-" | "@" )+ }
+//path_field_name = { (ASCII_ALPHA | "_" | "-" | "@" )+ }
+path_field_name = { (ASCII_ALPHA | "_" | "-" )+ }
 quoted_path_segment = ${ "\"" ~ inner_quoted_string ~ "\"" ~ path_index* }
 
 target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -20,7 +20,7 @@ lookup = { (path_segment | quoted_path_segment) ~ ("." ~ (path_segment | quoted_
 path_index =$ { "[" ~ inner_path_index ~ "]" }
 inner_path_index = { '0'..'9'+ }
 path_segment = ${ path_field_name ~ path_index* }
-path_field_name = { (ASCII_ALPHA | "_" | "-" )+ }
+path_field_name = { (ASCII_ALPHA | "_" | "-" | "@" )+ }
 quoted_path_segment = ${ "\"" ~ inner_quoted_string ~ "\"" ~ path_index* }
 
 target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -2,8 +2,38 @@ mapping = _{ SOI ~ statement ~ (NEWLINE+ ~ statement)* ~ NEWLINE* ~ EOI }
 
 statement = _{ assignment | function | if_statement }
 
-assignment = { target_path ~ "=" ~ query_arithmetic }
+assignment = { dot_target_path ~ "=" ~ query_arithmetic }
 
+///////////
+// PATHS //
+///////////
+
+// Query path with coalesce support: `.foo.(bar | "@baz")[3]`
+query_segment = _{ (path_segment | path_coalesce) }
+query_path = ${ query_segment ~ ("." ~ query_segment)*  }
+dot_query_path = ${ "." ~ query_path }
+
+// Target path without coalesce support: `.foo.bar."@baz"[3]`
+target_segment = _{ path_segment }
+target_path = ${ target_segment ~ ("." ~ target_segment)* }
+dot_target_path = ${ "." ~ target_path }
+
+// Grouping of path segments: `foo.bar."@baz"[3]`
+path_segment = !{ path_field_kind ~ path_index* }
+path_coalesce = !{ "(" ~ path_field_kind ~ ("|" ~ path_field_kind)+ ~ ")" }
+
+// Field names, regular and quoted: `baz`, `"@baz"`
+path_field_kind = _{ (path_field | path_field_quoted) }
+path_field = { (ASCII_ALPHA | "_" | "-" )+ }
+path_field_quoted = { "\"" ~ inner_quoted_string ~ "\"" }
+
+// Array indexing: `foo[2]`
+path_index = ${ "[" ~ inner_path_index ~ "]" }
+inner_path_index = { ASCII_DIGIT+ }
+
+////////////////
+// STATEMENTS //
+////////////////
 
 if_statement = {
     "if" ~ query_arithmetic ~ "{" ~ NEWLINE* ~
@@ -13,47 +43,21 @@ if_statement = {
     NEWLINE* ~ "}" )?
 }
 
-// Used by `src/event/lookup.rs`
-lookup = { (path_segment | quoted_path_segment) ~ ("." ~ (path_segment | quoted_path_segment))* }
+///////////////
+// FUNCTIONS //
+///////////////
 
-// Paths
-path_index =$ { "[" ~ inner_path_index ~ "]" }
-inner_path_index = { '0'..'9'+ }
-path_segment = ${ path_field_name ~ path_index* }
-//path_field_name = { (ASCII_ALPHA | "_" | "-" | "@" )+ }
-path_field_name = { (ASCII_ALPHA | "_" | "-" )+ }
-quoted_path_segment = ${ "\"" ~ inner_quoted_string ~ "\"" ~ path_index* }
-
-target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }
-
-// Functions
 function = {
     deletion |
     only_fields |
     merge
 }
 
-deletion = { "del(" ~ target_paths ~ ")" }
-only_fields = { "only_fields(" ~ target_paths ~ ")" }
-merge = { "merge(" ~ target_path ~ "," ~ query_arithmetic ~ ("," ~ query_arithmetic)? ~ ")" }
-
-// One or more path arguments for a given function.
-//
-// Can be used to parse functions that take one or more paths, e.g.:
-//
-// my_func = { "my_func(" ~ target_paths ~ ")" }
-// => my_func(.bar, .baz)
-//
-target_paths = _{ target_path ~ ("," ~ target_path)* }
-
-// Queries
-path_coalesce = !{ "(" ~ (path_segment | quoted_path_segment) ~ ("|" ~ (path_segment | quoted_path_segment))+ ~ ")" }
-
-dot_path = ${ ("." ~ (path_segment | quoted_path_segment | path_coalesce))+ }
+deletion = { "del(" ~ dot_query_path ~ ("," ~ dot_query_path)* ~ ")" }
+only_fields = { "only_fields(" ~ dot_query_path ~ ("," ~ dot_query_path)* ~ ")" }
+merge = { "merge(" ~ dot_query_path ~ "," ~ query_arithmetic ~ ("," ~ query_arithmetic)? ~ ")" }
 
 ident = @{ ASCII_ALPHANUMERIC ~ ( ASCII_ALPHANUMERIC | "_" )* }
-
-// Functions
 
 query_function = ${ ident ~ "(" ~ inner_function? ~ ")"  }
 
@@ -67,7 +71,9 @@ positional_item = { query_arithmetic }
 
 keyword_item = { ident ~ "=" ~ query_arithmetic }
 
-// end: Functions
+////////////////
+// PRIMITIVES //
+////////////////
 
 group = { "(" ~ query_arithmetic ~ ")" }
 
@@ -101,7 +107,11 @@ float = @{
 
 not_operator = { "!" ~ query_leaf }
 
-query_leaf = _{ not_operator | value | dot_path | group | query_function }
+///////////
+// QUERY //
+///////////
+
+query_leaf = _{ not_operator | value | dot_query_path | group | query_function }
 
 // Arithmetic, broken down into tiers in order to support operator precedence.
 // Operators of the same tier are resolved from left to right.
@@ -121,5 +131,9 @@ arithmetic_operator_boolean = { "||" | "&&" }
 query_arithmetic_boolean = { query_arithmetic_compare ~ (arithmetic_operator_boolean ~ query_arithmetic_compare)* }
 
 query_arithmetic = _{ query_arithmetic_boolean }
+
+///////////
+// OTHER //
+///////////
 
 WHITESPACE = _{ " " | "\t" }

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -102,13 +102,12 @@ impl Transform for AddFields {
         emit!(AddFieldsEventProcessed);
 
         for (key, value_or_template) in self.fields.clone() {
-            let key_string = key.to_string(); // TODO: Step 6 of https://github.com/timberio/vector/blob/c4707947bd876a0ff7d7aa36717ae2b32b731593/rfcs/2020-05-25-more-usable-logevents.md#sales-pitch.
             let value = match value_or_template {
                 TemplateOrValue::Template(v) => match v.render_string(&event) {
                     Ok(v) => v,
                     Err(_) => {
                         emit!(AddFieldsTemplateRenderingError {
-                            field: &format!("{}", &key),
+                            field: &format!("{}", key),
                         });
                         continue;
                     }
@@ -117,17 +116,21 @@ impl Transform for AddFields {
                 TemplateOrValue::Value(v) => v,
             };
             if self.overwrite {
-                if event.as_mut_log().insert(&key_string, value).is_some() {
+                if event
+                    .as_mut_log()
+                    .insert_path(key.clone().into(), value)
+                    .is_some()
+                {
                     emit!(AddFieldsFieldOverwritten {
-                        field: &format!("{}", &key),
+                        field: &format!("{}", key),
                     });
                 }
-            } else if event.as_mut_log().contains(&key_string) {
+            } else if event.as_mut_log().contains(&key.to_string()) {
                 emit!(AddFieldsFieldNotOverwritten {
-                    field: &format!("{}", &key),
+                    field: &format!("{}", key),
                 });
             } else {
-                event.as_mut_log().insert(&key_string, value);
+                event.as_mut_log().insert_path(key.clone().into(), value);
             }
         }
 

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -1,3 +1,18 @@
+[transforms.add_timestamp]
+  inputs = []
+  type = "add_fields"
+  fields."@timestamp" = 123
+[[tests]]
+  name = "add_timestamp"
+  [tests.input]
+    insert_at = "add_timestamp"
+    type = "raw"
+    value = ""
+  [[tests.outputs]]
+    extract_from = "add_timestamp"
+    [[tests.outputs.conditions]]
+      "@timestamp.equals" = 123
+
 [transforms.add_fields_nested]
   inputs = []
   type = "add_fields"

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -1,7 +1,8 @@
 [transforms.add_timestamp]
   inputs = []
   type = "add_fields"
-  fields."@timestamp" = 123
+  fields.'"@timestamp"' = 123
+  fields.foo.'"@timestamp"' = 456
 [[tests]]
   name = "add_timestamp"
   [tests.input]
@@ -12,6 +13,7 @@
     extract_from = "add_timestamp"
     [[tests.outputs.conditions]]
       "@timestamp.equals" = 123
+      "foo.@timestamp.equals" = 456
 
 [transforms.add_fields_nested]
   inputs = []

--- a/tests/data/fixtures/lookup/sufficiently_complex
+++ b/tests/data/fixtures/lookup/sufficiently_complex
@@ -1,1 +1,1 @@
-regular."quoted"."quoted but spaces"."quoted.but.periods".lookup[0].nested_lookup[0][0]
+regular."quoted"."@quoted #with /special [characters]"."quoted but spaces"."quoted.but.periods".lookup[0].nested_lookup[0][0]


### PR DESCRIPTION
Closes #4273

"@timestamp" is frequently (always?) used in the ELK stack and supporting this field would be nice for users transitioning from ELK.

Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
