### PR TITLE
feat(kubernetes platform): Force daemonset to redeploy when configmap is updated

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
-        {{ end }}
+        {{- end }}
       labels:
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -15,7 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{ end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{ end }}
       labels:
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -13,10 +13,9 @@ spec:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{ end }}
       labels:
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/kubernetes/vector.yaml
+++ b/distribution/kubernetes/vector.yaml
@@ -103,6 +103,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        checksum/config: 3cdf25b37a769fb1b12b40d3efed89539b7cea6f26110ad0b7166b419e9c9254
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector
@@ -133,7 +135,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-
+            
             - name: LOG
               value: info
           resources:


### PR DESCRIPTION
This feature includes a sha256 of the configmap in the daemonset's pod template. This forces Kubernetes to redeploy the agents when the vector toml is updated, ensuring agents are using up to date configuration.

﻿Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->


Closes #4045.