### PR TITLE
enhancement(kubernetes platform): Support exposing internal mertics out of the box in our Helm charts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,8 @@ dependencies = [
  "futures 0.3.5",
  "k8s-openapi",
  "k8s-test-framework",
+ "regex",
+ "reqwest",
  "serde_json",
  "tokio",
 ]

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -45,6 +45,8 @@ data:
       {{- end }}
     {{- end }}
 
+    {{- include "libvector.metricsConfigPartial" . | nindent 4  }}
+
     {{- range $sourceId, $source := .Values.sources }}
     [sources.{{ $sourceId }}]
       type = "{{ $source.type }}"

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
+            {{- include "libvector.metricsContainerPorts" . | nindent 12  }}
             {{- with .Values.extraContainersPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         {{- if not .Values.externalConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/distribution/helm/vector-agent/templates/podmonitor.yaml
+++ b/distribution/helm/vector-agent/templates/podmonitor.yaml
@@ -1,0 +1,1 @@
+{{- include "libvector.metricsPodMonitor" . -}}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -173,6 +173,17 @@ prometheusSink:
   # To be used in clusters that rely on Pod annotations in the form of
   # `prometheus.io/scrape` to discover scrape targets.
   addPodAnnotations: false
+  # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
+  # To be used in clusters that rely on prometheus-operator to gether metrics.
+  # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
+  # using prometheus-operator Helm chart to allow `PodMonitor` resources
+  # dicovery in all namespaces.
+  podMonitor:
+    # Whether to add the `PodMonitor` resource or not.
+    # `prometheus-operator` CRDs are necessary, otherwise you'll get an error.
+    enabled: false
+    # Additional relabelings to include in the `PodMonitor`.
+    extraRelabelings: []
 
 # Sources to add to the generated `vector` config (besides "built-in" kubernetes
 # logs source).

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -166,7 +166,7 @@ prometheusSink:
   # The address to listen at.
   listenAddress: "0.0.0.0"
   # The port to listen at.
-  listenPort: "8080"
+  listenPort: "9090"
   # Raw TOML config to embed at the vector source.
   rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -169,6 +169,10 @@ prometheusSink:
   listenPort: "8080"
   # Raw TOML config to embed at the vector source.
   rawConfig: null
+  # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
+  # To be used in clusters that rely on Pod annotations in the form of
+  # `prometheus.io/scrape` to discover scrape targets.
+  addPodAnnotations: false
 
 # Sources to add to the generated `vector` config (besides "built-in" kubernetes
 # logs source).

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -134,6 +134,42 @@ vectorSink:
   # Raw TOML config to embed at the vector sink.
   rawConfig: null
 
+# The "built-in" internal metrics source emitting Vector's internal opertaional
+# metrics.
+internalMetricsSource:
+  # Disable to omit the internal metrics source from being added.
+  enabled: true
+  # The name to use for the "built-in" internal metrics source.
+  sourceId: internal_metrics
+  # Raw TOML config to embed at the internal metrics source.
+  rawConfig: null
+
+# The "built-in" prometheus sink exposing metrics in the Prometheus scraping
+# format.
+# When using this "built-in" sink, we automatically configure container ports,
+# and ensure things are ready for discovery and scraping via Prometheus'
+# `kubernetes_sd_configs` jobs.
+prometheusSink:
+  # Disable to omit the prometheus sink from being added.
+  enabled: true
+  # The name to use for the "built-in" prometheus sink.
+  sinkId: prometheus_sink
+  # Inputs of the built-in prometheus sink.
+  # If you have built-in internal metrics source enabled, we'll add it as a
+  # input here under the hood, so you don't have to pass it here.
+  # Unless `excludeInternalMetrics` is set to `true`, in which case you're
+  # responsible of wiring up the internal metrics.
+  inputs: []
+  # Set this to `true` to opt-out from automatically adding the built-in
+  # internal metrics source to the inputs.
+  excludeInternalMetrics: false
+  # The address to listen at.
+  listenAddress: "0.0.0.0"
+  # The port to listen at.
+  listenPort: "8080"
+  # Raw TOML config to embed at the vector source.
+  rawConfig: null
+
 # Sources to add to the generated `vector` config (besides "built-in" kubernetes
 # logs source).
 sources: {}

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -34,6 +34,8 @@ data:
       {{- end }}
     {{- end }}
 
+    {{- include "libvector.metricsConfigPartial" . | nindent 4  }}
+
     {{- range $sourceId, $source := .Values.sources }}
     [sources.{{ $sourceId }}]
       type = "{{ $source.type }}"

--- a/distribution/helm/vector-aggregator/templates/podmonitor.yaml
+++ b/distribution/helm/vector-aggregator/templates/podmonitor.yaml
@@ -1,0 +1,1 @@
+{{- include "libvector.metricsPodMonitor" . -}}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -48,6 +48,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
+            {{- include "libvector.metricsContainerPorts" . | nindent 12  }}
             {{- with .Values.extraContainersPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -17,6 +17,7 @@ spec:
         {{- if not .Values.externalConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -209,7 +209,7 @@ prometheusSink:
   # The address to listen at.
   listenAddress: "0.0.0.0"
   # The port to listen at.
-  listenPort: "8080"
+  listenPort: "9090"
   # Raw TOML config to embed at the vector source.
   rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -216,6 +216,17 @@ prometheusSink:
   # To be used in clusters that rely on Pod annotations in the form of
   # `prometheus.io/scrape` to discover scrape targets.
   addPodAnnotations: false
+  # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
+  # To be used in clusters that rely on prometheus-operator to gether metrics.
+  # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
+  # using prometheus-operator Helm chart to allow `PodMonitor` resources
+  # dicovery in all namespaces.
+  podMonitor:
+    # Whether to add the `PodMonitor` resource or not.
+    # `prometheus-operator` CRDs are necessary, otherwise you'll get an error.
+    enabled: false
+    # Additional relabelings to include in the `PodMonitor`.
+    extraRelabelings: []
 
 # Sources to add to the generated `vector` config
 sources: {}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -212,6 +212,10 @@ prometheusSink:
   listenPort: "8080"
   # Raw TOML config to embed at the vector source.
   rawConfig: null
+  # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
+  # To be used in clusters that rely on Pod annotations in the form of
+  # `prometheus.io/scrape` to discover scrape targets.
+  addPodAnnotations: false
 
 # Sources to add to the generated `vector` config
 sources: {}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -177,6 +177,42 @@ vectorSource:
   # Raw TOML config to embed at the vector source.
   rawConfig: null
 
+# The "built-in" internal metrics source emitting Vector's internal opertaional
+# metrics.
+internalMetricsSource:
+  # Disable to omit the internal metrics source from being added.
+  enabled: true
+  # The name to use for the "built-in" internal metrics source.
+  sourceId: internal_metrics
+  # Raw TOML config to embed at the internal metrics source.
+  rawConfig: null
+
+# The "built-in" prometheus sink exposing metrics in the Prometheus scraping
+# format.
+# When using this "built-in" sink, we automatically configure container ports,
+# and ensure things are ready for discovery and scraping via Prometheus'
+# `kubernetes_sd_configs` jobs.
+prometheusSink:
+  # Disable to omit the prometheus sink from being added.
+  enabled: true
+  # The name to use for the "built-in" prometheus sink.
+  sinkId: prometheus_sink
+  # Inputs of the built-in prometheus sink.
+  # If you have built-in internal metrics source enabled, we'll add it as a
+  # input here under the hood, so you don't have to pass it here.
+  # Unless `excludeInternalMetrics` is set to `true`, in which case you're
+  # responsible of wiring up the internal metrics.
+  inputs: []
+  # Set this to `true` to opt-out from automatically adding the built-in
+  # internal metrics source to the inputs.
+  excludeInternalMetrics: false
+  # The address to listen at.
+  listenAddress: "0.0.0.0"
+  # The port to listen at.
+  listenPort: "8080"
+  # Raw TOML config to embed at the vector source.
+  rawConfig: null
+
 # Sources to add to the generated `vector` config
 sources: {}
   # source_name:

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -49,3 +49,17 @@ Internal metrics are common, so we share and reuse the definition.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common Vector Pod annotations to expose the built-in metrics pipeline for
+Prometheus scraping.
+Internal metrics are common, so we share and reuse the definition.
+*/}}
+{{- define "libvector.metricsPrometheusPodAnnotations" -}}
+{{- with .Values.prometheusSink }}
+{{- if and .enabled .addPodAnnotations -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: "{{ .listenPort }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -35,3 +35,17 @@ Internal metrics are common, so we share and reuse the definition.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common Vector container ports used by the built-in metrics pipeline.
+Internal metrics are common, so we share and reuse the definition.
+*/}}
+{{- define "libvector.metricsContainerPorts" -}}
+{{- with .Values.prometheusSink }}
+{{- if .enabled -}}
+- name: metrics
+  containerPort: {{ .listenPort }}
+  protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Common Vector configuration partial containing built-in metrics pipeline.
+Internal metrics are common, so we share and reuse the definition.
+*/}}
+{{- define "libvector.metricsConfigPartial" -}}
+{{- with .Values.internalMetricsSource }}
+{{- if .enabled }}
+# Emit internal Vector metrics.
+[sources.{{ .sourceId }}]
+  type = "internal_metrics"
+
+  {{- with .rawConfig }}
+  {{- . | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- with .Values.prometheusSink }}
+{{- if .enabled }}
+{{- $inputs := .inputs }}
+{{- if and $.Values.internalMetricsSource.enabled (not .excludeInternalMetrics) -}}
+{{- $inputs = prepend $inputs $.Values.internalMetricsSource.sourceId }}
+{{- end }}
+# Expose metrics for scraping in the Prometheus format.
+[sinks.{{ .sinkId }}]
+  type = "prometheus"
+  inputs = {{ $inputs | toJson }}
+  address = "{{ .listenAddress }}:{{ .listenPort }}"
+
+  {{- with .rawConfig }}
+  {{- . | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -78,6 +78,8 @@ metadata:
   labels:
     {{- include "libvector.labels" . | nindent 4 }}
 spec:
+  jobLabel: app.kubernetes.io/name
+
   selector:
     matchLabels:
       {{- include "libvector.selectorLabels" . | nindent 6 }}

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -54,7 +54,7 @@ data:
     [sinks.prometheus_sink]
       type = "prometheus"
       inputs = ["internal_metrics"]
-      address = "0.0.0.0:8080"
+      address = "0.0.0.0:9090"
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.
@@ -113,7 +113,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 71f4cc90c95a020c5a42658ca23574fc958cbe9ef674d78c8419a6d1dc4512bc
+        checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -150,7 +150,7 @@ spec:
               value: info
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: 9090
               protocol: TCP
           resources:
             {}

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -114,6 +114,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 71f4cc90c95a020c5a42658ca23574fc958cbe9ef674d78c8419a6d1dc4512bc
+        
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -46,6 +46,15 @@ data:
     # Ingest logs from Kubernetes.
     [sources.kubernetes_logs]
       type = "kubernetes_logs"
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      type = "prometheus"
+      inputs = ["internal_metrics"]
+      address = "0.0.0.0:8080"
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.
@@ -104,7 +113,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3cdf25b37a769fb1b12b40d3efed89539b7cea6f26110ad0b7166b419e9c9254
+        checksum/config: 71f4cc90c95a020c5a42658ca23574fc958cbe9ef674d78c8419a6d1dc4512bc
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector
@@ -139,6 +148,9 @@ spec:
             - name: LOG
               value: info
           ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           resources:
             {}
           volumeMounts:

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -125,6 +125,7 @@ spec:
     metadata:
       annotations:
         checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
+        
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -55,7 +55,7 @@ data:
     [sinks.prometheus_sink]
       type = "prometheus"
       inputs = ["internal_metrics"]
-      address = "0.0.0.0:8080"
+      address = "0.0.0.0:9090"
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1
@@ -124,7 +124,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
+        checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
       labels:
         app.kubernetes.io/name: vector-aggregator
@@ -148,7 +148,7 @@ spec:
               value: info
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: 9090
               protocol: TCP
           resources:
             {}

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -47,6 +47,15 @@ data:
     [sources.vector]
       type = "vector"
       address = "0.0.0.0:9000"
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      type = "prometheus"
+      inputs = ["internal_metrics"]
+      address = "0.0.0.0:8080"
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1
@@ -115,7 +124,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5ef9ad798d288ca3aec45303d221f8ce0c413ec73d25d498f509fed43a389b8c
+        checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector
@@ -137,6 +146,9 @@ spec:
             - name: LOG
               value: info
           ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           resources:
             {}
           volumeMounts:

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -71,7 +71,7 @@ data:
     [sinks.prometheus_sink]
       type = "prometheus"
       inputs = ["internal_metrics"]
-      address = "0.0.0.0:8080"
+      address = "0.0.0.0:9090"
 ---
 # Source: vector/charts/vector-aggregator/templates/configmap.yaml
 apiVersion: v1
@@ -110,7 +110,7 @@ data:
     [sinks.prometheus_sink]
       type = "prometheus"
       inputs = ["internal_metrics"]
-      address = "0.0.0.0:8080"
+      address = "0.0.0.0:9090"
 ---
 # Source: vector/charts/vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.
@@ -214,7 +214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fdd2b5ef4c07a83ec219b783e458a2d8797ed9b71f18180c1e6e88d2e2edb680
+        checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -251,7 +251,7 @@ spec:
               value: "info"
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: 9090
               protocol: TCP
           resources:
             {}
@@ -323,7 +323,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
+        checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
       labels:
         app.kubernetes.io/name: vector-aggregator
@@ -347,7 +347,7 @@ spec:
               value: "info"
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: 9090
               protocol: TCP
           resources:
             {}

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -215,6 +215,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fdd2b5ef4c07a83ec219b783e458a2d8797ed9b71f18180c1e6e88d2e2edb680
+        
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector
@@ -323,6 +324,7 @@ spec:
     metadata:
       annotations:
         checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
+        
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -63,6 +63,15 @@ data:
       type = "vector"
       inputs = ["kubernetes_logs"]
       address = "vector-aggregator:9000"
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      type = "prometheus"
+      inputs = ["internal_metrics"]
+      address = "0.0.0.0:8080"
 ---
 # Source: vector/charts/vector-aggregator/templates/configmap.yaml
 apiVersion: v1
@@ -93,6 +102,15 @@ data:
     [sources.vector]
       type = "vector"
       address = "0.0.0.0:9000"
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      type = "prometheus"
+      inputs = ["internal_metrics"]
+      address = "0.0.0.0:8080"
 ---
 # Source: vector/charts/vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.
@@ -196,7 +214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b97a22daf2ebfde5eb7486caecd73a826b30715e98fe40cc2c0a3a07ab1dc78
+        checksum/config: fdd2b5ef4c07a83ec219b783e458a2d8797ed9b71f18180c1e6e88d2e2edb680
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector
@@ -231,6 +249,9 @@ spec:
             - name: "LOG"
               value: "info"
           ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           resources:
             {}
           volumeMounts:
@@ -301,7 +322,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5ef9ad798d288ca3aec45303d221f8ce0c413ec73d25d498f509fed43a389b8c
+        checksum/config: e7dd4b56dd953d2210fd1090cf4fadf27424977efb7c8cf0131cd32892761aa5
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector
@@ -323,6 +344,9 @@ spec:
             - name: "LOG"
               value: "info"
           ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           resources:
             {}
           volumeMounts:

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 futures = "0.3"
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }
 k8s-test-framework = { version = "0.1", path = "../k8s-test-framework" }
+regex = "1"
+reqwest = { version = "0.10", features = ["json"] }
 serde_json = "1"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -4,6 +4,8 @@ use k8s_openapi::{
 };
 use k8s_test_framework::{Framework, Interface, Reader};
 
+pub mod metrics;
+
 pub const BUSYBOX_IMAGE: &str = "busybox:1.28";
 
 pub fn make_framework() -> Framework {

--- a/lib/k8s-e2e-tests/src/metrics.rs
+++ b/lib/k8s-e2e-tests/src/metrics.rs
@@ -1,0 +1,75 @@
+/// This helper function issues an HTTP request to the Prometheus-exposition
+/// format metrics endpoint, validates that it completes successfully and
+/// returns the response body.
+pub async fn load(url: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let response = reqwest::get(url).await?.error_for_status()?;
+    let body = response.text().await?;
+    Ok(body)
+}
+
+/// This helper function extracts the sum of `events_processed`-ish metrics
+/// across all labels.
+pub fn extract_events_poccessed_sum(metrics: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let re = regex::RegexBuilder::new(
+        r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)\{(?P<labels>[^}]*)\} (?P<value>.+)$",
+    )
+    .multi_line(true)
+    .build()
+    .expect("invalid regex");
+    re.captures_iter(&metrics)
+        .filter_map(|captures| {
+            let metric_name = &captures["name"];
+            let value = &captures["value"];
+            if !metric_name.contains("events_processed") {
+                return None;
+            }
+            Some(value.to_owned())
+        })
+        .try_fold::<u64, _, Result<u64, Box<dyn std::error::Error>>>(0u64, |acc, value| {
+            let value = value.parse::<u64>()?;
+            let next_acc = acc.checked_add(value).ok_or("u64 overflow")?;
+            Ok(next_acc)
+        })
+}
+
+/// This helper function performs an HTTP request to the specified URL and
+/// extracts the sum of `events_processed`-ish metrics across all labels.
+pub async fn get_events_processed(url: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let metrics = load(url).await?;
+    extract_events_poccessed_sum(&metrics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_events_poccessed_sum() {
+        let cases = vec![
+            (vec![r#"events_processed{} 123"#], 123),
+            (vec![r#"events_processed{method="POST"} 456"#], 456),
+            (
+                vec![
+                    r#"events_processed{} 123"#,
+                    r#"events_processed{method="POST"} 456"#,
+                ],
+                123 + 456,
+            ),
+            (vec![r#"other{} 789"#], 0),
+            (
+                vec![
+                    r#"events_processed{} 123"#,
+                    r#"events_processed{method="POST"} 456"#,
+                    r#"other{} 789"#,
+                ],
+                123 + 456,
+            ),
+        ];
+
+        for (input, expected_value) in cases {
+            let input = input.join("\n");
+            let actual_value = extract_events_poccessed_sum(&input).unwrap();
+            assert_eq!(expected_value, actual_value);
+        }
+    }
+}

--- a/lib/k8s-e2e-tests/src/metrics.rs
+++ b/lib/k8s-e2e-tests/src/metrics.rs
@@ -16,15 +16,15 @@ fn metrics_regex() -> regex::Regex {
     .expect("invalid regex")
 }
 
-/// This helper function extracts the sum of `events_processed`-ish metrics
+/// This helper function extracts the sum of `processed_events`-ish metrics
 /// across all labels.
-pub fn extract_events_poccessed_sum(metrics: &str) -> Result<u64, Box<dyn std::error::Error>> {
+pub fn extract_processed_events_sum(metrics: &str) -> Result<u64, Box<dyn std::error::Error>> {
     metrics_regex()
         .captures_iter(&metrics)
         .filter_map(|captures| {
             let metric_name = &captures["name"];
             let value = &captures["value"];
-            if !metric_name.contains("events_processed") {
+            if !metric_name.contains("processed_events") {
                 return None;
             }
             Some(value.to_owned())
@@ -46,10 +46,10 @@ pub fn extract_vector_started(metrics: &str) -> bool {
 }
 
 /// This helper function performs an HTTP request to the specified URL and
-/// extracts the sum of `events_processed`-ish metrics across all labels.
-pub async fn get_events_processed(url: &str) -> Result<u64, Box<dyn std::error::Error>> {
+/// extracts the sum of `processed_events`-ish metrics across all labels.
+pub async fn get_processed_events(url: &str) -> Result<u64, Box<dyn std::error::Error>> {
     let metrics = load(url).await?;
-    extract_events_poccessed_sum(&metrics)
+    extract_processed_events_sum(&metrics)
 }
 
 /// This helper function performs an HTTP request to the specified URL and
@@ -93,25 +93,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_events_poccessed_sum() {
+    fn test_extract_processed_events_sum() {
         let cases = vec![
             (vec![r#""#], 0),
-            (vec![r#"events_processed 123"#], 123),
-            (vec![r#"events_processed{} 123"#], 123),
-            (vec![r#"events_processed{method="POST"} 456"#], 456),
-            (vec![r#"events_processed{a="b",c="d"} 456"#], 456),
+            (vec![r#"processed_events 123"#], 123),
+            (vec![r#"processed_events{} 123"#], 123),
+            (vec![r#"processed_events{method="POST"} 456"#], 456),
+            (vec![r#"processed_events{a="b",c="d"} 456"#], 456),
             (
                 vec![
-                    r#"events_processed 123"#,
-                    r#"events_processed{method="POST"} 456"#,
+                    r#"processed_events 123"#,
+                    r#"processed_events{method="POST"} 456"#,
                 ],
                 123 + 456,
             ),
             (vec![r#"other{} 789"#], 0),
             (
                 vec![
-                    r#"events_processed{} 123"#,
-                    r#"events_processed{method="POST"} 456"#,
+                    r#"processed_events{} 123"#,
+                    r#"processed_events{method="POST"} 456"#,
                     r#"other{} 789"#,
                 ],
                 123 + 456,
@@ -119,10 +119,10 @@ mod tests {
             // Prefixes and suffixes
             (
                 vec![
-                    r#"events_processed 1"#,
-                    r#"events_processed_total 2"#,
-                    r#"vector_events_processed 3"#,
-                    r#"vector_events_processed_total 4"#,
+                    r#"processed_events 1"#,
+                    r#"processed_events_total 2"#,
+                    r#"vector_processed_events 3"#,
+                    r#"vector_processed_events_total 4"#,
                 ],
                 1 + 2 + 3 + 4,
             ),
@@ -130,7 +130,7 @@ mod tests {
 
         for (input, expected_value) in cases {
             let input = input.join("\n");
-            let actual_value = extract_events_poccessed_sum(&input).unwrap();
+            let actual_value = extract_processed_events_sum(&input).unwrap();
             assert_eq!(expected_value, actual_value);
         }
     }

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1383,7 +1383,12 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let events_processed_after = metrics::get_events_processed(&vector_metrics_url).await?;
 
     // Ensure we did get at least one event since before deployed the test pod.
-    assert!(events_processed_after >= events_processed_before + 1);
+    assert!(
+        events_processed_after >= events_processed_before + 1,
+        "before: {}, after: {}",
+        events_processed_before,
+        events_processed_after
+    );
 
     drop(test_pod);
     drop(test_namespace);

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1333,19 +1333,19 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // We want to capture the initial value for the `events_processed` metric,
+    // We want to capture the initial value for the `processed_events` metric,
     // but until the `kubernetes_logs` source loads the `Pod`s list, it's
     // internal file server discovers the log files, and some events get
     // a chance to be processed - we don't have a reason to beleive that
-    // the `events_processed` is even defined.
+    // the `processed_events` is even defined.
     // We give Vector some reasonable time to perform this initial bootstrap,
-    // and capture the `events_processed` value afterwards.
+    // and capture the `processed_events` value afterwards.
     println!("Waiting for Vector bootstrap");
     tokio::time::delay_for(std::time::Duration::from_secs(30)).await;
     println!("Done waiting for Vector bootstrap");
 
     // Capture events processed before deploying the test pod.
-    let events_processed_before = metrics::get_events_processed(&vector_metrics_url).await?;
+    let processed_events_before = metrics::get_processed_events(&vector_metrics_url).await?;
 
     let test_namespace = framework.namespace("test-vector-test-pod").await?;
 
@@ -1405,14 +1405,14 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     println!("Done waiting for `internal_metrics` to update");
 
     // Capture events processed after the test pod has finished.
-    let events_processed_after = metrics::get_events_processed(&vector_metrics_url).await?;
+    let processed_events_after = metrics::get_processed_events(&vector_metrics_url).await?;
 
     // Ensure we did get at least one event since before deployed the test pod.
     assert!(
-        events_processed_after > events_processed_before,
+        processed_events_after > processed_events_before,
         "before: {}, after: {}",
-        events_processed_before,
-        events_processed_after
+        processed_events_before,
+        processed_events_after
     );
 
     drop(test_pod);

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1325,6 +1325,9 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         vector_metrics_port_forward.local_addr_ipv4()
     );
 
+    // Assert that `vector_started`-ish metric is present.
+    metrics::assert_vector_started(&vector_metrics_url).await?;
+
     // Capture events processed before deploying the test pod.
     let events_processed_before = metrics::get_events_processed(&vector_metrics_url).await?;
 

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1317,11 +1317,12 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let vector_metrics_port_forward =
+    let mut vector_metrics_port_forward =
         framework.port_forward("test-vector", "daemonset/vector-agent", 8080, 8080)?;
+    vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
-        "http://localhost:{}/metrics",
-        vector_metrics_port_forward.local_port()
+        "http://{}/metrics",
+        vector_metrics_port_forward.local_addr_ipv4()
     );
 
     // Capture events processed before deploying the test pod.

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1318,7 +1318,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let mut vector_metrics_port_forward =
-        framework.port_forward("test-vector", "daemonset/vector-agent", 8080, 8080)?;
+        framework.port_forward("test-vector", "daemonset/vector-agent", 9090, 9090)?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1325,8 +1325,13 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         vector_metrics_port_forward.local_addr_ipv4()
     );
 
-    // Assert that `vector_started`-ish metric is present.
-    metrics::assert_vector_started(&vector_metrics_url).await?;
+    // Wait that `vector_started`-ish metric is present.
+    metrics::wait_for_vector_started(
+        &vector_metrics_url,
+        std::time::Duration::from_secs(5),
+        std::time::Instant::now() + std::time::Duration::from_secs(60),
+    )
+    .await?;
 
     // We want to capture the initial value for the `events_processed` metric,
     // but until the `kubernetes_logs` source loads the `Pod`s list, it's

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1409,7 +1409,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
 
     // Ensure we did get at least one event since before deployed the test pod.
     assert!(
-        events_processed_after >= events_processed_before + 1,
+        events_processed_after > events_processed_before,
         "before: {}, after: {}",
         events_processed_before,
         events_processed_after

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -48,3 +48,41 @@ async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
     drop(vector);
     Ok(())
 }
+
+/// This test validates that vector-aggregator chart properly exposes metrics in
+/// a Prometheus scraping format ot of the box.
+#[tokio::test]
+async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let framework = make_framework();
+
+    let vector = framework
+        .vector(
+            "test-vector",
+            HELM_CHART_VECTOR_AGGREGATOR,
+            VectorConfig::default(),
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            "test-vector",
+            "statefulset/vector-aggregator",
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let mut vector_metrics_port_forward =
+        framework.port_forward("test-vector", "statefulset/vector-aggregator", 8080, 8080)?;
+    vector_metrics_port_forward.wait_until_ready().await?;
+    let vector_metrics_url = format!(
+        "http://{}/metrics",
+        vector_metrics_port_forward.local_addr_ipv4()
+    );
+
+    // Assert that `vector_started`-ish metric is present.
+    metrics::assert_vector_started(&vector_metrics_url).await?;
+
+    drop(vector_metrics_port_forward);
+    drop(vector);
+    Ok(())
+}

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -72,7 +72,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let mut vector_metrics_port_forward =
-        framework.port_forward("test-vector", "statefulset/vector-aggregator", 8080, 8080)?;
+        framework.port_forward("test-vector", "statefulset/vector-aggregator", 9090, 9090)?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -80,7 +80,12 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Assert that `vector_started`-ish metric is present.
-    metrics::assert_vector_started(&vector_metrics_url).await?;
+    metrics::wait_for_vector_started(
+        &vector_metrics_url,
+        std::time::Duration::from_secs(5),
+        std::time::Instant::now() + std::time::Duration::from_secs(60),
+    )
+    .await?;
 
     drop(vector_metrics_port_forward);
     drop(vector);

--- a/lib/k8s-test-framework/src/exec_tail.rs
+++ b/lib/k8s-test-framework/src/exec_tail.rs
@@ -7,7 +7,7 @@ use tokio::process::Command;
 /// Exec a `tail` command reading the specified `file` within a `Container`
 /// in a `Pod` of a specified `resource` at the specified `namespace` via the
 /// specified `kubectl_command`.
-/// Returns a [`Reader`] that managed the reading process.
+/// Returns a [`Reader`] that manages the reading process.
 pub fn exec_tail(
     kubectl_command: &str,
     namespace: &str,

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -1,8 +1,8 @@
 //! The test framework main entry point.
 
 use super::{
-    exec_tail, kubernetes_version, log_lookup, namespace, test_pod, up_down, vector,
-    wait_for_resource, wait_for_rollout, Interface, Reader, Result,
+    exec_tail, kubernetes_version, log_lookup, namespace, port_forward, test_pod, up_down, vector,
+    wait_for_resource, wait_for_rollout, Interface, PortForwarder, Reader, Result,
 };
 
 /// Framework wraps the interface to the system with an easy-to-use rust API
@@ -66,6 +66,24 @@ impl Framework {
     /// `namespace`.
     pub fn exec_tail(&self, namespace: &str, resource: &str, file: &str) -> Result<Reader> {
         exec_tail(&self.interface.kubectl_command, namespace, resource, file)
+    }
+
+    /// Initialize port forward for a particular `resource` in a particular
+    /// `namespace` with a partucular pair of local/resource ports.
+    pub fn port_forward(
+        &self,
+        namespace: &str,
+        resource: &str,
+        local_port: u16,
+        resource_port: u16,
+    ) -> Result<PortForwarder> {
+        port_forward(
+            &self.interface.kubectl_command,
+            namespace,
+            resource,
+            local_port,
+            resource_port,
+        )
     }
 
     /// Exect a `kubectl --version`command returning a K8sVersion Struct

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -23,6 +23,7 @@ pub mod kubernetes_version;
 mod lock;
 mod log_lookup;
 pub mod namespace;
+mod port_forward;
 mod reader;
 mod resource_file;
 mod temp_file;
@@ -40,6 +41,8 @@ pub use framework::Framework;
 pub use interface::Interface;
 pub use lock::lock;
 use log_lookup::log_lookup;
+use port_forward::port_forward;
+pub use port_forward::PortForwarder;
 pub use reader::Reader;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/lib/k8s-test-framework/src/log_lookup.rs
+++ b/lib/k8s-test-framework/src/log_lookup.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 
 /// Initiate a log lookup (`kubectl log`) with the specified `kubectl_command`
 /// for the specified `resource` at the specified `namespace`.
-/// Returns a [`Reader`] that managed the reading process.
+/// Returns a [`Reader`] that manages the reading process.
 pub fn log_lookup(kubectl_command: &str, namespace: &str, resource: &str) -> Result<Reader> {
     let mut command = Command::new(kubectl_command);
 

--- a/lib/k8s-test-framework/src/port_forward.rs
+++ b/lib/k8s-test-framework/src/port_forward.rs
@@ -1,0 +1,71 @@
+//! Perform a port forward from a port listening on a local system to the
+//! a port exposed from a cluster-deployed resource.
+
+use super::Result;
+use std::process::{ExitStatus, Stdio};
+use tokio::process::{Child, Command};
+
+/// Initiate a port forward (`kubectl port-forward`) with the specified
+/// `kubectl_command` for the specified `resource` at the specified `namespace`
+/// and the specified local/cluster-resource ports pair.
+/// Returns a [`PortForwarder`] that manages the process.
+pub fn port_forward(
+    kubectl_command: &str,
+    namespace: &str,
+    resource: &str,
+    local_port: u16,
+    resource_port: u16,
+) -> Result<PortForwarder> {
+    let mut command = Command::new(kubectl_command);
+
+    command
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::inherit());
+
+    command.arg("port-forward");
+    command.arg("-n").arg(namespace);
+    command.arg(resource);
+    command.arg(format!("{}:{}", local_port, resource_port));
+
+    command.kill_on_drop(true);
+
+    let child = command.spawn()?;
+    Ok(PortForwarder {
+        child,
+        local_port,
+        resource_port,
+    })
+}
+
+/// Keeps track of the continiously running `kubectl port-forward` command,
+/// exposing the API to terminate it when needed.
+#[derive(Debug)]
+pub struct PortForwarder {
+    child: Child,
+    local_port: u16,
+    resource_port: u16,
+}
+
+impl PortForwarder {
+    /// Returns the local port that port forward was requested to listen on.
+    pub fn local_port(&self) -> u16 {
+        self.local_port
+    }
+
+    /// Returns the resource port that port forward was requested to forward to.
+    pub fn resource_port(&self) -> u16 {
+        self.resource_port
+    }
+
+    /// Wait for the `kubectl port-forward` process to exit and return the exit
+    /// code.
+    pub async fn wait(&mut self) -> std::io::Result<ExitStatus> {
+        (&mut self.child).await
+    }
+
+    /// Send a termination signal to the `kubectl port-forward` process.
+    pub fn kill(&mut self) -> std::io::Result<()> {
+        self.child.kill()
+    }
+}

--- a/lib/k8s-test-framework/src/port_forward.rs
+++ b/lib/k8s-test-framework/src/port_forward.rs
@@ -3,7 +3,10 @@
 
 use super::Result;
 use std::process::{ExitStatus, Stdio};
-use tokio::process::{Child, Command};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, ChildStdout, Command},
+};
 
 /// Initiate a port forward (`kubectl port-forward`) with the specified
 /// `kubectl_command` for the specified `resource` at the specified `namespace`
@@ -21,7 +24,7 @@ pub fn port_forward(
     command
         .stdin(Stdio::null())
         .stderr(Stdio::inherit())
-        .stdout(Stdio::inherit());
+        .stdout(Stdio::piped());
 
     command.arg("port-forward");
     command.arg("-n").arg(namespace);
@@ -30,11 +33,15 @@ pub fn port_forward(
 
     command.kill_on_drop(true);
 
-    let child = command.spawn()?;
+    let mut child = command.spawn()?;
+    let stdout = child.stdout.take().unwrap();
+    let reader = BufReader::new(stdout);
+
     Ok(PortForwarder {
-        child,
         local_port,
         resource_port,
+        child,
+        reader,
     })
 }
 
@@ -42,12 +49,48 @@ pub fn port_forward(
 /// exposing the API to terminate it when needed.
 #[derive(Debug)]
 pub struct PortForwarder {
-    child: Child,
     local_port: u16,
     resource_port: u16,
+    child: Child,
+    reader: BufReader<ChildStdout>,
 }
 
 impl PortForwarder {
+    /// Waits for port forward process to start listening on IPv4 and IPv6 local
+    /// sockets.
+    pub async fn wait_until_ready(&mut self) -> Result<()> {
+        let ready_string_ipv4 = format!(
+            "Forwarding from 127.0.0.1:{} -> {}",
+            self.local_port, self.resource_port
+        );
+        let ready_string_ipv6 = format!(
+            "Forwarding from [::1]:{} -> {}",
+            self.local_port, self.resource_port
+        );
+
+        let mut buf = String::new();
+        let mut seen_ipv4 = false;
+        let mut seen_ipv6 = false;
+        loop {
+            self.reader.read_line(&mut buf).await?;
+            print!("{}", &buf);
+
+            if buf.contains(&ready_string_ipv4) {
+                seen_ipv4 = true;
+            }
+            if buf.contains(&ready_string_ipv6) {
+                seen_ipv6 = true;
+            }
+
+            buf.clear();
+
+            if seen_ipv4 && seen_ipv6 {
+                break;
+            }
+        }
+        Ok(())
+    }
+
     /// Returns the local port that port forward was requested to listen on.
     pub fn local_port(&self) -> u16 {
         self.local_port
@@ -56,6 +99,18 @@ impl PortForwarder {
     /// Returns the resource port that port forward was requested to forward to.
     pub fn resource_port(&self) -> u16 {
         self.resource_port
+    }
+
+    /// Returns the local address (in the "host:port" form) to connect to
+    /// in order to reach the cluster resource port, at the IPv4 address family.
+    pub fn local_addr_ipv4(&self) -> String {
+        format!("127.0.0.1:{}", self.local_port)
+    }
+
+    /// Returns the local address (in the "host:port" form) to connect to
+    /// in order to reach the cluster resource port, at the IPv6 address family.
+    pub fn local_addr_ipv6(&self) -> String {
+        format!("[::1]:{}", self.local_port)
     }
 
     /// Wait for the `kubectl port-forward` process to exit and return the exit

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -116,6 +116,7 @@ if [[ -z "${SKIP_CONTAINER_IMAGE_PUBLISHING:-}" ]]; then
   # Make the container image accessible to the k8s cluster.
   if is_minikube_cache_enabled; then
     minikube cache add "$CONTAINER_IMAGE"
+    trap 'minikube cache delete "$CONTAINER_IMAGE"' EXIT
   else
     docker push "$CONTAINER_IMAGE"
   fi


### PR DESCRIPTION
This PR adds support for exposing `internal_metrics` via a `prometheus` sink in out Helm charts out of the box.
It also adds opt-in Prometheus annotations to `Pod` (`prometheus.io/scrape: "true"` and etc) and `prometheus-operator`-powered `PodMonitor` to simplify the integration into the existing cluster monitoring pipelines.

Closes #3799.

To do:

- [x] `prometheus` annotations
- [x] `prometheus-operator` `PodMonotor`s
- [x] E2E tests
- [x] fix race condition at E2E tests (https://github.com/timberio/vector/runs/1363029594?check_suite_focus=true)
- [ ] docs