### PR TITLE
fix(datadog_logs sink): use application/json for json encoding to Datadog

### DIFF
--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -319,6 +319,7 @@ mod tests {
         let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
         for (i, val) in output.iter().enumerate() {
+            assert_eq!(val.0.headers.get("Content-Type").unwrap(), "text/plain");
             assert_eq!(val.1, format!("{}\n", expected[i]));
         }
     }
@@ -353,6 +354,11 @@ mod tests {
         let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
         for (i, val) in output.iter().enumerate() {
+            assert_eq!(
+                val.0.headers.get("Content-Type").unwrap(),
+                "application/json"
+            );
+
             let mut json = serde_json::Deserializer::from_slice(&val.1[..])
                 .into_iter::<serde_json::Value>()
                 .map(|v| v.expect("decoding json"));

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -72,6 +72,7 @@ impl DatadogLogsConfig {
     fn batch_settings<T: Batch>(&self) -> Result<BatchSettings<T>, BatchError> {
         BatchSettings::default()
             .bytes(bytesize::kib(100u64))
+            .events(20)
             .timeout(1)
             .parse_config(self.batch)
     }


### PR DESCRIPTION
Closes #4687 
Closes #4720 

Sorry, this was caused when I factored both the text, and json encoding to use the same `build_request` method and neglected to change the `Content-Type` for each encoding. So json was being sent as text.

Regarding encoding the entire payload under `message`,  the code that encodes the message is [here](https://github.com/timberio/vector/blob/d99813e90c9668d4cfcf8d25abc329ed8eff4fb0/src/sinks/datadog/logs.rs#L206).

Currently, if there is no `message` field in the payload, it shows up in Datadog as follows:

![image](https://user-images.githubusercontent.com/192679/96848494-69cc5180-144c-11eb-938b-ebd7ff9ce93f.png)

If the message field is an object, for example, sending this:

```
{"message": {"subkey1": "subvalue1"}}
```

Results in this:

![image](https://user-images.githubusercontent.com/192679/96848929-ea8b4d80-144c-11eb-9025-4cebf558da2f.png)

It looks like datadog merges the fields from the message key into the parent object.


If the message is simple text, it looks like Datadog extracts just this field:

```
{"message": "the message", "key": "value"}
```

![image](https://user-images.githubusercontent.com/192679/96853320-1bba4c80-1452-11eb-9857-8662fb3a522b.png)

The other fields are stored as event attributes:

![image](https://user-images.githubusercontent.com/192679/96853413-3bea0b80-1452-11eb-9bf3-76a3795a10b6.png)



I can change the code so that it puts the entire log event into "message". Then we get the following in Datadog:

Sending this:

```
{"key1": "value1"}
```

Gives us:

![image](https://user-images.githubusercontent.com/192679/96851159-a2215f00-144f-11eb-94df-29a5301f94bc.png)


Which doesn't seem to add anything to what we currently have. So I think it looks like we are handling this ok. Please advise if you think it should be changed?

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

