### PR TITLE
enhancement(new_relic_logs sink): Fix API max payload size

### DIFF
--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -13,12 +13,20 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
+// New Relic Logs API accepts payloads up to 1MB (10^6 bytes)
+const MAX_PAYLOAD_SIZE: usize = 1000000 as usize;
+
 #[derive(Debug, Snafu)]
 enum BuildError {
     #[snafu(display(
         "Missing authentication key, must provide either 'license_key' or 'insert_key'"
     ))]
     MissingAuthParam,
+    #[snafu(display(
+        "Too high batch max size. The value must be {} bytes or less",
+        max_size
+    ))]
+    BatchMaxSize { max_size: usize },
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -114,10 +122,14 @@ impl NewRelicLogsConfig {
         };
 
         let batch = self.batch.use_size_as_bytes()?;
+        let max_payload_size = batch.max_bytes.unwrap_or(MAX_PAYLOAD_SIZE);
+        if max_payload_size > MAX_PAYLOAD_SIZE {
+            return Err(Box::new(BuildError::BatchMaxSize {
+                max_size: MAX_PAYLOAD_SIZE,
+            }));
+        }
         let batch = BatchConfig {
-            // The max request size is 10MiB, so in order to be comfortably
-            // within this we batch up to 5MiB.
-            max_bytes: Some(batch.max_bytes.unwrap_or(bytesize::mib(5u64) as usize)),
+            max_bytes: Some(batch.max_bytes.unwrap_or(MAX_PAYLOAD_SIZE)),
             max_events: None,
             ..batch
         };
@@ -191,10 +203,7 @@ mod tests {
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
-        assert_eq!(
-            http_config.batch.max_bytes,
-            Some(bytesize::mib(5u64) as usize)
-        );
+        assert_eq!(http_config.batch.max_bytes, Some(MAX_PAYLOAD_SIZE));
         assert_eq!(
             http_config.request.in_flight_limit,
             InFlightLimit::Fixed(100)
@@ -213,7 +222,7 @@ mod tests {
         let mut nr_config = NewRelicLogsConfig::default();
         nr_config.insert_key = Some("foo".to_owned());
         nr_config.region = Some(NewRelicLogsRegion::Eu);
-        nr_config.batch.max_size = Some(bytesize::mib(8u64) as usize);
+        nr_config.batch.max_size = Some(MAX_PAYLOAD_SIZE);
         nr_config.request.in_flight_limit = InFlightLimit::Fixed(12);
         nr_config.request.rate_limit_num = Some(24);
 
@@ -225,10 +234,7 @@ mod tests {
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
-        assert_eq!(
-            http_config.batch.max_bytes,
-            Some(bytesize::mib(8u64) as usize)
-        );
+        assert_eq!(http_config.batch.max_bytes, Some(MAX_PAYLOAD_SIZE));
         assert_eq!(
             http_config.request.in_flight_limit,
             InFlightLimit::Fixed(12)
@@ -249,7 +255,7 @@ mod tests {
         region = "eu"
 
         [batch]
-        max_size = 8388608
+        max_size = 838860
 
         [request]
         in_flight_limit = 12
@@ -265,10 +271,7 @@ mod tests {
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
-        assert_eq!(
-            http_config.batch.max_bytes,
-            Some(bytesize::mib(8u64) as usize)
-        );
+        assert_eq!(http_config.batch.max_bytes, Some(838860));
         assert_eq!(
             http_config.request.in_flight_limit,
             InFlightLimit::Fixed(12)
@@ -280,6 +283,25 @@ mod tests {
         );
         assert!(http_config.tls.is_none());
         assert!(http_config.auth.is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_relic_logs_check_config_custom_from_toml_batch_max_size_too_high() {
+        let config = r#"
+        insert_key = "foo"
+        region = "eu"
+
+        [batch]
+        max_size = 8388600
+
+        [request]
+        in_flight_limit = 12
+        rate_limit_num = 24
+    "#;
+        let nr_config: NewRelicLogsConfig = toml::from_str(&config).unwrap();
+
+        nr_config.create_config().unwrap();
     }
 
     #[tokio::test]

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -24,9 +24,9 @@ enum BuildError {
     MissingAuthParam,
     #[snafu(display(
         "Too high batch max size. The value must be {} bytes or less",
-        max_size
+        MAX_PAYLOAD_SIZE
     ))]
-    BatchMaxSize { max_size: usize },
+    BatchMaxSize,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -124,9 +124,7 @@ impl NewRelicLogsConfig {
         let batch = self.batch.use_size_as_bytes()?;
         let max_payload_size = batch.max_bytes.unwrap_or(MAX_PAYLOAD_SIZE);
         if max_payload_size > MAX_PAYLOAD_SIZE {
-            return Err(Box::new(BuildError::BatchMaxSize {
-                max_size: MAX_PAYLOAD_SIZE,
-            }));
+            return Err(Box::new(BuildError::BatchMaxSize));
         }
         let batch = BatchConfig {
             max_bytes: Some(batch.max_bytes.unwrap_or(MAX_PAYLOAD_SIZE)),

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 // New Relic Logs API accepts payloads up to 1MB (10^6 bytes)
-const MAX_PAYLOAD_SIZE: usize = 1000000 as usize;
+const MAX_PAYLOAD_SIZE: usize = 1_000_000 as usize;
 
 #[derive(Debug, Snafu)]
 enum BuildError {


### PR DESCRIPTION
New Relic Logs API max payload size is 10^6 bytes.
While I'm not 100% sure this sets the actual JSON payload
size to where it should be, it does seem like an improvement
compared to the old value of 5MiB.

I have opted to allow the user to set a lower batch size, 
should they so prefer.

Comments & Feedback welcome!

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
