### PR TITLE
fix(ci): Fix unset $PUSH for build-docker.sh

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -35,11 +35,11 @@ build() {
     docker buildx create --use --name vector-builder
     docker buildx install
 
-    docker buildx build \
+    eval docker buildx build \
       --platform="$PLATFORM" \
       --tag "$TAG" \
       target/artifacts \
-      -f "$DOCKERFILE" "${PUSH:+--push}"
+      -f "$DOCKERFILE" "${PUSH:+'--push'}"
   else
     docker build \
       --tag "$TAG" \


### PR DESCRIPTION
Resolves
https://github.com/timberio/vector/commit/26be119ac6c506cd50001b5fdc94adafdecb0f2d#r43596614

I opted to use the eval syntax mentioned in
http://mywiki.wooledge.org/BashFAQ/050#I_only_want_to_pass_options_if_the_runtime_data_needs_them
to still allow for quoting here to satsify shellcheck. This also seems
preferable to the field splitting example there (which isn't relevant in
our case since it is a single argument, but could be in other uses of
`${FOO+'--bar' 'baz'}` expansions).

Thanks for catching that @MOZGIII !