### PR TITLE
chore: Clean up redundancies in template

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     template::Template,
 };
-use bytes::Bytes;
 use chrono::{Duration, Utc};
 use futures::{
     future::{BoxFuture, FutureExt, TryFutureExt},
@@ -286,8 +285,8 @@ impl CloudwatchLogsSvc {
         key: &CloudwatchKey,
         client: CloudWatchLogsClient,
     ) -> Self {
-        let group_name = String::from_utf8_lossy(&key.group[..]).into_owned();
-        let stream_name = String::from_utf8_lossy(&key.stream[..]).into_owned();
+        let group_name = key.group.clone();
+        let stream_name = key.stream.clone();
 
         let create_missing_group = config.create_missing_group.unwrap_or(true);
         let create_missing_stream = config.create_missing_stream.unwrap_or(true);
@@ -412,8 +411,8 @@ impl EncodedLength for InputLogEvent {
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct CloudwatchKey {
-    group: Bytes,
-    stream: Bytes,
+    group: String,
+    stream: String,
 }
 
 fn encode_log(
@@ -445,7 +444,7 @@ fn partition_encode(
     group: &Template,
     stream: &Template,
 ) -> Option<PartitionInnerBuffer<InputLogEvent, CloudwatchKey>> {
-    let group = match group.render(&event) {
+    let group = match group.render_string(&event) {
         Ok(b) => b,
         Err(missing_keys) => {
             warn!(
@@ -457,7 +456,7 @@ fn partition_encode(
         }
     };
 
-    let stream = match stream.render(&event) {
+    let stream = match stream.render_string(&event) {
         Ok(b) => b,
         Err(missing_keys) => {
             warn!(

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -502,7 +502,7 @@ async fn healthcheck(
         return Ok(());
     }
 
-    let group_name = String::from_utf8_lossy(&config.group_name.get_ref()[..]).into_owned();
+    let group_name = config.group_name.get_ref().to_owned();
     let expected_group_name = group_name.clone();
 
     let request = DescribeLogGroupsRequest {


### PR DESCRIPTION
- Remove `src_bytes`: `Template` stores a clone of `src` (`src` and `src_bytes`), but barely uses `src_bytes`.
- Flip `From<&str>` and `From<String>`: avoid cloning twice in `From<String>` impl.
- Flip `render` and `render_string`: avoid cloning and UTF-8 parsing in `render_string`.
- Change `get_ref` to return `&str`, more fitting for its usage in `aws_cloudwatch_logs`.

Signed-off-by: Duy Do <juchiast@gmail.com>