### PR TITLE
chore(external docs): Update `log_to_metric` docs

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -467,7 +467,7 @@ _values: {
 #MetricEventDistribution: {
 	values: [float, ...]
 	sample_rates: [float, ...]
-	statistic: #DistributionStatistic
+	statistic: "histogram" | "summary"
 }
 
 #MetricEventGauge: {
@@ -508,8 +508,6 @@ _values: {
 })
 
 #MetricType: "counter" | "gauge" | "histogram" | "summary"
-
-#DistributionStatistic: "histogram" | "summary"
 
 #Object: {[_=string]: #Any}
 

--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -467,7 +467,7 @@ _values: {
 #MetricEventDistribution: {
 	values: [float, ...]
 	sample_rates: [float, ...]
-	statistic: "histogram" | "summary"
+	statistic: #DistributionStatistic
 }
 
 #MetricEventGauge: {
@@ -508,6 +508,8 @@ _values: {
 })
 
 #MetricType: "counter" | "gauge" | "histogram" | "summary"
+
+#DistributionStatistic: "histogram" | "summary"
 
 #Object: {[_=string]: #Any}
 

--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -321,6 +321,18 @@ components: {
 					type: "counter"
 				}
 
+				_passthrough_distribution: {
+					description: data_model.schema.metric.type.object.options.distribution.description
+					tags: {
+						"*": {
+							description: "Any tags present on the metric."
+							examples: [_values.local_host]
+							required: false
+						}
+					}
+					type: "gauge"
+				}
+
 				_passthrough_gauge: {
 					description: data_model.schema.metric.type.object.options.gauge.description
 					tags: {

--- a/docs/reference/components/sources/statsd.cue
+++ b/docs/reference/components/sources/statsd.cue
@@ -65,10 +65,11 @@ components: sources: statsd: {
 	}
 
 	output: metrics: {
-		counter:   output._passthrough_counter
-		gauge:     output._passthrough_gauge
-		histogram: output._passthrough_histogram
-		set:       output._passthrough_set
+		counter:   	  output._passthrough_counter
+		distribution: output._passthrough_distribution
+		gauge:        output._passthrough_gauge
+		histogram:    output._passthrough_histogram
+		set:          output._passthrough_set
 	}
 
 	how_it_works: {

--- a/docs/reference/components/sources/statsd.cue
+++ b/docs/reference/components/sources/statsd.cue
@@ -65,7 +65,7 @@ components: sources: statsd: {
 	}
 
 	output: metrics: {
-		counter:   	  output._passthrough_counter
+		counter:      output._passthrough_counter
 		distribution: output._passthrough_distribution
 		gauge:        output._passthrough_gauge
 		histogram:    output._passthrough_histogram

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -128,6 +128,7 @@ components: transforms: log_to_metric: {
 	examples: [
 		{
 			title: "Counter"
+			notes: "This example demonstrates counting HTTP status codes."
 			configuration: {
 				metrics: [
 					{
@@ -159,6 +160,7 @@ components: transforms: log_to_metric: {
 		},
 		{
 			title: "Sum"
+			notes: "In this example we'll demonstrate computing a sum by computing the total of orders placed."
 			configuration: {
 				metrics: [
 					{
@@ -189,6 +191,7 @@ components: transforms: log_to_metric: {
 		},
 		{
 			title: "Gauges"
+			notes: "In this example we'll demonstrate creating a gauge that represents the current CPU load averages."
 			configuration: {
 				metrics: [
 					{
@@ -247,6 +250,7 @@ components: transforms: log_to_metric: {
 		},
 		{
 			title: "Histogram"
+			notes: "This example demonstrates capturing timings in your logs."
 			configuration: {
 				metrics: [
 					{
@@ -281,6 +285,7 @@ components: transforms: log_to_metric: {
 		},
 		{
 			title: "Summary"
+			notes: "This example demonstrates capturing timings in your logs to compute summary."
 			configuration: {
 				metrics: [
 					{
@@ -315,6 +320,12 @@ components: transforms: log_to_metric: {
 		},
 		{
 			title: "Set"
+			notes: """
+				In this example we'll demonstrate how to use sets. Sets are primarly a Statsd concept 
+				that represent the number of unique values seens for a given metric. 
+				The idea is that you pass the unique/high-cardinality value as the metric value
+				and the metric store will count the number of unique values seen.
+				"""
 			configuration: {
 				metrics: [
 					{

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -64,6 +64,7 @@ components: transforms: log_to_metric: {
 						warnings: []
 						type: string: {
 							examples: ["duration_total"]
+							default: string
 						}
 						templateable: true
 					}
@@ -147,7 +148,6 @@ components: transforms: log_to_metric: {
 			}
 			output: [{metric: {
 				name: "response_total"
-				kind: "incremental"
 				tags: {
 					status: "200"
 					host:   "10.22.11.222"
@@ -179,7 +179,6 @@ components: transforms: log_to_metric: {
 			}
 			output: [{metric: {
 				name: "order_total"
-				kind: "incremental"
 				tags: {
 					host: "10.22.11.222"
 				}
@@ -219,7 +218,6 @@ components: transforms: log_to_metric: {
 			output: [
 				{metric: {
 					name: "1m_load_avg"
-					kind: "absolute"
 					tags: {
 						host: "10.22.11.222"
 					}
@@ -229,7 +227,6 @@ components: transforms: log_to_metric: {
 				}},
 				{metric: {
 					name: "5m_load_avg"
-					kind: "absolute"
 					tags: {
 						host: "10.22.11.222"
 					}
@@ -239,7 +236,6 @@ components: transforms: log_to_metric: {
 				}},
 				{metric: {
 					name: "15m_load_avg"
-					kind: "absolute"
 					tags: {
 						host: "10.22.11.222"
 					}
@@ -272,7 +268,6 @@ components: transforms: log_to_metric: {
 			}
 			output: [{metric: {
 				name: "time_ms"
-				kind: "incremental"
 				tags: {
 					status: "200"
 					host:   "10.22.11.222"
@@ -307,7 +302,6 @@ components: transforms: log_to_metric: {
 			}
 			output: [{metric: {
 				name: "time_ms"
-				kind: "incremental"
 				tags: {
 					status: "200"
 					host:   "10.22.11.222"
@@ -339,7 +333,6 @@ components: transforms: log_to_metric: {
 			}
 			output: [{metric: {
 				name: "remote_addr"
-				kind: "incremental"
 				tags: {
 					host: "10.22.11.222"
 				}

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -321,8 +321,8 @@ components: transforms: log_to_metric: {
 		{
 			title: "Set"
 			notes: """
-				In this example we'll demonstrate how to use sets. Sets are primarly a Statsd concept 
-				that represent the number of unique values seens for a given metric. 
+				In this example we'll demonstrate how to use sets. Sets are primarly a Statsd concept
+				that represent the number of unique values seens for a given metric.
 				The idea is that you pass the unique/high-cardinality value as the metric value
 				and the metric store will count the number of unique values seen.
 				"""

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -64,9 +64,9 @@ components: transforms: log_to_metric: {
 						warnings: []
 						type: string: {
 							examples: ["duration_total"]
-							default: string
+							default:      string
+							templateable: true
 						}
-						templateable: true
 					}
 					tags: {
 						description: "Key/value pairs representing [metric tags][docs.data-model.metric#tags]."
@@ -85,11 +85,11 @@ components: transforms: log_to_metric: {
 								"*": {
 									description: """
 	                      Key/value pairs representing [metric tags][docs.data-model.metric#tags].
+	                      Environment variables and field interpolation is allowed.
 	                      """
 									required: true
 									warnings: []
 									type: "*": {}
-									templateable: true
 								}
 							}
 						}

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -116,11 +116,10 @@ components: transforms: log_to_metric: {
 	}
 
 	output: metrics: {
-		counter:   output._passthrough_counter
-		gauge:     output._passthrough_gauge
-		histogram: output._passthrough_histogram
-		set:       output._passthrough_set
-		summary:   output._passthrough_summary
+		counter:   	  output._passthrough_counter
+		distribution: output._passthrough_distribution
+		gauge:     	  output._passthrough_gauge
+		set:       	  output._passthrough_set
 	}
 
 	examples: [

--- a/docs/reference/data_model/schema.cue
+++ b/docs/reference/data_model/schema.cue
@@ -101,7 +101,7 @@ data_model: schema: {
 								warnings: []
 								type: string: enum: #DistributionStatistic & {
 									histogram: "Counts values in buckets."
-									summary: "Calculates quantiles of values."
+									summary:   "Calculates quantiles of values."
 								}
 							}
 						}

--- a/docs/reference/data_model/schema.cue
+++ b/docs/reference/data_model/schema.cue
@@ -99,7 +99,7 @@ data_model: schema: {
 								description: "The statistic to be calculated from the values."
 								required:    true
 								warnings: []
-								type: string: enum: #DistributionStatistic & {
+								type: string: enum: {
 									histogram: "Counts values in buckets."
 									summary:   "Calculates quantiles of values."
 								}

--- a/docs/reference/data_model/schema.cue
+++ b/docs/reference/data_model/schema.cue
@@ -95,6 +95,15 @@ data_model: schema: {
 								warnings: []
 								type: array: items: type: float: examples: [12.0, 43.3, 25.2]
 							}
+							statistic: {
+								description: "The statistic to be calculated from the values."
+								required:    true
+								warnings: []
+								type: string: enum: #DistributionStatistic & {
+									histogram: "Counts values in buckets."
+									summary: "Calculates quantiles of values."
+								}
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Closes #4558

### Open questions

- [ ] Should the `type` of `_passthrough_histogram` and `_passthrough_summary` be `histogram` and `summary` respectively? This question also extends to `_passthrough_distribution`?

### Missing things

* `vector` source is missing `output: metrics:` field.

* `#MetricEvent` is missing kind` field.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
