### PR TITLE
fix(cli): Use temporary data directory during `validate` command

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -7,7 +7,7 @@ use exitcode::ExitCode;
 use std::{fmt, fs::remove_dir_all, path::PathBuf};
 use structopt::StructOpt;
 
-const TEMPORARY_DIRECTORY: &'static str = "validate_tmp";
+const TEMPORARY_DIRECTORY: &str = "validate_tmp";
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -7,6 +7,8 @@ use exitcode::ExitCode;
 use std::{fmt, fs::remove_dir_all, path::PathBuf};
 use structopt::StructOpt;
 
+const TEMPORARY_DIRECTORY: &'static str = "validate_tmp";
+
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
@@ -156,7 +158,7 @@ async fn validate_healthchecks(
 fn create_tmp_directory(config: &mut Config, fmt: &mut Formatter) -> Option<PathBuf> {
     match config
         .global
-        .resolve_and_make_data_subdir(None, "validate_tmp")
+        .resolve_and_make_data_subdir(None, TEMPORARY_DIRECTORY)
     {
         Ok(path) => {
             config.global.data_dir = Some(path.clone());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,7 @@
 use assert_cmd::prelude::*;
-use std::process::Command;
+use std::{fs::read_dir, process::Command};
+
+mod support;
 
 /// Returns `stdout` of `vector arguments`
 fn run_command(arguments: Vec<&str>) -> Vec<u8> {
@@ -24,6 +26,23 @@ fn assert_no_log_lines(output: Vec<u8>) {
     }
 }
 
+fn source_config(source: &str) -> String {
+    format!(
+        r#"
+data_dir = "${{VECTOR_DATA_DIR}}"
+
+[sources.in]
+{}
+
+[sinks.out]
+    inputs = ["in"]
+    type = "blackhole"
+    print_amount = 10000
+"#,
+        source
+    )
+}
+
 #[test]
 fn clean_list() {
     assert_no_log_lines(run_command(vec!["list"]));
@@ -32,4 +51,43 @@ fn clean_list() {
 #[test]
 fn clean_generate() {
     assert_no_log_lines(run_command(vec!["generate", "stdin//console"]));
+}
+
+#[test]
+fn validate_cleanup() {
+    // Create component directories with some file.
+    let dir = support::create_directory();
+    let mut path = dir.clone();
+    path.push("tmp");
+    path.set_extension("data");
+    support::overwrite_file(path.clone(), "");
+
+    // Config with some componenets that write to file system.
+    let config = support::create_file(
+        source_config(
+            r#"
+    type = "file"
+    include = ["./*.log_dummy"]"#,
+        )
+        .as_str(),
+    );
+
+    // Run vector
+    let mut cmd = Command::cargo_bin("vector").unwrap();
+    cmd.arg("validate")
+        .arg(config)
+        .env("VECTOR_DATA_DIR", dir.clone());
+
+    let output = cmd.output().expect("Failed to execute process");
+
+    assert_no_log_lines(output.stdout);
+
+    // Assert that data folder didn't change
+    assert_eq!(
+        vec![path],
+        read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>()
+    );
 }

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -6,15 +6,16 @@ use nix::{
     unistd::Pid,
 };
 use std::{
-    fs::OpenOptions,
-    io::Write,
     net::SocketAddr,
     path::PathBuf,
     process::{Child, Command},
     thread::sleep,
     time::{Duration, Instant},
 };
-use vector::test_util::{next_addr, temp_dir, temp_file};
+use vector::test_util::{next_addr, temp_file};
+
+mod support;
+use crate::support::{create_directory, create_file, overwrite_file};
 
 const STDIO_CONFIG: &'static str = r#"
     data_dir = "${VECTOR_DATA_DIR}"
@@ -48,33 +49,6 @@ const PROMETHEUS_SINK_CONFIG: &'static str = r#"
         address = "${VECTOR_TEST_ADDRESS}"
         namespace = "service"
 "#;
-
-/// Creates a file with given content
-fn create_file(config: &str) -> PathBuf {
-    let path = temp_file();
-    overwrite_file(path.clone(), config);
-    path
-}
-
-/// Overwrites file with given content
-fn overwrite_file(path: PathBuf, config: &str) {
-    let mut file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .unwrap();
-
-    file.write_all(config.as_bytes()).unwrap();
-    file.flush().unwrap();
-    file.sync_all().unwrap();
-}
-
-fn create_directory() -> PathBuf {
-    let path = temp_dir();
-    Command::new("mkdir").arg(path.clone()).assert().success();
-    path
-}
 
 fn source_config(source: &str) -> String {
     format!(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,17 +4,15 @@
 #![allow(clippy::type_complexity)]
 #![allow(dead_code)]
 
-use assert_cmd::prelude::*;
 use async_trait::async_trait;
 use futures::{future, FutureExt};
 use futures01::{sink::Sink, stream, sync::mpsc::Receiver, Async, Future, Stream};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::{
-    fs::OpenOptions,
+    fs::{create_dir, OpenOptions},
     io::Write,
     path::PathBuf,
-    process::Command,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
@@ -91,7 +89,7 @@ pub fn overwrite_file(path: PathBuf, config: &str) {
 
 pub fn create_directory() -> PathBuf {
     let path = temp_dir();
-    Command::new("mkdir").arg(path.clone()).assert().success();
+    create_dir(path.clone()).unwrap();
     path
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::type_complexity)]
 #![allow(dead_code)]
 
-use async_trait::async_trait;
 use assert_cmd::prelude::*;
+use async_trait::async_trait;
 use futures::{future, FutureExt};
 use futures01::{sink::Sink, stream, sync::mpsc::Receiver, Async, Future, Stream};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Ref #3930.

`validate` command now creates new directory "validate_tmp" in data_dir directory and changes data_dir path to "validate_tmp", and after its' completion the "validate_tmp" is deleted.


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
