### PR TITLE
chore(external docs): Add missing `endpoint` options

### DIFF
--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -62,7 +62,7 @@ components: sinks: datadog_logs: {
 		}
 		endpoint: {
 			common:      false
-			description: "The endpoint to stream logs to."
+			description: "The endpoint to send logs to."
 			required:    false
 			type: string: {
 				default: "intake.logs.datadoghq.com:10516"

--- a/docs/reference/components/sinks/influxdb_logs.cue
+++ b/docs/reference/components/sinks/influxdb_logs.cue
@@ -86,6 +86,14 @@ components: sinks: influxdb_logs: {
 				examples: ["vector-database", "iot-store"]
 			}
 		}
+		endpoint: {
+			description: "The endpoint to send logs to."
+			groups: ["v1", "v2"]
+			required: true
+			type: string: {
+				examples: ["http://localhost:8086/", "https://us-west-2-1.aws.cloud1.influxdata.com", "https://us-west-2-1.aws.cloud2.influxdata.com"]
+			}
+		}
 		namespace: {
 			description: "A prefix that will be added to all metric names."
 			groups: ["v1", "v2"]

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -86,6 +86,14 @@ components: sinks: influxdb_metrics: {
 				examples: ["vector-database", "iot-store"]
 			}
 		}
+		endpoint: {
+			description: "The endpoint to send metrics to."
+			groups: ["v1", "v2"]
+			required: true
+			type: string: {
+				examples: ["http://localhost:8086/", "https://us-west-2-1.aws.cloud1.influxdata.com", "https://us-west-2-1.aws.cloud2.influxdata.com"]
+			}
+		}
 		namespace: {
 			common:      true
 			description: "A prefix that will be added to all metric names."

--- a/docs/reference/components/sinks/logdna.cue
+++ b/docs/reference/components/sinks/logdna.cue
@@ -85,6 +85,15 @@ components: sinks: logdna: {
 				examples: ["staging", "production"]
 			}
 		}
+		endpoint: {
+			common:      false
+			description: "The endpoint to send logs to."
+			required:    false
+			type: string: {
+				default: "https://logs.logdna.com/logs/ingest"
+				examples: ["http://127.0.0.1", "http://example.com"]
+			}
+		}
 		hostname: {
 			description: "The hostname that will be attached to each batch of events."
 			required:    true

--- a/docs/reference/components/sinks/papertrail.cue
+++ b/docs/reference/components/sinks/papertrail.cue
@@ -53,7 +53,7 @@ components: sinks: papertrail: {
 
 	configuration: {
 		endpoint: {
-			description: "The endpoint to stream logs to."
+			description: "The endpoint to send logs to."
 			required:    true
 			type: string: {
 				examples: ["logs.papertrailapp.com:12345"]

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -70,7 +70,7 @@ components: sinks: sematext_metrics: {
 			}
 		}
 		endpoint: {
-			description:   "The endpoint that will be used to send metrics to. This option is required if `region` is not set."
+			description:   "The endpoint to send metrics to."
 			required:      true
 			relevant_when: "`region` is not set"
 			warnings: []


### PR DESCRIPTION
The `endpoint` option was accidentally excluded.