### PR TITLE
fix(ci): Add missing dependency to nightly docker-release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
           path: "./target/artifacts/vector-aarch64-unknown-linux-musl.tar.gz"
       - uses: actions/upload-artifact@v1
         with:
-          name: "vector-arm64.deb"
+          name: "vector-arm65.deb"
           path: "./target/artifacts/vector-arm64.deb"
       - uses: actions/upload-artifact@v1
         with:
@@ -153,8 +153,9 @@ jobs:
   release-docker:
     runs-on: ubuntu-latest
     needs:
-      - build-x86_64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-musl-packages
+      - build-x86_64-unknown-linux-gnu-packages
+      - build-x86_64-unknown-linux-musl-packages
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
           path: "./target/artifacts/vector-aarch64-unknown-linux-musl.tar.gz"
       - uses: actions/upload-artifact@v1
         with:
-          name: "vector-arm65.deb"
+          name: "vector-arm64.deb"
           path: "./target/artifacts/vector-arm64.deb"
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
The needed artifact, vector-amd64.deb is built by
build-x86_64-unknown-linux-gnu-packages but this was not listed as
a dependency. I think this resulted in the action running too early
sometimes, culminating in it failing to fetch vector-amd64.deb.

Example failure: https://github.com/timberio/vector/runs/1307027438?check_suite_focus=true

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
