### PR TITLE
fix(releasing): Fix flag for `usermod` in postinst deb script

### DIFF
--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -2,10 +2,10 @@
 set -e
 
 # Add Vector to adm group to read /var/logs
-usermod --append --gid adm vector || true
+usermod --append --groups adm vector || true
 
 # Add Vector to systemd-journal to read journald logs
-usermod --append --gid systemd-journal vector || true
+usermod --append --groups systemd-journal vector || true
 
 # Reload the daemon to reflect new group membership
 if command -v systemctl >/dev/null 2>&1


### PR DESCRIPTION
`-G` is `--groups` rather than `--gid` (the latter is the initial login
group for the user).

Fixes #4692 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
