### PR TITLE
fix(cli): Use temporary `wasm` artifact_cache directory during `validate` command

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -249,11 +249,15 @@ pub trait TransformConfig: core::fmt::Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct TransformContext {
     pub(super) resolver: Resolver,
+    pub(super) mode: BuildMode,
 }
 
 impl TransformContext {
     pub fn new_test() -> Self {
-        Self { resolver: Resolver }
+        Self {
+            resolver: Resolver,
+            mode: BuildMode::Normal,
+        }
     }
 
     pub fn resolver(&self) -> Resolver {
@@ -335,6 +339,16 @@ impl Config {
 
 fn healthcheck_default() -> bool {
     true
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuildMode {
+    /// Normal runtime
+    Normal,
+    /// Validate command
+    ///
+    /// Components should only change their behavior for this mode if necessary.
+    Validate,
 }
 
 #[cfg(all(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     buffers,
-    config::{DataType, SinkContext, TransformContext},
+    config::{BuildMode, DataType, SinkContext, TransformContext},
     dns::Resolver,
     event::Event,
     shutdown::SourceShutdownCoordinator,
@@ -32,6 +32,7 @@ pub struct Pieces {
 pub async fn build_pieces(
     config: &super::Config,
     diff: &ConfigDiff,
+    mode: BuildMode,
 ) -> Result<Pieces, Vec<String>> {
     let mut inputs = HashMap::new();
     let mut outputs = HashMap::new();
@@ -100,7 +101,7 @@ pub async fn build_pieces(
 
         let typetag = transform.inner.transform_type();
 
-        let cx = TransformContext { resolver };
+        let cx = TransformContext { resolver, mode };
 
         let input_type = transform.inner.input_type();
         let transform = match transform.inner.build(cx).await {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -12,7 +12,7 @@ mod task;
 
 use crate::{
     buffers,
-    config::{Config, ConfigDiff},
+    config::{BuildMode, Config, ConfigDiff},
     shutdown::SourceShutdownCoordinator,
     topology::{builder::Pieces, task::Task},
 };
@@ -70,7 +70,7 @@ pub async fn start_validated(
 }
 
 pub async fn build_or_log_errors(config: &Config, diff: &ConfigDiff) -> Option<Pieces> {
-    match builder::build_pieces(config, diff).await {
+    match builder::build_pieces(config, diff, BuildMode::Normal).await {
         Err(errors) => {
             for error in errors {
                 error!("Configuration error: {}", error);

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,5 +1,5 @@
 use vector::{
-    config::{self, ConfigDiff},
+    config::{self, BuildMode, ConfigDiff},
     topology,
 };
 
@@ -9,7 +9,7 @@ async fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
             let diff = ConfigDiff::initial(&c);
             match (
                 config::warnings(&c),
-                topology::builder::build_pieces(&c, &diff).await,
+                topology::builder::build_pieces(&c, &diff, BuildMode::Normal).await,
             ) {
                 (Some(warnings), Ok(_pieces)) => Ok(warnings),
                 (None, Ok(_pieces)) => Ok(vec![]),


### PR DESCRIPTION
Ref #3930 

To avoid creating directories and caches in runtime directory we:
* create them in a tmp directory
* manually check original path

### Open questions

- [ ] Is there a better way to modify `wasm` transform configuration than passing `BuildMode` around? 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
