### PR TITLE
enhancement(kubernetes platform): Add the ability to set conatiner ports at vector-agent Helm chart

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -58,6 +58,10 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          ports:
+            {{- with .Values.extraContainersPorts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -67,6 +67,10 @@ resources: {}
 nodeSelector: {}
 affinity: {}
 
+# Additional container ports to pass to the `vector` container of the `Pod`s
+# managed by `DaemonSet`.
+extraContainersPorts: []
+
 # Additional volumes to pass to the `Pod`s managed by `DaemonSet`.
 extraVolumes: []
 

--- a/distribution/kubernetes/vector.yaml
+++ b/distribution/kubernetes/vector.yaml
@@ -138,6 +138,7 @@ spec:
             
             - name: LOG
               value: info
+          ports:
           resources:
             {}
           volumeMounts:


### PR DESCRIPTION
This PR adds the ability to configure container ports. It is mostly useful to bind names to the exposed ports, which is required, in particular, if you're using `prometheus-operator`.

Closes #3808.