### PR TITLE
fix(metrics): Add event metrics to console sink

### DIFF
--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -2,6 +2,18 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
+pub struct ConsoleEventProcessed {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for ConsoleEventProcessed {
+    fn emit_metrics(&self) {
+        counter!("events_processed_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
 pub struct ConsoleFieldNotFound<'a> {
     pub missing_field: &'a str,
 }

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -2,7 +2,7 @@ use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::Event,
-    internal_events::ConsoleFieldNotFound,
+    internal_events::{ConsoleEventProcessed, ConsoleFieldNotFound},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         StreamSink,
@@ -143,6 +143,10 @@ impl StreamSink for WriterSink {
                     error!("Error writing to output: {}. Stopping sink.", error);
                     return Err(());
                 }
+
+                emit!(ConsoleEventProcessed {
+                    byte_size: buf.len(),
+                });
             }
         }
         Ok(())


### PR DESCRIPTION
This PR adds `processed_bytes_total` and `events_processed_total` metrics to the `console` sink. These metrics are already present on most of the other sinks and will be particularly useful in demo scenarios.