### PR TITLE
chore: fix shutdown tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ vector-api-client = { path = "lib/vector-api-client", optional = true }
 # Tokio / Futures
 futures01 = { package = "futures", version = "0.1.25" }
 futures = { version = "0.3", default-features = false, features = ["compat", "io-compat"] }
-tokio = { version = "0.2.13", features = ["blocking", "fs", "signal", "io-std", "macros", "rt-core", "rt-threaded", "uds", "sync"] }
+tokio = { version = "0.2.13", features = ["blocking", "fs", "signal", "io-std", "macros", "rt-core", "rt-threaded", "uds", "sync", "process"] }
 tokio-openssl = "0.4.0"
 tokio-retry = "0.2.0"
 tokio-util = { version = "0.3.1", features = ["codec"] }


### PR DESCRIPTION
It's still not clear to me how this snuck in, but it seems like we started relying on the tokio `process` feature without explicitly enabling it [here](https://github.com/timberio/vector/commit/881fbb3ef12cdc04715ea18c1a81e636ddb34c8e#diff-acc89eb37f2db3e476b2c19fc1702a4f9bd795d859c7ba1858d3caa8ac56e911R34). Presumably this worked because of some other dependency enabling the feature, but that ended up breaking [here](https://github.com/timberio/vector/runs/1244690291?check_suite_focus=true).

This change just enables the feature we rely on directly and now the tests are fine locally.
