### PR TITLE
enhancement(kubernetes_logs source): support for kubeconfigs as an alternative to in_cluster configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ wasm = ["lucet-runtime", "lucet-wasi", "lucetc", "vector-wasm"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.
-kubernetes = ["evmap", "k8s-openapi"]
+kubernetes = ["k8s-openapi", "serde_yaml", "evmap"]
 
 # API
 api = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ tower = { version = "0.3.1", git = "https://github.com/tower-rs/tower", rev = "4
 # Serde
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0.33", features = ["raw_value"] }
-serde_yaml = "0.8.13"
+serde_yaml = { version ="0.8.13", optional = true }
 
 # Prost
 prost = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ tower = { version = "0.3.1", git = "https://github.com/tower-rs/tower", rev = "4
 # Serde
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0.33", features = ["raw_value"] }
-serde_yaml = { version ="0.8.13", optional = true }
+serde_yaml = { version ="0.8.13" }
 
 # Prost
 prost = "0.6.1"
@@ -311,7 +311,7 @@ wasm = ["lucet-runtime", "lucet-wasi", "lucetc", "vector-wasm"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.
-kubernetes = ["k8s-openapi", "serde_yaml", "evmap"]
+kubernetes = ["k8s-openapi", "evmap"]
 
 # API
 api = [

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -157,7 +157,10 @@ components: sources: kubernetes_logs: {
 			common:      false
 			description: "Optional path to a kubeconfig file readable by Vector. If not set, Vector will try to connect to Kubernetes using in-cluster configuration."
 			required:    false
-			type: string: default: null
+			type: string: {
+				default: null
+				syntax:  "literal"
+			}
 		}
 		self_node_name: {
 			common:      false

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -153,6 +153,12 @@ components: sources: kubernetes_logs: {
 			required:    false
 			type: bool: default: true
 		}
+		kube_config_file: {
+			common:      false
+			description: "Optional path to a kubeconfig file readable by Vector. If not set, Vector will try to connect to Kubernetes using in-cluster configuration."
+			required:    false
+			type: string: default: null
+		}
 		self_node_name: {
 			common:      false
 			description: "The name of the Kubernetes `Node` this Vector instance runs at. Configured to use an env var by default, to be evaluated to a value provided by Kubernetes at Pod deploy time."

--- a/src/kubernetes/api_watcher.rs
+++ b/src/kubernetes/api_watcher.rs
@@ -251,7 +251,7 @@ mod tests {
 
             let config = client::Config {
                 base: server.base_url().parse().unwrap(),
-                token: "SOMEGARBAGETOKEN".to_string(),
+                token: Some("SOMEGARBAGETOKEN".to_string()),
                 tls_options: TlsOptions::default(),
             };
             let client = Client::new(config).unwrap();
@@ -641,7 +641,7 @@ mod tests {
 
             let config = client::Config {
                 base: server.base_url().parse().unwrap(),
-                token: "SOMEGARBAGETOKEN".to_string(),
+                token: Some("SOMEGARBAGETOKEN".to_string()),
                 tls_options: TlsOptions::default(),
             };
             let client = Client::new(config).unwrap();

--- a/src/kubernetes/client/config/in_cluster.rs
+++ b/src/kubernetes/client/config/in_cluster.rs
@@ -25,7 +25,7 @@ impl Config {
         let token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token";
         let root_ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
 
-        let token = std::fs::read_to_string(token_file).context(Token)?;
+        let token = Some(std::fs::read_to_string(token_file).context(Token)?);
 
         let tls_options = TlsOptions {
             ca_file: Some(root_ca_file.into()),

--- a/src/kubernetes/client/config/kubeconfig.rs
+++ b/src/kubernetes/client/config/kubeconfig.rs
@@ -56,11 +56,10 @@ fn kubeconfig_reader(config: &str) -> Result<Config, Error> {
 
     let base = cluster.server.parse().context(InvalidUrl)?;
 
-    // use inline token if defined, otherwise fallback to token_file
     let token = match &user.token {
         Some(t) => Some(t.clone()),
         None => match &user.token_file {
-            Some(file) => Some(std::fs::read_to_string(PathBuf::from(&file)).context(Token)?),
+            Some(file) => Some(std::fs::read_to_string(&file).context(Token)?),
             None => None,
         },
     };

--- a/src/kubernetes/client/config/kubeconfig.rs
+++ b/src/kubernetes/client/config/kubeconfig.rs
@@ -1,0 +1,231 @@
+//! Everything related to building a kubernetes client configuration from a kubeconfig file.
+//! Not all features of a kubeconfig are currently supported,
+//! e.g. password and OIDC auth as well as inlined certificates and keys.
+
+use super::Config;
+use crate::tls::TlsOptions;
+use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::kubernetes::client::config::kubeconfig_types::*;
+use std::path::{Path, PathBuf};
+
+impl Config {
+    /// Prepares a config by reading a kubeconfig file from defined path
+    pub fn kubeconfig(path: &Path) -> Result<Self, Error> {
+        kubeconfig_reader(&std::fs::read_to_string(path).context(IO)?)
+    }
+}
+
+fn kubeconfig_reader(config: &str) -> Result<Config, Error> {
+    let kc: Kubeconfig = serde_yaml::from_str(config).context(Parse)?;
+
+    // resolve "current_context"
+    let current_context = &kc.current_context;
+    let current_context = &kc
+        .contexts
+        .iter()
+        .find(|c| &c.name == current_context)
+        .context(MissingRelation {
+            from: "current_context",
+            missing: "context",
+        })?
+        .context;
+    let current_cluster = &current_context.cluster;
+    let current_user = &current_context.user;
+
+    // resolve cluster
+    let cluster = &kc
+        .clusters
+        .iter()
+        .find(|c| &c.name == current_cluster)
+        .context(MissingRelation {
+            from: "context.cluster",
+            missing: "cluster",
+        })?
+        .cluster;
+    // resolve user
+    let user = &kc
+        .auth_infos
+        .iter()
+        .find(|a| &a.name == current_user)
+        .context(MissingRelation {
+            from: "context.user",
+            missing: "auth_info",
+        })?
+        .auth_info;
+
+    let base = cluster.server.parse().context(InvalidUrl)?;
+
+    // use inline token if defined, otherwise fallback to token_file
+    let token = match &user.token {
+        Some(t) => Some(t.clone()),
+        None => match &user.token_file {
+            Some(file) => Some(std::fs::read_to_string(PathBuf::from(&file)).context(Token)?),
+            None => None,
+        },
+    };
+
+    let mut tls_options = TlsOptions::default();
+    tls_options.ca_file = cluster.certificate_authority.as_ref().map(PathBuf::from);
+    tls_options.crt_file = user.client_certificate.as_ref().map(PathBuf::from);
+    tls_options.key_file = user.client_key.as_ref().map(PathBuf::from);
+
+    Ok(Config {
+        base,
+        tls_options,
+        token,
+    })
+}
+
+/// An error returned when building an in-cluster configuration.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    /// The kube_config file does not exist or could not be opened for reading.
+    #[snafu(display("unable to load kubernetes configuration (kube_config)"))]
+    IO {
+        /// The underlying error.
+        source: std::io::Error,
+    },
+
+    /// The kube_config file could not be parsed as Json or Yaml
+    #[snafu(display("unable to parse kubernetes configuration (kube_config)"))]
+    Parse {
+        /// The underlying error.
+        source: serde_yaml::Error,
+    },
+
+    /// The token file could not be read successfully.
+    #[snafu(display("kube_config data relation could not be resolved"))]
+    MissingRelation {
+        /// What did we look for?
+        missing: &'static str,
+
+        /// Where did we look?
+        from: &'static str,
+    },
+
+    /// The token file could not be read successfully.
+    #[snafu(display("unable to read the token file"))]
+    Token {
+        /// The underlying error.
+        source: std::io::Error,
+    },
+
+    /// The configuration resulted in an invalid URL.
+    #[snafu(display("unable to construct a proper API server URL"))]
+    InvalidUrl {
+        /// The underlying error.
+        source: http::uri::InvalidUri,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KUBECONFIG_JSON: &str = r#"
+        {
+          "apiVersion": "v1",
+          "clusters": [
+            {
+              "cluster": {
+                "certificate-authority": "/certs/public.pem",
+                "server": "https://kubernetes.json.dev:4443"
+              },
+              "name": "public"
+            }
+          ],
+          "contexts": [
+            {
+              "name": "bar",
+              "context": {
+                "cluster": "public",
+                "user": "alice"
+              }
+            },
+            {
+              "name": "foo",
+              "context": {
+                "cluster": "public",
+                "user": "bob"
+              }
+            }
+          ],
+          "current-context": "foo",
+          "kind": "Config",
+          "users": [
+            {
+              "name": "alice",
+              "user": {
+                "client-certificate": "/certs/alice.crt",
+                "client-key": "/certs/alice.key"
+              }
+            },
+            {
+              "name": "bob",
+              "user": {
+                "client-certificate": "/certs/bob.crt",
+                "client-key": "/certs/bob.key"
+              }
+            }
+          ]
+        }
+    "#;
+
+    const KUBECONFIG_YAML: &str = r#"
+        apiVersion: v1
+        clusters:
+        - cluster:
+            certificate-authority: "/certs/public.pem"
+            server: https://kubernetes.yaml.dev:4443
+          name: public
+        contexts:
+        - name: bar
+          context:
+            cluster: public
+            user: alice
+        - name: foo
+          context:
+            cluster: public
+            user: bob
+        current-context: bar
+        kind: Config
+        users:
+        - name: alice
+          user:
+            token: abcdef654321
+        - name: bob
+          user:
+            client-certificate: "/certs/bob.crt"
+            client-key: "/certs/bob.key"
+    "#;
+
+    #[test]
+    fn test_read_kubeconfig() {
+        let kc = kubeconfig_reader(&KUBECONFIG_JSON).unwrap();
+        assert_eq!(kc.base, "https://kubernetes.json.dev:4443");
+        assert_eq!(kc.token, None);
+        assert_eq!(
+            kc.tls_options.ca_file.unwrap().to_str().unwrap(),
+            "/certs/public.pem"
+        );
+        assert_eq!(
+            kc.tls_options.crt_file.unwrap().to_str().unwrap(),
+            "/certs/bob.crt"
+        );
+        assert_eq!(
+            kc.tls_options.key_file.unwrap().to_str().unwrap(),
+            "/certs/bob.key"
+        );
+
+        let kc = kubeconfig_reader(&KUBECONFIG_YAML).unwrap();
+        assert_eq!(kc.base, "https://kubernetes.yaml.dev:4443");
+        assert_eq!(kc.token, Some("abcdef654321".to_string()));
+        assert_eq!(
+            kc.tls_options.ca_file.unwrap().to_str().unwrap(),
+            "/certs/public.pem"
+        );
+        assert_eq!(kc.tls_options.crt_file, None);
+        assert_eq!(kc.tls_options.key_file, None);
+    }
+}

--- a/src/kubernetes/client/config/kubeconfig.rs
+++ b/src/kubernetes/client/config/kubeconfig.rs
@@ -64,10 +64,12 @@ fn kubeconfig_reader(config: &str) -> Result<Config, Error> {
         },
     };
 
-    let mut tls_options = TlsOptions::default();
-    tls_options.ca_file = cluster.certificate_authority.as_ref().map(PathBuf::from);
-    tls_options.crt_file = user.client_certificate.as_ref().map(PathBuf::from);
-    tls_options.key_file = user.client_key.as_ref().map(PathBuf::from);
+    let tls_options = TlsOptions {
+        ca_file: cluster.certificate_authority.as_ref().map(PathBuf::from),
+        crt_file: user.client_certificate.as_ref().map(PathBuf::from),
+        key_file: user.client_key.as_ref().map(PathBuf::from),
+        ..Default::default()
+    };
 
     Ok(Config {
         base,

--- a/src/kubernetes/client/config/kubeconfig_types.rs
+++ b/src/kubernetes/client/config/kubeconfig_types.rs
@@ -1,0 +1,128 @@
+//! The contents of this module has been borrowed from https://github.com/clux/kube-rs
+//! Vendoring seemed preferable over depending, since all of the runtime client+http
+//! related features of the kube-rs crate isn't needed to parse a kubeconfig.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// [`Kubeconfig`] represents information on how to connect to a remote Kubernetes cluster
+/// that is normally stored in `~/.kube/config`
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Kubeconfig {
+    pub kind: Option<String>,
+    #[serde(rename = "apiVersion")]
+    pub api_version: Option<String>,
+    pub preferences: Option<Preferences>,
+    pub clusters: Vec<NamedCluster>,
+    #[serde(rename = "users")]
+    pub auth_infos: Vec<NamedAuthInfo>,
+    pub contexts: Vec<NamedContext>,
+    #[serde(rename = "current-context")]
+    pub current_context: String,
+    pub extensions: Option<Vec<NamedExtension>>,
+}
+
+/// Preferences stores extensions for cli.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Preferences {
+    pub colors: Option<bool>,
+    pub extensions: Option<Vec<NamedExtension>>,
+}
+
+/// NamedExtention associates name with extension.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamedExtension {
+    pub name: String,
+    pub extension: String,
+}
+
+/// NamedCluster associates name with cluster.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamedCluster {
+    pub name: String,
+    pub cluster: Cluster,
+}
+
+/// Cluster stores information to connect Kubernetes cluster.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Cluster {
+    pub server: String,
+    #[serde(rename = "insecure-skip-tls-verify")]
+    pub insecure_skip_tls_verify: Option<bool>,
+    #[serde(rename = "certificate-authority")]
+    pub certificate_authority: Option<String>,
+    #[serde(rename = "certificate-authority-data")]
+    pub certificate_authority_data: Option<String>,
+}
+
+/// NamedAuthInfo associates name with authentication.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamedAuthInfo {
+    pub name: String,
+    #[serde(rename = "user")]
+    pub auth_info: AuthInfo,
+}
+
+/// AuthInfo stores information to tell cluster who you are.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthInfo {
+    pub username: Option<String>,
+    pub password: Option<String>,
+
+    pub token: Option<String>,
+    #[serde(rename = "tokenFile")]
+    pub token_file: Option<String>,
+
+    #[serde(rename = "client-certificate")]
+    pub client_certificate: Option<String>,
+    #[serde(rename = "client-certificate-data")]
+    pub client_certificate_data: Option<String>,
+
+    #[serde(rename = "client-key")]
+    pub client_key: Option<String>,
+    #[serde(rename = "client-key-data")]
+    pub client_key_data: Option<String>,
+
+    #[serde(rename = "as")]
+    pub impersonate: Option<String>,
+    #[serde(rename = "as-groups")]
+    pub impersonate_groups: Option<Vec<String>>,
+
+    #[serde(rename = "auth-provider")]
+    pub auth_provider: Option<AuthProviderConfig>,
+
+    pub exec: Option<ExecConfig>,
+}
+
+/// AuthProviderConfig stores auth for specified cloud provider.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthProviderConfig {
+    pub name: String,
+    pub config: HashMap<String, String>,
+}
+
+/// ExecConfig stores credential-plugin configuration.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecConfig {
+    #[serde(rename = "apiVersion")]
+    pub api_version: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub command: String,
+    pub env: Option<Vec<HashMap<String, String>>>,
+}
+
+/// NamedContext associates name with context.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NamedContext {
+    pub name: String,
+    pub context: Context,
+}
+
+/// Context stores tuple of cluster and user information.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Context {
+    pub cluster: String,
+    pub user: String,
+    pub namespace: Option<String>,
+    pub extensions: Option<Vec<NamedExtension>>,
+}

--- a/src/kubernetes/client/config/kubeconfig_types.rs
+++ b/src/kubernetes/client/config/kubeconfig_types.rs
@@ -1,6 +1,20 @@
-//! The contents of this module has been borrowed from https://github.com/clux/kube-rs
-//! Vendoring seemed preferable over depending, since all of the runtime client+http
-//! related features of the kube-rs crate isn't needed to parse a kubeconfig.
+// The contents of this module has been taken from https://github.com/clux/kube-rs
+// without modification.
+//
+// # License: Apache License, Version 2.0
+// # Copyright 2021 Datadog
+//
+// # Licensed under the Apache License, Version 2.0 (the "License");
+// # you may not use this file except in compliance with the License.
+// # You may obtain a copy of the License at
+// #
+// #      http://www.apache.org/licenses/LICENSE-2.0
+// #
+// # Unless required by applicable law or agreed to in writing, software
+// # distributed under the License is distributed on an "AS IS" BASIS,
+// # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// # See the License for the specific language governing permissions and
+// # limitations under the License.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/kubernetes/client/config/mod.rs
+++ b/src/kubernetes/client/config/mod.rs
@@ -4,6 +4,8 @@ use crate::tls::TlsOptions;
 use http::Uri;
 
 pub mod in_cluster;
+pub mod kubeconfig;
+mod kubeconfig_types;
 
 /// A k8s client configuration.
 ///
@@ -20,7 +22,7 @@ pub struct Config {
     pub base: Uri,
 
     /// The bearer token to use at the `Authorization` header.
-    pub token: String,
+    pub token: Option<String>,
 
     /// The TLS configuration parameters to use at the HTTP client.
     pub tls_options: TlsOptions,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -99,6 +99,10 @@ pub struct Config {
 
     /// The default time zone for timestamps without an explicit zone.
     timezone: Option<TimeZone>,
+
+    /// Optional path to a kubeconfig file readable by Vector. If not set,
+    /// Vector will try to connect to Kubernetes using in-cluster configuration.
+    kube_config_file: Option<PathBuf>,
 }
 
 inventory::submit! {
@@ -165,7 +169,10 @@ impl Source {
         let field_selector = prepare_field_selector(config)?;
         let label_selector = prepare_label_selector(config);
 
-        let k8s_config = k8s::client::config::Config::in_cluster()?;
+        let k8s_config = match &config.kube_config_file {
+            Some(kc) => k8s::client::config::Config::kubeconfig(kc)?,
+            None => k8s::client::config::Config::in_cluster()?,
+        };
         let client = k8s::client::Client::new(k8s_config)?;
 
         let data_dir = globals.resolve_and_make_data_subdir(None, name)?;


### PR DESCRIPTION
This is my first PR to Vector. First of all, thank you for a great product.

I'm very excited about the Kubernetes support, however I don't plan to run Vector in-cluster, which, looks like the only thing supported at the moment.

This PR implements kubernetes source configuration via a kubeconfig file, which can be formatted as either yaml or json.

If `kube_config_file` is set in the source configuration, then this will be used, otherwise in_cluster configuration will be applied.

Please let me know whether something like this is usable for you. :)

Basic requirements for the kubeconfig current are:

- The kubeconfig file must have at least one context, and a `current-context` must be defined.
- The active context must refer to both a cluster and a user
- The context-referred cluster must exist in the `clusters`-section and the user must exist in the `auth-infos`-section

Supported auth-methods:

- None
- Client-cert file
- Token

Unsupported kubeconfig features:

- In-lined passwords
- In-lined client certs
- OIDC providers
- Extensions
- Unnamed contexts, clusters and users

( above list is probably not exhaustive )
