### PR TITLE
chore(ci): don't expand build failure link previews

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -407,4 +407,4 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       uses: Ilshidur/action-discord@0.3.0
       with:
-        args: "Master failed and is red: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+        args: "Master failed and is red: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"


### PR DESCRIPTION
To prevent links posted through the hook from expanding, since they never contain any useful information:

<img width="519" alt="image" src="https://user-images.githubusercontent.com/383250/97441900-832c3c80-1929-11eb-9473-f42d1a8711da.png">
