### PR TITLE
chore(metrics): Make Kubernetes op_kind an enum

### DIFF
--- a/src/internal_events/kubernetes/instrumenting_state.rs
+++ b/src/internal_events/kubernetes/instrumenting_state.rs
@@ -20,38 +20,60 @@ pub struct StateMaintenanceRequested;
 #[derive(Debug)]
 pub struct StateMaintenancePerformed;
 
+enum OpKind {
+    ItemAdded,
+    ItemDeleted,
+    ItemUpdated,
+    MaintenancePerformed,
+    MaintenanceRequested,
+    Resynced,
+}
+
+impl OpKind {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::ItemAdded => "item_added",
+            Self::ItemDeleted => "item_deleted",
+            Self::ItemUpdated => "item_updated",
+            Self::MaintenancePerformed => "maintenance_performed",
+            Self::MaintenanceRequested => "maintenance_requested",
+            Self::Resynced => "resynced",
+        }
+    }
+}
+
 impl InternalEvent for StateItemAdded {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_added");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::ItemAdded.as_str());
     }
 }
 
 impl InternalEvent for StateItemUpdated {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_updated");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::ItemUpdated.as_str());
     }
 }
 
 impl InternalEvent for StateItemDeleted {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "item_deleted");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::ItemDeleted.as_str());
     }
 }
 
 impl InternalEvent for StateResynced {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "resynced");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::Resynced.as_str());
     }
 }
 
 impl InternalEvent for StateMaintenanceRequested {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "maintenance_requested");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::MaintenanceRequested.as_str());
     }
 }
 
 impl InternalEvent for StateMaintenancePerformed {
     fn emit_metrics(&self) {
-        counter!("k8s_state_ops_total", 1, "op_kind" => "maintenance_performed");
+        counter!("k8s_state_ops_total", 1, "op_kind" => OpKind::MaintenancePerformed.as_str());
     }
 }


### PR DESCRIPTION
Aligned with the goals of PR #4848, this PR makes the `op_kind` field in Kubernetes metrics an enum, which has the same benefits as those outlined in that other PR.