### PR TITLE
perf(file source): send batches of lines

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -65,10 +65,10 @@ where
         self,
         mut chans: C,
         mut shutdown: impl Future + Unpin,
-    ) -> Result<Shutdown, <C as Sink<(Bytes, String)>>::Error>
+    ) -> Result<Shutdown, <C as Sink<Vec<(Bytes, String)>>>::Error>
     where
-        C: Sink<(Bytes, String)> + Unpin,
-        <C as Sink<(Bytes, String)>>::Error: std::error::Error,
+        C: Sink<Vec<(Bytes, String)>> + Unpin,
+        <C as Sink<Vec<(Bytes, String)>>>::Error: std::error::Error,
     {
         let mut fingerprint_buffer = Vec::new();
 
@@ -284,7 +284,8 @@ where
             });
 
             let start = time::Instant::now();
-            let mut stream = stream::iter(lines.drain(..).map(Ok));
+            let to_send = std::mem::take(&mut lines);
+            let mut stream = stream::once(futures::future::ok(to_send));
             let result = block_on(chans.send_all(&mut stream));
             match result {
                 Ok(()) => {}

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -135,7 +135,11 @@ impl<K, C> Logic<K, C> {
     }
 }
 
-impl<T, K, C> LineAgg<T, K, C> {
+impl<T, K, C> LineAgg<T, K, C>
+where
+    T: Stream<Item = (K, Bytes, C)> + Unpin,
+    K: Hash + Eq + Clone,
+{
     /// Create a new `LineAgg` using the specified `inner` stream and
     /// preconfigured `logic`.
     pub fn new(inner: T, logic: Logic<K, C>) -> Self {

--- a/src/sources/kubernetes_logs/util.rs
+++ b/src/sources/kubernetes_logs/util.rs
@@ -19,8 +19,8 @@ pub async fn run_file_server<PP, E, C, S>(
 where
     PP: PathsProvider + Send + 'static,
     E: FileSourceInternalEvents,
-    C: Sink<(Bytes, String)> + Unpin + Send + 'static,
-    <C as Sink<(Bytes, String)>>::Error: Error + Send,
+    C: Sink<Vec<(Bytes, String)>> + Unpin + Send + 'static,
+    <C as Sink<Vec<(Bytes, String)>>>::Error: Error + Send,
     S: Future + Unpin + Send + 'static,
 {
     let span = info_span!("file_server");


### PR DESCRIPTION
This modifies the file source to send its whole `Vec` of lines at once instead of one at a time. It also attempts to unravel some of the compat layers that have accumulated in this area of the code.

Locally this shows a ~20% or more improvement to performance.