### PR TITLE
chore: Change path matching for bors null job from ignore to exclude

### DIFF
--- a/.github/workflows/bors_null.yml
+++ b/.github/workflows/bors_null.yml
@@ -7,20 +7,21 @@ on:
     branches:
       - staging
       - trying
-    paths-ignore:
-      - ".github/workflows/bors.yml"
-      - "lib/**"
-      - "proto/**"
-      - "scripts/**"
-      - "skaffold/**"
-      - "src/**"
-      - "tests/**"
-      - "build.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "docker-compose.yml"
-      - "Makefile"
-      - "rust-toolchain"
+    paths:
+      - "!.github/workflows/bors.yml"
+      - "!benches/**"
+      - "!lib/**"
+      - "!proto/**"
+      - "!scripts/**"
+      - "!skaffold/**"
+      - "!src/**"
+      - "!tests/**"
+      - "!build.rs"
+      - "!Cargo.lock"
+      - "!Cargo.toml"
+      - "!docker-compose.yml"
+      - "!Makefile"
+      - "!rust-toolchain"
 
 env:
   VERBOSE: true


### PR DESCRIPTION
The `paths-ignore` option did not work the way I thought it did. If ANY files are outside the ignore it'll run itself. What we actually want is negated paths.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
