### PR TITLE
chore(sources): Add SourceContext

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -153,6 +153,7 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
     async fn build(
         &self,
         name: &str,
+        cx: SourceContext,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,
@@ -161,6 +162,21 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
     fn output_type(&self) -> DataType;
 
     fn source_type(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceContext {
+    pub(super) resolver: Resolver,
+}
+
+impl SourceContext {
+    pub fn new_test() -> Self {
+        Self { resolver: Resolver }
+    }
+
+    pub fn resolver(&self) -> Resolver {
+        self.resolver
+    }
 }
 
 pub type SourceDescription = ComponentDescription<Box<dyn SourceConfig>>;

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
     internal_events::{
         ApacheMetricsErrorResponse, ApacheMetricsEventReceived, ApacheMetricsHttpError,
@@ -52,6 +52,7 @@ impl SourceConfig for ApacheMetricsConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -327,6 +327,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         }
         .build(
             "default",
+            SourceContext::new_test(),
             &GlobalOptions::default(),
             ShutdownSignal::noop(),
             tx,
@@ -395,6 +396,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         }
         .build(
             "default",
+            SourceContext::new_test(),
             &GlobalOptions::default(),
             ShutdownSignal::noop(),
             tx,
@@ -436,6 +438,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         }
         .build(
             "default",
+            SourceContext::new_test(),
             &GlobalOptions::default(),
             ShutdownSignal::noop(),
             tx,

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
-    config::{DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{
+        DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription,
+    },
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
     Pipeline,
@@ -26,6 +28,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
     async fn build(
         &self,
         _: &str,
+        _cx: SourceContext,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -96,6 +96,7 @@ mod tests {
             }
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 sender,

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -1,6 +1,6 @@
 use super::util::MultilineConfig;
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::merge_state::LogEventMergeState,
     event::{self, Event, LogEvent, Value},
     internal_events::{
@@ -117,6 +117,7 @@ impl SourceConfig for DockerConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,6 +1,6 @@
 use super::util::MultilineConfig;
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::{FileEventReceived, FileSourceInternalEventsEmitter},
     line_agg::{self, LineAgg},
@@ -150,6 +150,7 @@ impl SourceConfig for FileConfig {
     async fn build(
         &self,
         name: &str,
+        _cx: SourceContext,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::GeneratorEventProcessed,
     shutdown::ShutdownSignal,
@@ -51,6 +51,7 @@ impl SourceConfig for GeneratorConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::{
         metric::{Metric, MetricKind, MetricValue},
         Event,
@@ -133,6 +133,7 @@ impl SourceConfig for HostMetricsConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext,
+        SourceDescription,
     },
     event::{Event, Value},
     shutdown::ShutdownSignal,
@@ -72,6 +73,7 @@ impl SourceConfig for SimpleHttpConfig {
     async fn build(
         &self,
         _: &str,
+        _cx: SourceContext,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -213,7 +213,7 @@ mod tests {
 
     use crate::shutdown::ShutdownSignal;
     use crate::{
-        config::{log_schema, GlobalOptions, SourceConfig},
+        config::{log_schema, GlobalOptions, SourceConfig, SourceContext},
         event::{Event, Value},
         test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
         Pipeline,
@@ -241,6 +241,7 @@ mod tests {
             }
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 sender,

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     metrics::Controller,
     metrics::{capture_metrics, get_controller},
     shutdown::ShutdownSignal,
@@ -30,6 +30,7 @@ impl SourceConfig for InternalMetricsConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::{Event, LogEvent, Value},
     internal_events::{JournaldEventReceived, JournaldInvalidRecord},
     shutdown::ShutdownSignal,
@@ -90,6 +90,7 @@ impl SourceConfig for JournaldConfig {
     async fn build(
         &self,
         name: &str,
+        _cx: SourceContext,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::{Event, Value},
     internal_events::{KafkaEventFailed, KafkaEventReceived, KafkaOffsetUpdateFailed},
     kafka::KafkaAuthConfig,
@@ -84,6 +84,7 @@ impl SourceConfig for KafkaSourceConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -12,7 +12,9 @@ use crate::internal_events::{
 };
 use crate::kubernetes as k8s;
 use crate::{
-    config::{DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{
+        DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription,
+    },
     dns::Resolver,
     shutdown::ShutdownSignal,
     sources,
@@ -98,6 +100,7 @@ impl SourceConfig for Config {
     async fn build(
         &self,
         name: &str,
+        _cx: SourceContext,
         globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::{HttpSourceAuthConfig, LogplexConfig};
     use crate::shutdown::ShutdownSignal;
     use crate::{
-        config::{log_schema, GlobalOptions, SourceConfig},
+        config::{log_schema, GlobalOptions, SourceConfig, SourceContext},
         event::Event,
         test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
         Pipeline,
@@ -197,6 +197,7 @@ mod tests {
             }
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 sender,

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext,
+        SourceDescription,
     },
     event::Event,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
@@ -48,6 +49,7 @@ impl SourceConfig for LogplexConfig {
     async fn build(
         &self,
         _: &str,
+        _cx: SourceContext,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{self, GlobalOptions, SourceConfig, SourceDescription},
+    config::{self, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
     internal_events::{
         MongoDBMetricsBsonParseError, MongoDBMetricsCollectCompleted, MongoDBMetricsRequestError,
@@ -122,6 +122,7 @@ impl SourceConfig for MongoDBMetricsConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         mut shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     internal_events::{
         PrometheusErrorResponse, PrometheusEventReceived, PrometheusHttpError,
         PrometheusParseError, PrometheusRequestCompleted,
@@ -42,6 +42,7 @@ impl SourceConfig for PrometheusConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -6,7 +6,8 @@ mod unix;
 use super::util::TcpSource;
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext,
+        SourceDescription,
     },
     shutdown::ShutdownSignal,
     tls::MaybeTlsSettings,
@@ -75,6 +76,7 @@ impl SourceConfig for SocketConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -136,7 +136,7 @@ impl SourceConfig for SocketConfig {
 mod test {
     use super::{tcp::TcpConfig, udp::UdpConfig, SocketConfig};
     use crate::{
-        config::{log_schema, GlobalOptions, SourceConfig},
+        config::{log_schema, GlobalOptions, SourceConfig, SourceContext},
         dns::Resolver,
         shutdown::{ShutdownSignal, SourceShutdownCoordinator},
         sinks::util::tcp::TcpSink,
@@ -182,6 +182,7 @@ mod test {
         let server = SocketConfig::from(TcpConfig::new(addr.into()))
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,
@@ -208,6 +209,7 @@ mod test {
         let server = SocketConfig::from(TcpConfig::new(addr.into()))
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,
@@ -241,6 +243,7 @@ mod test {
         let server = SocketConfig::from(config)
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,
@@ -289,6 +292,7 @@ mod test {
         let server = SocketConfig::from(config)
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,
@@ -339,6 +343,7 @@ mod test {
         let server = SocketConfig::from(config)
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,
@@ -388,7 +393,13 @@ mod test {
 
         // Start TCP Source
         let server = SocketConfig::from(TcpConfig::new(addr.into()))
-            .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
+            .build(
+                source_name,
+                SourceContext::new_test(),
+                &GlobalOptions::default(),
+                shutdown_signal,
+                tx,
+            )
             .await
             .unwrap()
             .compat();
@@ -430,7 +441,13 @@ mod test {
             shutdown_timeout_secs: 1,
             ..TcpConfig::new(addr.into())
         })
-        .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
+        .build(
+            source_name,
+            SourceContext::new_test(),
+            &GlobalOptions::default(),
+            shutdown_signal,
+            tx,
+        )
         .await
         .unwrap()
         .compat();
@@ -526,6 +543,7 @@ mod test {
         let server = SocketConfig::from(UdpConfig::new(addr))
             .build(
                 source_name,
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 shutdown_signal,
                 sender,
@@ -692,6 +710,7 @@ mod test {
         let server = SocketConfig::from(UnixConfig::new(in_path.clone()))
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 sender,

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -749,7 +749,7 @@ fn event_error(text: &str, code: u16, event: usize) -> Response {
 mod tests {
     use super::{parse_timestamp, SplunkConfig};
     use crate::{
-        config::{log_schema, GlobalOptions, SinkConfig, SinkContext, SourceConfig},
+        config::{log_schema, GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::Event,
         shutdown::ShutdownSignal,
         sinks::{
@@ -788,6 +788,7 @@ mod tests {
             }
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 sender,

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::{Event, LogEvent, Value},
     internal_events::{
         SplunkHECEventReceived, SplunkHECRequestBodyInvalid, SplunkHECRequestError,
@@ -79,6 +79,7 @@ impl SourceConfig for SplunkConfig {
     async fn build(
         &self,
         _: &str,
+        _cx: SourceContext,
         _: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     internal_events::{StatsdEventReceived, StatsdInvalidRecord, StatsdSocketError},
     shutdown::ShutdownSignal,
     sources::util::{SocketListenAddr, TcpSource},
@@ -68,6 +68,7 @@ impl SourceConfig for StatsdConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::{StdinEventReceived, StdinReadFailed},
     shutdown::ShutdownSignal,
@@ -47,6 +47,7 @@ impl SourceConfig for StdinConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -3,7 +3,8 @@ use super::util::{SocketListenAddr, TcpSource};
 use crate::sources::util::build_unix_source;
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext,
+        SourceDescription,
     },
     event::{Event, Value},
     internal_events::{SyslogEventReceived, SyslogUdpReadError, SyslogUdpUtf8Error},
@@ -82,6 +83,7 @@ impl SourceConfig for SyslogConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -101,7 +101,7 @@ mod test {
     use super::VectorConfig;
     use crate::shutdown::ShutdownSignal;
     use crate::{
-        config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig},
+        config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::{
             metric::{MetricKind, MetricValue},
             Metric,
@@ -121,6 +121,7 @@ mod test {
         let server = source
             .build(
                 "default",
+                SourceContext::new_test(),
                 &GlobalOptions::default(),
                 ShutdownSignal::noop(),
                 tx,

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -1,6 +1,8 @@
 use super::util::{SocketListenAddr, TcpSource};
 use crate::{
-    config::{DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{
+        DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceContext, SourceDescription,
+    },
     event::proto,
     internal_events::{VectorEventReceived, VectorProtoDecodeError},
     shutdown::ShutdownSignal,
@@ -48,6 +50,7 @@ impl SourceConfig for VectorConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     buffers,
-    config::{DataType, SinkContext, TransformContext},
+    config::{DataType, SinkContext, SourceContext, TransformContext},
     dns::Resolver,
     event::Event,
     shutdown::SourceShutdownCoordinator,
@@ -53,13 +53,14 @@ pub async fn build_pieces(
     {
         let (tx, rx) = mpsc::channel(1000);
         let pipeline = Pipeline::from_sender(tx);
+        let cx = SourceContext { resolver };
 
         let typetag = source.source_type();
 
         let (shutdown_signal, force_shutdown_tripwire) = shutdown_coordinator.register_source(name);
 
         let server = match source
-            .build(&name, &config.global, shutdown_signal, pipeline)
+            .build(&name, cx, &config.global, shutdown_signal, pipeline)
             .await
         {
             Err(error) => {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -810,7 +810,7 @@ mod source_finished_tests {
 ))]
 mod transient_state_tests {
     use crate::{
-        config::{Config, DataType, GlobalOptions, SourceConfig},
+        config::{Config, DataType, GlobalOptions, SourceConfig, SourceContext},
         shutdown::ShutdownSignal,
         sinks::blackhole::BlackholeConfig,
         sources::stdin::StdinConfig,
@@ -847,6 +847,7 @@ mod transient_state_tests {
         async fn build(
             &self,
             _name: &str,
+            _cx: SourceContext,
             _globals: &GlobalOptions,
             shutdown: ShutdownSignal,
             out: Pipeline,

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -7,7 +7,7 @@ use futures01::{Async, AsyncSink, Sink, Stream};
 use serde::{Deserialize, Serialize};
 use tokio::time::{delay_for, Duration};
 use vector::{
-    config::{self, GlobalOptions, SinkConfig, SinkContext, SourceConfig},
+    config::{self, GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext},
     shutdown::ShutdownSignal,
     test_util::{next_addr, random_lines, send_lines, start_topology, wait_for_tcp, CountReceiver},
     Event, Pipeline,
@@ -188,6 +188,7 @@ impl SourceConfig for ErrorSourceConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         _shutdown: ShutdownSignal,
         _out: Pipeline,
@@ -255,6 +256,7 @@ impl SourceConfig for PanicSourceConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         _shutdown: ShutdownSignal,
         _out: Pipeline,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -21,7 +21,7 @@ use std::{
 
 use tracing::{error, info};
 use vector::config::{
-    DataType, GlobalOptions, SinkConfig, SinkContext, SourceConfig, TransformConfig,
+    DataType, GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext, TransformConfig,
     TransformContext,
 };
 use vector::event::{metric::MetricValue, Event, Value};
@@ -135,6 +135,7 @@ impl SourceConfig for MockSourceConfig {
     async fn build(
         &self,
         _name: &str,
+        _cx: SourceContext,
         _globals: &GlobalOptions,
         shutdown: ShutdownSignal,
         out: Pipeline,


### PR DESCRIPTION
To inject the `Resolver` similar to the `TransformContext`. I need the
`Resolver` in the new `aws_s3` source. I figured I'd submit this change
separately since it was easy to pull out and I wanted thoughts sooner
than later.

Alternatively, it seems like the resolver is static now so we could drop
it from `SinkContext` and `TransformContext`. I wanted some confirmation
on that front though. I'm happy to reverse this and remove injection of
the `Resolver`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
