### PR TITLE
feat(remap transform): add `log` function

### DIFF
--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -1,5 +1,6 @@
 use crate::event::{Event, Value};
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 
 pub mod parser;
 pub mod query;
@@ -242,6 +243,64 @@ impl Function for MergeFn {
 
             _ => Err("parameters passed to merge are non-map values".into()),
         }
+    }
+}
+
+//------------------------------------------------------------------------------
+
+/// Represents the different log levels that can be used by LogFn
+#[derive(Debug, Clone, Copy)]
+pub(in crate::mapping) enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl TryFrom<&str> for LogLevel {
+    type Error = String;
+
+    fn try_from(level: &str) -> Result<Self> {
+        match level {
+            "trace" => Ok(Self::Trace),
+            "debug" => Ok(Self::Debug),
+            "info" => Ok(Self::Info),
+            "warn" => Ok(Self::Warn),
+            "error" => Ok(Self::Error),
+            _ => Err("invalid log level".to_string()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::mapping) struct LogFn {
+    msg: Box<dyn query::Function>,
+    level: Option<LogLevel>,
+}
+
+impl LogFn {
+    pub(in crate::mapping) fn new(msg: Box<dyn query::Function>, level: Option<LogLevel>) -> Self {
+        Self { msg, level }
+    }
+}
+
+impl Function for LogFn {
+    fn apply(&self, target: &mut Event) -> Result<()> {
+        let msg = self.msg.execute(target)?;
+        let msg = msg.into_bytes();
+        let level = self.level.unwrap_or(LogLevel::Info);
+        let string = String::from_utf8_lossy(&msg);
+
+        match level {
+            LogLevel::Trace => trace!("{:?}", string),
+            LogLevel::Debug => debug!("{:?}", string),
+            LogLevel::Info => info!("{:?}", string),
+            LogLevel::Warn => warn!("{:?}", string),
+            LogLevel::Error => error!("{:?}", string),
+        }
+
+        Ok(())
     }
 }
 

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -296,11 +296,11 @@ impl Function for LogFn {
         let level = self.level.unwrap_or(LogLevel::Info);
 
         match level {
-            LogLevel::Trace => trace!("{:?}", string),
-            LogLevel::Debug => debug!("{:?}", string),
-            LogLevel::Info => info!("{:?}", string),
-            LogLevel::Warn => warn!("{:?}", string),
-            LogLevel::Error => error!("{:?}", string),
+            LogLevel::Trace => trace!("{}", string),
+            LogLevel::Debug => debug!("{}", string),
+            LogLevel::Info => info!("{}", string),
+            LogLevel::Warn => warn!("{}", string),
+            LogLevel::Error => error!("{}", string),
         }
 
         Ok(())

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -287,10 +287,13 @@ impl LogFn {
 
 impl Function for LogFn {
     fn apply(&self, target: &mut Event) -> Result<()> {
-        let msg = self.msg.execute(target)?;
+        let msg = match self.msg.execute(target)? {
+            QueryValue::Value(value) => value,
+            _ => return Err("can only log Value parameters".to_string()),
+        };
         let msg = msg.into_bytes();
-        let level = self.level.unwrap_or(LogLevel::Info);
         let string = String::from_utf8_lossy(&msg);
+        let level = self.level.unwrap_or(LogLevel::Info);
 
         match level {
             LogLevel::Trace => trace!("{:?}", string),

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -29,12 +29,16 @@ target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }
 function = {
     deletion |
     only_fields |
-    merge
+    merge |
+    log
 }
 
 deletion = { "del(" ~ target_paths ~ ")" }
 only_fields = { "only_fields(" ~ target_paths ~ ")" }
 merge = { "merge(" ~ target_path ~ "," ~ query_arithmetic ~ ("," ~ query_arithmetic)? ~ ")" }
+log = { "log(" ~ query_arithmetic ~ ("," ~ "level" ~ "=" ~ loglevel)? ~ ")" }
+
+loglevel = { "trace" | "debug" | "info" | "warn" | "error" }
 
 // One or more path arguments for a given function.
 //

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -718,6 +718,7 @@
       "parts.query.hello.equals" = "world"
       "parts.fragment.equals" = "configuration"
 
+<<<<<<< HEAD
 [transforms.remap_function_ceil]
   inputs = []
   type = "remap"
@@ -847,4 +848,22 @@
     "foo[0].equals" = "bar"
     "foo[1].equals" = "bat"
     "foo[2].equals" = "fizz buzz"
+
+[transforms.remap_function_log]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    log(.foo, level=info)
+  """
+[[tests]]
+  name = "remap_function_log"
+  [tests.input]
+    insert_at = "remap_function_log"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "this should be unchanged"
+  [[tests.outputs]]
+    extract_from = "remap_function_log"
+    [[tests.outputs.conditions]]
+    "foo.equals" = "this should be unchanged"
 

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -718,7 +718,6 @@
       "parts.query.hello.equals" = "world"
       "parts.fragment.equals" = "configuration"
 
-<<<<<<< HEAD
 [transforms.remap_function_ceil]
   inputs = []
   type = "remap"


### PR DESCRIPTION
Closes #4234 

Added the log remap function.

Note, because this is an impure function (similar to `merge`) I haven't been able to use the new function methods, so there are a few additions to the pest file. This well need rethinking at some point. The log levels are an enum, and not a `Value`, so this could be another candidate for inclusion in `QueryValue` similar to `Regex`..

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
