### PR TITLE
chore(external docs): Restore templateable option

### DIFF
--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -179,6 +179,7 @@ components: sinks: elasticsearch: {
 			type: string: {
 				default: "vector-%F"
 				examples: ["application-{{ application_id }}-%Y-%m-%d", "vector-%Y-%m-%d"]
+				templateable: true
 			}
 		}
 		pipeline: {

--- a/docs/reference/components/sinks/file.cue
+++ b/docs/reference/components/sinks/file.cue
@@ -67,6 +67,7 @@ components: sinks: file: {
 			warnings: []
 			type: string: {
 				examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log"]
+				templateable: true
 			}
 		}
 	}

--- a/docs/reference/components/sinks/humio_logs.cue
+++ b/docs/reference/components/sinks/humio_logs.cue
@@ -90,6 +90,7 @@ components: sinks: humio_logs: {
 			type: string: {
 				default: null
 				examples: ["json", "none"]
+				templateable: true
 			}
 		}
 		host_key: {
@@ -110,6 +111,7 @@ components: sinks: humio_logs: {
 			type: string: {
 				default: null
 				examples: ["{{file}}", "/var/log/syslog", "UDP:514"]
+				templateable: true
 			}
 		}
 		token: {

--- a/docs/reference/components/sinks/loki.cue
+++ b/docs/reference/components/sinks/loki.cue
@@ -125,7 +125,18 @@ components: sinks: loki: {
 						"key":       "value"
 					},
 				]
-				options: {}
+				options: {
+					"*": {
+						common:      false
+						description: "Any Loki label"
+						required:    false
+						type: string: {
+							default: null
+							examples: ["vector", "{{ event_field }}"]
+							templateable: true
+						}
+					}
+				}
 			}
 		}
 		remove_label_fields: {


### PR DESCRIPTION
Signed-off-by: binarylogic <bjohnson@binarylogic.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
