### PR TITLE
chore(rfcs): Remap chaining parsing functions RFC

### DIFF
--- a/rfcs/2020-10-29-3736-remap-chain-parsing.md
+++ b/rfcs/2020-10-29-3736-remap-chain-parsing.md
@@ -95,14 +95,16 @@ are not required.
 
 Assigning values to variables is only permitted if the condition is wrapped
 with parentheses. If the condition is not wrapped in a group, only the
-    double equals (`==`) is permitted. This helps to avoid the potential bug
+double equals (`==`) is permitted. This helps to avoid the potential bug
 where a typo with a single equals results in valid, but incorrect code.
+
+The scoping for any assignment to variables in the condition is global within
+the script. The variable is modified even if the condition fails.
 
 *Note, `matches` is currently unimplemented, but in this example it is
 intended as a function that would match a regular expression and return any
 matching groups in a `Value::map`. If there were no match, it returns an 
 empty map.*
-
 
 ## Rationale
 
@@ -125,11 +127,11 @@ transform will likely be necessary to do the processing required.
 
 ## Drawbacks
 
-By allowing side effects within the condition, the user could potentially write
-code that they didn't intend. For example, The assignment still
-occurs even if the condition doesn't succeed. The script writer needs to be 
-aware that the variable will not still hold the original value if the predicate 
-doesn't succeed.
+Because the scope of the variables is global within the script, by allowing side
+effects within the condition, the user could potentially write code that they
+didn't intend. For example, The assignment still occurs even if the condition
+doesn't succeed. The script writer needs to be aware that the variable will not
+still hold the original value if the predicate doesn't succeed.
 
 
 ## Alternatives
@@ -178,6 +180,11 @@ values. However, I'm not convinced this would be a good idea as having
 conditions working differently depending on their context could be confusing for
 the user.
 
+### Scoping
+We could introduce scoping rules into the condition. Any modifications to the
+variables would only be visible in the block that is run should the condition
+succeed. This could avoid surprises outlined in the Drawbacks section where
+the state is modified even on failure.
 
 ## Outstanding Questions
 

--- a/rfcs/2020-10-29-3736-remap-chain-parsing.md
+++ b/rfcs/2020-10-29-3736-remap-chain-parsing.md
@@ -60,10 +60,19 @@ code blocks are run.
 ## Condition
 
 It is possible to have multiple statements within the condition. The statements
-must be surrounded with parentheses and separated by a semicolon.
+must be surrounded with parentheses and separated by either a semicolon or a
+new line.
 
 ```
 (statement1; statement2; statement3)
+```
+
+or
+
+```
+(statement1
+ statement2
+ statement3)
 ```
 
 This allows you to, for example, assign the results of a regular expression
@@ -73,12 +82,12 @@ you have the results to work with.
 The following code will be possible:
 
 ```coffee
-if ($match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/);
+if ($match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/)
     !is_empty($match)) {
   .method = $match.method
   .remote_addr = $match.remote_addr
   .source = "nginx"
-} else if ($match = matches(.message, /^(?P<remote_addr>[^\s]*).*"(?P<method>[^\s]*).*"$/);
+} else if ($match = matches(.message, /^(?P<remote_addr>[^\s]*).*"(?P<method>[^\s]*).*"$/)
            !is_empty($match)) {
   .method = $match.method
   .remote_addr = $match.remote_addr
@@ -90,7 +99,7 @@ if ($match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>
 
 The final statement must evaluate to a Boolean.
 
-If there is only a single predicate evaluated in the condition, the parentheses 
+If there is only a single predicate evaluated in the condition, the parentheses
 are not required.
 
 Assigning values to variables is only permitted if the condition is wrapped
@@ -103,7 +112,7 @@ the script. The variable is modified even if the condition fails.
 
 *Note, `matches` is currently unimplemented, but in this example it is
 intended as a function that would match a regular expression and return any
-matching groups in a `Value::map`. If there were no match, it returns an 
+matching groups in a `Value::map`. If there were no match, it returns an
 empty map.*
 
 ## Rationale

--- a/rfcs/2020-10-29-3736-remap-chain-parsing.md
+++ b/rfcs/2020-10-29-3736-remap-chain-parsing.md
@@ -1,22 +1,25 @@
 # RFC 3736 - 2020-10-29 - Ability to chain parsing functions in the remap syntax
 
-Vector needs to be able to parse a variety of log formats in different ways. 
+Vector needs to be able to parse a variety of log formats in different ways.
 
-This RFC proposes enhancements to the Remap language to give it the ability to chain multiple parsing strategies 
-in the language. For example, a number of regular expressions can be chained together 
-and each run sequentially until one passes.
+This RFC proposes enhancements to the Remap language to give it the ability to
+chain multiple parsing strategies in the language. For example, a number of
+regular expressions can be chained together and each run sequentially until one
+passes.
 
 
 ## Scope
 
-This RFC will focus on the syntax needed to enhance the Remap language to allow for multiple branches as well as the 
-functionality required to allow the scripts to most efficiently run within these branches.
+This RFC will focus on the syntax needed to enhance the Remap language to allow
+for multiple branches as well as the functionality required to allow the scripts
+to most efficiently run within these branches.
 
 ## Motivation
 
 The best way to achieve this currently is with the `swimlanes` transform.
 
-However, the complexity required to efficiently maintain multiple parsing strategies using swimlanes is fairly complex which
+However, the complexity required to efficiently maintain multiple parsing
+strategies using swimlanes is fairly complex which
 can lead to error prone and inefficient transforms.
 
 See issues:
@@ -26,8 +29,10 @@ See issues:
 
 ## Doc-level Proposal
 
-Within a `remap` mapping it is possible to specify a number of conditions. Each condition will be run sequentially - the first condition 
-that passes the associated mapping block will be performed. This is performed using `if...else if...else`:
+Within a `remap` mapping it is possible to specify a number of conditions. Each
+condition will be run sequentially - the first condition that passes the
+associated mapping block will be performed. This is performed using
+`if...else if...else`:
 
 ```
 if ... {
@@ -41,15 +46,20 @@ if ... {
 }
 ```
 
-The mapping will start at the condition specified by the first `if` and will proceed along each condition specified by each `else if` sequentially until
+The mapping will start at the condition specified by the first `if` and will
+proceed along each condition specified by each `else if` sequentially until
 it finds one that passes. The ensuing code block will be executed.
 
-A default code block can be specified at the end using `else`. This is run if none of the conditions pass. If there is no `else` and no condition matches,
-no code blocks are run.
+A default code block can be specified at the end using `else`. This is run if
+none of the conditions pass. If there is no `else` and no condition matches, no
+code blocks are run.
 
-The script is able to make the most of any processing that has been done to run the condition - for example, if a regular expression
-has been run, the block that is subsequently run can have access to the results of this regex. The Remap syntax also allows assignment to variables within 
-the condition. A condition is considered to be successful if the value it returns is not `false` or `nil`. This allows a regular expression match to pass 
+The script is able to make the most of any processing that has been done to run
+the condition - for example, if a regular expression has been run, the block
+that is subsequently run can have access to the results of this regex. The Remap
+syntax also allows assignment to variables within the condition. A condition is
+considered to be successful if the value it returns is not `false` or `nil`.
+This allows a regular expression match to pass 
 the condition and pass it's results into the block via the variable assignment.
 
 The following code will be possible:
@@ -68,35 +78,45 @@ if $match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[
 }
 ```
 
-*Note, `matches` is currently unimplemented, but in this example it is intended as a function that would match a regular expression and return any matching
-groups in a `Value::map`. If there were no match, it would return either `false` or `null`.* 
+*Note, `matches` is currently unimplemented, but in this example it is
+intended as a function that would match a regular expression and return any
+matching groups in a `Value::map`. If there were no match, it would return
+either `false` or `null`.* 
 
 
 
 ## Rationale
 
-If this functionality can be encapsulated within the Remap language it will allow users to simplify their configuration. All processing
-involved would be contained within a single transform that can be precisely designed to do what the user needs in the minimum number
-of steps.
+If this functionality can be encapsulated within the Remap language it will
+allow users to simplify their configuration. All processing involved would be
+contained within a single transform that can be precisely designed to do what
+the user needs in the minimum number of steps.
 
 ## Prior Art
 
-Currently, we have the [Swimlanes](https://vector.dev/docs/reference/transforms/swimlanes/) transform. Swimlanes can route the event to a transform or sink
-according to a provided condition. These transforms could be other remap transforms that can do the required processing for that condition.
+Currently, we have the [Swimlanes](https://vector.dev/docs/reference/transforms/swimlanes/)
+transform. Swimlanes can route the event to a transform or sink
+according to a provided condition. These transforms could be other remap
+transforms that can do the required processing for that condition.
 
-Whilst this is possible, it does complicate the user's configuration as they will need multiple transforms specified. With this RFC in place, only
-one transform will likely be necessary to do the processing required.
+Whilst this is possible, it does complicate the user's configuration as they
+will need multiple transforms specified. With this RFC in place, only one
+transform will likely be necessary to do the processing required.
 
 
 ## Drawbacks
 
-Allowing `if` statements to work with non-boolean values is a controversial topic in programming language design. It is possible to create
-unintended bugs because the code hasn't been explicit enough about what should and should not pass the condition. Decisions need to be 
-made as to what actually constitutes a failure condition - for example, should a result of `0` be a pass or a fail? This does add additional
-documentation requirements and cognitive load when writing the script.
+Allowing `if` statements to work with non-boolean values is a controversial
+topic in programming language design. It is possible to create unintended bugs
+because the code hasn't been explicit enough about what should and should not
+pass the condition. Decisions need to be made as to what actually constitutes
+a failure condition - for example, should a result of `0` be a pass or a fail?
+This does add additional documentation requirements and cognitive load when
+writing the script.
 
-The same can be said for allowing assignment within an `if` statement. The condition will be valid for both a single (`=`) and double (`==`) equals
-in the condition, yet both variations do very different things:
+The same can be said for allowing assignment within an `if` statement. The
+condition will be valid for both a single (`=`) and double (`==`) equals in the
+condition, yet both variations do very different things:
 
 ```
 if .foo == true {
@@ -112,16 +132,18 @@ if .foo = true {
 
 This has haunted C programmers for decades.
 
-Also, the assignment still occurs even if the condition doesn't succeed. Side effects such as this can be unexpected for the script writer
-and could cause unexpected bugs to creep in.
+Also, the assignment still occurs even if the condition doesn't succeed. Side
+effects such as this can be unexpected for the script writer and could cause
+unexpected bugs to creep in.
 
 
 ## Alternatives
 
 ### Enforce boolean conditions
-Allowing for non-boolean conditions in the `if` condition is not strictly necessary. A similar result could be achieved by running the regular
-expression twice, one with `match` which returns a boolean if it matches, and then again with `matches` which would extract the matches out of 
-the text.
+Allowing for non-boolean conditions in the `if` condition is not strictly
+necessary. A similar result could be achieved by running the regular expression
+twice, one with `match` which returns a boolean if it matches, and then again
+with `matches` which would extract the matches out of the text.
 
 ```coffeescript
 if match(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/) {
@@ -132,10 +154,12 @@ if match(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/) {
 }
 ```
 
-However, this has performance implications as the regular expression has to be run twice.
+However, this has performance implications as the regular expression has to be
+run twice.
 
 ### Use `switch`
-There are some alternative syntaxes that may be worth considering. One possibility that is common in many languages is a `switch` statement.
+There are some alternative syntaxes that may be worth considering. One
+possibility that is common in many languages is a `switch` statement.
 
 ```coffeescript
 switch {
@@ -155,27 +179,37 @@ switch {
 }
 ```
 
-The disadvantage of this approach is it is an extra syntactical element that needs to be added to the language that would require maintenance and
-make the language harder to learn. The advantage, however, is that we can then potentially avoid having to enable `if` statements to work with non-boolean 
-values. However, I'm not convinced this would be a good idea as having conditions working differently depending on their context could be confusing
-for the user.
+The disadvantage of this approach is it is an extra syntactical element that
+needs to be added to the language that would require maintenance and make the
+language harder to learn. The advantage, however, is that we can then
+potentially avoid having to enable `if` statements to work with non-boolean
+values. However, I'm not convinced this would be a good idea as having
+conditions working differently depending on their context could be confusing for
+the user.
 
 
 ## Outstanding Questions
 
-- One thing that the `swimlanes` can do that this RFC hasn't catered for is that `swimlanes` can send the event to different sinks depending on a condition. 
-With Remap there is only one possible component, another transform or a sink, that can accept the output of the mapping. Is this something that should 
-be catered for by the Remap language and this RFC?
+- One thing that the `swimlanes` can do that this RFC hasn't catered for is that
+`swimlanes` can send the event to different sinks depending on a condition. With
+Remap there is only one possible component, another transform or a sink, that
+can accept the output of the mapping. Is this something that should be catered
+for by the Remap language and this RFC?
 
 
 ## Plan Of Attack
 
 Incremental steps that execute this change. Generally this is in the form of:
 
-- [ ] Add `else if` to the remap language parser and add multiple branches to the `IfStatement` struct to handle multiple conditions.
-- [ ] Change the `IfStatement` functionality to treat non-boolean values as pass and fail for the conditional.
-- [ ] Enhance the remap parser to allow assignment within `if` statements. The underlying code already allows for assignments to 
-      pass on the assigned value to the outer expression, so no change should be necessary there.
-- [ ] Write the `matches` function that will run a regular expression and return any matched groups found. This is potentially out of scope
-      for this rfc, but would be useful nevertheless.
+- [ ] Add `else if` to the remap language parser and add multiple branches to
+      the `IfStatement` struct to handle multiple conditions.
+- [ ] Change the `IfStatement` functionality to treat non-boolean values as pass
+      and fail for the conditional.
+- [ ] Enhance the remap parser to allow assignment within `if` statements. The
+      underlying code already allows for assignments to 
+      pass on the assigned value to the outer expression, so no change should be
+      necessary there.
+- [ ] Write the `matches` function that will run a regular expression and return
+      any matched groups found. This is potentially out of scope for this rfc,
+      but would be useful nevertheless.
 

--- a/rfcs/2020-10-29-3736-remap-chain-parsing.md
+++ b/rfcs/2020-10-29-3736-remap-chain-parsing.md
@@ -1,0 +1,181 @@
+# RFC 3736 - 2020-10-29 - Ability to chain parsing functions in the remap syntax
+
+Vector needs to be able to parse a variety of log formats in different ways. 
+
+This RFC proposes enhancements to the Remap language to give it the ability to chain multiple parsing strategies 
+in the language. For example, a number of regular expressions can be chained together 
+and each run sequentially until one passes.
+
+
+## Scope
+
+This RFC will focus on the syntax needed to enhance the Remap language to allow for multiple branches as well as the 
+functionality required to allow the scripts to most efficiently run within these branches.
+
+## Motivation
+
+The best way to achieve this currently is with the `swimlanes` transform.
+
+However, the complexity required to efficiently maintain multiple parsing strategies using swimlanes is fairly complex which
+can lead to error prone and inefficient transforms.
+
+See issues:
+
+[#2418](https://github.com/timberio/vector/issues/2418)
+[#1477](https://github.com/timberio/vector/issues/1477)
+
+## Doc-level Proposal
+
+Within a `remap` mapping it is possible to specify a number of conditions. Each condition will be run sequentially - the first condition 
+that passes the associated mapping block will be performed. This is performed using `if...else if...else`:
+
+```
+if ... {
+   ...
+} else if ... {
+   ... 
+} else if ... {
+   ... 
+} else {
+   ...
+}
+```
+
+The mapping will start at the condition specified by the first `if` and will proceed along each condition specified by each `else if` sequentially until
+it finds one that passes. The ensuing code block will be executed.
+
+A default code block can be specified at the end using `else`. This is run if none of the conditions pass. If there is no `else` and no condition matches,
+no code blocks are run.
+
+The script is able to make the most of any processing that has been done to run the condition - for example, if a regular expression
+has been run, the block that is subsequently run can have access to the results of this regex. The Remap syntax also allows assignment to variables within 
+the condition. A condition is considered to be successful if the value it returns is not `false` or `nil`. This allows a regular expression match to pass 
+the condition and pass it's results into the block via the variable assignment.
+
+The following code will be possible:
+
+```coffee
+if $match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/) {
+  .method = $match.method
+  .remote_addr = $match.remote_addr
+  .source = "nginx"
+} else if $match = matches(.message, /^(?P<remote_addr>[^\s]*).*"(?P<method>[^\s]*).*"$/ {
+  .method = $match.method
+  .remote_addr = $match.remote_addr
+  .source = "haproxy"
+} else {
+  .source = "none"
+}
+```
+
+*Note, `matches` is currently unimplemented, but in this example it is intended as a function that would match a regular expression and return any matching
+groups in a `Value::map`. If there were no match, it would return either `false` or `null`.* 
+
+
+
+## Rationale
+
+If this functionality can be encapsulated within the Remap language it will allow users to simplify their configuration. All processing
+involved would be contained within a single transform that can be precisely designed to do what the user needs in the minimum number
+of steps.
+
+## Prior Art
+
+Currently, we have the [Swimlanes](https://vector.dev/docs/reference/transforms/swimlanes/) transform. Swimlanes can route the event to a transform or sink
+according to a provided condition. These transforms could be other remap transforms that can do the required processing for that condition.
+
+Whilst this is possible, it does complicate the user's configuration as they will need multiple transforms specified. With this RFC in place, only
+one transform will likely be necessary to do the processing required.
+
+
+## Drawbacks
+
+Allowing `if` statements to work with non-boolean values is a controversial topic in programming language design. It is possible to create
+unintended bugs because the code hasn't been explicit enough about what should and should not pass the condition. Decisions need to be 
+made as to what actually constitutes a failure condition - for example, should a result of `0` be a pass or a fail? This does add additional
+documentation requirements and cognitive load when writing the script.
+
+The same can be said for allowing assignment within an `if` statement. The condition will be valid for both a single (`=`) and double (`==`) equals
+in the condition, yet both variations do very different things:
+
+```
+if .foo == true {
+
+}
+```
+
+```
+if .foo = true {
+
+}
+```
+
+This has haunted C programmers for decades.
+
+Also, the assignment still occurs even if the condition doesn't succeed. Side effects such as this can be unexpected for the script writer
+and could cause unexpected bugs to creep in.
+
+
+## Alternatives
+
+### Enforce boolean conditions
+Allowing for non-boolean conditions in the `if` condition is not strictly necessary. A similar result could be achieved by running the regular
+expression twice, one with `match` which returns a boolean if it matches, and then again with `matches` which would extract the matches out of 
+the text.
+
+```coffeescript
+if match(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/) {
+  $match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/)
+  .method = $match.method
+  .remote_addr = $match.remote_addr
+  .source = "nginx"
+}
+```
+
+However, this has performance implications as the regular expression has to be run twice.
+
+### Use `switch`
+There are some alternative syntaxes that may be worth considering. One possibility that is common in many languages is a `switch` statement.
+
+```coffeescript
+switch {
+ ($match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/)): {
+    .method = $match.method
+    .remote_addr = $match.remote_addr
+    .source = "nginx"
+  }
+ ($match = matches(.message, /^(?P<remote_addr>[^\s]*).*"(?P<method>[^\s]*).*"$/): {
+    .method = $match.method
+    .remote_addr = $match.remote_addr
+    .source = "haproxy"
+  }
+  default: {
+    .source = "other"
+  }
+}
+```
+
+The disadvantage of this approach is it is an extra syntactical element that needs to be added to the language that would require maintenance and
+make the language harder to learn. The advantage, however, is that we can then potentially avoid having to enable `if` statements to work with non-boolean 
+values. However, I'm not convinced this would be a good idea as having conditions working differently depending on their context could be confusing
+for the user.
+
+
+## Outstanding Questions
+
+- One thing that the `swimlanes` can do that this RFC hasn't catered for is that `swimlanes` can send the event to different sinks depending on a condition. 
+With Remap there is only one possible component, another transform or a sink, that can accept the output of the mapping. Is this something that should 
+be catered for by the Remap language and this RFC?
+
+
+## Plan Of Attack
+
+Incremental steps that execute this change. Generally this is in the form of:
+
+- [ ] Add `else if` to the remap language parser and add multiple branches to the `IfStatement` struct to handle multiple conditions.
+- [ ] Change the `IfStatement` functionality to treat non-boolean values as pass and fail for the conditional.
+- [ ] Enhance the remap parser to allow assignment within `if` statements. The underlying code already allows for assignments to 
+      pass on the assigned value to the outer expression, so no change should be necessary there.
+- [ ] Write the `matches` function that will run a regular expression and return any matched groups found. This is potentially out of scope
+      for this rfc, but would be useful nevertheless.
+


### PR DESCRIPTION
Closes #3736 
Closes #2418 

Adds the ability to chain parsing functions to the Remap language. Each is run until one passes.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
