### PR TITLE
chore: Allow distribution/kubernetes/vector.yaml to be formatted incorrectly

### DIFF
--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -33,6 +33,7 @@ for FILE in $(git ls-files); do
     *ico) continue;;
     *sig) continue;;
     tests/data*) continue;;
+    distribution/kubernetes/vector.yaml) continue;;
   esac
 
   # check that the file contains trailing newline


### PR DESCRIPTION
This is a workaround until we fix the Helm formatting.