### PR TITLE
fix(metrics): add vector_ prefix to Prometheus metrics to ensure uniformity

### DIFF
--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -6,7 +6,7 @@ pub struct AddFieldsEventProcessed;
 
 impl InternalEvent for AddFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -21,7 +21,7 @@ impl<'a> InternalEvent for AddFieldsTemplateRenderingError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }
 
@@ -37,7 +37,7 @@ impl<'a> InternalEvent for AddFieldsTemplateInvalid<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }
 

--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -6,7 +6,7 @@ pub struct AddTagsEventProcessed;
 
 impl InternalEvent for AddTagsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -6,7 +6,7 @@ pub struct ANSIStripperEventProcessed;
 
 impl InternalEvent for ANSIStripperEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -25,7 +25,7 @@ impl InternalEvent for ANSIStripperFieldMissing<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("vector_processing_errors_total", 1, "error_type" => "field_missing");
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for ANSIStripperFieldInvalid<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "value_invalid");
+        counter!("vector_processing_errors_total", 1, "error_type" => "value_invalid");
     }
 }
 
@@ -65,6 +65,6 @@ impl InternalEvent for ANSIStripperFailed<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -15,8 +15,8 @@ impl InternalEvent for ApacheMetricsEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", self.count as u64);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -32,8 +32,8 @@ impl InternalEvent for ApacheMetricsRequestCompleted {
     }
 
     fn emit_metrics(&self) {
-        counter!("requests_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        counter!("vector_requests_completed_total", 1);
+        histogram!("vector_request_duration_nanoseconds", self.end - self.start);
     }
 }
 
@@ -54,7 +54,7 @@ impl InternalEvent for ApacheMetricsParseError<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("parse_errors_total", 1);
+        counter!("vector_parse_errors_total", 1);
     }
 }
 
@@ -70,7 +70,7 @@ impl InternalEvent for ApacheMetricsErrorResponse<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("http_error_response_total", 1);
+        counter!("vector_http_error_response_total", 1);
     }
 }
 
@@ -86,6 +86,6 @@ impl InternalEvent for ApacheMetricsHttpError<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("http_request_errors_total", 1);
+        counter!("vector_http_request_errors_total", 1);
     }
 }

--- a/src/internal_events/api.rs
+++ b/src/internal_events/api.rs
@@ -19,6 +19,6 @@ impl InternalEvent for ApiStarted {
     }
 
     fn emit_metrics(&self) {
-        counter!("api_started_total", 1);
+        counter!("vector_api_started_total", 1);
     }
 }

--- a/src/internal_events/auto_concurrency.rs
+++ b/src/internal_events/auto_concurrency.rs
@@ -24,7 +24,7 @@ impl InternalEvent for AutoConcurrencyLimit {
     }
 
     fn emit_metrics(&self) {
-        histogram!("auto_concurrency_limit", self.concurrency);
+        histogram!("vector_auto_concurrency_limit", self.concurrency);
     }
 }
 
@@ -35,7 +35,7 @@ pub struct AutoConcurrencyInFlight {
 
 impl InternalEvent for AutoConcurrencyInFlight {
     fn emit_metrics(&self) {
-        histogram!("auto_concurrency_in_flight", self.in_flight);
+        histogram!("vector_auto_concurrency_in_flight", self.in_flight);
     }
 }
 
@@ -46,7 +46,7 @@ pub struct AutoConcurrencyObservedRtt {
 
 impl InternalEvent for AutoConcurrencyObservedRtt {
     fn emit_metrics(&self) {
-        histogram!("auto_concurrency_observed_rtt", self.rtt);
+        histogram!("vector_auto_concurrency_observed_rtt", self.rtt);
     }
 }
 
@@ -57,6 +57,6 @@ pub struct AutoConcurrencyAveragedRtt {
 
 impl InternalEvent for AutoConcurrencyAveragedRtt {
     fn emit_metrics(&self) {
-        histogram!("auto_concurrency_averaged_rtt", self.rtt);
+        histogram!("vector_auto_concurrency_averaged_rtt", self.rtt);
     }
 }

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -22,14 +22,14 @@ pub(crate) struct AwsCloudwatchLogsSubscriptionParserFailedParse {
 impl InternalEvent for AwsCloudwatchLogsSubscriptionParserFailedParse {
     fn emit_logs(&self) {
         warn!(
-            message = "Event failed to parse as a CloudWatch Logs subscirption JSON message.",
+            message = "Event failed to parse as a CloudWatch Logs subscription JSON message.",
             %self.error,
             rate_limit_secs = 30
         )
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1,
+        counter!("vector_processing_errors_total", 1,
             "error_type" => "failed_parse",
         );
     }

--- a/src/internal_events/aws_kinesis_firehose.rs
+++ b/src/internal_events/aws_kinesis_firehose.rs
@@ -18,7 +18,7 @@ impl<'a> InternalEvent for AwsKinesisFirehoseRequestReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("requests_received_total", 1);
+        counter!("vector_requests_received_total", 1);
     }
 }
 
@@ -38,6 +38,6 @@ impl<'a> InternalEvent for AwsKinesisFirehoseRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_read_errors_total", 1);
+        counter!("vector_request_read_errors_total", 1);
     }
 }

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -8,7 +8,7 @@ pub struct AwsKinesisStreamsEventSent {
 
 impl InternalEvent for AwsKinesisStreamsEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/blackhole.rs
+++ b/src/internal_events/blackhole.rs
@@ -8,7 +8,7 @@ pub struct BlackholeEventReceived {
 
 impl InternalEvent for BlackholeEventReceived {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -6,7 +6,7 @@ pub struct CoercerEventProcessed;
 
 impl InternalEvent for CoercerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -27,6 +27,6 @@ impl<'a> InternalEvent for CoercerConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "type_conversion_failed");
+        counter!("vector_processing_errors_total", 1, "error_type" => "type_conversion_failed");
     }
 }

--- a/src/internal_events/concat.rs
+++ b/src/internal_events/concat.rs
@@ -6,7 +6,7 @@ pub struct ConcatEventProcessed;
 
 impl InternalEvent for ConcatEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -33,7 +33,7 @@ impl<'a> InternalEvent for ConcatSubstringError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }
 

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -16,6 +16,6 @@ impl<'a> InternalEvent for ConsoleFieldNotFound<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_not_found");
+        counter!("vector_processing_errors_total", 1, "error_type" => "field_not_found");
     }
 }

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -6,7 +6,7 @@ pub(crate) struct DedupeEventProcessed;
 
 impl InternalEvent for DedupeEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -25,6 +25,6 @@ impl InternalEvent for DedupeEventDiscarded {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_discarded_total", 1);
+        counter!("vector_events_discarded_total", 1);
     }
 }

--- a/src/internal_events/docker.rs
+++ b/src/internal_events/docker.rs
@@ -19,8 +19,8 @@ impl<'a> InternalEvent for DockerEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -40,7 +40,7 @@ impl<'a> InternalEvent for DockerContainerEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("container_events_processed_total", 1);
+        counter!("vector_container_events_processed_total", 1);
     }
 }
 
@@ -58,7 +58,7 @@ impl<'a> InternalEvent for DockerContainerWatch<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("containers_watched_total", 1);
+        counter!("vector_containers_watched_total", 1);
     }
 }
 
@@ -76,7 +76,7 @@ impl<'a> InternalEvent for DockerContainerUnwatch<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("containers_unwatched_total", 1);
+        counter!("vector_containers_unwatched_total", 1);
     }
 }
 
@@ -97,7 +97,7 @@ impl<'a> InternalEvent for DockerCommunicationError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("communication_errors_total", 1);
+        counter!("vector_communication_errors_total", 1);
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a> InternalEvent for DockerContainerMetadataFetchFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("container_metadata_fetch_errors_total", 1);
+        counter!("vector_container_metadata_fetch_errors_total", 1);
     }
 }
 
@@ -139,7 +139,7 @@ impl<'a> InternalEvent for DockerTimestampParseFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("timestamp_parse_errors_total", 1);
+        counter!("vector_timestamp_parse_errors_total", 1);
     }
 }
 
@@ -162,6 +162,6 @@ impl<'a> InternalEvent for DockerLoggingDriverUnsupported<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("logging_driver_errors_total", 1);
+        counter!("vector_logging_driver_errors_total", 1);
     }
 }

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -13,8 +13,8 @@ impl InternalEvent for ElasticSearchEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -33,6 +33,6 @@ impl<'a> InternalEvent for ElasticSearchMissingKeys<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("missing_keys_total", 1);
+        counter!("vector_missing_keys_total", 1);
     }
 }

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -21,11 +21,11 @@ impl InternalEvent for FileEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!(
-            "events_processed_total", 1,
+            "vector_events_processed_total", 1,
             "file" => self.file.to_owned(),
         );
         counter!(
-            "processed_bytes_total", self.byte_size as u64,
+            "vector_processed_bytes_total", self.byte_size as u64,
             "file" => self.file.to_owned(),
         );
     }
@@ -46,7 +46,7 @@ impl<'a> InternalEvent for FileChecksumFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "checksum_errors", 1,
+            "vector_checksum_errors", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -69,7 +69,7 @@ impl<'a> InternalEvent for FileFingerprintReadFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "fingerprint_read_errors", 1,
+            "vector_fingerprint_read_errors", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -93,7 +93,7 @@ impl<'a> InternalEvent for FileDeleteFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "file_delete_errors", 1,
+            "vector_file_delete_errors", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -114,7 +114,7 @@ impl<'a> InternalEvent for FileDeleted<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "files_deleted", 1,
+            "vector_files_deleted", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -135,7 +135,7 @@ impl<'a> InternalEvent for FileUnwatched<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "files_unwatched", 1,
+            "vector_files_unwatched", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -158,7 +158,7 @@ impl<'a> InternalEvent for FileWatchFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "file_watch_errors", 1,
+            "vector_file_watch_errors", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -181,7 +181,7 @@ impl<'a> InternalEvent for FileResumed<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "files_resumed", 1,
+            "vector_files_resumed", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -202,7 +202,7 @@ impl<'a> InternalEvent for FileAdded<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "files_added", 1,
+            "vector_files_added", 1,
             "file" => self.path.to_string_lossy().into_owned(),
         );
     }
@@ -219,7 +219,7 @@ impl InternalEvent for FileCheckpointed {
     }
 
     fn emit_metrics(&self) {
-        counter!("checkpoints_total", self.count as u64);
+        counter!("vector_checkpoints_total", self.count as u64);
     }
 }
 
@@ -234,7 +234,7 @@ impl InternalEvent for FileCheckpointWriteFailed {
     }
 
     fn emit_metrics(&self) {
-        counter!("checkpoint_write_errors_total", 1);
+        counter!("vector_checkpoint_write_errors_total", 1);
     }
 }
 

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for GrokParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -29,7 +29,7 @@ impl InternalEvent for GrokParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1,
+        counter!("vector_processing_errors_total", 1,
             "error_type" => "failed_match",
         );
     }
@@ -46,7 +46,7 @@ impl InternalEvent for GrokParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1,
+        counter!("vector_processing_errors_total", 1,
             "error_type" => "missing_field",
         );
     }
@@ -69,7 +69,7 @@ impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1,
+        counter!("vector_processing_errors_total", 1,
             "error_type" => "type_conversion_failed",
         );
     }

--- a/src/internal_events/heartbeat.rs
+++ b/src/internal_events/heartbeat.rs
@@ -13,6 +13,6 @@ impl InternalEvent for Heartbeat {
     }
 
     fn emit_metrics(&self) {
-        gauge!("uptime_seconds", self.since.elapsed().as_secs() as f64);
+        gauge!("vector_uptime_seconds", self.since.elapsed().as_secs() as f64);
     }
 }

--- a/src/internal_events/host_metrics.rs
+++ b/src/internal_events/host_metrics.rs
@@ -12,6 +12,6 @@ impl InternalEvent for HostMetricsEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("vector_events_processed_total", self.count as u64);
     }
 }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -17,8 +17,8 @@ impl InternalEvent for HTTPEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.events_count as u64);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", self.events_count as u64);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -39,6 +39,6 @@ impl<'a> InternalEvent for HTTPBadRequest<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("http_bad_requests_total", 1);
+        counter!("vector_http_bad_requests_total", 1);
     }
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -12,8 +12,8 @@ impl InternalEvent for JournaldEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -29,7 +29,7 @@ impl InternalEvent for JournaldInvalidRecord {
     }
 
     fn emit_metrics(&self) {
-        counter!("invalid_record_total", 1);
-        counter!("invalid_record_bytes_total", self.text.len() as u64);
+        counter!("vector_invalid_record_total", 1);
+        counter!("vector_invalid_record_bytes_total", self.text.len() as u64);
     }
 }

--- a/src/internal_events/kubernetes/instrumenting_state.rs
+++ b/src/internal_events/kubernetes/instrumenting_state.rs
@@ -22,36 +22,36 @@ pub struct StateMaintenancePerformed;
 
 impl InternalEvent for StateItemAdded {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_added");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "item_added");
     }
 }
 
 impl InternalEvent for StateItemUpdated {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_updated");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "item_updated");
     }
 }
 
 impl InternalEvent for StateItemDeleted {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_deleted");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "item_deleted");
     }
 }
 
 impl InternalEvent for StateResynced {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "resynced");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "resynced");
     }
 }
 
 impl InternalEvent for StateMaintenanceRequested {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "maintenance_requested");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "maintenance_requested");
     }
 }
 
 impl InternalEvent for StateMaintenancePerformed {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "maintenance_performed");
+        counter!("vector_k8s_state_ops_total", 1, "op_kind" => "maintenance_performed");
     }
 }

--- a/src/internal_events/kubernetes/instrumenting_watcher.rs
+++ b/src/internal_events/kubernetes/instrumenting_watcher.rs
@@ -7,7 +7,7 @@ pub struct WatchRequestInvoked;
 
 impl InternalEvent for WatchRequestInvoked {
     fn emit_metrics(&self) {
-        counter!("k8s_watch_requests_invoked_total", 1);
+        counter!("vector_k8s_watch_requests_invoked_total", 1);
     }
 }
 
@@ -22,7 +22,7 @@ impl<E: Debug> InternalEvent for WatchRequestInvocationFailed<E> {
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_watch_requests_failed_total", 1);
+        counter!("vector_k8s_watch_requests_failed_total", 1);
     }
 }
 
@@ -31,7 +31,7 @@ pub struct WatchStreamItemObtained;
 
 impl InternalEvent for WatchStreamItemObtained {
     fn emit_metrics(&self) {
-        counter!("k8s_watch_stream_items_obtained_total", 1);
+        counter!("vector_k8s_watch_stream_items_obtained_total", 1);
     }
 }
 
@@ -46,6 +46,6 @@ impl<E: Debug> InternalEvent for WatchStreamErrored<E> {
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_watch_stream_errors_total", 1);
+        counter!("vector_k8s_watch_stream_errors_total", 1);
     }
 }

--- a/src/internal_events/kubernetes/reflector.rs
+++ b/src/internal_events/kubernetes/reflector.rs
@@ -14,6 +14,6 @@ impl<E: std::fmt::Debug> InternalEvent for DesyncReceived<E> {
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_reflector_desyncs_total", 1);
+        counter!("vector_k8s_reflector_desyncs_total", 1);
     }
 }

--- a/src/internal_events/kubernetes/stream.rs
+++ b/src/internal_events/kubernetes/stream.rs
@@ -8,7 +8,7 @@ pub struct ChunkProcessed {
 
 impl InternalEvent for ChunkProcessed {
     fn emit_metrics(&self) {
-        counter!("k8s_stream_chunks_processed_total", 1);
-        counter!("k8s_stream_processed_bytes_total", self.byte_size as u64);
+        counter!("vector_k8s_stream_chunks_processed_total", 1);
+        counter!("vector_k8s_stream_processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -18,8 +18,8 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -37,7 +37,7 @@ impl InternalEvent for KubernetesLogsEventAnnotationFailed<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_event_annotation_failures_total", 1);
+        counter!("vector_k8s_event_annotation_failures_total", 1);
     }
 }
 
@@ -55,6 +55,6 @@ impl InternalEvent for KubernetesLogsDockerFormatParseFailed<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_docker_format_parse_failures_total", 1);
+        counter!("vector_k8s_docker_format_parse_failures_total", 1);
     }
 }

--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -20,7 +20,7 @@ impl<'a> InternalEvent for HerokuLogplexRequestReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("requests_received_total", 1);
+        counter!("vector_requests_received_total", 1);
     }
 }
 
@@ -39,6 +39,6 @@ impl InternalEvent for HerokuLogplexRequestReadError {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_read_errors_total", 1);
+        counter!("vector_request_read_errors_total", 1);
     }
 }

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -6,7 +6,7 @@ pub struct LuaEventProcessed;
 
 impl InternalEvent for LuaEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -17,7 +17,7 @@ pub struct LuaGcTriggered {
 
 impl InternalEvent for LuaGcTriggered {
     fn emit_metrics(&self) {
-        gauge!("memory_used", self.used_memory as f64);
+        gauge!("vector_memory_used", self.used_memory as f64);
     }
 }
 
@@ -32,7 +32,7 @@ impl InternalEvent for LuaScriptError {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }
 
@@ -47,6 +47,6 @@ impl InternalEvent for LuaBuildError {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
+        counter!("vector_processing_errors_total", 1);
     }
 }

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -11,7 +11,7 @@ impl InternalEvent for MetricToLogEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -30,6 +30,6 @@ impl<'a> InternalEvent for MetricToLogFailedSerialize {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_serialize");
+        counter!("vector_processing_errors_total", 1, "error_type" => "failed_serialize");
     }
 }

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -15,8 +15,8 @@ impl InternalEvent for MongoDBMetricsCollectCompleted {
     }
 
     fn emit_metrics(&self) {
-        counter!("collect_completed", 1);
-        histogram!("collect_duration_nanoseconds", self.end - self.start);
+        counter!("vector_collect_completed", 1);
+        histogram!("vector_collect_duration_nanoseconds", self.end - self.start);
     }
 }
 
@@ -31,7 +31,7 @@ impl<'a> InternalEvent for MongoDBMetricsRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_error", 1,
+        counter!("vector_request_error", 1,
             "component_kind" => "source",
             "component_type" => "mongodb_metrics",
         );
@@ -49,7 +49,7 @@ impl<'a> InternalEvent for MongoDBMetricsBsonParseError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("bson_parse_error", 1,
+        counter!("vector_bson_parse_error", 1,
             "component_kind" => "source",
             "component_type" => "mongodb_metrics",
         )

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -101,7 +101,7 @@ impl InternalEvent for VectorConfigLoadFailed {
     }
 
     fn emit_metrics(&self) {
-        counter!("config_load_errors_total", 1);
+        counter!("vector_config_load_errors_total", 1);
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -16,8 +16,8 @@ impl InternalEvent for PrometheusEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", self.count as u64);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -33,8 +33,8 @@ impl InternalEvent for PrometheusRequestCompleted {
     }
 
     fn emit_metrics(&self) {
-        counter!("requests_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        counter!("vector_requests_completed_total", 1);
+        histogram!("vector_request_duration_nanoseconds", self.end - self.start);
     }
 }
 
@@ -56,7 +56,7 @@ impl<'a> InternalEvent for PrometheusParseError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("parse_errors_total", 1);
+        counter!("vector_parse_errors_total", 1);
     }
 }
 
@@ -72,7 +72,7 @@ impl InternalEvent for PrometheusErrorResponse {
     }
 
     fn emit_metrics(&self) {
-        counter!("http_error_response_total", 1);
+        counter!("vector_http_error_response_total", 1);
     }
 }
 
@@ -88,6 +88,6 @@ impl InternalEvent for PrometheusHttpError {
     }
 
     fn emit_metrics(&self) {
-        counter!("http_request_errors_total", 1);
+        counter!("vector_http_request_errors_total", 1);
     }
 }

--- a/src/internal_events/reduce.rs
+++ b/src/internal_events/reduce.rs
@@ -6,7 +6,7 @@ pub(crate) struct ReduceEventProcessed;
 
 impl InternalEvent for ReduceEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -15,6 +15,6 @@ pub(crate) struct ReduceStaleEventFlushed;
 
 impl InternalEvent for ReduceStaleEventFlushed {
     fn emit_metrics(&self) {
-        counter!("stale_events_flushed_total", 1);
+        counter!("vector_stale_events_flushed_total", 1);
     }
 }

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for RegexParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -29,7 +29,7 @@ impl InternalEvent for RegexParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_match");
+        counter!("vector_processing_errors_total", 1, "error_type" => "failed_match");
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for RegexParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "missing_field");
+        counter!("vector_processing_errors_total", 1, "error_type" => "missing_field");
     }
 }
 
@@ -63,7 +63,7 @@ impl<'a> InternalEvent for RegexParserTargetExists<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "target_field_exists");
+        counter!("vector_processing_errors_total", 1, "error_type" => "target_field_exists");
     }
 }
 
@@ -84,6 +84,6 @@ impl<'a> InternalEvent for RegexParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "type_conversion_failed");
+        counter!("vector_processing_errors_total", 1, "error_type" => "type_conversion_failed");
     }
 }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -6,7 +6,7 @@ pub struct RemapEventProcessed;
 
 impl InternalEvent for RemapEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -34,6 +34,6 @@ impl InternalEvent for RemapFailedMapping {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_mapping");
+        counter!("vector_processing_errors_total", 1, "error_type" => "failed_mapping");
     }
 }

--- a/src/internal_events/remove_fields.rs
+++ b/src/internal_events/remove_fields.rs
@@ -6,7 +6,7 @@ pub struct RemoveFieldsEventProcessed;
 
 impl InternalEvent for RemoveFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 

--- a/src/internal_events/remove_tags.rs
+++ b/src/internal_events/remove_tags.rs
@@ -6,6 +6,6 @@ pub struct RemoveTagsEventProcessed;
 
 impl InternalEvent for RemoveTagsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }

--- a/src/internal_events/rename_fields.rs
+++ b/src/internal_events/rename_fields.rs
@@ -6,7 +6,7 @@ pub struct RenameFieldsEventProcessed;
 
 impl InternalEvent for RenameFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 

--- a/src/internal_events/sampler.rs
+++ b/src/internal_events/sampler.rs
@@ -6,7 +6,7 @@ pub struct SamplerEventProcessed;
 
 impl InternalEvent for SamplerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -15,6 +15,6 @@ pub struct SamplerEventDiscarded;
 
 impl InternalEvent for SamplerEventDiscarded {
     fn emit_metrics(&self) {
-        counter!("events_discarded_total", 1);
+        counter!("vector_events_discarded_total", 1);
     }
 }

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -20,7 +20,7 @@ impl InternalEvent for SematextMetricsInvalidMetricReceived {
 
     fn emit_metrics(&self) {
         counter!(
-            "processing_errors_total", 1,
+            "vector_processing_errors_total", 1,
             "error_type" => "invalid_metric",
         );
     }

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -30,8 +30,8 @@ impl InternalEvent for SocketEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1, "mode" => self.mode.as_str());
-        counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
+        counter!("vector_events_processed_total", 1, "mode" => self.mode.as_str());
+        counter!("vector_processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }
 
@@ -47,6 +47,6 @@ impl InternalEvent for SocketReceiveError {
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_errors_total", 1, "mode" => self.mode.as_str());
+        counter!("vector_connection_errors_total", 1, "mode" => self.mode.as_str());
     }
 }

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -6,7 +6,7 @@ pub struct SplitEventProcessed;
 
 impl InternalEvent for SplitEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for SplitFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("vector_processing_errors_total", 1, "error_type" => "field_missing");
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for SplitConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "convert_failed");
+        counter!("vector_processing_errors_total", 1, "error_type" => "convert_failed");
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -12,8 +12,8 @@ pub(crate) struct SplunkEventSent {
 
 impl InternalEvent for SplunkEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -32,7 +32,7 @@ impl InternalEvent for SplunkEventEncodeError {
     }
 
     fn emit_metrics(&self) {
-        counter!("encode_errors_total", 1);
+        counter!("vector_encode_errors_total", 1);
     }
 }
 
@@ -51,7 +51,7 @@ impl<'a> InternalEvent for SplunkSourceTypeMissingKeys<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("sourcetype_missing_keys_total", 1);
+        counter!("vector_sourcetype_missing_keys_total", 1);
     }
 }
 
@@ -70,7 +70,7 @@ impl<'a> InternalEvent for SplunkSourceMissingKeys<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("source_missing_keys_total", 1);
+        counter!("vector_source_missing_keys_total", 1);
     }
 }
 
@@ -89,7 +89,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("events_processed_total", 1);
+            counter!("vector_events_processed_total", 1);
         }
     }
 
@@ -108,7 +108,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("request_received_total", 1);
+            counter!("vector_request_received_total", 1);
         }
     }
 
@@ -144,7 +144,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("request_errors_total", 1);
+            counter!("vector_request_errors_total", 1);
         }
     }
 }

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -12,8 +12,8 @@ impl InternalEvent for StatsdEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1,);
-        counter!("processed_bytes_total", self.byte_size as u64,);
+        counter!("vector_events_processed_total", 1,);
+        counter!("vector_processed_bytes_total", self.byte_size as u64,);
     }
 }
 
@@ -29,8 +29,8 @@ impl InternalEvent for StatsdInvalidRecord<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("invalid_record_total", 1,);
-        counter!("invalid_record_bytes_total", self.text.len() as u64,);
+        counter!("vector_invalid_record_total", 1,);
+        counter!("vector_invalid_record_bytes_total", self.text.len() as u64,);
     }
 }
 
@@ -70,6 +70,6 @@ impl<T: std::fmt::Debug + std::fmt::Display> InternalEvent for StatsdSocketError
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_errors_total", 1);
+        counter!("vector_connection_errors_total", 1);
     }
 }

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -12,8 +12,8 @@ impl InternalEvent for StdinEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -28,6 +28,6 @@ impl InternalEvent for StdinReadFailed {
     }
 
     fn emit_metrics(&self) {
-        counter!("stdin_reads_failed_total", 1);
+        counter!("vector_stdin_reads_failed_total", 1);
     }
 }

--- a/src/internal_events/swimlanes.rs
+++ b/src/internal_events/swimlanes.rs
@@ -6,7 +6,7 @@ pub struct SwimlanesEventProcessed;
 
 impl InternalEvent for SwimlanesEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -15,6 +15,6 @@ pub struct SwimlanesEventDiscarded;
 
 impl InternalEvent for SwimlanesEventDiscarded {
     fn emit_metrics(&self) {
-        counter!("events_discarded_total", 1);
+        counter!("vector_events_discarded_total", 1);
     }
 }

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -12,8 +12,8 @@ impl InternalEvent for SyslogEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -28,7 +28,7 @@ impl InternalEvent for SyslogUdpReadError {
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_read_errors_total", 1, "mode" => "udp");
+        counter!("vector_connection_read_errors_total", 1, "mode" => "udp");
     }
 }
 
@@ -43,6 +43,6 @@ impl InternalEvent for SyslogUdpUtf8Error {
     }
 
     fn emit_metrics(&self) {
-        counter!("utf8_convert_errors_total", 1, "mode" => "udp");
+        counter!("vector_utf8_convert_errors_total", 1, "mode" => "udp");
     }
 }

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -9,7 +9,7 @@ impl InternalEvent for TagCardinalityLimitEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -29,7 +29,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("tag_value_limit_exceeded_total", 1);
+        counter!("vector_tag_value_limit_exceeded_total", 1);
     }
 }
 
@@ -49,7 +49,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("tag_value_limit_exceeded_total", 1);
+        counter!("vector_tag_value_limit_exceeded_total", 1);
     }
 }
 
@@ -66,6 +66,6 @@ impl<'a> InternalEvent for TagCardinalityValueLimitReached<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("value_limit_reached_total", 1);
+        counter!("vector_value_limit_reached_total", 1);
     }
 }

--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -16,7 +16,7 @@ impl InternalEvent for TcpConnectionEstablished {
     }
 
     fn emit_metrics(&self) {
-        counter!("connections_established_total", 1, "mode" => "tcp");
+        counter!("vector_connections_established_total", 1, "mode" => "tcp");
     }
 }
 
@@ -31,7 +31,7 @@ impl<E: std::error::Error> InternalEvent for TcpConnectionFailed<E> {
     }
 
     fn emit_metrics(&self) {
-        counter!("connections_failed_total", 1, "mode" => "tcp");
+        counter!("vector_connections_failed_total", 1, "mode" => "tcp");
     }
 }
 
@@ -46,7 +46,7 @@ impl InternalEvent for TcpConnectionDisconnected {
     }
 
     fn emit_metrics(&self) {
-        counter!("connections_disconnected_total", 1, "mode" => "tcp");
+        counter!("vector_connections_disconnected_total", 1, "mode" => "tcp");
     }
 }
 
@@ -59,7 +59,7 @@ impl InternalEvent for TcpConnectionShutdown {
     }
 
     fn emit_metrics(&self) {
-        counter!("connections_shutdown_total", 1, "mode" => "tcp");
+        counter!("vector_connections_shutdown_total", 1, "mode" => "tcp");
     }
 }
 
@@ -74,7 +74,7 @@ impl<T: std::fmt::Debug + std::fmt::Display> InternalEvent for TcpConnectionErro
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_errors_total", 1, "mode" => "tcp");
+        counter!("vector_connection_errors_total", 1, "mode" => "tcp");
     }
 }
 
@@ -89,7 +89,7 @@ impl InternalEvent for TcpFlushError {
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_flush_errors_total", 1, "mode" => "tcp");
+        counter!("vector_connection_flush_errors_total", 1, "mode" => "tcp");
     }
 }
 
@@ -104,7 +104,7 @@ impl InternalEvent for TcpEventSent {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -6,7 +6,7 @@ pub(crate) struct TokenizerEventProcessed;
 
 impl InternalEvent for TokenizerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("vector_events_processed_total", 1);
     }
 }
 
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("vector_processing_errors_total", 1, "error_type" => "field_missing");
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "convert_failed");
+        counter!("vector_processing_errors_total", 1, "error_type" => "convert_failed");
     }
 }

--- a/src/internal_events/udp.rs
+++ b/src/internal_events/udp.rs
@@ -19,6 +19,6 @@ impl InternalEvent for UdpSendIncomplete {
     }
 
     fn emit_metrics(&self) {
-        counter!("connection_send_errors_total", 1, "mode" => "udp");
+        counter!("vector_connection_send_errors_total", 1, "mode" => "udp");
     }
 }

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -9,8 +9,8 @@ pub struct VectorEventSent {
 
 impl InternalEvent for VectorEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -25,8 +25,8 @@ impl InternalEvent for VectorEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!("vector_events_processed_total", 1);
+        counter!("vector_processed_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -41,6 +41,6 @@ impl InternalEvent for VectorProtoDecodeError {
     }
 
     fn emit_metrics(&self) {
-        counter!("protobuf_decode_errors_total", 1);
+        counter!("vector_protobuf_decode_errors_total", 1);
     }
 }

--- a/src/internal_events/wasm/compilation.rs
+++ b/src/internal_events/wasm/compilation.rs
@@ -74,7 +74,7 @@ impl InternalEvent for WasmCompilationProgress {
     }
 
     fn emit_metrics(&self) {
-        counter!("wasm_compilation_total", 1,
+        counter!("vector_wasm_compilation_total", 1,
             "component_role" => self.role.as_const_str(),
             "state" => self.state.as_const_str(),
         );

--- a/src/internal_events/wasm/event_processing.rs
+++ b/src/internal_events/wasm/event_processing.rs
@@ -66,15 +66,15 @@ impl InternalEvent for EventProcessingProgress {
     }
 
     fn emit_metrics(&self) {
-        counter!("wasm_event_processing_total", 1,
+        counter!("vector_wasm_event_processing_total", 1,
             "component_role" => self.role.as_const_str(),
             "state" => self.state.as_const_str(),
         );
         match self.state {
-            State::Completed => counter!("events_processed_total", 1,
+            State::Completed => counter!("vector_events_processed_total", 1,
                 "component_role" => self.role.as_const_str(),
             ),
-            State::Errored => counter!("processing_errors_total", 1,
+            State::Errored => counter!("vector_processing_errors_total", 1,
                 "component_role" => self.role.as_const_str(),
             ),
             _ => (),

--- a/src/internal_events/windows.rs
+++ b/src/internal_events/windows.rs
@@ -17,7 +17,7 @@ impl<'a> InternalEvent for WindowsServiceStart<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_start", 1,
+        counter!("vector_windows_service_start", 1,
             "already_started" => self.already_started.to_string(),
         );
     }
@@ -39,7 +39,7 @@ impl<'a> InternalEvent for WindowsServiceStop<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_stop", 1,
+        counter!("vector_windows_service_stop", 1,
             "already_stopped" => self.already_stopped.to_string(),
         );
     }
@@ -59,7 +59,7 @@ impl<'a> InternalEvent for WindowsServiceRestart<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_restart", 1)
+        counter!("vector_windows_service_restart", 1)
     }
 }
 
@@ -77,7 +77,7 @@ impl<'a> InternalEvent for WindowsServiceInstall<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_install", 1,);
+        counter!("vector_windows_service_install", 1,);
     }
 }
 
@@ -95,7 +95,7 @@ impl<'a> InternalEvent for WindowsServiceUninstall<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_uninstall", 1,);
+        counter!("vector_windows_service_uninstall", 1,);
     }
 }
 
@@ -113,6 +113,6 @@ impl<'a> InternalEvent for WindowsServiceDoesNotExist<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("windows_service_does_not_exist", 1,);
+        counter!("vector_windows_service_does_not_exist", 1,);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -143,7 +143,7 @@ mod tests {
         }
         let _enter = span.enter();
 
-        counter!("labels_injected_total", 1);
+        counter!("vector_labels_injected_total", 1);
 
         let metric = super::capture_metrics(super::get_controller().unwrap())
             .map(|e| e.into_metric())


### PR DESCRIPTION
Prometheus [naming conventions](https://prometheus.io/docs/practices/naming/) dictate that metric names "should have a (single-word) application prefix relevant to the domain the metric belongs to." This PR adds the `vector_` prefix to the `config_load_errors_total` metric, thus bringing all process metrics in line with this standard.