### PR TITLE
fix(blackhole sink): Count total bytes for logs

### DIFF
--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -70,14 +70,11 @@ impl StreamSink for BlackholeSink {
     async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {
             let message_len = match event {
-                Event::Log(log) => log
-                    .get(crate::config::log_schema().message_key())
-                    .map(|v| v.as_bytes().len())
-                    .unwrap_or(0),
-                Event::Metric(metric) => {
-                    serde_json::to_string(&metric).map(|v| v.len()).unwrap_or(0)
-                }
-            };
+                Event::Log(log) => serde_json::to_string(&log),
+                Event::Metric(metric) => serde_json::to_string(&metric),
+            }
+            .map(|v| v.len())
+            .unwrap_or(0);
 
             self.total_events += 1;
             self.total_raw_bytes += message_len;

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -69,12 +69,7 @@ impl BlackholeSink {
 impl StreamSink for BlackholeSink {
     async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {
-            let message_len = match event {
-                Event::Log(log) => serde_json::to_string(&log),
-                Event::Metric(metric) => serde_json::to_string(&metric),
-            }
-            .map(|v| v.len())
-            .unwrap_or(0);
+            let message_len = std::mem::size_of_val(&event);
 
             self.total_events += 1;
             self.total_raw_bytes += message_len;


### PR DESCRIPTION
I opted to encode event as JSON to match `Metric` handling. I could be
convinced that we should use `size_of()` instead here and possibly in
other places that report processed bytes in relation to events.

**EDIT**: This now uses std::mem::size_of_val instead rather than serializing the event.

Fixes #4704

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
