### PR TITLE
chore(ci): Add make command for building the GraphQL schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,10 @@ build-x86_64-unknown-linux-musl: target/x86_64-unknown-linux-musl/release/vector
 build-aarch64-unknown-linux-musl: target/aarch64-unknown-linux-musl/release/vector ## Build a release binary for the aarch64-unknown-linux-gnu triple.
 	@echo "Output to ${<}"
 
+.PHONY: build-graphql-schema
+build-graphql-schema: ## Generate the `schema.json` for Vector's GraphQL API
+	${MAYBE_ENVIRONMENT_EXEC} cargo run -- graphql-schema --no-default-features --features=default-no-api-client
+
 ##@ Cross Compiling
 .PHONY: cross-enable
 cross-enable: cargo-install-cross

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ build-aarch64-unknown-linux-musl: target/aarch64-unknown-linux-musl/release/vect
 
 .PHONY: build-graphql-schema
 build-graphql-schema: ## Generate the `schema.json` for Vector's GraphQL API
-	${MAYBE_ENVIRONMENT_EXEC} cargo run -- graphql-schema --no-default-features --features=default-no-api-client
+	${MAYBE_ENVIRONMENT_EXEC} cargo run --bin graphql-schema --no-default-features --features=default-no-api-client
 
 ##@ Cross Compiling
 .PHONY: cross-enable


### PR DESCRIPTION
Building the GraphQL `schema.json` currently involves a fairly complex Cargo command. This PR adds a make command for convenience.