### PR TITLE
fix(apache_metrics source): Use configured namespace for `up` metric

### DIFF
--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -16,6 +16,7 @@ use futures::{
 use futures01::Sink;
 use hyper::{Body, Client, Request};
 use hyper_openssl::HttpsConnector;
+use parser::encode_namespace;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::collections::BTreeMap;
@@ -132,7 +133,7 @@ fn apache_metrics(
 
                             let results = parser::parse(&body, &namespace, Utc::now(), Some(&tags))
                                 .chain(vec![Ok(Metric {
-                                    name: "apache_up".into(),
+                                    name: encode_namespace(&namespace, "up"),
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
@@ -165,7 +166,7 @@ fn apache_metrics(
                             });
                             Some(
                                 stream::iter(vec![Metric {
-                                    name: "apache_up".into(),
+                                    name: encode_namespace(&namespace, "up"),
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
@@ -182,7 +183,7 @@ fn apache_metrics(
                             });
                             Some(
                                 stream::iter(vec![Metric {
-                                    name: "apache_up".into(),
+                                    name: encode_namespace(&namespace, "up"),
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
@@ -281,7 +282,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         let source = ApacheMetricsConfig {
             endpoints: vec![format!("http://{}", in_addr)],
             scrape_interval_secs: 1,
-            namespace: "apache".to_string(),
+            namespace: "custom".to_string(),
         }
         .build(
             "default",
@@ -303,7 +304,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             .map(|e| e.into_metric())
             .collect::<Vec<_>>();
 
-        match metrics.iter().find(|m| m.name == "apache_up") {
+        match metrics.iter().find(|m| m.name == "custom_up") {
             Some(m) => assert_eq!(m.value, MetricValue::Gauge { value: 1.0 }),
             None => error!("could not find apache_up metric in {:?}", metrics),
         }
@@ -377,7 +378,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         let source = ApacheMetricsConfig {
             endpoints: vec![format!("http://{}", in_addr)],
             scrape_interval_secs: 1,
-            namespace: "apache".to_string(),
+            namespace: "custom".to_string(),
         }
         .build(
             "default",
@@ -399,7 +400,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             .map(|e| e.into_metric())
             .collect::<Vec<_>>();
 
-        match metrics.iter().find(|m| m.name == "apache_up") {
+        match metrics.iter().find(|m| m.name == "custom_up") {
             Some(m) => assert_eq!(m.value, MetricValue::Gauge { value: 0.0 }),
             None => error!("could not find apache_up metric in {:?}", metrics),
         }

--- a/src/sources/apache_metrics/parser.rs
+++ b/src/sources/apache_metrics/parser.rs
@@ -143,6 +143,13 @@ pub fn parse(
         .into_iter()
 }
 
+pub fn encode_namespace(namespace: &str, name: &str) -> String {
+    match namespace {
+        "" => name.to_string(),
+        _ => format!("{}_{}", namespace, name),
+    }
+}
+
 fn line_to_metrics<'a>(
     key: &str,
     value: &str,
@@ -372,13 +379,6 @@ fn score_to_metric(
         value: MetricValue::Gauge {
             value: count.into(),
         },
-    }
-}
-
-fn encode_namespace(namespace: &str, name: &str) -> String {
-    match namespace {
-        "" => name.to_string(),
-        _ => format!("{}_{}", namespace, name),
     }
 }
 


### PR DESCRIPTION
Was previously hardcoding `apache_up` as the metric.

I was going to refactor this namespace encoding to share among metrics sources, but figured I'd punt in-lieu of #3896 which I hope to get to next sprint, which would make it a first-class field on the `Metric` type.
