### PR TITLE
chore(aws_kinesis_streams sink): remove Arc and fix event

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -12,6 +12,7 @@ mod auto_concurrency;
 mod aws_cloudwatch_logs_subscription_parser;
 #[cfg(feature = "sources-aws_kinesis_firehose")]
 mod aws_kinesis_firehose;
+#[cfg(feature = "sinks-aws_kinesis_streams")]
 mod aws_kinesis_streams;
 mod blackhole;
 #[cfg(feature = "transforms-coercer")]
@@ -109,6 +110,7 @@ pub use self::auto_concurrency::*;
 pub(crate) use self::aws_cloudwatch_logs_subscription_parser::*;
 #[cfg(feature = "sources-aws_kinesis_firehose")]
 pub use self::aws_kinesis_firehose::*;
+#[cfg(feature = "sinks-aws_kinesis_streams")]
 pub use self::aws_kinesis_streams::*;
 pub use self::blackhole::*;
 #[cfg(feature = "transforms-coercer")]

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -184,9 +184,12 @@ impl Service<Vec<Record>> for KinesisFirehoseService {
             delivery_stream_name: self.config.stream_name.clone(),
         };
 
-        Box::pin(
-            async move { client.put_record_batch(request).await }.instrument(info_span!("request")),
-        )
+        Box::pin(async move {
+            client
+                .put_record_batch(request)
+                .instrument(info_span!("request"))
+                .await
+        })
     }
 }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use futures::{future::BoxFuture, FutureExt};
+use futures::{future::BoxFuture, FutureExt, TryFutureExt};
 use futures01::{stream::iter_ok, Sink};
 use lazy_static::lazy_static;
 use rand::random;
@@ -185,13 +185,25 @@ impl Service<Vec<PutRecordsRequestEntry>> for KinesisService {
             events = %records.len(),
         );
 
+        let sizes: Vec<usize> = records.iter().map(|record| record.data.len()).collect();
+
         let client = Arc::clone(&self.client);
         let request = PutRecordsInput {
             records,
             stream_name: self.config.stream_name.clone(),
         };
 
-        Box::pin(async move { client.put_records(request).await }.instrument(info_span!("request")))
+        Box::pin(async move {
+            client
+                .put_records(request)
+                .inspect_ok(|_| {
+                    for byte_size in sizes {
+                        emit!(AwsKinesisStreamsEventSent { byte_size });
+                    }
+                })
+                .instrument(info_span!("request"))
+                .await
+        })
     }
 }
 
@@ -288,13 +300,8 @@ fn encode_event(
             .unwrap_or_default(),
     };
 
-    let data = Bytes::from(data);
-
-    emit!(AwsKinesisStreamsEventSent {
-        byte_size: data.len()
-    });
     Some(PutRecordsRequestEntry {
-        data,
+        data: Bytes::from(data),
         partition_key,
         ..Default::default()
     })

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -300,7 +300,12 @@ impl Service<Request> for S3Sink {
             ..Default::default()
         };
 
-        Box::pin(async move { client.put_object(request).await }.instrument(info_span!("request")))
+        Box::pin(async move {
+            client
+                .put_object(request)
+                .instrument(info_span!("request"))
+                .await
+        })
     }
 }
 


### PR DESCRIPTION
Noted while worked on #2755 

- Move `AwsKinesisStreamsEventSent` to correct place. The event should be generated on success request, not on event encoding.
- Remove duplicated `Arc` from `KinesisService`. Inner value of `rusoto_core::Client` already use `Arc`, so we had `Arc` over `Arc`.