### PR TITLE
chore(file source)!: migrate checkpoints to single JSON file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,8 @@ dependencies = [
  "quickcheck",
  "rand 0.7.3",
  "scan_fmt",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing 0.1.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ name = "file-source"
 version = "0.1.0"
 dependencies = [
  "bytes 0.5.6",
+ "chrono",
  "crc",
  "flate2",
  "futures 0.3.5",

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -17,6 +17,8 @@ flate2 = "1.0.6"
 winapi = { version = "0.3", features = ["winioctl"] }
 libc =  "0.2"
 tokio = { version = "0.2.13", features = ["time"] }
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0.33"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -19,6 +19,7 @@ libc =  "0.2"
 tokio = { version = "0.2.13", features = ["time"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.33"
+chrono = { version = "0.4.19", features = ["serde"] }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -333,11 +333,11 @@ mod test {
         {
             let mut chkptr = Checkpointer::new(&data_dir.path());
 
-            for (fingerprint, modified) in vec![&newer, &newish, &oldish, &older] {
+            for (fingerprint, modified) in &[&newer, &newish, &oldish, &older] {
                 chkptr.load_checkpoint(Checkpoint {
                     fingerprint: *fingerprint,
                     position,
-                    modified: modified.clone(),
+                    modified: *modified,
                 });
                 assert_eq!(chkptr.get_checkpoint(*fingerprint), Some(position));
                 chkptr.write_checkpoints().unwrap();

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -149,7 +149,7 @@ impl Checkpointer {
                         .modified_times
                         .get(&fingerprint)
                         .cloned()
-                        .unwrap_or_else(|| Utc::now()),
+                        .unwrap_or_else(Utc::now),
                 })
                 .collect(),
         }
@@ -245,7 +245,7 @@ impl Checkpointer {
         info!("Attempting to read legacy checkpoint files.");
         self.read_legacy_checkpoints(ignore_before);
 
-        if let Ok(_) = self.write_checkpoints() {
+        if self.write_checkpoints().is_ok() {
             fs::remove_dir_all(&self.directory).ok();
         }
     }

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -1,5 +1,6 @@
 use super::{fingerprinter::FileFingerprint, FilePosition};
 use glob::glob;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs, io,
@@ -7,8 +8,45 @@ use std::{
     time,
 };
 
+const TMP_FILE_NAME: &str = "checkpoints.new.json";
+const STABLE_FILE_NAME: &str = "checkpoints.json";
+
+/// This enum represents the file format of checkpoints persisted to disk. Right now there is only
+/// one variant, but any incompatible changes will require and additional variant to be added here
+/// and handled anywhere that we transit this format.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version", rename_all = "snake_case")]
+enum State {
+    #[serde(rename = "1")]
+    V1 { checkpoints: Vec<Checkpoint> },
+}
+
+/// A simple JSON-friendly struct of the fingerprint/position pair, since fingerprints as objects
+/// cannot be keys in a plain JSON map.
+#[derive(Debug, Serialize, Deserialize)]
+struct Checkpoint {
+    fingerprint: FileFingerprint,
+    position: FilePosition,
+}
+
+impl From<&HashMap<FileFingerprint, FilePosition>> for State {
+    fn from(map: &HashMap<FileFingerprint, FilePosition>) -> Self {
+        State::V1 {
+            checkpoints: map
+                .iter()
+                .map(|(&fingerprint, &position)| Checkpoint {
+                    fingerprint,
+                    position,
+                })
+                .collect(),
+        }
+    }
+}
+
 pub struct Checkpointer {
     directory: PathBuf,
+    tmp_file_path: PathBuf,
+    stable_file_path: PathBuf,
     glob_string: String,
     checkpoints: HashMap<FileFingerprint, FilePosition>,
 }
@@ -17,9 +55,14 @@ impl Checkpointer {
     pub fn new(data_dir: &Path) -> Checkpointer {
         let directory = data_dir.join("checkpoints");
         let glob_string = directory.join("*").to_string_lossy().into_owned();
+        let tmp_file_path = data_dir.join(TMP_FILE_NAME);
+        let stable_file_path = data_dir.join(STABLE_FILE_NAME);
+
         Checkpointer {
             directory,
             glob_string,
+            tmp_file_path,
+            stable_file_path,
             checkpoints: HashMap::new(),
         }
     }
@@ -29,6 +72,7 @@ impl Checkpointer {
     /// For each of the non-legacy variants, prepend an identifier byte that falls outside of the
     /// hex range used by the legacy implementation. This allows them to be differentiated by
     /// simply peeking at the first byte.
+    #[cfg(test)]
     fn encode(&self, fng: FileFingerprint, pos: FilePosition) -> PathBuf {
         use FileFingerprint::*;
 
@@ -81,6 +125,16 @@ impl Checkpointer {
         self.checkpoints.get(&fng).cloned()
     }
 
+    fn set_state(&mut self, state: State) {
+        match state {
+            State::V1 { checkpoints } => {
+                for checkpoint in checkpoints {
+                    self.set_checkpoint(checkpoint.fingerprint, checkpoint.position);
+                }
+            }
+        }
+    }
+
     /// Scan through a given list of fresh fingerprints (i.e. not legacy Unknown) to see if any
     /// match an existing legacy fingerprint. If so, upgrade the existing fingerprint.
     pub fn maybe_upgrade(&mut self, fresh: impl Iterator<Item = FileFingerprint>) {
@@ -94,7 +148,27 @@ impl Checkpointer {
         }
     }
 
+    /// Persist the current checkpoints state to disk, making our best effort to do so in an atomic
+    /// way that allow for recovering the previous state in the event of a crash.
     pub fn write_checkpoints(&mut self) -> Result<usize, io::Error> {
+        // First write the new checkpoints to a tmp file and flush it fully to disk. If vector
+        // dies anywhere during this section, the existing stable file will still be in its current
+        // valid state and we'll be able to recover.
+        let mut f = fs::File::create(&self.tmp_file_path)?;
+        serde_json::to_writer(&mut f, &State::from(&self.checkpoints))?;
+        f.sync_all()?;
+
+        // Once the temp file is fully flushed, rename the tmp file to replace the previous stable
+        // file. This is (almost?) always an atomic operation, which should prevent scenarios where
+        // we don't have at least one full valid file to recover from.
+        fs::rename(&self.tmp_file_path, &self.stable_file_path)?;
+
+        Ok(self.checkpoints.len())
+    }
+
+    /// Write checkpoints to disk in the legacy format. Used for compatibility testing only.
+    #[cfg(test)]
+    pub fn write_legacy_checkpoints(&mut self) -> Result<usize, io::Error> {
         fs::remove_dir_all(&self.directory).ok();
         fs::create_dir_all(&self.directory)?;
         for (&fng, &pos) in self.checkpoints.iter() {
@@ -103,7 +177,67 @@ impl Checkpointer {
         Ok(self.checkpoints.len())
     }
 
+    /// Read persisted checkpoints from disk, preferring the new JSON file format but falling back
+    /// to the legacy system when those files are found instead.
     pub fn read_checkpoints(&mut self, ignore_before: Option<time::SystemTime>) {
+        // First try reading from the tmp file location. If this works, it means that the previous
+        // process was interrupted in the process of checkpointing and the tmp file should contain
+        // more recent data that should be preferred.
+        match self.read_checkpoints_file(&self.tmp_file_path) {
+            Ok(state) => {
+                warn!(message = "Recovered checkpoint data from interrupted process.");
+                self.set_state(state);
+
+                // Try to move this tmp file to the stable location so we don't immediately overwrite
+                // it when we next persist checkpoints.
+                if let Err(error) = fs::rename(&self.tmp_file_path, &self.stable_file_path) {
+                    warn!(message = "Error persisting recovered checkpoint file.", %error);
+                }
+                return;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // This is expected, so no warning needed
+            }
+            Err(error) => {
+                error!(message = "Unable to recover checkpoint data from interrupted process.", %error);
+            }
+        }
+
+        // Next, attempt to read checkpoints from the stable file location. This is the
+        // expected location, so warn more aggressively if something goes wrong.
+        match self.read_checkpoints_file(&self.stable_file_path) {
+            Ok(state) => {
+                info!(message = "Loaded checkpoint data.");
+                self.set_state(state);
+                return;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // This is expected, so no warning needed
+            }
+            Err(error) => {
+                warn!(message = "Unable to load checkpoint data.", %error);
+                return;
+            }
+        }
+
+        // If we haven't returned yet, go ahead and look for the legacy files and try to read them.
+        info!("Attempting to read legacy checkpoint files.");
+        self.read_legacy_checkpoints(ignore_before);
+
+        if let Ok(_) = self.write_checkpoints() {
+            fs::remove_dir_all(&self.directory).ok();
+        }
+    }
+
+    // TODO: Do we have the equivalent of ignore_before here? How should we go about expiring
+    // checkpoints for files that we know longer care about? Was `ignore_before` correct for that
+    // in the first place?
+    fn read_checkpoints_file(&self, path: &Path) -> Result<State, io::Error> {
+        let reader = io::BufReader::new(fs::File::open(path)?);
+        serde_json::from_reader(reader).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    fn read_legacy_checkpoints(&mut self, ignore_before: Option<time::SystemTime>) {
         for path in glob(&self.glob_string).unwrap().flatten() {
             if let Some(ignore_before) = ignore_before {
                 if let Ok(Ok(modified)) = fs::metadata(&path).map(|metadata| metadata.modified()) {
@@ -121,7 +255,7 @@ impl Checkpointer {
 
 #[cfg(test)]
 mod test {
-    use super::{Checkpointer, FileFingerprint, FilePosition};
+    use super::{Checkpointer, FileFingerprint, FilePosition, STABLE_FILE_NAME, TMP_FILE_NAME};
     use tempfile::tempdir;
 
     #[test]
@@ -147,25 +281,32 @@ mod test {
 
     #[test]
     fn test_checkpointer_restart() {
-        let fingerprint: FileFingerprint = 0x1234567890abcdef.into();
-        let position: FilePosition = 1234;
-        let data_dir = tempdir().unwrap();
-        {
-            let mut chkptr = Checkpointer::new(&data_dir.path());
-            chkptr.set_checkpoint(fingerprint, position);
-            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
-            chkptr.write_checkpoints().ok();
-        }
-        {
-            let mut chkptr = Checkpointer::new(&data_dir.path());
-            assert_eq!(chkptr.get_checkpoint(fingerprint), None);
-            chkptr.read_checkpoints(None);
-            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+        let fingerprints = vec![
+            FileFingerprint::DevInode(1, 2),
+            FileFingerprint::Checksum(3456),
+            FileFingerprint::FirstLineChecksum(78910),
+            FileFingerprint::Unknown(1337),
+        ];
+        for fingerprint in fingerprints {
+            let position: FilePosition = 1234;
+            let data_dir = tempdir().unwrap();
+            {
+                let mut chkptr = Checkpointer::new(&data_dir.path());
+                chkptr.set_checkpoint(fingerprint, position);
+                assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+                chkptr.write_checkpoints().ok();
+            }
+            {
+                let mut chkptr = Checkpointer::new(&data_dir.path());
+                assert_eq!(chkptr.get_checkpoint(fingerprint), None);
+                chkptr.read_checkpoints(None);
+                assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+            }
         }
     }
 
     #[test]
-    fn test_checkpointer_upgrades() {
+    fn test_checkpointer_fingerprint_upgrades() {
         let new_fingerprint = FileFingerprint::DevInode(1, 2);
         let old_fingerprint = FileFingerprint::Unknown(new_fingerprint.to_legacy());
         let position: FilePosition = 1234;
@@ -186,6 +327,49 @@ mod test {
 
             assert_eq!(chkptr.get_checkpoint(new_fingerprint), Some(position));
             assert_eq!(chkptr.get_checkpoint(old_fingerprint), None);
+        }
+    }
+
+    #[test]
+    fn test_checkpointer_file_upgrades() {
+        let fingerprint = FileFingerprint::DevInode(1, 2);
+        let position: FilePosition = 1234;
+
+        let data_dir = tempdir().unwrap();
+
+        // Write out checkpoints in the legacy file format
+        {
+            let mut chkptr = Checkpointer::new(&data_dir.path());
+            chkptr.set_checkpoint(fingerprint, position);
+            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+            chkptr.write_legacy_checkpoints().unwrap();
+        }
+
+        // Ensure that the new files were not written but the old style of files were
+        assert_eq!(false, data_dir.path().join(TMP_FILE_NAME).exists());
+        assert_eq!(false, data_dir.path().join(STABLE_FILE_NAME).exists());
+        assert_eq!(true, data_dir.path().join("checkpoints").is_dir());
+
+        // Read from those old files, ensure the checkpoints were loaded properly, and then write
+        // them normally (i.e. in the new format)
+        {
+            let mut chkptr = Checkpointer::new(&data_dir.path());
+            chkptr.read_checkpoints(None);
+            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+            chkptr.write_checkpoints().unwrap();
+        }
+
+        // Ensure that the stable file is present, the tmp file is not, and the legacy files have
+        // been cleaned up
+        assert_eq!(false, data_dir.path().join(TMP_FILE_NAME).exists());
+        assert_eq!(true, data_dir.path().join(STABLE_FILE_NAME).exists());
+        assert_eq!(false, data_dir.path().join("checkpoints").is_dir());
+
+        // Ensure one last time that we can reread from the new files and get the same result
+        {
+            let mut chkptr = Checkpointer::new(&data_dir.path());
+            chkptr.read_checkpoints(None);
+            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
         }
     }
 }

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -159,8 +159,9 @@ impl Checkpointer {
         f.sync_all()?;
 
         // Once the temp file is fully flushed, rename the tmp file to replace the previous stable
-        // file. This is (almost?) always an atomic operation, which should prevent scenarios where
-        // we don't have at least one full valid file to recover from.
+        // file. This is an atomic operation on POSIX systems (and the stdlib claims to provide
+        // equivalent behavior on Windows), which should prevent scenarios where we don't have at
+        // least one full valid file to recover from.
         fs::rename(&self.tmp_file_path, &self.stable_file_path)?;
 
         Ok(self.checkpoints.len())

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -5,6 +5,7 @@ use crate::{
     FileSourceInternalEvents,
 };
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use futures::{
     executor::block_on,
     future::{select, Either},
@@ -37,7 +38,7 @@ where
     pub paths_provider: PP,
     pub max_read_bytes: usize,
     pub start_at_beginning: bool,
-    pub ignore_before: Option<time::SystemTime>,
+    pub ignore_before: Option<DateTime<Utc>>,
     pub max_line_bytes: usize,
     pub data_dir: PathBuf,
     pub glob_minimum_cooldown: Duration,
@@ -101,7 +102,8 @@ where
         existing_files.sort_by_key(|(path, _file_id)| {
             fs::metadata(&path)
                 .and_then(|m| m.created())
-                .unwrap_or_else(|_| time::SystemTime::now())
+                .map(|t| DateTime::<Utc>::from(t))
+                .unwrap_or_else(|_| Utc::now())
         });
 
         checkpointer.maybe_upgrade(existing_files.iter().map(|(_, id)| id).cloned());
@@ -252,7 +254,7 @@ where
 
                 if bytes_read > 0 {
                     global_bytes_read = global_bytes_read.saturating_add(bytes_read);
-                    checkpointer.set_checkpoint(file_id, watcher.get_file_position());
+                    checkpointer.update_checkpoint(file_id, watcher.get_file_position());
                 } else {
                     // Should the file be removed
                     if let Some(grace_period) = self.remove_after {

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -102,7 +102,7 @@ where
         existing_files.sort_by_key(|(path, _file_id)| {
             fs::metadata(&path)
                 .and_then(|m| m.created())
-                .map(|t| DateTime::<Utc>::from(t))
+                .map(DateTime::<Utc>::from)
                 .unwrap_or_else(|_| Utc::now())
         });
 

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -314,7 +314,7 @@ mod test {
         let p = read_until_with_max_size(&mut buf, &mut pos, b'3', &mut v, 1000).unwrap();
         assert_eq!(pos, 4);
         assert_eq!(p, None);
-        assert_eq!(&*v, []);
+        assert_eq!(&*v, [0; 0]);
 
         let mut buf = Cursor::new(&b"short\nthis is too long\nexact size\n11 eleven11\n"[..]);
         let mut pos = 0;
@@ -332,6 +332,6 @@ mod test {
         let p = read_until_with_max_size(&mut buf, &mut pos, b'\n', &mut v, 10).unwrap();
         assert_eq!(pos, 46);
         assert_eq!(p, None);
-        assert_eq!(&*v, []);
+        assert_eq!(&*v, [0; 0]);
     }
 }

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -51,7 +51,7 @@ impl FileWatcher {
 
         let too_old = if let (Some(ignore_before), Ok(modified_time)) = (
             ignore_before,
-            metadata.modified().map(|t| DateTime::<Utc>::from(t)),
+            metadata.modified().map(DateTime::<Utc>::from),
         ) {
             modified_time < ignore_before
         } else {

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -1,4 +1,5 @@
 use crate::{metadata_ext::PortableFileExt, FileSourceInternalEvents};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     fs::{self, File},
@@ -19,7 +20,7 @@ pub enum Fingerprinter {
     DevInode,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum FileFingerprint {
     Checksum(u64),
     FirstLineChecksum(u64),

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -9,6 +9,7 @@ use crate::{
     Pipeline,
 };
 use bytes::Bytes;
+use chrono::Utc;
 use file_source::{
     paths_provider::glob::{Glob, MatchOptions},
     FileServer, Fingerprinter,
@@ -24,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::convert::TryInto;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use tokio::task::spawn_blocking;
 
 #[derive(Debug, Snafu)]
@@ -193,7 +194,7 @@ pub fn file_source(
 ) -> super::Source {
     let ignore_before = config
         .ignore_older
-        .map(|secs| SystemTime::now() - Duration::from_secs(secs));
+        .map(|secs| Utc::now() - chrono::Duration::seconds(secs as i64));
     let glob_minimum_cooldown = Duration::from_millis(config.glob_minimum_cooldown);
 
     let paths_provider = Glob::new(&config.include, &config.exclude, MatchOptions::default())


### PR DESCRIPTION
Closes #1427
Closes #1779

This adds functionality to migrate existing checkpoints to a new JSON-based file approach. It should be fully compatible, both backwards and forwards. This fixes a couple of outstanding issues and opens the door to storing more information with checkpoints, allowing for more intelligent fingerprinting algorithms.

Once this has been deployed in a new version, we should be able to remove a lot of the old code and clean things up, just noting that users will need to transition through this version if they want to migrate older-style checkpoints.

The first commit also fixes a bug introduced in #1499 and better testing that would have caught it.