### PR TITLE
fix(external docs): Make Elasticsearch host config required

### DIFF
--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -5442,8 +5442,7 @@ require('custom_module')
   # The host of your Elasticsearch cluster. This should be the full URL as shown
   # in the example.
   #
-  # * optional
-  # * no default
+  # * required
   # * type: string
   host = "http://10.24.32.122:9000"
 


### PR DESCRIPTION
Addresses issue #4648 by making the `host` config required for the Elasticsearch sink, as is consistent with the [`ElasticSearchConfig`](https://github.com/timberio/vector/blob/master/src/sinks/elasticsearch.rs#L38-L40) struct.