### PR TITLE
chore(ci): Only check for diffs in the docs for `make check-docs`

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -22,12 +22,12 @@ fi
 echo "Validating ${DOCS_PATH}/**/*.cue formatting."
 
 cue fmt ${DOCS_PATH}/**/*.cue
-status="$(git status --porcelain docs)"
+status="$(git status --porcelain ${DOCS_PATH})"
 
 [[ -z "$status" ]] || {
 	echo >&2 "Incorrectly formatted Cue files"
 	echo >&2 "$status"
-	git diff docs
+	git diff ${DOCS_PATH}
 	exit 1
 }
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -22,12 +22,12 @@ fi
 echo "Validating ${DOCS_PATH}/**/*.cue formatting."
 
 cue fmt ${DOCS_PATH}/**/*.cue
-status="$(git status --porcelain)"
+status="$(git status --porcelain docs)"
 
 [[ -z "$status" ]] || {
 	echo >&2 "Incorrectly formatted Cue files"
 	echo >&2 "$status"
-	git diff
+	git diff docs
 	exit 1
 }
 


### PR DESCRIPTION
The check previously picking up changes to `Cargo.toml` and `.cargo/config` that happen as part of `make slim-builds` in CI.

Example: https://github.com/timberio/vector/pull/4101/checks?check_run_id=1226461323#step:9:15