### PR TITLE
feat(remap transform): add `split` function 

### DIFF
--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -26,7 +26,7 @@ impl Assignment {
 
 impl Function for Assignment {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        let v = self.function.execute(&target)?;
+        let v: Value = self.function.execute(&target)?.into();
         target.as_mut_log().insert(&self.path, v);
         Ok(())
     }
@@ -116,7 +116,7 @@ impl IfStatement {
 
 impl Function for IfStatement {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        match self.query.execute(target)? {
+        match self.query.execute(target)?.into() {
             Value::Boolean(true) => self.true_statement.apply(target),
             Value::Boolean(false) => self.false_statement.apply(target),
             _ => Err("query returned non-boolean value".to_string()),
@@ -214,10 +214,10 @@ impl MergeFn {
 
 impl Function for MergeFn {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        let from_value = self.from.execute(target)?;
+        let from_value = self.from.execute(target)?.into();
         let deep = match &self.deep {
             None => false,
-            Some(deep) => match deep.execute(target)? {
+            Some(deep) => match deep.execute(target)?.into() {
                 Value::Boolean(value) => value,
                 _ => return Err("deep parameter passed to merge is a non-boolean value".into()),
             },

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 pub mod parser;
 pub mod query;
 
+use query::query_value::QueryValue;
+
 pub type Result<T> = std::result::Result<T, String>;
 
 pub(self) trait Function: Send + core::fmt::Debug {
@@ -26,9 +28,13 @@ impl Assignment {
 
 impl Function for Assignment {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        let v: Value = self.function.execute(&target)?.into();
-        target.as_mut_log().insert(&self.path, v);
-        Ok(())
+        match self.function.execute(&target)? {
+            QueryValue::Value(v) => {
+                target.as_mut_log().insert(&self.path, v);
+                Ok(())
+            }
+            _ => Err("assignment must be from a value".to_string()),
+        }
     }
 }
 
@@ -116,9 +122,9 @@ impl IfStatement {
 
 impl Function for IfStatement {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        match self.query.execute(target)?.into() {
-            Value::Boolean(true) => self.true_statement.apply(target),
-            Value::Boolean(false) => self.false_statement.apply(target),
+        match self.query.execute(target)? {
+            QueryValue::Value(Value::Boolean(true)) => self.true_statement.apply(target),
+            QueryValue::Value(Value::Boolean(false)) => self.false_statement.apply(target),
             _ => Err("query returned non-boolean value".to_string()),
         }
     }
@@ -214,11 +220,11 @@ impl MergeFn {
 
 impl Function for MergeFn {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        let from_value = self.from.execute(target)?.into();
+        let from_value = self.from.execute(target)?;
         let deep = match &self.deep {
             None => false,
-            Some(deep) => match deep.execute(target)?.into() {
-                Value::Boolean(value) => value,
+            Some(deep) => match deep.execute(target)? {
+                QueryValue::Value(Value::Boolean(value)) => value,
                 _ => return Err("deep parameter passed to merge is a non-boolean value".into()),
             },
         };
@@ -229,7 +235,7 @@ impl Function for MergeFn {
         ))?;
 
         match (to_value, from_value) {
-            (Value::Map(ref mut map1), Value::Map(ref map2)) => {
+            (Value::Map(ref mut map1), QueryValue::Value(Value::Map(ref map2))) => {
                 merge_maps(map1, &map2, deep);
                 Ok(())
             }

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -62,11 +62,25 @@ argument_list = _{ argument ~ ("," ~ argument)* }
 
 argument = { positional_item | keyword_item }
 
-positional_item = { query_arithmetic }
+positional_item = { argument_item }
 
 keyword_item = { ident ~ "=" ~ query_arithmetic }
 
+argument_item = { query_arithmetic | regex }
+
 // end: Functions
+
+// Regex
+
+regex = ${ "/" ~ inner_regex_string ~ "/" ~ regex_flags }
+inner_regex_string = @{ regex_char* }
+regex_char = {
+    !("/" | "\\") ~ ANY
+    | "\\" ~ ANY
+}
+regex_flags = @{ ("i" | "g" | "m")* }
+
+// end: Regex
 
 group = { "(" ~ query_arithmetic ~ ")" }
 

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -630,6 +630,28 @@ mod tests {
                 r#".foo."invalid \k escape".sequence = "foo""#,
                 vec![" 1:6\n", "= expected path_field_name or quoted_path_segment"],
             ),
+            (
+                // An invalid regex.
+                // Technically this isn't a (pest) parser error, so the error doesn't include the
+                // line and column numbers of the offending regex.
+                r#".foo = split(.foo, /[aa/)"#,
+                vec!["invalid regex: regex parse error:"],
+            ),
+            (
+                // Regexes can't be parsed as part of a path
+                r#".foo = split(.foo, ./[aa]/)"#,
+                vec![" 1:21\n", "= expected path_field_name, quoted_path_segment, or path_coalesce"],
+            ),
+            (
+                // We cannot assign a regular expression to a field.
+                r#".foo = /ab/i"#,
+                vec![" 1:8\n", "= expected query"],
+            ),
+            (
+                // We cannot assign to a regular expression.
+                r#"/ab/ = .foo"#,
+                vec![" 1:1\n", "= expected if_statement, target_path, or function"],
+            ),
         ];
 
         for (mapping, exp_expressions) in cases {

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -337,7 +337,8 @@ fn regex_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>> {
             );
             map.insert("flags".to_string(), Value::from(flags));
 
-            let regex = DynamicRegex::try_from(Value::from(map))?;
+            let mut regex = DynamicRegex::try_from(Value::from(map))?;
+            regex.compile()?;
 
             Ok(Box::new(Literal::from(QueryValue::from(regex))))
         }
@@ -1266,12 +1267,11 @@ mod tests {
                     "foo".to_string(),
                     Box::new(SplitFn::new(
                         Box::new(QueryPath::from("bar")),
-                        Box::new(Literal::from(QueryValue::from(DynamicRegex::new(
-                            "a".to_string(),
-                            false,
-                            true,
-                            false,
-                        )))),
+                        Box::new(Literal::from(QueryValue::from({
+                            let mut regex = DynamicRegex::new("a".to_string(), false, true, false);
+                            regex.compile().unwrap();
+                            regex
+                        }))),
                         Some(Box::new(Literal::from(Value::from(2)))),
                     )),
                 ))]),

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -294,7 +294,6 @@ fn positional_item_from_pair(
         signature.as_str()
     ))?;
 
-    // let resolver = query_arithmetic_from_pair(pair.into_inner().next().ok_or(TOKEN_ERR)?)?;
     let resolver = argument_item_from_pair(pair.into_inner().next().ok_or(TOKEN_ERR)?)?;
 
     let keyword = parameter.keyword.to_owned();

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -323,10 +323,10 @@ fn regex_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>> {
                     flags
                         .as_str()
                         .chars()
-                        .map(|flag| Value::from(flag.to_string()))
+                        .map(|c| Value::from(c.to_string()))
                         .collect()
                 })
-                .unwrap_or(vec![]);
+                .unwrap_or_else(Vec::new);
 
             let mut map = BTreeMap::new();
             map.insert(

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -7,10 +7,10 @@ use crate::{
             self,
             arithmetic::Arithmetic,
             arithmetic::Operator,
-            regex::Regex,
             function::{Argument, ArgumentList, FunctionSignature, NotFn},
             path::Path as QueryPath,
             query_value::QueryValue,
+            regex::Regex,
             Literal,
         },
         Assignment, Deletion, Function, IfStatement, Mapping, MergeFn, Noop, OnlyFields, Result,
@@ -1262,12 +1262,9 @@ mod tests {
                     "foo".to_string(),
                     Box::new(SplitFn::new(
                         Box::new(QueryPath::from("bar")),
-                        Box::new(Literal::from(QueryValue::from(Regex::new(
-                            "a".to_string(),
-                            false,
-                            true,
-                            false,
-                        ).unwrap()))),
+                        Box::new(Literal::from(QueryValue::from(
+                            Regex::new("a".to_string(), false, true, false).unwrap(),
+                        ))),
                         Some(Box::new(Literal::from(Value::from(2)))),
                     )),
                 ))]),

--- a/src/mapping/query/arithmetic.rs
+++ b/src/mapping/query/arithmetic.rs
@@ -1,5 +1,5 @@
-use super::Function;
 use super::query_value::QueryValue;
+use super::Function;
 use crate::{
     event::{Event, Value},
     mapping::Result,
@@ -210,7 +210,8 @@ impl Function for Arithmetic {
                 },
                 vl => return Err(format!("unable to OR left-hand field type {:?}", vl)),
             },
-        }.into())
+        }
+        .into())
     }
 }
 

--- a/src/mapping/query/arithmetic.rs
+++ b/src/mapping/query/arithmetic.rs
@@ -1,4 +1,5 @@
 use super::Function;
+use super::query_value::QueryValue;
 use crate::{
     event::{Event, Value},
     mapping::Result,
@@ -71,9 +72,9 @@ fn compare_number_types(
 }
 
 impl Function for Arithmetic {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let left = self.left.execute(ctx);
-        let right = self.right.execute(ctx);
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let left = self.left.execute(ctx).map(Into::into);
+        let right = self.right.execute(ctx).map(Into::into);
 
         // TODO: A lot of these comparisons could potentially be baked into the
         // Value type. However, we would need to agree on general rules as to
@@ -209,7 +210,7 @@ impl Function for Arithmetic {
                 },
                 vl => return Err(format!("unable to OR left-hand field type {:?}", vl)),
             },
-        })
+        }.into())
     }
 }
 
@@ -393,7 +394,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/dynamic_regex.rs
+++ b/src/mapping/query/dynamic_regex.rs
@@ -1,0 +1,95 @@
+use crate::{event::Value, mapping::Result};
+use bytes::Bytes;
+use std::{collections::BTreeMap, convert::TryFrom};
+
+#[derive(Debug, Clone)]
+pub struct DynamicRegex {
+    pattern: String,
+    multiline: bool,
+    insensitive: bool,
+    global: bool,
+    compiled: Option<Result<regex::Regex>>,
+}
+
+impl DynamicRegex {
+    pub fn new(pattern: String, multiline: bool, insensitive: bool, global: bool) -> Self {
+        Self {
+            pattern,
+            multiline,
+            insensitive,
+            global,
+            compiled: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_global(&self) -> bool {
+        self.global
+    }
+
+    pub fn compile(&mut self) -> Result<&regex::Regex> {
+        if self.compiled.is_none() {
+            self.compiled = Some(
+                regex::RegexBuilder::new(&self.pattern)
+                    .case_insensitive(self.insensitive)
+                    .multi_line(self.multiline)
+                    .build()
+                    .map_err(|err| format!("invalid regex {}", err)),
+            );
+        }
+
+        self.compiled
+            .as_ref()
+            // We know this unwrap is safe because we have just populated the Option above.
+            .unwrap()
+            .as_ref()
+            .map_err(|err| err.to_string())
+    }
+}
+
+/// Our dynamic regex equality shouldn't rely on the compiled value
+/// as this is largely an implementation detail.
+/// Plus regex::Regex doesn't implement PartialEq.
+impl PartialEq for DynamicRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+            && self.multiline == other.multiline
+            && self.insensitive == other.insensitive
+            && self.global == other.global
+    }
+}
+
+impl TryFrom<BTreeMap<String, Value>> for DynamicRegex {
+    type Error = String;
+
+    /// Create a regex from a map containing fields :
+    /// pattern - The regex pattern
+    /// flags   - flags including i => Case insensitive, g => Global, m => Multiline.
+    fn try_from(map: BTreeMap<String, Value>) -> std::result::Result<Self, Self::Error> {
+        let pattern = map
+            .get("pattern")
+            .ok_or_else(|| "field is not a regular expression".to_string())
+            .and_then(|value| match value {
+                Value::Bytes(ref bytes) => Ok(String::from_utf8_lossy(bytes)),
+                _ => Err("regex pattern is not a valid string".to_string()),
+            })?
+            .to_string();
+
+        let (global, insensitive, multiline) = match map.get("flags") {
+            None => (false, false, false),
+            Some(Value::Array(ref flags)) => {
+                flags
+                    .iter()
+                    .fold((false, false, false), |(g, i, m), flag| match flag {
+                        v if v == &Value::from(Bytes::from_static(b"g")) => (true, i, m),
+                        v if v == &Value::from(Bytes::from_static(b"i")) => (g, true, m),
+                        v if v == &Value::from(Bytes::from_static(b"m")) => (g, i, true),
+                        _ => (g, i, m),
+                    })
+            }
+            Some(_) => return Err("regular expression flags is not an array".to_string()),
+        };
+
+        Ok(DynamicRegex::new(pattern, multiline, insensitive, global))
+    }
+}

--- a/src/mapping/query/dynamic_regex.rs
+++ b/src/mapping/query/dynamic_regex.rs
@@ -106,6 +106,28 @@ impl TryFrom<Value> for DynamicRegex {
     }
 }
 
+impl From<DynamicRegex> for Value {
+    fn from(regex: DynamicRegex) -> Self {
+        let mut map = BTreeMap::new();
+        map.insert("pattern".to_string(), Value::from(regex.pattern));
+
+        let mut flags = Vec::new();
+        if regex.insensitive {
+            flags.push(Value::from(Bytes::from_static(b"i")));
+        }
+        if regex.multiline {
+            flags.push(Value::from(Bytes::from_static(b"m")));
+        }
+        if regex.global {
+            flags.push(Value::from(Bytes::from_static(b"g")));
+        }
+
+        map.insert("flags".to_string(), Value::from(flags));
+
+        Value::from(map)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mapping/query/dynamic_regex.rs
+++ b/src/mapping/query/dynamic_regex.rs
@@ -1,6 +1,6 @@
 use crate::{event::Value, mapping::Result};
 use bytes::Bytes;
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::{collections::BTreeMap, convert::TryFrom, string::ToString};
 
 #[derive(Debug, Clone)]
 pub struct DynamicRegex {
@@ -28,44 +28,29 @@ impl DynamicRegex {
     }
 
     pub fn compile(&mut self) -> Result<&regex::Regex> {
-        if self.compiled.is_none() {
-            self.compiled = Some(
-                regex::RegexBuilder::new(&self.pattern)
-                    .case_insensitive(self.insensitive)
-                    .multi_line(self.multiline)
-                    .build()
-                    .map_err(|err| format!("invalid regex {}", err)),
-            );
-        }
+        // These are needed to avoid lifetime issues of using
+        // self within the ensuing closure.
+        let pattern = &self.pattern;
+        let insensitive = self.insensitive;
+        let multiline = self.multiline;
 
-        self.compiled
-            .as_ref()
-            // We know this unwrap is safe because we have just populated the Option above.
-            .unwrap()
-            .as_ref()
-            .map_err(|err| err.to_string())
+        let res = self.compiled.get_or_insert_with(|| {
+            regex::RegexBuilder::new(pattern)
+                .case_insensitive(insensitive)
+                .multi_line(multiline)
+                .build()
+                .map_err(|err| format!("invalid regex {}", err))
+        });
+
+        res.as_ref().clone().map_err(ToString::to_string)
     }
-}
 
-/// Our dynamic regex equality shouldn't rely on the compiled value
-/// as this is largely an implementation detail.
-/// Plus regex::Regex doesn't implement PartialEq.
-impl PartialEq for DynamicRegex {
-    fn eq(&self, other: &Self) -> bool {
-        self.pattern == other.pattern
-            && self.multiline == other.multiline
-            && self.insensitive == other.insensitive
-            && self.global == other.global
+    fn from_bytes(bytes: bytes::Bytes) -> Result<Self> {
+        let pattern = String::from_utf8_lossy(&bytes);
+        Ok(DynamicRegex::new(pattern.to_string(), false, false, false))
     }
-}
 
-impl TryFrom<BTreeMap<String, Value>> for DynamicRegex {
-    type Error = String;
-
-    /// Create a regex from a map containing fields :
-    /// pattern - The regex pattern
-    /// flags   - flags including i => Case insensitive, g => Global, m => Multiline.
-    fn try_from(map: BTreeMap<String, Value>) -> std::result::Result<Self, Self::Error> {
+    fn from_map(map: BTreeMap<String, Value>) -> Result<Self> {
         let pattern = map
             .get("pattern")
             .ok_or_else(|| "field is not a regular expression".to_string())
@@ -91,5 +76,59 @@ impl TryFrom<BTreeMap<String, Value>> for DynamicRegex {
         };
 
         Ok(DynamicRegex::new(pattern, multiline, insensitive, global))
+    }
+}
+
+/// Our dynamic regex equality shouldn't rely on the compiled value
+/// as this is largely an implementation detail.
+/// Plus regex::Regex doesn't implement PartialEq.
+impl PartialEq for DynamicRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+            && self.multiline == other.multiline
+            && self.insensitive == other.insensitive
+            && self.global == other.global
+    }
+}
+
+impl TryFrom<Value> for DynamicRegex {
+    type Error = String;
+
+    /// Create a regex from a String or a Map containing fields :
+    /// pattern - The regex pattern
+    /// flags   - flags including i => Case insensitive, g => Global, m => Multiline.
+    fn try_from(value: Value) -> Result<Self> {
+        match value {
+            Value::Map(map) => DynamicRegex::from_map(map),
+            Value::Bytes(bytes) => DynamicRegex::from_bytes(bytes),
+            _ => Err("regular expression should be a map or a string".to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_regex_from_string() {
+        let value = Value::from("abba");
+        let mut regex = DynamicRegex::try_from(value).unwrap();
+
+        // Test our regex is working case insensitively.
+        assert!(regex.compile().unwrap().is_match("abba"));
+    }
+
+    #[test]
+    fn create_regex_from_map() {
+        let mut map = BTreeMap::new();
+        map.insert("pattern".to_string(), Value::from("abba"));
+        map.insert("flags".to_string(), Value::from(vec![Value::from("i")]));
+        let value = Value::from(map);
+
+        let mut regex = DynamicRegex::try_from(value).unwrap();
+
+        // Test our regex is working case insensitively.
+        assert!(regex.compile().unwrap().is_match("AbBa"));
     }
 }

--- a/src/mapping/query/function/ceil.rs
+++ b/src/mapping/query/function/ceil.rs
@@ -18,28 +18,28 @@ impl CeilFn {
 }
 
 impl Function for CeilFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
-        let res = required!(ctx, self.query,
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let precision = optional_value!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required_value!(ctx, self.query,
                             Value::Float(f) => {
                                 Value::Float(round_to_precision(f, precision, f64::ceil))
                             },
                             v@Value::Integer(_) => v
         );
 
-        Ok(res)
+        Ok(res.into())
     }
 
     fn parameters() -> &'static [Parameter] {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Float(_)) | QueryValue::Value(Value::Integer(_))),
                 required: true,
             },
             Parameter {
                 keyword: "precision",
-                accepts: |v| matches!(v, Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Integer(_))),
                 required: false,
             },
         ]
@@ -120,7 +120,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/contains.rs
+++ b/src/mapping/query/function/contains.rs
@@ -50,17 +50,17 @@ impl Function for ContainsFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "substring",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "case_sensitive",
-                accepts: |v| matches!(v, Value::Boolean(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Boolean(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/contains.rs
+++ b/src/mapping/query/function/contains.rs
@@ -26,7 +26,7 @@ impl ContainsFn {
 }
 
 impl Function for ContainsFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let substring = {
             let bytes = required!(ctx, self.substring, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -43,7 +43,7 @@ impl Function for ContainsFn {
                 .filter(|&case_sensitive| !case_sensitive)
                 .any(|_| value.to_lowercase().contains(&substring.to_lowercase()));
 
-        Ok(Value::from(contains))
+        Ok(Value::from(contains).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -144,7 +144,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/contains.rs
+++ b/src/mapping/query/function/contains.rs
@@ -28,17 +28,17 @@ impl ContainsFn {
 impl Function for ContainsFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let substring = {
-            let bytes = required!(ctx, self.substring, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.substring, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
         let value = {
-            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
         let contains = value.contains(&substring)
-            || optional!(ctx, self.case_sensitive, Value::Boolean(b) => b)
+            || optional_value!(ctx, self.case_sensitive, Value::Boolean(b) => b)
                 .iter()
                 .filter(|&case_sensitive| !case_sensitive)
                 .any(|_| value.to_lowercase().contains(&substring.to_lowercase()));
@@ -144,7 +144,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/downcase.rs
+++ b/src/mapping/query/function/downcase.rs
@@ -14,18 +14,16 @@ impl DowncaseFn {
 
 impl Function for DowncaseFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(bytes) => {
-                Ok(Value::Bytes(String::from_utf8_lossy(&bytes).to_lowercase().into()).into())
-            }
-            value => unexpected_type!(value),
-        }
+        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+        Ok(QueryValue::from_value(
+            String::from_utf8_lossy(&bytes).to_lowercase(),
+        ))
     }
 
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/downcase.rs
+++ b/src/mapping/query/function/downcase.rs
@@ -14,7 +14,7 @@ impl DowncaseFn {
 
 impl Function for DowncaseFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+        let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
         Ok(QueryValue::from_value(
             String::from_utf8_lossy(&bytes).to_lowercase(),
         ))
@@ -58,13 +58,13 @@ mod tests {
                     event.as_mut_log().insert("foo", Value::from("FOO 2 bar"));
                     event
                 },
-                Ok(Value::from("foo 2 bar")),
+                Ok(QueryValue::from_value("foo 2 bar")),
                 DowncaseFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
             ),
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp);
         }
     }
 

--- a/src/mapping/query/function/downcase.rs
+++ b/src/mapping/query/function/downcase.rs
@@ -13,11 +13,11 @@ impl DowncaseFn {
 }
 
 impl Function for DowncaseFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        match self.query.execute(ctx)? {
-            Value::Bytes(bytes) => Ok(Value::Bytes(
-                String::from_utf8_lossy(&bytes).to_lowercase().into(),
-            )),
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        match self.query.execute(ctx)?.into() {
+            Value::Bytes(bytes) => {
+                Ok(Value::Bytes(String::from_utf8_lossy(&bytes).to_lowercase().into()).into())
+            }
             value => unexpected_type!(value),
         }
     }
@@ -66,7 +66,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/floor.rs
+++ b/src/mapping/query/function/floor.rs
@@ -18,28 +18,28 @@ impl FloorFn {
 }
 
 impl Function for FloorFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
-        let res = required!(ctx, self.query,
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let precision = optional_value!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required_value!(ctx, self.query,
                             Value::Float(f) => {
                                 Value::Float(round_to_precision(f, precision, f64::floor))
                             },
                             v@Value::Integer(_) => v
         );
 
-        Ok(res)
+        Ok(res.into())
     }
 
     fn parameters() -> &'static [Parameter] {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Float(_)) | QueryValue::Value(Value::Integer(_))),
                 required: true,
             },
             Parameter {
                 keyword: "precision",
-                accepts: |v| matches!(v, Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Integer(_))),
                 required: false,
             },
         ]
@@ -120,7 +120,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/format_number.rs
+++ b/src/mapping/query/function/format_number.rs
@@ -35,15 +35,15 @@ impl FormatNumberFn {
 
 impl Function for FormatNumberFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let value = required!(ctx, self.query,
+        let value = required_value!(ctx, self.query,
             Value::Integer(v) => Decimal::from_i64(v),
             Value::Float(v) => Decimal::from_f64(v),
         )
         .ok_or("unable to parse number")?;
 
-        let scale = optional!(ctx, self.scale, Value::Integer(v) => v);
-        let grouping_separator = optional!(ctx, self.grouping_separator, Value::Bytes(v) => v);
-        let decimal_separator = optional!(ctx, self.decimal_separator, Value::Bytes(v) => v)
+        let scale = optional_value!(ctx, self.scale, Value::Integer(v) => v);
+        let grouping_separator = optional_value!(ctx, self.grouping_separator, Value::Bytes(v) => v);
+        let decimal_separator = optional_value!(ctx, self.decimal_separator, Value::Bytes(v) => v)
             .unwrap_or_else(|| Bytes::from("."));
 
         // Split integral and fractional part of float.
@@ -162,7 +162,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("1234.567")),
+                Ok(QueryValue::from_value("1234.567")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(1234.567))),
                     None,
@@ -172,7 +172,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("1234.56")),
+                Ok(QueryValue::from_value("1234.56")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(1234.567))),
                     Some(2),
@@ -182,7 +182,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("1234,56")),
+                Ok(QueryValue::from_value("1234,56")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(1234.567))),
                     Some(2),
@@ -192,7 +192,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("1 234,56")),
+                Ok(QueryValue::from_value("1 234,56")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(1234.567))),
                     Some(2),
@@ -202,7 +202,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("11.222.333.444,567")),
+                Ok(QueryValue::from_value("11.222.333.444,567")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(11222333444.56789))),
                     Some(3),
@@ -212,7 +212,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("100")),
+                Ok(QueryValue::from_value("100")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(100.0))),
                     None,
@@ -222,7 +222,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("100.00")),
+                Ok(QueryValue::from_value("100.00")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(100.0))),
                     Some(2),
@@ -232,7 +232,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("123")),
+                Ok(QueryValue::from_value("123")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(123.45))),
                     Some(0),
@@ -242,7 +242,7 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::from("12345.00")),
+                Ok(QueryValue::from_value("12345.00")),
                 FormatNumberFn::new(
                     Box::new(Literal::from(Value::from(12345))),
                     Some(2),
@@ -253,7 +253,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp);
         }
     }
 }

--- a/src/mapping/query/function/format_timestamp.rs
+++ b/src/mapping/query/function/format_timestamp.rs
@@ -19,8 +19,8 @@ impl FormatTimestampFn {
 
 impl Function for FormatTimestampFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let format = required!(ctx, self.format, Value::Bytes(b) => String::from_utf8_lossy(&b).into_owned());
-        let ts = required!(ctx, self.query, Value::Timestamp(ts) => ts);
+        let format = required_value!(ctx, self.format, Value::Bytes(b) => String::from_utf8_lossy(&b).into_owned());
+        let ts = required_value!(ctx, self.query, Value::Timestamp(ts) => ts);
 
         try_format(&ts, &format).map(QueryValue::from_value)
     }
@@ -104,7 +104,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/md5.rs
+++ b/src/mapping/query/function/md5.rs
@@ -16,8 +16,8 @@ impl Function for Md5Fn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         use md5::{Digest, Md5};
 
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(bytes) => {
+        match self.query.execute(ctx)? {
+            QueryValue::Value(Value::Bytes(bytes)) => {
                 let md5 = hex::encode(Md5::digest(&bytes));
                 Ok(Value::Bytes(md5.into()).into())
             }
@@ -63,13 +63,13 @@ mod tests {
                     event.as_mut_log().insert("foo", Value::from("foo"));
                     event
                 },
-                Ok(Value::from("acbd18db4cc2f85cedef654fccc4a4d8")),
+                Ok(QueryValue::from_value("acbd18db4cc2f85cedef654fccc4a4d8")),
                 Md5Fn::new(Box::new(Path::from(vec![vec!["foo"]]))),
             ),
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp);
         }
     }
 

--- a/src/mapping/query/function/md5.rs
+++ b/src/mapping/query/function/md5.rs
@@ -13,13 +13,13 @@ impl Md5Fn {
 }
 
 impl Function for Md5Fn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         use md5::{Digest, Md5};
 
-        match self.query.execute(ctx)? {
+        match self.query.execute(ctx)?.into() {
             Value::Bytes(bytes) => {
                 let md5 = hex::encode(Md5::digest(&bytes));
-                Ok(Value::Bytes(md5.into()))
+                Ok(Value::Bytes(md5.into()).into())
             }
             v => unexpected_type!(v),
         }
@@ -69,7 +69,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/md5.rs
+++ b/src/mapping/query/function/md5.rs
@@ -28,7 +28,7 @@ impl Function for Md5Fn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -37,23 +37,43 @@ macro_rules! unexpected_type {
 }
 
 macro_rules! required {
-    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+ $(,)?) => {
-        match $fn.execute($ctx)?.into() {
-            $($pattern => $then,)+
+    ($ctx:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
+        match $fn.execute($ctx)? {
+            $($pattern $(if $if)? => $then,)+
             v => unexpected_type!(v),
         }
     }
 }
 
+macro_rules! required_value {
+    ($ctx:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
+        required!($ctx, $fn,
+            QueryValue::Value(value) => match value {
+                $($pattern $(if $if)? => $then,)+
+                v => unexpected_type!(v),
+            })
+    }
+}
+
 macro_rules! optional {
-    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+ $(,)?) => {
+    ($ctx:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
         $fn.as_ref()
             .map(|v| v.execute($ctx))
             .transpose()?
-            .map(|v| match v.into() {
-                $($pattern => $then,)+
+            .map(|v| match v {
+                $($pattern $(if $if)? => $then,)+
                 v => unexpected_type!(v),
             })
+    }
+}
+
+macro_rules! optional_value {
+    ($ctx:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
+        optional!($ctx, $fn,
+                  QueryValue::Value(value) => match value {
+                      $($pattern $(if $if)? => $then,)+
+                          v => unexpected_type!(v),
+                  })
     }
 }
 

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -134,6 +134,7 @@ build_signatures! {
     floor => FloorFn,
     ceil => CeilFn,
     parse_syslog => ParseSyslogFn,
+    split => SplitFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/not.rs
+++ b/src/mapping/query/function/not.rs
@@ -13,8 +13,9 @@ impl NotFn {
 
 impl Function for NotFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        self.query.execute(ctx).and_then(|v| match v.into() {
-            Value::Boolean(b) => Ok(Value::Boolean(!b).into()),
+        self.query.execute(ctx).and_then(|v| match v {
+            QueryValue::Value(Value::Boolean(b)) => Ok(Value::Boolean(!b).into()),
+            QueryValue::Value(v) => Err(format!("unable to perform NOT on {:?} value", v)),
             v => Err(format!("unable to perform NOT on {:?} value", v)),
         })
     }
@@ -51,7 +52,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/not.rs
+++ b/src/mapping/query/function/not.rs
@@ -12,10 +12,10 @@ impl NotFn {
 }
 
 impl Function for NotFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        self.query.execute(ctx).and_then(|v| match v {
-            Value::Boolean(b) => Ok(Value::Boolean(!b)),
-            _ => Err(format!("unable to perform NOT on {:?} value", v)),
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        self.query.execute(ctx).and_then(|v| match v.into() {
+            Value::Boolean(b) => Ok(Value::Boolean(!b).into()),
+            v => Err(format!("unable to perform NOT on {:?} value", v)),
         })
     }
 }
@@ -51,7 +51,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/now.rs
+++ b/src/mapping/query/function/now.rs
@@ -12,8 +12,8 @@ impl NowFn {
 }
 
 impl Function for NowFn {
-    fn execute(&self, _: &Event) -> Result<Value> {
-        Ok(Value::Timestamp(Utc::now()))
+    fn execute(&self, _: &Event) -> Result<QueryValue> {
+        Ok(Value::Timestamp(Utc::now()).into())
     }
 }
 

--- a/src/mapping/query/function/parse_duration.rs
+++ b/src/mapping/query/function/parse_duration.rs
@@ -48,7 +48,7 @@ impl ParseDurationFn {
 }
 
 impl Function for ParseDurationFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let value = {
             let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -79,7 +79,7 @@ impl Function for ParseDurationFn {
             .to_f64()
             .ok_or(format!("unable to format duration: '{}'", number))?;
 
-        Ok(Value::from(number))
+        Ok(Value::from(number).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -180,7 +180,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/parse_duration.rs
+++ b/src/mapping/query/function/parse_duration.rs
@@ -86,12 +86,12 @@ impl Function for ParseDurationFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "output",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
         ]

--- a/src/mapping/query/function/parse_duration.rs
+++ b/src/mapping/query/function/parse_duration.rs
@@ -50,12 +50,12 @@ impl ParseDurationFn {
 impl Function for ParseDurationFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let value = {
-            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
         let conversion_factor = {
-            let bytes = required!(ctx, self.output, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.output, Value::Bytes(v) => v);
             let output = String::from_utf8_lossy(&bytes).into_owned();
 
             UNITS
@@ -180,7 +180,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/parse_json.rs
+++ b/src/mapping/query/function/parse_json.rs
@@ -28,7 +28,7 @@ impl Function for ParseJsonFn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/parse_json.rs
+++ b/src/mapping/query/function/parse_json.rs
@@ -14,8 +14,8 @@ impl ParseJsonFn {
 
 impl Function for ParseJsonFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(b) => serde_json::from_slice(&b)
+        match self.query.execute(ctx)? {
+            QueryValue::Value(Value::Bytes(b)) => serde_json::from_slice(&b)
                 .map(|v: serde_json::Value| {
                     let v: Value = v.into();
                     v.into()
@@ -79,7 +79,7 @@ mod tests {
                         .insert("foo", Value::from("{\"field\": \"value\"}"));
                     event
                 },
-                Ok(Value::Map({
+                Ok(Value::from({
                     let mut map = BTreeMap::new();
                     map.insert("field".into(), Value::from("value"));
                     map
@@ -100,7 +100,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/parse_timestamp.rs
+++ b/src/mapping/query/function/parse_timestamp.rs
@@ -26,8 +26,8 @@ impl ParseTimestampFn {
 }
 
 impl Function for ParseTimestampFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let format = match self.format.execute(ctx)? {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let format = match self.format.execute(ctx)?.into() {
             Value::Bytes(b) => format!("timestamp|{}", String::from_utf8_lossy(&b)),
             v => unexpected_type!(v),
         };
@@ -35,20 +35,25 @@ impl Function for ParseTimestampFn {
         let conversion: Conversion = format.parse().map_err(|e| format!("{}", e))?;
 
         let result = match self.query.execute(ctx) {
-            Ok(v) => match v {
-                Value::Bytes(_) => conversion.convert(v).map_err(|e| e.to_string()),
-                Value::Timestamp(_) => Ok(v),
-                _ => unexpected_type!(v),
+            Ok(v) => {
+                let value = v.into();
+                match value {
+                    Value::Bytes(_) => conversion.convert(value).map(Into::into).map_err(|e| e.to_string()),
+                    Value::Timestamp(_) => Ok(value.into()),
+                    _ => unexpected_type!(value),
+                }
             },
             Err(err) => Err(err),
         };
+
         if result.is_err() {
             if let Some(v) = &self.default {
-                return match v.execute(ctx)? {
+                return match v.execute(ctx)?.into() {
                     Value::Bytes(v) => conversion
                         .convert(Value::Bytes(v))
+                        .map(Into::into)
                         .map_err(|e| e.to_string()),
-                    Value::Timestamp(v) => Ok(Value::Timestamp(v)),
+                    Value::Timestamp(v) => Ok(Value::Timestamp(v).into()),
                     v => unexpected_type!(v),
                 };
             }
@@ -173,7 +178,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/parse_timestamp.rs
+++ b/src/mapping/query/function/parse_timestamp.rs
@@ -38,11 +38,14 @@ impl Function for ParseTimestampFn {
             Ok(v) => {
                 let value = v.into();
                 match value {
-                    Value::Bytes(_) => conversion.convert(value).map(Into::into).map_err(|e| e.to_string()),
+                    Value::Bytes(_) => conversion
+                        .convert(value)
+                        .map(Into::into)
+                        .map_err(|e| e.to_string()),
                     Value::Timestamp(_) => Ok(value.into()),
                     _ => unexpected_type!(value),
                 }
-            },
+            }
             Err(err) => Err(err),
         };
 
@@ -65,17 +68,17 @@ impl Function for ParseTimestampFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_) | Value::Timestamp(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_)) | QueryValue::Value(Value::Timestamp(_))),
                 required: true,
             },
             Parameter {
                 keyword: "format",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "default",
-                accepts: |v| matches!(v, Value::Bytes(_) | Value::Timestamp(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_)) | QueryValue::Value(Value::Timestamp(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/parse_url.rs
+++ b/src/mapping/query/function/parse_url.rs
@@ -16,18 +16,18 @@ impl ParseUrlFn {
 }
 
 impl Function for ParseUrlFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
 
         Url::parse(&String::from_utf8_lossy(&bytes))
             .map_err(|e| format!("unable to parse url: {}", e))
-            .map(Into::into)
+            .map(QueryValue::from_value)
     }
 
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }
@@ -129,7 +129,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/round.rs
+++ b/src/mapping/query/function/round.rs
@@ -18,28 +18,28 @@ impl RoundFn {
 }
 
 impl Function for RoundFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
-        let res = required!(ctx, self.query,
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let precision = optional_value!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required_value!(ctx, self.query,
                             Value::Float(f) => {
                                 Value::Float(round_to_precision(f, precision, f64::round))
                             },
                             v@Value::Integer(_) => v
         );
 
-        Ok(res)
+        Ok(res.into())
     }
 
     fn parameters() -> &'static [Parameter] {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Float(_)) | QueryValue::Value(Value::Integer(_))),
                 required: true,
             },
             Parameter {
                 keyword: "precision",
-                accepts: |v| matches!(v, Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Integer(_))),
                 required: false,
             },
         ]
@@ -133,7 +133,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/sha1.rs
+++ b/src/mapping/query/function/sha1.rs
@@ -15,14 +15,10 @@ impl Sha1Fn {
 impl Function for Sha1Fn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         use sha1::{Digest, Sha1};
+        let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
+        let sha1 = hex::encode(Sha1::digest(&bytes));
 
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(bytes) => {
-                let sha1 = hex::encode(Sha1::digest(&bytes));
-                Ok(Value::Bytes(sha1.into()).into())
-            }
-            v => unexpected_type!(v),
-        }
+        Ok(Value::Bytes(sha1.into()).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -69,7 +65,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/sha1.rs
+++ b/src/mapping/query/function/sha1.rs
@@ -13,13 +13,13 @@ impl Sha1Fn {
 }
 
 impl Function for Sha1Fn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         use sha1::{Digest, Sha1};
 
-        match self.query.execute(ctx)? {
+        match self.query.execute(ctx)?.into() {
             Value::Bytes(bytes) => {
                 let sha1 = hex::encode(Sha1::digest(&bytes));
-                Ok(Value::Bytes(sha1.into()))
+                Ok(Value::Bytes(sha1.into()).into())
             }
             v => unexpected_type!(v),
         }
@@ -69,7 +69,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/sha1.rs
+++ b/src/mapping/query/function/sha1.rs
@@ -28,7 +28,7 @@ impl Function for Sha1Fn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/sha2.rs
+++ b/src/mapping/query/function/sha2.rs
@@ -17,7 +17,7 @@ impl Sha2Fn {
 }
 
 impl Function for Sha2Fn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let value = required!(ctx, self.query, Value::Bytes(v) => v);
         let variant = optional!(ctx, self.variant, Value::Bytes(v) => v);
 
@@ -36,7 +36,7 @@ impl Function for Sha2Fn {
             }
         };
 
-        Ok(Value::Bytes(hash.into()))
+        Ok(Value::Bytes(hash.into()).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -145,7 +145,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/sha2.rs
+++ b/src/mapping/query/function/sha2.rs
@@ -43,12 +43,12 @@ impl Function for Sha2Fn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "variant",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/sha2.rs
+++ b/src/mapping/query/function/sha2.rs
@@ -18,8 +18,8 @@ impl Sha2Fn {
 
 impl Function for Sha2Fn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let value = required!(ctx, self.query, Value::Bytes(v) => v);
-        let variant = optional!(ctx, self.variant, Value::Bytes(v) => v);
+        let value = required_value!(ctx, self.query, Value::Bytes(v) => v);
+        let variant = optional_value!(ctx, self.variant, Value::Bytes(v) => v);
 
         let hash = match variant.as_deref() {
             Some(b"SHA-224") => encode::<Sha224>(&value),
@@ -145,7 +145,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/sha3.rs
+++ b/src/mapping/query/function/sha3.rs
@@ -18,8 +18,8 @@ impl Sha3Fn {
 
 impl Function for Sha3Fn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let value = required!(ctx, self.query, Value::Bytes(v) => v);
-        let variant = optional!(ctx, self.variant, Value::Bytes(v) => v);
+        let value = required_value!(ctx, self.query, Value::Bytes(v) => v);
+        let variant = optional_value!(ctx, self.variant, Value::Bytes(v) => v);
 
         let hash = match variant.as_deref() {
             Some(b"SHA3-224") => encode::<Sha3_224>(&value),
@@ -129,7 +129,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/sha3.rs
+++ b/src/mapping/query/function/sha3.rs
@@ -17,7 +17,7 @@ impl Sha3Fn {
 }
 
 impl Function for Sha3Fn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let value = required!(ctx, self.query, Value::Bytes(v) => v);
         let variant = optional!(ctx, self.variant, Value::Bytes(v) => v);
 
@@ -34,7 +34,7 @@ impl Function for Sha3Fn {
             }
         };
 
-        Ok(Value::Bytes(hash.into()))
+        Ok(Value::Bytes(hash.into()).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -129,7 +129,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/sha3.rs
+++ b/src/mapping/query/function/sha3.rs
@@ -41,12 +41,12 @@ impl Function for Sha3Fn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "variant",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -24,12 +24,12 @@ impl SliceFn {
 impl Function for SliceFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let range = |len: i64| {
-            let start = match required!(ctx, self.start, Value::Integer(v) => v) {
+            let start = match required_value!(ctx, self.start, Value::Integer(v) => v) {
                 start if start < 0 => start + len,
                 start => start,
             };
 
-            let end = match optional!(ctx, self.end, Value::Integer(v) => v) {
+            let end = match optional_value!(ctx, self.end, Value::Integer(v) => v) {
                 Some(end) if end < 0 => end + len,
                 Some(end) => end,
                 None => len,
@@ -45,7 +45,7 @@ impl Function for SliceFn {
             }
         };
 
-        required! {
+        required_value! {
             ctx, self.query,
             Value::Bytes(v) => range(v.len() as i64)
                 .map(|range| v.slice(range))
@@ -164,7 +164,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 
@@ -215,7 +215,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -62,17 +62,17 @@ impl Function for SliceFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_) | Value::Array(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_)) | QueryValue::Value(Value::Array(_))),
                 required: true,
             },
             Parameter {
                 keyword: "start",
-                accepts: |v| matches!(v, Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Integer(_))),
                 required: true,
             },
             Parameter {
                 keyword: "end",
-                accepts: |v| matches!(v, Value::Integer(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Integer(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -22,7 +22,7 @@ impl SliceFn {
 }
 
 impl Function for SliceFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let range = |len: i64| {
             let start = match required!(ctx, self.start, Value::Integer(v) => v) {
                 start if start < 0 => start + len,
@@ -49,10 +49,12 @@ impl Function for SliceFn {
             ctx, self.query,
             Value::Bytes(v) => range(v.len() as i64)
                 .map(|range| v.slice(range))
-                .map(Value::from),
+                .map(Value::from)
+                .map(Into::into),
             Value::Array(mut v) => range(v.len() as i64)
                 .map(|range| v.drain(range).collect::<Vec<_>>())
-                .map(Value::from),
+                .map(Value::from)
+                .map(Into::into),
         }
     }
 
@@ -162,7 +164,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 
@@ -213,7 +215,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/split.rs
+++ b/src/mapping/query/function/split.rs
@@ -25,11 +25,10 @@ impl SplitFn {
 impl Function for SplitFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let string = {
-            let bytes = required!(ctx, self.path, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.path, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
-
-        let limit = optional!(ctx, self.limit, Value::Integer(i) => i)
+        let limit = optional_value!(ctx, self.limit, Value::Integer(i) => i)
             .map(|limit| {
                 if limit < 0 {
                     Err("limit is not a positive number".to_string())
@@ -106,8 +105,8 @@ impl TryFrom<ArgumentList> for SplitFn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mapping::query::regex::Regex;
     use crate::mapping::query::path::Path;
+    use crate::mapping::query::regex::Regex;
 
     #[test]
     fn check_split() {
@@ -191,7 +190,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/split.rs
+++ b/src/mapping/query/function/split.rs
@@ -55,13 +55,10 @@ impl Function for SplitFn {
                     None => to_value(Box::new(string.split(&pattern))),
                 })
             }
-            QueryValue::Regex(mut regex) => {
-                let regex = regex.compile()?;
-                Ok(match &limit {
-                    Some(ref limit) => to_value(Box::new(regex.splitn(&string, *limit))),
-                    None => to_value(Box::new(regex.split(&string))),
-                })
-            }
+            QueryValue::Regex(regex) => Ok(match &limit {
+                Some(ref limit) => to_value(Box::new(regex.regex().splitn(&string, *limit))),
+                None => to_value(Box::new(regex.regex().split(&string))),
+            }),
             _ => Err("invalid pattern".to_string()),
         }
     }
@@ -109,7 +106,7 @@ impl TryFrom<ArgumentList> for SplitFn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mapping::query::dynamic_regex::DynamicRegex;
+    use crate::mapping::query::regex::Regex;
     use crate::mapping::query::path::Path;
 
     #[test]
@@ -163,12 +160,9 @@ mod tests {
                 ])),
                 SplitFn::new(
                     Box::new(Path::from(vec![vec!["foo"]])),
-                    Box::new(Literal::from(QueryValue::from(DynamicRegex::new(
-                        " ".to_string(),
-                        false,
-                        false,
-                        false,
-                    )))),
+                    Box::new(Literal::from(QueryValue::from(
+                        Regex::new(" ".to_string(), false, false, false).unwrap(),
+                    ))),
                     Some(Box::new(Literal::from(Value::from(2)))),
                 ),
             ),
@@ -188,12 +182,9 @@ mod tests {
                 ])),
                 SplitFn::new(
                     Box::new(Path::from(vec![vec!["foo"]])),
-                    Box::new(Literal::from(QueryValue::from(DynamicRegex::new(
-                        "a".to_string(),
-                        false,
-                        true,
-                        false,
-                    )))),
+                    Box::new(Literal::from(QueryValue::from(
+                        Regex::new("a".to_string(), false, true, false).unwrap(),
+                    ))),
                     None,
                 ),
             ),

--- a/src/mapping/query/function/split.rs
+++ b/src/mapping/query/function/split.rs
@@ -1,0 +1,251 @@
+use super::prelude::*;
+use bytes::Bytes;
+use lazy_static::lazy_static;
+use std::collections::BTreeMap;
+use std::ops::Deref;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct SplitFn {
+    path: Box<dyn Function>,
+    pattern: Box<dyn Function>,
+    limit: Option<Box<dyn Function>>,
+}
+
+impl SplitFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        path: Box<dyn Function>,
+        pattern: Box<dyn Function>,
+        limit: Option<Box<dyn Function>>,
+    ) -> Self {
+        Self {
+            path,
+            pattern,
+            limit,
+        }
+    }
+}
+
+lazy_static! {
+    static ref I_FLAG: Value = Value::from(Bytes::from("i"));
+    static ref G_FLAG: Value = Value::from(Bytes::from("g"));
+    static ref M_FLAG: Value = Value::from(Bytes::from("m"));
+}
+
+/// Create a regex from a map containing fields :
+/// pattern - The regex pattern
+/// flags   - flags including i => Case insensitive, g => Global, m => Multiline.
+fn regex_from_map(mut map: BTreeMap<String, Value>) -> Result<(regex::Regex, bool)> {
+    let pattern = map
+        .remove("pattern")
+        .ok_or("Field is not a regular expression".to_string())?;
+
+    let flags = match map.remove("flags") {
+        None => Value::from(Vec::<Value>::new()),
+        Some(flags) => flags
+    };
+
+    match (flags, pattern) {
+        (Value::Array(ref flags), Value::Bytes(ref bytes)) => {
+            let (global, insensitive, multi_line) =
+                flags
+                    .iter()
+                    .fold((false, false, false), |(g, i, m), flag| match flag {
+                        v if v == G_FLAG.deref() => (true, i, m),
+                        v if v == I_FLAG.deref() => (g, true, m),
+                        v if v == M_FLAG.deref() => (g, i, true),
+                        _ => (g, i, m),
+                    });
+
+            let pattern = String::from_utf8_lossy(&bytes);
+            let regex = regex::RegexBuilder::new(&pattern)
+                .case_insensitive(insensitive)
+                .multi_line(multi_line)
+                .build()
+                .map_err(|err| format!("invalid regex {}", err))?;
+            Ok((regex, global))
+        }
+        _ => Err("Field regular expression is not a valid string".to_string()),
+    }
+}
+
+impl Function for SplitFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let string = {
+            let bytes = required!(ctx, self.path, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let limit = optional!(ctx, self.limit, Value::Integer(i) => i)
+            .map(|limit| {
+                if limit < 0 {
+                    Err("limit is not a positive number".to_string())
+                } else {
+                    Ok(limit as usize)
+                }
+            })
+            .transpose()?;
+
+        match self.pattern.execute(ctx)? {
+            Value::Bytes(path) => {
+                let pattern = String::from_utf8_lossy(&path).into_owned();
+
+                let iter: Box<dyn Iterator<Item = _>> = match limit {
+                    Some(limit) => Box::new(string.splitn(limit, &pattern)),
+                    None => Box::new(string.split(&pattern)),
+                };
+
+                Ok(Value::Array(
+                    iter.map(|sub| Value::Bytes(sub.to_string().into()))
+                        .collect(),
+                ))
+            }
+            Value::Map(pattern) => {
+                let (regex, _global) = regex_from_map(pattern)?;
+                let iter: Box<dyn Iterator<Item = _>> = match &limit {
+                    Some(ref limit) => Box::new(regex.splitn(&string, *limit)),
+                    None => Box::new(regex.split(&string)),
+                };
+
+                Ok(Value::Array(
+                    iter.map(|sub| Value::Bytes(sub.to_string().into()))
+                        .collect(),
+                ))
+            }
+            _ => Err("invalid pattern".to_string()),
+        }
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "pattern",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "limit",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for SplitFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let path = arguments.required("value")?;
+        let pattern = arguments.required("pattern")?;
+        let limit = arguments.optional("limit");
+
+        Ok(Self {
+            path,
+            pattern,
+            limit,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn check_split() {
+        let cases = vec![
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from(""));
+                    event
+                },
+                Ok(Value::from(vec![Value::from("")])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(Value::from(" "))),
+                    None,
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("This is a long string."));
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from("This"),
+                    Value::from("is"),
+                    Value::from("a"),
+                    Value::from("long"),
+                    Value::from("string."),
+                ])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(Value::from(" "))),
+                    None,
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("This is a long string."));
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from("This"),
+                    Value::from("is a long string."),
+                ])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(Value::from({
+                        let mut map = BTreeMap::new();
+                        map.insert("pattern".to_string(), Value::from(" "));
+                        map
+                    }))),
+                    Some(Box::new(Literal::from(Value::from(2)))),
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("ThisaisAlongAstring."));
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from("This"),
+                    Value::from("is"),
+                    Value::from("long"),
+                    Value::from("string."),
+                ])),
+                SplitFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(Value::from({
+                        let mut map = BTreeMap::new();
+                        map.insert("pattern".to_string(), Value::from("a"));
+                        map.insert("flags".to_string(), Value::from(vec![Value::from("i")]));
+                        map
+                    }))),
+                    None,
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/split.rs
+++ b/src/mapping/query/function/split.rs
@@ -54,7 +54,7 @@ impl Function for SplitFn {
                     None => to_value(Box::new(string.split(&pattern))),
                 })
             }
-            Value::Map(pattern) => {
+            pattern@Value::Map(_) => {
                 let mut regex = DynamicRegex::try_from(pattern)?;
                 let regex = regex.compile()?;
                 Ok(match &limit {

--- a/src/mapping/query/function/starts_with.rs
+++ b/src/mapping/query/function/starts_with.rs
@@ -26,43 +26,41 @@ impl StartsWithFn {
 }
 
 impl Function for StartsWithFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let substring = {
-            let bytes = required!(ctx, self.substring, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.substring, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
         let value = {
-            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
         let starts_with = value.starts_with(&substring)
-            || optional!(ctx, self.case_sensitive, Value::Boolean(b) => b)
+            || optional_value!(ctx, self.case_sensitive, Value::Boolean(b) => b)
                 .iter()
                 .filter(|&case_sensitive| !case_sensitive)
-                .any(|_| {
-                    value.to_lowercase().starts_with(&substring.to_lowercase())
-                });
+                .any(|_| value.to_lowercase().starts_with(&substring.to_lowercase()));
 
-        Ok(Value::from(starts_with))
+        Ok(Value::from(starts_with).into())
     }
 
     fn parameters() -> &'static [Parameter] {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "substring",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "case_sensitive",
-                accepts: |v| matches!(v, Value::Boolean(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Boolean(_))),
                 required: false,
             },
         ]
@@ -146,7 +144,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/strip_ansi_escape_codes.rs
+++ b/src/mapping/query/function/strip_ansi_escape_codes.rs
@@ -15,7 +15,7 @@ impl StripAnsiEscapeCodesFn {
 
 impl Function for StripAnsiEscapeCodesFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+        let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
 
         strip_ansi_escapes::strip(&bytes)
             .map(Bytes::from)
@@ -85,7 +85,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/strip_ansi_escape_codes.rs
+++ b/src/mapping/query/function/strip_ansi_escape_codes.rs
@@ -14,12 +14,13 @@ impl StripAnsiEscapeCodesFn {
 }
 
 impl Function for StripAnsiEscapeCodesFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
 
         strip_ansi_escapes::strip(&bytes)
             .map(Bytes::from)
             .map(Value::from)
+            .map(Into::into)
             .map_err(|e| e.to_string())
     }
 
@@ -84,7 +85,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/strip_ansi_escape_codes.rs
+++ b/src/mapping/query/function/strip_ansi_escape_codes.rs
@@ -27,7 +27,7 @@ impl Function for StripAnsiEscapeCodesFn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/strip_whitespace.rs
+++ b/src/mapping/query/function/strip_whitespace.rs
@@ -14,8 +14,8 @@ impl StripWhitespaceFn {
 
 impl Function for StripWhitespaceFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(b) => std::str::from_utf8(&b)
+        match self.query.execute(ctx)? {
+            QueryValue::Value(Value::Bytes(b)) => std::str::from_utf8(&b)
                 .map(|s| Value::Bytes(b.slice_ref(s.trim().as_bytes())))
                 .map(Into::into)
                 .map_err(|_| {
@@ -110,7 +110,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/strip_whitespace.rs
+++ b/src/mapping/query/function/strip_whitespace.rs
@@ -13,10 +13,11 @@ impl StripWhitespaceFn {
 }
 
 impl Function for StripWhitespaceFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        match self.query.execute(ctx)? {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        match self.query.execute(ctx)?.into() {
             Value::Bytes(b) => std::str::from_utf8(&b)
                 .map(|s| Value::Bytes(b.slice_ref(s.trim().as_bytes())))
+                .map(Into::into)
                 .map_err(|_| {
                     "unable to strip white_space from non-unicode string types".to_owned()
                 }),
@@ -109,7 +110,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/strip_whitespace.rs
+++ b/src/mapping/query/function/strip_whitespace.rs
@@ -28,7 +28,7 @@ impl Function for StripWhitespaceFn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/to_bool.rs
+++ b/src/mapping/query/function/to_bool.rs
@@ -29,7 +29,7 @@ impl Function for ToBooleanFn {
                         .map_err(|e| e.to_string()),
                     _ => unexpected_type!(value),
                 }
-            },
+            }
             Err(err) => Err(err),
         }
         .or_else(|err| match &self.default {
@@ -42,12 +42,22 @@ impl Function for ToBooleanFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Integer(_) | Value::Float(_) | Value::Bytes(_) | Value::Boolean(_)),
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Integer(_))
+                             | QueryValue::Value(Value::Float(_))
+                             | QueryValue::Value(Value::Bytes(_))
+                             | QueryValue::Value(Value::Boolean(_)))
+                },
                 required: true,
             },
             Parameter {
                 keyword: "default",
-                accepts: |v| matches!(v, Value::Integer(_) | Value::Float(_) | Value::Bytes(_) | Value::Boolean(_)),
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Integer(_))
+                             | QueryValue::Value(Value::Float(_))
+                             | QueryValue::Value(Value::Bytes(_))
+                             | QueryValue::Value(Value::Boolean(_)))
+                },
                 required: false,
             },
         ]

--- a/src/mapping/query/function/to_float.rs
+++ b/src/mapping/query/function/to_float.rs
@@ -17,20 +17,18 @@ impl ToFloatFn {
 impl Function for ToFloatFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         match self.query.execute(ctx) {
-            Ok(v) => {
-                let value = v.into();
-                match value {
-                    Value::Float(_) => Ok(value.into()),
-                    Value::Integer(i) => Ok(Value::Float(i as f64).into()),
-                    Value::Bytes(_) => Conversion::Float
-                        .convert(value)
-                        .map(Into::into)
-                        .map_err(|e| e.to_string()),
-                    Value::Boolean(b) => Ok(Value::Float(if b { 1.0 } else { 0.0 }).into()),
-                    Value::Timestamp(t) => Ok(Value::Float(t.timestamp() as f64).into()),
-                    _ => unexpected_type!(value),
-                }
-            }
+            Ok(QueryValue::Value(value)) => match value {
+                Value::Float(_) => Ok(value.into()),
+                Value::Integer(i) => Ok(Value::Float(i as f64).into()),
+                Value::Bytes(_) => Conversion::Float
+                    .convert(value)
+                    .map(Into::into)
+                    .map_err(|e| e.to_string()),
+                Value::Boolean(b) => Ok(Value::Float(if b { 1.0 } else { 0.0 }).into()),
+                Value::Timestamp(t) => Ok(Value::Float(t.timestamp() as f64).into()),
+                _ => unexpected_type!(value),
+            },
+            Ok(query) => unexpected_type!(query),
             Err(err) => Err(err),
         }
         .or_else(|err| match &self.default {
@@ -108,7 +106,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/to_float.rs
+++ b/src/mapping/query/function/to_float.rs
@@ -15,16 +15,22 @@ impl ToFloatFn {
 }
 
 impl Function for ToFloatFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         match self.query.execute(ctx) {
-            Ok(v) => match v {
-                Value::Float(_) => Ok(v),
-                Value::Integer(i) => Ok(Value::Float(i as f64)),
-                Value::Bytes(_) => Conversion::Float.convert(v).map_err(|e| e.to_string()),
-                Value::Boolean(b) => Ok(Value::Float(if b { 1.0 } else { 0.0 })),
-                Value::Timestamp(t) => Ok(Value::Float(t.timestamp() as f64)),
-                _ => unexpected_type!(v),
-            },
+            Ok(v) => {
+                let value = v.into();
+                match value {
+                    Value::Float(_) => Ok(value.into()),
+                    Value::Integer(i) => Ok(Value::Float(i as f64).into()),
+                    Value::Bytes(_) => Conversion::Float
+                        .convert(value)
+                        .map(Into::into)
+                        .map_err(|e| e.to_string()),
+                    Value::Boolean(b) => Ok(Value::Float(if b { 1.0 } else { 0.0 }).into()),
+                    Value::Timestamp(t) => Ok(Value::Float(t.timestamp() as f64).into()),
+                    _ => unexpected_type!(value),
+                }
+            }
             Err(err) => Err(err),
         }
         .or_else(|err| match &self.default {
@@ -102,7 +108,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/to_int.rs
+++ b/src/mapping/query/function/to_int.rs
@@ -17,8 +17,7 @@ impl ToIntegerFn {
 impl Function for ToIntegerFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         match self.query.execute(ctx) {
-            Ok(v) => {
-                let value = v.into();
+            Ok(QueryValue::Value(value)) => {
                 match value {
                     Value::Integer(_) => Ok(value.into()),
                     Value::Float(f) => Ok(Value::Integer(f as i64).into()),
@@ -31,6 +30,7 @@ impl Function for ToIntegerFn {
                     _ => unexpected_type!(value),
                 }
             }
+            Ok(query) => unexpected_type!(query),
             Err(err) => Err(err),
         }
         .or_else(|err| match &self.default {
@@ -108,7 +108,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/function/to_int.rs
+++ b/src/mapping/query/function/to_int.rs
@@ -15,16 +15,22 @@ impl ToIntegerFn {
 }
 
 impl Function for ToIntegerFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         match self.query.execute(ctx) {
-            Ok(v) => match v {
-                Value::Integer(_) => Ok(v),
-                Value::Float(f) => Ok(Value::Integer(f as i64)),
-                Value::Bytes(_) => Conversion::Integer.convert(v).map_err(|e| e.to_string()),
-                Value::Boolean(b) => Ok(Value::Integer(if b { 1 } else { 0 })),
-                Value::Timestamp(t) => Ok(Value::Integer(t.timestamp())),
-                _ => unexpected_type!(v),
-            },
+            Ok(v) => {
+                let value = v.into();
+                match value {
+                    Value::Integer(_) => Ok(value.into()),
+                    Value::Float(f) => Ok(Value::Integer(f as i64).into()),
+                    Value::Bytes(_) => Conversion::Integer
+                        .convert(value)
+                        .map(Into::into)
+                        .map_err(|e| e.to_string()),
+                    Value::Boolean(b) => Ok(Value::Integer(if b { 1 } else { 0 }).into()),
+                    Value::Timestamp(t) => Ok(Value::Integer(t.timestamp()).into()),
+                    _ => unexpected_type!(value),
+                }
+            }
             Err(err) => Err(err),
         }
         .or_else(|err| match &self.default {
@@ -102,7 +108,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/to_string.rs
+++ b/src/mapping/query/function/to_string.rs
@@ -15,12 +15,15 @@ impl ToStringFn {
 }
 
 impl Function for ToStringFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         match self.query.execute(ctx) {
-            Ok(v) => Ok(match v {
-                Value::Bytes(_) => v,
-                _ => Value::Bytes(v.as_bytes()),
-            }),
+            Ok(v) => {
+                let value: Value = v.into();
+                Ok(match value {
+                    Value::Bytes(_) => value.into(),
+                    _ => Value::Bytes(value.as_bytes()).into(),
+                })
+            }
             Err(err) => match &self.default {
                 Some(v) => v.execute(ctx),
                 None => Err(err),
@@ -97,7 +100,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/to_timestamp.rs
+++ b/src/mapping/query/function/to_timestamp.rs
@@ -33,12 +33,20 @@ impl Function for ToTimestampFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Integer(_) | Value::Bytes(_) | Value::Timestamp(_)),
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Integer(_))
+                                      | QueryValue::Value(Value::Bytes(_))
+                                      | QueryValue::Value(Value::Timestamp(_)))
+                },
                 required: true,
             },
             Parameter {
                 keyword: "default",
-                accepts: |v| matches!(v, Value::Integer(_) | Value::Bytes(_) | Value::Timestamp(_)),
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Integer(_))
+                                      | QueryValue::Value(Value::Bytes(_))
+                                      | QueryValue::Value(Value::Timestamp(_)))
+                },
                 required: false,
             },
         ]

--- a/src/mapping/query/function/to_timestamp.rs
+++ b/src/mapping/query/function/to_timestamp.rs
@@ -16,7 +16,7 @@ impl ToTimestampFn {
 }
 
 impl Function for ToTimestampFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         self.query
             .execute(ctx)
             .and_then(to_timestamp)
@@ -56,13 +56,15 @@ impl TryFrom<ArgumentList> for ToTimestampFn {
     }
 }
 
-fn to_timestamp(value: Value) -> Result<Value> {
+fn to_timestamp(v: QueryValue) -> Result<QueryValue> {
+    let value = v.into();
     match value {
         Value::Bytes(_) => Conversion::Timestamp
             .convert(value)
+            .map(Into::into)
             .map_err(|e| e.to_string()),
-        Value::Integer(i) => Ok(Value::Timestamp(Utc.timestamp(i, 0))),
-        Value::Timestamp(_) => Ok(value),
+        Value::Integer(i) => Ok(Value::Timestamp(Utc.timestamp(i, 0)).into()),
+        Value::Timestamp(_) => Ok(value.into()),
         _ => Err("unable to parse non-string or integer type to timestamp".to_string()),
     }
 }
@@ -140,7 +142,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/function/tokenize.rs
+++ b/src/mapping/query/function/tokenize.rs
@@ -16,7 +16,7 @@ impl TokenizeFn {
 impl Function for TokenizeFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         let value = {
-            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            let bytes = required_value!(ctx, self.query, Value::Bytes(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
         };
 
@@ -73,7 +73,7 @@ mod tests {
                 )];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/tokenize.rs
+++ b/src/mapping/query/function/tokenize.rs
@@ -35,7 +35,7 @@ impl Function for TokenizeFn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/truncate.rs
+++ b/src/mapping/query/function/truncate.rs
@@ -78,17 +78,20 @@ impl Function for TruncateFn {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::Bytes(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
                 required: true,
             },
             Parameter {
                 keyword: "limit",
-                accepts: |v| matches!(v, Value::Integer(_) | Value::Float(_)),
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Integer(_))
+                                      | QueryValue::Value(Value::Float(_)))
+                },
                 required: true,
             },
             Parameter {
                 keyword: "ellipsis",
-                accepts: |v| matches!(v, Value::Boolean(_)),
+                accepts: |v| matches!(v, QueryValue::Value(Value::Boolean(_))),
                 required: false,
             },
         ]

--- a/src/mapping/query/function/upcase.rs
+++ b/src/mapping/query/function/upcase.rs
@@ -13,11 +13,11 @@ impl UpcaseFn {
 }
 
 impl Function for UpcaseFn {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
-        match self.query.execute(ctx)? {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        match self.query.execute(ctx)?.into() {
             Value::Bytes(bytes) => Ok(Value::Bytes(
                 String::from_utf8_lossy(&bytes).to_uppercase().into(),
-            )),
+            ).into()),
             v => unexpected_type!(v),
         }
     }
@@ -66,7 +66,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 

--- a/src/mapping/query/function/upcase.rs
+++ b/src/mapping/query/function/upcase.rs
@@ -14,12 +14,8 @@ impl UpcaseFn {
 
 impl Function for UpcaseFn {
     fn execute(&self, ctx: &Event) -> Result<QueryValue> {
-        match self.query.execute(ctx)?.into() {
-            Value::Bytes(bytes) => Ok(Value::Bytes(
-                String::from_utf8_lossy(&bytes).to_uppercase().into(),
-            ).into()),
-            v => unexpected_type!(v),
-        }
+        let string = required_value!(ctx, self.query, Value::Bytes(bytes) => String::from_utf8_lossy(&bytes).into_owned());
+        Ok(Value::Bytes(string.to_uppercase().into()).into())
     }
 
     fn parameters() -> &'static [Parameter] {
@@ -66,7 +62,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 

--- a/src/mapping/query/function/upcase.rs
+++ b/src/mapping/query/function/upcase.rs
@@ -25,7 +25,7 @@ impl Function for UpcaseFn {
     fn parameters() -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_)),
+            accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
             required: true,
         }]
     }

--- a/src/mapping/query/function/uuid_v4.rs
+++ b/src/mapping/query/function/uuid_v4.rs
@@ -34,8 +34,8 @@ mod tests {
 
     #[test]
     fn uuid_v4() {
-        match UuidV4Fn::new().execute(&Event::from("")).unwrap().into() {
-            Value::Bytes(value) => {
+        match UuidV4Fn::new().execute(&Event::from("")).unwrap() {
+            QueryValue::Value(Value::Bytes(value)) => {
                 uuid::Uuid::parse_str(std::str::from_utf8(&value).unwrap()).expect("valid UUID V4")
             }
             _ => panic!("unexpected uuid_v4 output"),

--- a/src/mapping/query/function/uuid_v4.rs
+++ b/src/mapping/query/function/uuid_v4.rs
@@ -12,11 +12,11 @@ impl UuidV4Fn {
 }
 
 impl Function for UuidV4Fn {
-    fn execute(&self, _: &Event) -> Result<Value> {
+    fn execute(&self, _: &Event) -> Result<QueryValue> {
         let mut buf = [0; 36];
         let uuid = uuid::Uuid::new_v4().to_hyphenated().encode_lower(&mut buf);
 
-        Ok(Value::Bytes(Bytes::copy_from_slice(uuid.as_bytes())))
+        Ok(Value::Bytes(Bytes::copy_from_slice(uuid.as_bytes())).into())
     }
 }
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn uuid_v4() {
-        match UuidV4Fn::new().execute(&Event::from("")).unwrap() {
+        match UuidV4Fn::new().execute(&Event::from("")).unwrap().into() {
             Value::Bytes(value) => {
                 uuid::Uuid::parse_str(std::str::from_utf8(&value).unwrap()).expect("valid UUID V4")
             }

--- a/src/mapping/query/mod.rs
+++ b/src/mapping/query/mod.rs
@@ -9,9 +9,11 @@ pub mod function;
 pub mod path;
 pub mod query_value;
 
+use query_value::QueryValue;
+
 pub(in crate::mapping) trait Function: Send + core::fmt::Debug {
     /// Run the function to produce a [`Value`].
-    fn execute(&self, context: &Event) -> Result<query_value::QueryValue>;
+    fn execute(&self, context: &Event) -> Result<QueryValue>;
 
     /// Return the static set of parameters this function accepts.
     fn parameters() -> &'static [function::Parameter]
@@ -26,11 +28,19 @@ pub(in crate::mapping) trait Function: Send + core::fmt::Debug {
 
 #[derive(Debug)]
 pub(in crate::mapping) struct Literal {
-    value: Value,
+    value: QueryValue,
 }
 
 impl From<Value> for Literal {
     fn from(value: Value) -> Self {
+        Self {
+            value: QueryValue::Value(value),
+        }
+    }
+}
+
+impl From<QueryValue> for Literal {
+    fn from(value: QueryValue) -> Self {
         Self { value }
     }
 }
@@ -39,13 +49,13 @@ impl From<Value> for Literal {
 impl From<&str> for Literal {
     fn from(value: &str) -> Self {
         Self {
-            value: Value::from(value),
+            value: QueryValue::from_value(value),
         }
     }
 }
 
 impl Function for Literal {
     fn execute(&self, _: &Event) -> Result<query_value::QueryValue> {
-        Ok(self.value.clone().into())
+        Ok(self.value.clone())
     }
 }

--- a/src/mapping/query/mod.rs
+++ b/src/mapping/query/mod.rs
@@ -4,10 +4,10 @@ use crate::{
 };
 
 pub mod arithmetic;
-pub mod regex;
 pub mod function;
 pub mod path;
 pub mod query_value;
+pub mod regex;
 
 use query_value::QueryValue;
 

--- a/src/mapping/query/mod.rs
+++ b/src/mapping/query/mod.rs
@@ -4,12 +4,14 @@ use crate::{
 };
 
 pub mod arithmetic;
+pub mod dynamic_regex;
 pub mod function;
 pub mod path;
+pub mod query_value;
 
 pub(in crate::mapping) trait Function: Send + core::fmt::Debug {
     /// Run the function to produce a [`Value`].
-    fn execute(&self, context: &Event) -> Result<Value>;
+    fn execute(&self, context: &Event) -> Result<query_value::QueryValue>;
 
     /// Return the static set of parameters this function accepts.
     fn parameters() -> &'static [function::Parameter]
@@ -43,7 +45,7 @@ impl From<&str> for Literal {
 }
 
 impl Function for Literal {
-    fn execute(&self, _: &Event) -> Result<Value> {
-        Ok(self.value.clone())
+    fn execute(&self, _: &Event) -> Result<query_value::QueryValue> {
+        Ok(self.value.clone().into())
     }
 }

--- a/src/mapping/query/mod.rs
+++ b/src/mapping/query/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 pub mod arithmetic;
-pub mod dynamic_regex;
+pub mod regex;
 pub mod function;
 pub mod path;
 pub mod query_value;

--- a/src/mapping/query/path.rs
+++ b/src/mapping/query/path.rs
@@ -1,4 +1,4 @@
-use super::{Function, query_value::QueryValue};
+use super::{query_value::QueryValue, Function};
 use crate::{
     event::{util::log::get_value, Event, PathIter},
     mapping::Result,
@@ -93,8 +93,8 @@ impl Function for Path {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use crate::event::Value;
+    use serde_json::json;
 
     #[test]
     fn check_path_query() {

--- a/src/mapping/query/path.rs
+++ b/src/mapping/query/path.rs
@@ -183,7 +183,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event).map(Into::into), exp);
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
         }
     }
 }

--- a/src/mapping/query/path.rs
+++ b/src/mapping/query/path.rs
@@ -1,6 +1,6 @@
-use super::Function;
+use super::{Function, query_value::QueryValue};
 use crate::{
-    event::{util::log::get_value, Event, PathIter, Value},
+    event::{util::log::get_value, Event, PathIter},
     mapping::Result,
 };
 
@@ -42,7 +42,7 @@ impl From<Vec<Vec<&str>>> for Path {
 }
 
 impl Function for Path {
-    fn execute(&self, ctx: &Event) -> Result<Value> {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
         // Event.as_log returns a LogEvent struct rather than a naked
         // IndexMap<_, Value>, which means specifically for the first item in
         // the path we need to manually call .get.
@@ -86,7 +86,7 @@ impl Function for Path {
                 })?;
         }
 
-        Ok(value.clone())
+        Ok(value.clone().into())
     }
 }
 
@@ -94,6 +94,7 @@ impl Function for Path {
 mod tests {
     use super::*;
     use serde_json::json;
+    use crate::event::Value;
 
     #[test]
     fn check_path_query() {
@@ -182,7 +183,7 @@ mod tests {
         ];
 
         for (input_event, exp, query) in cases {
-            assert_eq!(query.execute(&input_event), exp);
+            assert_eq!(query.execute(&input_event).map(Into::into), exp);
         }
     }
 }

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -13,11 +13,24 @@ impl QueryValue {
     pub(in crate::mapping) fn from_value<T: Into<Value>>(value: T) -> Self {
         From::from(value.into())
     }
+
+    pub fn kind(&self) -> &str {
+        match self {
+            QueryValue::Value(value) => value.kind(),
+            QueryValue::Regex(_) => "regex",
+        }
+    }
 }
 
 impl From<Value> for QueryValue {
     fn from(value: Value) -> Self {
         Self::Value(value)
+    }
+}
+
+impl From<DynamicRegex> for QueryValue {
+    fn from(value: DynamicRegex) -> Self {
+        Self::Regex(value)
     }
 }
 

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -1,10 +1,10 @@
-use crate::event::Value;
 use super::dynamic_regex::DynamicRegex;
+use crate::event::Value;
 
 #[derive(PartialEq, Debug, Clone)]
 pub(in crate::mapping) enum QueryValue {
     Value(Value),
-    
+
     #[allow(dead_code)]
     Regex(DynamicRegex),
 }

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -9,6 +9,12 @@ pub(in crate::mapping) enum QueryValue {
     Regex(DynamicRegex),
 }
 
+impl QueryValue {
+    pub(in crate::mapping) fn from_value<T: Into<Value>>(value: T) -> Self {
+        From::from(value.into())
+    }
+}
+
 impl From<Value> for QueryValue {
     fn from(value: Value) -> Self {
         Self::Value(value)

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -1,0 +1,27 @@
+use crate::event::Value;
+use super::dynamic_regex::DynamicRegex;
+
+#[derive(PartialEq, Debug, Clone)]
+pub(in crate::mapping) enum QueryValue {
+    Value(Value),
+    
+    #[allow(dead_code)]
+    Regex(DynamicRegex),
+}
+
+impl From<Value> for QueryValue {
+    fn from(value: Value) -> Self {
+        Self::Value(value)
+    }
+}
+
+impl From<QueryValue> for Value {
+    fn from(value: QueryValue) -> Self {
+        use QueryValue::*;
+
+        match value {
+            Value(v) => v,
+            Regex(_r) => unimplemented!(), // r.into(),
+        }
+    }
+}

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -33,14 +33,3 @@ impl From<Regex> for QueryValue {
         Self::Regex(value)
     }
 }
-
-impl From<QueryValue> for Value {
-    fn from(value: QueryValue) -> Self {
-        use QueryValue::*;
-
-        match value {
-            Value(v) => v,
-            Regex(r) => r.into(),
-        }
-    }
-}

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -1,4 +1,4 @@
-use super::dynamic_regex::DynamicRegex;
+use super::regex::Regex;
 use crate::event::Value;
 
 #[derive(PartialEq, Debug, Clone)]
@@ -6,7 +6,7 @@ pub(in crate::mapping) enum QueryValue {
     Value(Value),
 
     #[allow(dead_code)]
-    Regex(DynamicRegex),
+    Regex(Regex),
 }
 
 impl QueryValue {
@@ -28,8 +28,8 @@ impl From<Value> for QueryValue {
     }
 }
 
-impl From<DynamicRegex> for QueryValue {
-    fn from(value: DynamicRegex) -> Self {
+impl From<Regex> for QueryValue {
+    fn from(value: Regex) -> Self {
         Self::Regex(value)
     }
 }

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -40,7 +40,7 @@ impl From<QueryValue> for Value {
 
         match value {
             Value(v) => v,
-            Regex(_r) => unimplemented!(), // r.into(),
+            Regex(r) => r.into(),
         }
     }
 }

--- a/src/mapping/query/regex.rs
+++ b/src/mapping/query/regex.rs
@@ -32,11 +32,7 @@ impl Regex {
         self.global
     }
 
-    fn compile(
-        pattern: &str,
-        multiline: bool,
-        insensitive: bool
-    ) -> Result<regex::Regex> {
+    fn compile(pattern: &str, multiline: bool, insensitive: bool) -> Result<regex::Regex> {
         regex::RegexBuilder::new(pattern)
             .case_insensitive(insensitive)
             .multi_line(multiline)

--- a/src/mapping/query/regex.rs
+++ b/src/mapping/query/regex.rs
@@ -1,5 +1,16 @@
 use crate::mapping::Result;
 
+/// Regex is created by the remap parser when a regex is parsed from the script.
+/// Regexes are parsed using the syntax /<pattern>/<flags>
+/// Currently the flags supported are
+/// i - case insensitive
+/// m - multiline
+/// g - global
+///
+/// Note the global flag is not actually a part of the compiled regex and is not used in all places,
+/// the flag is often used to determine which function to call when using the regex.. ie `replace` vs `replace_all`.
+/// Technically the other data - pattern, multiline, insensitive do not need to be stored as they are a part of the
+/// compiled regex, but it may be useful for debugging and testing.
 #[derive(Debug, Clone)]
 pub(in crate::mapping) struct Regex {
     pattern: String,
@@ -26,6 +37,7 @@ impl Regex {
         })
     }
 
+    /// Retrieve the compiled regex.
     pub fn regex(&self) -> &regex::Regex {
         &self.compiled
     }
@@ -40,13 +52,11 @@ impl Regex {
             .case_insensitive(insensitive)
             .multi_line(multiline)
             .build()
-            .map_err(|err| format!("invalid regex {}", err))
+            .map_err(|err| format!("invalid regex: {}", err))
     }
 }
 
-/// Our dynamic regex equality shouldn't rely on the compiled value
-/// as this is largely an implementation detail.
-/// Plus regex::Regex doesn't implement PartialEq.
+/// regex::Regex doesn't implement PartialEq.
 impl PartialEq for Regex {
     fn eq(&self, other: &Self) -> bool {
         self.pattern == other.pattern
@@ -61,10 +71,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn create_regex() {
+    fn create_regex_case_sensitive() {
         let regex = Regex::new("abba".to_string(), false, false, false).unwrap();
 
         // Test our regex is working case sensitively.
         assert!(regex.regex().is_match("abba"));
+        assert!(!regex.regex().is_match("aBbA"));
+    }
+
+    #[test]
+    fn create_regex_case_insensitive() {
+        let regex = Regex::new("abba".to_string(), false, true, false).unwrap();
+
+        // Test our regex is working case insensitively.
+        assert!(regex.regex().is_match("abba"));
+        assert!(regex.regex().is_match("aBbA"));
     }
 }

--- a/src/mapping/query/regex.rs
+++ b/src/mapping/query/regex.rs
@@ -1,9 +1,7 @@
-use crate::{event::Value, mapping::Result};
-use bytes::Bytes;
-use std::{collections::BTreeMap, convert::TryFrom, string::ToString};
+use crate::mapping::Result;
 
 #[derive(Debug, Clone)]
-pub struct Regex {
+pub(in crate::mapping) struct Regex {
     pattern: String,
     multiline: bool,
     insensitive: bool,
@@ -12,7 +10,12 @@ pub struct Regex {
 }
 
 impl Regex {
-    pub fn new(pattern: String, multiline: bool, insensitive: bool, global: bool) -> Result<Self> {
+    pub(in crate::mapping) fn new(
+        pattern: String,
+        multiline: bool,
+        insensitive: bool,
+        global: bool,
+    ) -> Result<Self> {
         let compiled = Self::compile(&pattern, multiline, insensitive)?;
         Ok(Self {
             pattern,
@@ -39,39 +42,6 @@ impl Regex {
             .build()
             .map_err(|err| format!("invalid regex {}", err))
     }
-
-    fn from_bytes(bytes: bytes::Bytes) -> Result<Self> {
-        let pattern = String::from_utf8_lossy(&bytes);
-        Regex::new(pattern.to_string(), false, false, false)
-    }
-
-    fn from_map(map: BTreeMap<String, Value>) -> Result<Self> {
-        let pattern = map
-            .get("pattern")
-            .ok_or_else(|| "field is not a regular expression".to_string())
-            .and_then(|value| match value {
-                Value::Bytes(ref bytes) => Ok(String::from_utf8_lossy(bytes)),
-                _ => Err("regex pattern is not a valid string".to_string()),
-            })?
-            .to_string();
-
-        let (global, insensitive, multiline) = match map.get("flags") {
-            None => (false, false, false),
-            Some(Value::Array(ref flags)) => {
-                flags
-                    .iter()
-                    .fold((false, false, false), |(g, i, m), flag| match flag {
-                        v if v == &Value::from(Bytes::from_static(b"g")) => (true, i, m),
-                        v if v == &Value::from(Bytes::from_static(b"i")) => (g, true, m),
-                        v if v == &Value::from(Bytes::from_static(b"m")) => (g, i, true),
-                        _ => (g, i, m),
-                    })
-            }
-            Some(_) => return Err("regular expression flags is not an array".to_string()),
-        };
-
-        Regex::new(pattern, multiline, insensitive, global)
-    }
 }
 
 /// Our dynamic regex equality shouldn't rely on the compiled value
@@ -86,43 +56,6 @@ impl PartialEq for Regex {
     }
 }
 
-impl TryFrom<Value> for Regex {
-    type Error = String;
-
-    /// Create a regex from a String or a Map containing fields :
-    /// pattern - The regex pattern
-    /// flags   - flags including i => Case insensitive, g => Global, m => Multiline.
-    fn try_from(value: Value) -> Result<Self> {
-        match value {
-            Value::Map(map) => Regex::from_map(map),
-            Value::Bytes(bytes) => Regex::from_bytes(bytes),
-            _ => Err("regular expression should be a map or a string".to_string()),
-        }
-    }
-}
-
-impl From<Regex> for Value {
-    fn from(regex: Regex) -> Self {
-        let mut map = BTreeMap::new();
-        map.insert("pattern".to_string(), Value::from(regex.pattern));
-
-        let mut flags = Vec::new();
-        if regex.insensitive {
-            flags.push(Value::from(Bytes::from_static(b"i")));
-        }
-        if regex.multiline {
-            flags.push(Value::from(Bytes::from_static(b"m")));
-        }
-        if regex.global {
-            flags.push(Value::from(Bytes::from_static(b"g")));
-        }
-
-        map.insert("flags".to_string(), Value::from(flags));
-
-        Value::from(map)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,28 +66,5 @@ mod tests {
 
         // Test our regex is working case sensitively.
         assert!(regex.regex().is_match("abba"));
-    }
-
-    #[test]
-    fn create_regex_from_string() {
-        let value = Value::from("abba");
-        let regex = Regex::try_from(value).unwrap();
-
-        // Test our regex is working case sensitively.
-        assert!(regex.regex().is_match("abba"));
-        assert!(!regex.regex().is_match("aBBa"));
-    }
-
-    #[test]
-    fn create_regex_from_map() {
-        let mut map = BTreeMap::new();
-        map.insert("pattern".to_string(), Value::from("abba"));
-        map.insert("flags".to_string(), Value::from(vec![Value::from("i")]));
-        let value = Value::from(map);
-
-        let regex = Regex::try_from(value).unwrap();
-
-        // Test our regex is working case insensitively.
-        assert!(regex.regex().is_match("AbBa"));
     }
 }

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -847,5 +847,5 @@
     [[tests.outputs.conditions]]
     "foo[0].equals" = "bar"
     "foo[1].equals" = "bat"
-    "foo[2].equals" = "fizzaxbbuzz"
+    "foo[2].equals" = "fizz buzz"
 

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -718,6 +718,7 @@
       "parts.query.hello.equals" = "world"
       "parts.fragment.equals" = "configuration"
 
+<<<<<<< HEAD
 [transforms.remap_function_ceil]
   inputs = []
   type = "remap"
@@ -807,4 +808,44 @@
     "a.appname.equals" = "OX-XXX-CONTEUDO:rpd"
     "a.procid.equals" = 6589
     "a.message.equals" = "bgp_listen_accept: %DAEMON-4: Connection attempt from unconfigured neighbor: 2001:XXX::219:166+57284"
+
+[transforms.remap_function_split_regex]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    .foo = split(.foo, /a.b/i, 3)
+  """
+[[tests]]
+  name = "remap_function_split_regex"
+  [tests.input]
+    insert_at = "remap_function_split_regex"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "barAbBbataabfizzaxbbuzz"
+  [[tests.outputs]]
+    extract_from = "remap_function_split_regex"
+    [[tests.outputs.conditions]]
+    "foo[0].equals" = "bar"
+    "foo[1].equals" = "bat"
+    "foo[2].equals" = "fizzaxbbuzz"
+
+[transforms.remap_function_split_string]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    .foo = split(.foo, " ", 3)
+  """
+[[tests]]
+  name = "remap_function_split_string"
+  [tests.input]
+    insert_at = "remap_function_split_string"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "bar bat fizz buzz"
+  [[tests.outputs]]
+    extract_from = "remap_function_split_string"
+    [[tests.outputs.conditions]]
+    "foo[0].equals" = "bar"
+    "foo[1].equals" = "bat"
+    "foo[2].equals" = "fizzaxbbuzz"
 

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -718,7 +718,6 @@
       "parts.query.hello.equals" = "world"
       "parts.fragment.equals" = "configuration"
 
-<<<<<<< HEAD
 [transforms.remap_function_ceil]
   inputs = []
   type = "remap"


### PR DESCRIPTION
Closes #3745 

This is the first stage of changes from [this comment](https://github.com/timberio/vector/issues/4091#issuecomment-702066049)

Split now works with a Regex that is represented as a `Value::Map`. No code to the actual parser has been changed yet.

This is just stage 1. Next work will need to be done to integrate this into the parser so that regexes can become first class objects.

