### PR TITLE
enhancement(kubernetes_logs source): Add PodIPs into Pod Metadata event annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ pulsar = { version = "1.0.0", default-features = false, features = ["tokio-runti
 task-compat = "0.1"
 cidr-utils = "0.4.2"
 pin-project = "1.0.1"
-k8s-openapi = { version = "0.9", features = ["v1_15"], optional = true }
+k8s-openapi = { version = "0.9", features = ["v1_16"], optional = true }
 portpicker = "0.1.0"
 sha-1 = "0.9"
 sha2 = "0.9"

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -7,7 +7,7 @@ description = "End-to-end tests of Vector in the Kubernetes environment"
 
 [dependencies]
 futures = "0.3"
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_15"] }
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }
 k8s-test-framework = { version = "0.1", path = "../k8s-test-framework" }
 serde_json = "1"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -4,6 +4,7 @@ use k8s_test_framework::{
     lock, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
 use std::collections::HashSet;
+use std::str::FromStr;
 
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
@@ -413,6 +414,8 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
+    let k8s_version = framework.kubernetes_version().await?;
+    let minor = u8::from_str(&k8s_version.minor()).expect("Couldn't get u8 from String!");
 
     // Read the rest of the log lines.
     let mut got_marker = false;
@@ -442,6 +445,16 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(val["kubernetes"]["pod_uid"].as_str().unwrap().len(), 36); // 36 is a standard UUID string length
         assert_eq!(val["kubernetes"]["pod_labels"]["label1"], "hello");
         assert_eq!(val["kubernetes"]["pod_labels"]["label2"], "world");
+
+        if minor < 16 {
+            assert!(val["kubernetes"]["pod_ip"].is_string());
+        } else {
+            assert!(val["kubernetes"]["pod_ip"].is_string());
+            assert!(!val["kubernetes"]["pod_ips"]
+                .as_array()
+                .expect("Couldn't take array from expected vec")
+                .is_empty());
+        }
         // We don't have the node name to compare this to, so just assert it's
         // a non-empty string.
         assert!(!val["kubernetes"]["pod_node_name"]

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Kubernetes Test Framework used to test Vector in Kubernetes"
 
 [dependencies]
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_15"] }
+k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }
 serde_json = "1"
 tempfile = "3"
 once_cell = "1"

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -1,8 +1,8 @@
 //! The test framework main entry point.
 
 use super::{
-    exec_tail, log_lookup, namespace, test_pod, up_down, vector, wait_for_resource,
-    wait_for_rollout, Interface, Reader, Result,
+    exec_tail, kubernetes_version, log_lookup, namespace, test_pod, up_down, vector,
+    wait_for_resource, wait_for_rollout, Interface, Reader, Result,
 };
 
 /// Framework wraps the interface to the system with an easy-to-use rust API
@@ -66,6 +66,12 @@ impl Framework {
     /// `namespace`.
     pub fn exec_tail(&self, namespace: &str, resource: &str, file: &str) -> Result<Reader> {
         exec_tail(&self.interface.kubectl_command, namespace, resource, file)
+    }
+
+    /// Exect a `kubectl --version`command returning a K8sVersion Struct
+    /// containing all version information  of the running Kubernetes test cluster.
+    pub async fn kubernetes_version(&self) -> Result<kubernetes_version::K8sVersion> {
+        kubernetes_version::get(&self.interface.kubectl_command).await
     }
 
     /// Wait for a set of `resources` in a specified `namespace` to achieve

--- a/lib/k8s-test-framework/src/kubernetes_version.rs
+++ b/lib/k8s-test-framework/src/kubernetes_version.rs
@@ -1,0 +1,70 @@
+//! Perform a version lookup.
+use super::Result;
+
+use std::process::Stdio;
+use tokio::process::Command;
+
+/// Exec a `kubectl` command to pull down the kubernetes version
+/// metadata for a running cluster for use in the test framework
+pub async fn get(kubectl_command: &str) -> Result<K8sVersion> {
+    let mut command = Command::new(kubectl_command);
+    command
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::piped());
+
+    command.arg("version");
+    command.arg("-o").arg("json");
+
+    command.kill_on_drop(true);
+
+    let reader = command.output().await?;
+    let json: serde_json::Value = serde_json::from_slice(&reader.stdout)?;
+
+    Ok(K8sVersion {
+        major: json["serverVersion"]["major"].to_string().replace("\"", ""),
+        minor: json["serverVersion"]["minor"].to_string().replace("\"", ""),
+        platform: json["serverVersion"]["platform"]
+            .to_string()
+            .replace("\"", ""),
+        git_version: json["serverVersion"]["gitVersion"]
+            .to_string()
+            .replace("\"", ""),
+    })
+}
+
+/// Maps K8s version metadata to struct to provide accessor
+/// methoads for use in testing framework
+#[derive(Debug)]
+pub struct K8sVersion {
+    /// Server Major Version
+    major: String,
+    /// Server Minor Version
+    minor: String,
+    /// Server Platform Target
+    platform: String,
+    /// Fully Qualified Version Number
+    git_version: String,
+}
+
+impl K8sVersion {
+    /// Accessor method for returning major version
+    pub fn major(&self) -> String {
+        self.major.to_string()
+    }
+
+    /// Accessor method for returning minor version
+    pub fn minor(&self) -> String {
+        self.minor.to_string()
+    }
+
+    /// Accessor method for returning platform target
+    pub fn platform(&self) -> String {
+        self.platform.to_string()
+    }
+
+    /// Accessor method for returning fully qualified version
+    pub fn version(&self) -> String {
+        self.git_version.to_string()
+    }
+}

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -19,6 +19,7 @@ mod exec_tail;
 pub mod framework;
 mod helm_values_file;
 pub mod interface;
+pub mod kubernetes_version;
 mod lock;
 mod log_lookup;
 pub mod namespace;

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use evmap::ReadHandle;
 use k8s_openapi::{
-    api::core::v1::{Container, Pod, PodSpec},
+    api::core::v1::{Container, Pod, PodSpec, PodStatus},
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,8 @@ pub struct FieldsSpec {
     pub pod_name: String,
     pub pod_namespace: String,
     pub pod_uid: String,
+    pub pod_ip: String,
+    pub pod_ips: String,
     pub pod_labels: String,
     pub pod_node_name: String,
     pub container_name: String,
@@ -32,6 +34,8 @@ impl Default for FieldsSpec {
             pod_name: "kubernetes.pod_name".to_owned(),
             pod_namespace: "kubernetes.pod_namespace".to_owned(),
             pod_uid: "kubernetes.pod_uid".to_owned(),
+            pod_ip: "kubernetes.pod_ip".to_owned(),
+            pod_ips: "kubernetes.pod_ips".to_owned(),
             pod_labels: "kubernetes.pod_labels".to_owned(),
             pod_node_name: "kubernetes.pod_node_name".to_owned(),
             container_name: "kubernetes.container_name".to_owned(),
@@ -72,6 +76,7 @@ impl PodMetadataAnnotator {
 
         annotate_from_file_info(log, &self.fields_spec, &file_info);
         annotate_from_metadata(log, &self.fields_spec, &pod.metadata);
+
         if let Some(ref pod_spec) = pod.spec {
             annotate_from_pod_spec(log, &self.fields_spec, pod_spec);
 
@@ -82,6 +87,10 @@ impl PodMetadataAnnotator {
             if let Some(container) = container {
                 annotate_from_container(log, &self.fields_spec, container);
             }
+        }
+
+        if let Some(ref pod_status) = pod.status {
+            annotate_from_pod_status(log, &self.fields_spec, pod_status);
         }
         Some(())
     }
@@ -130,6 +139,24 @@ fn annotate_from_pod_spec(log: &mut LogEvent, fields_spec: &FieldsSpec, pod_spec
     }
 }
 
+fn annotate_from_pod_status(log: &mut LogEvent, fields_spec: &FieldsSpec, pod_status: &PodStatus) {
+    for (ref key, ref val) in [(&fields_spec.pod_ip, &pod_status.pod_ip)].iter() {
+        if let Some(val) = val {
+            log.insert(key, val.to_owned());
+        }
+    }
+
+    for (ref key, ref val) in [(&fields_spec.pod_ips, &pod_status.pod_ips)].iter() {
+        if let Some(val) = val {
+            let inner: Vec<String> = val
+                .iter()
+                .filter_map(|v| v.ip.clone())
+                .collect::<Vec<String>>();
+            log.insert(key, inner);
+        }
+    }
+}
+
 fn annotate_from_container(log: &mut LogEvent, fields_spec: &FieldsSpec, container: &Container) {
     for (ref key, ref val) in [(&fields_spec.container_image, &container.image)].iter() {
         if let Some(val) = val {
@@ -141,6 +168,7 @@ fn annotate_from_container(log: &mut LogEvent, fields_spec: &FieldsSpec, contain
 #[cfg(test)]
 mod tests {
     use super::*;
+    use k8s_openapi::api::core::v1::PodIP;
 
     #[test]
     fn test_annotate_from_metadata() {
@@ -319,6 +347,106 @@ mod tests {
         for (fields_spec, pod_spec, expected) in cases.into_iter() {
             let mut log = LogEvent::default();
             annotate_from_pod_spec(&mut log, &fields_spec, &pod_spec);
+            assert_eq!(log, expected);
+        }
+    }
+
+    #[test]
+    fn test_annotate_from_pod_status() {
+        let cases = vec![
+            (
+                FieldsSpec::default(),
+                PodStatus::default(),
+                LogEvent::default(),
+            ),
+            (
+                FieldsSpec::default(),
+                PodStatus {
+                    pod_ip: Some("192.168.1.2".to_owned()),
+                    ..Default::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("kubernetes.pod_ip", "192.168.1.2");
+                    log
+                },
+            ),
+            (
+                FieldsSpec::default(),
+                PodStatus {
+                    pod_ips: Some(vec![PodIP {
+                        ip: Some("192.168.1.2".to_owned()),
+                    }]),
+                    ..Default::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    let mut ips_vec = Vec::new();
+                    ips_vec.push("192.168.1.2");
+                    log.insert("kubernetes.pod_ips", ips_vec);
+                    log
+                },
+            ),
+            (
+                FieldsSpec {
+                    pod_ip: "kubernetes.custom_pod_ip".to_owned(),
+                    pod_ips: "kubernetes.custom_pod_ips".to_owned(),
+                    ..FieldsSpec::default()
+                },
+                PodStatus {
+                    pod_ip: Some("192.168.1.2".to_owned()),
+                    pod_ips: Some(vec![
+                        PodIP {
+                            ip: Some("192.168.1.2".to_owned()),
+                        },
+                        PodIP {
+                            ip: Some("192.168.1.3".to_owned()),
+                        },
+                    ]),
+                    ..Default::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("kubernetes.custom_pod_ip", "192.168.1.2");
+                    let mut ips_vec = Vec::new();
+                    ips_vec.push("192.168.1.2");
+                    ips_vec.push("192.168.1.3");
+                    log.insert("kubernetes.custom_pod_ips", ips_vec);
+                    log
+                },
+            ),
+            (
+                FieldsSpec {
+                    pod_node_name: "node_name".to_owned(),
+                    ..FieldsSpec::default()
+                },
+                PodStatus {
+                    pod_ip: Some("192.168.1.2".to_owned()),
+                    pod_ips: Some(vec![
+                        PodIP {
+                            ip: Some("192.168.1.2".to_owned()),
+                        },
+                        PodIP {
+                            ip: Some("192.168.1.3".to_owned()),
+                        },
+                    ]),
+                    ..Default::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("kubernetes.pod_ip", "192.168.1.2");
+                    let mut ips_vec = Vec::new();
+                    ips_vec.push("192.168.1.2");
+                    ips_vec.push("192.168.1.3");
+                    log.insert("kubernetes.pod_ips", ips_vec);
+                    log
+                },
+            ),
+        ];
+
+        for (fields_spec, pod_status, expected) in cases.into_iter() {
+            let mut log = LogEvent::default();
+            annotate_from_pod_status(&mut log, &fields_spec, &pod_status);
             assert_eq!(log, expected);
         }
     }


### PR DESCRIPTION
Closes #4740 

Will probably need a thorough review @MOZGIII but ultimately pretty trivial. We tap `k8s_openapi` to get the `PodStatus` data that holds `PodIPs`. This also bumps the k8s feature level to `1_16` to support returning both the IPv4 _and_ IPv6 addresses attached to a pod in the case that both things do in fact exist.

Signed-off-by: Ian Henry <ianjhenry00@gmail.com>

