### PR TITLE
chore(external docs): Add `classes.egress_method` to tighten up `exam…

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -278,7 +278,7 @@ package metadata
 						"\( k )"?: _ | *null
 					}
 				}
-				input:  #LogEvent | [#LogEvent, ...] | string
+				input: #LogEvent | [#LogEvent, ...] | string
 
 				if classes.egress_method == "batch" {
 					output: [#LogEvent, ...] | null
@@ -299,7 +299,7 @@ package metadata
 						"\( k )"?: _ | *null
 					}
 				}
-				input:  #MetricEvent
+				input: #MetricEvent
 
 				if classes.egress_method == "batch" {
 					output: [#MetricEvent, ...] | null

--- a/docs/reference/components/sinks/azure_monitor_logs.cue
+++ b/docs/reference/components/sinks/azure_monitor_logs.cue
@@ -7,6 +7,7 @@ components: sinks: azure_monitor_logs: {
 
 	classes: {
 		commonly_used: false
+		egress_method: "batch"
 		function:      "transmit"
 		service_providers: ["Azure"]
 	}

--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -8,6 +8,7 @@ components: sources: apache_metrics: {
 	classes: {
 		commonly_used: false
 		deployment_roles: ["daemon", "sidecar"]
+		egress_method: "batch"
 		function: "collect"
 	}
 

--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -9,7 +9,7 @@ components: sources: apache_metrics: {
 		commonly_used: false
 		deployment_roles: ["daemon", "sidecar"]
 		egress_method: "batch"
-		function: "collect"
+		function:      "collect"
 	}
 
 	features: {

--- a/docs/reference/components/sources/aws_kinesis_firehose.cue
+++ b/docs/reference/components/sources/aws_kinesis_firehose.cue
@@ -8,6 +8,7 @@ components: sources: aws_kinesis_firehose: {
 	classes: {
 		commonly_used: false
 		deployment_roles: ["service"]
+		egress_method: "batch"
 		function: "receive"
 	}
 
@@ -119,12 +120,12 @@ components: sources: aws_kinesis_firehose: {
 					}
 				```
 				"""
-			output: {
+			output: [{
 				request_id: "ed1d787c-b9e2-4631-92dc-8e7c9d26d804"
 				source_arn: "arn:aws:firehose:us-east-1:111111111111:deliverystream/test"
 				timestamp:  "2020-09-14T19:12:40.138Z"
 				message:    "{\"messageType\":\"DATA_MESSAGE\",\"owner\":\"111111111111\",\"logGroup\":\"test\",\"logStream\":\"test\",\"subscriptionFilters\":[\"Destination\"],\"logEvents\":[{\"id\":\"35683658089614582423604394983260738922885519999578275840\",\"timestamp\":1600110569039,\"message\":\"{\\\"bytes\\\":26780,\\\"datetime\\\":\\\"14/Sep/2020:11:45:41 -0400\\\",\\\"host\\\":\\\"157.130.216.193\\\",\\\"method\\\":\\\"PUT\\\",\\\"protocol\\\":\\\"HTTP/1.0\\\",\\\"referer\\\":\\\"https://www.principalcross-platform.io/markets/ubiquitous\\\",\\\"request\\\":\\\"/expedite/convergence\\\",\\\"source_type\\\":\\\"stdin\\\",\\\"status\\\":301,\\\"user-identifier\\\":\\\"-\\\"}\"},{\"id\":\"35683658089659183914001456229543810359430816722590236673\",\"timestamp\":1600110569041,\"message\":\"{\\\"bytes\\\":17707,\\\"datetime\\\":\\\"14/Sep/2020:11:45:41 -0400\\\",\\\"host\\\":\\\"109.81.244.252\\\",\\\"method\\\":\\\"GET\\\",\\\"protocol\\\":\\\"HTTP/2.0\\\",\\\"referer\\\":\\\"http://www.investormission-critical.io/24/7/vortals\\\",\\\"request\\\":\\\"/scale/functionalities/optimize\\\",\\\"source_type\\\":\\\"stdin\\\",\\\"status\\\":502,\\\"user-identifier\\\":\\\"feeney1708\\\"}\"}]}"
-			}
+			}]
 		},
 	]
 

--- a/docs/reference/components/sources/aws_kinesis_firehose.cue
+++ b/docs/reference/components/sources/aws_kinesis_firehose.cue
@@ -9,7 +9,7 @@ components: sources: aws_kinesis_firehose: {
 		commonly_used: false
 		deployment_roles: ["service"]
 		egress_method: "batch"
-		function: "receive"
+		function:      "receive"
 	}
 
 	features: {

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -9,7 +9,7 @@ components: sources: file: {
 		commonly_used: true
 		deployment_roles: ["daemon", "sidecar"]
 		egress_method: "stream"
-		function: "collect"
+		function:      "collect"
 	}
 
 	features: {

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -8,6 +8,7 @@ components: sources: file: {
 	classes: {
 		commonly_used: true
 		deployment_roles: ["daemon", "sidecar"]
+		egress_method: "stream"
 		function: "collect"
 	}
 

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -8,6 +8,7 @@ components: sources: host_metrics: {
 	classes: {
 		commonly_used: false
 		deployment_roles: ["daemon"]
+		egress_method: "batch"
 		function: "collect"
 	}
 

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -9,7 +9,7 @@ components: sources: host_metrics: {
 		commonly_used: false
 		deployment_roles: ["daemon"]
 		egress_method: "batch"
-		function: "collect"
+		function:      "collect"
 	}
 
 	features: {

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -9,7 +9,7 @@ components: sources: http: {
 		commonly_used: false
 		deployment_roles: ["service", "sidecar"]
 		egress_method: "batch"
-		function: "receive"
+		function:      "receive"
 	}
 
 	features: {

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -8,6 +8,7 @@ components: sources: http: {
 	classes: {
 		commonly_used: false
 		deployment_roles: ["service", "sidecar"]
+		egress_method: "batch"
 		function: "receive"
 	}
 
@@ -126,12 +127,12 @@ components: sources: http: {
              \( _line )
              ```
              """
-			output: {
+			output: [{
 				host:         _host
 				message:      _line
 				timestamp:    "2020-10-01T11:23:25.333432Z"
 				"User-Agent": _user_agent
-			}
+			}]
 		},
 		{
 			_line:       "{\"key\": \"val\"}"
@@ -152,12 +153,12 @@ components: sources: http: {
              \( _line )
              ```
              """
-			output: {
+			output: [{
 				host:         _host
 				key:          "val"
 				timestamp:    "2020-10-01T11:23:25.333432Z"
 				"User-Agent": _user_agent
-			}
+			}]
 		},
 	]
 }

--- a/docs/reference/components/sources/journald.cue
+++ b/docs/reference/components/sources/journald.cue
@@ -8,6 +8,7 @@ components: sources: journald: {
 	classes: {
 		commonly_used: true
 		deployment_roles: ["daemon"]
+		egress_method: "batch"
 		function: "collect"
 	}
 
@@ -110,7 +111,7 @@ components: sources: journald: {
 			input: {
 				"2019-07-26 20:30:27 reply from 192.168.1.2: offset -0.001791 delay 0.000176, next query 1500s"
 			}
-			output: {
+			output: [{
 				timestamp:                "2019-07-26T20:30:27.000443Z"
 				message:                  "reply from 192.168.1.2: offset -0.001791 delay 0.000176, next query 1500s"
 				host:                     "lorien.example.com"
@@ -134,7 +135,7 @@ components: sources: journald: {
 				"_SYSTEMD_UNIT":          "ntpd.service"
 				"_SYSTEMD_SLICE":         "system.slice"
 				"_SYSTEMD_INVOCATION_ID": "496ad5cd046d48e29f37f559a6d176f8"
-			}
+			}]
 		},
 	]
 	how_it_works: {

--- a/docs/reference/components/sources/journald.cue
+++ b/docs/reference/components/sources/journald.cue
@@ -9,7 +9,7 @@ components: sources: journald: {
 		commonly_used: true
 		deployment_roles: ["daemon"]
 		egress_method: "batch"
-		function: "collect"
+		function:      "collect"
 	}
 
 	features: {

--- a/docs/reference/components/transforms/add_fields.cue
+++ b/docs/reference/components/transforms/add_fields.cue
@@ -5,16 +5,13 @@ components: transforms: add_fields: {
 	short_description: "Accepts log events and allows you to add one or more log fields."
 	long_description:  "Accepts log events and allows you to add one or more log fields."
 
-	_features: {
-		checkpoint: enabled: false
-		multiline: enabled:  false
-		tls: enabled:        false
-	}
-
 	classes: {
 		commonly_used: false
+		egress_method: "stream"
 		function:      "schema"
 	}
+
+	features: {}
 
 	statuses: {
 		development: "stable"

--- a/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
+++ b/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
@@ -7,11 +7,11 @@ components: transforms: aws_cloudwatch_logs_subscription_parser: {
 
 	classes: {
 		commonly_used: false
+		egress_method: "batch"
 		function:      "parse"
 	}
 
-	features: {
-	}
+	features: {}
 
 	statuses: {
 		development: "beta"

--- a/docs/reference/components/transforms/lua.cue
+++ b/docs/reference/components/transforms/lua.cue
@@ -7,6 +7,7 @@ components: transforms: lua: {
 
 	classes: {
 		commonly_used: true
+		egress_method: "stream"
 		function:      "program"
 	}
 

--- a/docs/reference/components/transforms/merge.cue
+++ b/docs/reference/components/transforms/merge.cue
@@ -7,11 +7,11 @@ components: transforms: merge: {
 
 	classes: {
 		commonly_used: false
+		egress_method: "stream"
 		function:      "aggregate"
 	}
 
-	features: {
-	}
+	features: {}
 
 	statuses: {
 		development: "beta"

--- a/docs/reference/components/transforms/reduce.cue
+++ b/docs/reference/components/transforms/reduce.cue
@@ -7,11 +7,11 @@ components: transforms: reduce: {
 
 	classes: {
 		commonly_used: false
+		egress_method: "stream"
 		function:      "aggregate"
 	}
 
-	features: {
-	}
+	features: {}
 
 	statuses: {
 		development: "beta"

--- a/docs/reference/components/transforms/regex_parser.cue
+++ b/docs/reference/components/transforms/regex_parser.cue
@@ -7,11 +7,11 @@ components: transforms: regex_parser: {
 
 	classes: {
 		commonly_used: true
+		egress_method: "stream"
 		function:      "parse"
 	}
 
-	features: {
-	}
+	features: {}
 
 	statuses: {
 		development: "stable"

--- a/docs/reference/components/transforms/swimlanes.cue
+++ b/docs/reference/components/transforms/swimlanes.cue
@@ -7,8 +7,11 @@ components: transforms: swimlanes: {
 
 	classes: {
 		commonly_used: false
+		egress_method: "stream"
 		function:      "route"
 	}
+
+	features: {}
 
 	statuses: {
 		development: "beta"


### PR DESCRIPTION
This adds a `classes.egress_method` that we can use to tighten up our schema. Specifically, the `examples.log.output` attribute. It ensures we're creating exmaples that demonstrate streaming or batching.