### PR TITLE
chore(ci): Only run E2E test suite on non-PRs, or if the opt-in label is set on the PR

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -142,10 +142,6 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-k8s-test-plan.outputs.matrix) }}
       fail-fast: false
-    if: |
-      !github.event.pull_request
-        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
-        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e all targets')
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -21,6 +21,7 @@ on:
       - "Makefile"
       - "rust-toolchain"
       - "distribution/**"
+  pull_request:
 
 env:
   AUTOINSTALL: true

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -48,6 +48,8 @@ jobs:
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
     runs-on: ubuntu-20.04
+    if: |
+      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
     steps:
       - uses: actions/checkout@v2
       - run: make ci-sweep
@@ -78,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    if: |
+      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
     steps:
       - uses: actions/github-script@v2
         id: set-matrix
@@ -133,6 +137,8 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-k8s-test-plan.outputs.matrix) }}
       fail-fast: false
+    if: |
+      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -50,7 +50,9 @@ jobs:
     name: Build - x86_64-unknown-linux-gnu
     runs-on: ubuntu-20.04
     if: |
-      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+      !github.event.pull_request
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e all targets')
     steps:
       - uses: actions/checkout@v2
       - run: make ci-sweep
@@ -82,7 +84,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     if: |
-      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+      !github.event.pull_request
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e all targets')
     steps:
       - uses: actions/github-script@v2
         id: set-matrix
@@ -139,7 +143,9 @@ jobs:
       matrix: ${{ fromJson(needs.compute-k8s-test-plan.outputs.matrix) }}
       fail-fast: false
     if: |
-      !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+      !github.event.pull_request
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
+        || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e all targets')
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR enables an opt-in way to run the K8s E2E tests for PRs in CI.