### PR TITLE
chore(external docs): Tiddy up cue schema

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -6,22 +6,23 @@
 package metadata
 
 #ConfigurationOptions: [Name=string]: {
-  common: bool
   description: string
-  groups: [...string]
+  groups?: [...string]
   name: Name
   relevant_when?: string
   required: bool
+
   warnings: [...{
     visibility_level: "component" | "option"
     text: string
   }]
 
-  if required {
-    common: true
+  if !required {
+    common: bool
   }
 
   sort?: int8
+
   type: {
     "[string]"?: {
       if !required {
@@ -105,6 +106,82 @@ package metadata
     }
   }
 
+  features: close({
+    if kind == "sink" {
+      batch: close({
+        enabled: bool
+        common: bool,
+        max_bytes: uint | null,
+        max_events: uint | null,
+        timeout_secs: uint8
+      })
+    }
+
+    if kind == "sink" {
+      buffer: close({
+        enabled: bool | string
+      })
+    }
+
+    if kind == "source" {
+      checkpoint: close({
+        enabled: bool
+      })
+    }
+
+    if kind == "sink" {
+      compression: close({
+        enabled: bool | null
+      })
+    }
+
+    if kind == "sink" {
+      encoding: close({
+        enabled: true
+
+        if enabled {
+          default: null
+          json: null
+          ndjson: null
+          text: null
+        }
+      })
+    }
+
+    if kind == "sink" {
+      healthcheck: close({
+        enabled: bool
+      })
+    }
+
+    if kind == "source" {
+      multiline: close({
+        enabled: bool
+      })
+    }
+
+    if kind == "sink" {
+      request: close({
+        enabled: bool
+      })
+    }
+
+    if kind == "source" || kind == "sink" {
+      tls: {
+        enabled: bool
+
+        if enabled {
+          can_enable: bool
+          can_verify_certificate: bool
+          if kind == "sink" {
+            can_verify_hostname: bool
+          }
+          enabled_default: bool
+        }
+      }
+    }
+  })
+
   // The various statuses of this component.
   statuses: {
     if kind == "source" || kind == "sink" {
@@ -174,18 +251,20 @@ package metadata
   }
 
   // Markdown-based sections that describe how the component works.
-  how_it_works: [Name=string]: {
-    name: Name
-    title: string
-    body: string
-    sub_sections?: [...{
-      title: string
-      body: string
-    }]
-  }
+  how_it_works: #HowItWorks
 }
 
 #Fields: [Name=string]: #Fields | _
+
+#HowItWorks: [Name=string]: {
+  name: Name
+  title: string
+  body: string
+  sub_sections?: [...{
+    title: string
+    body: string
+  }]
+}
 
 #LogEvents: [Name=string]: {
   description: string

--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -1,3 +1,227 @@
+// Root
+//
+// The root file defines the schema for all of Vector's reference metadata.
+// It does not include boilerplate or domain specific policies.
+
 package metadata
 
- #Fields: [Name=string]: #Fields | _
+#ConfigurationOptions: [Name=string]: {
+  common: bool
+  description: string
+  groups: [...string]
+  name: Name
+  relevant_when?: string
+  required: bool
+  warnings: [...{
+    visibility_level: "component" | "option"
+    text: string
+  }]
+
+  if required {
+    common: true
+  }
+
+  sort?: int8
+  type: {
+    "[string]"?: {
+      if !required {
+        default: [...string] | null
+      }
+      examples?: [...[...string]]
+      templateable?: bool
+    }
+    "bool"?: {
+      if !required {
+        default: bool | null
+      }
+    }
+    "object"?: {
+      examples: [{[Name=string]: _}, ...]
+      options: #ConfigurationOptions | {}
+    }
+    "string"?: {
+      if !required {
+        default: string | null
+      }
+
+      enum?: [Name=_]: string
+
+      examples: [...string] | *[
+        for k, v in enum {
+          k,
+        }
+      ]
+
+      templateable?: bool
+    }
+    "uint"?: {
+      if !required {
+        default: uint | null
+      }
+      examples?: [...uint],
+      unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
+    }
+  }
+}
+
+#Components: [Type=string]: {
+  // The component kind. This is set automatically.
+  kind: "sink" | "source" | "transform"
+
+  // A long description of the component, full of relevant keywords for SEO
+  // purposes.
+  long_description: string
+
+  // A short, one sentence description.
+  short_description: string
+
+  // The component title, used in text. For example, the `http` source has
+  // a title of "HTTP".
+  title: string
+
+  // The component type. This is set automatically.
+  type: Type
+
+  // Classes represent the various classifications for this component
+  classes: {
+    // Is this component commonly used? If so, we'll feature it in various
+    // sections in our documentation.
+    commonly_used: bool
+
+    if kind == "source" {
+      // The deploment roles that this source is applicable in.
+      // For example, you would not use the `file` source in the `service`
+      // role.
+      deployment_roles: ["daemon" | "service" | "sidecar", ...]
+    }
+
+    // The behavior function for this component. This is used as a filter to
+    // help users find components that serve a function.
+    function: string
+
+    if kind == "sink" {
+      // Any service providers that host the downstream service.
+      service_providers: [...string]
+    }
+  }
+
+  // The various statuses of this component.
+  statuses: {
+    if kind == "source" || kind == "sink" {
+      // The delivery status. At least once means we guarantee that events
+      // will be delivered at least once. Best effort means there is potential
+      // for data loss.
+      delivery: "at_least_once" | "best_effort"
+    }
+
+    // The developmnet status of this component. Beta means the component is
+    // new and has not proven to be stable. Prod ready means that component
+    // is reliable and settled.
+    development: "beta" | "stable" | "deprecated"
+  }
+
+  // Various support details for the component.
+  support: {
+    if kind == "transform" || kind == "sink" {
+      input_types: ["log" | "metric", ...]
+    }
+
+    // The platforms that this component is available in. It is possible for
+    // Vector to disable some components on a per-platform basis.
+    platforms: {
+      "aarch64-unknown-linux-gnu": bool
+      "aarch64-unknown-linux-musl": bool
+      "x86_64-apple-darwin": bool
+      "x86_64-pc-windows-msv": bool
+      "x86_64-unknown-linux-gnu": bool
+      "x86_64-unknown-linux-musl": bool
+    }
+
+    // Any requirements for this component to work properly. This should note
+    // external dependencies or configuration. These will be displayed
+    // prominently at the top of the component's docs.
+    requirements: [...string] | null
+
+    // Any warnings for this component. This should address any "gotchas" as
+    // part of using this source.
+    warnings: [...string] | null
+  }
+
+  configuration: #ConfigurationOptions
+
+  // Output events for the component.
+  if kind == "source" || kind == "transform" {
+    output: {
+      logs?: #LogEvents
+      metrics?: #MetricEvents
+    }
+  }
+
+  // Example uses for the component.
+  examples: {
+    log: [
+      ...{
+        title: string
+        "configuration": {
+          for k, v in configuration {
+            "\( k )"?: _ | *null
+          }
+        }
+        input: #Fields | string
+        "output": #Fields
+      }
+    ]
+  }
+
+  // Markdown-based sections that describe how the component works.
+  how_it_works: [Name=string]: {
+    name: Name
+    title: string
+    body: string
+    sub_sections?: [...{
+      title: string
+      body: string
+    }]
+  }
+}
+
+#Fields: [Name=string]: #Fields | _
+
+#LogEvents: [Name=string]: {
+  description: string
+  name: Name
+  fields: [Name=string]: {
+    description: string
+    name: Name,
+    relevant_when?: string
+    required: bool
+    type: {
+      "*": {}
+      "string"?: {
+        examples: [string, ...string]
+      }
+      "timestamp"?: {
+        examples: ["2020-11-01T21:15:47.443232Z"]
+      }
+    }
+  }
+}
+
+#MetricEvents: [Name=string]: {
+  description: string
+  relevant_when?: string
+  tags: [Name=string]: {
+    description: string
+    examples: [string, ...]
+    required: bool
+    name: Name
+  }
+  name: Name
+  type: "counter" | "guage" | "histogram" | "summary"
+}
+
+components: close({
+  sources: #Components
+  transforms: #Components
+  sinks: #Components
+})

--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -1,339 +1,241 @@
 package metadata
 
-components: close({
-  #LogEvents: [Name=string]: {
-    description: string
-    name: Name
-    fields: [Name=string]: {
-      description: string
-      name: Name,
-      relevant_when?: string
-      required: bool
+components: {
+  _conditions: {
+    examples: [
+      {
+        type: "check_fields"
+        "message.eq": "foo"
+        "message.not_eq": "foo"
+        "message.exists": true
+        "message.not_exists": true
+        "message.contains": "foo"
+        "message.not_contains": "foo"
+        "message.ends_with": "foo"
+        "message.not_ends_with": "foo"
+        "message.ip_cidr_contains": "10.0.0.0/8"
+        "message.not_ip_cidr_contains": "10.0.0.0/8"
+        "message.regex": " (any|of|these|five|words) "
+        "message.not_regex": " (any|of|these|five|words) "
+        "message.starts_with": "foo"
+        "message.not_starts_with": "foo"
+      }
+    ]
+    options: {
       type: {
-        "string"?: {
-          examples: [string, ...string]
-        }
-        "timestamp"?: {
-          examples: ["2020-11-01T21:15:47.443232Z"]
-        }
-      }
-    }
-  }
-
-  #MetricEvents: [Name=string]: {
-    description: string
-    relevant_when?: string
-    tags: [Name=string]: {
-      description: string
-      examples: [string, ...]
-      required: bool
-      name: Name
-    }
-    name: Name
-    type: "counter" | "guage" | "histogram" | "summary"
-  }
-
-  #ConfigurationOptions: [Name=string]: {
-    common: bool
-    description: string
-    groups: [...string]
-    name: Name
-    relevant_when?: string
-    required: bool
-    warnings: [...{
-      visibility_level: "component" | "option"
-      text: string
-    }]
-
-    if required {
-      common: true
-    }
-
-    sort?: int8
-    type: {
-      "[string]"?: {
-        if !required {
-          default: [...string] | null
-        }
-        examples?: [...[...string]]
-        templateable?: bool
-      }
-      "bool"?: {
-        if !required {
-          default: bool | null
-        }
-      }
-      "object"?: {
-        examples: [{[Name=string]: _}, ...]
-        options: #ConfigurationOptions | {}
-      }
-      "string"?: {
-        if !required {
-          default: string | null
-        }
-
-        enum?: [Name=_]: string
-
-        examples: [...string] | *[
-          for k, v in enum {
-            k,
+        common:      true
+        description: "The type of the condition to execute."
+        required:    false
+        warnings: []
+        type: string: {
+          default: "check_fields"
+          enum: {
+            check_fields: "Allows you to check individual fields against a list of conditions."
+            is_log:       "Returns true if the event is a log."
+            is_metric:    "Returns true if the event is a metric."
           }
-        ]
-
-        templateable?: bool
-      }
-      "uint"?: {
-        if !required {
-          default: uint | null
         }
-        examples?: [...uint],
-        unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
+      }
+      "*.eq": {
+        common:      true
+        description: "Check whether a field's contents exactly matches the value specified, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: ["foo"]
+        }
+      }
+      "*.exists": {
+        common:      false
+        description: "Check whether a field exists or does not exist, depending on the provided value being `true` or `false` respectively."
+        required:    false
+        warnings: []
+        type: bool: default: null
+      }
+      "*.not_*": {
+        common:      false
+        description: "Allow you to negate any condition listed here."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: []
+        }
+      }
+      "*.contains": {
+        common:      true
+        description: "Checks whether a string field contains a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: ["foo"]
+        }
+      }
+      "*.ends_with": {
+        common:      true
+        description: "Checks whether a string field ends with a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: ["suffix"]
+        }
+      }
+      "*.ip_cidr_contains": {
+        common:      false
+        description: "Checks whether an IP field is contained within a given [IP CIDR][urls.cidr] (works with IPv4 and IPv6). This may be a single string or a list of strings, in which case this evaluates to true if the IP field is contained within any of the CIDRs in the list."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: ["10.0.0.0/8", "2000::/10", "192.168.0.0/16"]
+        }
+      }
+      "*.regex": {
+        common:      true
+        description: "Checks whether a string field matches a [regular expression][urls.regex]. Vector uses the [documented Rust Regex syntax][urls.rust_regex_syntax]. Note that this condition is considerably more expensive than a regular string match (such as `starts_with` or `contains`) so the use of those conditions are preferred where possible."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: [" (any|of|these|five|words) "]
+        }
+      }
+      "*.starts_with": {
+        common:      true
+        description: "Checks whether a string field starts with a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
+        required:    false
+        warnings: []
+        type: string: {
+          default: null
+          examples: ["prefix"]
+        }
       }
     }
   }
 
-  #Components: [Type=string]: {
-    // The component kind. This is set automatically.
-    kind: "sink" | "source" | "transform"
+  {[Kind=string]: [Name=string]: {
+    _features: {
+      tls: {
+        enabled: bool
 
-    // A long description of the component, full of relevant keywords for SEO
-    // purposes.
-    long_description: string
-
-    // A short, one sentence description.
-    short_description: string
-
-    // The component title, used in text. For example, the `http` source has
-    // a title of "HTTP".
-    title: string
-
-    // The component type. This is set automatically.
-    type: Type
-
-    // Classes represent the various classifications for this component
-    classes: {
-      // Is this component commonly used? If so, we'll feature it in various
-      // sections in our documentation.
-      commonly_used: bool
-
-      if kind == "source" {
-        // The deploment roles that this source is applicable in.
-        // For example, you would not use the `file` source in the `service`
-        // role.
-        deployment_roles: ["daemon" | "service" | "sidecar", ...]
-      }
-
-      // The behavior function for this component. This is used as a filter to
-      // help users find components that serve a function.
-      function: string
-
-      if kind == "sink" {
-        // Any service providers that host the downstream service.
-        service_providers: [...string]
+        if enabled {
+          can_enable: bool
+          can_verify_certificate: bool
+          can_verify_hostname: bool
+          enabled_default: bool
+        }
       }
     }
 
-    // The various statuses of this component.
-    statuses: {
-      if kind == "source" || kind == "sink" {
-        // The delivery status. At least once means we guarantee that events
-        // will be delivered at least once. Best effort means there is potential
-        // for data loss.
-        delivery: "at_least_once" | "best_effort"
-      }
+    configuration: {
+      if _features.tls.enabled {
+        tls: {
+          common: false
+          description: "Configures the TLS options for connections from this source."
+          required: false
+          type: object: options: {
+            if _features.tls.can_enable {
+              enabled: {
+                common: false
+                description: "Require TLS for incoming connections. If this is set, an identity certificate is also required."
+                required: false
+                type: bool: default: _features.tls.enabled_default
+              }
+            }
 
-      // The developmnet status of this component. Beta means the component is
-      // new and has not proven to be stable. Prod ready means that component
-      // is reliable and settled.
-      development: "beta" | "stable" | "deprecated"
-    }
+            ca_file: {
+              common: false
+              description: "Absolute path to an additional CA certificate file, in DER or PEM format (X.509), or an in-line CA certificate in PEM format."
+              required: false
+              type: string: {
+                default: null
+                examples: ["/path/to/certificate_authority.crt"]
+              }
+            }
+            crt_file: {
+              common: false
+              description: "Absolute path to a certificate file used to identify this server, in DER or PEM format (X.509) or PKCS#12, or an in-line certificate in PEM format. If this is set, and is not a PKCS#12 archive, `key_file` must also be set. This is required if `enabled` is set to `true`."
+              required: false
+              type: string: {
+                default: null
+                examples: ["/path/to/host_certificate.crt"]
+              }
+            }
+            key_file: {
+              common: false
+              description: "Absolute path to a private key file used to identify this server, in DER or PEM format (PKCS#8), or an in-line private key in PEM format."
+              required: false
+              type: string: {
+                default: null
+                examples: ["/path/to/host_certificate.key"]
+              }
+            }
+            key_pass: {
+              common: false
+              description: "Pass phrase used to unlock the encrypted key file. This has no effect unless `key_file` is set."
+              required: false
+              type: string: {
+                default: null
+                examples: ["${KEY_PASS_ENV_VAR}", "PassWord1"]
+              }
+            }
 
-    // Various support details for the component.
-    support: {
-      if kind == "transform" || kind == "sink" {
-        input_types: ["log" | "metric", ...]
-      }
+            if _features.tls.enabled_default {
+              verify_certificate: {
+                common: false
+                description: "If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if the certificate is not valid. If `false` (the default), Vector will not request a certificate from the client."
+                required: false
+                type: bool: default: false
+              }
+            }
 
-      // The platforms that this component is available in. It is possible for
-      // Vector to disable some components on a per-platform basis.
-      platforms: {
-        "aarch64-unknown-linux-gnu": bool
-        "aarch64-unknown-linux-musl": bool
-        "x86_64-apple-darwin": bool
-        "x86_64-pc-windows-msv": bool
-        "x86_64-unknown-linux-gnu": bool
-        "x86_64-unknown-linux-musl": bool
-      }
-
-      // Any requirements for this component to work properly. This should note
-      // external dependencies or configuration. These will be displayed
-      // prominently at the top of the component's docs.
-      requirements: [...string] | null
-
-      // Any warnings for this component. This should address any "gotchas" as
-      // part of using this source.
-      warnings: [...string] | null
-    }
-
-    configuration: #ConfigurationOptions & {
-      _conditions: {
-        examples: [
-          {
-            type: "check_fields"
-            "message.eq": "foo"
-            "message.not_eq": "foo"
-            "message.exists": true
-            "message.not_exists": true
-            "message.contains": "foo"
-            "message.not_contains": "foo"
-            "message.ends_with": "foo"
-            "message.not_ends_with": "foo"
-            "message.ip_cidr_contains": "10.0.0.0/8"
-            "message.not_ip_cidr_contains": "10.0.0.0/8"
-            "message.regex": " (any|of|these|five|words) "
-            "message.not_regex": " (any|of|these|five|words) "
-            "message.starts_with": "foo"
-            "message.not_starts_with": "foo"
-          }
-        ]
-        options: {
-          type: {
-            common:      true
-            description: "The type of the condition to execute."
-            required:    false
-            warnings: []
-            type: string: {
-              default: "check_fields"
-              enum: {
-                check_fields: "Allows you to check individual fields against a list of conditions."
-                is_log:       "Returns true if the event is a log."
-                is_metric:    "Returns true if the event is a metric."
+            if _features.tls.can_verify_hostname {
+              verify_hostname: {
+                common: false
+                description: "If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote host name."
+                required: false
+                type: bool: default: true
               }
             }
           }
-          "*.eq": {
-            common:      true
-            description: "Check whether a field's contents exactly matches the value specified, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: ["foo"]
-            }
-          }
-          "*.exists": {
-            common:      false
-            description: "Check whether a field exists or does not exist, depending on the provided value being `true` or `false` respectively."
-            required:    false
-            warnings: []
-            type: bool: default: null
-          }
-          "*.not_*": {
-            common:      false
-            description: "Allow you to negate any condition listed here."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: []
-            }
-          }
-          "*.contains": {
-            common:      true
-            description: "Checks whether a string field contains a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: ["foo"]
-            }
-          }
-          "*.ends_with": {
-            common:      true
-            description: "Checks whether a string field ends with a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: ["suffix"]
-            }
-          }
-          "*.ip_cidr_contains": {
-            common:      false
-            description: "Checks whether an IP field is contained within a given [IP CIDR][urls.cidr] (works with IPv4 and IPv6). This may be a single string or a list of strings, in which case this evaluates to true if the IP field is contained within any of the CIDRs in the list."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: ["10.0.0.0/8", "2000::/10", "192.168.0.0/16"]
-            }
-          }
-          "*.regex": {
-            common:      true
-            description: "Checks whether a string field matches a [regular expression][urls.regex]. Vector uses the [documented Rust Regex syntax][urls.rust_regex_syntax]. Note that this condition is considerably more expensive than a regular string match (such as `starts_with` or `contains`) so the use of those conditions are preferred where possible."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: [" (any|of|these|five|words) "]
-            }
-          }
-          "*.starts_with": {
-            common:      true
-            description: "Checks whether a string field starts with a string argument, case sensitive. This may be a single string or a list of strings, in which case this evaluates to true if any of the list matches."
-            required:    false
-            warnings: []
-            type: string: {
-              default: null
-              examples: ["prefix"]
-            }
-          }
         }
       }
+
       "type": {
         description: "The component type. This is a required field for all components and tells Vector which component to use."
         required: true
         sort: -2
         "type": string: enum:
-          "(Name)": "The type of this component."
+          "\(Name)": "The type of this component."
       }
     }
 
-    // Output events for the component.
-    output: {
-      logs?: #LogEvents
-      metrics?: #MetricEvents
-    }
 
-    // Example uses for the component.
-    examples: {
-      log: [
-        ...{
-          title: string
-          "configuration": {
-            for k, v in configuration {
-              "\( k )"?: _ | *null
-            }
-          }
-          input: #Fields | string
-          "output": #Fields
+    how_it_works: {
+      environment_variables: {
+        title: "Environment Variables"
+        body: #"""
+              Environment variables are supported through all of Vector's
+              configuration. Simply add ${MY_ENV_VAR} in your Vector
+              configuration file and the variable will be replaced before being
+              evaluated.
+
+              Learn more in the [configuration manual](/docs/manual/setup/configuration).
+              """#
+      }
+
+      if _features.tls.enabled {
+        tls: {
+          title: "Transport Layer Security (TLS)"
+          body: #"""
+                Vector uses [Openssl][urls.openssl] for TLS protocols. You can
+                enable and adjust TLS behavior via the `tls.*` options.
+                """#
         }
-      ]
+      }
     }
-
-    // Markdown-based sections that describe how the component works.
-    how_it_works: [Name=string]: {
-      name: Name
-      title: string
-      body: string
-      sub_sections?: [...{
-        title: string
-        body: string
-      }]
-    }
-  }
-
-  sources: #Components
-  transforms: #Components
-  sinks: #Components
-})
+  }}
+}

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -2,15 +2,4 @@ package metadata
 
 components: sinks: [Name=string]: {
   kind: "sink"
-
-  _features: {
-    batch: {
-      enabled: bool
-      common: bool,
-      max_bytes: uint | null,
-      max_events: uint | null,
-      timeout_secs: uint8
-    }
-    buffer: enabled: bool
-  }
 }

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -1,0 +1,16 @@
+package metadata
+
+components: sinks: [Name=string]: {
+  kind: "sink"
+
+  _features: {
+    batch: {
+      enabled: bool
+      common: bool,
+      max_bytes: uint | null,
+      max_events: uint | null,
+      timeout_secs: uint8
+    }
+    buffer: enabled: bool
+  }
+}

--- a/docs/reference/components/sinks/azure_monitor_logs.cue
+++ b/docs/reference/components/sinks/azure_monitor_logs.cue
@@ -5,12 +5,18 @@ components: sinks: azure_monitor_logs: {
   short_description: "Batches log events to [Azure Monitor's][urls.azure_monitor] logs via the [REST endpoint][urls.azure_monitor_logs_endpoints]."
   long_description: "[Azure Monitor][urls.azure_monitor] is a service in Azure that provides performance and availability monitoring for applications and services in Azure, other cloud environments, or on-premises. Azure Monitor collects data from multiple sources into a common data platform where it can be analyzed for trends and anomalies."
 
-  _features: {
+  classes: {
+    commonly_used: false
+    function: "transmit"
+    service_providers: ["Azure"]
+  }
+
+  features: {
     batch: {
       enabled: true
-      common: false,
-      max_bytes: 30000000,
-      max_events: null,
+      common: false
+      max_bytes: 30000000
+      max_events: null
       timeout_secs: 1
     }
     buffer: enabled: true
@@ -31,12 +37,6 @@ components: sinks: azure_monitor_logs: {
       can_verify_hostname: true
       enabled_default: true
     }
-  }
-
-  classes: {
-    commonly_used: false
-    function: "transmit"
-    service_providers: ["Azure"]
   }
 
   statuses: {

--- a/docs/reference/components/sinks/azure_monitor_logs.cue
+++ b/docs/reference/components/sinks/azure_monitor_logs.cue
@@ -14,7 +14,6 @@ components: sinks: azure_monitor_logs: {
       timeout_secs: 1
     }
     buffer: enabled: true
-    checkpoint: enabled: false
     compression: enabled: false
     encoding: {
       enabled: true
@@ -24,7 +23,6 @@ components: sinks: azure_monitor_logs: {
       text: null
     }
     healthcheck: enabled: true
-    multiline: enabled: false
     request: enabled: false
     tls: {
       enabled: true

--- a/docs/reference/components/sources.cue
+++ b/docs/reference/components/sources.cue
@@ -9,13 +9,13 @@ components: sources: [Name=string]: {
     function: "collect" | "receive" | "test"
   }
 
-  _features: {
+  features: {
     checkpoint: enabled: bool
     multiline: enabled: bool
   }
 
   configuration: {
-    if _features.checkpoint.enabled {
+    if features.checkpoint.enabled {
       data_dir: {
         common: false
         description: "The directory used to persist file checkpoint positions. By default, the [global `data_dir` option][docs.global-options#data_dir] is used. Please make sure the Vector project has write permissions to this dir."
@@ -27,7 +27,7 @@ components: sources: [Name=string]: {
       }
     }
 
-    if _features.multiline.enabled {
+    if features.multiline.enabled {
       multiline: {
         common: false
         description: "Multiline parsing configuration. If not specified, multiline parsing is disabled."
@@ -98,7 +98,7 @@ components: sources: [Name=string]: {
   }
 
   how_it_works: {
-    if _features.checkpoint.enabled {
+    if features.checkpoint.enabled {
       checkpointing: {
         title: "Checkpointing"
         body: #"""

--- a/docs/reference/components/sources.cue
+++ b/docs/reference/components/sources.cue
@@ -12,21 +12,11 @@ components: sources: [Name=string]: {
   _features: {
     checkpoint: enabled: bool
     multiline: enabled: bool
-    tls: {
-      enabled: bool
-
-      if enabled {
-        can_enable: bool
-        can_verify_certificate: bool
-        can_verify_hostname: bool
-        enabled_default: bool
-      }
-    }
   }
 
   configuration: {
     if _features.checkpoint.enabled {
-      _data_dir: {
+      data_dir: {
         common: false
         description: "The directory used to persist file checkpoint positions. By default, the [global `data_dir` option][docs.global-options#data_dir] is used. Please make sure the Vector project has write permissions to this dir."
         required: false
@@ -73,79 +63,6 @@ components: sources: [Name=string]: {
             type: uint: {
               examples: [1_000, 600_000]
               unit: "milliseconds"
-            }
-          }
-        }
-      }
-    }
-
-    if _features.tls.enabled {
-      tls: {
-        common: false
-        description: "Configures the TLS options for connections from this source."
-        required: false
-        type: object: options: {
-          if _features.tls.can_enable {
-            enabled: {
-              common: false
-              description: "Require TLS for incoming connections. If this is set, an identity certificate is also required."
-              required: false
-              type: bool: default: _features.tls.enabled_default
-            }
-          }
-
-          ca_file: {
-            common: false
-            description: "Absolute path to an additional CA certificate file, in DER or PEM format (X.509), or an in-line CA certificate in PEM format."
-            required: false
-            type: string: {
-              default: null
-              examples: ["/path/to/certificate_authority.crt"]
-            }
-          }
-          crt_file: {
-            common: false
-            description: "Absolute path to a certificate file used to identify this server, in DER or PEM format (X.509) or PKCS#12, or an in-line certificate in PEM format. If this is set, and is not a PKCS#12 archive, `key_file` must also be set. This is required if `enabled` is set to `true`."
-            required: false
-            type: string: {
-              default: null
-              examples: ["/path/to/host_certificate.crt"]
-            }
-          }
-          key_file: {
-            common: false
-            description: "Absolute path to a private key file used to identify this server, in DER or PEM format (PKCS#8), or an in-line private key in PEM format."
-            required: false
-            type: string: {
-              default: null
-              examples: ["/path/to/host_certificate.key"]
-            }
-          }
-          key_pass: {
-            common: false
-            description: "Pass phrase used to unlock the encrypted key file. This has no effect unless `key_file` is set."
-            required: false
-            type: string: {
-              default: null
-              examples: ["${KEY_PASS_ENV_VAR}", "PassWord1"]
-            }
-          }
-
-          if _features.tls.enabled_default {
-            verify_certificate: {
-              common: false
-              description: "If `true`, Vector will require a TLS certificate from the connecting host and terminate the connection if the certificate is not valid. If `false` (the default), Vector will not request a certificate from the client."
-              required: false
-              type: bool: default: false
-            }
-          }
-
-          if _features.tls.can_verify_hostname {
-            verify_hostname: {
-              common: false
-              description: "If `true` (the default), Vector will validate the configured remote host name against the remote host's TLS certificate. Do NOT set this to `false` unless you understand the risks of not verifying the remote host name."
-              required: false
-              type: bool: default: true
             }
           }
         }
@@ -201,28 +118,6 @@ components: sources: [Name=string]: {
             By default, the `\( Name )` source will augment events with helpful
             context keys as shown in the "Output" section.
             """#
-    }
-
-    environment_variables: {
-      title: "Environment Variables"
-      body: #"""
-            Environment variables are supported through all of Vector's
-            configuration. Simply add ${MY_ENV_VAR} in your Vector
-            configuration file and the variable will be replaced before being
-            evaluated.
-
-            Learn more in the [configuration manual](/docs/manual/setup/configuration).
-            """#
-    }
-
-    if _features.tls.enabled {
-      tls: {
-        title: "Transport Layer Security (TLS)"
-        body: #"""
-              Vector uses [Openssl][urls.openssl] for TLS protocols. You can
-              enable and adjust TLS behavior via the `tls.*` options.
-              """#
-      }
     }
   }
 }

--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -5,16 +5,16 @@ components: sources: apache_metrics: {
   long_description: "fill me in"
   short_description: "Collect metrics from an Apache HTTPD server."
 
-  _features: {
-    checkpoint: enabled: false
-    multiline: enabled: false
-    tls: enabled: false
-  }
-
   classes: {
     commonly_used: false
     deployment_roles: ["daemon", "sidecar"]
     function: "collect"
+  }
+
+  features: {
+    checkpoint: enabled: false
+    multiline: enabled: false
+    tls: enabled: false
   }
 
   statuses: {
@@ -51,7 +51,6 @@ components: sources: apache_metrics: {
   configuration: {
     endpoints: {
       description: "mod_status endpoints to scrape metrics from."
-      common: true
       required: true
       type: "[string]": {
         examples: [["http://localhost:8080/server-status/?auto"]]

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -5,16 +5,16 @@ components: sources: file: {
   long_description: ""
   short_description: "Collect logs by tailing one more files."
 
-  _features: {
-    checkpoint: enabled: true
-    multiline: enabled: true
-    tls: enabled: false
-  }
-
   classes: {
     commonly_used: true
     deployment_roles: ["daemon", "sidecar"]
     function: "collect"
+  }
+
+  features: {
+    checkpoint: enabled: true
+    multiline: enabled: true
+    tls: enabled: false
   }
 
   statuses: {
@@ -121,7 +121,6 @@ components: sources: file: {
       }
     }
     include: {
-      common: true
       description: "Array of file patterns to include. [Globbing](#globbing) is supported."
       required: true
       type: "[string]": examples: [["/var/log/nginx/*.log"]]

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -5,22 +5,21 @@ components: sources: http: {
   long_description: ""
   short_description: "Receive logs through the HTTP protocol"
 
-  _features: {
+  classes: {
+    commonly_used: false
+    deployment_roles: ["service", "sidecar"]
+    function: "receive"
+  }
+
+  features: {
     checkpoint: enabled: false
     multiline: enabled: false
     tls: {
       enabled: true
       can_enable: false
       can_verify_certificate: true
-      can_verify_hostname: true
       enabled_default: false
     }
-  }
-
-  classes: {
-    commonly_used: false
-    deployment_roles: ["service", "sidecar"]
-    function: "receive"
   }
 
   statuses: {

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -99,7 +99,7 @@ components: sources: http: {
           description: "Any field contained in your JSON payload"
           relevant_when: "`encoding` != \"text\""
           required: false
-          type: _
+          type: "*": {}
         }
         timestamp: fields._timestamp
       }

--- a/docs/reference/components/transforms.cue
+++ b/docs/reference/components/transforms.cue
@@ -3,8 +3,6 @@ package metadata
 components: transforms: [Name=string]: {
   kind: "transform"
 
-  _features: tls: enabled: false
-
   // Example uses for the component.
   examples: {
     log: [

--- a/docs/reference/components/transforms.cue
+++ b/docs/reference/components/transforms.cue
@@ -3,6 +3,8 @@ package metadata
 components: transforms: [Name=string]: {
   kind: "transform"
 
+  _features: tls: enabled: false
+
   // Example uses for the component.
   examples: {
     log: [

--- a/docs/reference/components/transforms/swimlanes.cue
+++ b/docs/reference/components/transforms/swimlanes.cue
@@ -5,12 +5,6 @@ components: transforms: swimlanes: {
 	short_description: "Accepts log events and allows you to route events across parallel streams using logical filters."
 	long_description:  "Accepts log events and allows you to route events across parallel streams using logical filters."
 
-	_features: {
-		checkpoint: enabled: false
-		multiline: enabled:  false
-		tls: enabled:        false
-	}
-
 	classes: {
 		commonly_used: false
 		function:      "route"
@@ -41,7 +35,7 @@ components: transforms: swimlanes: {
 			description: "A table of swimlane identifiers to logical conditions representing the filter of the swimlane. Each swimlane can then be referenced as an input by other components with the name `<transform_name>.<swimlane_id>`."
 			required:    true
 			warnings: []
-			type: object: configuration._conditions
+			type: object: components._conditions
 		}
 	}
 


### PR DESCRIPTION
This cleans up the cue base schema:

* The `docs/reference.cue` defines the entire schema as recommended by the Cue docs.
* The intermediate files enforce domain-specific policies and boilerplate.
* The leaves define the actual data.