### PR TITLE
feat(kubernetes_logs source): Add ingestion timestamp

### DIFF
--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -94,6 +94,9 @@ pub struct Config {
     glob_minimum_cooldown_ms: usize,
 
     /// A field to use to set the timestamp when Vector ingested the event.
+    /// This is useful to compute the latency between important event processing
+    /// stages, i.e. the time delta between log line was written and when it was
+    /// processed by the `kubernetes_logs` source.
     ingestion_timestamp_field: Option<String>,
 }
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -92,6 +92,9 @@ pub struct Config {
     /// a significant overhead.
     #[serde(default = "default_glob_minimum_cooldown_ms")]
     glob_minimum_cooldown_ms: usize,
+
+    /// A field to use to set the timestamp when Vector ingested the event.
+    ingestion_timestamp_field: Option<String>,
 }
 
 inventory::submit! {
@@ -159,6 +162,7 @@ struct Source {
     exclude_paths: Vec<glob::Pattern>,
     max_read_bytes: usize,
     glob_minimum_cooldown: Duration,
+    ingestion_timestamp_field: Option<String>,
 }
 
 impl Source {
@@ -197,6 +201,7 @@ impl Source {
             exclude_paths,
             max_read_bytes: config.max_read_bytes,
             glob_minimum_cooldown,
+            ingestion_timestamp_field: config.ingestion_timestamp_field.clone(),
         })
     }
 
@@ -215,6 +220,7 @@ impl Source {
             exclude_paths,
             max_read_bytes,
             glob_minimum_cooldown,
+            ingestion_timestamp_field,
         } = self;
 
         let watcher = k8s::api_watcher::ApiWatcher::new(client, Pod::watch_pod_for_all_namespaces);
@@ -309,7 +315,7 @@ impl Source {
                 file: &file,
                 byte_size: bytes.len(),
             });
-            let mut event = create_event(bytes, &file);
+            let mut event = create_event(bytes, &file, ingestion_timestamp_field.as_deref());
             if annotator.annotate(&mut event, &file).is_none() {
                 emit!(KubernetesLogsEventAnnotationFailed { event: &event });
             }
@@ -376,7 +382,7 @@ impl Source {
     }
 }
 
-fn create_event(line: Bytes, file: &str) -> Event {
+fn create_event(line: Bytes, file: &str, ingestion_timestamp_field: Option<&str>) -> Event {
     let mut event = Event::from(line);
 
     // Add source type.
@@ -387,6 +393,13 @@ fn create_event(line: Bytes, file: &str) -> Event {
 
     // Add file.
     event.as_mut_log().insert(FILE_KEY, file.to_owned());
+
+    // Add ingestion timestamp if requested.
+    if let Some(ingestion_timestamp_field) = ingestion_timestamp_field {
+        event
+            .as_mut_log()
+            .insert(ingestion_timestamp_field, chrono::Utc::now());
+    }
 
     event
 }


### PR DESCRIPTION
This PR adds (an opt-in) filling of the ingestion timestamp to the `kubernetes_logs` source.