### PR TITLE
chore(ci): Update localstack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.1",
+ "http",
  "hyper",
  "hyper-rustls",
  "hyper-unix-connector",
@@ -1372,19 +1372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
-name = "elastic_responses"
-version = "0.21.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0edd76d9dcdffc1b2e65178df45a4b8d805581571839d3bca9fa188043eb66"
-dependencies = [
- "http 0.1.21",
- "quick-error",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,7 +1962,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.1",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -2025,7 +2012,7 @@ dependencies = [
  "bitflags",
  "bytes 0.5.6",
  "headers-core",
- "http 0.2.1",
+ "http",
  "mime",
  "sha-1 0.8.2",
  "time 0.1.43",
@@ -2037,7 +2024,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.1",
+ "http",
 ]
 
 [[package]]
@@ -2279,17 +2266,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
@@ -2306,7 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.6",
- "http 0.2.1",
+ "http",
 ]
 
 [[package]]
@@ -2347,7 +2323,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.1",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -2368,7 +2344,7 @@ checksum = "ed123fc8c1833f305468df3c3a6a837c34a7ae616567d40a5e3c2bf3cac2e31d"
 dependencies = [
  "antidote",
  "bytes 0.5.6",
- "http 0.2.1",
+ "http",
  "hyper",
  "linked_hash_set",
  "once_cell",
@@ -2600,7 +2576,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "chrono",
- "http 0.2.1",
+ "http",
  "percent-encoding",
  "serde",
  "serde-value",
@@ -3257,7 +3233,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "futures 0.3.5",
- "http 0.2.1",
+ "http",
  "httparse",
  "lazy_static",
  "log",
@@ -4417,7 +4393,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.1",
+ "http",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -4505,7 +4481,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "futures 0.3.5",
- "http 0.2.1",
+ "http",
  "hyper",
  "hyper-tls",
  "lazy_static",
@@ -4540,6 +4516,21 @@ dependencies = [
  "shlex",
  "tokio",
  "zeroize",
+]
+
+[[package]]
+name = "rusoto_es"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a49c8259ada24cb2c64d2a2aee0ca150eed3aef91d102063d8efca747ccaa3"
+dependencies = [
+ "async-trait",
+ "bytes 0.5.6",
+ "futures 0.3.5",
+ "rusoto_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -4608,7 +4599,7 @@ dependencies = [
  "futures 0.3.5",
  "hex",
  "hmac 0.8.1",
- "http 0.2.1",
+ "http",
  "hyper",
  "log",
  "md5",
@@ -5899,7 +5890,7 @@ version = "0.1.0"
 source = "git+https://github.com/tokio-rs/tracing?rev=f470db1b0354b368f62f9ee4d763595d16373231#f470db1b0354b368f62f9ee4d763595d16373231"
 dependencies = [
  "futures 0.3.5",
- "http 0.2.1",
+ "http",
  "pin-project",
  "tower-layer",
  "tower-make",
@@ -5929,7 +5920,7 @@ dependencies = [
  "base64 0.12.3",
  "byteorder",
  "bytes 0.5.6",
- "http 0.2.1",
+ "http",
  "httparse",
  "input_buffer",
  "log",
@@ -6197,7 +6188,6 @@ dependencies = [
  "derivative 1.0.4",
  "derive_is_enum_variant",
  "dirs 3.0.1",
- "elastic_responses",
  "evmap",
  "exitcode",
  "file-source",
@@ -6212,7 +6202,7 @@ dependencies = [
  "heim",
  "hex",
  "hostname",
- "http 0.2.1",
+ "http",
  "human_format",
  "hyper",
  "hyper-openssl",
@@ -6263,6 +6253,7 @@ dependencies = [
  "rusoto_cloudwatch",
  "rusoto_core",
  "rusoto_credential",
+ "rusoto_es",
  "rusoto_firehose",
  "rusoto_kinesis",
  "rusoto_logs",
@@ -6453,7 +6444,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
  "headers",
- "http 0.2.1",
+ "http",
  "hyper",
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ metrics-tracing-context = { version = "0.1.0-alpha"  }
 
 # Aws
 rusoto_core = { version = "0.45.0", features = ["encoding"], optional = true }
+rusoto_es = { version = "0.45.0", optional = true }
 rusoto_s3 = { version = "0.45.0", optional = true }
 rusoto_logs = { version = "0.45.0", optional = true }
 rusoto_cloudwatch = { version = "0.45.0", optional = true }
@@ -210,7 +211,6 @@ tempfile = "3.0.6"
 libc = "0.2.78"
 libz-sys = "1.1.2"
 walkdir = "2.2.7"
-elastic_responses = "0.21.0-pre.4"
 matches = "0.1.8"
 pretty_assertions = "0.6.1"
 tokio01-test = "0.1.1"
@@ -476,7 +476,7 @@ aws-integration-tests = [
 aws-cloudwatch-logs-integration-tests = ["sinks-aws_cloudwatch_logs"]
 aws-cloudwatch-metrics-integration-tests = ["sinks-aws_cloudwatch_metrics"]
 aws-ec2-metadata-integration-tests = ["transforms-aws_ec2_metadata"]
-aws-kinesis-firehose-integration-tests = ["sinks-aws_kinesis_firehose", "sinks-elasticsearch"]
+aws-kinesis-firehose-integration-tests = ["sinks-aws_kinesis_firehose", "sinks-elasticsearch", "rusoto_es"]
 aws-kinesis-streams-integration-tests = ["sinks-aws_kinesis_streams"]
 aws-s3-integration-tests = ["sinks-aws_s3"]
 clickhouse-integration-tests = ["sinks-clickhouse"]

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ ifeq ($(CONTAINER_TOOL),podman)
 	 timberiodev/mock-ec2-metadata:latest
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_localstack_aws \
 	 -e SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose \
-	 localstack/localstack-full:0.11.6
+	 localstack/localstack:0.11.6
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_mockwatchlogs \
 	 -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
 else
@@ -313,7 +313,7 @@ else
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_localstack_aws \
 	 -p 4566:4566 -p 4571:4571 \
 	 -e SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose \
-	 localstack/localstack-full:0.11.6
+	 localstack/localstack:0.11.6
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws -p 6000:6000 --name vector_mockwatchlogs \
 	 -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
 endif

--- a/Makefile
+++ b/Makefile
@@ -298,22 +298,22 @@ stop-test-integration: stop-integration-pulsar stop-integration-splunk
 .PHONY: start-integration-aws
 start-integration-aws:
 ifeq ($(CONTAINER_TOOL),podman)
-	$(CONTAINER_TOOL) $(CONTAINER_ENCLOSURE) create --replace --name vector-test-integration-aws -p 8111:8111 -p 4568:4568 -p 4572:4572 -p 4582:4582 -p 4571:4571 -p 4573:4573 -p 6000:6000
+	$(CONTAINER_TOOL) $(CONTAINER_ENCLOSURE) create --replace --name vector-test-integration-aws -p 4566:4566 -p 4571:4571 -p 6000:6000
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_ec2_metadata \
 	 timberiodev/mock-ec2-metadata:latest
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_localstack_aws \
-	 -e SERVICES=kinesis:4568,s3:4572,cloudwatch:4582,elasticsearch:4571,firehose:4573 \
-	 localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
+	 -e SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose \
+	 localstack/localstack-full:0.11.6
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_mockwatchlogs \
 	 -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
 else
 	$(CONTAINER_TOOL) $(CONTAINER_ENCLOSURE) create vector-test-integration-aws
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws -p 8111:8111 --name vector_ec2_metadata \
 	 timberiodev/mock-ec2-metadata:latest
-	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws -p 4568:4568 -p 4572:4572 \
-	 -p 4582:4582 -p 4571:4571 -p 4573:4573 --name vector_localstack_aws \
-	 -e SERVICES=kinesis:4568,s3:4572,cloudwatch:4582,elasticsearch:4571,firehose:4573 \
-	 localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
+	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws --name vector_localstack_aws \
+	 -p 4566:4566 -p 4571:4571 \
+	 -e SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose \
+	 localstack/localstack-full:0.11.6
 	$(CONTAINER_TOOL) run -d --$(CONTAINER_ENCLOSURE)=vector-test-integration-aws -p 6000:6000 --name vector_mockwatchlogs \
 	 -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
 endif

--- a/config/examples/file_to_cloudwatch_metrics.toml
+++ b/config/examples/file_to_cloudwatch_metrics.toml
@@ -42,4 +42,4 @@ encoding = "json"
 inputs = ["log_to_metric"]
 type = "aws_cloudwatch_metrics"
 namespace = "vector"
-endpoint = "http://localhost:4582"
+endpoint = "http://localhost:4566"

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -448,7 +448,7 @@ mod integration_tests {
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
             namespace: "vector".into(),
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4582".to_owned()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".to_owned()),
             ..Default::default()
         }
     }

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -297,6 +297,7 @@ mod integration_tests {
     };
     use futures::{compat::Sink01CompatExt, SinkExt, StreamExt};
     use rusoto_core::Region;
+    use rusoto_es::{CreateElasticsearchDomainRequest, Es, EsClient};
     use rusoto_firehose::{
         CreateDeliveryStreamInput, ElasticsearchDestinationConfiguration, KinesisFirehose,
         KinesisFirehoseClient,
@@ -310,14 +311,14 @@ mod integration_tests {
 
         let region = Region::Custom {
             name: "localstack".into(),
-            endpoint: "http://localhost:4573".into(),
+            endpoint: "http://localhost:4566".into(),
         };
 
         ensure_stream(region, stream.clone()).await;
 
         let config = KinesisFirehoseSinkConfig {
             stream_name: stream.clone(),
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4573".into()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
             encoding: EncodingConfig::from(Encoding::Json), // required for ES destination w/ localstack
             compression: Compression::None,
             batch: BatchConfig {
@@ -364,27 +365,55 @@ mod integration_tests {
             .send()
             .await
             .unwrap()
-            .json::<elastic_responses::search::SearchResponse<Value>>()
+            .json::<Value>()
             .await
-            .unwrap();
+            .expect("could not issue Elasticsearch search request");
 
-        assert_eq!(input.len() as u64, response.total());
+        let total = response["hits"]["total"]["value"]
+            .as_u64()
+            .expect("Elasticsearch response does not include hits->total->value");
+        let hits = response["hits"]["hits"]
+            .as_array()
+            .expect("Elasticsearch response does not include hits->hits");
+
+        assert_eq!(input.len() as u64, total);
         let input = input
             .into_iter()
             .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
             .collect::<Vec<_>>();
-        for hit in response.into_hits() {
-            let event = hit.into_document().unwrap();
-            assert!(input.contains(&event));
+        for hit in hits {
+            let hit = hit
+                .get("_source")
+                .expect("Elasticsearch hit missing _source");
+            assert!(input.contains(&hit));
         }
     }
 
+    /// creates ES domain with the given name and returns the ARN
+    async fn ensure_elasticsearch_domain(region: Region, domain_name: String) -> String {
+        let client = EsClient::new(region);
+
+        let req = CreateElasticsearchDomainRequest {
+            domain_name,
+            ..Default::default()
+        };
+
+        match client.create_elasticsearch_domain(req).await {
+            Ok(res) => res.domain_status.expect("no domain status").arn,
+            Err(e) => panic!("Unable to create the Elasticsearch domain {:?}", e),
+        }
+    }
+
+    /// creates ES domain and Firehose delivery stream
     async fn ensure_stream(region: Region, delivery_stream_name: String) {
+        let es_domain_arn =
+            ensure_elasticsearch_domain(region.clone(), delivery_stream_name.clone()).await;
+
         let client = KinesisFirehoseClient::new(region);
 
         let es_config = ElasticsearchDestinationConfiguration {
             index_name: delivery_stream_name.clone(),
-            domain_arn: Some("doesn't matter".into()),
+            domain_arn: Some(es_domain_arn),
             role_arn: "doesn't matter".into(),
             type_name: Some("doesn't matter".into()),
             ..Default::default()
@@ -398,7 +427,7 @@ mod integration_tests {
 
         match client.create_delivery_stream(req).await {
             Ok(_) => (),
-            Err(e) => println!("Unable to create the delivery stream {:?}", e),
+            Err(e) => panic!("Unable to create the delivery stream {:?}", e),
         };
     }
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -372,11 +372,11 @@ mod integration_tests {
         let total = response["hits"]["total"]["value"]
             .as_u64()
             .expect("Elasticsearch response does not include hits->total->value");
+        assert_eq!(input.len() as u64, total);
+
         let hits = response["hits"]["hits"]
             .as_array()
             .expect("Elasticsearch response does not include hits->hits");
-
-        assert_eq!(input.len() as u64, total);
         let input = input
             .into_iter()
             .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -393,7 +393,7 @@ mod integration_tests {
 
         let region = Region::Custom {
             name: "localstack".into(),
-            endpoint: "http://localhost:4568".into(),
+            endpoint: "http://localhost:4566".into(),
         };
 
         ensure_stream(region.clone(), stream.clone()).await;
@@ -401,7 +401,7 @@ mod integration_tests {
         let config = KinesisSinkConfig {
             stream_name: stream.clone(),
             partition_key_field: None,
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4568".into()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
             encoding: Encoding::Text.into(),
             compression: Compression::None,
             batch: BatchConfig {
@@ -489,6 +489,13 @@ mod integration_tests {
             Ok(_) => (),
             Err(e) => panic!("Unable to check the stream {:?}", e),
         };
+
+        // Wait for localstack to persist stream, otherwise it returns ResourceNotFound errors
+        // during PutRecords
+        //
+        // I initially tried using `wait_for` with `DescribeStream` but localstack would
+        // successfully return the stream before it was able to accept PutRecords requests
+        delay_for(Duration::from_secs(1)).await;
     }
 
     fn gen_stream() -> String {

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -571,7 +571,7 @@ mod integration_tests {
         assert!(key.ends_with(".log"));
 
         let obj = get_object(key).await;
-        assert_eq!(obj.content_encoding, None);
+        assert_eq!(obj.content_encoding, Some("identity".to_string()));
 
         let response_lines = get_lines(obj).await;
         assert_eq!(lines, response_lines);
@@ -683,7 +683,7 @@ mod integration_tests {
     fn client() -> S3Client {
         let region = Region::Custom {
             name: "minio".to_owned(),
-            endpoint: "http://localhost:4572".to_owned(),
+            endpoint: "http://localhost:4566".to_owned(),
         };
 
         use rusoto_core::HttpClient;
@@ -707,7 +707,7 @@ mod integration_tests {
                 timeout_secs: Some(5),
                 ..Default::default()
             },
-            region: RegionOrEndpoint::with_endpoint("http://localhost:4572".to_owned()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".to_owned()),
             ..Default::default()
         }
     }

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -718,7 +718,7 @@ mod integration_tests {
         run_insert_tests(
             ElasticSearchConfig {
                 auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
-                endpoint: "http://localhost:4571".into(),
+                endpoint: "http://localhost:4566".into(),
                 ..config()
             },
             false,

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -654,25 +654,33 @@ mod integration_tests {
             .send()
             .await
             .unwrap()
-            .json::<elastic_responses::search::SearchResponse<Value>>()
+            .json::<Value>()
             .await
             .unwrap();
 
-        assert_eq!(1, response.total());
+        let total = response["hits"]["total"]
+            .as_u64()
+            .expect("Elasticsearch response does not include hits->total");
+        assert_eq!(1, total);
 
-        let hit = response.into_hits().next().unwrap();
-        assert_eq!("42", hit.id());
+        let hits = response["hits"]["hits"]
+            .as_array()
+            .expect("Elasticsearch response does not include hits->hits");
 
-        let doc = hit.document().unwrap();
-        assert_eq!(None, doc["my_id"].as_str());
+        let hit = hits.iter().next().unwrap();
+        assert_eq!("42", hit["_id"]);
 
-        let value = hit.into_document().unwrap();
+        let value = hit
+            .get("_source")
+            .expect("Elasticsearch hit missing _source");
+        assert_eq!(None, value["my_id"].as_str());
+
         let expected = json!({
             "message": "raw log line",
             "foo": "bar",
             "timestamp": input_event.as_log()[crate::config::log_schema().timestamp_key()],
         });
-        assert_eq!(expected, value);
+        assert_eq!(&expected, value);
     }
 
     #[tokio::test]
@@ -718,7 +726,7 @@ mod integration_tests {
         run_insert_tests(
             ElasticSearchConfig {
                 auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
-                endpoint: "http://localhost:4566".into(),
+                endpoint: "http://localhost:4571".into(),
                 ..config()
             },
             false,
@@ -798,22 +806,31 @@ mod integration_tests {
             .send()
             .await
             .unwrap()
-            .json::<elastic_responses::search::SearchResponse<Value>>()
+            .json::<Value>()
             .await
             .unwrap();
 
-        if break_events {
-            assert_ne!(input.len() as u64, response.total());
-        } else {
-            assert_eq!(input.len() as u64, response.total());
+        let total = response["hits"]["total"]
+            .as_u64()
+            .expect("Elasticsearch response does not include hits->total");
 
+        if break_events {
+            assert_ne!(input.len() as u64, total);
+        } else {
+            assert_eq!(input.len() as u64, total);
+
+            let hits = response["hits"]["hits"]
+                .as_array()
+                .expect("Elasticsearch response does not include hits->hits");
             let input = input
                 .into_iter()
                 .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
                 .collect::<Vec<_>>();
-            for hit in response.into_hits() {
-                let event = hit.into_document().unwrap();
-                assert!(input.contains(&event));
+            for hit in hits {
+                let hit = hit
+                    .get("_source")
+                    .expect("Elasticsearch hit missing _source");
+                assert!(input.contains(&hit));
             }
         }
     }


### PR DESCRIPTION
Updates to latest localstack tag. I need this for some of the S3+SQS
work, but figured I'd do it separately.

The biggest change is that localstack now exposes all services on the
same port, 4566, simplifying our setup.

Additional changes due to localstack changes:

I updated `aws_s3` sink tests to use "Identity" for Content-Encoding as
this appears to be the default encoding now

I added a sleep in `aws_kinesis_streams` test to allow localstack to
fully create the stream (it was getting `ResourceNotFound` errors when
the sink tried to publish via `PutRecords`). I tried a `wait_for` with
`DescribeStream`, but the stream was successfully returned by that
before it was ready, still.

I updated `aws_kinesis_firehose` to create the Elasticsearch domain as
localstack now lazily starts Elasticsearch upon domain creation.

I updated `aws_kinesis_firehose` tests to just deserialize requests
directly rather than using `elastic_responses` (which allowed me to drop
this dependency). The localstack update included an ES update which
caused me to run into elastic-rs/elastic#361
. I was going to update `elastic_responses` to include this change but
the `elastic_responses` crate was dropped in newer versions of that
repo.  I then attempted to switch to the actual client that repo
provides but ran into async issues with it depending on futures01
(elastic-rs/elastic#414). That Github issue
for that indicated to me that it seems like that repo was being
deprecated in-lieu of the official client. Given we only needed an
exceedingly small subset of functionality, I just decided to parse it
with `serde_json::Value` rather than switch to the new crate; however,
that seems like the preferred option for the future is an option for the
future if we come to need a more robust ES integration.