### PR TITLE
feat(remap transform): add `starts_with` and `ends_with` functions

### DIFF
--- a/src/mapping/query/function/ends_with.rs
+++ b/src/mapping/query/function/ends_with.rs
@@ -1,0 +1,152 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct EndsWithFn {
+    query: Box<dyn Function>,
+    substring: Box<dyn Function>,
+    case_sensitive: Option<Box<dyn Function>>,
+}
+
+impl EndsWithFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        substring: &str,
+        case_sensitive: bool,
+    ) -> Self {
+        let substring = Box::new(Literal::from(Value::from(substring)));
+        let case_sensitive = Some(Box::new(Literal::from(Value::from(case_sensitive))) as _);
+
+        Self {
+            query,
+            substring,
+            case_sensitive,
+        }
+    }
+}
+
+impl Function for EndsWithFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let substring = {
+            let bytes = required!(ctx, self.substring, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let value = {
+            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let ends_with = value.ends_with(&substring)
+            || optional!(ctx, self.case_sensitive, Value::Boolean(b) => b)
+                .iter()
+                .filter(|&case_sensitive| !case_sensitive)
+                .any(|_| {
+                    value.to_lowercase().ends_with(&substring.to_lowercase())
+                });
+
+        Ok(Value::from(ends_with))
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "substring",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "case_sensitive",
+                accepts: |v| matches!(v, Value::Boolean(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for EndsWithFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let substring = arguments.required("substring")?;
+        let case_sensitive = arguments.optional("case_sensitive");
+
+        Ok(Self {
+            query,
+            substring,
+            case_sensitive,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn ends_with() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                EndsWithFn::new(Box::new(Path::from(vec![vec!["foo"]])), "", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("bar"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("bar"))), "foobar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("bar"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "oba", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("fooBAR"))), "BAR", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "BAR", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                EndsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "BAR", false),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -126,6 +126,8 @@ build_signatures! {
     parse_duration => ParseDurationFn,
     format_number => FormatNumberFn,
     parse_url => ParseUrlFn,
+    starts_with => StartsWithFn,
+    ends_with => EndsWithFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/starts_with.rs
+++ b/src/mapping/query/function/starts_with.rs
@@ -1,0 +1,152 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct StartsWithFn {
+    query: Box<dyn Function>,
+    substring: Box<dyn Function>,
+    case_sensitive: Option<Box<dyn Function>>,
+}
+
+impl StartsWithFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        substring: &str,
+        case_sensitive: bool,
+    ) -> Self {
+        let substring = Box::new(Literal::from(Value::from(substring)));
+        let case_sensitive = Some(Box::new(Literal::from(Value::from(case_sensitive))) as _);
+
+        Self {
+            query,
+            substring,
+            case_sensitive,
+        }
+    }
+}
+
+impl Function for StartsWithFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let substring = {
+            let bytes = required!(ctx, self.substring, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let value = {
+            let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+
+        let starts_with = value.starts_with(&substring)
+            || optional!(ctx, self.case_sensitive, Value::Boolean(b) => b)
+                .iter()
+                .filter(|&case_sensitive| !case_sensitive)
+                .any(|_| {
+                    value.to_lowercase().starts_with(&substring.to_lowercase())
+                });
+
+        Ok(Value::from(starts_with))
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "substring",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "case_sensitive",
+                accepts: |v| matches!(v, Value::Boolean(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for StartsWithFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let substring = arguments.required("substring")?;
+        let case_sensitive = arguments.optional("case_sensitive");
+
+        Ok(Self {
+            query,
+            substring,
+            case_sensitive,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn starts_with() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                StartsWithFn::new(Box::new(Path::from(vec![vec!["foo"]])), "", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foo"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foo"))), "foobar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foo"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "oba", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("FOObar"))), "FOO", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "FOO", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                StartsWithFn::new(Box::new(Literal::from(Value::from("foobar"))), "FOO", false),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -473,6 +473,9 @@
     .b = contains(.bar, substring = "bar")
     .c = contains(.bar, substring = "BAR", case_sensitive = true)
     .d = contains(.bar, substring = "BAR", case_sensitive = false)
+    .e = contains(.foobar, substring = "oba")
+    .f = contains(.foobar, substring = "OBA", case_sensitive = true)
+    .g = contains(.foobar, substring = "OBA", case_sensitive = false)
   """
 [[tests]]
   name = "remap_function_contains"
@@ -482,6 +485,7 @@
     [tests.input.log_fields]
       foo = "foo"
       bar = "bar"
+      foobar = "foobar"
   [[tests.outputs]]
     extract_from = "remap_function_contains"
     [[tests.outputs.conditions]]
@@ -489,6 +493,63 @@
       "b.equals" = true
       "c.equals" = false
       "d.equals" = true
+      "e.equals" = true
+      "f.equals" = false
+      "g.equals" = true
+
+[transforms.remap_function_starts_with]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = starts_with(.foobar, substring = .foo)
+    .b = starts_with(.foobar, substring = "foo")
+    .c = starts_with(.foobar, substring = "bar")
+    .d = starts_with(.foobar, substring = "FOO", case_sensitive = true)
+    .e = starts_with(.foobar, substring = "FOO", case_sensitive = false)
+  """
+[[tests]]
+  name = "remap_function_starts_with"
+  [tests.input]
+    insert_at = "remap_function_starts_with"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "foo"
+      foobar = "foobar"
+  [[tests.outputs]]
+    extract_from = "remap_function_starts_with"
+    [[tests.outputs.conditions]]
+      "a.equals" = true
+      "b.equals" = true
+      "c.equals" = false
+      "d.equals" = false
+      "e.equals" = true
+
+[transforms.remap_function_ends_with]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = ends_with(.foobar, substring = .bar)
+    .b = ends_with(.foobar, substring = "bar")
+    .c = ends_with(.foobar, substring = "foo")
+    .d = ends_with(.foobar, substring = "BAR", case_sensitive = true)
+    .e = ends_with(.foobar, substring = "BAR", case_sensitive = false)
+  """
+[[tests]]
+  name = "remap_function_ends_with"
+  [tests.input]
+    insert_at = "remap_function_ends_with"
+    type = "log"
+    [tests.input.log_fields]
+      bar = "bar"
+      foobar = "foobar"
+  [[tests.outputs]]
+    extract_from = "remap_function_ends_with"
+    [[tests.outputs.conditions]]
+      "a.equals" = true
+      "b.equals" = true
+      "c.equals" = false
+      "d.equals" = false
+      "e.equals" = true
 
 [transforms.remap_function_slice]
   inputs = []


### PR DESCRIPTION
Closes #4637 
Closes #4638 

This adds the `starts_with` and `ends_with` remap functions.

As these are largely just copies of the `contains` function, there was the potential for some code reuse here. I have chosen not to do this as I don't think the additional code complexity warrants the few lines of code that might be saved.

Also note, the issues ask for the final parameter to be `case_insensitive`. I have made this parameter `case_sensitive` to remain consistent with the existing `contains` function.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
