### PR TITLE
chore(ci): Run behavior tests for PRs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -131,7 +131,7 @@ jobs:
         run: cargo test --no-fail-fast --no-default-features --features default-msvc
 
   test-misc:
-    name: Shutdown - Linux
+    name: Miscellaneous - Linux
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,7 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
+      - run: make test-behavior
 
   cross-linux:
     name: Cross - ${{ matrix.target }}
@@ -154,6 +155,7 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
+      - run: make test-behavior
 
   test-windows:
     name: Unit - Windows


### PR DESCRIPTION
They seem to run fairly quickly (2 minutes locally).

This in response to a commit sneaking through to master that broke one
of them:
https://github.com/timberio/vector/runs/1314766689?check_suite_focus=true

Also renames the shutdown test action in the master workflow to match
the fact that it runs miscellaneous tests.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>