### PR TITLE
chore: Allow setting literal env variable values via `global` at Helm charts

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/distribution/helm/vector-shared/templates/_env.tpl
+++ b/distribution/helm/vector-shared/templates/_env.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Common container env variables.
+*/}}
+{{- define "libvector.globalEnv" -}}
+{{- $global := default (dict) .Values.global }}
+{{- $global := default (dict) $global.vector }}
+{{- range $key, $value := $global.commonEnvKV }}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/distribution/kubernetes/vector.yaml
+++ b/distribution/kubernetes/vector.yaml
@@ -133,6 +133,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            
             - name: LOG
               value: info
           resources:

--- a/scripts/deploy-kubernetes-test.sh
+++ b/scripts/deploy-kubernetes-test.sh
@@ -68,7 +68,7 @@ up() {
   HELM_VALUES+=(
     # Set a reasonable log level to avoid issues with internal logs
     # overwriting console output.
-    --set "env[0].name=LOG,env[0].value=info"
+    --set "global.vector.commonEnvKV.LOG=info"
   )
 
   if [[ -n "$CUSTOM_HELM_VALUES_FILE" ]]; then


### PR DESCRIPTION
This PR solves an issue that was overlooked at #4257. 