### PR TITLE
fix(azure_monitor_logs sink): Use Signer::sign_to_vec to support older OpenSSL versions

### DIFF
--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -263,8 +263,9 @@ impl AzureMonitorLogsSink {
             len, CONTENT_TYPE, X_MS_DATE, rfc1123date, RESOURCE
         );
         let mut signer = sign::Signer::new(hash::MessageDigest::sha256(), &self.shared_key)?;
+        signer.update(string_to_hash.as_bytes())?;
 
-        let signature = signer.sign_oneshot_to_vec(string_to_hash.as_bytes())?;
+        let signature = signer.sign_to_vec()?;
         let signature_base64 = base64::encode_block(&signature);
 
         Ok(format!(


### PR DESCRIPTION
azure_monitor_logs: Use Signer::sign_to_vec to support older OpenSSL versions

Closes #4616 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
