### PR TITLE
chore(ci): Remove the problem matcher from the check-component-features

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -371,7 +371,6 @@ jobs:
     container: timberio/ci_image
     steps:
       - uses: actions/checkout@v2
-      - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: echo "home/runner/.local/bin" >> "$GITHUB_PATH"
       - run: make check-component-features

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,7 +177,6 @@ jobs:
     container: timberio/ci_image
     steps:
       - uses: actions/checkout@v2
-      - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: echo "home/runner/.local/bin" >> "$GITHUB_PATH"
       - run: make check-component-features


### PR DESCRIPTION
We have a lot of warnings coming from the `check-component-features`, and it looks like we don't intend to fix them and keep them strictly warning-less. I'd say it's thus meaningful to see those warnings in the CI, as it clutters the real issues.
The proposed fix for now implemented in this is to remove the problem matchers from the `check-component-features` CI runs.