### PR TITLE
chore(ci): Use a static timestamp for datadog_metrics test

### DIFF
--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -595,12 +595,11 @@ mod tests {
 
     #[test]
     fn encode_counter() {
-        let now = Utc::now().timestamp();
         let interval = 60;
         let events = vec![
             Metric {
                 name: "total".into(),
-                timestamp: None,
+                timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Counter { value: 1.5 },
@@ -625,7 +624,7 @@ mod tests {
 
         assert_eq!(
             json,
-            format!("{{\"series\":[{{\"metric\":\"ns.total\",\"type\":\"count\",\"interval\":60,\"points\":[[{},1.5]],\"tags\":null}},{{\"metric\":\"ns.check\",\"type\":\"count\",\"interval\":60,\"points\":[[1542182950,1.0]],\"tags\":[\"empty_tag:\",\"normal_tag:value\",\"true_tag:true\"]}}]}}", now)
+            r#"{"series":[{"metric":"ns.total","type":"count","interval":60,"points":[[1542182950,1.5]],"tags":null},{"metric":"ns.check","type":"count","interval":60,"points":[[1542182950,1.0]],"tags":["empty_tag:","normal_tag:value","true_tag:true"]}]}"#
         );
     }
 


### PR DESCRIPTION
Previously it was exercising the `None` behavior of metric timestamps to
set it to the current time, but this would fail if the test ran close to
the end of a second where our `Utc::now()` would not match the
`Utc::now()` at the time of assignment.

If we want to exercise this logic, we could inject a function that
returns the current time.

Fixes #4664

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
