### PR TITLE
chore(ci): Run test-shutdown and test-cli on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,25 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
+
+  test-misc:
+    name: Miscellaneous - Linux
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: make ci-sweep
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: make slim-builds
+      - run: make test-shutdown
+      - run: make test-cli
       - run: make test-behavior
 
   cross-linux:


### PR DESCRIPTION
These seem to run quickly:

* ~50s for test-shutdown, most of which is the 30s sleep for kafka in
  the Makefile
* ~2s for test-cli

Given this, I think it is worth running them on PRs.

I just copied the miscellaneous test action from the master workflow
(moving test-behavior down).

Again, I think it'd be nice to have an action that ran the build setup
and cached the result to split up these tests into separate actions, but
this'll do for now. For one, the current behavior will have it fail as
soon as it hits an error where it'd be nice to run them all regardless.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
