### PR TITLE
enhancement(logplex source): annotate logs with query parameters

### DIFF
--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -114,9 +114,8 @@ components: sources: http: {
 		query_parameters: {
 			common:      false
 			description: "A list of URL query parameters to include in the log event. These will override any values included in the body with conflicting names."
-			required: false
-			warnings: []
-			type: array {
+			required:    false
+			type: array: {
 				default: null
 				items: type: string: examples: ["application", "source"]
 			}

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -77,7 +77,7 @@ components: sources: http: {
 		}
 		headers: {
 			common:      false
-			description: "A list of HTTP headers to include in the log event. These will override any values included in the JSON payload with conflicting names. An empty string will be inserted into the log event if the corresponding HTTP header was missing."
+			description: "A list of HTTP headers to include in the log event. These will override any values included in the JSON payload with conflicting names."
 			required:    false
 			type: array: {
 				default: null
@@ -109,6 +109,16 @@ components: sources: http: {
 						}
 					}
 				}
+			}
+		}
+		query_parameters: {
+			common:      false
+			description: "A list of URL query parameters to include in the log event. These will override any values included in the body with conflicting names."
+			required: false
+			warnings: []
+			type: array {
+				default: null
+				items: type: string: examples: ["application", "source"]
 			}
 		}
 	}

--- a/docs/reference/components/sources/logplex.cue
+++ b/docs/reference/components/sources/logplex.cue
@@ -70,8 +70,9 @@ components: sources: logplex: {
 	}
 
 	configuration: {
-		address: sources.http.configuration.address
-		auth:    sources.http.configuration.auth
+		address:          sources.http.configuration.address
+		auth:             sources.http.configuration.auth
+		query_parameters: sources.http.configuration.query_parameters
 	}
 
 	output: logs: line: {

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -119,16 +119,13 @@ fn add_headers(
     headers: HeaderMap,
 ) -> Vec<Event> {
     for header_name in headers_config {
-        let value = headers
-            .get(header_name)
-            .map(HeaderValue::as_bytes)
-            .map(<&[u8]>::to_owned)
-            .map(Bytes::from);
+        let value = headers.get(header_name).map(HeaderValue::as_bytes);
 
         for event in events.iter_mut() {
-            event
-                .as_mut_log()
-                .insert(header_name as &str, Value::from(value.to_owned()));
+            event.as_mut_log().insert(
+                header_name as &str,
+                Value::from(value.map(Bytes::copy_from_slice)),
+            );
         }
     }
 

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     event::{Event, Value},
     shutdown::ShutdownSignal,
-    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig},
+    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters},
     tls::TlsConfig,
     Pipeline,
 };
@@ -126,27 +126,6 @@ fn add_headers(
         for event in events.iter_mut() {
             event.as_mut_log().insert(
                 header_name as &str,
-                Value::from(Bytes::from(value.to_owned())),
-            );
-        }
-    }
-
-    events
-}
-
-fn add_query_parameters(
-    mut events: Vec<Event>,
-    query_parameters_config: &[String],
-    query_parameters: HashMap<String, String>,
-) -> Vec<Event> {
-    for query_parameter_name in query_parameters_config {
-        let value = query_parameters
-            .get(query_parameter_name)
-            .map(String::as_bytes)
-            .unwrap_or_default();
-        for event in events.iter_mut() {
-            event.as_mut_log().insert(
-                query_parameter_name as &str,
                 Value::from(Bytes::from(value.to_owned())),
             );
         }

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -507,7 +507,7 @@ mod tests {
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["User-Agent"], "test_client".into());
             assert_eq!(log["Upgrade-Insecure-Requests"], "false".into());
-            assert_eq!(log["AbsentHeader"], Value::Null.into());
+            assert_eq!(log["AbsentHeader"], Value::Null);
             assert!(log.get(log_schema().timestamp_key()).is_some());
             assert_eq!(log[log_schema().source_type_key()], "http".into());
         }
@@ -539,7 +539,7 @@ mod tests {
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["source"], "staging".into());
             assert_eq!(log["region"], "gb".into());
-            assert_eq!(log["absent"], Value::Null.into());
+            assert_eq!(log["absent"], Value::Null);
             assert!(log.get(log_schema().timestamp_key()).is_some());
             assert_eq!(log[log_schema().source_type_key()], "http".into());
         }

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     event::{Event, Value},
     shutdown::ShutdownSignal,
-    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters},
+    sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     tls::TlsConfig,
     Pipeline,
 };
@@ -126,10 +126,9 @@ fn add_headers(
             .map(Bytes::from);
 
         for event in events.iter_mut() {
-            event.as_mut_log().insert(
-                header_name as &str,
-                Value::from(value.to_owned()),
-            );
+            event
+                .as_mut_log()
+                .insert(header_name as &str, Value::from(value.to_owned()));
         }
     }
 

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -122,11 +122,13 @@ fn add_headers(
         let value = headers
             .get(header_name)
             .map(HeaderValue::as_bytes)
-            .unwrap_or_default();
+            .map(<&[u8]>::to_owned)
+            .map(Bytes::from);
+
         for event in events.iter_mut() {
             event.as_mut_log().insert(
                 header_name as &str,
-                Value::from(Bytes::from(value.to_owned())),
+                Value::from(value.to_owned()),
             );
         }
     }
@@ -509,7 +511,7 @@ mod tests {
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["User-Agent"], "test_client".into());
             assert_eq!(log["Upgrade-Insecure-Requests"], "false".into());
-            assert_eq!(log["AbsentHeader"], "".into());
+            assert_eq!(log["AbsentHeader"], Value::Null.into());
             assert!(log.get(log_schema().timestamp_key()).is_some());
             assert_eq!(log[log_schema().source_type_key()], "http".into());
         }
@@ -541,7 +543,7 @@ mod tests {
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["source"], "staging".into());
             assert_eq!(log["region"], "gb".into());
-            assert_eq!(log["absent"], "".into());
+            assert_eq!(log["absent"], Value::Null.into());
             assert!(log.get(log_schema().timestamp_key()).is_some());
             assert_eq!(log[log_schema().source_type_key()], "http".into());
         }

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -2,10 +2,10 @@ use crate::{
     config::{
         log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
     },
-    event::{Event},
+    event::Event,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     shutdown::ShutdownSignal,
-    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters},
+    sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     tls::TlsConfig,
     Pipeline,
 };

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -2,10 +2,10 @@ use crate::{
     config::{
         log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
     },
-    event::{Event, Value},
+    event::{Event},
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     shutdown::ShutdownSignal,
-    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig},
+    sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters},
     tls::TlsConfig,
     Pipeline,
 };
@@ -119,27 +119,6 @@ fn decode_message(body: Bytes, header_map: HeaderMap) -> Result<Vec<Event>, Erro
     }
 
     Ok(events)
-}
-
-fn add_query_parameters(
-    mut events: Vec<Event>,
-    query_parameters_config: &[String],
-    query_parameters: HashMap<String, String>,
-) -> Vec<Event> {
-    for query_parameter_name in query_parameters_config {
-        let value = query_parameters
-            .get(query_parameter_name)
-            .map(String::as_bytes)
-            .unwrap_or_default();
-        for event in events.iter_mut() {
-            event.as_mut_log().insert(
-                query_parameter_name as &str,
-                Value::from(Bytes::from(value.to_owned())),
-            );
-        }
-    }
-
-    events
 }
 
 fn get_header<'a>(header_map: &'a HeaderMap, name: &str) -> Result<&'a str, ErrorMessage> {

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(log[&log_schema().host_key()], "host".into());
         assert_eq!(log[log_schema().source_type_key()], "logplex".into());
         assert_eq!(log["appname"], "lumberjack-store".into());
-        assert_eq!(log["absent"], Value::Null.into());
+        assert_eq!(log["absent"], Value::Null);
     }
 
     #[test]

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -196,7 +196,7 @@ mod tests {
     use crate::shutdown::ShutdownSignal;
     use crate::{
         config::{log_schema, GlobalOptions, SourceConfig},
-        event::Event,
+        event::{Event, Value},
         test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
         Pipeline,
     };
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(log[&log_schema().host_key()], "host".into());
         assert_eq!(log[log_schema().source_type_key()], "logplex".into());
         assert_eq!(log["appname"], "lumberjack-store".into());
-        assert_eq!(log["absent"], "".into());
+        assert_eq!(log["absent"], Value::Null.into());
     }
 
     #[test]

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -11,7 +11,7 @@ use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use futures01::Sink;
 use headers::{Authorization, HeaderMapExt};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, error::Error, fmt, net::SocketAddr};
+use std::{collections::HashMap, convert::TryFrom, error::Error, fmt, net::SocketAddr};
 use warp::{
     filters::BoxedFilter,
     http::{HeaderMap, StatusCode},
@@ -107,7 +107,12 @@ impl HttpSourceAuth {
 
 #[async_trait]
 pub trait HttpSource: Clone + Send + Sync + 'static {
-    fn build_event(&self, body: Bytes, header_map: HeaderMap) -> Result<Vec<Event>, ErrorMessage>;
+    fn build_event(
+        &self,
+        body: Bytes,
+        header_map: HeaderMap,
+        query_params: HashMap<String, String>,
+    ) -> Result<Vec<Event>, ErrorMessage>;
 
     fn run(
         self,
@@ -130,46 +135,52 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
             .and(warp::header::optional::<String>("authorization"))
             .and(warp::header::headers_cloned())
             .and(warp::body::bytes())
-            .and_then(move |auth_header, headers: HeaderMap, body: Bytes| {
-                info!("Handling HTTP request: {:?}", headers);
+            .and(warp::query::<HashMap<String, String>>())
+            .and_then(
+                move |auth_header,
+                      headers: HeaderMap,
+                      body: Bytes,
+                      query_params: HashMap<String, String>| {
+                    info!("Handling HTTP request: {:?}", headers);
 
-                let out = out.clone();
+                    let out = out.clone();
 
-                let body_size = body.len();
-                let events = match auth.is_valid(&auth_header) {
-                    Ok(()) => self.build_event(body, headers),
-                    Err(err) => Err(err),
-                };
+                    let body_size = body.len();
+                    let events = match auth.is_valid(&auth_header) {
+                        Ok(()) => self.build_event(body, headers, query_params),
+                        Err(err) => Err(err),
+                    };
 
-                async move {
-                    match events {
-                        Ok(events) => {
-                            emit!(HTTPEventsReceived {
-                                events_count: events.len(),
-                                byte_size: body_size,
-                            });
-                            out.send_all(futures01::stream::iter_ok(events))
-                                .compat()
-                                .map_err(move |e: futures01::sync::mpsc::SendError<Event>| {
-                                    // can only fail if receiving end disconnected, so we are shutting down,
-                                    // probably not gracefully.
-                                    error!("Failed to forward events, downstream is closed");
-                                    error!("Tried to send the following event: {:?}", e);
-                                    warp::reject::custom(RejectShuttingDown)
-                                })
-                                .map_ok(|_| warp::reply())
-                                .await
-                        }
-                        Err(err) => {
-                            emit!(HTTPBadRequest {
-                                error_code: err.code,
-                                error_message: err.message.as_str(),
-                            });
-                            Err(warp::reject::custom(err))
+                    async move {
+                        match events {
+                            Ok(events) => {
+                                emit!(HTTPEventsReceived {
+                                    events_count: events.len(),
+                                    byte_size: body_size,
+                                });
+                                out.send_all(futures01::stream::iter_ok(events))
+                                    .compat()
+                                    .map_err(move |e: futures01::sync::mpsc::SendError<Event>| {
+                                        // can only fail if receiving end disconnected, so we are shutting down,
+                                        // probably not gracefully.
+                                        error!("Failed to forward events, downstream is closed");
+                                        error!("Tried to send the following event: {:?}", e);
+                                        warp::reject::custom(RejectShuttingDown)
+                                    })
+                                    .map_ok(|_| warp::reply())
+                                    .await
+                            }
+                            Err(err) => {
+                                emit!(HTTPBadRequest {
+                                    error_code: err.code,
+                                    error_message: err.message.as_str(),
+                                });
+                                Err(warp::reject::custom(err))
+                            }
                         }
                     }
-                }
-            });
+                },
+            );
 
         let ping = warp::get().and(warp::path("ping")).map(|| "pong");
         let routes = svc.or(ping).recover(|r: Rejection| async move {

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event::Event,
+    event::{Event, Value},
     internal_events::{HTTPBadRequest, HTTPEventsReceived},
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
@@ -18,6 +18,27 @@ use warp::{
     reject::Rejection,
     Filter,
 };
+
+pub fn add_query_parameters(
+    mut events: Vec<Event>,
+    query_parameters_config: &[String],
+    query_parameters: HashMap<String, String>,
+) -> Vec<Event> {
+    for query_parameter_name in query_parameters_config {
+        let value = query_parameters
+            .get(query_parameter_name)
+            .map(String::as_bytes)
+            .unwrap_or_default();
+        for event in events.iter_mut() {
+            event.as_mut_log().insert(
+                query_parameter_name as &str,
+                Value::from(Bytes::from(value.to_owned())),
+            );
+        }
+    }
+
+    events
+}
 
 #[derive(Serialize, Debug)]
 pub struct ErrorMessage {

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -111,7 +111,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         &self,
         body: Bytes,
         header_map: HeaderMap,
-        query_params: HashMap<String, String>,
+        query_parameters: HashMap<String, String>,
     ) -> Result<Vec<Event>, ErrorMessage>;
 
     fn run(
@@ -140,14 +140,14 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 move |auth_header,
                       headers: HeaderMap,
                       body: Bytes,
-                      query_params: HashMap<String, String>| {
+                      query_parameters: HashMap<String, String>| {
                     info!("Handling HTTP request: {:?}", headers);
 
                     let out = out.clone();
 
                     let body_size = body.len();
                     let events = match auth.is_valid(&auth_header) {
-                        Ok(()) => self.build_event(body, headers, query_params),
+                        Ok(()) => self.build_event(body, headers, query_parameters),
                         Err(err) => Err(err),
                     };
 

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -25,14 +25,11 @@ pub fn add_query_parameters(
     query_parameters: HashMap<String, String>,
 ) -> Vec<Event> {
     for query_parameter_name in query_parameters_config {
-        let value = query_parameters
-            .get(query_parameter_name)
-            .map(String::as_bytes)
-            .unwrap_or_default();
+        let value = query_parameters.get(query_parameter_name);
         for event in events.iter_mut() {
             event.as_mut_log().insert(
                 query_parameter_name as &str,
-                Value::from(Bytes::from(value.to_owned())),
+                Value::from(value.map(String::to_owned)),
             );
         }
     }

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -7,7 +7,7 @@ mod tcp;
 mod unix;
 
 #[cfg(feature = "sources-utils-http")]
-pub use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig};
+pub use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters};
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpSource};

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -7,7 +7,7 @@ mod tcp;
 mod unix;
 
 #[cfg(feature = "sources-utils-http")]
-pub use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig, add_query_parameters};
+pub use self::http::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig};
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpSource};


### PR DESCRIPTION
Allow annotation of logs via query parameters for http + logplex source,
in a similar fashion as is currently supported for HTTP headers.

This is particularly useful with the logplex source as it allows for a
single vector instance to be used as a drain for multiple Heroku
applications.

Closes #4732

Signed-off-by: Christian Gregg <christian@bissy.io>
