### PR TITLE
chore(logs): Prefer Display over Debug for errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,8 +434,9 @@ make fmt
 
 - Always use the [Tracing crate](https://tracing.rs/tracing/)'s key/value style for log events.
 - Events should be capitalized and end with a period, `.`.
-- Never use `e` or `err` - always spell out `error` to enrich logs and make it clear what the output is.
-- Prefer Display over Debug, `?error` and not `%error`.
+- Never use `e` or `err` - always spell out `error` to enrich logs and make it
+  clear what the output is.
+- Prefer Display over Debug, `%error` and not `?error`.
 
 Nope!
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -134,7 +134,7 @@ impl Application {
                 if watch_config {
                     // Start listening for config changes immediately.
                     config::watcher::spawn_thread(&config_paths, None).map_err(|error| {
-                        error!(message = "Unable to start config watcher.", error = ?error);
+                        error!(message = "Unable to start config watcher.", %error);
                         exitcode::CONFIG
                     })?;
                 }

--- a/src/buffers/disk/leveldb_buffer.rs
+++ b/src/buffers/disk/leveldb_buffer.rs
@@ -198,7 +198,7 @@ impl Stream for Reader {
                     Ok(Async::Ready(Some(event)))
                 }
                 Err(error) => {
-                    error!(message = "Error deserializing proto.", error = ?error);
+                    error!(message = "Error deserializing proto.", %error);
                     debug_assert!(false);
                     self.poll()
                 }

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -62,7 +62,7 @@ impl BufferInputCloner {
             BufferInputCloner::Memory(tx, when_full) => {
                 let inner = tx
                     .clone()
-                    .sink_map_err(|error| error!(message = "Sender error.", error = ?error));
+                    .sink_map_err(|error| error!(message = "Sender error.", %error));
                 if when_full == &WhenFull::DropNewest {
                     Box::new(DropWhenFull { inner })
                 } else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,7 +169,7 @@ impl std::str::FromStr for LogFormat {
 
 pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {
     for error in errors {
-        error!(message = "Configuration error.", error = ?error);
+        error!(message = "Configuration error.", %error);
     }
 
     exitcode::CONFIG

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -123,7 +123,7 @@ fn open_config(path: &Path) -> Option<File> {
                 error!(message = "Config file not found in path.", path = ?path);
                 None
             } else {
-                error!(message = "Error opening config file.", error = ?error);
+                error!(message = "Error opening config file.", %error);
                 None
             }
         }

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -51,7 +51,7 @@ pub fn spawn_thread(
                     // We need to read paths to resolve any inode changes that may have happened.
                     // And we need to do it before raising sighup to avoid missing any change.
                     if let Err(error) = add_paths(&mut watcher, &config_paths) {
-                        error!(message = "Failed to read files to watch.", error = ?error);
+                        error!(message = "Failed to read files to watch.", %error);
                         break;
                     }
 
@@ -66,7 +66,7 @@ pub fn spawn_thread(
         thread::sleep(RETRY_TIMEOUT);
 
         watcher = create_watcher(&config_paths)
-            .map_err(|error| error!(message = "Failed to create file watcher.", error = ?error))
+            .map_err(|error| error!(message = "Failed to create file watcher.", %error))
             .ok();
 
         if watcher.is_some() {
@@ -94,7 +94,7 @@ pub fn spawn_thread(
 fn raise_sighup() {
     use nix::sys::signal;
     let _ = signal::raise(signal::Signal::SIGHUP).map_err(|error| {
-        error!(message = "Unable to reload configuration file. Restart Vector to reload it.", cause = ?error)
+        error!(message = "Unable to reload configuration file. Restart Vector to reload it.", cause = %error)
     });
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -151,7 +151,7 @@ impl Auth {
             Auth::Bearer { token } => match Authorization::bearer(&token) {
                 Ok(auth) => req.headers_mut().typed_insert(auth),
                 Err(error) => {
-                    error!(message = "Invalid bearer token.", token = %token, error = ?error)
+                    error!(message = "Invalid bearer token.", token = %token, %error)
                 }
             },
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -150,9 +150,7 @@ impl Auth {
             }
             Auth::Bearer { token } => match Authorization::bearer(&token) {
                 Ok(auth) => req.headers_mut().typed_insert(auth),
-                Err(error) => {
-                    error!(message = "Invalid bearer token.", token = %token, %error)
-                }
+                Err(error) => error!(message = "Invalid bearer token.", token = %token, %error),
             },
         }
     }

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -65,7 +65,7 @@ impl InternalEvent for LogToMetricTemplateRenderError {
         let error = format!("Keys {:?} do not exist on the event.", self.missing_keys);
         warn!(
             message = "Failed to render template.",
-            error = ?error,
+            %error,
             rate_limit_secs = 30
         );
     }

--- a/src/kubernetes/multi_response_decoder.rs
+++ b/src/kubernetes/multi_response_decoder.rs
@@ -37,7 +37,7 @@ where
                 }
                 Err(ResponseError::NeedMoreData) => break,
                 Err(error) => {
-                    error!(message = "Error while decoding response.", pending_data = ?self.pending_data, ?error);
+                    error!(message = "Error while decoding response.", pending_data = ?self.pending_data, %error);
                     self.responses_buffer.push(Err(error));
                     break;
                 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -177,7 +177,7 @@ fn control_service(service: &ServiceInfo, action: ControlAction) -> exitcode::Ex
     match res {
         Ok(()) => exitcode::OK,
         Err(error) => {
-            error!(message = "Error controlling service.", error = ?error);
+            error!(message = "Error controlling service.", %error);
             exitcode::SOFTWARE
         }
     }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -200,7 +200,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             let buffer = PartitionBuffer::new(VecBuffer::new(batch.size));
             let svc_sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
                 .sink_map_err(
-                    |error| error!(message = "Fatal cloudwatchlogs sink error.", error = ?error),
+                    |error| error!(message = "Fatal cloudwatchlogs sink error.", %error),
                 )
                 .with_flat_map(move |event| {
                     iter_ok(partition_encode(event, &encoding, &log_group, &log_stream))
@@ -474,7 +474,7 @@ fn partition_encode(
 
     encoding.apply_rules(&mut event);
     let event = encode_log(event.into_log(), encoding)
-        .map_err(|error| error!(message = "Could not encode event.", error = ?error, rate_limit_secs = 5))
+        .map_err(|error| error!(message = "Could not encode event.", %error, rate_limit_secs = 5))
         .ok()?;
 
     Some(PartitionInnerBuffer::new(event, key))
@@ -548,12 +548,12 @@ impl RetryLogic for CloudwatchRetryLogic {
         match error {
             CloudwatchError::Put(err) => match err {
                 RusotoError::Service(PutLogEventsError::ServiceUnavailable(error)) => {
-                    error!(message = "Put logs service unavailable.", error = ?error);
+                    error!(message = "Put logs service unavailable.", %error);
                     true
                 }
 
                 RusotoError::HttpDispatch(error) => {
-                    error!(message = "Put logs HTTP dispatch.", error = ?error);
+                    error!(message = "Put logs HTTP dispatch.", %error);
                     true
                 }
 
@@ -582,7 +582,7 @@ impl RetryLogic for CloudwatchRetryLogic {
 
             CloudwatchError::Describe(err) => match err {
                 RusotoError::Service(DescribeLogStreamsError::ServiceUnavailable(error)) => {
-                    error!(message = "Describe streams service unavailable.", error = ?error);
+                    error!(message = "Describe streams service unavailable.", %error);
                     true
                 }
 
@@ -599,7 +599,7 @@ impl RetryLogic for CloudwatchRetryLogic {
                 }
 
                 RusotoError::HttpDispatch(error) => {
-                    error!(message = "Describe streams HTTP dispatch.", error = ?error);
+                    error!(message = "Describe streams HTTP dispatch.", %error);
                     true
                 }
 
@@ -608,7 +608,7 @@ impl RetryLogic for CloudwatchRetryLogic {
 
             CloudwatchError::CreateStream(err) => match err {
                 RusotoError::Service(CreateLogStreamError::ServiceUnavailable(error)) => {
-                    error!(message = "Create stream service unavailable.", error = ?error);
+                    error!(message = "Create stream service unavailable.", %error);
                     true
                 }
 
@@ -625,7 +625,7 @@ impl RetryLogic for CloudwatchRetryLogic {
                 }
 
                 RusotoError::HttpDispatch(error) => {
-                    error!(message = "Create stream HTTP dispatch.", error = ?error);
+                    error!(message = "Create stream HTTP dispatch.", %error);
                     true
                 }
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -199,9 +199,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
         let sink = {
             let buffer = PartitionBuffer::new(VecBuffer::new(batch.size));
             let svc_sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
-                .sink_map_err(
-                    |error| error!(message = "Fatal cloudwatchlogs sink error.", %error),
-                )
+                .sink_map_err(|error| error!(message = "Fatal cloudwatchlogs sink error.", %error))
                 .with_flat_map(move |event| {
                     iter_ok(partition_encode(event, &encoding, &log_group, &log_stream))
                 });

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -140,7 +140,7 @@ impl CloudWatchMetricsSvc {
                 cx.acker(),
             )
             .sink_map_err(
-                |error| error!(message = "CloudwatchMetrics sink error.", error = ?error),
+                |error| error!(message = "CloudwatchMetrics sink error.", %error),
             );
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -139,9 +139,7 @@ impl CloudWatchMetricsSvc {
                 batch.timeout,
                 cx.acker(),
             )
-            .sink_map_err(
-                |error| error!(message = "CloudwatchMetrics sink error.", %error),
-            );
+            .sink_map_err(|error| error!(message = "CloudwatchMetrics sink error.", %error));
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -165,7 +165,7 @@ impl KinesisFirehoseService {
                 cx.acker(),
             )
             .sink_map_err(
-                |error| error!(message = "Fatal kinesis firehose sink error.", error = ?error),
+                |error| error!(message = "Fatal kinesis firehose sink error.", %error),
             )
             .with_flat_map(move |e| iter_ok(encode_event(e, &encoding)));
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -164,9 +164,7 @@ impl KinesisFirehoseService {
                 batch.timeout,
                 cx.acker(),
             )
-            .sink_map_err(
-                |error| error!(message = "Fatal kinesis firehose sink error.", %error),
-            )
+            .sink_map_err(|error| error!(message = "Fatal kinesis firehose sink error.", %error))
             .with_flat_map(move |e| iter_ok(encode_event(e, &encoding)));
 
         Ok(sink)

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -169,7 +169,7 @@ impl KinesisService {
                 cx.acker(),
             )
             .sink_map_err(
-                |error| error!(message = "Fatal kinesis streams sink error.", error = ?error),
+                |error| error!(message = "Fatal kinesis streams sink error.", %error),
             )
             .with_flat_map(move |e| iter_ok(encode_event(e, &partition_key_field, &encoding)));
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -168,9 +168,7 @@ impl KinesisService {
                 batch.timeout,
                 cx.acker(),
             )
-            .sink_map_err(
-                |error| error!(message = "Fatal kinesis streams sink error.", %error),
-            )
+            .sink_map_err(|error| error!(message = "Fatal kinesis streams sink error.", %error))
             .with_flat_map(move |e| iter_ok(encode_event(e, &partition_key_field, &encoding)));
 
         Ok(sink)

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -216,7 +216,7 @@ impl S3SinkConfig {
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .with_flat_map(move |e| iter_ok(encode_event(e, &key_prefix, &encoding)))
-            .sink_map_err(|error| error!(message = "Sink failed to flush.", error = ?error));
+            .sink_map_err(|error| error!(message = "Sink failed to flush.", %error));
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -126,9 +126,7 @@ impl SinkConfig for AzureMonitorLogsConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(
-            |error| error!(message = "Fatal azure_monitor_logs sink error.", %error),
-        );
+        .sink_map_err(|error| error!(message = "Fatal azure_monitor_logs sink error.", %error));
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -127,7 +127,7 @@ impl SinkConfig for AzureMonitorLogsConfig {
             cx.acker(),
         )
         .sink_map_err(
-            |error| error!(message = "Fatal azure_monitor_logs sink error.", error = ?error),
+            |error| error!(message = "Fatal azure_monitor_logs sink error.", %error),
         );
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -85,7 +85,7 @@ impl SinkConfig for ClickhouseConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal clickhouse sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal clickhouse sink error.", %error));
 
         let healthcheck = healthcheck(client, self.clone()).boxed();
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -97,7 +97,7 @@ fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Option
         Event::Log(log) => match encoding.codec() {
             Encoding::Json => serde_json::to_string(&log)
                 .map_err(|error| {
-                    error!(message = "Error encoding json.", error = ?error);
+                    error!(message = "Error encoding json.", %error);
                 })
                 .ok(),
             Encoding::Text => {
@@ -116,7 +116,7 @@ fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Option
         Event::Metric(metric) => match encoding.codec() {
             Encoding::Json => serde_json::to_string(&metric)
                 .map_err(|error| {
-                    error!(message = "Error encoding json.", error = ?error);
+                    error!(message = "Error encoding json.", %error);
                 })
                 .ok(),
             Encoding::Text => Some(format!("{}", metric)),
@@ -140,7 +140,7 @@ impl StreamSink for WriterSink {
                 if let Err(error) = self.output.write_all(buf.as_bytes()).await {
                     // Error when writing to stdout/stderr is likely irrecoverable,
                     // so stop the sink.
-                    error!(message = "Error writing to output. Stopping sink.", error = ?error);
+                    error!(message = "Error writing to output. Stopping sink.", %error);
                     return Err(());
                 }
 

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -121,7 +121,7 @@ impl DatadogLogsConfig {
             cx.acker(),
         )
         .sink_map_err(
-            |error| error!(message = "Fatal datadog_logs text sink error.", error = ?error),
+            |error| error!(message = "Fatal datadog_logs text sink error.", %error),
         );
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -120,9 +120,7 @@ impl DatadogLogsConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(
-            |error| error!(message = "Fatal datadog_logs text sink error.", %error),
-        );
+        .sink_map_err(|error| error!(message = "Fatal datadog_logs text sink error.", %error));
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -190,9 +190,7 @@ impl SinkConfig for DatadogConfig {
         let buffer = PartitionBuffer::new(MetricBuffer::new(batch.size));
 
         let svc_sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
-            .sink_map_err(
-                |error| error!(message = "Fatal datadog metric sink error.", %error),
-            )
+            .sink_map_err(|error| error!(message = "Fatal datadog metric sink error.", %error))
             .with_flat_map(move |event: Event| {
                 let ep = DatadogEndpoint::from_metric(&event);
                 iter_ok(Some(PartitionInnerBuffer::new(event, ep)))

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -191,7 +191,7 @@ impl SinkConfig for DatadogConfig {
 
         let svc_sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .sink_map_err(
-                |error| error!(message = "Fatal datadog metric sink error.", error = ?error),
+                |error| error!(message = "Fatal datadog metric sink error.", %error),
             )
             .with_flat_map(move |event: Event| {
                 let ep = DatadogEndpoint::from_metric(&event);

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -130,7 +130,7 @@ impl SinkConfig for ElasticSearchConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal elasticsearch sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal elasticsearch sink error.", %error));
 
         Ok((
             super::VectorSink::Futures01Sink(Box::new(sink)),

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -214,7 +214,7 @@ impl FileSink {
                             debug!(message = "Closing all the open files.");
                             for (path, file) in self.files.iter_mut() {
                                 if let Err(error) = file.close().await {
-                                    error!(message = "Failed to close file.", path = ?path, error = ?error);
+                                    error!(message = "Failed to close file.", path = ?path, %error);
                                 } else{
                                     trace!(message = "Successfully closed file.", path = ?path);
                                 }
@@ -233,13 +233,13 @@ impl FileSink {
                             // We got an expired file. All we really want is to
                             // flush and close it.
                             if let Err(error) = expired_file.close().await {
-                                error!(message = "Failed to close file.", path = ?path, error = ?error);
+                                error!(message = "Failed to close file.", path = ?path, %error);
                             }
                             drop(expired_file); // ignore close error
                         }
                         Some(Err(error)) => error!(
                             message = "An error occurred while expiring a file.",
-                            error = ?error,
+                            %error,
                         ),
                     }
                 }
@@ -274,7 +274,7 @@ impl FileSink {
                     // We couldn't open the file for this event.
                     // Maybe other events will work though! Just log
                     // the error and skip this event.
-                    error!(message = "Unable to open the file.", path = ?path, error = ?error);
+                    error!(message = "Unable to open the file.", path = ?path, %error);
                     return;
                 }
             };
@@ -287,7 +287,7 @@ impl FileSink {
 
         trace!(message = "Writing an event to file.", path = ?path);
         if let Err(error) = write_event_to_file(file, event, &self.encoding).await {
-            error!(message = "Failed to write file.", path = ?path, error = ?error);
+            error!(message = "Failed to write file.", path = ?path, %error);
         }
     }
 }

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -231,9 +231,7 @@ impl GcsSink {
         let buffer = PartitionBuffer::new(Buffer::new(batch.size, config.compression));
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
-            .sink_map_err(
-                |error| error!(message = "Fatal gcp_cloud_storage error.", %error),
-            )
+            .sink_map_err(|error| error!(message = "Fatal gcp_cloud_storage error.", %error))
             .with_flat_map(move |e| iter_ok(encode_event(e, &key_prefix, &encoding)));
 
         Ok(VectorSink::Futures01Sink(Box::new(sink)))

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -232,7 +232,7 @@ impl GcsSink {
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .sink_map_err(
-                |error| error!(message = "Fatal gcp_cloud_storage error.", error = ?error),
+                |error| error!(message = "Fatal gcp_cloud_storage error.", %error),
             )
             .with_flat_map(move |e| iter_ok(encode_event(e, &key_prefix, &encoding)));
 

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -144,7 +144,7 @@ impl GcpCredentials {
                 if let Err(error) = this.regenerate_token().await {
                     error!(
                         message = "Failed to update GCP authentication token.",
-                        ?error
+                        %error
                     );
                 }
             }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -94,7 +94,7 @@ impl SinkConfig for PubsubConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal gcp_pubsub sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal gcp_pubsub sink error.", %error));
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -140,7 +140,7 @@ impl SinkConfig for StackdriverConfig {
             cx.acker(),
         )
         .sink_map_err(
-            |error| error!(message = "Fatal gcp_stackdriver_logs sink error.", error = ?error),
+            |error| error!(message = "Fatal gcp_stackdriver_logs sink error.", %error),
         );
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -139,9 +139,7 @@ impl SinkConfig for StackdriverConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(
-            |error| error!(message = "Fatal gcp_stackdriver_logs sink error.", %error),
-        );
+        .sink_map_err(|error| error!(message = "Fatal gcp_stackdriver_logs sink error.", %error));
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -69,7 +69,7 @@ impl SinkConfig for HoneycombConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal honeycomb sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal honeycomb sink error.", %error));
 
         let healthcheck = healthcheck(self.clone(), client).boxed();
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -139,7 +139,7 @@ impl SinkConfig for HttpSinkConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal HTTP sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal HTTP sink error.", %error));
 
         let sink = super::VectorSink::Futures01Sink(Box::new(sink));
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -137,7 +137,7 @@ impl SinkConfig for InfluxDBLogsConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal influxdb_logs sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal influxdb_logs sink error.", %error));
 
         Ok((VectorSink::Futures01Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -140,7 +140,7 @@ impl InfluxDBSvc {
                 batch.timeout,
                 cx.acker(),
             )
-            .sink_map_err(|error| error!(message = "Fatal influxdb sink error.", error = ?error));
+            .sink_map_err(|error| error!(message = "Fatal influxdb sink error.", %error));
 
         Ok(VectorSink::Futures01Sink(Box::new(sink)))
     }

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -177,13 +177,13 @@ impl Sink for KafkaSink {
             Err((error, record)) => {
                 // Docs suggest this will only happen when the producer queue is full, so let's
                 // treat it as we do full buffers in other sinks
-                debug!(message = "The rdkafka queue full.", error = ?error);
+                debug!(message = "The rdkafka queue full.", %error);
                 self.poll_complete()?;
 
                 match self.producer.send_result(record) {
                     Ok(f) => f,
                     Err((error, _record)) => {
-                        debug!(message = "The rdkafka queue still full.", error = ?error);
+                        debug!(message = "The rdkafka queue still full.", %error);
                         return Ok(AsyncSink::NotReady(item));
                     }
                 }
@@ -213,7 +213,7 @@ impl Sink for KafkaSink {
                         Ok((partition, offset)) => trace!(
                             message = "Produced message.", parition = ?partition, offset = ?offset
                         ),
-                        Err((error, _msg)) => error!(message = "Kafka error.", error = ?error),
+                        Err((error, _msg)) => error!(message = "Kafka error.", %error),
                     };
 
                     self.pending_acks.insert(seqno);
@@ -227,7 +227,7 @@ impl Sink for KafkaSink {
                 }
 
                 // request got canceled (according to docs)
-                Err(error) => error!(message = "Delivery future canceled.", error = ?error),
+                Err(error) => error!(message = "Delivery future canceled.", %error),
             }
         }
     }

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -93,7 +93,7 @@ impl SinkConfig for LogdnaConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal logdna sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal logdna sink error.", %error));
 
         let healthcheck = healthcheck(self.clone(), client).boxed();
 

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -108,7 +108,7 @@ impl SinkConfig for LokiConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal loki sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal loki sink error.", %error));
 
         let healthcheck = healthcheck(self.clone(), client).boxed();
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -189,7 +189,7 @@ impl Sink for PulsarSink {
                     }
                     self.acker.ack(num_to_ack);
                 }
-                Err(error) => error!(message = "Pulsar sink generated an error.", error = ?error),
+                Err(error) => error!(message = "Pulsar sink generated an error.", %error),
             }
         }
     }

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -151,9 +151,7 @@ impl SematextMetricsService {
                 batch.timeout,
                 cx.acker(),
             )
-            .sink_map_err(
-                |error| error!(message = "Fatal sematext metrics sink error.", %error),
-            );
+            .sink_map_err(|error| error!(message = "Fatal sematext metrics sink error.", %error));
 
         Ok(VectorSink::Futures01Sink(Box::new(sink)))
     }

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -152,7 +152,7 @@ impl SematextMetricsService {
                 cx.acker(),
             )
             .sink_map_err(
-                |error| error!(message = "Fatal sematext metrics sink error.", error = ?error),
+                |error| error!(message = "Fatal sematext metrics sink error.", %error),
             );
 
         Ok(VectorSink::Futures01Sink(Box::new(sink)))

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -110,7 +110,7 @@ impl SinkConfig for HecSinkConfig {
             client.clone(),
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal splunk_hec sink error.", error = ?error));
+        .sink_map_err(|error| error!(message = "Fatal splunk_hec sink error.", %error));
 
         let healthcheck = healthcheck(self.clone(), client).boxed();
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -109,7 +109,7 @@ impl SinkConfig for StatsdSinkConfig {
                     batch.timeout,
                     cx.acker(),
                 )
-                .sink_map_err(|error| error!(message = "Fatal statsd sink error.", error = ?error))
+                .sink_map_err(|error| error!(message = "Fatal statsd sink error.", %error))
                 .with_flat_map(move |event| {
                     stream::iter_ok(encode_event(event, namespace.as_deref()))
                 });
@@ -437,11 +437,11 @@ mod test {
         let socket = UdpSocket::bind(addr).await.unwrap();
         tokio::spawn(async move {
             UdpFramed::new(socket, BytesCodec::new())
-                .map_err(|error| error!(message = "Error reading line.", error = ?error))
+                .map_err(|error| error!(message = "Error reading line.", %error))
                 .map_ok(|(bytes, _addr)| bytes.freeze())
                 .forward(
                     tx.sink_compat().sink_map_err(
-                        |error| error!(message = "Error sending event.", error = ?error),
+                        |error| error!(message = "Error sending event.", %error),
                     ),
                 )
                 .await

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -440,9 +440,8 @@ mod test {
                 .map_err(|error| error!(message = "Error reading line.", %error))
                 .map_ok(|(bytes, _addr)| bytes.freeze())
                 .forward(
-                    tx.sink_compat().sink_map_err(
-                        |error| error!(message = "Error sending event.", %error),
-                    ),
+                    tx.sink_compat()
+                        .sink_map_err(|error| error!(message = "Error sending event.", %error)),
                 )
                 .await
                 .unwrap()

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -77,7 +77,7 @@ pub fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Op
         b.push(b'\n');
         Bytes::from(b)
     })
-    .map_err(|error| error!(message = "Unable to encode.", error = ?error))
+    .map_err(|error| error!(message = "Unable to encode.", %error))
     .ok()
 }
 

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -117,7 +117,7 @@ where
             }
             Err(error) => {
                 if self.remaining_attempts == 0 {
-                    error!(message = "Retries exhausted; dropping the request.", error = ?error);
+                    error!(message = "Retries exhausted; dropping the request.", %error);
                     return None;
                 }
 
@@ -128,7 +128,7 @@ where
                     } else {
                         error!(
                             message = "Non-retriable error; dropping the request.",
-                            error = ?error
+                            %error
                         );
                         None
                     }
@@ -138,7 +138,7 @@ where
                 } else {
                     error!(
                         message = "Unexpected error type; dropping the request.",
-                        error = ?error
+                        %error
                     );
                     None
                 }

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -729,7 +729,7 @@ where
                         error!(message = "Response wasn't successful.", response = ?response);
                     }
                     Err(error) => {
-                        error!(message = "Request failed.", error = ?error,);
+                        error!(message = "Request failed.", %error,);
                     }
                 }
 

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -280,7 +280,7 @@ impl Sink for TcpSink {
                             return match connection.start_send(line) {
                                 Ok(AsyncSink::NotReady(line)) => Ok(AsyncSink::NotReady(line)),
                                 Err(error) => {
-                                    error!(message = "Connection disconnected.", error = ?error);
+                                    error!(message = "Connection disconnected.", %error);
                                     self.state = TcpSinkState::Disconnected;
                                     return Ok(AsyncSink::Ready);
                                 }

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -119,7 +119,7 @@ impl UdpConnector {
             match self.connect().await {
                 Ok(socket) => return socket,
                 Err(error) => {
-                    error!(message = "Unable to connect UDP socket.", error = ?error);
+                    error!(message = "Unable to connect UDP socket.", %error);
                     delay_for(backoff.next().unwrap()).await;
                 }
             }
@@ -253,7 +253,7 @@ impl UdpSink {
                     Ok(Async::NotReady) => return Ok(Async::NotReady),
                     Ok(Async::Ready(socket)) => State::Connected(socket),
                     Err(error) => {
-                        error!(message = "Unable to connect UDP socket.", error = ?error);
+                        error!(message = "Unable to connect UDP socket.", %error);
                         State::Backoff(self.next_delay01())
                     }
                 },
@@ -285,7 +285,7 @@ impl Sink for UdpSink {
                 match udp_send(socket, &line) {
                     Err(error) => {
                         self.state = State::Backoff(self.next_delay01());
-                        error!(message = "Send failed.", error = ?error);
+                        error!(message = "Send failed.", %error);
                         Ok(AsyncSink::NotReady(line))
                     }
                     Ok(_) => Ok(AsyncSink::Ready),

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -140,7 +140,7 @@ fn apache_metrics(
     out: Pipeline,
 ) -> super::Source {
     let out = out
-        .sink_map_err(|error| error!(message = "Error sending metric.", error = ?error))
+        .sink_map_err(|error| error!(message = "Error sending metric.", %error))
         .sink_compat();
     let task = tokio::time::interval(Duration::from_secs(interval))
         .take_until(shutdown)
@@ -329,7 +329,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
         tokio::spawn(async move {
             if let Err(error) = Server::bind(&in_addr).serve(make_svc).await {
-                error!(message = "Server error.", error = ?error);
+                error!(message = "Server error.", %error);
             }
         });
         wait_for_tcp(in_addr).await;
@@ -397,7 +397,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
         tokio::spawn(async move {
             if let Err(error) = Server::bind(&in_addr).serve(make_svc).await {
-                error!(message = "Server error.", error = ?error);
+                error!(message = "Server error.", %error);
             }
         });
         wait_for_tcp(in_addr).await;

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -34,7 +34,7 @@ pub async fn firehose(
             // can only fail if receiving end disconnected, so we are shutting down,
             // probably not gracefully.
             error!(message = "Failed to forward events, downstream is closed.");
-            error!(message = "Tried to send the following event.", error = ?error);
+            error!(message = "Tried to send the following event.", %error);
             warp::reject::custom(error)
         })
         .map_ok(|_| {

--- a/src/sources/docker.rs
+++ b/src/sources/docker.rs
@@ -134,7 +134,7 @@ impl SourceConfig for DockerConfig {
                 Err(error) => {
                     error!(
                         message = "Listing currently running containers failed.",
-                        ?error
+                        %error
                     );
                 }
             }
@@ -536,7 +536,7 @@ impl EventStreamBuilder {
             }
             // In case of any error we have to notify the main thread that it should try again. This is %error because the API doesn't support Display.
             if let Err(error) = this.main_send.send(Err(id)) {
-                error!(message = "Unable to send ContainerId to main.", error = %error);
+                error!(message = "Unable to send ContainerId to main.", %error);
             }
         });
 
@@ -630,7 +630,7 @@ impl EventStreamBuilder {
         };
         // This is %error because the API doesn't support Display.
         if let Err(error) = self.main_send.send(result) {
-            error!(message = "Unable to return ContainerLogInfo to main.", error = %error);
+            error!(message = "Unable to return ContainerLogInfo to main.", %error);
         }
     }
 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -280,7 +280,7 @@ pub fn file_source(
         })
         .boxed()
         .compat()
-        .map_err(|error| error!(message="File server unexpectedly stopped.", error = ?error))
+        .map_err(|error| error!(message="File server unexpectedly stopped.", %error))
     }))
 }
 

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -102,7 +102,7 @@ impl GeneratorConfig {
                 })
                 .collect::<Vec<Event>>();
             let (sink, _) = out.send_all(iter_ok(events)).compat().await.map_err(
-                |error| error!(message="Error sending generated lines.", error = ?error),
+                |error| error!(message="Error sending generated lines.", %error),
             )?;
             out = sink;
         }

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -101,9 +101,11 @@ impl GeneratorConfig {
                     }
                 })
                 .collect::<Vec<Event>>();
-            let (sink, _) = out.send_all(iter_ok(events)).compat().await.map_err(
-                |error| error!(message="Error sending generated lines.", %error),
-            )?;
+            let (sink, _) = out
+                .send_all(iter_ok(events))
+                .compat()
+                .await
+                .map_err(|error| error!(message="Error sending generated lines.", %error))?;
             out = sink;
         }
         Ok(())

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -176,7 +176,7 @@ impl HostMetricsConfig {
                 .send_all(futures01::stream::iter_ok(metrics))
                 .compat()
                 .await
-                .map_err(|error| error!(message = "Error sending host metrics.", error = ?error))?;
+                .map_err(|error| error!(message = "Error sending host metrics.", %error))?;
             out = sink;
         }
 
@@ -268,7 +268,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load CPU times.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load CPU times.", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -349,7 +349,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load memory info.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load memory info.", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -395,7 +395,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load swap info.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load swap info.", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -418,7 +418,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load load average info.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load load average info.", %error, rate_limit_secs = 60);
                 vec![]
             }
         };
@@ -503,7 +503,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load network I/O counters.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load network I/O counters.", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -552,7 +552,7 @@ impl HostMetricsConfig {
                                 error!(
                                     message = "Failed to load partition usage data.",
                                     mount_point = ?partition.mount_point(),
-                                    ?error,
+                                    %error,
                                     rate_limit_secs = 60,
                                 )
                             })
@@ -598,7 +598,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load partitions info", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load partitions info", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -658,7 +658,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load disk I/O info.", error = ?error, rate_limit_secs = 60);
+                error!(message = "Failed to load disk I/O info.", %error, rate_limit_secs = 60);
                 vec![]
             }
         }
@@ -701,7 +701,7 @@ impl HostMetricsConfig {
 
 async fn filter_result<T>(result: Result<T, Error>, message: &'static str) -> Option<T> {
     result
-        .map_err(|error| error!(message, ?error, rate_limit_secs = 60))
+        .map_err(|error| error!(message, %error, rate_limit_secs = 60))
         .ok()
 }
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -68,7 +68,7 @@ async fn run(
             .send_all(futures01::stream::iter_ok(metrics))
             .compat()
             .await
-            .map_err(|error| error!(message = "Error sending internal metrics.", error = ?error))?;
+            .map_err(|error| error!(message = "Error sending internal metrics.", %error))?;
         out = sink;
     }
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -170,7 +170,7 @@ impl JournaldConfig {
             Err(error) => {
                 error!(
                     message = "Could not retrieve saved journald checkpoint.",
-                    error = ?error
+                    %error
                 );
                 None
             }
@@ -347,7 +347,7 @@ where
                     Some(Err(error)) => {
                         error!(
                             message = "Could not read from journald source.",
-                            error = ?error,
+                            %error,
                         );
                         break;
                     }
@@ -386,7 +386,7 @@ where
                     if let Err(error) = self.checkpointer.set(&cursor).await {
                         error!(
                             message = "Could not set journald checkpoint.",
-                            ?error,
+                            %error,
                             filename = ?self.checkpointer.filename,
                         );
                     }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -175,14 +175,14 @@ fn kafka_source(
             // Error: implementation of `futures_core::stream::Stream` is not general enough
             // .forward(
             //     out.sink_compat()
-            //         .sink_map_err(|error| error!(message = "Error sending to sink.", error = ?error)),
+            //         .sink_map_err(|error| error!(message = "Error sending to sink.", %error)),
             // )
             .for_each(|item| {
                 let out = out.clone();
                 async move {
                     if let Ok(item) = item {
                         if let Err(error) = out.send(item).compat().await {
-                            error!(message = "Error sending to sink.", error = ?error);
+                            error!(message = "Error sending to sink.", %error);
                         }
                     }
                 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -313,9 +313,7 @@ impl Source {
             let fut = util::run_file_server(file_server, file_source_tx, shutdown).map(|result| {
                 match result {
                     Ok(FileServerShutdown) => info!(message = "File server completed gracefully."),
-                    Err(error) => {
-                        error!(message = "File server exited with an error.", %error)
-                    }
+                    Err(error) => error!(message = "File server exited with an error.", %error),
                 }
             });
             slot.bind(Box::pin(fut));

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -111,7 +111,7 @@ impl SourceConfig for Config {
         let fut = source.run(out, shutdown);
         let fut = fut.map(|result| {
             result.map_err(|error| {
-                error!(message = "Source future failed.", error = ?error);
+                error!(message = "Source future failed.", %error);
             })
         });
         let fut = Box::pin(fut);
@@ -303,7 +303,7 @@ impl Source {
                 util::cancel_on_signal(reflector_process, shutdown).map(|result| match result {
                     Ok(()) => info!(message = "Reflector process completed gracefully."),
                     Err(error) => {
-                        error!(message = "Reflector process exited with an error.", error = ?error)
+                        error!(message = "Reflector process exited with an error.", %error)
                     }
                 });
             slot.bind(Box::pin(fut));
@@ -314,7 +314,7 @@ impl Source {
                 match result {
                     Ok(FileServerShutdown) => info!(message = "File server completed gracefully."),
                     Err(error) => {
-                        error!(message = "File server exited with an error.", error = ?error)
+                        error!(message = "File server exited with an error.", %error)
                     }
                 }
             });
@@ -332,11 +332,11 @@ impl Source {
                     Ok(Ok(())) => info!(message = "Event processing loop completed gracefully."),
                     Ok(Err(error)) => error!(
                         message = "Event processing loop exited with an error.",
-                        ?error
+                        %error
                     ),
                     Err(error) => error!(
                         message = "Event processing loop timed out during the shutdown.",
-                        ?error
+                        %error
                     ),
                 };
             });

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -136,7 +136,7 @@ impl SourceConfig for MongoDBMetricsConfig {
         .await?;
 
         let mut out = out
-            .sink_map_err(|error| error!(message = "Error sending metric.", error = ?error))
+            .sink_map_err(|error| error!(message = "Error sending metric.", %error))
             .sink_compat();
 
         Ok(Box::new(

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -78,7 +78,7 @@ fn prometheus(
     out: Pipeline,
 ) -> super::Source {
     let out = out
-        .sink_map_err(|error| error!(message = "Error sending metric.", error = ?error))
+        .sink_map_err(|error| error!(message = "Error sending metric.", %error))
         .sink_compat();
     let task = tokio::time::interval(Duration::from_secs(interval))
         .take_until(shutdown)
@@ -234,7 +234,7 @@ mod test {
 
         tokio::spawn(async move {
             if let Err(error) = Server::bind(&in_addr).serve(make_svc).await {
-                error!(message = "Server error.", error = ?error);
+                error!(message = "Server error.", %error);
             }
         });
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -46,8 +46,7 @@ pub fn udp(
     mut shutdown: ShutdownSignal,
     out: Pipeline,
 ) -> Source {
-    let mut out =
-        out.sink_map_err(|error| error!(message = "Error sending event.", %error));
+    let mut out = out.sink_map_err(|error| error!(message = "Error sending event.", %error));
 
     Box::new(
         async move {

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -47,7 +47,7 @@ pub fn udp(
     out: Pipeline,
 ) -> Source {
     let mut out =
-        out.sink_map_err(|error| error!(message = "Error sending event.", error = ?error));
+        out.sink_map_err(|error| error!(message = "Error sending event.", %error));
 
     Box::new(
         async move {

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -734,7 +734,7 @@ fn event_error(text: &str, code: u16, event: usize) -> Response {
         Ok(string) => response_json(StatusCode::BAD_REQUEST, string),
         Err(error) => {
             // This should never happen.
-            error!(message = "Error encoding json body.", error = ?error);
+            error!(message = "Error encoding json body.", %error);
             response_json(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 splunk_response::SERVER_ERROR.clone(),

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -138,7 +138,7 @@ async fn statsd_udp(config: UdpConfig, shutdown: ShutdownSignal, out: Pipeline) 
                 // https://github.com/rust-lang/rust/issues/64552#issuecomment-669728225
                 let mut metrics = stream::iter(metrics).boxed();
                 if let Err(error) = out.send_all(&mut metrics).await {
-                    error!(message = "Error sending metric.", error = ?error);
+                    error!(message = "Error sending metric.", %error);
                     break;
                 }
             }

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -102,7 +102,7 @@ where
         })
         .forward(
             out.sink_map_err(
-                |error| error!(message = "Unable to send event to out.", error = ?error),
+                |error| error!(message = "Unable to send event to out.", %error),
             )
             .sink_compat(),
         )

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -101,10 +101,8 @@ where
             create_event(Bytes::from(line), &host_key, &hostname)
         })
         .forward(
-            out.sink_map_err(
-                |error| error!(message = "Unable to send event to out.", %error),
-            )
-            .sink_compat(),
+            out.sink_map_err(|error| error!(message = "Unable to send event to out.", %error))
+                .sink_compat(),
         )
         .inspect(|_| info!("Finished sending"));
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -263,7 +263,7 @@ pub fn udp(
     shutdown: ShutdownSignal,
     out: Pipeline,
 ) -> super::Source {
-    let out = out.sink_map_err(|error| error!(message = "Error sending line.", error = ?error));
+    let out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
 
     Box::new(
         async move {

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -182,7 +182,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                         // can only fail if receiving end disconnected, so we are shutting down,
                                         // probably not gracefully.
                                         error!(message = "Failed to forward events, downstream is closed.");
-                                        error!(message = "Tried to send the following event.", error = ?error);
+                                        error!(message = "Tried to send the following event.", %error);
                                         warp::reject::custom(RejectShuttingDown)
                                     })
                                     .map_ok(|_| warp::reply())

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -72,8 +72,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> crate::Result<crate::sources::Source> {
-        let out =
-            out.sink_map_err(|error| error!(message = "Error sending event.", %error));
+        let out = out.sink_map_err(|error| error!(message = "Error sending event.", %error));
 
         let listenfd = ListenFd::from_env();
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -30,7 +30,7 @@ async fn make_listener(
         SocketListenAddr::SocketAddr(addr) => match tls.bind(&addr).await {
             Ok(listener) => Some(listener),
             Err(error) => {
-                error!(message = "Failed to bind to listener socket.", error = ?error);
+                error!(message = "Failed to bind to listener socket.", %error);
                 None
             }
         },
@@ -38,7 +38,7 @@ async fn make_listener(
             Ok(Some(listener)) => match TcpListener::from_std(listener) {
                 Ok(listener) => Some(listener.into()),
                 Err(error) => {
-                    error!(message = "Failed to bind to listener socket.", error = ?error);
+                    error!(message = "Failed to bind to listener socket.", %error);
                     None
                 }
             },
@@ -47,7 +47,7 @@ async fn make_listener(
                 None
             }
             Err(error) => {
-                error!(message = "Failed to take listen FD.", error = ?error);
+                error!(message = "Failed to take listen FD.", %error);
                 None
             }
         },
@@ -73,7 +73,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
         out: Pipeline,
     ) -> crate::Result<crate::sources::Source> {
         let out =
-            out.sink_map_err(|error| error!(message = "Error sending event.", error = ?error));
+            out.sink_map_err(|error| error!(message = "Error sending event.", %error));
 
         let listenfd = ListenFd::from_env();
 
@@ -116,7 +116,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
                             Err(error) => {
                                 error!(
                                     message = "Failed to accept socket.",
-                                    error = ?error
+                                    %error
                                 );
                                 return;
                             }
@@ -190,7 +190,7 @@ async fn handle_stream(
                     let socket: Option<&TcpStream> = reader.get_ref().get_ref();
                     if let Some(socket) = socket {
                         if let Err(error) = socket.shutdown(std::net::Shutdown::Write) {
-                            warn!(message = "Failed in signalling to the other side to close the TCP channel.", error = ?error);
+                            warn!(message = "Failed in signalling to the other side to close the TCP channel.", %error);
                         }
                     } else {
                         // Connection hasn't yet been established so we are done here.
@@ -214,7 +214,7 @@ async fn handle_stream(
             source.build_event(frame, host).map(Ok)
         }
         Err(error) => {
-            warn!(message = "Failed to read data from TCP source.", error = ?error);
+            warn!(message = "Failed to read data from TCP source.", %error);
             None
         }
     }))

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -33,7 +33,7 @@ where
     D: Decoder<Item = String, Error = E> + Clone + Send + 'static,
     E: From<std::io::Error> + std::fmt::Debug + std::fmt::Display,
 {
-    let out = out.sink_map_err(|error| error!(message = "Error sending line.", error = ?error));
+    let out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
 
     let fut = async move {
         let mut listener =
@@ -45,7 +45,7 @@ where
         while let Some(socket) = stream.next().await {
             let socket = match socket {
                 Err(error) => {
-                    error!(message = "Failed to accept socket.", error = ?error);
+                    error!(message = "Failed to accept socket.", %error);
                     continue;
                 }
                 Ok(socket) => socket,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -181,7 +181,7 @@ pub async fn build_pieces(
                             Ok(())
                         }
                         Ok(Err(error)) => {
-                            error!(message = "Healthcheck: Failed Reason.", error = ?error);
+                            error!(message = "Healthcheck: Failed Reason.", %error);
                             Err(())
                         }
                         Err(_) => {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -73,7 +73,7 @@ pub async fn build_or_log_errors(config: &Config, diff: &ConfigDiff) -> Option<P
     match builder::build_pieces(config, diff).await {
         Err(errors) => {
             for error in errors {
-                error!(message = "Configuration error.", error = ?error);
+                error!(message = "Configuration error.", %error);
             }
             None
         }

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -225,7 +225,7 @@ impl MetadataClient {
     async fn run(&mut self) {
         loop {
             if let Err(error) = self.refresh_metadata().await {
-                error!(message = "Unable to fetch EC2 metadata; Retrying.", error = ?error);
+                error!(message = "Unable to fetch EC2 metadata; Retrying.", %error);
                 delay_for(Duration::from_secs(1)).await;
                 continue;
             }

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -224,7 +224,7 @@ impl Lua {
                 .lua
                 .gc_collect()
                 .context(RuntimeErrorGC)
-                .map_err(|error| error!(error = ?error, rate_limit = 30));
+                .map_err(|error| error!(%error, rate_limit = 30));
             self.invocations_after_gc = 0;
         }
     }
@@ -280,7 +280,7 @@ impl RuntimeTransform for Lua {
                 })
             })
             .context(RuntimeErrorHooksInit)
-            .map_err(|error| error!(error = ?error, rate_limit = 30));
+            .map_err(|error| error!(%error, rate_limit = 30));
 
         self.attempt_gc();
     }
@@ -302,7 +302,7 @@ impl RuntimeTransform for Lua {
                 })
             })
             .context(RuntimeErrorHooksInit)
-            .map_err(|error| error!(error = ?error, rate_limit = 30));
+            .map_err(|error| error!(%error, rate_limit = 30));
 
         self.attempt_gc();
     }
@@ -323,7 +323,7 @@ impl RuntimeTransform for Lua {
                 })
             })
             .context(RuntimeErrorTimerHandler)
-            .map_err(|error| error!(error = ?error, rate_limit = 30));
+            .map_err(|error| error!(%error, rate_limit = 30));
 
         self.attempt_gc();
     }

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -88,7 +88,7 @@ impl ReduceState {
                         match get_value_merger(v, strat) {
                             Ok(m) => Some((k, m)),
                             Err(error) => {
-                                warn!(message = "Failed to create merger.", field = ?k, error = ?error);
+                                warn!(message = "Failed to create merger.", field = ?k, %error);
                                 None
                             }
                         }
@@ -111,7 +111,7 @@ impl ReduceState {
                                 entry.insert(m);
                             }
                             Err(error) => {
-                                warn!(message = "Failed to merge value.", error = ?error);
+                                warn!(message = "Failed to merge value.", %error);
                             }
                         }
                     } else {
@@ -120,7 +120,7 @@ impl ReduceState {
                 }
                 hash_map::Entry::Occupied(mut entry) => {
                     if let Err(error) = entry.get_mut().add(v.clone()) {
-                        warn!(message = "Failed to merge value.", error = ?error);
+                        warn!(message = "Failed to merge value.", %error);
                     }
                 }
             }
@@ -132,7 +132,7 @@ impl ReduceState {
         let mut event = Event::new_empty_log().into_log();
         for (k, v) in self.fields.drain() {
             if let Err(error) = v.insert_into(k, &mut event) {
-                warn!(message = "Failed to merge values for field.", error = ?error);
+                warn!(message = "Failed to merge values for field.", %error);
             }
         }
         event

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -173,7 +173,7 @@ fn create_tmp_directory(config: &mut Config, fmt: &mut Formatter) -> Option<Path
 
 fn remove_tmp_directory(path: PathBuf) {
     if let Err(error) = remove_dir_all(&path) {
-        error!(message = "Failed to remove temporary directory.", path = ?path, error = ?error);
+        error!(message = "Failed to remove temporary directory.", path = ?path, %error);
     }
 }
 


### PR DESCRIPTION
The update to CONTRIBUTING.md said to prefer `Display` (%) for
formatting errors, but showed an example using `Debug` (?). I updated
the example to use % and switched all existing ? usage for errors to %.

Also switched from `error = %error` to the shorthand `%error`.

Follow up to https://github.com/timberio/vector/pull/4737

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
