### PR TITLE
docs(splunk_hec source): Correct port to `8088`

### DIFF
--- a/.meta/sources/splunk_hec.toml.erb
+++ b/.meta/sources/splunk_hec.toml.erb
@@ -12,7 +12,7 @@ features = [
 ]
 function_category = "receive"
 output_types = ["log"]
-requirements.network_port = "80"
+requirements.network_port = "8088"
 service_providers = ["Splunk"]
 strategies = ["service"]
 through_description = "the [Splunk HTTP Event Collector protocol][urls.splunk_hec_protocol]"
@@ -22,7 +22,7 @@ through_description = "the [Splunk HTTP Event Collector protocol][urls.splunk_he
 [sources.splunk_hec.options.address]
 type = "string"
 common = true
-default = "0.0.0.0:80"
+default = "0.0.0.0:8088"
 description = """\
 The address to accept connections on.\
 """


### PR DESCRIPTION
Implementation uses `8088` port.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
