### PR TITLE
enhancement(data model): Add `namespace` to `Metric` 

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -58,6 +58,7 @@ message Metric {
     AggregatedHistogram aggregated_histogram = 9;
     AggregatedSummary aggregated_summary = 10;
   }
+  string namespace = 11;
 }
 
 message Counter {

--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -67,6 +67,7 @@ mod test {
         assert_eq!(
             cond.check(&Event::from(Metric {
                 name: "test metric".to_string(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -67,6 +67,7 @@ mod test {
         assert_eq!(
             cond.check(&Event::from(Metric {
                 name: "test metric".to_string(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -192,6 +192,12 @@ impl From<proto::EventWrapper> for Event {
 
                 let name = proto.name;
 
+                let namespace = if proto.namespace.is_empty() {
+                    None
+                } else {
+                    Some(proto.namespace)
+                };
+
                 let timestamp = proto
                     .timestamp
                     .map(|ts| chrono::Utc.timestamp(ts.seconds, ts.nanos as u32));
@@ -236,6 +242,7 @@ impl From<proto::EventWrapper> for Event {
 
                 Event::Metric(Metric {
                     name,
+                    namespace,
                     timestamp,
                     tags,
                     kind,
@@ -294,11 +301,14 @@ impl From<Event> for proto::EventWrapper {
             }
             Event::Metric(Metric {
                 name,
+                namespace,
                 timestamp,
                 tags,
                 kind,
                 value,
             }) => {
+                let namespace = namespace.unwrap_or_default();
+
                 let timestamp = timestamp.map(|ts| prost_types::Timestamp {
                     seconds: ts.timestamp(),
                     nanos: ts.timestamp_subsec_nanos() as i32,
@@ -361,6 +371,7 @@ impl From<Event> for proto::EventWrapper {
 
                 let event = EventProto::Metric(proto::Metric {
                     name,
+                    namespace,
                     timestamp,
                     tags,
                     kind,

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -296,6 +296,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "exception_total".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -303,6 +304,7 @@ mod tests {
             },
             Metric {
                 name: "bytes_out".into(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789)),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -310,6 +312,7 @@ mod tests {
             },
             Metric {
                 name: "healthcheck".into(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789)),
                 tags: Some(
                     vec![("region".to_owned(), "local".to_owned())]
@@ -356,6 +359,7 @@ mod tests {
     fn encode_events_absolute_gauge() {
         let events = vec![Metric {
             name: "temperature".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -379,6 +383,7 @@ mod tests {
     fn encode_events_distribution() {
         let events = vec![Metric {
             name: "latency".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -407,6 +412,7 @@ mod tests {
     fn encode_events_set() {
         let events = vec![Metric {
             name: "users".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -469,6 +475,7 @@ mod integration_tests {
         for i in 0..100 {
             let event = Event::Metric(Metric {
                 name: format!("counter-{}", 0),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -489,6 +496,7 @@ mod integration_tests {
         for i in 0..10 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", gauge_name),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -501,6 +509,7 @@ mod integration_tests {
         for i in 0..10 {
             let event = Event::Metric(Metric {
                 name: format!("distribution-{}", distribution_name),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789)),
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -174,6 +174,7 @@ mod test {
     fn encodes_counter() {
         let event = Event::Metric(Metric {
             name: "foos".into(),
+            namespace: None,
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
             tags: Some(
                 vec![
@@ -197,6 +198,7 @@ mod test {
     fn encodes_set() {
         let event = Event::Metric(Metric {
             name: "users".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -214,6 +216,7 @@ mod test {
     fn encodes_histogram_without_timestamp() {
         let event = Event::Metric(Metric {
             name: "glork".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -233,6 +236,7 @@ mod test {
     fn encodes_metric_text() {
         let event = Event::Metric(Metric {
             name: "users".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -548,6 +548,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "total".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -555,6 +556,7 @@ mod tests {
             },
             Metric {
                 name: "check".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -562,6 +564,7 @@ mod tests {
             },
             Metric {
                 name: "unsupported".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Absolute,
@@ -599,6 +602,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -606,6 +610,7 @@ mod tests {
             },
             Metric {
                 name: "check".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -613,6 +618,7 @@ mod tests {
             },
             Metric {
                 name: "unsupported".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Absolute,
@@ -633,6 +639,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "unsupported".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -640,6 +647,7 @@ mod tests {
             },
             Metric {
                 name: "volume".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -659,6 +667,7 @@ mod tests {
     fn encode_set() {
         let events = vec![Metric {
             name: "users".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Incremental,
@@ -765,6 +774,7 @@ mod tests {
         // https://docs.datadoghq.com/developers/metrics/metrics_type/?tab=histogram#metric-type-definition
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Incremental,
@@ -788,6 +798,7 @@ mod tests {
         // https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Incremental,

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -90,6 +90,7 @@ mod tests {
         let metrics = vec![
             Event::from(Metric {
                 name: "metric1".to_string(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms(21, 0, 1)),
                 tags: Some(
                     vec![("os.host".to_string(), "somehost".to_string())]
@@ -101,6 +102,7 @@ mod tests {
             }),
             Event::from(Metric {
                 name: "metric2".to_string(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms(21, 0, 2)),
                 tags: Some(
                     vec![("os.host".to_string(), "somehost".to_string())]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -386,6 +386,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -393,6 +394,7 @@ mod tests {
             },
             Metric {
                 name: "check".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -412,6 +414,7 @@ mod tests {
     fn test_encode_gauge() {
         let events = vec![Metric {
             name: "meter".to_owned(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -429,6 +432,7 @@ mod tests {
     fn test_encode_set() {
         let events = vec![Metric {
             name: "users".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -448,6 +452,7 @@ mod tests {
     fn test_encode_histogram_v1() {
         let events = vec![Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -487,6 +492,7 @@ mod tests {
     fn test_encode_histogram() {
         let events = vec![Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -526,6 +532,7 @@ mod tests {
     fn test_encode_summary_v1() {
         let events = vec![Metric {
             name: "requests_sum".to_owned(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -565,6 +572,7 @@ mod tests {
     fn test_encode_summary() {
         let events = vec![Metric {
             name: "requests_sum".to_owned(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -605,6 +613,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "requests".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -616,6 +625,7 @@ mod tests {
             },
             Metric {
                 name: "dense_stats".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -627,6 +637,7 @@ mod tests {
             },
             Metric {
                 name: "sparse_stats".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -704,6 +715,7 @@ mod tests {
     fn test_encode_distribution_empty_stats() {
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -722,6 +734,7 @@ mod tests {
     fn test_encode_distribution_zero_counts_stats() {
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -740,6 +753,7 @@ mod tests {
     fn test_encode_distribution_unequal_stats() {
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -758,6 +772,7 @@ mod tests {
     fn test_encode_distribution_summary() {
         let events = vec![Metric {
             name: "requests".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -811,6 +826,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "cpu".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -818,6 +834,7 @@ mod tests {
             },
             Metric {
                 name: "mem".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Absolute,
@@ -966,6 +983,7 @@ mod integration_tests {
         for i in 0..10 {
             let event = Event::Metric(Metric {
                 name: metric.to_string(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -1049,6 +1067,7 @@ mod integration_tests {
     fn create_event(i: i32) -> Event {
         Event::Metric(Metric {
             name: format!("counter-{}", i),
+            namespace: None,
             timestamp: None,
             tags: Some(
                 vec![

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -508,6 +508,7 @@ mod tests {
     fn test_encode_counter() {
         let metric = Metric {
             name: "hits".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -528,6 +529,7 @@ mod tests {
     fn test_encode_gauge() {
         let metric = Metric {
             name: "temperature".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -548,6 +550,7 @@ mod tests {
     fn test_encode_set() {
         let metric = Metric {
             name: "users".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -570,6 +573,7 @@ mod tests {
     fn test_encode_expired_set() {
         let metric = Metric {
             name: "users".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -592,6 +596,7 @@ mod tests {
     fn test_encode_distribution() {
         let metric = Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -616,6 +621,7 @@ mod tests {
     fn test_encode_histogram() {
         let metric = Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -641,6 +647,7 @@ mod tests {
     fn test_encode_summary() {
         let metric = Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -666,6 +673,7 @@ mod tests {
     fn test_encode_distribution_summary() {
         let metric = Metric {
             name: "requests".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Absolute,

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -253,6 +253,7 @@ mod tests {
     fn test_encode_counter_event() {
         let events = vec![Metric {
             name: "jvm.pool.used".into(),
+            namespace: None,
             timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)),
             tags: None,
             kind: MetricKind::Incremental,
@@ -269,6 +270,7 @@ mod tests {
     fn test_encode_counter_event_no_namespace() {
         let events = vec![Metric {
             name: "used".into(),
+            namespace: None,
             timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)),
             tags: None,
             kind: MetricKind::Incremental,
@@ -286,6 +288,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "jvm.pool.used".into(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -293,6 +296,7 @@ mod tests {
             },
             Metric {
                 name: "jvm.pool.committed".into(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 1)),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -347,6 +351,7 @@ mod tests {
         for (i, (metric, val)) in metrics.iter().enumerate() {
             let event = Event::from(Metric {
                 name: metric.to_string(),
+                namespace: None,
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, i as u32)),
                 tags: Some(
                     vec![("os.host".to_owned(), "somehost".to_owned())]

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -289,6 +289,7 @@ mod test {
     fn test_encode_counter() {
         let metric1 = Metric {
             name: "counter".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -305,6 +306,7 @@ mod test {
     fn test_encode_absolute_counter() {
         let metric1 = Metric {
             name: "counter".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -322,6 +324,7 @@ mod test {
     fn test_encode_gauge() {
         let metric1 = Metric {
             name: "gauge".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -338,6 +341,7 @@ mod test {
     fn test_encode_absolute_gauge() {
         let metric1 = Metric {
             name: "gauge".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -354,6 +358,7 @@ mod test {
     fn test_encode_distribution() {
         let metric1 = Metric {
             name: "distribution".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -374,6 +379,7 @@ mod test {
     fn test_encode_set() {
         let metric1 = Metric {
             name: "set".to_owned(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags()),
             kind: MetricKind::Incremental,
@@ -411,6 +417,7 @@ mod test {
         let events = vec![
             Event::Metric(Metric {
                 name: "counter".to_owned(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -418,6 +425,7 @@ mod test {
             }),
             Event::Metric(Metric {
                 name: "histogram".to_owned(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -144,6 +144,7 @@ impl Batch for MetricBuffer {
                         // and emit the difference between previous and current as a Counter
                         let delta = MetricEntry(Metric {
                             name: item.name.to_string(),
+                            namespace: item.namespace.clone(),
                             timestamp: item.timestamp,
                             tags: item.tags.clone(),
                             kind: MetricKind::Incremental,
@@ -179,6 +180,7 @@ impl Batch for MetricBuffer {
                             // Otherwise we start from zero value
                             Metric {
                                 name: item.name.to_string(),
+                                namespace: item.namespace.clone(),
                                 timestamp: item.timestamp,
                                 tags: item.tags.clone(),
                                 kind: MetricKind::Absolute,
@@ -343,6 +345,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: "counter-0".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -354,6 +357,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Incremental,
@@ -365,6 +369,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -391,6 +396,7 @@ mod test {
             [
                 Metric {
                     name: "counter-0".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -398,6 +404,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-0".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Incremental,
@@ -405,6 +412,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-1".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -412,6 +420,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-1".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Incremental,
@@ -419,6 +428,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Incremental,
@@ -426,6 +436,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Incremental,
@@ -439,6 +450,7 @@ mod test {
             [
                 Metric {
                     name: "counter-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -446,6 +458,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -463,6 +476,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Absolute,
@@ -474,6 +488,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: format!("counter-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Absolute,
@@ -501,6 +516,7 @@ mod test {
             [
                 Metric {
                     name: "counter-0".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -508,6 +524,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-1".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -515,6 +532,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -522,6 +540,7 @@ mod test {
                 },
                 Metric {
                     name: "counter-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -539,6 +558,7 @@ mod test {
         for i in 1..5 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Incremental,
@@ -550,6 +570,7 @@ mod test {
         for i in 1..5 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Incremental,
@@ -575,6 +596,7 @@ mod test {
             [
                 Metric {
                     name: "gauge-1".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -582,6 +604,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -589,6 +612,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -596,6 +620,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-4".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -613,6 +638,7 @@ mod test {
         for i in 3..6 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Absolute,
@@ -626,6 +652,7 @@ mod test {
         for i in 1..4 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Incremental,
@@ -637,6 +664,7 @@ mod test {
         for i in 2..5 {
             let event = Event::Metric(Metric {
                 name: format!("gauge-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("staging")),
                 kind: MetricKind::Absolute,
@@ -664,6 +692,7 @@ mod test {
             [
                 Metric {
                     name: "gauge-1".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -671,6 +700,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -678,6 +708,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -685,6 +716,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-4".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -692,6 +724,7 @@ mod test {
                 },
                 Metric {
                     name: "gauge-5".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("staging")),
                     kind: MetricKind::Absolute,
@@ -709,6 +742,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: "set-0".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -722,6 +756,7 @@ mod test {
         for i in 0..4 {
             let event = Event::Metric(Metric {
                 name: "set-0".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -747,6 +782,7 @@ mod test {
             sorted(&buffer[0].clone()),
             [Metric {
                 name: "set-0".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -767,6 +803,7 @@ mod test {
         for _ in 2..6 {
             let event = Event::Metric(Metric {
                 name: "dist-2".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -782,6 +819,7 @@ mod test {
         for i in 2..6 {
             let event = Event::Metric(Metric {
                 name: format!("dist-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -810,6 +848,7 @@ mod test {
             [
                 Metric {
                     name: "dist-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -821,6 +860,7 @@ mod test {
                 },
                 Metric {
                     name: "dist-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -832,6 +872,7 @@ mod test {
                 },
                 Metric {
                     name: "dist-4".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -843,6 +884,7 @@ mod test {
                 },
                 Metric {
                     name: "dist-5".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -875,6 +917,7 @@ mod test {
         for _ in 2..5 {
             let event = Event::Metric(Metric {
                 name: "buckets-2".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Absolute,
@@ -891,6 +934,7 @@ mod test {
         for i in 2..5 {
             let event = Event::Metric(Metric {
                 name: format!("buckets-{}", i),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Absolute,
@@ -920,6 +964,7 @@ mod test {
             [
                 Metric {
                     name: "buckets-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -932,6 +977,7 @@ mod test {
                 },
                 Metric {
                     name: "buckets-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -944,6 +990,7 @@ mod test {
                 },
                 Metric {
                     name: "buckets-4".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -966,6 +1013,7 @@ mod test {
         for _ in 0..3 {
             let event = Event::Metric(Metric {
                 name: "buckets-2".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -982,6 +1030,7 @@ mod test {
         for i in 1..4 {
             let event = Event::Metric(Metric {
                 name: "buckets-2".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(tag("production")),
                 kind: MetricKind::Incremental,
@@ -1011,6 +1060,7 @@ mod test {
             [
                 Metric {
                     name: "buckets-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -1023,6 +1073,7 @@ mod test {
                 },
                 Metric {
                     name: "buckets-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Incremental,
@@ -1046,6 +1097,7 @@ mod test {
             for i in 2..5 {
                 let event = Event::Metric(Metric {
                     name: format!("quantiles-{}", i),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -1076,6 +1128,7 @@ mod test {
             [
                 Metric {
                     name: "quantiles-2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -1088,6 +1141,7 @@ mod test {
                 },
                 Metric {
                     name: "quantiles-3".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,
@@ -1100,6 +1154,7 @@ mod test {
                 },
                 Metric {
                     name: "quantiles-4".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(tag("production")),
                     kind: MetricKind::Absolute,

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -174,6 +174,7 @@ fn apache_metrics(
                             let results = parser::parse(&body, &namespace, Utc::now(), Some(&tags))
                                 .chain(vec![Ok(Metric {
                                     name: encode_namespace(&namespace, "up"),
+                                    namespace: None,
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
@@ -207,6 +208,7 @@ fn apache_metrics(
                             Some(
                                 stream::iter(vec![Metric {
                                     name: encode_namespace(&namespace, "up"),
+                                    namespace: None,
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
@@ -224,6 +226,7 @@ fn apache_metrics(
                             Some(
                                 stream::iter(vec![Metric {
                                     name: encode_namespace(&namespace, "up"),
+                                    namespace: None,
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,

--- a/src/sources/apache_metrics/parser.rs
+++ b/src/sources/apache_metrics/parser.rs
@@ -161,6 +161,7 @@ fn line_to_metrics<'a>(
         result.map(move |statistic| match statistic {
             StatusFieldStatistic::ServerUptimeSeconds(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "uptime_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: tags.cloned(),
                 kind: MetricKind::Absolute,
@@ -170,6 +171,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::TotalAccesses(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "access_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: tags.cloned(),
                 kind: MetricKind::Absolute,
@@ -179,6 +181,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::TotalKBytes(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "sent_bytes_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: tags.cloned(),
                 kind: MetricKind::Absolute,
@@ -188,6 +191,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::TotalDuration(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "duration_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: tags.cloned(),
                 kind: MetricKind::Absolute,
@@ -197,6 +201,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::CPUUser(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "cpu_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -209,6 +214,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUSystem(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "cpu_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -221,6 +227,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUChildrenUser(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "cpu_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -233,6 +240,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUChildrenSystem(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "cpu_seconds_total"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -245,6 +253,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPULoad(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "cpu_load"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: tags.cloned(),
                 kind: MetricKind::Absolute,
@@ -253,6 +262,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::IdleWorkers(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "workers"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -267,6 +277,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::BusyWorkers(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "workers"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -280,6 +291,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::ConnsTotal(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "connections"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -293,6 +305,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::ConnsAsyncWriting(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "connections"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -306,6 +319,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::ConnsAsyncClosing(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "connections"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -319,6 +333,7 @@ fn line_to_metrics<'a>(
             })),
             StatusFieldStatistic::ConnsAsyncKeepAlive(value) => Box::new(iter::once(Metric {
                 name: encode_namespace(namespace, "connections"),
+                namespace: None,
                 timestamp: Some(now),
                 tags: {
                     let mut tags = tags.cloned().unwrap_or_default();
@@ -369,6 +384,7 @@ fn score_to_metric(
 ) -> Metric {
     Metric {
         name: encode_namespace(namespace, "scoreboard"),
+        namespace: None,
         timestamp: Some(now),
         tags: {
             let mut tags = tags.cloned().unwrap_or_default();
@@ -506,6 +522,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             vec![
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "closing"}),
                     kind: MetricKind::Absolute,
@@ -513,6 +530,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "keepalive"}),
                     kind: MetricKind::Absolute,
@@ -520,6 +538,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "total"}),
                     kind: MetricKind::Absolute,
@@ -527,6 +546,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "writing"}),
                     kind: MetricKind::Absolute,
@@ -534,6 +554,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "closing"}),
                     kind: MetricKind::Absolute,
@@ -541,6 +562,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "dnslookup"}),
                     kind: MetricKind::Absolute,
@@ -548,6 +570,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "finishing"}),
                     kind: MetricKind::Absolute,
@@ -555,6 +578,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "idle_cleanup"}),
                     kind: MetricKind::Absolute,
@@ -562,6 +586,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "keepalive"}),
                     kind: MetricKind::Absolute,
@@ -569,6 +594,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "logging"}),
                     kind: MetricKind::Absolute,
@@ -576,6 +602,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "open"}),
                     kind: MetricKind::Absolute,
@@ -583,6 +610,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "reading"}),
                     kind: MetricKind::Absolute,
@@ -590,6 +618,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "sending"}),
                     kind: MetricKind::Absolute,
@@ -597,6 +626,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "starting"}),
                     kind: MetricKind::Absolute,
@@ -604,6 +634,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "waiting"}),
                     kind: MetricKind::Absolute,
@@ -611,6 +642,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_uptime_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -618,6 +650,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_workers".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "busy"}),
                     kind: MetricKind::Absolute,
@@ -625,6 +658,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_workers".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "idle"}),
                     kind: MetricKind::Absolute,
@@ -698,6 +732,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             vec![
                 Metric {
                     name: "apache_access_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -705,6 +740,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "closing"}),
                     kind: MetricKind::Absolute,
@@ -712,6 +748,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "keepalive"}),
                     kind: MetricKind::Absolute,
@@ -719,6 +756,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "total"}),
                     kind: MetricKind::Absolute,
@@ -726,6 +764,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_connections".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "writing"}),
                     kind: MetricKind::Absolute,
@@ -733,6 +772,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_cpu_load".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -740,6 +780,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_cpu_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"type" => "children_system"}),
                     kind: MetricKind::Absolute,
@@ -747,6 +788,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_cpu_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"type" => "children_user"}),
                     kind: MetricKind::Absolute,
@@ -754,6 +796,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_cpu_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"type" => "system"}),
                     kind: MetricKind::Absolute,
@@ -761,6 +804,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_cpu_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"type" => "user"}),
                     kind: MetricKind::Absolute,
@@ -768,6 +812,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_duration_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -775,6 +820,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "closing"}),
                     kind: MetricKind::Absolute,
@@ -782,6 +828,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "dnslookup"}),
                     kind: MetricKind::Absolute,
@@ -789,6 +836,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "finishing"}),
                     kind: MetricKind::Absolute,
@@ -796,6 +844,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "idle_cleanup"}),
                     kind: MetricKind::Absolute,
@@ -803,6 +852,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "keepalive"}),
                     kind: MetricKind::Absolute,
@@ -810,6 +860,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "logging"}),
                     kind: MetricKind::Absolute,
@@ -817,6 +868,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "open"}),
                     kind: MetricKind::Absolute,
@@ -824,6 +876,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "reading"}),
                     kind: MetricKind::Absolute,
@@ -831,6 +884,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "sending"}),
                     kind: MetricKind::Absolute,
@@ -838,6 +892,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "starting"}),
                     kind: MetricKind::Absolute,
@@ -845,6 +900,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_scoreboard".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "waiting"}),
                     kind: MetricKind::Absolute,
@@ -852,6 +908,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_sent_bytes_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -859,6 +916,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_uptime_seconds_total".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -866,6 +924,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_workers".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "busy"}),
                     kind: MetricKind::Absolute,
@@ -873,6 +932,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 },
                 Metric {
                     name: "apache_workers".into(),
+                    namespace: None,
                     timestamp: Some(now),
                     tags: Some(map! {"state" => "idle"}),
                     kind: MetricKind::Absolute,
@@ -908,6 +968,7 @@ ConnsTotal: 1
             metrics,
             vec![Metric {
                 name: "apache_connections".into(),
+                namespace: None,
                 timestamp: Some(now),
                 tags: Some(map! {"state" => "total"}),
                 kind: MetricKind::Absolute,

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -671,6 +671,7 @@ impl HostMetricsConfig {
     ) -> Metric {
         Metric {
             name: self.namespace.encode(name),
+            namespace: None,
             timestamp: Some(timestamp),
             kind: MetricKind::Absolute,
             value: MetricValue::Counter { value },
@@ -687,6 +688,7 @@ impl HostMetricsConfig {
     ) -> Metric {
         Metric {
             name: self.namespace.encode(name),
+            namespace: None,
             timestamp: Some(timestamp),
             kind: MetricKind::Absolute,
             value: MetricValue::Gauge { value },

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -317,6 +317,7 @@ impl MongoDBMetrics {
     ) -> Metric {
         Metric {
             name: self.encode_namespace(name),
+            namespace: None,
             timestamp: Some(Utc::now()),
             tags: Some(tags),
             kind: MetricKind::Absolute,

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -42,6 +42,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                 for metric in vec {
                     let counter = Metric {
                         name: group.name.clone(),
+                        namespace: None,
                         timestamp: None,
                         tags: has_values_or_none(metric.labels),
                         kind: MetricKind::Absolute,
@@ -57,6 +58,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                 for metric in vec {
                     let gauge = Metric {
                         name: group.name.clone(),
+                        namespace: None,
                         timestamp: None,
                         tags: has_values_or_none(metric.labels),
                         kind: MetricKind::Absolute,
@@ -94,6 +96,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                 for (tags, aggregate) in aggregates {
                     let hist = Metric {
                         name: group.name.clone(),
+                        namespace: None,
                         timestamp: None,
                         tags: has_values_or_none(tags),
                         kind: MetricKind::Absolute,
@@ -132,6 +135,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                 for (tags, aggregate) in aggregates {
                     let summary = Metric {
                         name: group.name.clone(),
+                        namespace: None,
                         timestamp: None,
                         tags: has_values_or_none(tags),
                         kind: MetricKind::Absolute,
@@ -182,6 +186,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "uptime".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -234,6 +239,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "name".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![
@@ -248,6 +254,7 @@ mod test {
                 },
                 Metric {
                     name: "name2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![
@@ -264,6 +271,7 @@ mod test {
                 },
                 Metric {
                     name: "name2".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![("labelname".into(), "val1".into()),]
@@ -293,6 +301,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "http_requests_total".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![
@@ -307,6 +316,7 @@ mod test {
                 },
                 Metric {
                     name: "http_requests_total".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![
@@ -335,6 +345,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "latency".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -353,6 +364,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "metric_without_timestamp_and_labels".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -371,6 +383,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "no_labels".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -389,6 +402,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "msdos_file_access_time_seconds".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -417,6 +431,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "name".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(map! {"tag" => "}"}),
                 kind: MetricKind::Absolute,
@@ -436,6 +451,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "name".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(map! {"tag" => "a,b"}),
                 kind: MetricKind::Absolute,
@@ -455,6 +471,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "name".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(map! {"tag" => "\\n"}),
                 kind: MetricKind::Absolute,
@@ -474,6 +491,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "name".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(map! {"tag" => " * "}),
                 kind: MetricKind::Absolute,
@@ -492,6 +510,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "telemetry_scrape_size_bytes_count".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -535,6 +554,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "something_weird".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![("problem".into(), "division by zero".into())]
@@ -562,6 +582,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "latency".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(
                         vec![("env".into(), "production".into())]
@@ -573,6 +594,7 @@ mod test {
                 },
                 Metric {
                     name: "latency".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(vec![("env".into(), "testing".into())].into_iter().collect()),
                     kind: MetricKind::Absolute,
@@ -598,6 +620,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "uptime".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -605,6 +628,7 @@ mod test {
                 },
                 Metric {
                     name: "temperature".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -612,6 +636,7 @@ mod test {
                 },
                 Metric {
                     name: "launch_count".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -657,6 +682,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "uptime".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -664,6 +690,7 @@ mod test {
                 },
                 Metric {
                     name: "last_downtime".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -671,6 +698,7 @@ mod test {
                 },
                 Metric {
                     name: "temperature".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -678,6 +706,7 @@ mod test {
                 },
                 Metric {
                     name: "temperature_7_days_average".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -706,6 +735,7 @@ mod test {
             parse(exp),
             Ok(vec![Metric {
                 name: "http_request_duration_seconds".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -770,6 +800,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "gitlab_runner_job_duration_seconds".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(vec![("runner".into(), "z".into())].into_iter().collect()),
                     kind: MetricKind::Absolute,
@@ -785,6 +816,7 @@ mod test {
                 },
                 Metric {
                     name: "gitlab_runner_job_duration_seconds".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(vec![("runner".into(), "x".into())].into_iter().collect()),
                     kind: MetricKind::Absolute,
@@ -800,6 +832,7 @@ mod test {
                 },
                 Metric {
                     name: "gitlab_runner_job_duration_seconds".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(vec![("runner".into(), "y".into())].into_iter().collect()),
                     kind: MetricKind::Absolute,
@@ -845,6 +878,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "rpc_duration_seconds".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(vec![("service".into(), "a".into())].into_iter().collect()),
                     kind: MetricKind::Absolute,
@@ -857,6 +891,7 @@ mod test {
                 },
                 Metric {
                     name: "go_gc_duration_seconds".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: None,
                     kind: MetricKind::Absolute,
@@ -904,6 +939,7 @@ mod test {
             Ok(vec![
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "in", "host" => "*"}),
                     kind: MetricKind::Absolute,
@@ -911,6 +947,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "in", "host" => "_"}),
                     kind: MetricKind::Absolute,
@@ -918,6 +955,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "in", "host" => "nginx-vts-status"}),
                     kind: MetricKind::Absolute,
@@ -925,6 +963,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "out", "host" => "*"}),
                     kind: MetricKind::Absolute,
@@ -932,6 +971,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "out", "host" => "_"}),
                     kind: MetricKind::Absolute,
@@ -939,6 +979,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_bytes".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"direction" => "out", "host" => "nginx-vts-status"}),
                     kind: MetricKind::Absolute,
@@ -946,6 +987,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "bypass"}),
                     kind: MetricKind::Absolute,
@@ -953,6 +995,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "expired"}),
                     kind: MetricKind::Absolute,
@@ -960,6 +1003,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "hit"}),
                     kind: MetricKind::Absolute,
@@ -967,6 +1011,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "miss"}),
                     kind: MetricKind::Absolute,
@@ -974,6 +1019,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "revalidated"}),
                     kind: MetricKind::Absolute,
@@ -981,6 +1027,7 @@ mod test {
                 },
                 Metric {
                     name: "nginx_server_cache".into(),
+                    namespace: None,
                     timestamp: None,
                     tags: Some(map! {"host" => "*", "status" => "scarce"}),
                     kind: MetricKind::Absolute,

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -58,6 +58,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             let val: f64 = parts[0].parse()?;
             Metric {
                 name,
+                namespace: None,
                 timestamp: None,
                 tags,
                 kind: MetricKind::Incremental,
@@ -70,6 +71,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             let val: f64 = parts[0].parse()?;
             Metric {
                 name,
+                namespace: None,
                 timestamp: None,
                 tags,
                 kind: MetricKind::Incremental,
@@ -95,6 +97,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
             match parse_direction(parts[0])? {
                 None => Metric {
                     name,
+                    namespace: None,
                     timestamp: None,
                     tags,
                     kind: MetricKind::Absolute,
@@ -102,6 +105,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 },
                 Some(sign) => Metric {
                     name,
+                    namespace: None,
                     timestamp: None,
                     tags,
                     kind: MetricKind::Incremental,
@@ -113,6 +117,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
         }
         "s" => Metric {
             name,
+            namespace: None,
             timestamp: None,
             tags,
             kind: MetricKind::Incremental,
@@ -244,6 +249,7 @@ mod test {
             parse("foo:1|c"),
             Ok(Metric {
                 name: "foo".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -258,6 +264,7 @@ mod test {
             parse("foo:1|c|#tag1,tag2:value"),
             Ok(Metric {
                 name: "foo".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -279,6 +286,7 @@ mod test {
             parse("bar:2|c|@0.1"),
             Ok(Metric {
                 name: "bar".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -293,6 +301,7 @@ mod test {
             parse("bar:2|c|@0"),
             Ok(Metric {
                 name: "bar".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -307,6 +316,7 @@ mod test {
             parse("glork:320|ms|@0.1"),
             Ok(Metric {
                 name: "glork".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -325,6 +335,7 @@ mod test {
             parse("glork:320|h|@0.1|#region:us-west1,production,e:"),
             Ok(Metric {
                 name: "glork".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -351,6 +362,7 @@ mod test {
             parse("glork:320|d|@0.1|#region:us-west1,production,e:"),
             Ok(Metric {
                 name: "glork".into(),
+                namespace: None,
                 timestamp: None,
                 tags: Some(
                     vec![
@@ -377,6 +389,7 @@ mod test {
             parse("gaugor:333|g"),
             Ok(Metric {
                 name: "gaugor".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -391,6 +404,7 @@ mod test {
             parse("gaugor:-4|g"),
             Ok(Metric {
                 name: "gaugor".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -401,6 +415,7 @@ mod test {
             parse("gaugor:+10|g"),
             Ok(Metric {
                 name: "gaugor".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -415,6 +430,7 @@ mod test {
             parse("uniques:765|s"),
             Ok(Metric {
                 name: "uniques".into(),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -142,6 +142,7 @@ mod test {
             Event::from("source"),
             Event::Metric(Metric {
                 name: String::from("also test a metric"),
+                namespace: None,
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Absolute,

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -102,6 +102,7 @@ mod tests {
     fn add_tags() {
         let event = Event::Metric(Metric {
             name: "bar".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -130,6 +131,7 @@ mod tests {
         tags.insert("region".to_string(), "us-east-1".to_string());
         let event = Event::Metric(Metric {
             name: "bar".into(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags),
             kind: MetricKind::Absolute,

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -215,6 +215,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             Ok(Metric {
                 name,
+                namespace: None,
                 timestamp,
                 tags,
                 kind: MetricKind::Incremental,
@@ -231,6 +232,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             Ok(Metric {
                 name,
+                namespace: None,
                 timestamp,
                 tags,
                 kind: MetricKind::Incremental,
@@ -251,6 +253,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             Ok(Metric {
                 name,
+                namespace: None,
                 timestamp,
                 tags,
                 kind: MetricKind::Incremental,
@@ -271,6 +274,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             Ok(Metric {
                 name,
+                namespace: None,
                 timestamp,
                 tags,
                 kind: MetricKind::Absolute,
@@ -292,6 +296,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 
             Ok(Metric {
                 name,
+                namespace: None,
                 timestamp,
                 tags,
                 kind: MetricKind::Incremental,
@@ -382,6 +387,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "status".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -413,6 +419,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "http_requests_total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: Some(
                     vec![
@@ -448,6 +455,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "exception_total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -493,6 +501,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "amount_total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -520,6 +529,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "memory_rss_bytes".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Absolute,
@@ -594,6 +604,7 @@ mod tests {
             output.pop().unwrap().into_metric(),
             Metric {
                 name: "exception_total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -604,6 +615,7 @@ mod tests {
             output.pop().unwrap().into_metric(),
             Metric {
                 name: "status".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -647,6 +659,7 @@ mod tests {
             output.pop().unwrap().into_metric(),
             Metric {
                 name: "xyz_exception_total".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -657,6 +670,7 @@ mod tests {
             output.pop().unwrap().into_metric(),
             Metric {
                 name: "local_abc_status_set".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -686,6 +700,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "unique_user_ip".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -714,6 +729,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "response_time".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -744,6 +760,7 @@ mod tests {
             metric.into_metric(),
             Metric {
                 name: "response_time".into(),
+                namespace: None,
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,

--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -83,6 +83,7 @@ mod test {
     fn to_lua_metric() {
         let event = Event::Metric(Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -133,6 +134,7 @@ mod test {
         }"#;
         let expected = Event::Metric(Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,

--- a/src/transforms/lua/v2/interop/metric.rs
+++ b/src/transforms/lua/v2/interop/metric.rs
@@ -198,6 +198,7 @@ impl<'a> FromLua<'a> for Metric {
 
         Ok(Metric {
             name,
+            namespace: None,
             timestamp,
             tags,
             kind,
@@ -227,6 +228,7 @@ mod test {
     fn to_lua_counter_full() {
         let metric = Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
             tags: Some(
                 vec![("example tag".to_string(), "example value".to_string())]
@@ -259,6 +261,7 @@ mod test {
     fn to_lua_counter_minimal() {
         let metric = Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -277,6 +280,7 @@ mod test {
     fn to_lua_gauge() {
         let metric = Metric {
             name: "example gauge".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -290,6 +294,7 @@ mod test {
     fn to_lua_set() {
         let metric = Metric {
             name: "example set".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -313,6 +318,7 @@ mod test {
     fn to_lua_distribution() {
         let metric = Metric {
             name: "example distribution".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -338,6 +344,7 @@ mod test {
     fn to_lua_aggregated_histogram() {
         let metric = Metric {
             name: "example histogram".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -366,6 +373,7 @@ mod test {
     fn to_lua_aggregated_summary() {
         let metric = Metric {
             name: "example summary".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,
@@ -398,6 +406,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -430,6 +439,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10)),
             tags: Some(
                 vec![("example tag".to_string(), "example value".to_string())]
@@ -454,6 +464,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example gauge".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -474,6 +485,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example set".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -500,6 +512,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example distribution".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -526,6 +539,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example histogram".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -554,6 +568,7 @@ mod test {
         }"#;
         let expected = Metric {
             name: "example summary".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -739,6 +739,7 @@ mod tests {
 
         let event = Event::Metric(Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,
@@ -747,6 +748,7 @@ mod tests {
 
         let expected = Event::Metric(Metric {
             name: "example counter".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Absolute,

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -128,6 +128,7 @@ mod tests {
     fn transform_counter() {
         let counter = Metric {
             name: "counter".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: Some(tags()),
             kind: MetricKind::Absolute,
@@ -154,6 +155,7 @@ mod tests {
     fn transform_gauge() {
         let gauge = Metric {
             name: "gauge".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Absolute,
@@ -178,6 +180,7 @@ mod tests {
     fn transform_set() {
         let set = Metric {
             name: "set".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Absolute,
@@ -205,6 +208,7 @@ mod tests {
     fn transform_distribution() {
         let distro = Metric {
             name: "distro".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Absolute,
@@ -246,6 +250,7 @@ mod tests {
     fn transform_histogram() {
         let histo = Metric {
             name: "histo".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Absolute,
@@ -292,6 +297,7 @@ mod tests {
     fn transform_summary() {
         let summary = Metric {
             name: "summary".into(),
+            namespace: None,
             timestamp: Some(ts()),
             tags: None,
             kind: MetricKind::Absolute,

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -82,6 +82,7 @@ mod tests {
     fn remove_tags() {
         let event = Event::Metric(Metric {
             name: "foo".into(),
+            namespace: None,
             timestamp: None,
             tags: Some(
                 vec![
@@ -110,6 +111,7 @@ mod tests {
     fn remove_all_tags() {
         let event = Event::Metric(Metric {
             name: "foo".into(),
+            namespace: None,
             timestamp: None,
             tags: Some(
                 vec![("env".to_owned(), "production".to_owned())]
@@ -130,6 +132,7 @@ mod tests {
     fn remove_tags_from_none() {
         let event = Event::Metric(Metric {
             name: "foo".into(),
+            namespace: None,
             timestamp: None,
             tags: None,
             kind: MetricKind::Incremental,

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -242,6 +242,7 @@ mod tests {
     fn make_metric(tags: BTreeMap<String, String>) -> Event {
         Event::Metric(Metric {
             name: "event".into(),
+            namespace: None,
             timestamp: None,
             tags: Some(tags),
             kind: metric::MetricKind::Incremental,


### PR DESCRIPTION
First of the PRs for #3896

Adds `namespace` field to `struct Metric` and wires this change through the code base. 

Does not change behavior of componenets.  

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
