### PR TITLE
chore(metrics): Align error_type enum values

### DIFF
--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl InternalEvent for ANSIStripperFieldMissing<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for ANSIStripperFieldInvalid<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "value_invalid");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::ValueInvalid.as_str());
     }
 }
 

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl InternalEvent for ANSIStripperFieldMissing<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::FieldMissing);
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for ANSIStripperFieldInvalid<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::ValueInvalid.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::ValueInvalid);
     }
 }
 

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserFailedParse {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::ParseFailed.as_str(),
+            "error_type" => &ErrorType::ParseFailed,
         );
     }
 }

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserFailedParse {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "failed_parse",
+            "error_type" => ErrorTypes::ParseFailed.as_str(),
         );
     }
 }

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -27,6 +27,6 @@ impl<'a> InternalEvent for CoercerConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "type_conversion_failed");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
     }
 }

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -27,6 +27,6 @@ impl<'a> InternalEvent for CoercerConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::TypeConversionFailed);
     }
 }

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -28,6 +28,6 @@ impl<'a> InternalEvent for ConsoleFieldNotFound<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_not_found");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
     }
 }

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -28,6 +28,6 @@ impl<'a> InternalEvent for ConsoleFieldNotFound<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::FieldMissing);
     }
 }

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl InternalEvent for GrokParserFailedMatch<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::MatchFailed.as_str(),
+            "error_type" => &ErrorType::MatchFailed,
         );
     }
 }
@@ -47,7 +47,7 @@ impl InternalEvent for GrokParserMissingField<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::FieldMissing.as_str(),
+            "error_type" => &ErrorType::FieldMissing,
         );
     }
 }
@@ -70,7 +70,7 @@ impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::TypeConversionFailed.as_str(),
+            "error_type" => &ErrorType::TypeConversionFailed,
         );
     }
 }

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl InternalEvent for GrokParserFailedMatch<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "failed_match",
+            "error_type" => ErrorTypes::MatchFailed.as_str(),
         );
     }
 }
@@ -47,7 +47,7 @@ impl InternalEvent for GrokParserMissingField<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "missing_field",
+            "error_type" => ErrorTypes::FieldMissing.as_str(),
         );
     }
 }
@@ -70,7 +70,7 @@ impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "type_conversion_failed",
+            "error_type" => ErrorTypes::TypeConversionFailed.as_str(),
         );
     }
 }

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 use serde_json::Error;
 
@@ -35,7 +35,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::ParseFailed.as_str(),
+            "error_type" => &ErrorType::ParseFailed,
         );
     }
 }
@@ -56,7 +56,7 @@ impl<'a> InternalEvent for JsonParserTargetExists<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => ErrorTypes::TargetFieldExists.as_str(),
+            "error_type" => &ErrorType::TargetFieldExists,
         );
     }
 }

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 use serde_json::Error;
 
@@ -35,7 +35,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "failed_parse",
+            "error_type" => ErrorTypes::ParseFailed.as_str(),
         );
     }
 }
@@ -56,7 +56,7 @@ impl<'a> InternalEvent for JsonParserTargetExists<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "error_type" => "target_field_exists",
+            "error_type" => ErrorTypes::TargetFieldExists.as_str(),
         );
     }
 }

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 use std::num::ParseFloatError;
 
@@ -29,7 +29,7 @@ impl<'a> InternalEvent for LogToMetricFieldNotFound<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => "field_not_found",
+                 "error_type" => ErrorTypes::FieldMissing.as_str(),
         );
     }
 }
@@ -51,7 +51,7 @@ impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => "parse_error",
+                 "error_type" => ErrorTypes::ParseFailed.as_str(),
         );
     }
 }
@@ -72,7 +72,7 @@ impl InternalEvent for LogToMetricTemplateRenderError {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => "render_error",
+                 "error_type" => ErrorTypes::RenderError.as_str(),
         );
     }
 }
@@ -88,7 +88,7 @@ impl InternalEvent for LogToMetricTemplateParseError {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => "template_error",
+                 "error_type" => ErrorTypes::TemplateError.as_str(),
         );
     }
 }

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 use std::num::ParseFloatError;
 
@@ -29,7 +29,7 @@ impl<'a> InternalEvent for LogToMetricFieldNotFound<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => ErrorTypes::FieldMissing.as_str(),
+                 "error_type" => &ErrorType::FieldMissing,
         );
     }
 }
@@ -51,7 +51,7 @@ impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => ErrorTypes::ParseFailed.as_str(),
+                 "error_type" => &ErrorType::ParseFailed,
         );
     }
 }
@@ -72,7 +72,7 @@ impl InternalEvent for LogToMetricTemplateRenderError {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => ErrorTypes::RenderError.as_str(),
+                 "error_type" => &ErrorType::RenderError,
         );
     }
 }
@@ -88,7 +88,7 @@ impl InternalEvent for LogToMetricTemplateParseError {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => ErrorTypes::TemplateError.as_str(),
+                 "error_type" => &ErrorType::TemplateError,
         );
     }
 }

--- a/src/internal_events/logfmt_parser.rs
+++ b/src/internal_events/logfmt_parser.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl InternalEvent for LogfmtParserMissingField<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors", 1,
-            "error_type" => "missing_field",
+            "error_type" => ErrorTypes::FieldMissing.as_str(),
         );
     }
 }
@@ -49,7 +49,7 @@ impl<'a> InternalEvent for LogfmtParserConversionFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors", 1,
-            "error_type" => "type_conversion_failed",
+            "error_type" => ErrorTypes::TypeConversionFailed.as_str(),
         );
     }
 }

--- a/src/internal_events/logfmt_parser.rs
+++ b/src/internal_events/logfmt_parser.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl InternalEvent for LogfmtParserMissingField<'_> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors", 1,
-            "error_type" => ErrorTypes::FieldMissing.as_str(),
+            "error_type" => &ErrorType::FieldMissing,
         );
     }
 }
@@ -49,7 +49,7 @@ impl<'a> InternalEvent for LogfmtParserConversionFailed<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors", 1,
-            "error_type" => ErrorTypes::TypeConversionFailed.as_str(),
+            "error_type" => &ErrorType::TypeConversionFailed,
         );
     }
 }

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 use serde_json::Error;
 
@@ -30,6 +30,6 @@ impl<'a> InternalEvent for MetricToLogFailedSerialize {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::SerializationFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::SerializationFailed);
     }
 }

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 use serde_json::Error;
 
@@ -30,6 +30,6 @@ impl<'a> InternalEvent for MetricToLogFailedSerialize {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_serialize");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::SerializationFailed.as_str());
     }
 }

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -210,6 +210,39 @@ pub fn emit(event: impl InternalEvent) {
     event.emit_metrics();
 }
 
+// Possible values for the "error_type" tag
+pub enum ErrorTypes {
+    FieldMissing,
+    InvalidMetric,
+    MappingFailed,
+    MatchFailed,
+    ParseFailed,
+    RenderError,
+    SerializationFailed,
+    TargetFieldExists,
+    TemplateError,
+    TypeConversionFailed,
+    ValueInvalid,
+}
+
+impl ErrorTypes {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::FieldMissing => "field_missing",
+            Self::InvalidMetric => "invalid_metric",
+            Self::MappingFailed => "mapping_failed",
+            Self::MatchFailed => "match_failed",
+            Self::ParseFailed => "parse_failed",
+            Self::RenderError => "render_error",
+            Self::SerializationFailed => "serialization_failed",
+            Self::TargetFieldExists => "target_field_exists",
+            Self::TemplateError => "template_error",
+            Self::TypeConversionFailed => "type_conversion_failed",
+            Self::ValueInvalid => "value_invalid",
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! emit {
     ($event:expr) => {

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -211,7 +211,7 @@ pub fn emit(event: impl InternalEvent) {
 }
 
 // Possible values for the "error_type" tag
-pub enum ErrorTypes {
+pub enum ErrorType {
     FieldMissing,
     InvalidMetric,
     MappingFailed,
@@ -225,8 +225,10 @@ pub enum ErrorTypes {
     ValueInvalid,
 }
 
-impl ErrorTypes {
-    fn as_str(&self) -> &str {
+impl std::ops::Deref for ErrorType {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
         match self {
             Self::FieldMissing => "field_missing",
             Self::InvalidMetric => "invalid_metric",

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl InternalEvent for RegexParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::MatchFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::MatchFailed);
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for RegexParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::FieldMissing);
     }
 }
 
@@ -63,7 +63,7 @@ impl<'a> InternalEvent for RegexParserTargetExists<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TargetFieldExists.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::TargetFieldExists);
     }
 }
 
@@ -84,6 +84,6 @@ impl<'a> InternalEvent for RegexParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::TypeConversionFailed);
     }
 }

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl InternalEvent for RegexParserFailedMatch<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_match");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::MatchFailed.as_str());
     }
 }
 
@@ -44,7 +44,7 @@ impl InternalEvent for RegexParserMissingField<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "missing_field");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
     }
 }
 
@@ -63,7 +63,7 @@ impl<'a> InternalEvent for RegexParserTargetExists<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "target_field_exists");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TargetFieldExists.as_str());
     }
 }
 
@@ -84,6 +84,6 @@ impl<'a> InternalEvent for RegexParserConversionFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "type_conversion_failed");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
     }
 }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl InternalEvent for RemapFailedMapping {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_mapping");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::MappingFailed.as_str());
     }
 }
 

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl InternalEvent for RemapFailedMapping {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::MappingFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::MappingFailed);
     }
 }
 

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use crate::event::metric::{MetricKind, MetricValue};
 use metrics::counter;
 
@@ -21,7 +21,7 @@ impl InternalEvent for SematextMetricsInvalidMetricReceived {
     fn emit_metrics(&self) {
         counter!(
             "processing_errors_total", 1,
-            "error_type" => "invalid_metric",
+            "error_type" => ErrorTypes::InvalidMetric.as_str(),
         );
     }
 }

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use crate::event::metric::{MetricKind, MetricValue};
 use metrics::counter;
 
@@ -21,7 +21,7 @@ impl InternalEvent for SematextMetricsInvalidMetricReceived {
     fn emit_metrics(&self) {
         counter!(
             "processing_errors_total", 1,
-            "error_type" => ErrorTypes::InvalidMetric.as_str(),
+            "error_type" => &ErrorType::InvalidMetric,
         );
     }
 }

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for SplitFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for SplitConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "convert_failed");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
     }
 }

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for SplitFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::FieldMissing);
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for SplitConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::TypeConversionFailed);
     }
 }

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use crate::event::metric::{MetricKind, MetricValue};
 use metrics::counter;
 
@@ -19,6 +19,6 @@ impl<'a> InternalEvent for StatsdInvalidMetricReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "invalid_metric");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::InvalidMetric.as_str());
     }
 }

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use crate::event::metric::{MetricKind, MetricValue};
 use metrics::counter;
 
@@ -19,6 +19,6 @@ impl<'a> InternalEvent for StatsdInvalidMetricReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::InvalidMetric.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::InvalidMetric);
     }
 }

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -1,4 +1,4 @@
-use super::{ErrorTypes, InternalEvent};
+use super::{ErrorType, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::FieldMissing);
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
+        counter!("processing_errors_total", 1, "error_type" => &ErrorType::TypeConversionFailed);
     }
 }

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -1,4 +1,4 @@
-use super::InternalEvent;
+use super::{ErrorTypes, InternalEvent};
 use metrics::counter;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "field_missing");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::FieldMissing.as_str());
     }
 }
 
@@ -46,6 +46,6 @@ impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "convert_failed");
+        counter!("processing_errors_total", 1, "error_type" => ErrorTypes::TypeConversionFailed.as_str());
     }
 }


### PR DESCRIPTION
When working on Cue configuration for internal metrics in PR #4820, I noticed some discrepancies in the possible values for `error_type` (a tag for the `processing_errors_total` metric). This PR provides a convenient enum mechanism for keeping these values aligned.