### PR TITLE
fix(syslog source): Fixes the value of `source_ip` in UDP mode from `ipaddress:port` to `ipaddress`

### DIFF
--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -283,7 +283,7 @@ pub fn udp(
                     async move {
                         match frame {
                             Ok((bytes, received_from)) => {
-                                let received_from = received_from.to_string().into();
+                                let received_from = received_from.ip().to_string().into();
 
                                 std::str::from_utf8(&bytes)
                                     .map_err(|error| emit!(SyslogUdpUtf8Error { error }))


### PR DESCRIPTION
The Syslog source in UDP mode uses `std::net:SocketAddr` (which represents the socket as `ipaddress:port`) as the value of the `source_ip` field. The TCP mode uses `SocketListenAddr` which represents just the `ipaddress`. This results in the `source_ip` field being set as `127.0.0.1` in TCP mode and as `127.0.0.1:1234` in UDP mode.

This PR calls the `ip()` method on `received_from` in the `udp` function. This results in the `source_ip` field to be set to `ipaddress` in both cases.

Before:

```
Oct 28 14:25:07 a-k53d9h7imuxj vector[358336]: {"host":"127.0.0.1","message":"test message","source_ip":"127.0.0.1:6712","source_type":"syslog","timestamp":"2020-10-28T18:25:07.917801031Z"}
```

After:

```
Oct 28 14:26:12 a-k53d9h7imuxj vector[358336]: {"host":"127.0.0.1","message":"test message","source_ip":"127.0.0.1","source_type":"syslog","timestamp":"2020-10-28T18:26:12.872801751Z"}
```

Closes #4792.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
