### PR TITLE
enhancement(kubernetes_logs source): Advanced container filtering

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -65,6 +65,7 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
             "test-pod",
             "echo MARKER",
             vec![],
+            vec![],
         ))?)
         .await?;
     framework
@@ -147,6 +148,7 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
             "test-pod",
             &format!("echo {}", test_message),
             vec![],
+            vec![],
         ))?)
         .await?;
     framework
@@ -209,6 +211,7 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
             "test-vector-test-pod",
             "test-pod",
             "echo MARKER",
+            vec![],
             vec![],
         ))?)
         .await?;
@@ -313,6 +316,7 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
             "test-pod",
             &format!("echo -e {}", test_messages.join(r"\\n")),
             vec![],
+            vec![],
         ))?)
         .await?;
     framework
@@ -395,6 +399,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
             "test-pod",
             "echo MARKER",
             vec![("label1", "hello"), ("label2", "world")],
+            vec![],
         ))?)
         .await?;
     framework
@@ -492,6 +497,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             "test-pod-excluded",
             "echo EXCLUDED_MARKER",
             vec![("vector.dev/exclude", "true")],
+            vec![],
         ))?)
         .await?;
     framework
@@ -508,6 +514,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             "test-vector-test-pod",
             "test-pod-control",
             "echo CONTROL_MARKER",
+            vec![],
             vec![],
         ))?)
         .await?;
@@ -664,6 +671,7 @@ kubernetesLogsSource:
                     name,
                     "echo EXCLUDED_MARKER",
                     label_set,
+                    vec![],
                 ))?)
                 .await?,
         );
@@ -686,6 +694,7 @@ kubernetesLogsSource:
             "test-vector-test-pod",
             "test-pod-control",
             "echo CONTROL_MARKER",
+            vec![],
             vec![],
         ))?)
         .await?;
@@ -833,6 +842,7 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
                 "test-pod",
                 "echo MARKER",
                 vec![],
+                vec![],
             ))?)
             .await?;
         framework
@@ -920,6 +930,7 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
             "test-vector-test-pod",
             "test-pod",
             "echo MARKER",
+            vec![],
             vec![],
         ))?)
         .await?;

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -799,6 +799,149 @@ kubernetesLogsSource:
     Ok(())
 }
 
+/// This test validates that vector-agent properly filters out the logs from
+/// particular containers that are requested to be excluded from collection,
+/// based on k8s API `Pod` annotations.
+#[tokio::test]
+async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let framework = make_framework();
+
+    let vector = framework
+        .vector(
+            "test-vector",
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                ..Default::default()
+            },
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            "test-vector",
+            "daemonset/vector-agent",
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod_with_containers(
+            "test-vector-test-pod",
+            "test-pod",
+            vec![],
+            vec![("vector.dev/exclude-containers/by-name/excluded", "true")],
+            vec![
+                make_test_container("excluded", "echo EXCLUDED_MARKER"),
+                make_test_container("control", "echo CONTROL_MARKER"),
+            ],
+        ))?)
+        .await?;
+    framework
+        .wait(
+            "test-vector-test-pod",
+            vec!["pods/test-pod"],
+            WaitFor::Condition("initialized"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the log lines until the reasonable amount of time passes for us
+    // to be confident that vector should've picked up the excluded message
+    // if it wasn't filtering it.
+    let mut got_control_marker = false;
+    let mut lines_till_we_give_up: usize = 10000;
+    let (stop_tx, mut stop_rx) = futures::channel::mpsc::channel(0);
+    loop {
+        let line = tokio::select! {
+            result = stop_rx.next() => {
+                result.unwrap();
+                log_reader.kill()?;
+                continue;
+            }
+            line = log_reader.read_line() => line,
+        };
+        let line = match line {
+            Some(line) => line,
+            None => break,
+        };
+        println!("Got line: {:?}", line);
+
+        lines_till_we_give_up -= 1;
+        if lines_till_we_give_up <= 0 {
+            println!("Giving up");
+            log_reader.kill()?;
+            break;
+        }
+
+        if !line.starts_with("{") {
+            // This isn't a json, must be an entry from Vector's own log stream.
+            continue;
+        }
+
+        let val = parse_json(&line)?;
+
+        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+            // A log from something other than our test pod, pretend we don't
+            // see it.
+            continue;
+        }
+
+        // Ensure we got the log event from the test pod.
+        assert_eq!(val["kubernetes"]["pod_name"], "test-pod");
+
+        // Ensure we got the log event from the control container.
+        assert_eq!(val["kubernetes"]["container_name"], "control");
+
+        // Ensure the test sanity by validating that we got the control marker.
+        // If we get an excluded marker here - it's an error.
+        assert_eq!(val["message"], "CONTROL_MARKER");
+
+        if got_control_marker {
+            // We've already seen one control marker! This is not good, we only
+            // emitted one.
+            panic!("Control marker seen more than once");
+        }
+
+        // Remember that we've seen a control marker.
+        got_control_marker = true;
+
+        // Request termination in a while.
+        let mut stop_tx = stop_tx.clone();
+        tokio::spawn(async move {
+            // Wait for two minutes - a reasonable time for vector internals to
+            // pick up new `Pod` and collect events from them in idle load.
+            // Here, we're assuming that if the `Pod` that was supposed to be
+            // ignored was in fact collected (meaning something's wrong with
+            // the exclusion logic), we'd see it's data within this time frame.
+            // It's not enough to just wait for `Pod` complete, we should still
+            // apply a reasonably big timeout before we stop waiting for the
+            // logs to appear to have high confidence that Vector has enough
+            // time to pick them up and spit them out.
+            let duration = std::time::Duration::from_secs(120);
+            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            tokio::time::delay_for(duration).await;
+            println!("Stop timer complete");
+            stop_tx.send(()).await.unwrap();
+        });
+    }
+
+    // Ensure log reader exited.
+    log_reader.wait().await.expect("log reader wait failed");
+
+    assert!(got_control_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(vector);
+    Ok(())
+}
+
 /// This test validates that vector-agent properly collects logs from multiple
 /// `Namespace`s and `Pod`s.
 #[tokio::test]

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -942,6 +942,155 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// This test validates that vector-agent properly filters out the logs matching
+/// the exclusion glob patterns specified at the `kubernetes_logs`
+/// configuration.
+#[tokio::test]
+async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let framework = make_framework();
+
+    const CONFIG: &str = r#"
+kubernetesLogsSource:
+  rawConfig: |
+    exclude_paths_glob_patterns = ["/var/log/pods/test-vector-test-pod_test-pod_*/excluded/**"]
+"#;
+
+    let vector = framework
+        .vector(
+            "test-vector",
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
+                ..Default::default()
+            },
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            "test-vector",
+            "daemonset/vector-agent",
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod_with_containers(
+            "test-vector-test-pod",
+            "test-pod",
+            vec![],
+            vec![],
+            vec![
+                make_test_container("excluded", "echo EXCLUDED_MARKER"),
+                make_test_container("control", "echo CONTROL_MARKER"),
+            ],
+        ))?)
+        .await?;
+    framework
+        .wait(
+            "test-vector-test-pod",
+            vec!["pods/test-pod"],
+            WaitFor::Condition("initialized"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the log lines until the reasonable amount of time passes for us
+    // to be confident that vector should've picked up the excluded message
+    // if it wasn't filtering it.
+    let mut got_control_marker = false;
+    let mut lines_till_we_give_up: usize = 10000;
+    let (stop_tx, mut stop_rx) = futures::channel::mpsc::channel(0);
+    loop {
+        let line = tokio::select! {
+            result = stop_rx.next() => {
+                result.unwrap();
+                log_reader.kill()?;
+                continue;
+            }
+            line = log_reader.read_line() => line,
+        };
+        let line = match line {
+            Some(line) => line,
+            None => break,
+        };
+        println!("Got line: {:?}", line);
+
+        lines_till_we_give_up -= 1;
+        if lines_till_we_give_up <= 0 {
+            println!("Giving up");
+            log_reader.kill()?;
+            break;
+        }
+
+        if !line.starts_with("{") {
+            // This isn't a json, must be an entry from Vector's own log stream.
+            continue;
+        }
+
+        let val = parse_json(&line)?;
+
+        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+            // A log from something other than our test pod, pretend we don't
+            // see it.
+            continue;
+        }
+
+        // Ensure we got the log event from the test pod.
+        assert_eq!(val["kubernetes"]["pod_name"], "test-pod");
+
+        // Ensure we got the log event from the control container.
+        assert_eq!(val["kubernetes"]["container_name"], "control");
+
+        // Ensure the test sanity by validating that we got the control marker.
+        // If we get an excluded marker here - it's an error.
+        assert_eq!(val["message"], "CONTROL_MARKER");
+
+        if got_control_marker {
+            // We've already seen one control marker! This is not good, we only
+            // emitted one.
+            panic!("Control marker seen more than once");
+        }
+
+        // Remember that we've seen a control marker.
+        got_control_marker = true;
+
+        // Request termination in a while.
+        let mut stop_tx = stop_tx.clone();
+        tokio::spawn(async move {
+            // Wait for two minutes - a reasonable time for vector internals to
+            // pick up new `Pod` and collect events from them in idle load.
+            // Here, we're assuming that if the `Pod` that was supposed to be
+            // ignored was in fact collected (meaning something's wrong with
+            // the exclusion logic), we'd see it's data within this time frame.
+            // It's not enough to just wait for `Pod` complete, we should still
+            // apply a reasonably big timeout before we stop waiting for the
+            // logs to appear to have high confidence that Vector has enough
+            // time to pick them up and spit them out.
+            let duration = std::time::Duration::from_secs(120);
+            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            tokio::time::delay_for(duration).await;
+            println!("Stop timer complete");
+            stop_tx.send(()).await.unwrap();
+        });
+    }
+
+    // Ensure log reader exited.
+    log_reader.wait().await.expect("log reader wait failed");
+
+    assert!(got_control_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(vector);
+    Ok(())
+}
+
 /// This test validates that vector-agent properly collects logs from multiple
 /// `Namespace`s and `Pod`s.
 #[tokio::test]

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -832,7 +832,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             "test-vector-test-pod",
             "test-pod",
             vec![],
-            vec![("vector.dev/exclude-containers/by-name/excluded", "true")],
+            vec![("vector.dev/exclude-containers", "excluded")],
             vec![
                 make_test_container("excluded", "echo EXCLUDED_MARKER"),
                 make_test_container("control", "echo CONTROL_MARKER"),

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -914,16 +914,17 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
         // Request termination in a while.
         let mut stop_tx = stop_tx.clone();
         tokio::spawn(async move {
-            // Wait for two minutes - a reasonable time for vector internals to
-            // pick up new `Pod` and collect events from them in idle load.
-            // Here, we're assuming that if the `Pod` that was supposed to be
-            // ignored was in fact collected (meaning something's wrong with
-            // the exclusion logic), we'd see it's data within this time frame.
+            // Wait for 30 seconds - a reasonable time for vector internals to
+            // ingest logs for each container in a `Pod` in idle load.
+            // Here, we're assuming that if the container log file that was
+            // supposed to be ignored was in fact collected (meaning something's
+            // wrong with the exclusion logic), we'd see it's data within this
+            // time frame.
             // It's not enough to just wait for `Pod` complete, we should still
             // apply a reasonably big timeout before we stop waiting for the
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
-            let duration = std::time::Duration::from_secs(120);
+            let duration = std::time::Duration::from_secs(30);
             println!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::delay_for(duration).await;
             println!("Stop timer complete");
@@ -1063,16 +1064,16 @@ kubernetesLogsSource:
         // Request termination in a while.
         let mut stop_tx = stop_tx.clone();
         tokio::spawn(async move {
-            // Wait for two minutes - a reasonable time for vector internals to
-            // pick up new `Pod` and collect events from them in idle load.
-            // Here, we're assuming that if the `Pod` that was supposed to be
+            // Wait for 30 seconds - a reasonable time for vector internals to
+            // ingest logs for each log file of a `Pod` in idle load.
+            // Here, we're assuming that if the log file that was supposed to be
             // ignored was in fact collected (meaning something's wrong with
             // the exclusion logic), we'd see it's data within this time frame.
             // It's not enough to just wait for `Pod` complete, we should still
             // apply a reasonably big timeout before we stop waiting for the
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
-            let duration = std::time::Duration::from_secs(120);
+            let duration = std::time::Duration::from_secs(30);
             println!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::delay_for(duration).await;
             println!("Stop timer complete");

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -6,6 +6,7 @@ use super::path_helpers::build_pod_logs_directory;
 use crate::kubernetes as k8s;
 use evmap::ReadHandle;
 use file_source::paths_provider::PathsProvider;
+use glob::Pattern;
 use k8s_openapi::api::core::v1::Pod;
 use std::path::PathBuf;
 
@@ -13,12 +14,19 @@ use std::path::PathBuf;
 /// the k8s API.
 pub struct K8sPathsProvider {
     pods_state_reader: ReadHandle<String, k8s::state::evmap::Value<Pod>>,
+    exclude_paths: Vec<Pattern>,
 }
 
 impl K8sPathsProvider {
     /// Create a new [`K8sPathsProvider`].
-    pub fn new(pods_state_reader: ReadHandle<String, k8s::state::evmap::Value<Pod>>) -> Self {
-        Self { pods_state_reader }
+    pub fn new(
+        pods_state_reader: ReadHandle<String, k8s::state::evmap::Value<Pod>>,
+        exclude_paths: Vec<Pattern>,
+    ) -> Self {
+        Self {
+            pods_state_reader,
+            exclude_paths,
+        }
     }
 }
 
@@ -46,7 +54,8 @@ impl PathsProvider for K8sPathsProvider {
                     .get_one()
                     .expect("we are supposed to be working with single-item values only");
                 trace!(message = "Providing log paths for pod", ?uid);
-                list_pod_log_paths(real_glob, pod)
+                let paths_iter = list_pod_log_paths(real_glob, pod);
+                exclude_paths(paths_iter, &self.exclude_paths)
             })
             .collect()
     }
@@ -91,9 +100,26 @@ fn real_glob(pattern: &str) -> impl Iterator<Item = PathBuf> {
         .flat_map(|paths| paths.into_iter())
 }
 
+fn exclude_paths<'a>(
+    iter: impl Iterator<Item = PathBuf> + 'a,
+    patterns: &'a [Pattern],
+) -> impl Iterator<Item = PathBuf> + 'a {
+    iter.filter(move |path| {
+        !patterns.iter().any(|pattern| {
+            pattern.matches_path_with(
+                path,
+                glob::MatchOptions {
+                    require_literal_separator: true,
+                    ..Default::default()
+                },
+            )
+        })
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{extract_pod_logs_directory, list_pod_log_paths};
+    use super::{exclude_paths, extract_pod_logs_directory, list_pod_log_paths};
     use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
     use std::path::PathBuf;
 
@@ -224,6 +250,69 @@ mod tests {
             let actual_paths: Vec<_> = list_pod_log_paths(mock_glob, &pod).collect();
             let expected_paths: Vec<_> = expected_paths.into_iter().map(PathBuf::from).collect();
             assert_eq!(actual_paths, expected_paths)
+        }
+    }
+
+    #[test]
+    fn test_exclude_paths() {
+        let cases = vec![
+            // No exclusion pattern allows everything.
+            (
+                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+                vec![],
+                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+            ),
+            // Test a filter that doesn't apply to anything.
+            (
+                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+                vec!["notmatched"],
+                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+            ),
+            // Multiple filters.
+            (
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log",
+                ],
+                vec!["notmatched", "**/b.log", "**/c.log"],
+                vec!["/var/log/pods/a.log"],
+            ),
+            // Requires literal path separator (`*` does not include dirs).
+            (
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log",
+                ],
+                vec!["*/b.log", "**/c.log"],
+                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+            ),
+            // Filtering by container name with a real-life-like file path.
+            (
+                vec![
+                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/container1/1.log",
+                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/container1/2.log",
+                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/container2/1.log",
+                ],
+                vec!["**/container1/**"],
+                vec!["/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/container2/1.log"],
+            ),
+        ];
+
+        for (input_paths, str_patterns, expected_paths) in cases {
+            let patterns: Vec<_> = str_patterns
+                .iter()
+                .map(|pattern| glob::Pattern::new(pattern).unwrap())
+                .collect();
+            let actual_paths: Vec<_> =
+                exclude_paths(input_paths.into_iter().map(Into::into), &patterns).collect();
+            let expected_paths: Vec<_> = expected_paths.into_iter().map(PathBuf::from).collect();
+            assert_eq!(
+                actual_paths, expected_paths,
+                "failed for patterns {:?}",
+                &str_patterns
+            )
         }
     }
 }

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -77,6 +77,9 @@ where
     extract_pod_logs_directory(pod)
         .into_iter()
         .flat_map(move |dir| {
+            let dir = dir
+                .to_str()
+                .expect("non-utf8 path to pod logs dir is not supported");
             glob_impl(
                 // We seek to match the paths like
                 // `<pod_logs_dir>/<container_name>/<n>.log` - paths managed by
@@ -84,12 +87,7 @@ where
                 // architecture.
                 // In some setups, there will also be paths like
                 // `<pod_logs_dir>/<hash>.log` - those we want to skip.
-                &[
-                    dir.to_str()
-                        .expect("non-utf8 path to pod logs dir is not supported"),
-                    "*/*.log",
-                ]
-                .join("/"),
+                &[dir, "*/*.log"].join("/"),
             )
         })
 }

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -6,7 +6,6 @@ use super::path_helpers::build_pod_logs_directory;
 use crate::kubernetes as k8s;
 use evmap::ReadHandle;
 use file_source::paths_provider::PathsProvider;
-use glob::Pattern;
 use k8s_openapi::api::core::v1::Pod;
 use std::path::PathBuf;
 
@@ -14,14 +13,14 @@ use std::path::PathBuf;
 /// the k8s API.
 pub struct K8sPathsProvider {
     pods_state_reader: ReadHandle<String, k8s::state::evmap::Value<Pod>>,
-    exclude_paths: Vec<Pattern>,
+    exclude_paths: Vec<glob::Pattern>,
 }
 
 impl K8sPathsProvider {
     /// Create a new [`K8sPathsProvider`].
     pub fn new(
         pods_state_reader: ReadHandle<String, k8s::state::evmap::Value<Pod>>,
-        exclude_paths: Vec<Pattern>,
+        exclude_paths: Vec<glob::Pattern>,
     ) -> Self {
         Self {
             pods_state_reader,
@@ -146,7 +145,7 @@ fn real_glob(pattern: &str) -> impl Iterator<Item = PathBuf> {
 
 fn exclude_paths<'a>(
     iter: impl Iterator<Item = PathBuf> + 'a,
-    patterns: impl AsRef<[Pattern]> + 'a,
+    patterns: impl AsRef<[glob::Pattern]> + 'a,
 ) -> impl Iterator<Item = PathBuf> + 'a {
     iter.filter(move |path| {
         !patterns.as_ref().iter().any(|pattern| {

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -106,10 +106,10 @@ fn real_glob(pattern: &str) -> impl Iterator<Item = PathBuf> {
 
 fn exclude_paths<'a>(
     iter: impl Iterator<Item = PathBuf> + 'a,
-    patterns: &'a [Pattern],
+    patterns: impl AsRef<[Pattern]> + 'a,
 ) -> impl Iterator<Item = PathBuf> + 'a {
     iter.filter(move |path| {
-        !patterns.iter().any(|pattern| {
+        !patterns.as_ref().iter().any(|pattern| {
             pattern.matches_path_with(
                 path,
                 glob::MatchOptions {

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -95,9 +95,15 @@ where
 }
 
 fn real_glob(pattern: &str) -> impl Iterator<Item = PathBuf> {
-    glob::glob(pattern)
-        .expect("the pattern is supposed to always be correct")
-        .flat_map(|paths| paths.into_iter())
+    glob::glob_with(
+        pattern,
+        glob::MatchOptions {
+            require_literal_separator: true,
+            ..Default::default()
+        },
+    )
+    .expect("the pattern is supposed to always be correct")
+    .flat_map(|paths| paths.into_iter())
 }
 
 fn exclude_paths<'a>(

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -193,7 +193,7 @@ impl Source {
         );
         let reflector_process = reflector.run();
 
-        let paths_provider = K8sPathsProvider::new(state_reader.clone());
+        let paths_provider = K8sPathsProvider::new(state_reader.clone(), vec![]);
         let annotator = PodMetadataAnnotator::new(state_reader, fields_spec);
 
         // TODO: maybe some of the parameters have to be configurable.

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -70,6 +70,9 @@ pub struct Config {
 
     /// Specifies the field names for metadata annotation.
     annotation_fields: pod_metadata_annotator::FieldsSpec,
+
+    /// A list of glob patterns to exclude from reading the files.
+    exclude_paths_glob_patterns: Vec<PathBuf>,
 }
 
 inventory::submit! {
@@ -134,6 +137,7 @@ struct Source {
     fields_spec: pod_metadata_annotator::FieldsSpec,
     field_selector: String,
     label_selector: String,
+    exclude_paths: Vec<glob::Pattern>,
 }
 
 impl Source {
@@ -151,6 +155,17 @@ impl Source {
 
         let data_dir = globals.resolve_and_make_data_subdir(None, name)?;
 
+        let exclude_paths = config
+            .exclude_paths_glob_patterns
+            .iter()
+            .map(|pattern| {
+                let pattern = pattern
+                    .to_str()
+                    .ok_or_else(|| "glob pattern is not a valid UTF-8 string")?;
+                Ok(glob::Pattern::new(pattern)?)
+            })
+            .collect::<crate::Result<Vec<_>>>()?;
+
         Ok(Self {
             client,
             data_dir,
@@ -158,6 +173,7 @@ impl Source {
             fields_spec: config.annotation_fields.clone(),
             field_selector,
             label_selector,
+            exclude_paths,
         })
     }
 
@@ -173,6 +189,7 @@ impl Source {
             fields_spec,
             field_selector,
             label_selector,
+            exclude_paths,
         } = self;
 
         let watcher = k8s::api_watcher::ApiWatcher::new(client, Pod::watch_pod_for_all_namespaces);
@@ -193,7 +210,7 @@ impl Source {
         );
         let reflector_process = reflector.run();
 
-        let paths_provider = K8sPathsProvider::new(state_reader.clone(), vec![]);
+        let paths_provider = K8sPathsProvider::new(state_reader.clone(), exclude_paths);
         let annotator = PodMetadataAnnotator::new(state_reader, fields_spec);
 
         // TODO: maybe some of the parameters have to be configurable.


### PR DESCRIPTION
This PR adds two new ways to filter logs to the `kubernetes_logs` source:

1. Filtering by `Pod` *annotation* in the form of `vector.dev/exclude-containers: "<container_name_1>,<container_name_2>,<...>"` - log files from the `<container_name_1>` and `<container_name_2>` are excluded.
2. Filtering by the file exclusion patterns configured at the Vector configuration at the `kubernetes_logs` source - for a pattern `/var/log/pods/pod-namepspace_pod-name_pod-uid/**` all the files matching that pattern will be excluded.

Closes #4213.
Closes #4270.

To do:

- [x] E2E tests
- [ ] docs