### PR TITLE
feat(remap): add variable support

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -10,8 +10,9 @@ if_statement = { "if" ~ boolean_expr ~ block ~ ("else" ~ block)? }
 
 // Primary ---------------------------------------------------------------------
 
-primary  =  { value | path | group }
+primary  =  { value | variable | path | group }
 value    =  { string | float | integer | boolean | null }
+variable = ${ "$" ~ ident }
 group    =  { "(" ~ expression ~ ")" }
 
 // Function Calls --------------------------------------------------------------
@@ -66,7 +67,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 // Other ----------------------------------------------------------------------
 
 ident  = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
-target = _{ path }
+target = _{ variable | path }
 block  =  { "{" ~ NEWLINE* ~ (expression ~ (NEWLINE+ ~ expression)*) ~ NEWLINE* ~ "}" }
 
 string_inner = @{ char* }

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -100,6 +100,7 @@ impl fmt::Display for Rule {
             string_inner,
             target,
             value,
+            variable,
             WHITESPACE,
         ]
     }

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -17,6 +17,7 @@ pub(super) use block::Block;
 pub(super) use function::Function;
 pub(super) use if_statement::IfStatement;
 pub(super) use not::Not;
+pub(super) use variable::Variable;
 
 pub use literal::Literal;
 pub use noop::Noop;
@@ -95,4 +96,5 @@ expression_dispatch![
     Noop,
     Not,
     Path,
+    Variable,
 ];

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -10,6 +10,7 @@ pub enum Error {
 #[derive(Debug)]
 pub(crate) enum Target {
     Path(Vec<Vec<String>>),
+    Variable(String),
 }
 
 #[derive(Debug)]
@@ -32,6 +33,9 @@ impl Expression for Assignment {
             None => Ok(None),
             Some(value) => {
                 match &self.target {
+                    Target::Variable(ident) => {
+                        state.variables_mut().insert(ident.clone(), value.clone());
+                    }
                     Target::Path(path) => object
                         .insert(&path, value.clone())
                         .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -12,6 +12,12 @@ pub(crate) struct Variable {
     ident: String,
 }
 
+impl Variable {
+    pub fn new(ident: String) -> Self {
+        Self { ident }
+    }
+}
+
 impl Expression for Variable {
     fn execute(&self, state: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
         state

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -134,6 +134,7 @@ mod tests {
     #[test]
     fn it_works() {
         let cases: Vec<(&str, Result<Option<Value>>)> = vec![
+            (r#".foo = null || "bar""#, Ok(Some("bar".into()))),
             (r#"$foo = null || "bar""#, Ok(Some("bar".into()))),
             // (r#".foo == .bar"#, Ok(Some(Value::Boolean(false)))),
             (

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn it_works() {
         let cases: Vec<(&str, Result<Option<Value>>)> = vec![
-            (r#".foo = null || "bar""#, Ok(Some("bar".into()))),
+            (r#"$foo = null || "bar""#, Ok(Some("bar".into()))),
             // (r#".foo == .bar"#, Ok(Some(Value::Boolean(false)))),
             (
                 r#".foo == .bar"#,
@@ -152,11 +152,11 @@ mod tests {
             //     r#".a.b.(c | d) == .e."f.g"[2].(h | i)"#,
             //     Ok(Some(Value::Boolean(false))),
             // ),
-            (".bar = true\n.foo = .bar", Ok(Some(Value::Boolean(true)))),
+            ("$bar = true\n.foo = $bar", Ok(Some(Value::Boolean(true)))),
             (
                 r#"{
-                    .foo = "foo"
-                    .foo = .foo + "bar"
+                    $foo = "foo"
+                    .foo = $foo + "bar"
                     .foo
                 }"#,
                 Ok(Some("foobar".into())),

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -3,6 +3,7 @@
 use crate::{
     expression::{
         Arithmetic, Assignment, Block, Function, IfStatement, Literal, Noop, Not, Path, Target,
+        Variable,
     },
     Argument, Error, Expr, Function as Fn, Operator, Result, Value,
 };
@@ -93,9 +94,17 @@ impl Parser<'_> {
 
     /// Return the target type to which a value is being assigned.
     ///
-    /// This returns a `target_path` target.
+    /// This can either return a `variable` or a `target_path` target, depending
+    /// on the parser rule being processed.
     fn target_from_pair(&self, pair: Pair<R>) -> Result<Target> {
         match pair.as_rule() {
+            R::variable => Ok(Target::Variable(
+                pair.into_inner()
+                    .next()
+                    .ok_or(e(R::variable))?
+                    .as_str()
+                    .to_owned(),
+            )),
             R::path => Ok(Target::Path(
                 self.path_segments_from_pairs(pair.into_inner())?,
             )),
@@ -158,6 +167,7 @@ impl Parser<'_> {
 
         match pair.as_rule() {
             R::value => self.value_from_pair(pair.into_inner().next().ok_or(e(R::value))?),
+            R::variable => self.variable_from_pair(pair),
             R::path => self.path_from_pair(pair),
             R::group => self.expression_from_pair(pair.into_inner().next().ok_or(e(R::group))?),
             _ => Err(e(R::primary)),
@@ -298,6 +308,13 @@ impl Parser<'_> {
             .collect::<Result<_>>()
     }
 
+    /// Parse a [`Variable`] value, e.g. "$foo"
+    fn variable_from_pair(&self, pair: Pair<R>) -> Result<Expr> {
+        let ident = pair.into_inner().next().ok_or(e(R::variable))?;
+
+        Ok(Expr::from(Variable::new(ident.as_str().to_owned())))
+    }
+
     fn escaped_string_from_pair(&self, pair: Pair<R>) -> Result<String> {
         // This is only executed once per string at parse time, and so I'm not
         // losing sleep over the reallocation. However, if we want to mutate the
@@ -381,18 +398,18 @@ mod tests {
             ),
             (
                 ".foo = to_string",
-                vec![" 1:8\n", "= expected if_statement, not, path, or block"],
+                vec![" 1:8\n", "= expected assignment, if_statement, not, or block"],
             ),
             (
                 r#"foo = "bar""#,
                 vec![
                     " 1:1\n",
-                    "= expected EOI, if_statement, not, path, or block",
+                    "= expected EOI, assignment, if_statement, not, or block",
                 ],
             ),
             (
                 r#".foo.bar = "baz" and this"#,
-                vec![" 1:18\n", "= expected EOI, if_statement, not, operator_boolean_expr, operator_equality, operator_comparison, operator_addition, operator_multiplication, path, or block"],
+                vec![" 1:18\n", "= expected EOI, assignment, if_statement, not, operator_boolean_expr, operator_equality, operator_comparison, operator_addition, operator_multiplication, or block"],
             ),
             (r#".foo.bar = "baz" +"#, vec![" 1:19", "= expected not"]),
             (
@@ -407,7 +424,7 @@ mod tests {
                 "if .foo { }",
                 vec![
                     " 1:11\n",
-                    "= expected if_statement, not, path, or block",
+                    "= expected assignment, if_statement, not, or block",
                 ],
             ),
             (
@@ -431,7 +448,7 @@ mod tests {
                 // Due to the explicit list of allowed escape chars our grammar
                 // doesn't actually recognize this as a string literal.
                 r#".foo = "invalid escape \k sequence""#,
-                vec![" 1:8\n", "= expected if_statement, not, path, or block"],
+                vec![" 1:8\n", "= expected assignment, if_statement, not, or block"],
             ),
             (
                 // Same here as above.
@@ -446,12 +463,12 @@ mod tests {
             (
                 // We cannot assign a regular expression to a field.
                 r#".foo = /ab/i"#,
-                vec![" 1:8\n", "= expected if_statement, not, path, or block"],
+                vec![" 1:8\n", "= expected assignment, if_statement, not, or block"],
             ),
             (
                 // We cannot assign to a regular expression.
                 r#"/ab/ = .foo"#,
-                vec![" 1:1\n", "= expected EOI, if_statement, not, path, or block"],
+                vec![" 1:1\n", "= expected EOI, assignment, if_statement, not, or block"],
             ),
         ];
 


### PR DESCRIPTION
This adds variable support to the remap language:

```rust
// variable assignment
$foo = "bar"

// path assignment and variable reference
.bar = $foo
```

This was removed in https://github.com/timberio/vector/pull/4695 (340842453a65875e3898f145bc332d2c4e104e76) to reduce the complexity of that PR and have it move forward without too much unrelated discussions.

Now that all the recent remap-lang changes have been merged, I'm re-introducing the concept of variables in this PR.

## Motivation

I'm happy to _not_ do this if there is opposition to this, but I'll posit my motivation for why I think it makes sense to add variables to the language.

**only manipulate the target object if you need to**

Remap language already supports assigning to paths, but if you want to hold a temporary value, right now you must assign and then delete that value to a field within the target object:

```rust
.url_parts = parse_url(.my_url) // note: we don't support "parse_url(.my_url).scheme"
.scheme = .url_parts.scheme
del(".url_parts")
```

Not only is this inconvenient, it also introduces two failure modes:

* You forget to delete the temporary field, polluting your events
* You assign a temporary value to an existing field, overwriting the previous value

**make conditions more readable**

Now that we support the Remap language in conditions (#4743), variables can help keep those conditions more readable:

```rust
$starts_with_date = match(trim(.timestamp), /^\d{4}-\d{2}-\d{2}.+/)
$other_check = to_bool(/* ... */)
$final_check = /* ... */ || /* ... */

$starts_with_date && $other_check && $final_check
```

**allow variable assignment in immutable contexts**

Not only that, but we plan on introducing an "immutable mode" for Remap (#4744), which would make the target object immutable. This does not apply to variables, since their mutability is "internal", meaning they don't mutate the outside world, and so there is no harm in being able to assign to variables in an immutable context.

Meaning, without variables, you wouldn't even be able to do the things we did in the first and second example because you can't assign values to target paths in an immutable context.

## Syntax

For a discussion and arguments for the `$foo = "bar"` syntax, see the related issue (https://github.com/timberio/vector/issues/4419). The TL;DR is that this syntax is similar to jq, and it prevents accidental variable assignments if you'd write `foo = "bar"` but intended to write `.foo = "bar"` (which would result in an error-free, but unexpected outcome of the script).

## Future Work

With this change, you can **store** values in variables, and **retrieve** those values, but you can't **traverse** containers:

```rust
.foo.bar = "baz" // works
$foo = .foo      // works

$foo             // returns { "bar": "baz" }
$foo.bar         // fails to compile
```

I think the latter should be valid syntax.

closes #4419 