### PR TITLE
chore(deps): bump pin-project from 0.4.26 to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
  "hyper-unix-connector",
  "log",
  "mio-named-pipes",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "rustls 0.18.1",
  "rustls-native-certs",
  "serde",
@@ -2445,7 +2445,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "socket2",
  "tokio",
  "tower-service",
@@ -2512,7 +2512,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tokio",
 ]
 
@@ -4019,11 +4019,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal 0.4.26",
+ "pin-project-internal 0.4.27",
 ]
 
 [[package]]
@@ -4037,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4826,7 +4826,7 @@ dependencies = [
  "log",
  "md5",
  "percent-encoding",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version",
@@ -4847,7 +4847,7 @@ dependencies = [
  "dirs 2.0.2",
  "futures 0.3.5",
  "hyper",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "regex",
  "serde",
  "serde_json",
@@ -4942,7 +4942,7 @@ dependencies = [
  "log",
  "md5",
  "percent-encoding",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "rusoto_credential",
  "rustc_version",
  "serde",
@@ -5508,7 +5508,7 @@ dependencies = [
  "doc-comment",
  "futures 0.1.29",
  "futures-core",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "snafu-derive",
 ]
 
@@ -5619,7 +5619,7 @@ checksum = "fcbeca004dfaec7b6fd818d8ae6359eaea21770d134f137c4cb8fb5fa92b5a33"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tokio",
 ]
 
@@ -6071,7 +6071,7 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tokio",
  "tungstenite",
 ]
@@ -6126,7 +6126,7 @@ source = "git+https://github.com/tower-rs/tower?rev=43168944220ed32dab83cb4f11f7
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6161,7 +6161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
 dependencies = [
  "futures-util",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tokio",
  "tokio-test",
  "tower-layer",
@@ -6238,7 +6238,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
  "futures-task",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tracing 0.1.21",
 ]
 
@@ -6247,7 +6247,7 @@ name = "tracing-futures"
 version = "0.2.6"
 source = "git+https://github.com/tokio-rs/tracing?rev=f470db1b0354b368f62f9ee4d763595d16373231#f470db1b0354b368f62f9ee4d763595d16373231"
 dependencies = [
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tracing 0.1.19",
 ]
 
@@ -6312,7 +6312,7 @@ source = "git+https://github.com/tokio-rs/tracing?rev=f470db1b0354b368f62f9ee4d7
 dependencies = [
  "futures 0.3.5",
  "http",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tower-layer",
  "tower-make",
  "tower-service",
@@ -6724,7 +6724,7 @@ dependencies = [
  "openssl-probe",
  "pest",
  "pest_derive",
- "pin-project 0.4.26",
+ "pin-project 1.0.1",
  "portpicker",
  "pretty_assertions",
  "prometheus-parser",
@@ -6940,7 +6940,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "scoped-tls",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ bloom = "0.3.2"
 pulsar = { version = "1.0.0", default-features = false, features = ["tokio-runtime"], optional = true }
 task-compat = "0.1"
 cidr-utils = "0.4.2"
-pin-project = "0.4.26"
+pin-project = "1.0.1"
 k8s-openapi = { version = "0.9", features = ["v1_15"], optional = true }
 portpicker = "0.1.0"
 sha-1 = "0.9"


### PR DESCRIPTION
[pin-project](https://crates.io/crates/pin_project) changelog: https://github.com/taiki-e/pin-project/blob/master/CHANGELOG.md (nothing major, looks like stabilization).
Need clippy rule: `pattern_type_mismatch`. Unfortunately this rule will be available only in clippy with rust 1.47: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-147