### PR TITLE
fix(config): Add endpoint config to Elasticsearch sink

### DIFF
--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -146,6 +146,14 @@ components: sinks: elasticsearch: {
 				default: "_doc"
 			}
 		}
+		endpoint: {
+			description: "The Elasticsearch endpoint to send logs to. This should be the full URL as shown in the example."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["http://10.24.32.122:9000", "https://example.com"]
+			}
+		}
 		headers: {
 			common:      false
 			description: "Options for custom headers."


### PR DESCRIPTION
Addresses #4648. This PR is a complement to #4777, which updates the current vector.dev site by updating the old TOML/ERB sources and targeting the `v0.10` branch. This PR "updates" the future Cue-driven site.