### PR TITLE
chore(external docs): Fill in missing parts of the documentation at the kubernetes_logs source

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -137,6 +137,17 @@ components: sources: kubernetes_logs: {
 				default: "${VECTOR_SELF_NODE_NAME}"
 			}
 		}
+		exclude_paths_glob_patterns: {
+			common: false
+			description: """
+				A list of glob patterns to exclude from reading the files.
+				"""
+			required: false
+			type: array: {
+				default: []
+				items: type: string: examples: ["**/exclude/**"]
+			}
+		}
 		extra_field_selector: {
 			common: false
 			description: """

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -22,8 +22,19 @@ components: sources: kubernetes_logs: {
 				url:      urls.kubernetes
 				versions: ">= 1.14"
 
-				interface: file_system: {
-					directory: _directory
+				interface: {
+					file_system: {
+						directory: _directory
+					}
+					socket: {
+						api: {
+							title: "kube-apiserver"
+							url:   "dynamically detected at runtime"
+						}
+						direction: "outgoing"
+						ssl: "required"
+						protocols: ["http"]
+					}
 				}
 			}
 		}

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -32,7 +32,7 @@ components: sources: kubernetes_logs: {
 							url:   "dynamically detected at runtime"
 						}
 						direction: "outgoing"
-						ssl: "required"
+						ssl:       "required"
 						protocols: ["http"]
 					}
 				}
@@ -185,7 +185,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.container_image": {
 				description: "Container image."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["busybox:1.30"]
 					default: null
@@ -194,7 +194,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.container_name": {
 				description: "Container name."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["coredns"]
 					default: null
@@ -203,7 +203,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.pod_labels": {
 				description: "Pod labels name."
 				required:    false
-				common:    true
+				common:      true
 				type: object: {
 					examples: [{"mylabel": "myvalue"}]
 					options: {}
@@ -212,7 +212,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.pod_name": {
 				description: "Pod name."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["coredns-qwertyuiop-qwert"]
 					default: null
@@ -221,7 +221,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.pod_namespace": {
 				description: "Pod namespace."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["kube-system"]
 					default: null
@@ -230,7 +230,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.pod_node_name": {
 				description: "Pod node name."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["minikube"]
 					default: null
@@ -239,7 +239,7 @@ components: sources: kubernetes_logs: {
 			"kubernetes.pod_uid": {
 				description: "Pod uid."
 				required:    false
-				common:    true
+				common:      true
 				type: string: {
 					examples: ["ba46d8c9-9541-4f6b-bbf9-d23b36f2f136"]
 					default: null

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -157,6 +157,40 @@ components: sources: kubernetes_logs: {
 		fields: {}
 	}
 
+	examples: [
+		{
+			title: "Sample Output"
+			configuration: {
+				type: "kubernetes_logs"
+			}
+			input: """
+				```text
+				F1015 11:01:46.499073       1 main.go:39] error getting server version: Get \"https://10.96.0.1:443/version?timeout=32s\": dial tcp 10.96.0.1:443: connect: network is unreachable
+				```
+				"""
+			output: log: {
+				"file": "/var/log/pods/kube-system_storage-provisioner_93bde4d0-9731-4785-a80e-cd27ba8ad7c2/storage-provisioner/1.log"
+				"kubernetes": {
+					"container_image": "gcr.io/k8s-minikube/storage-provisioner:v3"
+					"container_name":  "storage-provisioner"
+					"pod_labels": {
+						"addonmanager.kubernetes.io/mode": "Reconcile"
+						"gcp-auth-skip-secret":            "true"
+						"integration-test":                "storage-provisioner"
+					}
+					"pod_name":      "storage-provisioner"
+					"pod_namespace": "kube-system"
+					"pod_node_name": "minikube"
+					"pod_uid":       "93bde4d0-9731-4785-a80e-cd27ba8ad7c2"
+				}
+				"message":     "F1015 11:01:46.499073       1 main.go:39] error getting server version: Get \"https://10.96.0.1:443/version?timeout=32s\": dial tcp 10.96.0.1:443: connect: network is unreachable"
+				"source_type": "kubernetes_logs"
+				"stream":      "stderr"
+				"timestamp":   "2020-10-15T11:01:46.499555308Z"
+			}
+		},
+	]
+
 	how_it_works: {
 		connecting_to_kubernetes_api: {
 			title: "Connecting To The Kubernetes API server"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -126,6 +126,30 @@ components: sources: kubernetes_logs: {
 				default: "${VECTOR_SELF_NODE_NAME}"
 			}
 		}
+		extra_field_selector: {
+			common: false
+			description: """
+				Specifies the field selector to filter `Pod`s with, to be used in addition to the built-in `Node` filter.
+				The name of the Kubernetes `Node` this Vector instance runs at. Configured to use an env var by default, to be evaluated to a value provided by Kubernetes at Pod deploy time.
+				"""
+			required: false
+			type: array: {
+				default: []
+				items: type: string: examples: ["metadata.name!=pod-name-to-exclude"]
+			}
+		}
+		extra_label_selector: {
+			common: false
+			description: """
+				Specifies the label selector to filter `Pod`s with, to be used in
+				addition to the built-in `vector.dev/exclude` filter.
+				"""
+			required: false
+			type: array: {
+				default: []
+				items: type: string: examples: ["my_custom_label!=my_value"]
+			}
+		}
 	}
 
 	output: logs: line: {

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -153,8 +153,93 @@ components: sources: kubernetes_logs: {
 	}
 
 	output: logs: line: {
-		description: "fill in"
-		fields: {}
+		description: "An individual line from a `Pod` log file."
+		fields: {
+			file: {
+				description: "The absolute path of originating file."
+				required:    true
+				type: string: examples: ["\(_directory)/pods/pod-namespace_pod-name_pod-uid/container/1.log"]
+			}
+			"kubernetes.container_image": {
+				description: "Container image."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["busybox:1.30"]
+					default: null
+				}
+			}
+			"kubernetes.container_name": {
+				description: "Container name."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["coredns"]
+					default: null
+				}
+			}
+			"kubernetes.pod_labels": {
+				description: "Pod labels name."
+				required:    false
+				common:    true
+				type: object: {
+					examples: [{"mylabel": "myvalue"}]
+					options: {}
+				}
+			}
+			"kubernetes.pod_name": {
+				description: "Pod name."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["coredns-qwertyuiop-qwert"]
+					default: null
+				}
+			}
+			"kubernetes.pod_namespace": {
+				description: "Pod namespace."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["kube-system"]
+					default: null
+				}
+			}
+			"kubernetes.pod_node_name": {
+				description: "Pod node name."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["minikube"]
+					default: null
+				}
+			}
+			"kubernetes.pod_uid": {
+				description: "Pod uid."
+				required:    false
+				common:    true
+				type: string: {
+					examples: ["ba46d8c9-9541-4f6b-bbf9-d23b36f2f136"]
+					default: null
+				}
+			}
+			message: {
+				description: "The raw line from the Pod log file."
+				required:    true
+				type: string: examples: ["53.126.150.246 - - [01/Oct/2020:11:25:58 -0400] \"GET /disintermediate HTTP/2.0\" 401 20308"]
+			}
+			source_type: {
+				description: "The name of the source type."
+				required:    true
+				type: string: examples: ["kubernetes_logs"]
+			}
+			stream: {
+				description: "The name of the stream the log line was sumbitted to."
+				required:    true
+				type: string: examples: ["stdout", "stderr"]
+			}
+			timestamp: fields._current_timestamp
+		}
 	}
 
 	examples: [

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -15,7 +15,7 @@ components: sources: kubernetes_logs: {
 
 	features: {
 		collect: {
-			checkpoint: enabled: false
+			checkpoint: enabled: true
 			from: {
 				name:     "Kubernetes"
 				thing:    "\(name) nodes"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -276,24 +276,22 @@ components: sources: kubernetes_logs: {
 				```
 				"""
 			output: log: {
-				"file": "/var/log/pods/kube-system_storage-provisioner_93bde4d0-9731-4785-a80e-cd27ba8ad7c2/storage-provisioner/1.log"
-				"kubernetes": {
-					"container_image": "gcr.io/k8s-minikube/storage-provisioner:v3"
-					"container_name":  "storage-provisioner"
-					"pod_labels": {
-						"addonmanager.kubernetes.io/mode": "Reconcile"
-						"gcp-auth-skip-secret":            "true"
-						"integration-test":                "storage-provisioner"
-					}
-					"pod_name":      "storage-provisioner"
-					"pod_namespace": "kube-system"
-					"pod_node_name": "minikube"
-					"pod_uid":       "93bde4d0-9731-4785-a80e-cd27ba8ad7c2"
+				"file":                       "/var/log/pods/kube-system_storage-provisioner_93bde4d0-9731-4785-a80e-cd27ba8ad7c2/storage-provisioner/1.log"
+				"kubernetes.container_image": "gcr.io/k8s-minikube/storage-provisioner:v3"
+				"kubernetes.container_name":  "storage-provisioner"
+				"kubernetes.pod_labels": {
+					"addonmanager.kubernetes.io/mode": "Reconcile"
+					"gcp-auth-skip-secret":            "true"
+					"integration-test":                "storage-provisioner"
 				}
-				"message":     "F1015 11:01:46.499073       1 main.go:39] error getting server version: Get \"https://10.96.0.1:443/version?timeout=32s\": dial tcp 10.96.0.1:443: connect: network is unreachable"
-				"source_type": "kubernetes_logs"
-				"stream":      "stderr"
-				"timestamp":   "2020-10-15T11:01:46.499555308Z"
+				"kubernetes.pod_name":      "storage-provisioner"
+				"kubernetes.pod_namespace": "kube-system"
+				"kubernetes.pod_node_name": "minikube"
+				"kubernetes.pod_uid":       "93bde4d0-9731-4785-a80e-cd27ba8ad7c2"
+				"message":                  "F1015 11:01:46.499073       1 main.go:39] error getting server version: Get \"https://10.96.0.1:443/version?timeout=32s\": dial tcp 10.96.0.1:443: connect: network is unreachable"
+				"source_type":              "kubernetes_logs"
+				"stream":                   "stderr"
+				"timestamp":                "2020-10-15T11:01:46.499555308Z"
 			}
 		},
 	]

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -26,15 +26,6 @@ components: sources: kubernetes_logs: {
 					file_system: {
 						directory: _directory
 					}
-					socket: {
-						api: {
-							title: "kube-apiserver"
-							url:   "dynamically detected at runtime"
-						}
-						direction: "outgoing"
-						ssl:       "required"
-						protocols: ["http"]
-					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR fills in some details at the `kubernetes_logs` source docs.

@binarylogic, could you do a pass on making the values fit the schema? I'm having a hard time figuring out the error cause, as errors are in pretty much all of the components.

Closes #4594.
Closes #4587.