### PR TITLE
feat(remap transform): add `replace` and `flatten` remap functions

### DIFF
--- a/src/mapping/query/function/flatten.rs
+++ b/src/mapping/query/function/flatten.rs
@@ -1,0 +1,362 @@
+use super::prelude::*;
+use std::collections::btree_map;
+
+/// An iterator to walk over maps allowing us to flatten nested maps to a single level.
+struct MapFlatten<'a> {
+    values: btree_map::Iter<'a, String, Value>,
+    inner: Option<Box<MapFlatten<'a>>>,
+    parent: Option<String>,
+}
+
+impl<'a> MapFlatten<'a> {
+    fn new(values: btree_map::Iter<'a, String, Value>) -> Self {
+        Self {
+            values,
+            inner: None,
+            parent: None,
+        }
+    }
+
+    fn new_from_parent(parent: String, values: btree_map::Iter<'a, String, Value>) -> Self {
+        Self {
+            values,
+            inner: None,
+            parent: Some(parent),
+        }
+    }
+
+    /// Returns the key with the parent prepended.
+    fn new_key(&self, key: &str) -> String {
+        match self.parent {
+            None => key.to_string(),
+            Some(ref parent) => format!("{}.{}", parent, key),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for MapFlatten<'a> {
+    type Item = (String, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ref mut inner) = self.inner {
+            let next = inner.next();
+            if next.is_some() {
+                return next;
+            } else {
+                self.inner = None;
+            }
+        }
+
+        let next = self.values.next();
+        match next {
+            Some((key, Value::Map(value))) => {
+                self.inner = Some(Box::new(MapFlatten::new_from_parent(
+                    self.new_key(key),
+                    value.iter(),
+                )));
+                self.next()
+            }
+            Some((key, value)) => Some((self.new_key(key), value)),
+            None => None,
+        }
+    }
+}
+
+/// Create an iterator that can walk a tree of Array values.
+/// This can be used to flatten the array.
+struct ValueFlatten<'a> {
+    values: std::slice::Iter<'a, Value>,
+    inner: Option<Box<ValueFlatten<'a>>>,
+}
+
+impl<'a> ValueFlatten<'a> {
+    fn new(values: std::slice::Iter<'a, Value>) -> Self {
+        ValueFlatten {
+            values,
+            inner: None,
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for ValueFlatten<'a> {
+    type Item = &'a Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate over our inner list first.
+        if let Some(ref mut inner) = self.inner {
+            let next = inner.next();
+            if next.is_some() {
+                return next;
+            } else {
+                // The inner list has been exhausted.
+                self.inner = None;
+            }
+        }
+
+        // Then iterate over our values.
+        let next = self.values.next();
+        if let Some(Value::Array(next)) = next {
+            // Create a new iterator for this child list.
+            self.inner = Some(Box::new(ValueFlatten::new(next.iter())));
+            self.next()
+        } else {
+            next
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::mapping) struct FlattenFn {
+    value: Box<dyn Function>,
+}
+
+impl FlattenFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(value: Box<dyn Function>) -> Self {
+        FlattenFn { value }
+    }
+}
+
+impl Function for FlattenFn {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let value = required_value!(ctx, self.value,
+        Value::Array(arr) => Value::Array(
+            ValueFlatten::new(arr.iter()).cloned().collect()
+        ),
+        Value::Map(map) => Value::Map(
+            MapFlatten::new(map.iter()).map(|(k, v)| (k, v.clone())).collect()
+        ));
+
+        Ok(value.into())
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            accepts: |v| {
+                matches!(v, QueryValue::Value(Value::Array(_)) |
+                                      QueryValue::Value(Value::Map(_))
+                )
+            },
+            required: true,
+        }]
+    }
+}
+
+impl TryFrom<ArgumentList> for FlattenFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let value = arguments.required("value")?;
+        Ok(Self { value })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mapping::query::path::Path;
+    use serde_json::json;
+
+    #[test]
+    fn check_flatten() {
+        let cases = vec![
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from(vec![Value::from(42)]));
+                    event
+                },
+                Ok(Value::from(vec![Value::from(42)])),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert(
+                        "foo",
+                        Value::from(vec![
+                            Value::from(42),
+                            Value::from(vec![Value::from(43), Value::from(44)]),
+                        ]),
+                    );
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from(42),
+                    Value::from(43),
+                    Value::from(44),
+                ])),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert(
+                        "foo",
+                        Value::from(vec![Value::from(42), Value::Array(vec![]), Value::from(43)]),
+                    );
+                    event
+                },
+                Ok(Value::from(vec![Value::from(42), Value::from(43)])),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert(
+                        "foo",
+                        Value::from(vec![
+                            Value::from(42),
+                            Value::from(vec![
+                                Value::from(43),
+                                Value::from(44),
+                                Value::from(vec![Value::from(45), Value::from(46)]),
+                            ]),
+                        ]),
+                    );
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from(42),
+                    Value::from(43),
+                    Value::from(44),
+                    Value::from(45),
+                    Value::from(46),
+                ])),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert(
+                        "foo",
+                        Value::from(vec![
+                            Value::from(vec![Value::from(42), Value::from(43)]),
+                            Value::from(vec![Value::from(44), Value::from(45)]),
+                        ]),
+                    );
+                    event
+                },
+                Ok(Value::from(vec![
+                    Value::from(42),
+                    Value::from(43),
+                    Value::from(44),
+                    Value::from(45),
+                ])),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    let map = json!({"parent": "child"});
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!({"parent": "child"}))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    let map = json!({"parent": { "child1": 1,
+                                                 "child2": 2},
+                                     "key": "val"});
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!({"parent.child1": 1,
+                                      "parent.child2": 2,
+                                      "key": "val"}))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    let map = json!({"parent": { "child1": 1,
+                                                 "child2": { "grandchild1": 1,
+                                                             "grandchild2": 2}},
+                                     "key": "val"});
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!({"parent.child1": 1,
+                                      "parent.child2.grandchild1": 1,
+                                      "parent.child2.grandchild2": 2,
+                                      "key": "val"}))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                // If the root object is a map, child arrays are not flattened.
+                {
+                    let mut event = Event::from("");
+                    let map = json!({"parent": { "child1": [1, [2, 3]],
+                                                 "child2": { "grandchild1": 1,
+                                                             "grandchild2": [1, [2, 3], 4]}},
+                                     "key": "val"});
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!({"parent.child1": [1, [2, 3]],
+                                      "parent.child2.grandchild1": 1,
+                                      "parent.child2.grandchild2": [1, [2, 3], 4],
+                                      "key": "val"}))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                // If the root object is an array, child maps are not flattened.
+                {
+                    let mut event = Event::from("");
+                    let map = json!(
+                        [
+                            {"parent1": {"child1": 1,
+                                         "child2": 2}},
+                            [
+                                {"parent2": {"child3": 3,
+                                             "child4": 4}},
+                                {"parent3": {"child5": 5}}
+                            ]
+                        ]
+                    );
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!(
+                    [
+                        {"parent1": {"child1": 1,
+                                     "child2": 2}},
+                        {"parent2": {"child3": 3,
+                                     "child4": 4}},
+                        {"parent3": {"child5": 5}}
+                    ]
+                ))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    let map = json!(
+                        {"parent1": { "child1": { "grandchild1": 1 },
+                                       "child2": { "grandchild2": 2,
+                                                    "grandchild3": 3 }
+                        },
+                         "parent2": 4}
+                    );
+                    event.as_mut_log().insert("foo", Value::from(map));
+                    event
+                },
+                Ok(Value::from(json!({"parent1.child1.grandchild1": 1,
+                                      "parent1.child2.grandchild2": 2,
+                                      "parent1.child2.grandchild3": 3,
+                                      "parent2": 4}))),
+                FlattenFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
+        }
+    }
+}

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -160,6 +160,7 @@ build_signatures! {
     parse_syslog => ParseSyslogFn,
     split => SplitFn,
     replace => ReplaceFn,
+    flatten => FlattenFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -159,6 +159,7 @@ build_signatures! {
     ceil => CeilFn,
     parse_syslog => ParseSyslogFn,
     split => SplitFn,
+    replace => ReplaceFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/replace.rs
+++ b/src/mapping/query/function/replace.rs
@@ -1,0 +1,155 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct ReplaceFn {
+    value: Box<dyn Function>,
+    pattern: Box<dyn Function>,
+    with: Box<dyn Function>,
+}
+
+impl ReplaceFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        value: Box<dyn Function>,
+        pattern: Box<dyn Function>,
+        with: Box<dyn Function>,
+    ) -> Self {
+        ReplaceFn {
+            value,
+            pattern,
+            with,
+        }
+    }
+}
+
+impl Function for ReplaceFn {
+    fn execute(&self, ctx: &Event) -> Result<QueryValue> {
+        let value = required_value!(ctx, self.value, Value::Bytes(v) => String::from_utf8_lossy(&v).into_owned());
+        let with = required_value!(ctx, self.with, Value::Bytes(v) => String::from_utf8_lossy(&v).into_owned());
+
+        match self.pattern.execute(ctx)? {
+            QueryValue::Value(Value::Bytes(path)) => {
+                let pattern = String::from_utf8_lossy(&path).into_owned();
+                let replaced = value.replace(&pattern, &with);
+                Ok(Value::Bytes(replaced.into()).into())
+            }
+            QueryValue::Regex(regex) => {
+                let replaced = if regex.is_global() {
+                    regex.regex().replace_all(&value, with.as_str())
+                } else {
+                    regex.regex().replace(&value, with.as_str())
+                };
+
+                Ok(Value::Bytes(replaced.into_owned().into()).into())
+            }
+            _ => Err("invalid pattern".to_string()),
+        }
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
+                required: true,
+            },
+            Parameter {
+                keyword: "pattern",
+                accepts: |v| {
+                    matches!(v, QueryValue::Value(Value::Bytes(_))
+                             | QueryValue::Regex(_))
+                },
+                required: true,
+            },
+            Parameter {
+                keyword: "with",
+                accepts: |v| matches!(v, QueryValue::Value(Value::Bytes(_))),
+                required: true,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for ReplaceFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let value = arguments.required("value")?;
+        let pattern = arguments.required("pattern")?;
+        let with = arguments.required("with")?;
+
+        Ok(Self {
+            value,
+            pattern,
+            with,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mapping::query::path::Path;
+    use crate::mapping::query::regex::Regex;
+
+    #[test]
+    fn check_replace() {
+        let cases = vec![
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("I like apples and bananas"));
+                    event
+                },
+                Ok(Value::from("I like opples ond bononos")),
+                ReplaceFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(QueryValue::from(
+                        Regex::new("a".to_string(), false, false, true).unwrap(),
+                    ))),
+                    Box::new(Literal::from(Value::from("o"))),
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("I like apples and bananas"));
+                    event
+                },
+                Ok(Value::from("I like opples and bananas")),
+                ReplaceFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(QueryValue::from(
+                        Regex::new("a".to_string(), false, false, false).unwrap(),
+                    ))),
+                    Box::new(Literal::from(Value::from("o"))),
+                ),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event
+                        .as_mut_log()
+                        .insert("foo", Value::from("I like [apples] and bananas"));
+                    event
+                },
+                Ok(Value::from("I like biscuits and bananas")),
+                ReplaceFn::new(
+                    Box::new(Path::from(vec![vec!["foo"]])),
+                    Box::new(Literal::from(QueryValue::from(
+                        Regex::new("\\[apples\\]".to_string(), false, false, true).unwrap(),
+                    ))),
+                    Box::new(Literal::from(Value::from("biscuits"))),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp.map(QueryValue::Value));
+        }
+    }
+}

--- a/src/mapping/query/regex.rs
+++ b/src/mapping/query/regex.rs
@@ -42,7 +42,6 @@ impl Regex {
         &self.compiled
     }
 
-    #[allow(dead_code)]
     pub fn is_global(&self) -> bool {
         self.global
     }

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -866,3 +866,43 @@
     [[tests.outputs.conditions]]
     "foo.equals" = "this should be unchanged"
 
+[transforms.remap_function_replace_regex]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    .bip = replace(.foo, /Eggs/gi, "beans")
+    .bar = replace(.foo, /Eggs/i, "beans")
+    .zop = replace(.foo, /Eggs/, "beans")
+  """
+[[tests]]
+  name = "remap_function_replace_regex"
+  [tests.input]
+    insert_at = "remap_function_replace_regex"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "peas, eggs, chips and more eggs"
+  [[tests.outputs]]
+    extract_from = "remap_function_replace_regex"
+    [[tests.outputs.conditions]]
+    "bip.equals" = "peas, beans, chips and more beans"
+    "bar.equals" = "peas, beans, chips and more eggs"
+    "zop.equals" = "peas, eggs, chips and more eggs"
+
+[transforms.remap_function_replace_string]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    .foo = replace(.foo, "eggs", "beans")
+  """
+[[tests]]
+  name = "remap_function_replace_string"
+  [tests.input]
+    insert_at = "remap_function_replace_string"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "peas, eggs, chips and more eggs"
+  [[tests.outputs]]
+    extract_from = "remap_function_replace_string"
+    [[tests.outputs.conditions]]
+    "foo.equals" = "peas, beans, chips and more beans"
+

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -721,7 +721,7 @@
 [transforms.remap_function_ceil]
   inputs = []
   type = "remap"
-  mapping = """
+  source = """
     .a = ceil(.num)
     .b = ceil(.num, precision = 1)
     .c = ceil(.num, precision = 2)
@@ -743,7 +743,7 @@
 [transforms.remap_function_floor]
   inputs = []
   type = "remap"
-  mapping = """
+  source = """
     .a = floor(.num)
     .b = floor(.num, precision = 1)
     .c = floor(.num, precision = 2)
@@ -765,7 +765,7 @@
 [transforms.remap_function_round]
   inputs = []
   type = "remap"
-  mapping = """
+  source = """
     .a = round(.num)
     .b = round(.num, precision = 1)
     .c = round(.num, precision = 2)
@@ -787,7 +787,7 @@
 [transforms.remap_function_parse_syslog]
   inputs = []
   type = "remap"
-  mapping = """
+  source = """
    .a = parse_syslog(.a)
    """
 [[tests]]
@@ -811,7 +811,7 @@
 [transforms.remap_function_split_regex]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     .foo = split(.foo, /a.b/i, 3)
   """
 [[tests]]
@@ -831,7 +831,7 @@
 [transforms.remap_function_split_string]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     .foo = split(.foo, " ", 3)
   """
 [[tests]]
@@ -851,7 +851,7 @@
 [transforms.remap_function_log]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     log(.foo, level=info)
   """
 [[tests]]
@@ -869,7 +869,7 @@
 [transforms.remap_function_replace_regex]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     .bip = replace(.foo, /Eggs/gi, "beans")
     .bar = replace(.foo, /Eggs/i, "beans")
     .zop = replace(.foo, /Eggs/, "beans")
@@ -891,7 +891,7 @@
 [transforms.remap_function_replace_string]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     .foo = replace(.foo, "eggs", "beans")
   """
 [[tests]]
@@ -909,7 +909,7 @@
 [transforms.remap_function_flatten_array]
   inputs=[]
   type = "remap"
-  mapping = """
+  source = """
     .foo = flatten(parse_json(.foo))
   """
 [[tests]]

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -906,3 +906,28 @@
     [[tests.outputs.conditions]]
     "foo.equals" = "peas, beans, chips and more beans"
 
+[transforms.remap_function_flatten_array]
+  inputs=[]
+  type = "remap"
+  mapping = """
+    .foo = flatten(parse_json(.foo))
+  """
+[[tests]]
+  name = "remap_function_flatten_array"
+  [tests.input]
+    insert_at = "remap_function_flatten_array"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "[1, 2, [3, 4, [5, 6], 7], [8, 9]]"
+  [[tests.outputs]]
+    extract_from = "remap_function_flatten_array"
+    [[tests.outputs.conditions]]
+    "foo[0].equals" = 1
+    "foo[1].equals" = 2
+    "foo[2].equals" = 3
+    "foo[3].equals" = 4
+    "foo[4].equals" = 5
+    "foo[5].equals" = 6
+    "foo[6].equals" = 7
+    "foo[7].equals" = 8
+    "foo[8].equals" = 9


### PR DESCRIPTION
Closes #3750 
Closes #3752 

This adds `replace` and `flatten` remap functions.

Note with the `flatten` function, it flattens both Arrays and Maps, but it does not attempt to flatten a value that is a combination of Arrays and Maps. The rules for flattening are determined according to what the top level value is. So an Array of Maps is flattened as an Array, and an Map of Arrays is flatten as a Map.


Creating this as draft for now, as it may need some additional work to merge it into #4695 