### PR TITLE
fix(networking): Adjust auto concurrency tuning defaults

### DIFF
--- a/src/sinks/util/auto_concurrency/mod.rs
+++ b/src/sinks/util/auto_concurrency/mod.rs
@@ -18,24 +18,26 @@ pub(self) fn instant_now() -> std::time::Instant {
     tokio::time::Instant::now().into()
 }
 
+// The defaults for these values were chosen after running several
+// simulations on a test service that had various responses to load. The
+// values are the best balances found between competing outcomes.
 #[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 pub struct AutoConcurrencySettings {
+    // This value maintained high concurrency without holding it too
+    // high under adverse conditions.
     #[serde(default)]
     #[derivative(Default(value = "0.9"))]
     pub(super) decrease_ratio: f64,
 
-    // This value was picked as a reasonable default while we ensure the
-    // viability of the system. This value may need adjustment if later
-    // analysis discovers we need higher or lower weighting on past RTT
-    // weighting.
+    // This value achieved the best balance between quick response and
+    // stability.
     #[serde(default)]
-    #[derivative(Default(value = "0.5"))]
+    #[derivative(Default(value = "0.7"))]
     pub(super) ewma_alpha: f64,
 
-    // This was picked as a reasonable default threshold ratio to avoid
-    // dropping concurrency too aggressively when there is fluctuation
-    // in the RTT measurements.
+    // This value avoided changing concurrency too aggressively when
+    // there is fluctuation in the RTT measurements.
     #[serde(default)]
     #[derivative(Default(value = "0.05"))]
     pub(super) rtt_threshold_ratio: f64,

--- a/tests/data/auto-concurrency/constant-link.toml
+++ b/tests/data/auto-concurrency/constant-link.toml
@@ -7,11 +7,11 @@ delay = 0.100
 
 [stats.in_flight]
 max = [22, 29]
-mean = [10.0, 13.0]
+mean = [10.0, 14.0]
 
 [controller.in_flight]
 max = [22, 29]
-mean = [10.0, 13.0]
+mean = [10.0, 14.0]
 
 [controller.concurrency_limit]
 max = [22, 30]

--- a/tests/data/auto-concurrency/constant-link.toml
+++ b/tests/data/auto-concurrency/constant-link.toml
@@ -15,7 +15,7 @@ mean = [10.0, 13.0]
 
 [controller.concurrency_limit]
 max = [22, 30]
-mode = [10, 25]
+mode = [10, 30]
 mean = [10.0, 15.0]
 
 [controller.observed_rtt]

--- a/tests/data/auto-concurrency/jittery-link-small.toml
+++ b/tests/data/auto-concurrency/jittery-link-small.toml
@@ -8,15 +8,15 @@ jitter = 0.1
 
 [stats.in_flight]
 max = [20, 35]
-mean = [10.0, 20.0]
+mean = [9.0, 20.0]
 
 [controller.in_flight]
 max = [20, 35]
-mean = [10.0, 20.0]
+mean = [9.0, 20.0]
 
 [controller.concurrency_limit]
 max = [20, 35]
-mean = [10.0, 20.0]
+mean = [9.0, 20.0]
 
 [controller.observed_rtt]
 mean = [0.100, 0.130]


### PR DESCRIPTION
I used the `http_test_server` to run many tests, average the data, and then eyeball the graphs to see which produced the best results. The only parameter that needed obvious tuning was `ewma_alpha`. I still think we are not doing the right thing with the `rtt_threshold_ratio`  parameter, but it's not clear how to do it better. More testing on #3671 may point to a better solution.

@jszwedko @binarylogic I can clean up the scripts I used and contribute them to https://github.com/timberio/http_test_server if you think it's worth they're having around for posterity. They're a bit of a one-shot mess at the moment though.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes: #2530 