### PR TITLE
chore(journald source): remove extra shutdown

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -182,7 +182,6 @@ impl JournaldConfig {
             include_units,
             exclude_units,
             channel: out,
-            shutdown: shutdown.clone(),
             checkpointer,
             batch_size,
             remap_priority,
@@ -324,7 +323,6 @@ struct JournaldServer<J, T> {
     include_units: HashSet<String>,
     exclude_units: HashSet<String>,
     channel: T,
-    shutdown: ShutdownSignal,
     checkpointer: Checkpointer,
     batch_size: usize,
     remap_priority: bool,
@@ -344,10 +342,7 @@ where
 
             for _ in 0..self.batch_size {
                 let text = match self.journal.next().await {
-                    None => {
-                        let _ = self.shutdown.await;
-                        return;
-                    }
+                    None => return,
                     Some(Ok(text)) => text,
                     Some(Err(err)) => {
                         error!(


### PR DESCRIPTION
Resolve comment https://github.com/timberio/vector/pull/4243/#discussion_r511314467
@juchiast I only have a question is it correct to stop source and return from function? Or we should block a function forever? (with something like `futures::future::pending().await`)