### PR TITLE
feat(remap): support else-if conditional expression

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -6,7 +6,7 @@ expression = _{ assignment | if_statement | boolean_expr | block }
 // Statements ------------------------------------------------------------------
 
 assignment   = { target ~ "=" ~ expression }
-if_statement = { "if" ~ boolean_expr ~ block ~ ("else" ~ block)? }
+if_statement = { "if" ~ boolean_expr ~ block ~ ("else if" ~ boolean_expr ~ block)* ~ ("else" ~ block)? }
 
 // Primary ---------------------------------------------------------------------
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -169,6 +169,35 @@ mod tests {
                 "#,
                 Ok(Some(true.into())),
             ),
+            (r#"if false { 1 }"#, Ok(None)),
+            (r#"if true { 1 }"#, Ok(Some(1.into()))),
+            (r#"if false { 1 } else { 2 }"#, Ok(Some(2.into()))),
+            (r#"if false { 1 } else if false { 2 }"#, Ok(None)),
+            (r#"if false { 1 } else if true { 2 }"#, Ok(Some(2.into()))),
+            (
+                r#"if false { 1 } else if false { 2 } else { 3 }"#,
+                Ok(Some(3.into())),
+            ),
+            (
+                r#"if false { 1 } else if true { 2 } else { 3 }"#,
+                Ok(Some(2.into())),
+            ),
+            (
+                r#"if false { 1 } else if false { 2 } else if false { 3 }"#,
+                Ok(None),
+            ),
+            (
+                r#"if false { 1 } else if false { 2 } else if true { 3 }"#,
+                Ok(Some(3.into())),
+            ),
+            (
+                r#"if false { 1 } else if true { 2 } else if false { 3 } else { 4 }"#,
+                Ok(Some(2.into())),
+            ),
+            (
+                r#"if false { 1 } else if false { 2 } else if false { 3 } else { 4 }"#,
+                Ok(Some(4.into())),
+            ),
         ];
 
         for (script, result) in cases {


### PR DESCRIPTION
This updates the remap-lang grammar to extend if statements with support for else-if conditionals:

```rust
if false {
	0
} else if false { 
	1
} else if true {
	2
} else {
	3
}
// => 2
```

I had this lying around from my previous work on refactoring the remap-lang implementation, I pulled it out at the last minute to not overcomplicate the PR (similar to #4802), but after reading @FungusHumungus RFC in #4808 I figured it'd be worth to re-submit the PR.

This doesn't do anything that's described in @FungusHumungus's RFC _other than_ extending if statements to support `else if` cases, which is a trivial thing to add and something people probably expect to exist regardless.

As with variables (#4802), I'm happy to drop this proposal, but I think its table stakes for any language, even one that focusses on simplicity (or perhaps even more so, as it would be unintuitive to many not to have this feature). It could be said that the same can be achieved through nested if-else statements, but that can become tedious rather quickly.

In terms of implementation, I opted not to make the blocks optional for single expressions (which would have made the explicit support for `else if` in the grammar unnecessary), to not extend other parts of the language in this PR. We could still do that in a follow-up PR, but I'm hesitant to do that right now (or at all).