### PR TITLE
feat(remap transform): add `floor`, `round` and `ceil` remap functions

### DIFF
--- a/src/mapping/query/function/ceil.rs
+++ b/src/mapping/query/function/ceil.rs
@@ -1,0 +1,117 @@
+use super::prelude::*;
+use super::util::round_to_precision;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct CeilFn {
+    query: Box<dyn Function>,
+    precision: Option<Box<dyn Function>>,
+}
+
+impl CeilFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        precision: Option<Box<dyn Function>>,
+    ) -> Self {
+        Self { query, precision }
+    }
+}
+
+impl Function for CeilFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required!(ctx, self.query,
+                            Value::Float(f) => {
+                                Value::Float(round_to_precision(f, precision, |f| f.ceil()))
+                            },
+                            v@Value::Integer(_) => v
+        );
+
+        Ok(res)
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "precision",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for CeilFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let precision = arguments.optional("precision");
+
+        Ok(Self { query, precision })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn ceil() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                CeilFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1235.0)),
+                CeilFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234)),
+                CeilFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.4)),
+                CeilFn::new(
+                    Box::new(Literal::from(Value::Float(1234.39429))),
+                    Some(Box::new(Literal::from(Value::from(1)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(3.1416)),
+                CeilFn::new(
+                    Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
+                    Some(Box::new(Literal::from(Value::from(4)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    9876543210123456789098765432101234567890987654321.98766,
+                )),
+                CeilFn::new(
+                    Box::new(Literal::from(Value::Float(
+                        9876543210123456789098765432101234567890987654321.987654321,
+                    ))),
+                    Some(Box::new(Literal::from(Value::from(5)))),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/ceil.rs
+++ b/src/mapping/query/function/ceil.rs
@@ -71,6 +71,15 @@ mod tests {
                 CeilFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
             ),
             (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from(1234.2));
+                    event
+                },
+                Ok(Value::from(1235.0)),
+                CeilFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
                 Event::from(""),
                 Ok(Value::from(1235.0)),
                 CeilFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),

--- a/src/mapping/query/function/ceil.rs
+++ b/src/mapping/query/function/ceil.rs
@@ -22,7 +22,7 @@ impl Function for CeilFn {
         let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(ctx, self.query,
                             Value::Float(f) => {
-                                Value::Float(round_to_precision(f, precision, |f| f.ceil()))
+                                Value::Float(round_to_precision(f, precision, f64::ceil))
                             },
                             v@Value::Integer(_) => v
         );

--- a/src/mapping/query/function/floor.rs
+++ b/src/mapping/query/function/floor.rs
@@ -1,0 +1,117 @@
+use super::prelude::*;
+use super::util::round_to_precision;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct FloorFn {
+    query: Box<dyn Function>,
+    precision: Option<Box<dyn Function>>,
+}
+
+impl FloorFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        precision: Option<Box<dyn Function>>,
+    ) -> Self {
+        Self { query, precision }
+    }
+}
+
+impl Function for FloorFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required!(ctx, self.query,
+                            Value::Float(f) => {
+                                Value::Float(round_to_precision(f, precision, |f| f.floor()))
+                            },
+                            v@Value::Integer(_) => v
+        );
+
+        Ok(res)
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "precision",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for FloorFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let precision = arguments.optional("precision");
+
+        Ok(Self { query, precision })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn floor() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                FloorFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.0)),
+                FloorFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234)),
+                FloorFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.3)),
+                FloorFn::new(
+                    Box::new(Literal::from(Value::Float(1234.39429))),
+                    Some(Box::new(Literal::from(Value::from(1)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(3.1415)),
+                FloorFn::new(
+                    Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
+                    Some(Box::new(Literal::from(Value::from(4)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    9876543210123456789098765432101234567890987654321.98765,
+                )),
+                FloorFn::new(
+                    Box::new(Literal::from(Value::Float(
+                        9876543210123456789098765432101234567890987654321.987654321,
+                    ))),
+                    Some(Box::new(Literal::from(Value::from(5)))),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/floor.rs
+++ b/src/mapping/query/function/floor.rs
@@ -71,6 +71,15 @@ mod tests {
                 FloorFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
             ),
             (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from(1234.2));
+                    event
+                },
+                Ok(Value::from(1234.0)),
+                FloorFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
                 Event::from(""),
                 Ok(Value::from(1234.0)),
                 FloorFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),

--- a/src/mapping/query/function/floor.rs
+++ b/src/mapping/query/function/floor.rs
@@ -22,7 +22,7 @@ impl Function for FloorFn {
         let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(ctx, self.query,
                             Value::Float(f) => {
-                                Value::Float(round_to_precision(f, precision, |f| f.floor()))
+                                Value::Float(round_to_precision(f, precision, f64::floor))
                             },
                             v@Value::Integer(_) => v
         );

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -1,6 +1,8 @@
 #![macro_use]
 
 mod not;
+mod util;
+
 pub(in crate::mapping) use not::NotFn;
 
 use super::Function;
@@ -128,6 +130,9 @@ build_signatures! {
     parse_url => ParseUrlFn,
     starts_with => StartsWithFn,
     ends_with => EndsWithFn,
+    round => RoundFn,
+    floor => FloorFn,
+    ceil => CeilFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/round.rs
+++ b/src/mapping/query/function/round.rs
@@ -71,6 +71,15 @@ mod tests {
                 RoundFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
             ),
             (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from(1234.5));
+                    event
+                },
+                Ok(Value::from(1235.0)),
+                RoundFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
                 Event::from(""),
                 Ok(Value::from(1235.0)),
                 RoundFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),

--- a/src/mapping/query/function/round.rs
+++ b/src/mapping/query/function/round.rs
@@ -22,7 +22,7 @@ impl Function for RoundFn {
         let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(ctx, self.query,
                             Value::Float(f) => {
-                                Value::Float(round_to_precision(f, precision, |f| f.round()))
+                                Value::Float(round_to_precision(f, precision, f64::round))
                             },
                             v@Value::Integer(_) => v
         );

--- a/src/mapping/query/function/round.rs
+++ b/src/mapping/query/function/round.rs
@@ -1,0 +1,130 @@
+use super::prelude::*;
+use super::util::round_to_precision;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct RoundFn {
+    query: Box<dyn Function>,
+    precision: Option<Box<dyn Function>>,
+}
+
+impl RoundFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        precision: Option<Box<dyn Function>>,
+    ) -> Self {
+        Self { query, precision }
+    }
+}
+
+impl Function for RoundFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let precision = optional!(ctx, self.precision, Value::Integer(v) => v).unwrap_or(0);
+        let res = required!(ctx, self.query,
+                            Value::Float(f) => {
+                                Value::Float(round_to_precision(f, precision, |f| f.round()))
+                            },
+                            v@Value::Integer(_) => v
+        );
+
+        Ok(res)
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Float(_) | Value::Integer(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "precision",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for RoundFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let precision = arguments.optional("precision");
+
+        Ok(Self { query, precision })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn round() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                RoundFn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1235.0)),
+                RoundFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.0)),
+                RoundFn::new(Box::new(Literal::from(Value::Float(1234.4))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234)),
+                RoundFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.3)),
+                RoundFn::new(
+                    Box::new(Literal::from(Value::Float(1234.33429))),
+                    Some(Box::new(Literal::from(Value::from(1)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(1234.4)),
+                RoundFn::new(
+                    Box::new(Literal::from(Value::Float(1234.39429))),
+                    Some(Box::new(Literal::from(Value::from(1)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(3.1416)),
+                RoundFn::new(
+                    Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
+                    Some(Box::new(Literal::from(Value::from(4)))),
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    9876543210123456789098765432101234567890987654321.98765,
+                )),
+                RoundFn::new(
+                    Box::new(Literal::from(Value::Float(
+                        9876543210123456789098765432101234567890987654321.987654321,
+                    ))),
+                    Some(Box::new(Literal::from(Value::from(5)))),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/util.rs
+++ b/src/mapping/query/function/util.rs
@@ -1,0 +1,10 @@
+/// Rounds the given number to the given precision.
+/// Takes a function parameter so the exact rounding function (ceil, floor or round)
+/// can be specified.
+pub(in crate::mapping) fn round_to_precision<F>(num: f64, precision: i64, fun: F) -> f64
+where
+    F: Fn(f64) -> f64,
+{
+    let multiplier = 10_f64.powf(precision as f64);
+    fun(num * multiplier as f64) / multiplier
+}

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -717,3 +717,69 @@
       "parts.query.length_eq" = 1
       "parts.query.hello.equals" = "world"
       "parts.fragment.equals" = "configuration"
+
+[transforms.remap_function_ceil]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = ceil(.num)
+    .b = ceil(.num, precision = 1)
+    .c = ceil(.num, precision = 2)
+  """
+[[tests]]
+  name = "remap_function_ceil"
+  [tests.input]
+    insert_at = "remap_function_ceil"
+    type = "log"
+    [tests.input.log_fields]
+      num = 92.489
+  [[tests.outputs]]
+    extract_from = "remap_function_ceil"
+    [[tests.outputs.conditions]]
+      "a.equals" = 93
+      "b.equals" = 92.5
+      "c.equals" = 92.49
+
+[transforms.remap_function_floor]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = floor(.num)
+    .b = floor(.num, precision = 1)
+    .c = floor(.num, precision = 2)
+  """
+[[tests]]
+  name = "remap_function_floor"
+  [tests.input]
+    insert_at = "remap_function_floor"
+    type = "log"
+    [tests.input.log_fields]
+      num = 92.489
+  [[tests.outputs]]
+    extract_from = "remap_function_floor"
+    [[tests.outputs.conditions]]
+      "a.equals" = 92
+      "b.equals" = 92.4
+      "c.equals" = 92.48
+
+[transforms.remap_function_round]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = round(.num)
+    .b = round(.num, precision = 1)
+    .c = round(.num, precision = 2)
+  """
+[[tests]]
+  name = "remap_function_round"
+  [tests.input]
+    insert_at = "remap_function_round"
+    type = "log"
+    [tests.input.log_fields]
+      num = 92.489
+  [[tests.outputs]]
+    extract_from = "remap_function_round"
+    [[tests.outputs.conditions]]
+      "a.equals" = 92
+      "b.equals" = 92.5
+      "c.equals" = 92.49


### PR DESCRIPTION
Closes #4231  
Closes #4232 
Closes #4233 

Adds floor, ceil and round remap functions.

Because there is quite a lot of code duplication here, I experimented with creating a macro to avoid the repetition. What I found was that due to the way the `build_signatures` macro works, I would still need to create a separate file for each function, each with a single line invoking my macro. The result was would be that if someone wanted to find the code to look up the details of the function they would have to browse through several files. The added complexity didn't feel worth it. So there is a bit of duplication, but I think it makes for more easily understandable code.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
