### PR TITLE
fix(config): Make host config required in Elasticsearch sink

### DIFF
--- a/.meta/sinks/elasticsearch.toml.erb
+++ b/.meta/sinks/elasticsearch.toml.erb
@@ -165,6 +165,7 @@ A custom header to be added to each outgoing Elasticsearch request.\
 type = "string"
 common = true
 examples = ["http://10.24.32.122:9000"]
+required = true
 description = """\
 The host of your Elasticsearch cluster. This should be the full URL as shown \
 in the example.\


### PR DESCRIPTION
Fixes #4648 by updating the TOML/ERB sources. In a separate PR I'll update the Cue sources that will be used for the future site.