### PR TITLE
[Merged by Bors] - docs(metrics): Update documentation around Summary metric

### DIFF
--- a/.meta/sinks/prometheus.toml.erb
+++ b/.meta/sinks/prometheus.toml.erb
@@ -69,7 +69,8 @@ Given the following histogram metric events:
     "value": {
       "type": "distribution",
       "values": [0.243],
-      "sample_rates": [1.0]
+      "sample_rates": [1.0],
+      "statistic": "histogram"
     }
   },
   {
@@ -78,7 +79,8 @@ Given the following histogram metric events:
     "value": {
       "type": "distribution",
       "values": [0.546],
-      "sample_rates": [1.0]
+      "sample_rates": [1.0],
+      "statistic": "histogram"
     }
   }
 ]

--- a/.meta/transforms/log_to_metric.toml.erb
+++ b/.meta/transforms/log_to_metric.toml.erb
@@ -28,8 +28,9 @@ description = "The metric type."
 [transforms.log_to_metric.options.metrics.children.type.enum]
 counter = "A [counter metric type][docs.data-model.metric#counter]."
 gauge = "A [gauge metric type][docs.data-model.metric#gauge]."
-histogram = "A [distribution metric type][docs.data-model.metric#distribution]."
+histogram = "A [distribution metric type with histogram statistic][docs.data-model.metric#distribution]."
 set = "A [set metric type][docs.data-model.metric#set]."
+summary = "A [distribution metric type with summary statistic][docs.data-model.metric#distribution]."
 
 [transforms.log_to_metric.options.metrics.children.field]
 type = "string"
@@ -119,6 +120,7 @@ structure:
   "distribution": {
     "values": [54.2],
     "sample_rates": [1.0]
+    "statistic": "histogram"
   }
 }
 ```


### PR DESCRIPTION
Ref #2603

Second part of documentation updates. First part https://github.com/timberio/vector-website/pull/128


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
