### PR TITLE
enhancement(remap): display full error chain

### DIFF
--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -12,7 +12,7 @@ use expression::Expr;
 use operator::Operator;
 
 pub mod prelude;
-pub use error::Error;
+pub use error::{Error, RemapError};
 pub use expression::{Expression, Literal, Noop, Path};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
@@ -233,17 +233,14 @@ mod tests {
             ),
         ];
 
-        for (script, result) in cases {
-            let program = Program::new(script, &[Box::new(RegexPrinter)])
-                .map_err(|e| {
-                    println!("{}", &e);
-                    e
-                })
-                .unwrap();
+        for (script, expectation) in cases {
+            let program = Program::new(script, &[Box::new(RegexPrinter)]).unwrap();
             let mut runtime = Runtime::new(State::default());
             let mut event = HashMap::default();
 
-            assert_eq!(runtime.execute(&mut event, &program), result);
+            let result = runtime.execute(&mut event, &program).map_err(|e| e.0);
+
+            assert_eq!(expectation, result);
         }
     }
 }

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -1,4 +1,4 @@
-use crate::{parser, Error, Expr, Function, Result};
+use crate::{parser, Error, Expr, Function, RemapError};
 use pest::Parser;
 
 /// The program to execute.
@@ -13,14 +13,18 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn new(source: &str, function_definitions: &[Box<dyn Function>]) -> Result<Self> {
+    pub fn new(
+        source: &str,
+        function_definitions: &[Box<dyn Function>],
+    ) -> Result<Self, RemapError> {
         let pairs = parser::Parser::parse(parser::Rule::program, source)
-            .map_err(|s| Error::Parser(s.to_string()))?;
+            .map_err(|s| Error::Parser(s.to_string()))
+            .map_err(RemapError)?;
 
         let parser = parser::Parser {
             function_definitions,
         };
-        let expressions = parser.pairs_to_expressions(pairs)?;
+        let expressions = parser.pairs_to_expressions(pairs).map_err(RemapError)?;
 
         Ok(Self { expressions })
     }

--- a/lib/remap-lang/src/runtime.rs
+++ b/lib/remap-lang/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{Expression, Object, Program, Result, State, Value};
+use crate::{Expression, Object, Program, RemapError, State, Value};
 
 #[derive(Debug, Default)]
 pub struct Runtime {
@@ -16,12 +16,13 @@ impl Runtime {
         &mut self,
         object: &mut impl Object,
         program: &Program,
-    ) -> Result<Option<Value>> {
+    ) -> Result<Option<Value>, RemapError> {
         let mut values = program
             .expressions
             .iter()
             .map(|expression| expression.execute(&mut self.state, object))
-            .collect::<Result<Vec<Option<Value>>>>()?;
+            .collect::<crate::Result<Vec<Option<Value>>>>()
+            .map_err(RemapError)?;
 
         Ok(values.pop().flatten())
     }

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -34,7 +34,7 @@ pub struct Remap {
 }
 
 impl Remap {
-    fn execute(&self, event: &Event) -> remap::Result<Option<remap::Value>> {
+    fn execute(&self, event: &Event) -> Result<Option<remap::Value>, remap::RemapError> {
         // TODO(jean): This clone exists until remap-lang has an "immutable"
         // mode.
         //
@@ -130,7 +130,7 @@ mod test {
                 log_event![],
                 ".",
                 Err(
-                    "parser error:  --> 1:2\n  |\n1 | .\n  |  ^---\n  |\n  = expected path_segment",
+                    "remap error: parser error:  --> 1:2\n  |\n1 | .\n  |  ^---\n  |\n  = expected path_segment",
                 ),
                 Ok(()),
             ),


### PR DESCRIPTION
This change makes sure we get more detailed error messages in Vector's log output whenever a remap-lang error occurs.

It changes this:

```
error for function "foo_func"
```

Into this:

```
remap error: error for function "foo_func": missing required argument "arg1" (position 0)
```