### PR TITLE
enhancement(reload): Resolve port conflict in sinks

### DIFF
--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -31,6 +31,10 @@ pub fn compile(raw: ConfigBuilder) -> Result<Config, Vec<String>> {
         errors.extend(type_errors);
     }
 
+    if let Err(type_errors) = validation::check_resources(&config) {
+        errors.extend(type_errors);
+    }
+
     if errors.is_empty() {
         Ok(config)
     } else {

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -79,4 +79,8 @@ impl Difference {
     pub fn changed_and_added(&self) -> impl Iterator<Item = &String> {
         self.to_change.iter().chain(self.to_add.iter())
     }
+
+    pub fn removed_and_changed(&self) -> impl Iterator<Item = &String> {
+        self.to_change.iter().chain(self.to_remove.iter())
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -190,6 +190,9 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
 
     fn sink_type(&self) -> &'static str;
 
+    /// Resources that the sink is using.
+    /// These resources shouldn't be used in the build method as that can result
+    /// in a build error. Only the sinks are contrained by this.
     fn resources(&self) -> Vec<Resource> {
         Vec::new()
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -278,7 +278,7 @@ impl Resource {
     /// From given components returns all that have a resource conflict with any other componenet.
     pub fn conflicts<K: Eq + Hash + Clone>(
         components: impl IntoIterator<Item = (K, Vec<Resource>)>,
-    ) -> impl IntoIterator<Item = K> {
+    ) -> impl Iterator<Item = K> {
         let mut resource_map = HashMap::<Resource, HashSet<K>>::new();
         for (key, resources) in components {
             for resource in resources {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -298,28 +298,6 @@ impl Resource {
             .flat_map(|(_, componenets)| componenets)
             .collect()
     }
-
-    /// From given components returns all that have a resource conflict with any other component.
-    pub fn conflicts_hashset<K: Eq + Hash + Clone>(
-        components: Vec<(K, HashSet<Resource>)>,
-    ) -> HashSet<K> {
-        let mut conflicted = HashSet::new();
-        for i in 0..componenets.len() {
-            for j in i + 1..components.len() {
-                if componenets[i]
-                    .1
-                    .intersection(&components[j].1)
-                    .next()
-                    .is_some()
-                {
-                    conflicted.insert(components[i].0.clone());
-                    conflicted.insert(components[j].0.clone());
-                }
-            }
-        }
-
-        conflicted
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -192,7 +192,7 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
 
     /// Resources that the sink is using.
     /// These resources shouldn't be used in the build method as that can result
-    /// in a build error. Only the sinks are contrained by this.
+    /// in a build error. Only the sinks are constrained by this.
     fn resources(&self) -> Vec<Resource> {
         Vec::new()
     }
@@ -271,7 +271,7 @@ pub type TransformDescription = ComponentDescription<Box<dyn TransformConfig>>;
 
 inventory::collect!(TransformDescription);
 
-/// Unique things, like port, of which only one owner can be.
+/// Unique thing, like port, of which only one owner can be.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Resource {
     Port(u16),
@@ -297,6 +297,28 @@ impl Resource {
             .filter(|(_, componenets)| componenets.len() > 1)
             .flat_map(|(_, componenets)| componenets)
             .collect()
+    }
+
+    /// From given components returns all that have a resource conflict with any other component.
+    pub fn conflicts_hashset<K: Eq + Hash + Clone>(
+        components: Vec<(K, HashSet<Resource>)>,
+    ) -> HashSet<K> {
+        let mut conflicted = HashSet::new();
+        for i in 0..componenets.len() {
+            for j in i + 1..components.len() {
+                if componenets[i]
+                    .1
+                    .intersection(&components[j].1)
+                    .next()
+                    .is_some()
+                {
+                    conflicted.insert(components[i].0.clone());
+                    conflicted.insert(components[j].0.clone());
+                }
+            }
+        }
+
+        conflicted
     }
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,5 +1,5 @@
 use super::{Config, DataType, Resource};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 pub fn check_shape(config: &Config) -> Result<(), Vec<String>> {
     let mut errors = vec![];
@@ -52,8 +52,7 @@ pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
             .sinks
             .iter()
             .map(|(name, config)| (name, config.inner.resources())),
-    )
-    .collect::<HashSet<_>>();
+    );
     if conflicting_componenets.is_empty() {
         Ok(())
     } else {

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -70,20 +70,25 @@ pub fn default_flush_period_secs() -> u64 {
     60
 }
 
+impl Default for PrometheusSinkConfig {
+    fn default() -> Self {
+        Self {
+            namespace: None,
+            address: default_address(),
+            buckets: default_histogram_buckets(),
+            quantiles: default_summary_quantiles(),
+            flush_period_secs: default_flush_period_secs(),
+        }
+    }
+}
+
 inventory::submit! {
     SinkDescription::new::<PrometheusSinkConfig>("prometheus")
 }
 
 impl GenerateConfig for PrometheusSinkConfig {
     fn generate_config() -> toml::Value {
-        toml::Value::try_from(&Self {
-            namespace: None,
-            address: default_address(),
-            buckets: default_histogram_buckets(),
-            quantiles: default_summary_quantiles(),
-            flush_period_secs: default_flush_period_secs(),
-        })
-        .unwrap()
+        toml::Value::try_from(&Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffers::Acker,
-    config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    config::{DataType, GenerateConfig, Resource, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
     sinks::util::{
         encode_namespace,
@@ -114,6 +114,10 @@ impl SinkConfig for PrometheusSinkConfig {
 
     fn sink_type(&self) -> &'static str {
         "prometheus"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![Resource::Port(self.address.port())]
     }
 }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -431,8 +431,8 @@ impl RunningTopology {
             self.setup_inputs(&name, new_pieces);
         }
 
-        // Since inputs of diff.sinks.to_change need to be replaced to avoid loosing events
-        // that requires for new pieces to be built, so waiting on changed sinks is done here
+        // Since inputs of diff.sinks.to_change need to be replaced to avoid losing events
+        // that requires for new_pieces to be built, so waiting on changed sinks is done here
         // instead of in fn shutdown_diff. A consequence of that is a strict requirement on
         // the sinks with resources to not use their resources in the build method, but only
         // once they have been run. Otherwise build will fail.

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -37,9 +37,9 @@ pub struct CounterConfig {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct GaugeConfig {
-    field: String,
-    name: Option<String>,
-    tags: Option<IndexMap<String, String>>,
+    pub field: String,
+    pub name: Option<String>,
+    pub tags: Option<IndexMap<String, String>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]


### PR DESCRIPTION
Closes #4031 

Adds `Resource` which configs of sinks can report as having. This information is used to:
* Validate that there aren't port conflicts among the sinks in the config.
* Detect conflicting sinks, among a new and an old config, during reload. If found, we wait for them to finish before starting new ones. Crucially, sinks with resources should not use them during build phase, otherwise conflict can still occur. 

### Todo
After merging this, open issues for:
- [x] Extending resources to sources
	- Will enable detection of more resource conflicts in config.
	- Reload will be more robust.
	- Resource conflicts between sinks and sources would be detected. 
- [x] Enhance error reporting of conflicting usages of resources. 
	- Useful after resources have been extended to sources.

  

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
