### PR TITLE
chore(external docs): Add options to `cue vet` command line

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -21,7 +21,7 @@ if ! [ -x "$(command -v cue)" ]; then
   exit 1
 fi
 
-errors=$(cue vet ${DOCS_PATH}/*.cue ${DOCS_PATH}/**/*.cue)
+errors=$(cue vet --concrete --all-errors ${DOCS_PATH}/*.cue ${DOCS_PATH}/**/*.cue)
 
 if [ -n "$errors" ]; then
   printf "Failed!\n\n%s\n" "${errors}"


### PR DESCRIPTION
When a component instance is not completely specified, `cue vet`
produces the less than helpful error that `some instances are
incomplete; use the -c flag to show errors or suppress this message`.
Adding the `--concrete` option causes it to produce messages about which
specific fields were incomplete.

Additionally, the `--all-errors` causes `cue vet` to print all the
errors rather than just the first, reducing the number of
trial-and-error cycles necessary.

Signed-off-by: Bruce Guenter <bruce@timber.io>