### PR TITLE
chore(external docs): Add `input` key for metric types support

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -91,7 +91,14 @@ _values: {
 
 	configuration: #Schema
 
-	if kind == "source" || kind == "transform" {
+	if Kind == "transform" || Kind == "sink" {
+		input: {
+			logs:    bool
+			metrics: false | #MetricInput
+		}
+	}
+
+	if Kind == "source" || Kind == "transform" {
 		// `output` documents output of the component. This is very important
 		// as it communicate which events and fields are emitted.
 		output: {
@@ -112,11 +119,11 @@ _values: {
 					}
 				}
 
-				if kind == "source" {
+				if Kind == "source" {
 					input: string
 				}
 
-				if kind != "source" {
+				if Kind != "source" {
 					input: #LogEvent | [#LogEvent, ...]
 				}
 
@@ -341,6 +348,15 @@ _values: {
 	fields:      #Schema
 })
 
+#MetricInput: {
+	counter:      bool
+	distribution: bool
+	gauge:        bool
+	histogram:    bool
+	summary:      bool
+	set:          bool
+}
+
 #MetricEvent: {
 	tags: [Name=string]: string
 	close({counter: #MetricEventCounter}) |
@@ -443,11 +459,6 @@ _values: {
 
 #Support: {
 	_args: kind: string
-	let Args = _args
-
-	if Args.kind == "transform" || Args.kind == "sink" {
-		input_types: [#EventType, ...]
-	}
 
 	// `platforms` describes which platforms this component is available on.
 	//

--- a/docs/reference/components/sinks/azure_monitor_logs.cue
+++ b/docs/reference/components/sinks/azure_monitor_logs.cue
@@ -46,8 +46,6 @@ components: sinks: azure_monitor_logs: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -97,5 +95,10 @@ components: sinks: azure_monitor_logs: {
 				examples: ["${AZURE_MONITOR_SHARED_KEY_ENV_VAR}", "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="]
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 }

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -33,8 +33,6 @@ components: sinks: sematext_metrics: {
 	}
 
 	support: {
-		input_types: ["metric"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -45,7 +43,14 @@ components: sinks: sematext_metrics: {
 		}
 
 		requirements: []
-		warnings: []
+		warnings: [
+			#"""
+				[Sematext monitoring][urls.sematext_monitoring] only accepts metrics which contain a single value.
+				Therefore, only `counter` and `gauge` metrics are supported. If you'd like to ingest other
+				metric types please consider using the [`metric_to_log` transform][docs.transforms.metric_to_log]
+				with the `sematext_logs` sink.
+				"""#,
+		]
 		notices: []
 	}
 
@@ -81,19 +86,23 @@ components: sinks: sematext_metrics: {
 			}
 		}
 	}
+
+	input: {
+		logs: false
+		metrics: {
+			counter:      true
+			distribution: false
+			gauge:        true
+			histogram:    false
+			set:          false
+			summary:      false
+		}
+	}
+
 	how_it_works: {
 		metric_types: {
-			title: "Metric Types"
+			title: "Metric Namespaces"
 			body: #"""
-				[Sematext monitoring](https://sematext.com/docs/monitoring/) accepts metrics which contain a single value.
-				These are the Counter and Gauge Vector metric types.
-
-				<Alert type="info">
-				Other metric types are not supported. The following metric types will not be sent to Sematext:
-
-				`aggregated_histogram`, `aggregated_summary`, `distribution`, `set`
-				</Alert>
-
 				All metrics are sent with a namespace. If no namespace is included with the metric, the metric name becomes
 				the namespace and the metric is named `value`.
 				"""#

--- a/docs/reference/components/transforms/add_fields.cue
+++ b/docs/reference/components/transforms/add_fields.cue
@@ -18,8 +18,6 @@ components: transforms: add_fields: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -70,6 +68,11 @@ components: transforms: add_fields: {
 			warnings: []
 			type: bool: default: true
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	how_it_works: {

--- a/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
+++ b/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
@@ -18,8 +18,6 @@ components: transforms: aws_cloudwatch_logs_subscription_parser: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -42,6 +40,11 @@ components: transforms: aws_cloudwatch_logs_subscription_parser: {
 			warnings: []
 			type: string: default: "message"
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	output: logs: line: {

--- a/docs/reference/components/transforms/dedupe.cue
+++ b/docs/reference/components/transforms/dedupe.cue
@@ -19,8 +19,6 @@ components: transforms: dedupe: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -85,6 +83,11 @@ components: transforms: dedupe: {
 				}
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	how_it_works: {

--- a/docs/reference/components/transforms/lua.cue
+++ b/docs/reference/components/transforms/lua.cue
@@ -18,8 +18,6 @@ components: transforms: lua: {
 	}
 
 	support: {
-		input_types: ["log", "metric"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -209,6 +207,18 @@ components: transforms: lua: {
 					"2": "Lua transform API version 2"
 				}
 			}
+		}
+	}
+
+	input: {
+		logs: true
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			set:          true
+			summary:      true
 		}
 	}
 

--- a/docs/reference/components/transforms/merge.cue
+++ b/docs/reference/components/transforms/merge.cue
@@ -18,8 +18,6 @@ components: transforms: merge: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -78,6 +76,11 @@ components: transforms: merge: {
 				examples: [["host"], ["host", "parent.child"]]
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	examples: log: [

--- a/docs/reference/components/transforms/reduce.cue
+++ b/docs/reference/components/transforms/reduce.cue
@@ -18,8 +18,6 @@ components: transforms: reduce: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -118,6 +116,11 @@ components: transforms: reduce: {
 				}
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	examples: log: [

--- a/docs/reference/components/transforms/regex_parser.cue
+++ b/docs/reference/components/transforms/regex_parser.cue
@@ -18,8 +18,6 @@ components: transforms: regex_parser: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -85,6 +83,11 @@ components: transforms: regex_parser: {
 			}
 		}
 		types: components._types
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	examples: log: [

--- a/docs/reference/components/transforms/remove_fields.cue
+++ b/docs/reference/components/transforms/remove_fields.cue
@@ -18,8 +18,6 @@ components: transforms: remove_fields: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -50,5 +48,10 @@ components: transforms: remove_fields: {
 				examples: [["field1", "field2", "parent.child"]]
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 }

--- a/docs/reference/components/transforms/remove_tags.cue
+++ b/docs/reference/components/transforms/remove_tags.cue
@@ -18,8 +18,6 @@ components: transforms: remove_tags: {
 	}
 
 	support: {
-		input_types: ["metric"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -42,6 +40,18 @@ components: transforms: remove_tags: {
 			type: "[string]": {
 				examples: [["tag1", "tag2"]]
 			}
+		}
+	}
+
+	input: {
+		logs: false
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			set:          true
+			summary:      true
 		}
 	}
 }

--- a/docs/reference/components/transforms/rename_fields.cue
+++ b/docs/reference/components/transforms/rename_fields.cue
@@ -18,8 +18,6 @@ components: transforms: rename_fields: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -57,6 +55,11 @@ components: transforms: rename_fields: {
 				options: {}
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	how_it_works: {

--- a/docs/reference/components/transforms/sampler.cue
+++ b/docs/reference/components/transforms/sampler.cue
@@ -18,8 +18,6 @@ components: transforms: sampler: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -64,5 +62,10 @@ components: transforms: sampler: {
 				unit: null
 			}
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 }

--- a/docs/reference/components/transforms/split.cue
+++ b/docs/reference/components/transforms/split.cue
@@ -18,8 +18,6 @@ components: transforms: split: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -71,6 +69,11 @@ components: transforms: split: {
 			}
 		}
 		types: components._types
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	examples: log: [

--- a/docs/reference/components/transforms/swimlanes.cue
+++ b/docs/reference/components/transforms/swimlanes.cue
@@ -18,8 +18,6 @@ components: transforms: swimlanes: {
 	}
 
 	support: {
-		input_types: ["log"]
-
 		platforms: {
 			"aarch64-unknown-linux-gnu":  true
 			"aarch64-unknown-linux-musl": true
@@ -41,6 +39,11 @@ components: transforms: swimlanes: {
 			warnings: []
 			type: object: components._conditions
 		}
+	}
+
+	input: {
+		logs:    true
+		metrics: false
 	}
 
 	examples: log: [


### PR DESCRIPTION
This adds support for an `input` key that documents support for the various Vector event types, including individual metric types.