### PR TITLE
fix(loki sink): Send auth header for healchecks

### DIFF
--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -196,7 +196,11 @@ impl HttpSink for LokiConfig {
 async fn healthcheck(config: LokiConfig, mut client: HttpClient) -> crate::Result<()> {
     let uri = format!("{}ready", config.endpoint);
 
-    let req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
+    let mut req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
+
+    if let Some(auth) = &config.auth {
+        auth.apply(&mut req);
+    }
 
     let res = client.send(req).await?;
 
@@ -211,8 +215,10 @@ async fn healthcheck(config: LokiConfig, mut client: HttpClient) -> crate::Resul
 mod tests {
     use super::*;
     use crate::sinks::util::http::HttpSink;
-    use crate::sinks::util::test::load_sink;
+    use crate::sinks::util::test::{build_test_server, load_sink};
+    use crate::test_util;
     use crate::Event;
+    use futures::StreamExt;
 
     #[test]
     fn interpolate_labels() {
@@ -276,6 +282,46 @@ mod tests {
         assert_eq!(record.event.event, expected_line);
 
         assert_eq!(record.labels[0], ("bar".to_string(), "bar".to_string()));
+    }
+
+    #[tokio::test]
+    async fn healthcheck_includes_auth() {
+        let (mut config, cx) = load_sink::<LokiConfig>(
+            r#"
+            endpoint = "http://localhost:3100"
+            labels = {test_name = "placeholder"}
+			auth.strategy = "basic"
+			auth.user = "username"
+			auth.password = "some_password"
+        "#,
+        )
+        .unwrap();
+
+        let addr = test_util::next_addr();
+        let endpoint = format!("http://{}", addr);
+        config.endpoint = endpoint
+            .clone()
+            .parse::<http::Uri>()
+            .expect("could not create URI")
+            .into();
+
+        let (rx, _trigger, server) = build_test_server(addr);
+        tokio::spawn(server);
+
+        let tls = TlsSettings::from_options(&config.tls).expect("could not create TLS settings");
+        let client = HttpClient::new(cx.resolver(), tls).expect("could not cerate HTTP client");
+
+        healthcheck(config.clone(), client)
+            .await
+            .expect("healthcheck failed");
+
+        let output = rx.take(1).collect::<Vec<_>>().await;
+        assert_eq!(
+            Some(&http::header::HeaderValue::from_static(
+                "Basic dXNlcm5hbWU6c29tZV9wYXNzd29yZA=="
+            )),
+            output[0].0.headers.get("authorization")
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #3710

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
