### PR TITLE
chore(external docs): Make cue option types stricter

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -61,16 +61,15 @@ package metadata
 			templateable?: bool
 		}}) |
 		close({"uint": {
-				if !required {
-					default: uint | null
-				}
-				examples?: [...uint]
-				unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
-			}}) |
-		close({"object": {
-				examples: [...{[Name=string]: _}]
-				options: #ConfigurationOptions | {}
+			if !required {
+				default: uint | null
 			}
+			examples?: [...uint]
+			unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
+		}}) |
+		close({"object": {
+			examples: [...{[Name=string]: _}]
+			options: #ConfigurationOptions | {}
 		}})
 }
 

--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -23,9 +23,9 @@ package metadata
 
 	sort?: int8
 
-	type: {
-		"*"?: {}
-		"[string]"?: {
+	type:
+		close({"*": {}}) |
+		close({"[string]": {
 			if !required {
 				default: [...string] | null
 			}
@@ -39,17 +39,13 @@ package metadata
 			]]
 
 			templateable?: bool
-		}
-		"bool"?: {
+		}}) |
+		close({"bool": {
 			if !required {
 				default: bool | null
 			}
-		}
-		"object"?: {
-			examples: [...{[Name=string]: _}]
-			options: #ConfigurationOptions | {}
-		}
-		"string"?: {
+		}}) |
+		close({"string": {
 			if !required {
 				default: string | null
 			}
@@ -63,15 +59,19 @@ package metadata
 			]
 
 			templateable?: bool
-		}
-		"uint"?: {
-			if !required {
-				default: uint | null
+		}}) |
+		close({"uint": {
+				if !required {
+					default: uint | null
+				}
+				examples?: [...uint]
+				unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
+			}}) |
+		close({"object": {
+				examples: [...{[Name=string]: _}]
+				options: #ConfigurationOptions | {}
 			}
-			examples?: [...uint]
-			unit: "bytes" | "logs" | "milliseconds" | "seconds" | null
-		}
-	}
+		}})
 }
 
 #Components: [Type=string]: {


### PR DESCRIPTION
This implements the suggestion in https://github.com/timberio/vector/issues/4303#issuecomment-704735708. Unfortunately, this significantly increases the `cue export ...` time to the point where it won't finish. I've confirmed that each clause increases the `export` time exponentially. The first 4 additions completed in under 30 seconds.