### PR TITLE
chore(external docs): Clean up array type

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -491,7 +491,25 @@ _values: {
 #Timestamp: =~"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{6}Z"
 
 #Type: {
-	_args: required: bool
+	_args: {
+		arrays: true
+		required: bool
+	}
+	let Args = _args
+
+	// `*` represents a wildcard type.
+	//
+	// For example, the `sinks.http.headers.*` option allows for arbitrary
+	// key/value pairs.
+	close({"array": #TypeArray & {_args: required: Args.required}}) |
+	#TypePrimitive
+}
+
+#TypePrimitive: {
+	_args: {
+		arrays: true
+		required: bool
+	}
 	let Args = _args
 
 	// `*` represents a wildcard type.
@@ -499,9 +517,6 @@ _values: {
 	// For example, the `sinks.http.headers.*` option allows for arbitrary
 	// key/value pairs.
 	close({"*": close({})}) |
-	close({"[float]": #TypeArrayOfFloats & {_args: required: Args.required}}) |
-	close({"[string]": #TypeArrayOfStrings & {_args: required: Args.required}}) |
-	close({"[uint]": #TypeArrayOfUints & {_args: required: Args.required}}) |
 	close({"bool": #TypeBool & {_args: required: Args.required}}) |
 	close({"float": #TypeFloat & {_args: required: Args.required}}) |
 	close({"object": #TypeObject & {_args: required: Args.required}}) |
@@ -510,65 +525,18 @@ _values: {
 	close({"uint": #TypeUint & {_args: required: Args.required}})
 }
 
-#TypeArrayOfFloats: {
+#TypeArray: {
 	_args: required: bool
 	let Args = _args
 
 	if !Args.required {
 		// `default` sets the default value.
-		default: [...float] | null
+		default: [..._] | null
 	}
 
-	// `examples` clarify values through examples. This should be used
-	// when examples cannot be derived from the `default` or `enum`
-	// options.
-	examples: [...[...float]]
-}
-
-#TypeArrayOfUints: {
-	_args: required: bool
-	let Args = _args
-
-	if !Args.required {
-		// `default` sets the default value.
-		default: [...uint] | null
-	}
-
-	// `examples` clarify values through examples. This should be used
-	// when examples cannot be derived from the `default` or `enum`
-	// options.
-	examples: [...[...uint]]
-}
-
-#TypeArrayOfStrings: {
-	_args: required: bool
-	let Args = _args
-
-	if !Args.required {
-		// `default` sets the default value.
-		default: [...string] | null
-	}
-
-	// `enum` restricts the value to a set of values.
-	//
-	//      enum: {
-	//       json: "Encodes the data via application/json"
-	//       text: "Encodes the data via text/plain"
-	//      }
-	enum?: #Enum
-
-	// `examples` clarify values through examples. This should be used
-	// when examples cannot be derived from the `default` or `enum`
-	// options.
-	examples: [...[...string]] | *[[
-			for k, v in enum {
-			k
-		},
-	]]
-
-	// `templateable` means that the option supports dynamic templated
-	// values.
-	templateable?: bool
+	// Set `required` to `true` to force disable defaults. Defaults should
+	// be specified on the array level and not the type level.
+	items: type: #TypePrimitive & {_args: required: true}
 }
 
 #TypeBool: {

--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -492,7 +492,7 @@ _values: {
 
 #Type: {
 	_args: {
-		arrays: true
+		arrays:   true
 		required: bool
 	}
 	let Args = _args
@@ -507,7 +507,7 @@ _values: {
 
 #TypePrimitive: {
 	_args: {
-		arrays: true
+		arrays:   true
 		required: bool
 	}
 	let Args = _args
@@ -531,7 +531,7 @@ _values: {
 
 	if !Args.required {
 		// `default` sets the default value.
-		default: [..._] | null
+		default: [...] | null
 	}
 
 	// Set `required` to `true` to force disable defaults. Defaults should

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -60,7 +60,7 @@ components: sinks: sematext_metrics: {
 			required:      true
 			relevant_when: "`endpoint` is not set"
 			warnings: []
-			type: [string]: {
+			type: string: {
 				enum: {
 					us: "United States"
 					eu: "Europe"

--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -55,8 +55,8 @@ components: sources: apache_metrics: {
 		endpoints: {
 			description: "mod_status endpoints to scrape metrics from."
 			required:    true
-			type: "[string]": {
-				examples: [["http://localhost:8080/server-status/?auto"]]
+			type: array: {
+				items: type: string: examples: ["http://localhost:8080/server-status/?auto"]
 			}
 		}
 		interval_secs: {

--- a/docs/reference/components/sources/docker.cue
+++ b/docs/reference/components/sources/docker.cue
@@ -85,9 +85,9 @@ components: sources: docker: {
 				all containers will be included.
 				"""
 			required: false
-			type: "[string]": {
-				examples: [["serene_", "serene_leakey", "ad08cc418cf9"]]
+			type: array: {
 				default: null
+				items: type: string: examples: ["serene_", "serene_leakey", "ad08cc418cf9"]
 			}
 		}
 		include_labels: {
@@ -98,9 +98,9 @@ components: sources: docker: {
 				described label's synatx in [docker object labels docs][urls.docker_object_labels].
 				"""
 			required: false
-			type: "[string]": {
-				examples: [["com.example.vendor=Timber Inc.", "com.example.name=Vector"]]
+			type: array: {
 				default: null
+				items: type: string: examples: ["com.example.vendor=Timber Inc.", "com.example.name=Vector"]
 			}
 		}
 		include_images: {
@@ -110,9 +110,9 @@ components: sources: docker: {
 				images will be included.
 				"""
 			required: false
-			type: "[string]": {
-				examples: [["httpd", "redis"]]
+			type: array: {
 				default: null
+				items: type: string: examples: ["httpd", "redis"]
 			}
 		}
 		retry_backoff_secs: {

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -43,9 +43,9 @@ components: sources: file: {
 			common:      false
 			description: "Array of file patterns to exclude. [Globbing](#globbing) is supported.*Takes precedence over the [`include` option](#include).*"
 			required:    false
-			type: "[string]": {
+			type: array: {
 				default: null
-				examples: [["/var/log/nginx/*.[0-9]*.log"]]
+				items: type: string: examples: ["/var/log/nginx/*.[0-9]*.log"]
 			}
 		}
 		file_key: {
@@ -125,7 +125,7 @@ components: sources: file: {
 		include: {
 			description: "Array of file patterns to include. [Globbing](#globbing) is supported."
 			required:    true
-			type: "[string]": examples: [["/var/log/nginx/*.log"]]
+			type: array: items: type: string: examples: ["/var/log/nginx/*.log"]
 		}
 		max_line_bytes: {
 			common:      false

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -45,9 +45,9 @@ components: sources: host_metrics: {
 			description: "The list of host metric collector services to use. Defaults to all collectors."
 			common:      true
 			required:    false
-			type: "[string]": {
+			type: array: {
 				default: ["cpu", "disk", "filesystem", "load", "memory", "network"]
-				enum: {
+				items: type: string: enum: {
 					cpu:        "Metrics related to CPU utilization."
 					disk:       "Metrics related to disk I/O utilization."
 					filesystem: "Metrics related to filesystem space utilization."
@@ -90,9 +90,9 @@ components: sources: host_metrics: {
 								Defaults to including all devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: ["*"]
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 						excludes: {
@@ -103,9 +103,9 @@ components: sources: host_metrics: {
 								Defaults to excluding no devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: []
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 					}
@@ -130,9 +130,9 @@ components: sources: host_metrics: {
 								Defaults to including all devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: ["*"]
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 						excludes: {
@@ -143,9 +143,9 @@ components: sources: host_metrics: {
 								Defaults to excluding no devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: []
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 					}
@@ -163,9 +163,9 @@ components: sources: host_metrics: {
 								Defaults to including all filesystems.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: ["*"]
-								examples: [["ntfs"], ["ext*"]]
+								items: type: string: examples: ["ntfs", "ext*"]
 							}
 						}
 						excludes: {
@@ -176,9 +176,9 @@ components: sources: host_metrics: {
 								Defaults to excluding no filesystems.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: []
-								examples: [["ntfs"], ["ext*"]]
+								items: type: string: examples: ["ntfs", "ext*"]
 							}
 						}
 					}
@@ -196,9 +196,9 @@ components: sources: host_metrics: {
 								Defaults to including all mount points.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: ["*"]
-								examples: [["/home"], ["/raid*"]]
+								items: type: string: examples: ["/home", "/raid*"]
 							}
 						}
 						excludes: {
@@ -209,9 +209,9 @@ components: sources: host_metrics: {
 								Defaults to excluding no mount points.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: []
-								examples: [["/home"], ["/raid*"]]
+								items: type: string: examples: ["/home", "/raid*"]
 							}
 						}
 					}
@@ -236,9 +236,9 @@ components: sources: host_metrics: {
 								Defaults to including all devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: ["*"]
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 						excludes: {
@@ -249,9 +249,9 @@ components: sources: host_metrics: {
 								Defaults to excluding no devices.
 								The patterns are matched using [globbing](#globbing).
 								"""#
-							type: "[string]": {
+							type: array: {
 								default: []
-								examples: [["sda"], ["dm-*"]]
+								items: type: string: examples: ["sda", "dm-*"]
 							}
 						}
 					}

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -73,9 +73,9 @@ components: sources: http: {
 			common:      false
 			description: "A list of HTTP headers to include in the log event. These will override any values included in the JSON payload with conflicting names. An empty string will be inserted into the log event if the corresponding HTTP header was missing."
 			required:    false
-			type: "[string]": {
+			type: array: {
 				default: null
-				examples: [["User-Agent", "X-My-Custom-Header"]]
+				items: type: string: examples: ["User-Agent", "X-My-Custom-Header"]
 			}
 		}
 	}

--- a/docs/reference/components/sources/journald.cue
+++ b/docs/reference/components/sources/journald.cue
@@ -70,9 +70,9 @@ components: sources: journald: {
 			description: "The list of unit names to exclude from monitoring. Unit names lacking a `\".\"` will have `\".service\"` appended to make them a valid service unit name."
 			required:    false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: []
-				examples: [["badservice", "sysinit.target"]]
+				items: type: string: examples: ["badservice", "sysinit.target"]
 			}
 		}
 		include_units: {
@@ -80,9 +80,9 @@ components: sources: journald: {
 			description: "The list of unit names to monitor. If empty or not present, all units are accepted. Unit names lacking a `\".\"` will have `\".service\"` appended to make them a valid service unit name."
 			required:    false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: []
-				examples: [["ntpd", "sysinit.target"]]
+				items: type: string: examples: ["ntpd", "sysinit.target"]
 			}
 		}
 		journalctl_path: {

--- a/docs/reference/components/sources/prometheus.cue
+++ b/docs/reference/components/sources/prometheus.cue
@@ -43,8 +43,8 @@ components: sources: prometheus: {
 			description: "Endpoints to scrape metrics from."
 			required:    true
 			warnings: ["You must explicitly add the path to your endpoints. Vector will _not_ automatically add `/metics`."]
-			type: "[string]": {
-				examples: [["http://localhost:9090/metrics"]]
+			type: array: {
+				items: type: string: examples: ["http://localhost:9090/metrics"]
 			}
 		}
 		scrape_interval_secs: {

--- a/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
+++ b/docs/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
@@ -83,8 +83,7 @@ components: transforms: aws_cloudwatch_logs_subscription_parser: {
 			subscription_filters: {
 				description: "The list of subscription filter names that the logs were sent by."
 				required:    true
-				type: "[string]": {examples: [["Destination"]]
-				}
+				type: array: items: type: string: examples: ["Destination"]
 			}
 		}
 	}

--- a/docs/reference/components/transforms/dedupe.cue
+++ b/docs/reference/components/transforms/dedupe.cue
@@ -65,9 +65,9 @@ components: transforms: dedupe: {
 						description: "The field names to ignore when deciding if an Event is a duplicate. Incompatible with the `fields.match` option."
 						required:    false
 						warnings: []
-						type: "[string]": {
+						type: array: {
 							default: null
-							examples: [["field1", "parent.child_field"]]
+							items: type: string: examples: ["field1", "parent.child_field"]
 						}
 					}
 					match: {
@@ -75,9 +75,9 @@ components: transforms: dedupe: {
 						description: "The field names considered when deciding if an Event is a duplicate. This can also be globally set via the [global `log_schema` options][docs.reference.global-options#log_schema]. Incompatible with the `fields.ignore` option."
 						required:    false
 						warnings: []
-						type: "[string]": {
+						type: array: {
 							default: ["timestamp", "host", "message"]
-							examples: [["field1", "parent.child_field"], ["host", "message"]]
+							items: type: string: examples: ["field1", "parent.child_field", "host", "message"]
 						}
 					}
 				}

--- a/docs/reference/components/transforms/lua.cue
+++ b/docs/reference/components/transforms/lua.cue
@@ -119,9 +119,9 @@ components: transforms: lua: {
 			groups: ["module"]
 			required: false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: null
-				examples: [["/etc/vector/lua"]]
+				items: type: string: examples: ["/etc/vector/lua"]
 			}
 		}
 		source: {

--- a/docs/reference/components/transforms/merge.cue
+++ b/docs/reference/components/transforms/merge.cue
@@ -44,9 +44,9 @@ components: transforms: merge: {
 				"""
 			required: false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: ["message"]
-				examples: [["message"], ["message", "parent.child"]]
+				items: type: string: examples: ["message", "parent.child"]
 			}
 		}
 		partial_event_marker_field: {
@@ -71,9 +71,9 @@ components: transforms: merge: {
 				"""
 			required: false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: []
-				examples: [["host"], ["host", "parent.child"]]
+				items: type: string: examples: ["host", "parent.child"]
 			}
 		}
 	}

--- a/docs/reference/components/transforms/reduce.cue
+++ b/docs/reference/components/transforms/reduce.cue
@@ -65,9 +65,9 @@ components: transforms: reduce: {
 			description: "An ordered list of fields by which to group events. Each group is combined independently, allowing you to keep independent events separate. When no fields are specified, all events will be combined in a single group. Events missing a specified field will be combined in their own group."
 			required:    false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: []
-				examples: [["request_id"], ["user_id", "transaction_id"]]
+				items: type: string: examples: ["request_id", "user_id", "transaction_id"]
 			}
 		}
 		merge_strategies: {

--- a/docs/reference/components/transforms/regex_parser.cue
+++ b/docs/reference/components/transforms/regex_parser.cue
@@ -68,9 +68,7 @@ components: transforms: regex_parser: {
 			description: "The Regular Expressions to apply. Do not include the leading or trailing `/` in any of the expressions."
 			required:    true
 			warnings: []
-			type: "[string]": {
-				examples: [["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"]]
-			}
+			type: array: items: type: string: examples: ["^(?P<timestamp>[\\\\w\\\\-:\\\\+]+) (?P<level>\\\\w+) (?P<message>.*)$"]
 		}
 		target_field: {
 			common:      false

--- a/docs/reference/components/transforms/remove_fields.cue
+++ b/docs/reference/components/transforms/remove_fields.cue
@@ -44,9 +44,7 @@ components: transforms: remove_fields: {
 			description: "The log field names to drop."
 			required:    true
 			warnings: []
-			type: "[string]": {
-				examples: [["field1", "field2", "parent.child"]]
-			}
+			type: array: items: type: string: examples: ["field1", "field2", "parent.child"]
 		}
 	}
 

--- a/docs/reference/components/transforms/remove_tags.cue
+++ b/docs/reference/components/transforms/remove_tags.cue
@@ -37,9 +37,7 @@ components: transforms: remove_tags: {
 			description: "The tag names to drop."
 			required:    true
 			warnings: []
-			type: "[string]": {
-				examples: [["tag1", "tag2"]]
-			}
+			type: array: items: type: string: examples: ["tag1", "tag2"]
 		}
 	}
 

--- a/docs/reference/components/transforms/sampler.cue
+++ b/docs/reference/components/transforms/sampler.cue
@@ -48,9 +48,9 @@ components: transforms: sampler: {
 			description: "A list of regular expression patterns to exclude events from sampling. If an event's key field (see `key_field`) matches _any_ of these patterns it will _not_ be sampled."
 			required:    false
 			warnings: []
-			type: "[string]": {
+			type: array: {
 				default: null
-				examples: [["[error]", "field2"]]
+				items: type: string: examples: ["[error]", "field2"]
 			}
 		}
 		rate: {

--- a/docs/reference/components/transforms/split.cue
+++ b/docs/reference/components/transforms/split.cue
@@ -54,9 +54,7 @@ components: transforms: split: {
 			description: "The field names assigned to the resulting tokens, in order."
 			required:    true
 			warnings: []
-			type: "[string]": {
-				examples: [["timestamp", "level", "message", "parent.child"]]
-			}
+			type: array: items: type: string: examples: ["timestamp", "level", "message", "parent.child"]
 		}
 		separator: {
 			common:      true

--- a/docs/reference/data_model/schema.cue
+++ b/docs/reference/data_model/schema.cue
@@ -84,17 +84,16 @@ data_model: schema: {
 								description: "The rate at which each individual value was sampled."
 								required:    true
 								warnings: []
-								type: "[uint]": {
-									examples: [[12, 43, 25]]
+								type: array: items: type: uint: {
+									examples: [12, 43, 25]
+									unit: null
 								}
 							}
 							values: {
 								description: "The list of values contained within the distribution."
 								required:    true
 								warnings: []
-								type: "[float]": {
-									examples: [[12.0, 43.3, 25.2]]
-								}
+								type: array: items: type: float: examples: [12.0, 43.3, 25.2]
 							}
 						}
 					}
@@ -145,8 +144,9 @@ data_model: schema: {
 								description: "The buckets contained within this histogram."
 								required:    true
 								warnings: []
-								type: "[uint]": {
-									examples: [[1, 2, 5, 10, 25]]
+								type: array: items: type: uint: {
+									examples: [1, 2, 5, 10, 25]
+									unit: null
 								}
 							}
 							count: {
@@ -162,8 +162,9 @@ data_model: schema: {
 								description: "The number of values contained within each bucket."
 								required:    true
 								warnings: []
-								type: "[uint]": {
-									examples: [[1, 10, 25, 100]]
+								type: array: items: type: uint: {
+									examples: [1, 10, 25, 100]
+									unit: null
 								}
 							}
 							sum: {
@@ -192,9 +193,7 @@ data_model: schema: {
 								description: "The list of unique values."
 								required:    true
 								warnings: []
-								type: "[string]": {
-									examples: [["value1", "value2"]]
-								}
+								type: array: items: type: string: examples: ["value1", "value2"]
 							}
 						}
 					}
@@ -229,8 +228,8 @@ data_model: schema: {
 								description: "The quantiles contained within the summary, where 0 ≤ quantile ≤ 1."
 								required:    true
 								warnings: []
-								type: "[float]": {
-									examples: [[0.1, 0.5, 0.75, 1.0]]
+								type: array: {
+									items: type: float: examples: [0.1, 0.5, 0.75, 1.0]
 								}
 							}
 							sum: {
@@ -245,8 +244,8 @@ data_model: schema: {
 								description: "The values contained within the summary that align with the `quantiles`."
 								required:    true
 								warnings: []
-								type: "[float]": {
-									examples: [[2.1, 4.68, 23.02, 120.1]]
+								type: array: {
+									items: type: float: examples: [2.1, 4.68, 23.02, 120.1]
 								}
 							}
 						}


### PR DESCRIPTION
This cleans up the #Field `array` types by implementing them with recursion. Instead of:

```
type: "[string]": {
  default: null
  examples: [["[error]", "field2"]]
}
```

We now do:

```
type: array: {
  default: null
  items: type: string: examples: ["[error]", "field2"]]
}
```

cc @sghall since this was breaking the Graphql schema on the website.