### PR TITLE
fix(config): Make query_parameters optional

### DIFF
--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -25,6 +25,7 @@ pub struct SimpleHttpConfig {
     encoding: Encoding,
     #[serde(default)]
     headers: Vec<String>,
+    #[serde(default)]
     query_parameters: Vec<String>,
     tls: Option<TlsConfig>,
     auth: Option<HttpSourceAuthConfig>,

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -24,6 +24,7 @@ use warp::http::{HeaderMap, StatusCode};
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct LogplexConfig {
     address: SocketAddr,
+    #[serde(default)]
     query_parameters: Vec<String>,
     tls: Option<TlsConfig>,
     auth: Option<HttpSourceAuthConfig>,


### PR DESCRIPTION
For logplex and http sources.

Follow up to #4733 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>