### PR TITLE
fix: Renamed mongo metrics to new naming standards

### DIFF
--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -15,7 +15,7 @@ impl InternalEvent for MongoDBMetricsCollectCompleted {
     }
 
     fn emit_metrics(&self) {
-        counter!("collect_completed", 1);
+        counter!("collect_completed_total", 1);
         histogram!("collect_duration_nanoseconds", self.end - self.start);
     }
 }
@@ -31,10 +31,7 @@ impl<'a> InternalEvent for MongoDBMetricsRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_error", 1,
-            "component_kind" => "source",
-            "component_type" => "mongodb_metrics",
-        );
+        counter!("request_error_total", 1);
     }
 }
 
@@ -49,9 +46,6 @@ impl<'a> InternalEvent for MongoDBMetricsBsonParseError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("bson_parse_error", 1,
-            "component_kind" => "source",
-            "component_type" => "mongodb_metrics",
-        )
+        counter!("bson_parse_error_total", 1);
     }
 }


### PR DESCRIPTION
Signed-off-by: James Turnbull <james@lovedthanlost.net>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
