### PR TITLE
feat(remap): compile-time program result type checking

### DIFF
--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{expression, function, parser::Rule, value};
+use crate::{expression, function, parser::Rule, program, value};
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -6,6 +6,9 @@ use std::fmt;
 pub enum Error {
     #[error("parser error: {0}")]
     Parser(String),
+
+    #[error("program error")]
+    Program(#[from] program::Error),
 
     #[error("unexpected token sequence")]
     Rule(#[from] Rule),
@@ -107,7 +110,7 @@ impl fmt::Display for Rule {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct RemapError(pub(crate) Error);
 
 impl StdError for RemapError {
@@ -127,6 +130,12 @@ impl fmt::Display for RemapError {
         }
 
         Ok(())
+    }
+}
+
+impl From<Error> for RemapError {
+    fn from(error: Error) -> Self {
+        RemapError(error)
     }
 }
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -2,7 +2,7 @@ use crate::{expression, function, parser::Rule, program, value};
 use std::error::Error as StdError;
 use std::fmt;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("parser error: {0}")]
     Parser(String),

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -1,4 +1,5 @@
 use crate::{CompilerState, Object, Result, State, Value, ValueKind};
+use std::fmt;
 
 pub(super) mod arithmetic;
 pub(super) mod assignment;
@@ -70,18 +71,22 @@ pub enum ResolveKind {
 }
 
 impl ResolveKind {
+    /// Returns `true` if this is a [`ResolveKind::Exact`].
     pub fn is_exact(&self) -> bool {
         matches!(self, ResolveKind::Exact(_))
     }
 
+    /// Returns `true` if this is a [`ResolveKind::Any`].
     pub fn is_any(&self) -> bool {
         matches!(self, ResolveKind::Any)
     }
 
+    /// Returns `true` if this is a [`ResolveKind::Maybe`].
     pub fn is_maybe(&self) -> bool {
         matches!(self, ResolveKind::Maybe(_))
     }
 
+    /// Get a collection of [`ValueKind`]s accepted by this [`ResolveKind`].
     pub fn value_kinds(&self) -> Vec<ValueKind> {
         use ResolveKind::*;
 
@@ -90,6 +95,88 @@ impl ResolveKind {
             OneOf(v) => v.clone(),
             Exact(v) => vec![*v],
             Maybe(v) => v.value_kinds(),
+        }
+    }
+
+    /// Merge two [`ResolveKind`]s, such that the new `ResolveKind` provides the
+    /// most constraint possible resolve kind variant.
+    pub fn merge(&self, other: &Self) -> Self {
+        use ResolveKind::*;
+
+        if let Maybe(kind) = self {
+            let other = match other {
+                Maybe(v) => v,
+                _ => other,
+            };
+
+            return Maybe(Box::new(kind.merge(other)));
+        }
+
+        if let Maybe(kind) = other {
+            return Maybe(Box::new(self.merge(kind)));
+        }
+
+        if self.is_any() || other.is_any() {
+            return Any;
+        }
+
+        let mut kinds: Vec<_> = self
+            .value_kinds()
+            .into_iter()
+            .chain(other.value_kinds().into_iter())
+            .collect();
+
+        kinds.sort();
+        kinds.dedup();
+
+        if kinds.len() == 1 {
+            Exact(kinds[0])
+        } else {
+            OneOf(kinds)
+        }
+    }
+
+    /// Returns `true` if the _other_ [`ResolveKind`] is contained within the
+    /// current one.
+    ///
+    /// That is to say, its constraints must be more strict or equal to the
+    /// constraints of the current one.
+    pub fn contains(&self, other: &Self) -> bool {
+        // If we don't expect none, but the other does, the other's requirement
+        // is less strict than ours.
+        if !self.is_maybe() && other.is_maybe() {
+            return false;
+        }
+
+        let self_kinds = self.value_kinds();
+        let other_kinds = other.value_kinds();
+
+        for kind in other_kinds {
+            if !self_kinds.contains(&kind) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl fmt::Display for ResolveKind {
+    /// Print a human readable version of the resolve kind constraints.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ResolveKind::*;
+
+        match self {
+            Any => f.write_str("any value"),
+            OneOf(v) => {
+                f.write_str("any of ")?;
+                f.write_str(&v.iter().map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
+            }
+            Exact(v) => f.write_str(&v),
+            Maybe(v) => {
+                f.write_str("none or ")?;
+                f.write_str(&v.to_string())
+            }
         }
     }
 }
@@ -154,3 +241,62 @@ expression_dispatch![
     Path,
     Variable,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contains() {
+        use ResolveKind::*;
+        use ValueKind::*;
+
+        let cases = vec![
+            (true, Any, Any),
+            (true, Any, Exact(String)),
+            (true, Any, Exact(Integer)),
+            (true, Any, OneOf(vec![Float, Boolean])),
+            (true, Any, OneOf(vec![Map])),
+            (false, Any, Maybe(Box::new(Any))),
+            (true, Exact(String), Exact(String)),
+            (true, Exact(String), OneOf(vec![String])),
+            (false, Exact(String), Exact(Array)),
+            (false, Exact(String), OneOf(vec![Integer])),
+            (false, Exact(String), OneOf(vec![Integer, Float])),
+            (false, Exact(String), Maybe(Box::new(Any))),
+        ];
+
+        for (expect, this, other) in cases {
+            assert_eq!(this.contains(&other), expect);
+        }
+    }
+
+    #[test]
+    fn test_merge() {
+        use ResolveKind::*;
+        use ValueKind::*;
+
+        let cases = vec![
+            (Any, Any, Any),
+            (Maybe(Box::new(Any)), Maybe(Box::new(Any)), Any),
+            (Maybe(Box::new(Any)), Any, Maybe(Box::new(Any))),
+            (Any, OneOf(vec![Integer, String]), Any),
+            (OneOf(vec![Integer, Float]), Exact(Integer), Exact(Float)),
+            (Exact(Integer), Exact(Integer), Exact(Integer)),
+            (
+                Maybe(Box::new(Exact(Integer))),
+                Maybe(Box::new(Exact(Integer))),
+                Exact(Integer),
+            ),
+            (
+                OneOf(vec![String, Integer, Float, Boolean]),
+                OneOf(vec![Integer, String]),
+                OneOf(vec![Float, Boolean]),
+            ),
+        ];
+
+        for (expect, this, other) in cases {
+            assert_eq!(this.merge(&other), expect);
+        }
+    }
+}

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -53,7 +53,7 @@ pub enum Error {
 /// This includes whether the expression is fallible, whether it can return
 /// "nothing", and a list of values the expression can resolve to.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct TypeCheck {
+pub struct TypeDef {
     /// True, if an expression can return an error.
     ///
     /// Some expressions are infallible (e.g. the [`Literal`] expression, or any
@@ -73,7 +73,7 @@ pub struct TypeCheck {
     pub constraint: ValueConstraint,
 }
 
-impl TypeCheck {
+impl TypeDef {
     pub fn is_fallible(&self) -> bool {
         self.fallible
     }
@@ -82,7 +82,7 @@ impl TypeCheck {
         self.optional
     }
 
-    /// Merge two [`TypeCheck`]s, such that the new `TypeCheck` provides the
+    /// Merge two [`TypeDef`]s, such that the new `TypeDef` provides the
     /// strictest type check possible.
     pub fn merge(&self, other: &Self) -> Self {
         let fallible = self.is_fallible() || other.is_fallible();
@@ -96,7 +96,7 @@ impl TypeCheck {
         }
     }
 
-    /// Returns `true` if the _other_ [`TypeCheck`] is contained within the
+    /// Returns `true` if the _other_ [`TypeDef`] is contained within the
     /// current one.
     ///
     /// That is to say, its constraints must be more strict or equal to the
@@ -119,7 +119,7 @@ impl TypeCheck {
 
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>>;
-    fn type_check(&self, state: &CompilerState) -> TypeCheck;
+    fn type_def(&self, state: &CompilerState) -> TypeDef;
 }
 
 dyn_clone::clone_trait_object!(Expression);
@@ -148,9 +148,9 @@ macro_rules! expression_dispatch {
                 }
             }
 
-            fn type_check(&self, state: &CompilerState) -> TypeCheck {
+            fn type_def(&self, state: &CompilerState) -> TypeDef {
                 match self {
-                    $(Expr::$expr(expression) => expression.type_check(state)),+
+                    $(Expr::$expr(expression) => expression.type_def(state)),+
                 }
             }
         }

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -1,5 +1,4 @@
-use crate::{CompilerState, Object, Result, State, Value, ValueKind};
-use std::fmt;
+use crate::{CompilerState, Object, Result, State, Value, ValueConstraint, ValueKind};
 
 pub(super) mod arithmetic;
 pub(super) mod assignment;
@@ -48,142 +47,9 @@ pub enum Error {
     Variable(#[from] variable::Error),
 }
 
-/// What kind of value an expression is going to resolve to.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ResolveKind {
-    /// The expression can resolve to any value at runtime.
-    ///
-    /// This applies to any [`Object`] value that hasn't been coerced yet.
-    Any,
-
-    /// The expressions resolves to one of the defined [`ValueKind`]s.
-    OneOf(Vec<ValueKind>),
-
-    /// The expression resolves to an exact value.
-    Exact(ValueKind),
-
-    /// If the expression succeeds, it might resolve to a value, but doesn't
-    /// have to.
-    ///
-    /// For example, and if-statement without an else-condition can resolve to
-    /// nothing if the if-condition does not match.
-    Maybe(Box<ResolveKind>),
-}
-
-impl ResolveKind {
-    /// Returns `true` if this is a [`ResolveKind::Exact`].
-    pub fn is_exact(&self) -> bool {
-        matches!(self, ResolveKind::Exact(_))
-    }
-
-    /// Returns `true` if this is a [`ResolveKind::Any`].
-    pub fn is_any(&self) -> bool {
-        matches!(self, ResolveKind::Any)
-    }
-
-    /// Returns `true` if this is a [`ResolveKind::Maybe`].
-    pub fn is_maybe(&self) -> bool {
-        matches!(self, ResolveKind::Maybe(_))
-    }
-
-    /// Get a collection of [`ValueKind`]s accepted by this [`ResolveKind`].
-    pub fn value_kinds(&self) -> Vec<ValueKind> {
-        use ResolveKind::*;
-
-        match self {
-            Any => ValueKind::all(),
-            OneOf(v) => v.clone(),
-            Exact(v) => vec![*v],
-            Maybe(v) => v.value_kinds(),
-        }
-    }
-
-    /// Merge two [`ResolveKind`]s, such that the new `ResolveKind` provides the
-    /// most constraint possible resolve kind variant.
-    pub fn merge(&self, other: &Self) -> Self {
-        use ResolveKind::*;
-
-        if let Maybe(kind) = self {
-            let other = match other {
-                Maybe(v) => v,
-                _ => other,
-            };
-
-            return Maybe(Box::new(kind.merge(other)));
-        }
-
-        if let Maybe(kind) = other {
-            return Maybe(Box::new(self.merge(kind)));
-        }
-
-        if self.is_any() || other.is_any() {
-            return Any;
-        }
-
-        let mut kinds: Vec<_> = self
-            .value_kinds()
-            .into_iter()
-            .chain(other.value_kinds().into_iter())
-            .collect();
-
-        kinds.sort();
-        kinds.dedup();
-
-        if kinds.len() == 1 {
-            Exact(kinds[0])
-        } else {
-            OneOf(kinds)
-        }
-    }
-
-    /// Returns `true` if the _other_ [`ResolveKind`] is contained within the
-    /// current one.
-    ///
-    /// That is to say, its constraints must be more strict or equal to the
-    /// constraints of the current one.
-    pub fn contains(&self, other: &Self) -> bool {
-        // If we don't expect none, but the other does, the other's requirement
-        // is less strict than ours.
-        if !self.is_maybe() && other.is_maybe() {
-            return false;
-        }
-
-        let self_kinds = self.value_kinds();
-        let other_kinds = other.value_kinds();
-
-        for kind in other_kinds {
-            if !self_kinds.contains(&kind) {
-                return false;
-            }
-        }
-
-        true
-    }
-}
-
-impl fmt::Display for ResolveKind {
-    /// Print a human readable version of the resolve kind constraints.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ResolveKind::*;
-
-        match self {
-            Any => f.write_str("any value"),
-            OneOf(v) => {
-                f.write_str("any of ")?;
-                f.write_str(&v.iter().map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
-            }
-            Exact(v) => f.write_str(&v),
-            Maybe(v) => {
-                f.write_str("none or ")?;
-                f.write_str(&v.to_string())
-            }
-        }
-    }
-}
-
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>>;
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind;
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint;
 }
 
 dyn_clone::clone_trait_object!(Expression);
@@ -212,7 +78,7 @@ macro_rules! expression_dispatch {
                 }
             }
 
-            fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+            fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
                 match self {
                     $(Expr::$expr(expression) => expression.resolves_to(state)),+
                 }
@@ -248,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        use ResolveKind::*;
+        use ValueConstraint::*;
         use ValueKind::*;
 
         let cases = vec![
@@ -273,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        use ResolveKind::*;
+        use ValueConstraint::*;
         use ValueKind::*;
 
         let cases = vec![

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -1,29 +1,26 @@
-use crate::{
-    CompilerState, Object, ProgramState, Result, TypeDef, Value, ValueConstraint, ValueKind,
-};
+use crate::{state, Object, Result, TypeDef, Value};
 
-pub(super) mod arithmetic;
-pub(super) mod assignment;
+mod arithmetic;
+mod assignment;
 mod block;
-pub(super) mod function;
-pub(super) mod if_statement;
+mod function;
+mod if_statement;
 mod literal;
 mod noop;
-pub(super) mod not;
-pub(super) mod path;
-pub(super) mod variable;
+mod not;
+mod path;
+mod variable;
 
-pub(super) use arithmetic::Arithmetic;
-pub(super) use assignment::{Assignment, Target};
-pub(super) use block::Block;
-pub(super) use function::Function;
-pub(super) use if_statement::IfStatement;
-pub(super) use not::Not;
-pub(super) use variable::Variable;
-
+pub use arithmetic::Arithmetic;
+pub use assignment::{Assignment, Target};
+pub use block::Block;
+pub use function::Function;
+pub use if_statement::IfStatement;
 pub use literal::Literal;
 pub use noop::Noop;
+pub use not::Not;
 pub use path::Path;
+pub use variable::Variable;
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
@@ -50,8 +47,9 @@ pub enum Error {
 }
 
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>>;
-    fn type_def(&self, state: &CompilerState) -> TypeDef;
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object)
+        -> Result<Option<Value>>;
+    fn type_def(&self, state: &state::Compiler) -> TypeDef;
 }
 
 dyn_clone::clone_trait_object!(Expression);
@@ -69,18 +67,18 @@ macro_rules! expression_dispatch {
         /// Any expression that stores other expressions internally will still
         /// have to box this enum, to avoid infinite recursion.
         #[derive(Debug, Clone)]
-        pub(crate) enum Expr {
+        pub enum Expr {
             $($expr($expr)),+
         }
 
         impl Expression for Expr {
-            fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+            fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
                 match self {
                     $(Expr::$expr(expression) => expression.execute(state, object)),+
                 }
             }
 
-            fn type_def(&self, state: &CompilerState) -> TypeDef {
+            fn type_def(&self, state: &state::Compiler) -> TypeDef {
                 match self {
                     $(Expr::$expr(expression) => expression.type_def(state)),+
                 }
@@ -116,8 +114,8 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        use ValueConstraint::*;
-        use ValueKind::*;
+        use value::Constraint::*;
+        use value::Kind::*;
 
         let cases = vec![
             (true, Any, Any),
@@ -139,8 +137,8 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        use ValueConstraint::*;
-        use ValueKind::*;
+        use value::Constraint::*;
+        use value::Kind::*;
 
         let cases = vec![
             (Any, Any, Any),

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -3,12 +3,12 @@ use crate::{state, Object, Result, TypeDef, Value};
 mod arithmetic;
 mod assignment;
 mod block;
-mod function;
+pub(crate) mod function;
 mod if_statement;
 mod literal;
 mod noop;
 mod not;
-mod path;
+pub(crate) mod path;
 mod variable;
 
 pub use arithmetic::Arithmetic;
@@ -110,7 +110,7 @@ expression_dispatch![
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::value;
 
     #[test]
     fn test_contains() {

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -23,7 +23,7 @@ pub use literal::Literal;
 pub use noop::Noop;
 pub use path::Path;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("expected expression, got none")]
     Missing,

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Object, Result, State, Value, ValueConstraint, ValueKind};
+use crate::{CompilerState, Object, ProgramState, Result, Value, ValueConstraint, ValueKind};
 
 pub(super) mod arithmetic;
 pub(super) mod assignment;
@@ -118,7 +118,7 @@ impl TypeDef {
 }
 
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>>;
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>>;
     fn type_def(&self, state: &CompilerState) -> TypeDef;
 }
 
@@ -142,7 +142,7 @@ macro_rules! expression_dispatch {
         }
 
         impl Expression for Expr {
-            fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+            fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
                 match self {
                     $(Expr::$expr(expression) => expression.execute(state, object)),+
                 }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -1,5 +1,5 @@
 use super::{
-    CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value, ValueKind,
+    CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value, ValueKind,
 };
 use crate::Operator;
 
@@ -48,23 +48,23 @@ impl Expression for Arithmetic {
         result.map(Some).map_err(Into::into)
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         let lhs_kind = self.lhs.resolves_to(state);
         let rhs_kind = self.rhs.resolves_to(state);
 
         use Operator::*;
         match self.op {
             Or => lhs_kind.merge(&rhs_kind),
-            Multiply | Add => ResolveKind::OneOf(vec![
+            Multiply | Add => ValueConstraint::OneOf(vec![
                 ValueKind::String,
                 ValueKind::Integer,
                 ValueKind::Float,
             ]),
             Remainder | Subtract | Divide => {
-                ResolveKind::OneOf(vec![ValueKind::Integer, ValueKind::Float])
+                ValueConstraint::OneOf(vec![ValueKind::Integer, ValueKind::Float])
             }
             And | Equal | NotEqual | Greater | GreaterOrEqual | Less | LessOrEqual => {
-                ResolveKind::Exact(ValueKind::Boolean)
+                ValueConstraint::Exact(ValueKind::Boolean)
             }
         }
     }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -1,4 +1,6 @@
-use super::{Expr, Expression, Object, Result, State, Value};
+use super::{
+    CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value, ValueKind,
+};
 use crate::Operator;
 
 #[derive(Debug, Clone)]
@@ -44,5 +46,23 @@ impl Expression for Arithmetic {
         };
 
         result.map(Some).map_err(Into::into)
+    }
+
+    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+        use Operator::*;
+        match self.op {
+            Or => ResolveKind::Any,
+            Multiply | Add => ResolveKind::OneOf(vec![
+                ValueKind::String,
+                ValueKind::Integer,
+                ValueKind::Float,
+            ]),
+            Remainder | Subtract | Divide => {
+                ResolveKind::OneOf(vec![ValueKind::Integer, ValueKind::Float])
+            }
+            And | Equal | NotEqual | Greater | GreaterOrEqual | Less | LessOrEqual => {
+                ResolveKind::Exact(ValueKind::Boolean)
+            }
+        }
     }
 }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -1,5 +1,5 @@
 use super::{
-    CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value, ValueConstraint,
+    CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueConstraint,
     ValueKind,
 };
 use crate::Operator;
@@ -52,14 +52,14 @@ impl Expression for Arithmetic {
         result.map(Some).map_err(Into::into)
     }
 
-    fn type_check(&self, state: &CompilerState) -> TypeCheck {
+    fn type_def(&self, state: &CompilerState) -> TypeDef {
         use Operator::*;
         let constraint = match self.op {
             Or => self
                 .lhs
-                .type_check(state)
+                .type_def(state)
                 .constraint
-                .merge(&self.rhs.type_check(state).constraint),
+                .merge(&self.rhs.type_def(state).constraint),
             Multiply | Add => ValueConstraint::OneOf(vec![
                 ValueKind::String,
                 ValueKind::Integer,
@@ -73,7 +73,7 @@ impl Expression for Arithmetic {
             }
         };
 
-        TypeCheck {
+        TypeDef {
             fallible: true,
             optional: false,
             constraint,
@@ -84,16 +84,16 @@ impl Expression for Arithmetic {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_check, Literal, Noop, ValueConstraint::*, ValueKind::*};
+    use crate::{test_type_def, Literal, Noop, ValueConstraint::*, ValueKind::*};
 
-    test_type_check![
+    test_type_def![
         or_exact {
             expr: |_| Arithmetic::new(
                 Box::new(Literal::from("foo").into()),
                 Box::new(Literal::from(true).into()),
                 Operator::Or,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![String, Boolean])
@@ -106,7 +106,7 @@ mod tests {
                 Box::new(Literal::from(true).into()),
                 Operator::Or,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Any,
@@ -119,7 +119,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Multiply,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![String, Integer, Float]),
@@ -132,7 +132,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Add,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![String, Integer, Float]),
@@ -145,7 +145,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Remainder,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![Integer, Float]),
@@ -158,7 +158,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Subtract,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![Integer, Float]),
@@ -171,7 +171,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Divide,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: OneOf(vec![Integer, Float]),
@@ -184,7 +184,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::And,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -197,7 +197,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Equal,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -210,7 +210,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::NotEqual,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -223,7 +223,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Greater,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -236,7 +236,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::GreaterOrEqual,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -249,7 +249,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::Less,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -262,7 +262,7 @@ mod tests {
                 Box::new(Noop.into()),
                 Operator::LessOrEqual,
             ),
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: true,
                 optional: false,
                 constraint: Exact(Boolean),

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -35,6 +35,9 @@ impl Expression for Arithmetic {
             Divide => lhs.try_div(rhs),
             Add => lhs.try_add(rhs),
             Subtract => lhs.try_sub(rhs),
+
+            // TODO: make `Or` infallible, `Null`, `false` and `None` resolve to
+            // rhs, everything else resolves to lhs
             Or => lhs.try_or(rhs),
             And => lhs.try_and(rhs),
             Remainder => lhs.try_rem(rhs),
@@ -76,4 +79,194 @@ impl Expression for Arithmetic {
             constraint,
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_type_check, Literal, Noop, ValueConstraint::*, ValueKind::*};
+
+    test_type_check![
+        or_exact {
+            expr: |_| Arithmetic::new(
+                Box::new(Literal::from("foo").into()),
+                Box::new(Literal::from(true).into()),
+                Operator::Or,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![String, Boolean])
+            },
+        }
+
+        or_any {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Literal::from(true).into()),
+                Operator::Or,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Any,
+            },
+        }
+
+        multiply {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Multiply,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![String, Integer, Float]),
+            },
+        }
+
+        add {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Add,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![String, Integer, Float]),
+            },
+        }
+
+        remainder {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Remainder,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![Integer, Float]),
+            },
+        }
+
+        subtract {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Subtract,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![Integer, Float]),
+            },
+        }
+
+        divide {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Divide,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: OneOf(vec![Integer, Float]),
+            },
+        }
+
+        and {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::And,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        equal {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Equal,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        not_equal {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::NotEqual,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        greater {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Greater,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        greater_or_equal {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::GreaterOrEqual,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        less {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::Less,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        less_or_equal {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::LessOrEqual,
+            ),
+            def: TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+    ];
 }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -48,10 +48,13 @@ impl Expression for Arithmetic {
         result.map(Some).map_err(Into::into)
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+        let lhs_kind = self.lhs.resolves_to(state);
+        let rhs_kind = self.rhs.resolves_to(state);
+
         use Operator::*;
         match self.op {
-            Or => ResolveKind::Any,
+            Or => lhs_kind.merge(&rhs_kind),
             Multiply | Add => ResolveKind::OneOf(vec![
                 ValueKind::String,
                 ValueKind::Integer,

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -1,5 +1,5 @@
 use super::{
-    CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueConstraint,
+    CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value, ValueConstraint,
     ValueKind,
 };
 use crate::Operator;
@@ -18,7 +18,7 @@ impl Arithmetic {
 }
 
 impl Expression for Arithmetic {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let lhs = self
             .lhs
             .execute(state, object)?

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -81,7 +81,12 @@ impl Expression for Arithmetic {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{
+        expression::{Literal, Noop},
+        test_type_def,
+        value::Constraint::*,
+        value::Kind::*,
+    };
 
     test_type_def![
         or_exact {

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -27,7 +27,7 @@ impl Assignment {
             Target::Variable(ident) => state.variable_types_mut().insert(ident.clone(), type_check),
             Target::Path(segments) => {
                 let path = crate::expression::path::segments_to_path(segments);
-                state.variable_types_mut().insert(path, type_check)
+                state.path_query_types_mut().insert(path, type_check)
             }
         };
 
@@ -66,7 +66,7 @@ impl Expression for Assignment {
                 .unwrap_or_default(),
             Target::Path(segments) => {
                 let path = crate::expression::path::segments_to_path(segments);
-                state.variable_type(&path).cloned().unwrap_or_default()
+                state.path_query_type(&path).cloned().unwrap_or_default()
             }
         }
     }

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -58,18 +58,18 @@ impl Expression for Assignment {
         }
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         match &self.target {
             Target::Variable(ident) => state
                 .variable_kind(ident.clone())
                 .cloned()
-                .unwrap_or(ResolveKind::Any),
+                .unwrap_or(ValueConstraint::Any),
             Target::Path(segments) => {
                 let path = crate::expression::path::segments_to_path(segments);
                 state
                     .variable_kind(&path)
                     .cloned()
-                    .unwrap_or(ResolveKind::Any)
+                    .unwrap_or(ValueConstraint::Any)
             }
         }
     }

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value};
+use crate::{CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -36,7 +36,7 @@ impl Assignment {
 }
 
 impl Expression for Assignment {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = self.value.execute(state, object)?;
 
         match value {

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -80,7 +80,7 @@ impl Expression for Assignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Kind::*, value::Constraint::*, Literal};
+    use crate::{expression::Literal, test_type_def, value::Constraint::*, value::Kind::*};
 
     test_type_def![
         variable {

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value};
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("unable to insert value in path: {0}")]
     PathInsertion(String),

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,4 +1,4 @@
-use crate::{Expr, Expression, Object, Result, State, Value};
+use crate::{CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Block {
@@ -20,5 +20,12 @@ impl Expression for Block {
         }
 
         Ok(value)
+    }
+
+    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+        self.expressions
+            .last()
+            .map(|e| e.resolves_to(state))
+            .unwrap_or(ResolveKind::Any)
     }
 }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Block {
@@ -22,10 +22,10 @@ impl Expression for Block {
         Ok(value)
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         self.expressions
             .last()
             .map(|e| e.resolves_to(state))
-            .unwrap_or(ResolveKind::Any)
+            .unwrap_or(ValueConstraint::Any)
     }
 }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value};
+use crate::{CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Block {
@@ -22,10 +22,13 @@ impl Expression for Block {
         Ok(value)
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
+    fn type_check(&self, state: &CompilerState) -> TypeCheck {
         self.expressions
             .last()
-            .map(|e| e.resolves_to(state))
-            .unwrap_or(ValueConstraint::Any)
+            .map(|e| e.type_check(state))
+            .unwrap_or(TypeCheck {
+                optional: true,
+                ..Default::default()
+            })
     }
 }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,7 +1,7 @@
-use crate::{CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value};
+use crate::{state, Expr, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
-pub(crate) struct Block {
+pub struct Block {
     expressions: Vec<Expr>,
 }
 
@@ -12,7 +12,11 @@ impl Block {
 }
 
 impl Expression for Block {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let mut value = None;
 
         for expr in &self.expressions {
@@ -22,7 +26,7 @@ impl Expression for Block {
         Ok(value)
     }
 
-    fn type_def(&self, state: &CompilerState) -> TypeDef {
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
         let mut type_defs = self
             .expressions
             .iter()
@@ -48,7 +52,7 @@ impl Expression for Block {
 mod tests {
     use super::*;
     use crate::{
-        expression::Arithmetic, test_type_def, Literal, Operator, ValueConstraint::*, ValueKind::*,
+        expression::Arithmetic, test_type_def, value::Kind::*, value::Constraint::*, Literal, Operator,
     };
 
     test_type_def![

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -52,7 +52,11 @@ impl Expression for Block {
 mod tests {
     use super::*;
     use crate::{
-        expression::Arithmetic, test_type_def, value::Kind::*, value::Constraint::*, Literal, Operator,
+        expression::{Arithmetic, Literal},
+        test_type_def,
+        value::Constraint::*,
+        value::Kind::*,
+        Operator,
     };
 
     test_type_def![

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value};
+use crate::{CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Block {
@@ -12,7 +12,7 @@ impl Block {
 }
 
 impl Expression for Block {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let mut value = None;
 
         for expr in &self.expressions {

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -189,3 +189,21 @@ impl Expression for ArgumentValidator {
         self.expression.type_check(state)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_type_check, Noop, ValueConstraint::*};
+
+    test_type_check![pass_through {
+        expr: |_| {
+            let function = Box::new(Noop);
+            Function { function }
+        },
+        def: TypeCheck {
+            fallible: false,
+            optional: true,
+            constraint: Any
+        },
+    }];
+}

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,6 +1,7 @@
 use super::Error as E;
 use crate::{
-    Argument, ArgumentList, Expression, Function as Fn, Object, Result, State, Value, ValueKind,
+    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, ResolveKind, Result,
+    State, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -125,6 +126,10 @@ impl Expression for Function {
     fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
         self.function.execute(state, object)
     }
+
+    fn resolves_to(&self, state: &crate::CompilerState) -> ResolveKind {
+        self.function.resolves_to(state)
+    }
 }
 
 #[derive(Clone)]
@@ -178,5 +183,9 @@ impl Expression for ArgumentValidator {
         }
 
         Ok(Some(value))
+    }
+
+    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+        self.expression.resolves_to(state)
     }
 }

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, ResolveKind, Result,
+    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, ValueConstraint, Result,
     State, Value, ValueKind,
 };
 
@@ -127,7 +127,7 @@ impl Expression for Function {
         self.function.execute(state, object)
     }
 
-    fn resolves_to(&self, state: &crate::CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &crate::CompilerState) -> ValueConstraint {
         self.function.resolves_to(state)
     }
 }
@@ -185,7 +185,7 @@ impl Expression for ArgumentValidator {
         Ok(Some(value))
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         self.expression.resolves_to(state)
     }
 }

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{
-    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, ValueConstraint, Result,
-    State, Value, ValueKind,
+    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, Result, State,
+    TypeCheck, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -127,8 +127,8 @@ impl Expression for Function {
         self.function.execute(state, object)
     }
 
-    fn resolves_to(&self, state: &crate::CompilerState) -> ValueConstraint {
-        self.function.resolves_to(state)
+    fn type_check(&self, state: &crate::CompilerState) -> TypeCheck {
+        self.function.type_check(state)
     }
 }
 
@@ -185,7 +185,7 @@ impl Expression for ArgumentValidator {
         Ok(Some(value))
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
-        self.expression.resolves_to(state)
+    fn type_check(&self, state: &CompilerState) -> TypeCheck {
+        self.expression.type_check(state)
     }
 }

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,5 +1,7 @@
 use super::Error as E;
-use crate::{Argument, ArgumentList, Expression, Function as Fn, Object, Result, State, Value};
+use crate::{
+    Argument, ArgumentList, Expression, Function as Fn, Object, Result, State, Value, ValueKind,
+};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -19,7 +21,7 @@ pub enum Error {
     Expression(&'static str),
 
     #[error(r#"incorrect value type for argument "{0}" (got "{0}")"#)]
-    Value(&'static str, &'static str),
+    Value(&'static str, ValueKind),
 }
 
 #[derive(Debug, Clone)]

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{
     Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, Result, State,
-    TypeCheck, Value, ValueKind,
+    TypeDef, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -127,8 +127,8 @@ impl Expression for Function {
         self.function.execute(state, object)
     }
 
-    fn type_check(&self, state: &crate::CompilerState) -> TypeCheck {
-        self.function.type_check(state)
+    fn type_def(&self, state: &crate::CompilerState) -> TypeDef {
+        self.function.type_def(state)
     }
 }
 
@@ -185,22 +185,22 @@ impl Expression for ArgumentValidator {
         Ok(Some(value))
     }
 
-    fn type_check(&self, state: &CompilerState) -> TypeCheck {
-        self.expression.type_check(state)
+    fn type_def(&self, state: &CompilerState) -> TypeDef {
+        self.expression.type_def(state)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_check, Noop, ValueConstraint::*};
+    use crate::{test_type_def, Noop, ValueConstraint::*};
 
-    test_type_check![pass_through {
+    test_type_def![pass_through {
         expr: |_| {
             let function = Box::new(Noop);
             Function { function }
         },
-        def: TypeCheck {
+        def: TypeDef {
             fallible: false,
             optional: true,
             constraint: Any

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -4,7 +4,7 @@ use crate::{
     Result, TypeDef, Value, ValueKind,
 };
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("undefined")]
     Undefined,

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{
-    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, Result, State,
-    TypeDef, Value, ValueKind,
+    Argument, ArgumentList, CompilerState, Expression, Function as Fn, Object, ProgramState,
+    Result, TypeDef, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -123,7 +123,7 @@ impl Function {
 }
 
 impl Expression for Function {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         self.function.execute(state, object)
     }
 
@@ -168,7 +168,7 @@ impl ArgumentValidator {
 }
 
 impl Expression for ArgumentValidator {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = self
             .expression
             .execute(state, object)?

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -201,7 +201,7 @@ impl Expression for ArgumentValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Constraint::*, Noop};
+    use crate::{expression::Noop, test_type_def, value::Constraint::*};
 
     test_type_def![pass_through {
         expr: |_| {

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -50,3 +50,41 @@ impl Expression for IfStatement {
         true_type_check.merge(&false_type_check)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_type_check, Literal, Noop, ValueConstraint::*, ValueKind::*};
+
+    test_type_check![
+        concrete_type_def {
+            expr: |_| {
+                let conditional = Box::new(Literal::from(true).into());
+                let true_expression = Box::new(Literal::from(true).into());
+                let false_expression = Box::new(Literal::from(true).into());
+
+                IfStatement::new(conditional, true_expression, false_expression)
+            },
+            def: TypeCheck {
+                fallible: false,
+                optional: false,
+                constraint: Exact(Boolean),
+            },
+        }
+
+        optional_any {
+            expr: |_| {
+                let conditional = Box::new(Literal::from(true).into());
+                let true_expression = Box::new(Literal::from(true).into());
+                let false_expression = Box::new(Noop.into());
+
+                IfStatement::new(conditional, true_expression, false_expression)
+            },
+            def: TypeCheck {
+                fallible: false,
+                optional: true,
+                constraint: Any,
+            },
+        }
+    ];
+}

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -43,12 +43,12 @@ impl Expression for IfStatement {
         }
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         let true_resolves = self.true_expression.resolves_to(state);
         let false_resolves = self.false_expression.resolves_to(state);
 
         if true_resolves.is_any() || false_resolves.is_any() {
-            return ResolveKind::Any;
+            return ValueConstraint::Any;
         }
 
         let true_value_kinds = true_resolves.value_kinds();
@@ -60,15 +60,15 @@ impl Expression for IfStatement {
             .collect::<Vec<_>>();
 
         let resolve = if kinds.len() == 1 {
-            ResolveKind::Exact(kinds[0])
+            ValueConstraint::Exact(kinds[0])
         } else {
-            ResolveKind::OneOf(kinds)
+            ValueConstraint::OneOf(kinds)
         };
 
         // FIXME: at this point, we might only have resolves from if or else, so
         // if the other is "maybe", the result can still be exact.
         if true_resolves.is_maybe() || false_resolves.is_maybe() {
-            ResolveKind::Maybe(Box::new(resolve))
+            ValueConstraint::Maybe(Box::new(resolve))
         } else {
             resolve
         }

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -43,34 +43,10 @@ impl Expression for IfStatement {
         }
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
-        let true_resolves = self.true_expression.resolves_to(state);
-        let false_resolves = self.false_expression.resolves_to(state);
+    fn type_check(&self, state: &CompilerState) -> TypeCheck {
+        let true_type_check = self.true_expression.type_check(state);
+        let false_type_check = self.false_expression.type_check(state);
 
-        if true_resolves.is_any() || false_resolves.is_any() {
-            return ValueConstraint::Any;
-        }
-
-        let true_value_kinds = true_resolves.value_kinds();
-        let false_value_kinds = false_resolves.value_kinds();
-
-        let kinds = true_value_kinds
-            .into_iter()
-            .chain(false_value_kinds.into_iter())
-            .collect::<Vec<_>>();
-
-        let resolve = if kinds.len() == 1 {
-            ValueConstraint::Exact(kinds[0])
-        } else {
-            ValueConstraint::OneOf(kinds)
-        };
-
-        // FIXME: at this point, we might only have resolves from if or else, so
-        // if the other is "maybe", the result can still be exact.
-        if true_resolves.is_maybe() || false_resolves.is_maybe() {
-            ValueConstraint::Maybe(Box::new(resolve))
-        } else {
-            resolve
-        }
+        true_type_check.merge(&false_type_check)
     }
 }

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -43,20 +43,20 @@ impl Expression for IfStatement {
         }
     }
 
-    fn type_check(&self, state: &CompilerState) -> TypeCheck {
-        let true_type_check = self.true_expression.type_check(state);
-        let false_type_check = self.false_expression.type_check(state);
+    fn type_def(&self, state: &CompilerState) -> TypeDef {
+        let true_type_def = self.true_expression.type_def(state);
+        let false_type_def = self.false_expression.type_def(state);
 
-        true_type_check.merge(&false_type_check)
+        true_type_def.merge(&false_type_def)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_check, Literal, Noop, ValueConstraint::*, ValueKind::*};
+    use crate::{test_type_def, Literal, Noop, ValueConstraint::*, ValueKind::*};
 
-    test_type_check![
+    test_type_def![
         concrete_type_def {
             expr: |_| {
                 let conditional = Box::new(Literal::from(true).into());
@@ -65,7 +65,7 @@ mod tests {
 
                 IfStatement::new(conditional, true_expression, false_expression)
             },
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: false,
                 optional: false,
                 constraint: Exact(Boolean),
@@ -80,7 +80,7 @@ mod tests {
 
                 IfStatement::new(conditional, true_expression, false_expression)
             },
-            def: TypeCheck {
+            def: TypeDef {
                 fallible: false,
                 optional: true,
                 constraint: Any,

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -46,10 +46,11 @@ impl Expression for IfStatement {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        let true_type_def = self.true_expression.type_def(state);
-        let false_type_def = self.false_expression.type_def(state);
-
-        true_type_def.merge(false_type_def)
+        self.conditional
+            .type_def(state)
+            .fallible_unless(value::Kind::Boolean)
+            .merge(self.true_expression.type_def(state))
+            .merge(self.false_expression.type_def(state))
     }
 }
 

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{value, Expr, Expression, Object, Result, State, Value};
+use crate::{value, Expr, Expression, Object, Result, State, Value, ValueKind};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -34,7 +34,7 @@ impl Expression for IfStatement {
             Some(Value::Boolean(true)) => self.true_expression.execute(state, object),
             Some(Value::Boolean(false)) | None => self.false_expression.execute(state, object),
             Some(v) => Err(E::from(Error::from(value::Error::Expected(
-                Value::Boolean(true).kind(),
+                ValueKind::Boolean,
                 v.kind(),
             )))
             .into()),

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -3,7 +3,7 @@ use crate::{
     value, CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value, ValueKind,
 };
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("invalid value kind")]
     Value(#[from] value::Error),

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -49,14 +49,19 @@ impl Expression for IfStatement {
         let true_type_def = self.true_expression.type_def(state);
         let false_type_def = self.false_expression.type_def(state);
 
-        true_type_def.merge(&false_type_def)
+        true_type_def.merge(false_type_def)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Kind::*, value::Constraint::*, Literal, Noop};
+    use crate::{
+        expression::{Literal, Noop},
+        test_type_def,
+        value::Constraint::*,
+        value::Kind::*,
+    };
 
     test_type_def![
         concrete_type_def {

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -31,7 +31,7 @@ impl IfStatement {
 }
 
 impl Expression for IfStatement {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         match self.conditional.execute(state, object)? {
             Some(Value::Boolean(true)) => self.true_expression.execute(state, object),
             Some(Value::Boolean(false)) | None => self.false_expression.execute(state, object),

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,4 @@
-use crate::{Expression, Object, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -12,5 +12,9 @@ impl<T: Into<Value>> From<T> for Literal {
 impl Expression for Literal {
     fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(self.0.clone()))
+    }
+
+    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+        ResolveKind::Exact(self.0.kind())
     }
 }

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value, ValueConstraint};
+use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value, ValueConstraint};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -14,8 +14,8 @@ impl Expression for Literal {
         Ok(Some(self.0.clone()))
     }
 
-    fn type_check(&self, _: &CompilerState) -> TypeCheck {
-        TypeCheck {
+    fn type_def(&self, _: &CompilerState) -> TypeDef {
+        TypeDef {
             constraint: ValueConstraint::Exact(self.0.kind()),
             ..Default::default()
         }
@@ -25,48 +25,48 @@ impl Expression for Literal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_check, Literal, ValueConstraint::*, ValueKind::*};
+    use crate::{test_type_def, ValueConstraint::*, ValueKind::*};
     use std::collections::BTreeMap;
 
-    test_type_check![
+    test_type_def![
         boolean {
             expr: |_| Literal::from(true),
-            def: TypeCheck { constraint: Exact(Boolean), ..Default::default() },
+            def: TypeDef { constraint: Exact(Boolean), ..Default::default() },
         }
 
         string {
             expr: |_| Literal::from("foo"),
-            def: TypeCheck { constraint: Exact(String), ..Default::default() },
+            def: TypeDef { constraint: Exact(String), ..Default::default() },
         }
 
         integer {
             expr: |_| Literal::from(123),
-            def: TypeCheck { constraint: Exact(Integer), ..Default::default() },
+            def: TypeDef { constraint: Exact(Integer), ..Default::default() },
         }
 
         float {
             expr: |_| Literal::from(123.456),
-            def: TypeCheck { constraint: Exact(Float), ..Default::default() },
+            def: TypeDef { constraint: Exact(Float), ..Default::default() },
         }
 
         array {
             expr: |_| Literal::from(vec!["foo"]),
-            def: TypeCheck { constraint: Exact(Array), ..Default::default() },
+            def: TypeDef { constraint: Exact(Array), ..Default::default() },
         }
 
         map {
             expr: |_| Literal::from(BTreeMap::default()),
-            def: TypeCheck { constraint: Exact(Map), ..Default::default() },
+            def: TypeDef { constraint: Exact(Map), ..Default::default() },
         }
 
         timestamp {
             expr: |_| Literal::from(chrono::Utc::now()),
-            def: TypeCheck { constraint: Exact(Timestamp), ..Default::default() },
+            def: TypeDef { constraint: Exact(Timestamp), ..Default::default() },
         }
 
         null {
             expr: |_| Literal::from(()),
-            def: TypeCheck { constraint: Exact(Null), ..Default::default() },
+            def: TypeDef { constraint: Exact(Null), ..Default::default() },
         }
     ];
 }

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -14,7 +14,7 @@ impl Expression for Literal {
         Ok(Some(self.0.clone()))
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
-        ResolveKind::Exact(self.0.kind())
+    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
+        ValueConstraint::Exact(self.0.kind())
     }
 }

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -21,3 +21,52 @@ impl Expression for Literal {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_type_check, Literal, ValueConstraint::*, ValueKind::*};
+    use std::collections::BTreeMap;
+
+    test_type_check![
+        boolean {
+            expr: |_| Literal::from(true),
+            def: TypeCheck { constraint: Exact(Boolean), ..Default::default() },
+        }
+
+        string {
+            expr: |_| Literal::from("foo"),
+            def: TypeCheck { constraint: Exact(String), ..Default::default() },
+        }
+
+        integer {
+            expr: |_| Literal::from(123),
+            def: TypeCheck { constraint: Exact(Integer), ..Default::default() },
+        }
+
+        float {
+            expr: |_| Literal::from(123.456),
+            def: TypeCheck { constraint: Exact(Float), ..Default::default() },
+        }
+
+        array {
+            expr: |_| Literal::from(vec!["foo"]),
+            def: TypeCheck { constraint: Exact(Array), ..Default::default() },
+        }
+
+        map {
+            expr: |_| Literal::from(BTreeMap::default()),
+            def: TypeCheck { constraint: Exact(Map), ..Default::default() },
+        }
+
+        timestamp {
+            expr: |_| Literal::from(chrono::Utc::now()),
+            def: TypeCheck { constraint: Exact(Timestamp), ..Default::default() },
+        }
+
+        null {
+            expr: |_| Literal::from(()),
+            def: TypeCheck { constraint: Exact(Null), ..Default::default() },
+        }
+    ];
+}

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
+use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value, ValueConstraint};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -14,7 +14,10 @@ impl Expression for Literal {
         Ok(Some(self.0.clone()))
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
-        ValueConstraint::Exact(self.0.kind())
+    fn type_check(&self, _: &CompilerState) -> TypeCheck {
+        TypeCheck {
+            constraint: ValueConstraint::Exact(self.0.kind()),
+            ..Default::default()
+        }
     }
 }

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,6 +1,4 @@
-use crate::{
-    CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value, ValueConstraint,
-};
+use crate::{state, value, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -12,13 +10,13 @@ impl<T: Into<Value>> From<T> for Literal {
 }
 
 impl Expression for Literal {
-    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(self.0.clone()))
     }
 
-    fn type_def(&self, _: &CompilerState) -> TypeDef {
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            constraint: ValueConstraint::Exact(self.0.kind()),
+            constraint: value::Constraint::Exact(self.0.kind()),
             ..Default::default()
         }
     }
@@ -27,7 +25,7 @@ impl Expression for Literal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, ValueConstraint::*, ValueKind::*};
+    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
     use std::collections::BTreeMap;
 
     test_type_def![

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,6 @@
-use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value, ValueConstraint};
+use crate::{
+    CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value, ValueConstraint,
+};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -10,7 +12,7 @@ impl<T: Into<Value>> From<T> for Literal {
 }
 
 impl Expression for Literal {
-    fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(self.0.clone()))
     }
 

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -3,6 +3,12 @@ use crate::{state, value, Expression, Object, Result, TypeDef, Value};
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
 
+impl Literal {
+    pub fn boxed(self) -> Box<dyn Expression> {
+        Box::new(self)
+    }
+}
+
 impl<T: Into<Value>> From<T> for Literal {
     fn from(value: T) -> Self {
         Self(value.into())

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
+use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
@@ -8,7 +8,10 @@ impl Expression for Noop {
         Ok(None)
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
-        ValueConstraint::Maybe(Box::new(ValueConstraint::Any))
+    fn type_check(&self, _: &CompilerState) -> TypeCheck {
+        TypeCheck {
+            optional: true,
+            ..Default::default()
+        }
     }
 }

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,4 +1,4 @@
-use crate::{Expression, Object, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
@@ -6,5 +6,9 @@ pub struct Noop;
 impl Expression for Noop {
     fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(None)
+    }
+
+    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+        ResolveKind::Maybe(Box::new(ResolveKind::Any))
     }
 }

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -15,3 +15,17 @@ impl Expression for Noop {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_type_check;
+
+    test_type_check![noop {
+        expr: |_| Noop,
+        def: TypeCheck {
+            optional: true,
+            ..Default::default()
+        },
+    }];
+}

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
@@ -8,7 +8,7 @@ impl Expression for Noop {
         Ok(None)
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
-        ResolveKind::Maybe(Box::new(ResolveKind::Any))
+    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
+        ValueConstraint::Maybe(Box::new(ValueConstraint::Any))
     }
 }

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value};
+use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
@@ -8,8 +8,8 @@ impl Expression for Noop {
         Ok(None)
     }
 
-    fn type_check(&self, _: &CompilerState) -> TypeCheck {
-        TypeCheck {
+    fn type_def(&self, _: &CompilerState) -> TypeDef {
+        TypeDef {
             optional: true,
             ..Default::default()
         }
@@ -19,11 +19,11 @@ impl Expression for Noop {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_type_check;
+    use crate::test_type_def;
 
-    test_type_check![noop {
+    test_type_def![noop {
         expr: |_| Noop,
-        def: TypeCheck {
+        def: TypeDef {
             optional: true,
             ..Default::default()
         },

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,10 +1,10 @@
-use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value};
+use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
 
 impl Expression for Noop {
-    fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(None)
     }
 

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,14 +1,14 @@
-use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
+use crate::{state, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
 
 impl Expression for Noop {
-    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(None)
     }
 
-    fn type_def(&self, _: &CompilerState) -> TypeDef {
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
             optional: true,
             ..Default::default()

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,6 +1,7 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value,
+    ValueConstraint, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -35,8 +36,12 @@ impl Expression for Not {
         })
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
-        ValueConstraint::Exact(ValueKind::Boolean)
+    fn type_check(&self, _: &CompilerState) -> TypeCheck {
+        TypeCheck {
+            fallible: true,
+            optional: true,
+            constraint: ValueConstraint::Exact(ValueKind::Boolean),
+        }
     }
 }
 

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,6 +1,6 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value, ValueKind,
+    value, CompilerState, Expr, Expression, Object, ValueConstraint, Result, State, Value, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -35,8 +35,8 @@ impl Expression for Not {
         })
     }
 
-    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
-        ResolveKind::Exact(ValueKind::Boolean)
+    fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
+        ValueConstraint::Exact(ValueKind::Boolean)
     }
 }
 

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,5 +1,7 @@
 use super::Error as E;
-use crate::{value, Expr, Expression, Object, Result, State, Value, ValueKind};
+use crate::{
+    value, CompilerState, Expr, Expression, Object, ResolveKind, Result, State, Value, ValueKind,
+};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -31,6 +33,10 @@ impl Expression for Not {
             })
             .transpose()
         })
+    }
+
+    fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+        ResolveKind::Exact(ValueKind::Boolean)
     }
 }
 

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -48,6 +48,7 @@ impl Expression for Not {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{test_type_check, Noop, ValueConstraint::*, ValueKind::*};
 
     #[test]
     fn not() {
@@ -81,4 +82,13 @@ mod tests {
             assert_eq!(got, exp);
         }
     }
+
+    test_type_check![boolean {
+        expr: |_| Not::new(Box::new(Noop.into())),
+        def: TypeCheck {
+            fallible: true,
+            optional: true,
+            constraint: Exact(Boolean),
+        },
+    }];
 }

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{value, Expr, Expression, Object, Result, State, Value};
+use crate::{value, Expr, Expression, Object, Result, State, Value, ValueKind};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -24,7 +24,7 @@ impl Expression for Not {
             opt.map(|v| match v {
                 Value::Boolean(b) => Ok(Value::Boolean(!b)),
                 _ => Err(E::from(Error::from(value::Error::Expected(
-                    Value::Boolean(true).kind(),
+                    ValueKind::Boolean,
                     v.kind(),
                 )))
                 .into()),

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, Result, State, TypeCheck, Value,
-    ValueConstraint, ValueKind,
+    value, CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueConstraint,
+    ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -36,8 +36,8 @@ impl Expression for Not {
         })
     }
 
-    fn type_check(&self, _: &CompilerState) -> TypeCheck {
-        TypeCheck {
+    fn type_def(&self, _: &CompilerState) -> TypeDef {
+        TypeDef {
             fallible: true,
             optional: true,
             constraint: ValueConstraint::Exact(ValueKind::Boolean),
@@ -48,7 +48,7 @@ impl Expression for Not {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_check, Noop, ValueConstraint::*, ValueKind::*};
+    use crate::{test_type_def, Noop, ValueConstraint::*, ValueKind::*};
 
     #[test]
     fn not() {
@@ -83,9 +83,9 @@ mod tests {
         }
     }
 
-    test_type_check![boolean {
+    test_type_def![boolean {
         expr: |_| Not::new(Box::new(Noop.into())),
-        def: TypeCheck {
+        def: TypeDef {
             fallible: true,
             optional: true,
             constraint: Exact(Boolean),

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{
-    value, CompilerState, Expr, Expression, Object, Result, State, TypeDef, Value, ValueConstraint,
-    ValueKind,
+    value, CompilerState, Expr, Expression, Object, ProgramState, Result, TypeDef, Value,
+    ValueConstraint, ValueKind,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -22,7 +22,7 @@ impl Not {
 }
 
 impl Expression for Not {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         self.expression.execute(state, object).and_then(|opt| {
             opt.map(|v| match v {
                 Value::Boolean(b) => Ok(Value::Boolean(!b)),
@@ -71,7 +71,7 @@ mod tests {
             ),
         ];
 
-        let mut state = crate::State::default();
+        let mut state = crate::ProgramState::default();
         let mut object = std::collections::HashMap::default();
 
         for (exp, func) in cases {

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -4,7 +4,7 @@ use crate::{
     ValueConstraint, ValueKind,
 };
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("invalid value kind")]
     Value(#[from] value::Error),

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -42,11 +42,11 @@ impl Expression for Path {
     /// A path resolves to `Any` by default, but the script might assign
     /// specific values to paths during its execution, which increases our exact
     /// understanding of the value kind the path contains.
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         state
             .path_query_kind(&segments_to_path(&self.segments))
             .cloned()
-            .unwrap_or(ResolveKind::Any)
+            .unwrap_or(ValueConstraint::Any)
     }
 }
 

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
+use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -42,11 +42,14 @@ impl Expression for Path {
     /// A path resolves to `Any` by default, but the script might assign
     /// specific values to paths during its execution, which increases our exact
     /// understanding of the value kind the path contains.
-    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
+    fn type_check(&self, state: &CompilerState) -> TypeCheck {
         state
-            .path_query_kind(&segments_to_path(&self.segments))
+            .path_query_type(&segments_to_path(&self.segments))
             .cloned()
-            .unwrap_or(ValueConstraint::Any)
+            .unwrap_or(TypeCheck {
+                fallible: true,
+                ..Default::default()
+            })
     }
 }
 

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("missing path: {0}")]
     Missing(String),

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value};
+use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -31,7 +31,7 @@ impl Path {
 }
 
 impl Expression for Path {
-    fn execute(&self, _: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         object
             .find(&self.segments)
             .map_err(|e| E::from(Error::Resolve(e)))?

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -69,7 +69,7 @@ pub(crate) fn segments_to_path(segments: &[Vec<String>]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Kind::*, value::Constraint::*};
+    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
 
     test_type_def![
         ident_match {

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{Expression, Object, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -25,5 +25,12 @@ impl Expression for Variable {
             .cloned()
             .ok_or_else(|| E::from(Error::Undefined(self.ident.to_owned())).into())
             .map(Some)
+    }
+
+    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+        state
+            .variable_kind(&self.ident)
+            .cloned()
+            .unwrap_or(ResolveKind::Any)
     }
 }

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
+use crate::{CompilerState, Expression, Object, Result, State, TypeCheck, Value, ValueConstraint};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -27,10 +27,14 @@ impl Expression for Variable {
             .map(Some)
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
+    fn type_check(&self, state: &CompilerState) -> TypeCheck {
         state
-            .variable_kind(&self.ident)
+            .variable_type(&self.ident)
             .cloned()
-            .unwrap_or(ValueConstraint::Any)
+            .unwrap_or(TypeCheck {
+                fallible: true,
+                optional: false,
+                constraint: ValueConstraint::Any,
+            })
     }
 }

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, ResolveKind, Result, State, Value};
+use crate::{CompilerState, Expression, Object, ValueConstraint, Result, State, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -27,10 +27,10 @@ impl Expression for Variable {
             .map(Some)
     }
 
-    fn resolves_to(&self, state: &CompilerState) -> ResolveKind {
+    fn resolves_to(&self, state: &CompilerState) -> ValueConstraint {
         state
             .variable_kind(&self.ident)
             .cloned()
-            .unwrap_or(ResolveKind::Any)
+            .unwrap_or(ValueConstraint::Any)
     }
 }

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,5 +1,5 @@
 use super::Error as E;
-use crate::{CompilerState, Expression, Object, Result, State, TypeDef, Value};
+use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -19,7 +19,7 @@ impl Variable {
 }
 
 impl Expression for Variable {
-    fn execute(&self, state: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
         state
             .variable(&self.ident)
             .cloned()

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -47,7 +47,7 @@ impl Expression for Variable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Kind::*, value::Constraint::*};
+    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
 
     test_type_def![
         ident_match {

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,7 +1,7 @@
 use super::Error as E;
 use crate::{CompilerState, Expression, Object, ProgramState, Result, TypeDef, Value};
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error("undefined variable: {0}")]
     Undefined(String),

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -88,6 +88,24 @@ pub enum Argument {
     Regex(regex::Regex),
 }
 
+impl From<Box<dyn Expression>> for Argument {
+    fn from(expr: Box<dyn Expression>) -> Self {
+        Argument::Expression(expr)
+    }
+}
+
+impl<T: Expression + 'static> From<Box<T>> for Argument {
+    fn from(expr: Box<T>) -> Self {
+        Argument::Expression(expr)
+    }
+}
+
+impl From<regex::Regex> for Argument {
+    fn from(regex: regex::Regex) -> Self {
+        Argument::Regex(regex)
+    }
+}
+
 impl TryInto<Box<dyn Expression>> for Argument {
     type Error = Error;
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -2,7 +2,7 @@ use crate::{Expression, Result, Value};
 use core::convert::TryInto;
 use std::collections::HashMap;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error(r#"expected expression argument, got regex"#)]
     ArgumentExprRegex,

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -6,6 +6,7 @@ mod parser;
 mod program;
 mod runtime;
 mod state;
+mod test_util;
 mod value;
 mod value_constraint;
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -15,7 +15,7 @@ use operator::Operator;
 
 pub mod prelude;
 pub use error::{Error, RemapError};
-pub use expression::{Expression, Literal, Noop, Path, TypeCheck};
+pub use expression::{Expression, Literal, Noop, Path, TypeDef};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;
@@ -161,8 +161,8 @@ mod tests {
             Ok(Some(format!("regex: {:?}", self.0).into()))
         }
 
-        fn type_check(&self, _: &CompilerState) -> TypeCheck {
-            TypeCheck::default()
+        fn type_def(&self, _: &CompilerState) -> TypeDef {
+            TypeDef::default()
         }
     }
 
@@ -241,7 +241,7 @@ mod tests {
         ];
 
         for (script, expectation) in cases {
-            let accept = TypeCheck {
+            let accept = TypeDef {
                 fallible: true,
                 optional: true,
                 constraint: ValueConstraint::Any,

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -18,7 +18,7 @@ pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;
 pub use state::State;
-pub use value::Value;
+pub use value::{Value, ValueKind};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -17,7 +17,7 @@ pub use expression::{Expression, Literal, Noop, Path, ResolveKind};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;
-pub use state::State;
+pub use state::{CompilerState, State};
 pub use value::{Value, ValueKind};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -7,18 +7,20 @@ mod program;
 mod runtime;
 mod state;
 mod value;
+mod value_constraint;
 
 use expression::Expr;
 use operator::Operator;
 
 pub mod prelude;
 pub use error::{Error, RemapError};
-pub use expression::{Expression, Literal, Noop, Path, ResolveKind};
+pub use expression::{Expression, Literal, Noop, Path};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;
 pub use state::{CompilerState, State};
 pub use value::{Value, ValueKind};
+pub use value_constraint::ValueConstraint;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -158,8 +160,8 @@ mod tests {
             Ok(Some(format!("regex: {:?}", self.0).into()))
         }
 
-        fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
-            ResolveKind::Any
+        fn resolves_to(&self, _: &CompilerState) -> ValueConstraint {
+            ValueConstraint::Any
         }
     }
 
@@ -238,7 +240,7 @@ mod tests {
         ];
 
         for (script, expectation) in cases {
-            let accept = ResolveKind::Maybe(Box::new(ResolveKind::Any));
+            let accept = ValueConstraint::Maybe(Box::new(ValueConstraint::Any));
             let program = Program::new(script, &[Box::new(RegexPrinter)], accept).unwrap();
             let mut runtime = Runtime::new(State::default());
             let mut event = HashMap::default();

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -12,13 +12,6 @@ mod value_constraint;
 use expression::Expr;
 use operator::Operator;
 
-// TODO: update fmt::Display, move to the error, and properly print details about optional and fallible...
-//
-// "expected to resolve to (infallible)? optional/concrete type(s) string(, integer, float)"
-//
-// Only show details of "fallible/infallible" and "optional/concrete" when they
-// differ between the two, otherwise just show the type differences.
-
 pub mod prelude;
 pub use error::{Error, RemapError};
 pub use expression::{Expression, Literal, Noop, Path, TypeCheck};

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -157,6 +157,10 @@ mod tests {
         fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
             Ok(Some(format!("regex: {:?}", self.0).into()))
         }
+
+        fn resolves_to(&self, _: &CompilerState) -> ResolveKind {
+            ResolveKind::Any
+        }
     }
 
     #[test]
@@ -234,7 +238,8 @@ mod tests {
         ];
 
         for (script, expectation) in cases {
-            let program = Program::new(script, &[Box::new(RegexPrinter)]).unwrap();
+            let accept = ResolveKind::Maybe(Box::new(ResolveKind::Any));
+            let program = Program::new(script, &[Box::new(RegexPrinter)], accept).unwrap();
             let mut runtime = Runtime::new(State::default());
             let mut event = HashMap::default();
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -13,7 +13,7 @@ use operator::Operator;
 
 pub mod prelude;
 pub use error::{Error, RemapError};
-pub use expression::{Expression, Literal, Noop, Path};
+pub use expression::{Expression, Literal, Noop, Path, ResolveKind};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -19,7 +19,7 @@ pub use expression::{Expression, Literal, Noop, Path, TypeDef};
 pub use function::{Argument, ArgumentList, Function, Parameter};
 pub use program::Program;
 pub use runtime::Runtime;
-pub use state::{CompilerState, State};
+pub use state::{CompilerState, ProgramState};
 pub use value::{Value, ValueKind};
 pub use value_constraint::ValueConstraint;
 
@@ -157,7 +157,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct RegexPrinterFn(regex::Regex);
     impl Expression for RegexPrinterFn {
-        fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+        fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
             Ok(Some(format!("regex: {:?}", self.0).into()))
         }
 
@@ -248,7 +248,7 @@ mod tests {
             };
 
             let program = Program::new(script, &[Box::new(RegexPrinter)], accept).unwrap();
-            let mut runtime = Runtime::new(State::default());
+            let mut runtime = Runtime::new(ProgramState::default());
             let mut event = HashMap::default();
 
             let result = runtime.execute(&mut event, &program).map_err(|e| e.0);

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -130,6 +130,7 @@ fn vec_path_to_string(path: &[Vec<String>]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::function::ArgumentList;
     use std::collections::HashMap;
 
     #[derive(Debug, Clone)]

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -1,27 +1,25 @@
 mod error;
-mod expression;
-mod function;
 mod operator;
 mod parser;
 mod program;
 mod runtime;
-mod state;
 mod test_util;
-mod value;
-mod value_constraint;
+mod type_def;
 
-use expression::Expr;
-use operator::Operator;
-
+pub mod expression;
+pub mod function;
 pub mod prelude;
+pub mod state;
+pub mod value;
+
 pub use error::{Error, RemapError};
-pub use expression::{Expression, Literal, Noop, Path, TypeDef};
-pub use function::{Argument, ArgumentList, Function, Parameter};
+pub use expression::{Expr, Expression};
+pub use function::{Function, Parameter};
+pub use operator::Operator;
 pub use program::Program;
 pub use runtime::Runtime;
-pub use state::{CompilerState, ProgramState};
-pub use value::{Value, ValueKind};
-pub use value_constraint::ValueConstraint;
+pub use type_def::TypeDef;
+pub use value::Value;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -157,11 +155,11 @@ mod tests {
     #[derive(Debug, Clone)]
     struct RegexPrinterFn(regex::Regex);
     impl Expression for RegexPrinterFn {
-        fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
+        fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
             Ok(Some(format!("regex: {:?}", self.0).into()))
         }
 
-        fn type_def(&self, _: &CompilerState) -> TypeDef {
+        fn type_def(&self, _: &state::Compiler) -> TypeDef {
             TypeDef::default()
         }
     }
@@ -244,11 +242,11 @@ mod tests {
             let accept = TypeDef {
                 fallible: true,
                 optional: true,
-                constraint: ValueConstraint::Any,
+                constraint: value::Constraint::Any,
             };
 
             let program = Program::new(script, &[Box::new(RegexPrinter)], accept).unwrap();
-            let mut runtime = Runtime::new(ProgramState::default());
+            let mut runtime = Runtime::new(state::Program::default());
             let mut event = HashMap::default();
 
             let result = runtime.execute(&mut event, &program).map_err(|e| e.0);

--- a/lib/remap-lang/src/operator.rs
+++ b/lib/remap-lang/src/operator.rs
@@ -2,7 +2,7 @@ use std::convert::AsRef;
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-pub(crate) enum Operator {
+pub enum Operator {
     Multiply,
     Divide,
     Remainder,

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -5,7 +5,8 @@ use crate::{
         Arithmetic, Assignment, Block, Function, IfStatement, Literal, Noop, Not, Path, Target,
         Variable,
     },
-    Argument, CompilerState, Error, Expr, Function as Fn, Operator, Result, Value,
+    function::Argument,
+    state, Error, Expr, Function as Fn, Operator, Result, Value,
 };
 use pest::iterators::{Pair, Pairs};
 use regex::{Regex, RegexBuilder};
@@ -15,7 +16,7 @@ use std::str::FromStr;
 #[grammar = "../grammar.pest"]
 pub(super) struct Parser<'a> {
     pub function_definitions: &'a [Box<dyn Fn>],
-    pub compiler_state: CompilerState,
+    pub compiler_state: state::Compiler,
 }
 
 type R = Rule;

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::{
     Argument, ArgumentList, Error, Expression, Function, Literal, Noop, Object, Parameter, Path,
-    Result, State, Value,
+    Result, State, Value, ValueKind,
 };

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::{
     Argument, ArgumentList, Error, Expression, Function, Literal, Noop, Object, Parameter, Path,
-    Result, State, Value, ValueKind,
+    ProgramState, Result, Value, ValueKind,
 };

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -1,4 +1,11 @@
-pub use crate::{
-    Argument, ArgumentList, Error, Expression, Function, Literal, Noop, Object, Parameter, Path,
-    ProgramState, Result, Value, ValueKind,
-};
+// commonly used modules
+pub use crate::{expression, function, state, value};
+
+// commonly used top-level crate types
+pub use crate::{Error, Expression, Function, Object, Result, TypeDef, Value};
+
+// commonly used expressions
+pub use crate::expression::{Literal, Noop, Path, Variable};
+
+// commonly used function types
+pub use crate::function::{Argument, ArgumentList, Parameter};

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -1,5 +1,13 @@
-use crate::{parser, CompilerState, Error, Expr, Function, RemapError};
+use crate::{
+    parser, CompilerState, Error as E, Expr, Expression, Function, RemapError, ResolveKind,
+};
 use pest::Parser;
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum Error {
+    #[error("program is expected to resolve to {0}, but instead resolves to {1}")]
+    ResolvesTo(ResolveKind, ResolveKind),
+}
 
 /// The program to execute.
 ///
@@ -16,9 +24,10 @@ impl Program {
     pub fn new(
         source: &str,
         function_definitions: &[Box<dyn Function>],
+        must_resolve_to: ResolveKind,
     ) -> Result<Self, RemapError> {
         let pairs = parser::Parser::parse(parser::Rule::program, source)
-            .map_err(|s| Error::Parser(s.to_string()))
+            .map_err(|s| E::Parser(s.to_string()))
             .map_err(RemapError)?;
 
         let compiler_state = CompilerState::default();
@@ -30,6 +39,51 @@ impl Program {
 
         let expressions = parser.pairs_to_expressions(pairs).map_err(RemapError)?;
 
+        let will_resolve_to = expressions
+            .last()
+            .map(|e| e.resolves_to(&parser.compiler_state))
+            .unwrap_or_else(|| ResolveKind::Maybe(Box::new(ResolveKind::Any)));
+
+        if !must_resolve_to.contains(&will_resolve_to) {
+            return Err(RemapError::from(E::from(Error::ResolvesTo(
+                must_resolve_to,
+                will_resolve_to,
+            ))));
+        }
+
         Ok(Self { expressions })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ValueKind;
+
+    #[test]
+    fn program_test() {
+        use ResolveKind::*;
+
+        let cases = vec![
+            (".foo", Any, Ok(())),
+            (
+                ".foo",
+                Exact(ValueKind::String),
+                Err("remap error: program error: program is expected to resolve to string, but instead resolves to any value".to_owned()),
+            ),
+            (
+                "false || 2",
+                OneOf(vec![ValueKind::String, ValueKind::Float]),
+                Err("remap error: program error: program is expected to resolve to any of string, float, but instead resolves to any of integer, boolean".to_owned()),
+            ),
+        ];
+
+        for (source, must_resolve_to, expect) in cases {
+            let program = Program::new(source, &[], must_resolve_to)
+                .map(|_| ())
+                .map_err(|e| e.to_string());
+
+            assert_eq!(program, expect);
+        }
     }
 }

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -1,4 +1,4 @@
-use crate::{parser, Error, Expr, Function, RemapError};
+use crate::{parser, CompilerState, Error, Expr, Function, RemapError};
 use pest::Parser;
 
 /// The program to execute.
@@ -21,9 +21,13 @@ impl Program {
             .map_err(|s| Error::Parser(s.to_string()))
             .map_err(RemapError)?;
 
-        let parser = parser::Parser {
+        let compiler_state = CompilerState::default();
+
+        let mut parser = parser::Parser {
             function_definitions,
+            compiler_state,
         };
+
         let expressions = parser.pairs_to_expressions(pairs).map_err(RemapError)?;
 
         Ok(Self { expressions })

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -40,11 +40,11 @@ impl fmt::Display for ResolvesToError {
 
         if optional_diff {
             if want.is_optional() {
-                want_str.push_str(" optional");
+                want_str.push_str(" or no");
             }
 
             if got.is_optional() {
-                got_str.push_str(" optional");
+                got_str.push_str(" or no");
             }
         }
 

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -2,7 +2,7 @@ use crate::{parser, CompilerState, Error as E, Expr, Expression, Function, Remap
 use pest::Parser;
 use std::fmt;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error(transparent)]
     ResolvesTo(#[from] ResolvesToError),
@@ -11,7 +11,7 @@ pub enum Error {
     Fallible,
 }
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub struct ResolvesToError(TypeDef, TypeDef);
 
 impl fmt::Display for ResolvesToError {

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -1,4 +1,4 @@
-use crate::{parser, CompilerState, Error as E, Expr, Expression, Function, RemapError, TypeDef};
+use crate::{parser, state, Error as E, Expr, Expression, Function, RemapError, TypeDef};
 use pest::Parser;
 use std::fmt;
 
@@ -91,7 +91,7 @@ impl Program {
             .map_err(|s| E::Parser(s.to_string()))
             .map_err(RemapError)?;
 
-        let compiler_state = CompilerState::default();
+        let compiler_state = state::Compiler::default();
 
         let mut parser = parser::Parser {
             function_definitions,
@@ -128,13 +128,13 @@ impl Program {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ValueConstraint, ValueKind};
+    use crate::value;
     use std::error::Error;
 
     #[test]
     fn program_test() {
-        use ValueConstraint::*;
-        use ValueKind::*;
+        use value::Constraint::*;
+        use value::Kind::*;
 
         let cases = vec![
             (".foo", TypeDef { fallible: true, ..Default::default()}, Ok(())),

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -46,10 +46,10 @@ impl fmt::Display for ResolvesToError {
             if got.is_optional() {
                 got_str.push_str(" optional");
             }
-        } else {
-            want_str.push_str(" value");
-            got_str.push_str(" value");
         }
+
+        want_str.push_str(" value");
+        got_str.push_str(" value");
 
         let want_kinds = want.constraint.value_kinds();
         let got_kinds = got.constraint.value_kinds();

--- a/lib/remap-lang/src/runtime.rs
+++ b/lib/remap-lang/src/runtime.rs
@@ -1,12 +1,12 @@
-use crate::{Expression, Object, Program, ProgramState, RemapError, Value};
+use crate::{state, Expression, Object, Program, RemapError, Value};
 
 #[derive(Debug, Default)]
 pub struct Runtime {
-    state: ProgramState,
+    state: state::Program,
 }
 
 impl Runtime {
-    pub fn new(state: ProgramState) -> Self {
+    pub fn new(state: state::Program) -> Self {
         Self { state }
     }
 

--- a/lib/remap-lang/src/runtime.rs
+++ b/lib/remap-lang/src/runtime.rs
@@ -1,12 +1,12 @@
-use crate::{Expression, Object, Program, RemapError, State, Value};
+use crate::{Expression, Object, Program, ProgramState, RemapError, Value};
 
 #[derive(Debug, Default)]
 pub struct Runtime {
-    state: State,
+    state: ProgramState,
 }
 
 impl Runtime {
-    pub fn new(state: State) -> Self {
+    pub fn new(state: ProgramState) -> Self {
         Self { state }
     }
 

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -25,6 +25,18 @@ pub struct CompilerState {
     /// variable will have at runtime, so that the compiler can then check the
     /// variable kinds at compile-time when a variable is called.
     variable_kinds: HashMap<String, ResolveKind>,
+
+    /// The [`ResolveKind`] each path query is expected to have.
+    ///
+    /// By default, the first time a path is queried, it resolves to `Any`, but
+    /// when a path is used to assign a value to, we can potentially narrow down
+    /// the list of values the path will resolve to.
+    ///
+    /// FIXME: this won't work for coalesced paths. We're either going to
+    /// disallow those in assignments, which makes this easier to fix, or we're
+    /// going to always return `Any` for coalesced paths. Either way, this is a
+    /// known bug that we need to fix soon.
+    path_query_kinds: HashMap<String, ResolveKind>,
 }
 
 impl CompilerState {
@@ -34,5 +46,13 @@ impl CompilerState {
 
     pub fn variable_kinds_mut(&mut self) -> &mut HashMap<String, ResolveKind> {
         &mut self.variable_kinds
+    }
+
+    pub fn path_query_kind(&self, key: impl AsRef<str>) -> Option<&ResolveKind> {
+        self.path_query_kinds.get(key.as_ref())
+    }
+
+    pub fn path_query_kinds_mut(&mut self) -> &mut HashMap<String, ResolveKind> {
+        &mut self.path_query_kinds
     }
 }

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{ResolveKind, Value};
+use crate::{ValueConstraint, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
@@ -19,14 +19,14 @@ impl State {
 /// State held by the compiler as it parses the program source.
 #[derive(Debug, Default)]
 pub struct CompilerState {
-    /// The [`ResolveKind`] each variable is expected to have.
+    /// The [`ValueConstraint`] each variable is expected to have.
     ///
     /// This allows assignment operations to tell the compiler what kinds each
     /// variable will have at runtime, so that the compiler can then check the
     /// variable kinds at compile-time when a variable is called.
-    variable_kinds: HashMap<String, ResolveKind>,
+    variable_kinds: HashMap<String, ValueConstraint>,
 
-    /// The [`ResolveKind`] each path query is expected to have.
+    /// The [`ValueConstraint`] each path query is expected to have.
     ///
     /// By default, the first time a path is queried, it resolves to `Any`, but
     /// when a path is used to assign a value to, we can potentially narrow down
@@ -36,23 +36,23 @@ pub struct CompilerState {
     /// disallow those in assignments, which makes this easier to fix, or we're
     /// going to always return `Any` for coalesced paths. Either way, this is a
     /// known bug that we need to fix soon.
-    path_query_kinds: HashMap<String, ResolveKind>,
+    path_query_kinds: HashMap<String, ValueConstraint>,
 }
 
 impl CompilerState {
-    pub fn variable_kind(&self, key: impl AsRef<str>) -> Option<&ResolveKind> {
+    pub fn variable_kind(&self, key: impl AsRef<str>) -> Option<&ValueConstraint> {
         self.variable_kinds.get(key.as_ref())
     }
 
-    pub fn variable_kinds_mut(&mut self) -> &mut HashMap<String, ResolveKind> {
+    pub fn variable_kinds_mut(&mut self) -> &mut HashMap<String, ValueConstraint> {
         &mut self.variable_kinds
     }
 
-    pub fn path_query_kind(&self, key: impl AsRef<str>) -> Option<&ResolveKind> {
+    pub fn path_query_kind(&self, key: impl AsRef<str>) -> Option<&ValueConstraint> {
         self.path_query_kinds.get(key.as_ref())
     }
 
-    pub fn path_query_kinds_mut(&mut self) -> &mut HashMap<String, ResolveKind> {
+    pub fn path_query_kinds_mut(&mut self) -> &mut HashMap<String, ValueConstraint> {
         &mut self.path_query_kinds
     }
 }

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{ValueConstraint, Value};
+use crate::{TypeCheck, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
@@ -24,7 +24,7 @@ pub struct CompilerState {
     /// This allows assignment operations to tell the compiler what kinds each
     /// variable will have at runtime, so that the compiler can then check the
     /// variable kinds at compile-time when a variable is called.
-    variable_kinds: HashMap<String, ValueConstraint>,
+    variable_types: HashMap<String, TypeCheck>,
 
     /// The [`ValueConstraint`] each path query is expected to have.
     ///
@@ -36,23 +36,23 @@ pub struct CompilerState {
     /// disallow those in assignments, which makes this easier to fix, or we're
     /// going to always return `Any` for coalesced paths. Either way, this is a
     /// known bug that we need to fix soon.
-    path_query_kinds: HashMap<String, ValueConstraint>,
+    path_query_types: HashMap<String, TypeCheck>,
 }
 
 impl CompilerState {
-    pub fn variable_kind(&self, key: impl AsRef<str>) -> Option<&ValueConstraint> {
-        self.variable_kinds.get(key.as_ref())
+    pub fn variable_type(&self, key: impl AsRef<str>) -> Option<&TypeCheck> {
+        self.variable_types.get(key.as_ref())
     }
 
-    pub fn variable_kinds_mut(&mut self) -> &mut HashMap<String, ValueConstraint> {
-        &mut self.variable_kinds
+    pub fn variable_types_mut(&mut self) -> &mut HashMap<String, TypeCheck> {
+        &mut self.variable_types
     }
 
-    pub fn path_query_kind(&self, key: impl AsRef<str>) -> Option<&ValueConstraint> {
-        self.path_query_kinds.get(key.as_ref())
+    pub fn path_query_type(&self, key: impl AsRef<str>) -> Option<&TypeCheck> {
+        self.path_query_types.get(key.as_ref())
     }
 
-    pub fn path_query_kinds_mut(&mut self) -> &mut HashMap<String, ValueConstraint> {
-        &mut self.path_query_kinds
+    pub fn path_query_types_mut(&mut self) -> &mut HashMap<String, TypeCheck> {
+        &mut self.path_query_types
     }
 }

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -15,3 +15,24 @@ impl State {
         &mut self.variables
     }
 }
+
+/// State held by the compiler as it parses the program source.
+#[derive(Debug, Default)]
+pub struct CompilerState {
+    /// The [`ResolveKind`] each variable is expected to have.
+    ///
+    /// This allows assignment operations to tell the compiler what kinds each
+    /// variable will have at runtime, so that the compiler can then check the
+    /// variable kinds at compile-time when a variable is called.
+    variable_kinds: HashMap<String, ResolveKind>,
+}
+
+impl CompilerState {
+    pub fn variable_kind(&self, key: impl AsRef<str>) -> Option<&ResolveKind> {
+        self.variable_kinds.get(key.as_ref())
+    }
+
+    pub fn variable_kinds_mut(&mut self) -> &mut HashMap<String, ResolveKind> {
+        &mut self.variable_kinds
+    }
+}

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{TypeCheck, Value};
+use crate::{TypeDef, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
@@ -24,7 +24,7 @@ pub struct CompilerState {
     /// This allows assignment operations to tell the compiler what kinds each
     /// variable will have at runtime, so that the compiler can then check the
     /// variable kinds at compile-time when a variable is called.
-    variable_types: HashMap<String, TypeCheck>,
+    variable_types: HashMap<String, TypeDef>,
 
     /// The [`ValueConstraint`] each path query is expected to have.
     ///
@@ -36,23 +36,23 @@ pub struct CompilerState {
     /// disallow those in assignments, which makes this easier to fix, or we're
     /// going to always return `Any` for coalesced paths. Either way, this is a
     /// known bug that we need to fix soon.
-    path_query_types: HashMap<String, TypeCheck>,
+    path_query_types: HashMap<String, TypeDef>,
 }
 
 impl CompilerState {
-    pub fn variable_type(&self, key: impl AsRef<str>) -> Option<&TypeCheck> {
+    pub fn variable_type(&self, key: impl AsRef<str>) -> Option<&TypeDef> {
         self.variable_types.get(key.as_ref())
     }
 
-    pub fn variable_types_mut(&mut self) -> &mut HashMap<String, TypeCheck> {
+    pub fn variable_types_mut(&mut self) -> &mut HashMap<String, TypeDef> {
         &mut self.variable_types
     }
 
-    pub fn path_query_type(&self, key: impl AsRef<str>) -> Option<&TypeCheck> {
+    pub fn path_query_type(&self, key: impl AsRef<str>) -> Option<&TypeDef> {
         self.path_query_types.get(key.as_ref())
     }
 
-    pub fn path_query_types_mut(&mut self) -> &mut HashMap<String, TypeCheck> {
+    pub fn path_query_types_mut(&mut self) -> &mut HashMap<String, TypeDef> {
         &mut self.path_query_types
     }
 }

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{ResolveKind, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -2,11 +2,11 @@ use crate::{TypeDef, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
-pub struct State {
+pub struct ProgramState {
     variables: HashMap<String, Value>,
 }
 
-impl State {
+impl ProgramState {
     pub fn variable(&self, key: impl AsRef<str>) -> Option<&Value> {
         self.variables.get(key.as_ref())
     }

--- a/lib/remap-lang/src/state.rs
+++ b/lib/remap-lang/src/state.rs
@@ -2,11 +2,11 @@ use crate::{TypeDef, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
-pub struct ProgramState {
+pub struct Program {
     variables: HashMap<String, Value>,
 }
 
-impl ProgramState {
+impl Program {
     pub fn variable(&self, key: impl AsRef<str>) -> Option<&Value> {
         self.variables.get(key.as_ref())
     }
@@ -18,15 +18,15 @@ impl ProgramState {
 
 /// State held by the compiler as it parses the program source.
 #[derive(Debug, Default)]
-pub struct CompilerState {
-    /// The [`ValueConstraint`] each variable is expected to have.
+pub struct Compiler {
+    /// The [`Constraint`] each variable is expected to have.
     ///
     /// This allows assignment operations to tell the compiler what kinds each
     /// variable will have at runtime, so that the compiler can then check the
     /// variable kinds at compile-time when a variable is called.
     variable_types: HashMap<String, TypeDef>,
 
-    /// The [`ValueConstraint`] each path query is expected to have.
+    /// The [`Constraint`] each path query is expected to have.
     ///
     /// By default, the first time a path is queried, it resolves to `Any`, but
     /// when a path is used to assign a value to, we can potentially narrow down
@@ -39,7 +39,7 @@ pub struct CompilerState {
     path_query_types: HashMap<String, TypeDef>,
 }
 
-impl CompilerState {
+impl Compiler {
     pub fn variable_type(&self, key: impl AsRef<str>) -> Option<&TypeDef> {
         self.variable_types.get(key.as_ref())
     }

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+#[macro_export]
+macro_rules! test_type_check {
+    ($($name:ident { expr: $expr:expr, def: $def:expr, })+) => {
+        mod type_check {
+            use super::*;
+
+            $(
+                #[test]
+                fn $name() {
+                    let mut state = CompilerState::default();
+                    let expression: Box<dyn Expression> = Box::new($expr(&mut state));
+
+                    assert_eq!(expression.type_check(&state), $def);
+                }
+            )+
+        }
+    };
+}

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 #[macro_export]
-macro_rules! test_type_check {
+macro_rules! test_type_def {
     ($($name:ident { expr: $expr:expr, def: $def:expr, })+) => {
-        mod type_check {
+        mod type_def {
             use super::*;
 
             $(
@@ -11,7 +11,7 @@ macro_rules! test_type_check {
                     let mut state = CompilerState::default();
                     let expression: Box<dyn Expression> = Box::new($expr(&mut state));
 
-                    assert_eq!(expression.type_check(&state), $def);
+                    assert_eq!(expression.type_def(&state), $def);
                 }
             )+
         }

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 #[macro_export]
 macro_rules! test_type_def {
     ($($name:ident { expr: $expr:expr, def: $def:expr, })+) => {

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -8,7 +8,7 @@ macro_rules! test_type_def {
             $(
                 #[test]
                 fn $name() {
-                    let mut state = CompilerState::default();
+                    let mut state = state::Compiler::default();
                     let expression: Box<dyn Expression> = Box::new($expr(&mut state));
 
                     assert_eq!(expression.type_def(&state), $def);

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -1,4 +1,4 @@
-use crate::ValueConstraint;
+use crate::value;
 
 /// Properties for a given expression that express the expected outcome of the
 /// expression.
@@ -19,11 +19,11 @@ pub struct TypeDef {
     /// nothing if the if-condition does not match.
     pub optional: bool,
 
-    /// The [`ValueConstraint`] applied to this type check.
+    /// The [`value::Constraint`] applied to this type check.
     ///
-    /// This resolves to a list of [`ValueKind`]s the expression is expected to
-    /// return.
-    pub constraint: ValueConstraint,
+    /// This resolves to a list of [`value::Kind`]s the expression is expected
+    /// to return.
+    pub constraint: value::Constraint,
 }
 
 impl TypeDef {
@@ -65,7 +65,7 @@ impl TypeDef {
         self.constraint.contains(&other.constraint)
     }
 
-    pub fn fallible_unless(mut self, constraint: impl Into<ValueConstraint>) -> Self {
+    pub fn fallible_unless(mut self, constraint: impl Into<value::Constraint>) -> Self {
         if !constraint.into().contains(&self.constraint) {
             self.fallible = true
         }
@@ -73,7 +73,7 @@ impl TypeDef {
         self
     }
 
-    pub fn with_constraint(mut self, constraint: impl Into<ValueConstraint>) -> Self {
+    pub fn with_constraint(mut self, constraint: impl Into<value::Constraint>) -> Self {
         self.constraint = constraint.into();
         self
     }

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -1,0 +1,127 @@
+use crate::ValueConstraint;
+
+/// Properties for a given expression that express the expected outcome of the
+/// expression.
+///
+/// This includes whether the expression is fallible, whether it can return
+/// "nothing", and a list of values the expression can resolve to.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct TypeDef {
+    /// True, if an expression can return an error.
+    ///
+    /// Some expressions are infallible (e.g. the [`Literal`] expression, or any
+    /// custom function designed to be infallible).
+    pub fallible: bool,
+
+    /// True, if an expression can resolve to "nothing".
+    ///
+    /// For example, and if-statement without an else-condition can resolve to
+    /// nothing if the if-condition does not match.
+    pub optional: bool,
+
+    /// The [`ValueConstraint`] applied to this type check.
+    ///
+    /// This resolves to a list of [`ValueKind`]s the expression is expected to
+    /// return.
+    pub constraint: ValueConstraint,
+}
+
+impl TypeDef {
+    pub fn is_fallible(&self) -> bool {
+        self.fallible
+    }
+
+    pub fn into_fallible(mut self, fallible: bool) -> Self {
+        self.fallible = fallible;
+        self
+    }
+
+    pub fn is_optional(&self) -> bool {
+        self.optional
+    }
+
+    pub fn into_optional(mut self, optional: bool) -> Self {
+        self.optional = optional;
+        self
+    }
+
+    /// Returns `true` if the _other_ [`TypeDef`] is contained within the
+    /// current one.
+    ///
+    /// That is to say, its constraints must be more strict or equal to the
+    /// constraints of the current one.
+    pub fn contains(&self, other: &Self) -> bool {
+        // If we don't expect none, but the other does, the other's requirement
+        // is less strict than ours.
+        if !self.is_optional() && other.is_optional() {
+            return false;
+        }
+
+        // The same applies to fallible checks.
+        if !self.is_fallible() && other.is_fallible() {
+            return false;
+        }
+
+        self.constraint.contains(&other.constraint)
+    }
+
+    pub fn fallible_unless(mut self, constraint: impl Into<ValueConstraint>) -> Self {
+        if !constraint.into().contains(&self.constraint) {
+            self.fallible = true
+        }
+
+        self
+    }
+
+    pub fn with_constraint(mut self, constraint: impl Into<ValueConstraint>) -> Self {
+        self.constraint = constraint.into();
+        self
+    }
+
+    pub fn merge(self, other: Self) -> Self {
+        let TypeDef {
+            fallible,
+            optional,
+            constraint,
+        } = other;
+
+        // TODO: take `self`
+        let constraint = self.constraint.merge(&constraint);
+
+        Self {
+            fallible: self.is_fallible() || fallible,
+            optional: self.is_optional() || optional,
+            constraint,
+        }
+    }
+
+    pub fn merge_optional(self, other: Option<Self>) -> Self {
+        match other {
+            Some(other) => self.merge(other),
+            None => self,
+        }
+    }
+
+    /// Similar to `merge_optional`, except that the optional `TypeDef` is
+    /// considered to be the "default" for the `self` `TypeDef`.
+    ///
+    /// The implication of this is that the resulting `TypeDef` will be equal to
+    /// `self` or `other`, if either of the two is infallible and non-optional.
+    ///
+    /// If neither are, the two type definitions are merged as usual.
+    pub fn merge_with_default_optional(self, other: Option<Self>) -> Self {
+        if !self.is_fallible() && !self.is_optional() {
+            return self;
+        }
+
+        match other {
+            None => self,
+
+            // If `self` isn't exact, see if `other` is.
+            Some(other) if !other.is_fallible() && !other.is_optional() => other,
+
+            // Otherwise merge the optional as usual.
+            Some(other) => self.merge(other),
+        }
+    }
+}

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -18,7 +18,7 @@ pub enum Value {
     Null,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Copy)]
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, Ord, PartialOrd)]
 pub enum ValueKind {
     String,
     Integer,

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -37,6 +37,12 @@ impl fmt::Display for ValueKind {
 }
 
 impl ValueKind {
+    pub fn all() -> Vec<Self> {
+        use ValueKind::*;
+
+        vec![String, Integer, Float, Boolean, Map, Array, Timestamp, Null]
+    }
+
     pub fn as_str(&self) -> &'static str {
         use ValueKind::*;
 

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -186,6 +186,12 @@ impl From<&str> for Value {
     }
 }
 
+impl From<()> for Value {
+    fn from(_: ()) -> Self {
+        Value::Null
+    }
+}
+
 impl From<BTreeMap<String, Value>> for Value {
     fn from(value: BTreeMap<String, Value>) -> Self {
         Value::Map(value)

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -272,6 +272,13 @@ macro_rules! value_impl {
                 }
             }
 
+            pub fn [<as_ $func _mut>](&mut self) -> Option<&mut $ret> {
+                match self {
+                    Value::$variant(v) => Some(v),
+                    _ => None,
+                }
+            }
+
             pub fn [<try_ $func>](self) -> Result<$ret, Error> {
                 match self {
                     Value::$variant(v) => Ok(v),

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -84,7 +84,7 @@ impl From<&Value> for ValueKind {
     }
 }
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
     #[error(r#"expected "{0}", got "{1}""#)]
     Expected(ValueKind, ValueKind),

--- a/lib/remap-lang/src/value/kind.rs
+++ b/lib/remap-lang/src/value/kind.rs
@@ -1,0 +1,69 @@
+use super::Value;
+use std::fmt;
+use std::ops::Deref;
+
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, Ord, PartialOrd)]
+pub enum Kind {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    Map,
+    Array,
+    Timestamp,
+    Null,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self)
+    }
+}
+
+impl Kind {
+    pub fn all() -> Vec<Self> {
+        use Kind::*;
+
+        vec![String, Integer, Float, Boolean, Map, Array, Timestamp, Null]
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        use Kind::*;
+
+        match self {
+            String => "string",
+            Integer => "integer",
+            Float => "float",
+            Boolean => "boolean",
+            Map => "map",
+            Array => "array",
+            Timestamp => "timestamp",
+            Null => "null",
+        }
+    }
+}
+
+impl Deref for Kind {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl From<&Value> for Kind {
+    fn from(value: &Value) -> Self {
+        use Kind::*;
+
+        match value {
+            Value::String(_) => String,
+            Value::Integer(_) => Integer,
+            Value::Float(_) => Float,
+            Value::Boolean(_) => Boolean,
+            Value::Map(_) => Map,
+            Value::Array(_) => Array,
+            Value::Timestamp(_) => Timestamp,
+            Value::Null => Null,
+        }
+    }
+}

--- a/lib/remap-lang/src/value_constraint.rs
+++ b/lib/remap-lang/src/value_constraint.rs
@@ -1,0 +1,132 @@
+use crate::ValueKind;
+use std::fmt;
+
+/// The constraint of a set of [`ValueKind`]s.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ValueConstraint {
+    /// Any value kind is accepted.
+    Any,
+
+    /// A subset of value kinds is accepted.
+    OneOf(Vec<ValueKind>),
+
+    /// Exactly one value kind is accepted
+    Exact(ValueKind),
+
+    /// Either none, or a value kind constraint is accepted.
+    ///
+    /// For example, and if-statement without an else-condition can resolve to
+    /// nothing if the if-condition does not match.
+    Maybe(Box<ValueConstraint>),
+}
+
+impl ValueConstraint {
+    /// Returns `true` if this is a [`ValueConstraint::Exact`].
+    pub fn is_exact(&self) -> bool {
+        matches!(self, Self::Exact(_))
+    }
+
+    /// Returns `true` if this is a [`ValueConstraint::Any`].
+    pub fn is_any(&self) -> bool {
+        matches!(self, Self::Any)
+    }
+
+    /// Returns `true` if this is a [`ValueConstraint::Maybe`].
+    pub fn is_maybe(&self) -> bool {
+        matches!(self, Self::Maybe(_))
+    }
+
+    /// Get a collection of [`ValueKind`]s accepted by this [`ValueConstraint`].
+    pub fn value_kinds(&self) -> Vec<ValueKind> {
+        use ValueConstraint::*;
+
+        match self {
+            Any => ValueKind::all(),
+            OneOf(v) => v.clone(),
+            Exact(v) => vec![*v],
+            Maybe(v) => v.value_kinds(),
+        }
+    }
+
+    /// Merge two [`ValueConstraint`]s, such that the new `ValueConstraint`
+    /// provides the most constraint possible value constraint.
+    pub fn merge(&self, other: &Self) -> Self {
+        use ValueConstraint::*;
+
+        if let Maybe(kind) = self {
+            let other = match other {
+                Maybe(v) => v,
+                _ => other,
+            };
+
+            return Maybe(Box::new(kind.merge(other)));
+        }
+
+        if let Maybe(kind) = other {
+            return Maybe(Box::new(self.merge(kind)));
+        }
+
+        if self.is_any() || other.is_any() {
+            return Any;
+        }
+
+        let mut kinds: Vec<_> = self
+            .value_kinds()
+            .into_iter()
+            .chain(other.value_kinds().into_iter())
+            .collect();
+
+        kinds.sort();
+        kinds.dedup();
+
+        if kinds.len() == 1 {
+            Exact(kinds[0])
+        } else {
+            OneOf(kinds)
+        }
+    }
+
+    /// Returns `true` if the _other_ [`ValueConstraint`] is contained within
+    /// the current one.
+    ///
+    /// That is to say, its constraints must be more strict or equal to the
+    /// constraints of the current one.
+    pub fn contains(&self, other: &Self) -> bool {
+        // If we don't expect none, but the other does, the other's requirement
+        // is less strict than ours.
+        if !self.is_maybe() && other.is_maybe() {
+            return false;
+        }
+
+        let self_kinds = self.value_kinds();
+        let other_kinds = other.value_kinds();
+
+        for kind in other_kinds {
+            if !self_kinds.contains(&kind) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl fmt::Display for ValueConstraint {
+    /// Print a human readable version of the value constraint.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ValueConstraint::*;
+
+        match self {
+            Any => f.write_str("any value"),
+            OneOf(v) => {
+                f.write_str("any of ")?;
+                f.write_str(&v.iter().map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
+            }
+            Exact(v) => f.write_str(&v),
+            Maybe(v) => {
+                f.write_str("none or ")?;
+                f.write_str(&v.to_string())
+            }
+        }
+    }
+}

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -124,13 +124,13 @@ mod test {
             (
                 log_event![],
                 "",
-                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to any optional value"),
+                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to any value"),
                 Ok(()),
             ),
             (
                 log_event!["foo" => "string"],
                 ".foo",
-                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to any value"),
+                Err("remap error: program error: expected to resolve to boolean or no value, but instead resolves to any value"),
                 Ok(()),
             ),
             (

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -49,15 +49,3 @@ impl InternalEvent for RemapConditionExecutionFailed {
         )
     }
 }
-
-#[derive(Debug, Copy, Clone)]
-pub struct RemapConditionNonBooleanReturned;
-
-impl InternalEvent for RemapConditionNonBooleanReturned {
-    fn emit_logs(&self) {
-        warn!(
-            message = "Remap condition non-boolean value returned.",
-            rate_limit_secs = 120
-        )
-    }
-}

--- a/src/remap/function.rs
+++ b/src/remap/function.rs
@@ -122,8 +122,8 @@ fn is_scalar_value(value: &Value) -> bool {
     use Value::*;
 
     match value {
-        Integer(_) | Float(_) | String(_) | Boolean(_) => true,
-        Timestamp(_) | Map(_) | Array(_) | Null => false,
+        Integer(_) | Float(_) | String(_) | Boolean(_) | Null => true,
+        Timestamp(_) | Map(_) | Array(_) => false,
     }
 }
 

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -62,6 +62,27 @@ impl Expression for CeilFn {
 
         Ok(res.into())
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let value_def = self
+            .value
+            .type_def(state)
+            .fallible_unless(vec![Integer, Float]);
+        let precision_def = self
+            .precision
+            .as_ref()
+            .map(|precision| precision.type_def(state).fallible_unless(Integer));
+
+        value_def
+            .clone()
+            .merge_optional(precision_def)
+            .with_constraint(match value_def.constraint {
+                v if v.is(Float) || v.is(Integer) => v,
+                _ => vec![Integer, Float].into(),
+            })
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -89,6 +89,41 @@ impl Expression for CeilFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_float {
+            expr: |_| CeilFn {
+                value: Literal::from(1.0).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        value_integer {
+            expr: |_| CeilFn {
+                value: Literal::from(1).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        value_float_or_integer {
+            expr: |_| CeilFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                precision: None,
+            },
+            def: TypeDef { fallible: true, constraint: vec![Integer, Float].into(), ..Default::default() },
+        }
+
+        fallible_precision {
+            expr: |_| CeilFn {
+                value: Literal::from(1).boxed(),
+                precision: Some(Variable::new("foo".to_owned()).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn ceil() {

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -46,7 +46,7 @@ impl CeilFn {
 }
 
 impl Expression for CeilFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +118,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -46,7 +46,11 @@ impl CeilFn {
 }
 
 impl Expression for CeilFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +122,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -63,7 +63,11 @@ impl ContainsFn {
 }
 
 impl Expression for ContainsFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -81,6 +85,23 @@ impl Expression for ContainsFn {
                 .any(|_| value.to_lowercase().contains(&substring.to_lowercase()));
 
         Ok(Some(contains.into()))
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .merge(
+                self.substring
+                    .type_def(state)
+                    .fallible_unless(value::Kind::String),
+            )
+            .merge_optional(self.case_sensitive.as_ref().map(|case_sensitive| {
+                case_sensitive
+                    .type_def(state)
+                    .fallible_unless(value::Kind::Boolean)
+            }))
+            .with_constraint(value::Kind::Boolean)
     }
 }
 
@@ -144,7 +165,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -63,7 +63,7 @@ impl ContainsFn {
 }
 
 impl Expression for ContainsFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -144,7 +144,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -70,4 +70,18 @@ impl Expression for DelFn {
 
         Ok(None)
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.paths
+            .iter()
+            .fold(TypeDef::default(), |acc, expression| {
+                acc.merge(
+                    expression
+                        .type_def(state)
+                        .fallible_unless(value::Kind::String),
+                )
+            })
+            .with_constraint(value::Constraint::Any)
+            .into_optional(true)
+    }
 }

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -85,3 +85,20 @@ impl Expression for DelFn {
             .into_optional(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| DelFn { paths: vec![Literal::from("foo").boxed()] },
+            def: TypeDef { optional: true, constraint: value::Constraint::Any, ..Default::default() },
+        }
+
+        fallible_expression {
+            expr: |_| DelFn { paths: vec![Variable::new("foo".to_owned()).boxed(), Literal::from("foo").boxed()] },
+            def: TypeDef { fallible: true, optional: true, constraint: value::Constraint::Any },
+        }
+    ];
+}

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -52,7 +52,11 @@ pub struct DelFn {
 }
 
 impl Expression for DelFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let paths = self
             .paths
             .iter()

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -52,7 +52,7 @@ pub struct DelFn {
 }
 
 impl Expression for DelFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let paths = self
             .paths
             .iter()

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -37,7 +37,7 @@ impl DowncaseFn {
 }
 
 impl Expression for DowncaseFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)
@@ -69,7 +69,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -37,7 +37,7 @@ impl DowncaseFn {
 }
 
 impl Expression for DowncaseFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)
@@ -69,7 +69,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -47,6 +47,13 @@ impl Expression for DowncaseFn {
             .map(Ok)
             .transpose()
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -86,4 +86,16 @@ mod tests {
             assert_eq!(got, exp);
         }
     }
+
+    remap::test_type_def![
+        string {
+            expr: |_| DowncaseFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        non_string {
+            expr: |_| DowncaseFn { value: Literal::from(true).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+    ];
 }

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -37,7 +37,11 @@ impl DowncaseFn {
 }
 
 impl Expression for DowncaseFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -63,7 +63,7 @@ impl EndsWithFn {
 }
 
 impl Expression for EndsWithFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -144,7 +144,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -111,6 +111,45 @@ impl Expression for EndsWithFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| EndsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| EndsWithFn {
+                value: Literal::from(true).boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        substring_non_string {
+            expr: |_| EndsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from(true).boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        case_sensitive_non_boolean {
+            expr: |_| EndsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn ends_with() {

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -63,7 +63,7 @@ impl EndsWithFn {
 }
 
 impl Expression for EndsWithFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -144,7 +144,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -85,6 +85,41 @@ impl Expression for FloorFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_float {
+            expr: |_| FloorFn {
+                value: Literal::from(1.0).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        value_integer {
+            expr: |_| FloorFn {
+                value: Literal::from(1).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        value_float_or_integer {
+            expr: |_| FloorFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                precision: None,
+            },
+            def: TypeDef { fallible: true, constraint: vec![Integer, Float].into(), ..Default::default() },
+        }
+
+        fallible_precision {
+            expr: |_| FloorFn {
+                value: Literal::from(1).boxed(),
+                precision: Some(Variable::new("foo".to_owned()).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn floor() {

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -46,7 +46,7 @@ impl FloorFn {
 }
 
 impl Expression for FloorFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +118,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -58,6 +58,27 @@ impl Expression for FloorFn {
 
         Ok(res.into())
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let value_def = self
+            .value
+            .type_def(state)
+            .fallible_unless(vec![Integer, Float]);
+        let precision_def = self
+            .precision
+            .as_ref()
+            .map(|precision| precision.type_def(state).fallible_unless(Integer));
+
+        value_def
+            .clone()
+            .merge_optional(precision_def)
+            .with_constraint(match value_def.constraint {
+                v if v.is(Float) || v.is(Integer) => v,
+                _ => vec![Integer, Float].into(),
+            })
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -46,7 +46,7 @@ impl FloorFn {
 }
 
 impl Expression for FloorFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +118,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -46,7 +46,11 @@ impl FloorFn {
 }
 
 impl Expression for FloorFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -80,7 +80,7 @@ impl FormatNumberFn {
 }
 
 impl Expression for FormatNumberFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value,
             Value::Integer(v) => Decimal::from_i64(v),
             Value::Float(v) => Decimal::from_f64(v),
@@ -221,7 +221,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -80,7 +80,7 @@ impl FormatNumberFn {
 }
 
 impl Expression for FormatNumberFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value,
             Value::Integer(v) => Decimal::from_i64(v),
             Value::Float(v) => Decimal::from_f64(v),
@@ -221,7 +221,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -187,6 +187,41 @@ impl Expression for FormatNumberFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_integer {
+            expr: |_| FormatNumberFn {
+                value: Literal::from(1).boxed(),
+                scale: None,
+                decimal_separator: None,
+                grouping_separator: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_float {
+            expr: |_| FormatNumberFn {
+                value: Literal::from(1.0).boxed(),
+                scale: None,
+                decimal_separator: None,
+                grouping_separator: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        // TODO(jean): we should update the function to ignore `None` values,
+        // instead of aborting.
+        optional_scale {
+            expr: |_| FormatNumberFn {
+                value: Literal::from(1.0).boxed(),
+                scale: Some(Box::new(Noop)),
+                decimal_separator: None,
+                grouping_separator: None,
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+    ];
 
     #[test]
     fn format_number() {

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -87,6 +87,25 @@ mod tests {
     use super::*;
     use crate::map;
     use chrono::TimeZone;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_and_format {
+            expr: |_| FormatTimestampFn {
+                value: Literal::from(chrono::Utc::now()).boxed(),
+                format: Literal::from("%s").boxed(),
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        optional_value {
+            expr: |_| FormatTimestampFn {
+                value: Box::new(Noop),
+                format: Literal::from("%s").boxed(),
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+    ];
 
     #[test]
     fn format_timestamp() {

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -49,7 +49,7 @@ impl FormatTimestampFn {
 }
 
 impl Expression for FormatTimestampFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let format = required!(state, object, self.format, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let ts = required!(state, object, self.value, Value::Timestamp(ts) => ts);
 
@@ -108,7 +108,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -55,6 +55,20 @@ impl Expression for FormatTimestampFn {
 
         try_format(&ts, &format).map(Into::into).map(Some)
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        let format_def = self
+            .format
+            .type_def(state)
+            .fallible_unless(value::Kind::String);
+
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::Timestamp)
+            .merge(format_def)
+            .into_fallible(true) // due to `try_format`
+            .with_constraint(value::Kind::String)
+    }
 }
 
 fn try_format(dt: &DateTime<Utc>, format: &str) -> Result<String> {

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -49,7 +49,11 @@ impl FormatTimestampFn {
 }
 
 impl Expression for FormatTimestampFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let format = required!(state, object, self.format, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let ts = required!(state, object, self.value, Value::Timestamp(ts) => ts);
 

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -49,7 +49,7 @@ impl FormatTimestampFn {
 }
 
 impl Expression for FormatTimestampFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let format = required!(state, object, self.format, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let ts = required!(state, object, self.value, Value::Timestamp(ts) => ts);
 
@@ -108,7 +108,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -56,6 +56,13 @@ impl Expression for MatchFn {
             }
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::Boolean)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -46,7 +46,7 @@ impl MatchFn {
 }
 
 impl Expression for MatchFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         required!(
             state, object, self.value,
 
@@ -92,7 +92,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -46,7 +46,7 @@ impl MatchFn {
 }
 
 impl Expression for MatchFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         required!(
             state, object, self.value,
 
@@ -92,7 +92,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -69,6 +69,33 @@ impl Expression for MatchFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| MatchFn {
+                value: Literal::from("foo").boxed(),
+                pattern: Regex::new("").unwrap(),
+            },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| MatchFn {
+                value: Literal::from(1).boxed(),
+                pattern: Regex::new("").unwrap(),
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| MatchFn {
+                value: Box::new(Noop),
+                pattern: Regex::new("").unwrap(),
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: Boolean.into() },
+        }
+    ];
 
     #[test]
     fn r#match() {

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -46,7 +46,11 @@ impl MatchFn {
 }
 
 impl Expression for MatchFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         required!(
             state, object, self.value,
 

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -63,6 +63,24 @@ impl Expression for Md5Fn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| Md5Fn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| Md5Fn { value: Literal::from(1).boxed() },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| Md5Fn { value: Box::new(Noop) },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+    ];
 
     #[test]
     fn md5() {

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -50,6 +50,13 @@ impl Expression for Md5Fn {
             })
         })
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -36,7 +36,11 @@ impl Md5Fn {
 }
 
 impl Expression for Md5Fn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use md5::{Digest, Md5};
 
         self.value.execute(state, object).map(|r| {
@@ -68,7 +72,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -36,7 +36,7 @@ impl Md5Fn {
 }
 
 impl Expression for Md5Fn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use md5::{Digest, Md5};
 
         self.value.execute(state, object).map(|r| {
@@ -68,7 +68,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -18,7 +18,7 @@ impl Function for Now {
 struct NowFn;
 
 impl Expression for NowFn {
-    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(Utc::now().into()))
     }
 }

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -29,3 +29,16 @@ impl Expression for NowFn {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    remap::test_type_def![static_def {
+        expr: |_| NowFn,
+        def: TypeDef {
+            constraint: value::Kind::Timestamp.into(),
+            ..Default::default()
+        },
+    }];
+}

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -21,4 +21,11 @@ impl Expression for NowFn {
     fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(Utc::now().into()))
     }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef {
+            constraint: value::Kind::Timestamp.into(),
+            ..Default::default()
+        }
+    }
 }

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -18,7 +18,7 @@ impl Function for Now {
 struct NowFn;
 
 impl Expression for NowFn {
-    fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
         Ok(Some(Utc::now().into()))
     }
 }

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -52,7 +52,7 @@ pub struct OnlyFieldsFn {
 }
 
 impl Expression for OnlyFieldsFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let paths = self
             .paths
             .iter()

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -52,7 +52,7 @@ pub struct OnlyFieldsFn {
 }
 
 impl Expression for OnlyFieldsFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let paths = self
             .paths
             .iter()

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -68,4 +68,18 @@ impl Expression for OnlyFieldsFn {
 
         Ok(None)
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.paths
+            .iter()
+            .fold(TypeDef::default(), |acc, expression| {
+                acc.merge(
+                    expression
+                        .type_def(state)
+                        .fallible_unless(value::Kind::String),
+                )
+            })
+            .with_constraint(value::Constraint::Any)
+            .into_optional(true)
+    }
 }

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -52,7 +52,11 @@ pub struct OnlyFieldsFn {
 }
 
 impl Expression for OnlyFieldsFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let paths = self
             .paths
             .iter()

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -83,3 +83,20 @@ impl Expression for OnlyFieldsFn {
             .into_optional(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| OnlyFieldsFn { paths: vec![Literal::from("foo").boxed()] },
+            def: TypeDef { optional: true, constraint: value::Constraint::Any, ..Default::default() },
+        }
+
+        fallible_expression {
+            expr: |_| OnlyFieldsFn { paths: vec![Variable::new("foo".to_owned()).boxed(), Literal::from("foo").boxed()] },
+            def: TypeDef { fallible: true, optional: true, constraint: value::Constraint::Any },
+        }
+    ];
+}

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -79,7 +79,11 @@ impl ParseDurationFn {
 }
 
 impl Expression for ParseDurationFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -133,6 +133,24 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| ParseDurationFn {
+                value: Literal::from("foo").boxed(),
+                output: Literal::from("foo").boxed(),
+            },
+            def: TypeDef { fallible: true, constraint: value::Kind::Float.into(), ..Default::default() },
+        }
+
+        optional_expression {
+            expr: |_| ParseDurationFn {
+                value: Box::new(Noop),
+                output: Literal::from("foo").boxed(),
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Float.into() },
+        }
+    ];
+
     #[test]
     fn parse_duration() {
         let cases = vec![

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -112,6 +112,20 @@ impl Expression for ParseDurationFn {
 
         Ok(Some(number.into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        let output_def = self
+            .output
+            .type_def(state)
+            .fallible_unless(value::Kind::String);
+
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .merge(output_def)
+            .into_fallible(true) // parsing errors
+            .with_constraint(value::Kind::Float)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -79,7 +79,7 @@ impl ParseDurationFn {
 }
 
 impl Expression for ParseDurationFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -184,7 +184,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -79,7 +79,7 @@ impl ParseDurationFn {
 }
 
 impl Expression for ParseDurationFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -184,7 +184,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -90,6 +90,57 @@ impl Expression for ParseJsonFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| ParseJsonFn {
+                value: Literal::from("foo").boxed(),
+                default: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                ..Default::default()
+            },
+        }
+
+        optional_default {
+            expr: |_| ParseJsonFn {
+                value: Literal::from("foo").boxed(),
+                default: Some(Box::new(Noop)),
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                ..Default::default()
+            },
+        }
+
+        optional_value {
+            expr: |_| ParseJsonFn {
+                value: Box::new(Noop),
+                default: Some(Literal::from("foo").boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                ..Default::default()
+            },
+        }
+
+        optional_value_and_default {
+            expr: |_| ParseJsonFn {
+                value: Box::new(Noop),
+                default: Some(Box::new(Noop)),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: true,
+                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+            },
+        }
+    ];
 
     #[test]
     fn parse_json() {

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -47,7 +47,7 @@ impl ParseJsonFn {
 }
 
 impl Expression for ParseJsonFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let to_json = |value| match value {
             Value::String(bytes) => serde_json::from_slice(&bytes)
                 .map(|v: serde_json::Value| {
@@ -106,7 +106,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -68,6 +68,22 @@ impl Expression for ParseJsonFn {
             to_json,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let default_def = self
+            .default
+            .as_ref()
+            .map(|default| default.type_def(state).fallible_unless(String));
+
+        self.value
+            .type_def(state)
+            .fallible_unless(String)
+            .merge_with_default_optional(default_def)
+            .into_fallible(true) // JSON parsing errors
+            .with_constraint(vec![String, Boolean, Integer, Float, Array, Map, Null])
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -47,7 +47,11 @@ impl ParseJsonFn {
 }
 
 impl Expression for ParseJsonFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let to_json = |value| match value {
             Value::String(bytes) => serde_json::from_slice(&bytes)
                 .map(|v: serde_json::Value| {
@@ -106,7 +110,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -111,6 +111,13 @@ impl Expression for ParseSyslogFn {
 
         Ok(Some(message_to_value(parsed)))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::Map)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -126,6 +126,23 @@ mod tests {
     use crate::map;
     use chrono::prelude::*;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| ParseSyslogFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: value::Kind::Map.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| ParseSyslogFn { value: Literal::from(1).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::Map.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| ParseSyslogFn { value: Box::new(Noop) },
+            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Map.into() },
+        }
+    ];
+
     #[test]
     fn parses() {
         let cases = vec![

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -100,7 +100,7 @@ fn message_to_value(message: Message<&str>) -> Value {
 }
 
 impl Expression for ParseSyslogFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let message = required!(state, object, self.value, Value::String(v) => String::from_utf8_lossy(&v).into_owned());
 
         let parsed = syslog_loose::parse_message_with_year(&message, resolve_year);
@@ -160,7 +160,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -182,7 +182,7 @@ mod tests {
             }
         }
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
         let mut object = map![];
 
         let msg = format!(

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -100,7 +100,11 @@ fn message_to_value(message: Message<&str>) -> Value {
 }
 
 impl Expression for ParseSyslogFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let message = required!(state, object, self.value, Value::String(v) => String::from_utf8_lossy(&v).into_owned());
 
         let parsed = syslog_loose::parse_message_with_year(&message, resolve_year);
@@ -160,7 +164,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -182,7 +186,7 @@ mod tests {
             }
         }
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
         let mut object = map![];
 
         let msg = format!(

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -136,6 +136,82 @@ mod tests {
     use crate::map;
     use chrono::{DateTime, Utc};
 
+    remap::test_type_def![
+        value_fallible_no_default {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from("<timestamp>").boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+
+        value_fallible_default_fallible {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from("<timestamp>").boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: Some(Literal::from("<timestamp>").boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+
+        value_fallible_default_infallible {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from("<timestamp>").boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: Some(Literal::from(chrono::Utc::now()).boxed()),
+            },
+            def: TypeDef {
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+
+        value_infallible_no_default {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from(chrono::Utc::now()).boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: None,
+            },
+            def: TypeDef {
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+
+        value_infallible_default_fallible {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from(chrono::Utc::now()).boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: Some(Literal::from("<timestamp>").boxed()),
+            },
+            def: TypeDef {
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+
+        value_infallible_default_infallible {
+            expr: |_| ParseTimestampFn {
+                value: Literal::from(chrono::Utc::now()).boxed(),
+                format: Literal::from("<format>").boxed(),
+                default: Some(Literal::from(chrono::Utc::now()).boxed()),
+            },
+            def: TypeDef {
+                constraint: value::Kind::Timestamp.into(),
+                ..Default::default()
+            },
+        }
+    ];
+
     #[test]
     fn parse_timestamp() {
         let cases = vec![

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -64,7 +64,7 @@ impl ParseTimestampFn {
 }
 
 impl Expression for ParseTimestampFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let format = {
             let bytes = required!(state, object, self.format, Value::String(v) => v);
             format!("timestamp|{}", String::from_utf8_lossy(&bytes))
@@ -145,7 +145,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -64,7 +64,11 @@ impl ParseTimestampFn {
 }
 
 impl Expression for ParseTimestampFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let format = {
             let bytes = required!(state, object, self.format, Value::String(v) => v);
             format!("timestamp|{}", String::from_utf8_lossy(&bytes))
@@ -145,7 +149,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -94,6 +94,18 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| ParseUrlFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::Map.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| ParseUrlFn { value: Box::new(Noop) },
+            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Map.into() },
+        }
+    ];
+
     #[test]
     fn parse_url() {
         let cases = vec![

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -40,7 +40,7 @@ impl ParseUrlFn {
 }
 
 impl Expression for ParseUrlFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         Url::parse(&String::from_utf8_lossy(&bytes))
@@ -132,7 +132,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -49,6 +49,14 @@ impl Expression for ParseUrlFn {
             .map(Into::into)
             .map(Some)
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .into_fallible(true) // URL parsing error
+            .with_constraint(value::Kind::Map)
+    }
 }
 
 impl From<Url> for event::Value {

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -40,7 +40,7 @@ impl ParseUrlFn {
 }
 
 impl Expression for ParseUrlFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         Url::parse(&String::from_utf8_lossy(&bytes))
@@ -132,7 +132,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -40,7 +40,11 @@ impl ParseUrlFn {
 }
 
 impl Expression for ParseUrlFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         Url::parse(&String::from_utf8_lossy(&bytes))

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -137,6 +137,103 @@ mod test {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        infallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                with: Literal::from("foo").boxed(),
+                count: None,
+            },
+            def: TypeDef {
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        value_fallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from(10).boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                with: Literal::from("foo").boxed(),
+                count: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        pattern_expression_infallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: Literal::from("foo").boxed().into(),
+                with: Literal::from("foo").boxed(),
+                count: None,
+            },
+            def: TypeDef {
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        pattern_expression_fallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: Literal::from(10).boxed().into(),
+                with: Literal::from("foo").boxed(),
+                count: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        with_fallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                with: Literal::from(10).boxed(),
+                count: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        count_infallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                with: Literal::from("foo").boxed(),
+                count: Some(Literal::from(10).boxed()),
+            },
+            def: TypeDef {
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+
+        count_fallible {
+            expr: |_| ReplaceFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                with: Literal::from("foo").boxed(),
+                count: Some(Literal::from("foo").boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::String.into(),
+                ..Default::default()
+            },
+        }
+    ];
+
     #[test]
     fn check_replace_string() {
         let cases = vec![

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -72,7 +72,7 @@ impl ReplaceFn {
 }
 
 impl Expression for ReplaceFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let with = required!(state, object, self.with, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let count = optional!(state, object, self.count, Value::Integer(v) => v).unwrap_or(-1);
@@ -164,7 +164,7 @@ mod test {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -230,7 +230,7 @@ mod test {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -276,7 +276,7 @@ mod test {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -72,7 +72,11 @@ impl ReplaceFn {
 }
 
 impl Expression for ReplaceFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let with = required!(state, object, self.with, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let count = optional!(state, object, self.count, Value::Integer(v) => v).unwrap_or(-1);
@@ -117,7 +121,7 @@ mod test {
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("a"))),
+                    Box::new(Literal::from("a")).into(),
                     "o",
                     None,
                 ),
@@ -127,7 +131,7 @@ mod test {
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("a"))),
+                    Box::new(Literal::from("a")).into(),
                     "o",
                     Some(-1),
                 ),
@@ -137,7 +141,7 @@ mod test {
                 Ok(Some("I like apples and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("a"))),
+                    Box::new(Literal::from("a")).into(),
                     "o",
                     Some(0),
                 ),
@@ -147,7 +151,7 @@ mod test {
                 Ok(Some("I like opples and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("a"))),
+                    Box::new(Literal::from("a")).into(),
                     "o",
                     Some(1),
                 ),
@@ -157,14 +161,14 @@ mod test {
                 Ok(Some("I like opples ond bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("a"))),
+                    Box::new(Literal::from("a")).into(),
                     "o",
                     Some(2),
                 ),
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -183,7 +187,7 @@ mod test {
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     None,
                 ),
@@ -193,7 +197,7 @@ mod test {
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(-1),
                 ),
@@ -203,7 +207,7 @@ mod test {
                 Ok(Some("I like apples and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(0),
                 ),
@@ -213,7 +217,7 @@ mod test {
                 Ok(Some("I like opples and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(1),
                 ),
@@ -223,14 +227,14 @@ mod test {
                 Ok(Some("I like opples ond bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(2),
                 ),
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -249,7 +253,7 @@ mod test {
                 Ok(Some("I like biscuits and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Literal::from("I like apples and bananas")),
-                    Argument::Expression(Box::new(Literal::from("apples"))),
+                    Box::new(Literal::from("apples")).into(),
                     "biscuits",
                     None,
                 ),
@@ -259,7 +263,7 @@ mod test {
                 Ok(Some("I like opples and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Path::from("foo")),
-                    Argument::Regex(regex::Regex::new("a").unwrap()),
+                    regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(1),
                 ),
@@ -269,14 +273,14 @@ mod test {
                 Ok(Some("I like biscuits and bananas".into())),
                 ReplaceFn::new(
                     Box::new(Path::from("foo")),
-                    Argument::Regex(regex::Regex::new("\\[apples\\]").unwrap()),
+                    regex::Regex::new("\\[apples\\]").unwrap().into(),
                     "biscuits",
                     None,
                 ),
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -106,6 +106,30 @@ impl Expression for ReplaceFn {
             }
         }
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let with_def = self.with.type_def(state).fallible_unless(String);
+
+        let count_def = self
+            .count
+            .as_ref()
+            .map(|count| count.type_def(state).fallible_unless(Integer));
+
+        let pattern_def = match &self.pattern {
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(String)),
+            Argument::Regex(_) => None, // regex is a concrete infallible type
+        };
+
+        self.value
+            .type_def(state)
+            .fallible_unless(String)
+            .merge(with_def)
+            .merge_optional(pattern_def)
+            .merge_optional(count_def)
+            .with_constraint(String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -46,7 +46,7 @@ impl RoundFn {
 }
 
 impl Expression for RoundFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +118,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -58,6 +58,27 @@ impl Expression for RoundFn {
 
         Ok(res.into())
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let value_def = self
+            .value
+            .type_def(state)
+            .fallible_unless(vec![Integer, Float]);
+        let precision_def = self
+            .precision
+            .as_ref()
+            .map(|precision| precision.type_def(state).fallible_unless(Integer));
+
+        value_def
+            .clone()
+            .merge_optional(precision_def)
+            .with_constraint(match value_def.constraint {
+                v if v.is(Float) || v.is(Integer) => v,
+                _ => vec![Integer, Float].into(),
+            })
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -85,6 +85,41 @@ impl Expression for RoundFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_float {
+            expr: |_| RoundFn {
+                value: Literal::from(1.0).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        value_integer {
+            expr: |_| RoundFn {
+                value: Literal::from(1).boxed(),
+                precision: None,
+            },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        value_float_or_integer {
+            expr: |_| RoundFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                precision: None,
+            },
+            def: TypeDef { fallible: true, constraint: vec![Integer, Float].into(), ..Default::default() },
+        }
+
+        fallible_precision {
+            expr: |_| RoundFn {
+                value: Literal::from(1).boxed(),
+                precision: Some(Variable::new("foo".to_owned()).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn round() {

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -46,7 +46,7 @@ impl RoundFn {
 }
 
 impl Expression for RoundFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -118,7 +118,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -46,7 +46,11 @@ impl RoundFn {
 }
 
 impl Expression for RoundFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -36,7 +36,7 @@ impl Sha1Fn {
 }
 
 impl Expression for Sha1Fn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         use ::sha1::{Digest, Sha1};
 
         self.value.execute(state, object).map(|r| {
@@ -70,7 +70,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -36,7 +36,7 @@ impl Sha1Fn {
 }
 
 impl Expression for Sha1Fn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use ::sha1::{Digest, Sha1};
 
         self.value.execute(state, object).map(|r| {
@@ -70,7 +70,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -59,6 +59,24 @@ impl Expression for Sha1Fn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| Sha1Fn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| Sha1Fn { value: Literal::from(1).boxed() },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| Sha1Fn { value: Box::new(Noop) },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+    ];
 
     #[test]
     fn sha1() {

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -36,7 +36,11 @@ impl Sha1Fn {
 }
 
 impl Expression for Sha1Fn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use ::sha1::{Digest, Sha1};
 
         self.value.execute(state, object).map(|r| {

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -46,6 +46,13 @@ impl Expression for Sha1Fn {
             })
         })
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -87,6 +87,41 @@ fn encode<T: Digest>(value: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| Sha2Fn {
+                value: Literal::from("foo").boxed(),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| Sha2Fn {
+                value: Literal::from(1).boxed(),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| Sha2Fn {
+                value: Box::new(Noop),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+
+        variant_fallible {
+            expr: |_| Sha2Fn {
+                value: Literal::from("foo").boxed(),
+                variant: Some(Variable::new("foo".to_string()).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn sha2() {

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -41,7 +41,7 @@ impl Sha2Fn {
 }
 
 impl Expression for Sha2Fn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 
@@ -139,7 +139,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -63,6 +63,19 @@ impl Expression for Sha2Fn {
 
         Ok(Some(hash.into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .merge_optional(
+                self.variant
+                    .as_ref()
+                    .map(|variant| variant.type_def(state).fallible_unless(value::Kind::String)),
+            )
+            .into_fallible(true) // unknown variant enum
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[inline]

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -41,7 +41,11 @@ impl Sha2Fn {
 }
 
 impl Expression for Sha2Fn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -41,7 +41,7 @@ impl Sha2Fn {
 }
 
 impl Expression for Sha2Fn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 
@@ -139,7 +139,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -41,7 +41,11 @@ impl Sha3Fn {
 }
 
 impl Expression for Sha3Fn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -61,6 +61,19 @@ impl Expression for Sha3Fn {
 
         Ok(Some(hash.into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .merge_optional(
+                self.variant
+                    .as_ref()
+                    .map(|variant| variant.type_def(state).fallible_unless(value::Kind::String)),
+            )
+            .into_fallible(true) // unknown variant enum
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[inline]

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -41,7 +41,7 @@ impl Sha3Fn {
 }
 
 impl Expression for Sha3Fn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 
@@ -123,7 +123,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -85,6 +85,41 @@ fn encode<T: Digest>(value: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| Sha3Fn {
+                value: Literal::from("foo").boxed(),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| Sha3Fn {
+                value: Literal::from(1).boxed(),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_optional {
+            expr: |_| Sha3Fn {
+                value: Box::new(Noop),
+                variant: None,
+            },
+            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+        }
+
+        variant_fallible {
+            expr: |_| Sha3Fn {
+                value: Literal::from("foo").boxed(),
+                variant: Some(Variable::new("foo".to_string()).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn sha3() {

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -41,7 +41,7 @@ impl Sha3Fn {
 }
 
 impl Expression for Sha3Fn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
         let variant = optional!(state, object, self.variant, Value::String(v) => v);
 
@@ -123,7 +123,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -55,7 +55,7 @@ impl SliceFn {
 }
 
 impl Expression for SliceFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let start = required!(state, object, self.start, Value::Integer(v) => v);
         let end = optional!(state, object, self.end, Value::Integer(v) => v);
 
@@ -163,7 +163,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -212,7 +212,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -248,7 +248,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -122,6 +122,36 @@ impl Expression for SliceFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| SliceFn {
+                value: Literal::from("foo").boxed(),
+                start: Literal::from(0).boxed(),
+                end: None,
+            },
+            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+        }
+
+        value_array {
+            expr: |_| SliceFn {
+                value: Literal::from(vec!["foo"]).boxed(),
+                start: Literal::from(0).boxed(),
+                end: None,
+            },
+            def: TypeDef { fallible: true, constraint: Array.into(), ..Default::default() },
+        }
+
+        value_unknown {
+            expr: |_| SliceFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                start: Literal::from(0).boxed(),
+                end: None,
+            },
+            def: TypeDef { fallible: true, constraint: vec![String, Array].into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn bytes() {

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -55,7 +55,7 @@ impl SliceFn {
 }
 
 impl Expression for SliceFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let start = required!(state, object, self.start, Value::Integer(v) => v);
         let end = optional!(state, object, self.end, Value::Integer(v) => v);
 
@@ -163,7 +163,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -212,7 +212,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func
@@ -248,7 +248,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -55,7 +55,11 @@ impl SliceFn {
 }
 
 impl Expression for SliceFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let start = required!(state, object, self.start, Value::Integer(v) => v);
         let end = optional!(state, object, self.end, Value::Integer(v) => v);
 

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -50,7 +50,11 @@ pub(crate) struct SplitFn {
 }
 
 impl Expression for SplitFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let limit: usize = self
             .limit

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -50,7 +50,7 @@ pub(crate) struct SplitFn {
 }
 
 impl Expression for SplitFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let string: String = self
             .value
             .execute(state, object)?

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -50,7 +50,7 @@ pub(crate) struct SplitFn {
 }
 
 impl Expression for SplitFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let string: String = self
             .value
             .execute(state, object)?

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -76,4 +76,25 @@ impl Expression for SplitFn {
 
         Ok(Some(value))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        let limit_def = self
+            .limit
+            .as_ref()
+            .map(|limit| limit.type_def(state).fallible_unless(vec![Integer, Float]));
+
+        let pattern_def = match &self.pattern {
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(String)),
+            Argument::Regex(_) => None, // regex is a concrete infallible type
+        };
+
+        self.value
+            .type_def(state)
+            .fallible_unless(String)
+            .merge_optional(limit_def)
+            .merge_optional(pattern_def)
+            .with_constraint(Array)
+    }
 }

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -98,3 +98,85 @@ impl Expression for SplitFn {
             .with_constraint(Array)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    remap::test_type_def![
+        infallible {
+            expr: |_| SplitFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                limit: None,
+            },
+            def: TypeDef {
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+
+        value_fallible {
+            expr: |_| SplitFn {
+                value: Literal::from(10).boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                limit: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+
+        pattern_expression_infallible {
+            expr: |_| SplitFn {
+                value: Literal::from("foo").boxed(),
+                pattern: Literal::from("foo").boxed().into(),
+                limit: None,
+            },
+            def: TypeDef {
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+
+        pattern_expression_fallible {
+            expr: |_| SplitFn {
+                value: Literal::from("foo").boxed(),
+                pattern: Literal::from(10).boxed().into(),
+                limit: None,
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+
+        limit_infallible {
+            expr: |_| SplitFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                limit: Some(Literal::from(10).boxed()),
+            },
+            def: TypeDef {
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+
+        limit_fallible {
+            expr: |_| SplitFn {
+                value: Literal::from("foo").boxed(),
+                pattern: regex::Regex::new("foo").unwrap().into(),
+                limit: Some(Literal::from("foo").boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                constraint: value::Kind::Array.into(),
+                ..Default::default()
+            },
+        }
+    ];
+}

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -63,7 +63,7 @@ impl StartsWithFn {
 }
 
 impl Expression for StartsWithFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -144,7 +144,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -82,6 +82,23 @@ impl Expression for StartsWithFn {
 
         Ok(Some(starts_with.into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .merge(
+                self.substring
+                    .type_def(state)
+                    .fallible_unless(value::Kind::String),
+            )
+            .merge_optional(self.case_sensitive.as_ref().map(|case_sensitive| {
+                case_sensitive
+                    .type_def(state)
+                    .fallible_unless(value::Kind::Boolean)
+            }))
+            .with_constraint(value::Kind::Boolean)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -63,7 +63,7 @@ impl StartsWithFn {
 }
 
 impl Expression for StartsWithFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -144,7 +144,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -105,6 +105,45 @@ impl Expression for StartsWithFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        value_string {
+            expr: |_| StartsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| StartsWithFn {
+                value: Literal::from(true).boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        substring_non_string {
+            expr: |_| StartsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from(true).boxed(),
+                case_sensitive: None,
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        case_sensitive_non_boolean {
+            expr: |_| StartsWithFn {
+                value: Literal::from("foo").boxed(),
+                substring: Literal::from("foo").boxed(),
+                case_sensitive: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+    ];
 
     #[test]
     fn starts_with() {

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -63,7 +63,11 @@ impl StartsWithFn {
 }
 
 impl Expression for StartsWithFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -37,7 +37,11 @@ impl StripAnsiEscapeCodesFn {
 }
 
 impl Expression for StripAnsiEscapeCodesFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         strip_ansi_escapes::strip(&bytes)

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -37,7 +37,7 @@ impl StripAnsiEscapeCodesFn {
 }
 
 impl Expression for StripAnsiEscapeCodesFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         strip_ansi_escapes::strip(&bytes)
@@ -83,7 +83,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -37,7 +37,7 @@ impl StripAnsiEscapeCodesFn {
 }
 
 impl Expression for StripAnsiEscapeCodesFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         strip_ansi_escapes::strip(&bytes)
@@ -83,7 +83,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -46,6 +46,16 @@ impl Expression for StripAnsiEscapeCodesFn {
             .map(Into::into)
             .map_err(|e| e.to_string().into())
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            // TODO: Can probably remove this, as it only fails if writing to
+            //       the buffer fails.
+            .into_fallible(true)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -63,6 +63,18 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| StripAnsiEscapeCodesFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        fallible_expression {
+            expr: |_| StripAnsiEscapeCodesFn { value: Literal::from(10).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+    ];
+
     #[test]
     fn strip_ansi_escape_codes() {
         let cases = vec![

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -36,7 +36,7 @@ impl StripWhitespaceFn {
 }
 
 impl Expression for StripWhitespaceFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
 
         Ok(Some(value.trim().into()))
@@ -83,7 +83,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -36,7 +36,11 @@ impl StripWhitespaceFn {
 }
 
 impl Expression for StripWhitespaceFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
 
         Ok(Some(value.trim().into()))

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -36,7 +36,7 @@ impl StripWhitespaceFn {
 }
 
 impl Expression for StripWhitespaceFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
 
         Ok(Some(value.trim().into()))
@@ -83,7 +83,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -41,6 +41,13 @@ impl Expression for StripWhitespaceFn {
 
         Ok(Some(value.trim().into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -55,6 +55,18 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| StripWhitespaceFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        fallible_expression {
+            expr: |_| StripWhitespaceFn { value: Literal::from(10).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+    ];
+
     #[test]
     fn strip_whitespace() {
         let cases = vec![

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -72,6 +72,20 @@ impl Expression for ToBoolFn {
             to_bool,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        self.value
+            .type_def(state)
+            .fallible_unless(vec![Boolean, Integer, Float, Null])
+            .merge_with_default_optional(self.default.as_ref().map(|default| {
+                default
+                    .type_def(state)
+                    .fallible_unless(vec![Boolean, Integer, Float, Null])
+            }))
+            .with_constraint(Boolean)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -47,7 +47,7 @@ impl ToBoolFn {
 }
 
 impl Expression for ToBoolFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use Value::*;
 
         let to_bool = |value| match value {
@@ -99,7 +99,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -92,6 +92,107 @@ impl Expression for ToBoolFn {
 mod tests {
     use super::*;
     use crate::map;
+    use std::collections::BTreeMap;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        boolean_infallible {
+            expr: |_| ToBoolFn { value: Literal::from(true).boxed(), default: None },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        integer_infallible {
+            expr: |_| ToBoolFn { value: Literal::from(1).boxed(), default: None },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        float_infallible {
+            expr: |_| ToBoolFn { value: Literal::from(1.0).boxed(), default: None },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        null_infallible {
+            expr: |_| ToBoolFn { value: Literal::from(()).boxed(), default: None },
+            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+        }
+
+        string_fallible {
+            expr: |_| ToBoolFn { value: Literal::from("foo").boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        map_fallible {
+            expr: |_| ToBoolFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        array_fallible {
+            expr: |_| ToBoolFn { value: Literal::from(vec![0]).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        timestamp_fallible {
+            expr: |_| ToBoolFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+        }
+
+        fallible_value_without_default {
+            expr: |_| ToBoolFn { value: Literal::from("foo".to_owned()).boxed(), default: None },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Boolean.into(),
+            },
+        }
+
+       fallible_value_with_fallible_default {
+            expr: |_| ToBoolFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Boolean.into(),
+            },
+        }
+
+       fallible_value_with_infallible_default {
+            expr: |_| ToBoolFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(true).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Boolean.into(),
+            },
+        }
+
+        infallible_value_with_fallible_default {
+            expr: |_| ToBoolFn {
+                value: Literal::from(true).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Boolean.into(),
+            },
+        }
+
+        infallible_value_with_infallible_default {
+            expr: |_| ToBoolFn {
+                value: Literal::from(true).boxed(),
+                default: Some(Literal::from(true).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Boolean.into(),
+            },
+        }
+    ];
 
     #[test]
     fn to_bool() {

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -58,11 +58,12 @@ impl Expression for ToBoolFn {
             Boolean(_) => Ok(value),
             Integer(v) => Ok(Boolean(v != 0)),
             Float(v) => Ok(Boolean(v != 0.0)),
+            Null => Ok(Boolean(false)),
             String(_) => Conversion::Boolean
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            _ => Err("unable to convert value to boolean".into()),
+            Array(_) | Map(_) | Timestamp(_) => Err("unable to convert value to boolean".into()),
         };
 
         super::convert_value_or_default(

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -47,7 +47,11 @@ impl ToBoolFn {
 }
 
 impl Expression for ToBoolFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use Value::*;
 
         let to_bool = |value| match value {
@@ -99,7 +103,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -47,7 +47,11 @@ impl ToFloatFn {
 }
 
 impl Expression for ToFloatFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use Value::*;
 
         let to_float = |value| match value {
@@ -99,7 +103,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -58,11 +58,12 @@ impl Expression for ToFloatFn {
             Float(_) => Ok(value),
             Integer(v) => Ok(Float(v as f64)),
             Boolean(v) => Ok(Float(if v { 1.0 } else { 0.0 })),
+            Null => Ok(0.0.into()),
             String(_) => Conversion::Float
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            _ => Err("unable to convert value to float".into()),
+            Array(_) | Map(_) | Timestamp(_) => Err("unable to convert value to float".into()),
         };
 
         super::convert_value_or_default(

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -72,6 +72,20 @@ impl Expression for ToFloatFn {
             to_float,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        self.value
+            .type_def(state)
+            .fallible_unless(vec![Float, Integer, Boolean, Null])
+            .merge_with_default_optional(self.default.as_ref().map(|default| {
+                default
+                    .type_def(state)
+                    .fallible_unless(vec![Float, Integer, Boolean, Null])
+            }))
+            .with_constraint(Float)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -47,7 +47,7 @@ impl ToFloatFn {
 }
 
 impl Expression for ToFloatFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use Value::*;
 
         let to_float = |value| match value {
@@ -99,7 +99,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -92,6 +92,107 @@ impl Expression for ToFloatFn {
 mod tests {
     use super::*;
     use crate::map;
+    use std::collections::BTreeMap;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        boolean_infallible {
+            expr: |_| ToFloatFn { value: Literal::from(true).boxed(), default: None },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        integer_infallible {
+            expr: |_| ToFloatFn { value: Literal::from(1).boxed(), default: None },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        float_infallible {
+            expr: |_| ToFloatFn { value: Literal::from(1.0).boxed(), default: None },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        null_infallible {
+            expr: |_| ToFloatFn { value: Literal::from(()).boxed(), default: None },
+            def: TypeDef { constraint: Float.into(), ..Default::default() },
+        }
+
+        string_fallible {
+            expr: |_| ToFloatFn { value: Literal::from("foo").boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+        }
+
+        map_fallible {
+            expr: |_| ToFloatFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+        }
+
+        array_fallible {
+            expr: |_| ToFloatFn { value: Literal::from(vec![0]).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+        }
+
+        timestamp_infallible {
+            expr: |_| ToFloatFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+        }
+
+        fallible_value_without_default {
+            expr: |_| ToFloatFn { value: Variable::new("foo".to_owned()).boxed(), default: None },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Float.into(),
+            },
+        }
+
+       fallible_value_with_fallible_default {
+            expr: |_| ToFloatFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Float.into(),
+            },
+        }
+
+       fallible_value_with_infallible_default {
+            expr: |_| ToFloatFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Float.into(),
+            },
+        }
+
+        infallible_value_with_fallible_default {
+            expr: |_| ToFloatFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Float.into(),
+            },
+        }
+
+        infallible_value_with_infallible_default {
+            expr: |_| ToFloatFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Float.into(),
+            },
+        }
+    ];
 
     #[test]
     fn to_float() {

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -47,7 +47,7 @@ impl ToIntFn {
 }
 
 impl Expression for ToIntFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use Value::*;
 
         let to_int = |value| match value {
@@ -99,7 +99,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -72,6 +72,20 @@ impl Expression for ToIntFn {
             to_int,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        self.value
+            .type_def(state)
+            .fallible_unless(vec![Integer, Float, Boolean, Null])
+            .merge_with_default_optional(self.default.as_ref().map(|default| {
+                default
+                    .type_def(state)
+                    .fallible_unless(vec![Integer, Float, Boolean, Null])
+            }))
+            .with_constraint(Integer)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -92,6 +92,107 @@ impl Expression for ToIntFn {
 mod tests {
     use super::*;
     use crate::map;
+    use std::collections::BTreeMap;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        boolean_infallible {
+            expr: |_| ToIntFn { value: Literal::from(true).boxed(), default: None },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        integer_infallible {
+            expr: |_| ToIntFn { value: Literal::from(1).boxed(), default: None },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        float_infallible {
+            expr: |_| ToIntFn { value: Literal::from(1.0).boxed(), default: None },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        null_infallible {
+            expr: |_| ToIntFn { value: Literal::from(()).boxed(), default: None },
+            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+        }
+
+        string_fallible {
+            expr: |_| ToIntFn { value: Literal::from("foo").boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+
+        map_fallible {
+            expr: |_| ToIntFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+
+        array_fallible {
+            expr: |_| ToIntFn { value: Literal::from(vec![0]).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+
+        timestamp_infallible {
+            expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
+            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+        }
+
+        fallible_value_without_default {
+            expr: |_| ToIntFn { value: Variable::new("foo".to_owned()).boxed(), default: None },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Integer.into(),
+            },
+        }
+
+       fallible_value_with_fallible_default {
+            expr: |_| ToIntFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Integer.into(),
+            },
+        }
+
+       fallible_value_with_infallible_default {
+            expr: |_| ToIntFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Integer.into(),
+            },
+        }
+
+        infallible_value_with_fallible_default {
+            expr: |_| ToIntFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Integer.into(),
+            },
+        }
+
+        infallible_value_with_infallible_default {
+            expr: |_| ToIntFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Integer.into(),
+            },
+        }
+    ];
 
     #[test]
     fn to_int() {

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -58,11 +58,12 @@ impl Expression for ToIntFn {
             Integer(_) => Ok(value),
             Float(v) => Ok(Integer(v as i64)),
             Boolean(v) => Ok(Integer(if v { 1 } else { 0 })),
+            Null => Ok(0.into()),
             String(_) => Conversion::Integer
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            _ => Err("unable to convert value to integer".into()),
+            Array(_) | Map(_) | Timestamp(_) => Err("unable to convert value to integer".into()),
         };
 
         super::convert_value_or_default(

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -47,7 +47,11 @@ impl ToIntFn {
 }
 
 impl Expression for ToIntFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use Value::*;
 
         let to_int = |value| match value {
@@ -99,7 +103,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -62,6 +62,15 @@ impl Expression for ToStringFn {
             to_string,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .merge_with_default_optional(
+                self.default.as_ref().map(|default| default.type_def(state)),
+            )
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -46,7 +46,11 @@ impl ToStringFn {
 }
 
 impl Expression for ToStringFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let to_string = |value| match value {
             Value::String(_) => Ok(value),
             _ => Ok(value.as_string_lossy()),
@@ -90,7 +94,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -46,7 +46,7 @@ impl ToStringFn {
 }
 
 impl Expression for ToStringFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let to_string = |value| match value {
             Value::String(_) => Ok(value),
             _ => Ok(value.as_string_lossy()),
@@ -90,7 +90,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -77,6 +77,107 @@ impl Expression for ToStringFn {
 mod tests {
     use super::*;
     use crate::map;
+    use std::collections::BTreeMap;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        boolean_infallible {
+            expr: |_| ToStringFn { value: Literal::from(true).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        integer_infallible {
+            expr: |_| ToStringFn { value: Literal::from(1).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        float_infallible {
+            expr: |_| ToStringFn { value: Literal::from(1.0).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        null_infallible {
+            expr: |_| ToStringFn { value: Literal::from(()).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        string_infallible {
+            expr: |_| ToStringFn { value: Literal::from("foo").boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        map_infallible {
+            expr: |_| ToStringFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        array_infallible {
+            expr: |_| ToStringFn { value: Literal::from(vec![0]).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        timestamp_infallible {
+            expr: |_| ToStringFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None},
+            def: TypeDef { constraint: String.into(), ..Default::default() },
+        }
+
+        fallible_value_without_default {
+            expr: |_| ToStringFn { value: Variable::new("foo".to_owned()).boxed(), default: None},
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: String.into(),
+            },
+        }
+
+        fallible_value_with_fallible_default {
+            expr: |_| ToStringFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                default: Some(Variable::new("foo".to_owned()).boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: String.into(),
+            },
+        }
+
+       fallible_value_with_infallible_default {
+            expr: |_| ToStringFn {
+                value: Variable::new("foo".to_owned()).boxed(),
+                default: Some(Literal::from(true).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: String.into(),
+            },
+        }
+
+        infallible_value_with_fallible_default {
+            expr: |_| ToStringFn {
+                value: Literal::from(true).boxed(),
+                default: Some(Variable::new("foo".to_owned()).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: String.into(),
+            },
+        }
+
+        infallible_value_with_infallible_default {
+            expr: |_| ToStringFn {
+                value: Literal::from(true).boxed(),
+                default: Some(Literal::from(true).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: String.into(),
+            },
+        }
+    ];
 
     #[test]
     fn to_string() {

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -110,6 +110,107 @@ impl Expression for ToTimestampFn {
 mod tests {
     use super::*;
     use crate::map;
+    use std::collections::BTreeMap;
+    use value::Kind::*;
+
+    remap::test_type_def![
+        timestamp_infallible {
+            expr: |_| ToTimestampFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None},
+            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        integer_infallible {
+            expr: |_| ToTimestampFn { value: Literal::from(1).boxed(), default: None},
+            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        float_infallible {
+            expr: |_| ToTimestampFn { value: Literal::from(1.0).boxed(), default: None},
+            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        null_fallible {
+            expr: |_| ToTimestampFn { value: Literal::from(()).boxed(), default: None},
+            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        string_fallible {
+            expr: |_| ToTimestampFn { value: Literal::from("foo").boxed(), default: None},
+            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        map_fallible {
+            expr: |_| ToTimestampFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
+            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        array_fallible {
+            expr: |_| ToTimestampFn { value: Literal::from(vec![0]).boxed(), default: None},
+            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        boolean_fallible {
+            expr: |_| ToTimestampFn { value: Literal::from(true).boxed(), default: None},
+            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+        }
+
+        fallible_value_without_default {
+            expr: |_| ToTimestampFn { value: Variable::new("foo".to_owned()).boxed(), default: None},
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Timestamp.into(),
+            },
+        }
+
+       fallible_value_with_fallible_default {
+            expr: |_| ToTimestampFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: true,
+                optional: false,
+                constraint: Timestamp.into(),
+            },
+        }
+
+       fallible_value_with_infallible_default {
+            expr: |_| ToTimestampFn {
+                value: Literal::from(vec![0]).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Timestamp.into(),
+            },
+        }
+
+        infallible_value_with_fallible_default {
+            expr: |_| ToTimestampFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(vec![0]).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Timestamp.into(),
+            },
+        }
+
+        infallible_value_with_infallible_default {
+            expr: |_| ToTimestampFn {
+                value: Literal::from(1).boxed(),
+                default: Some(Literal::from(1).boxed()),
+            },
+            def: TypeDef {
+                fallible: false,
+                optional: false,
+                constraint: Timestamp.into(),
+            },
+        }
+    ];
 
     #[test]
     fn to_timestamp() {

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -90,6 +90,20 @@ impl Expression for ToTimestampFn {
             to_timestamp,
         )
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        self.value
+            .type_def(state)
+            .fallible_unless(vec![Timestamp, Integer, Float])
+            .merge_with_default_optional(self.default.as_ref().map(|default| {
+                default
+                    .type_def(state)
+                    .fallible_unless(vec![Timestamp, Integer, Float])
+            }))
+            .with_constraint(Timestamp)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -64,7 +64,7 @@ impl ToTimestampFn {
 }
 
 impl Expression for ToTimestampFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         use Value::*;
 
         let to_timestamp = |value| match value {
@@ -124,7 +124,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -64,7 +64,11 @@ impl ToTimestampFn {
 }
 
 impl Expression for ToTimestampFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         use Value::*;
 
         let to_timestamp = |value| match value {
@@ -124,7 +128,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -73,13 +73,15 @@ impl Expression for ToTimestampFn {
 
         let to_timestamp = |value| match value {
             Timestamp(_) => Ok(value),
+            Integer(v) => Ok(Timestamp(Utc.timestamp(v, 0))),
+            Float(v) => Ok(Timestamp(Utc.timestamp(v.round() as i64, 0))),
             String(_) => Conversion::Timestamp
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            Integer(v) => Ok(Timestamp(Utc.timestamp(v, 0))),
-            Float(v) => Ok(Timestamp(Utc.timestamp(v.round() as i64, 0))),
-            _ => Err("unable to convert value to timestamp".into()),
+            Boolean(_) | Array(_) | Map(_) | Null => {
+                Err("unable to convert value to timestamp".into())
+            }
         };
 
         super::convert_value_or_default(

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -37,7 +37,7 @@ impl TokenizeFn {
 }
 
 impl Expression for TokenizeFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -78,7 +78,7 @@ mod tests {
                     TokenizeFn::new(Box::new(Literal::from("217.250.207.207 - - [07/Sep/2020:16:38:00 -0400] \"DELETE /deliverables/next-generation/user-centric HTTP/1.1\" 205 11881"))),
                 )];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -37,7 +37,7 @@ impl TokenizeFn {
 }
 
 impl Expression for TokenizeFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -78,7 +78,7 @@ mod tests {
                     TokenizeFn::new(Box::new(Literal::from("217.250.207.207 - - [07/Sep/2020:16:38:00 -0400] \"DELETE /deliverables/next-generation/user-centric HTTP/1.1\" 205 11881"))),
                 )];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -37,7 +37,11 @@ impl TokenizeFn {
 }
 
 impl Expression for TokenizeFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -68,6 +68,18 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        value_string {
+            expr: |_| TokenizeFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: value::Kind::Array.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| TokenizeFn { value: Literal::from(10).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::Array.into(), ..Default::default() },
+        }
+    ];
+
     #[test]
     fn tokenize() {
         let cases = vec![(

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -54,6 +54,13 @@ impl Expression for TokenizeFn {
 
         Ok(Some(tokens))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::Array)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -66,7 +66,7 @@ impl TruncateFn {
 }
 
 impl Expression for TruncateFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         let mut value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -184,7 +184,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -74,9 +74,11 @@ impl Expression for TruncateFn {
 
         let limit = required!(
             state, object, self.limit,
-            Value::Float(f) if f >= 0.0 => f.floor() as usize,
-            Value::Integer(i) if i >= 0 => i as usize,
+            Value::Float(f) => f.floor() as i64,
+            Value::Integer(i) => i as i64,
         );
+
+        let limit = if limit < 0 { 0 } else { limit as usize };
 
         let ellipsis =
             optional!(state, object, self.ellipsis, Value::Boolean(v) => v).unwrap_or_default();

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -66,7 +66,7 @@ impl TruncateFn {
 }
 
 impl Expression for TruncateFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         let mut value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -184,7 +184,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -66,7 +66,11 @@ impl TruncateFn {
 }
 
 impl Expression for TruncateFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         let mut value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -128,6 +128,62 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        infallible {
+            expr: |_| TruncateFn {
+                value: Literal::from("foo").boxed(),
+                limit: Literal::from(1).boxed(),
+                ellipsis: None,
+            },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        value_non_string {
+            expr: |_| TruncateFn {
+                value: Literal::from(false).boxed(),
+                limit: Literal::from(1).boxed(),
+                ellipsis: None,
+            },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        limit_float {
+            expr: |_| TruncateFn {
+                value: Literal::from("foo").boxed(),
+                limit: Literal::from(1.0).boxed(),
+                ellipsis: None,
+            },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        limit_non_number {
+            expr: |_| TruncateFn {
+                value: Literal::from("foo").boxed(),
+                limit: Literal::from("bar").boxed(),
+                ellipsis: None,
+            },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        ellipsis_boolean {
+            expr: |_| TruncateFn {
+                value: Literal::from("foo").boxed(),
+                limit: Literal::from(10).boxed(),
+                ellipsis: Some(Literal::from(true).boxed()),
+            },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        ellipsis_non_boolean {
+            expr: |_| TruncateFn {
+                value: Literal::from("foo").boxed(),
+                limit: Literal::from("bar").boxed(),
+                ellipsis: Some(Literal::from("baz").boxed()),
+            },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+    ];
+
     #[test]
     fn truncate() {
         let cases = vec![

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -102,6 +102,25 @@ impl Expression for TruncateFn {
 
         Ok(Some(value.into()))
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind::*;
+
+        self.value
+            .type_def(state)
+            .fallible_unless(String)
+            .merge(
+                self.limit
+                    .type_def(state)
+                    .fallible_unless(vec![Integer, Float]),
+            )
+            .merge_optional(
+                self.ellipsis
+                    .as_ref()
+                    .map(|ellipsis| ellipsis.type_def(state).fallible_unless(Boolean)),
+            )
+            .with_constraint(String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -61,6 +61,18 @@ mod tests {
     use super::*;
     use crate::map;
 
+    remap::test_type_def![
+        string {
+            expr: |_| UpcaseFn { value: Literal::from("foo").boxed() },
+            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+        }
+
+        non_string {
+            expr: |_| UpcaseFn { value: Literal::from(true).boxed() },
+            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+        }
+    ];
+
     #[test]
     fn upcase() {
         let cases = vec![

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -47,6 +47,13 @@ impl Expression for UpcaseFn {
             .map(Ok)
             .transpose()
     }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value
+            .type_def(state)
+            .fallible_unless(value::Kind::String)
+            .with_constraint(value::Kind::String)
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -37,7 +37,11 @@ impl UpcaseFn {
 }
 
 impl Expression for UpcaseFn {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -37,7 +37,7 @@ impl UpcaseFn {
 }
 
 impl Expression for UpcaseFn {
-    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)
@@ -69,7 +69,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -37,7 +37,7 @@ impl UpcaseFn {
 }
 
 impl Expression for UpcaseFn {
-    fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut ProgramState, object: &mut dyn Object) -> Result<Option<Value>> {
         self.value
             .execute(state, object)?
             .map(String::try_from)
@@ -69,7 +69,7 @@ mod tests {
             ),
         ];
 
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
 
         for (mut object, exp, func) in cases {
             let got = func

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -24,6 +24,13 @@ impl Expression for UuidV4Fn {
 
         Ok(Some(Bytes::copy_from_slice(uuid.as_bytes()).into()))
     }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef {
+            constraint: value::Kind::String.into(),
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -18,7 +18,7 @@ impl Function for UuidV4 {
 struct UuidV4Fn;
 
 impl Expression for UuidV4Fn {
-    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
         let mut buf = [0; 36];
         let uuid = uuid::Uuid::new_v4().to_hyphenated().encode_lower(&mut buf);
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn uuid_v4() {
-        let mut state = remap::ProgramState::default();
+        let mut state = state::Program::default();
         let mut object = map![];
         let value = UuidV4Fn.execute(&mut state, &mut object).unwrap().unwrap();
 

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -18,7 +18,7 @@ impl Function for UuidV4 {
 struct UuidV4Fn;
 
 impl Expression for UuidV4Fn {
-    fn execute(&self, _: &mut State, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut ProgramState, _: &mut dyn Object) -> Result<Option<Value>> {
         let mut buf = [0; 36];
         let uuid = uuid::Uuid::new_v4().to_hyphenated().encode_lower(&mut buf);
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn uuid_v4() {
-        let mut state = remap::State::default();
+        let mut state = remap::ProgramState::default();
         let mut object = map![];
         let value = UuidV4Fn.execute(&mut state, &mut object).unwrap().unwrap();
 

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -39,6 +39,14 @@ mod tests {
     use crate::map;
     use std::convert::TryFrom;
 
+    remap::test_type_def![static_def {
+        expr: |_| UuidV4Fn,
+        def: TypeDef {
+            constraint: value::Kind::String.into(),
+            ..Default::default()
+        },
+    }];
+
     #[test]
     fn uuid_v4() {
         let mut state = state::Program::default();

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -5,7 +5,7 @@ use crate::{
     transforms::{FunctionTransform, Transform},
     Result,
 };
-use remap::{value, Program, Runtime};
+use remap::{value, Program, Runtime, TypeDef};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
@@ -50,8 +50,16 @@ pub struct Remap {
 
 impl Remap {
     pub fn new(config: RemapConfig) -> crate::Result<Remap> {
+        let accepts = TypeDef {
+            fallible: true,
+            optional: true,
+            constraint: value::Constraint::Any,
+        };
+
+        let program = Program::new(&config.source, &crate::remap::FUNCTIONS_MUT, accepts)?;
+
         Ok(Remap {
-            program: Program::new(&config.source, &crate::remap::FUNCTIONS_MUT)?,
+            program,
             drop_on_err: config.drop_on_err,
         })
     }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -5,7 +5,7 @@ use crate::{
     transforms::{FunctionTransform, Transform},
     Result,
 };
-use remap::{Program, Runtime};
+use remap::{value, Program, Runtime};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]


### PR DESCRIPTION
This PR implements RFC #4862.

_This PR is best reviewed \*per commit\*. While the full diff is rather large, most of that comes from numerous tests._

## User-Level Changes

1. **does not** alter any of the grammar of the Remap language.
2. **does not** add any new functions.
3. **does not** change anything for the Remap _transform_
3. **does** invalidate certain scripts in certain component conditions.

As for the last point, the one place this currently invalidates certain Remap scripts is if you use remap as a condition.

Take for example:

```toml
[transforms.reduce]
    type = "reduce"
    starts_when.type = "remap"
    starts_when.source = "1337"
```

The `Condition` trait we use only allows returning boolean values (for performance reasons), so the only thing we could do was to accept the above `starts_when` condition, but always return `false` because `1337` is not a boolean. 

After this PR, we can check the return value at boot-time, which allows us to return an error and prevent the above example config from being valid, pointing out that `starts_when.source` needs to resolve to a boolean. A user can use any of the available functions or operations to make sure the return value is a boolean:

* `to_bool(1337)` — true
* `1337 >= 0` — true
* `contains(to_string(1337), substring = "133")` — true
* etc

This PR has **no impact** on the Remap transform, as the return value of the script isn't relevant to the outcome of the transform (the script is used to manipulate events, not to resolve to a final value).

## Program Type Check

When compiling a Remap script, the callee informs the program which results it expects. The following constraints can be defined:

* fallible or not
* optional value or not _(support for optional values will probably be removed from Remap soon, to make things easier to grok)_
* one or more value type constraints

For example:

```rust
TypeDef {
	fallible: false,
	optional: false,
	constraint: Constraint::Any,
}
```

The above constraint requires the program to be infallible, and return a concrete value type of any kind.

Exact value constraints can be defined as `Any`, `Exact(Boolean)`. Multiple value kinds are defined as `OneOf(vec![Integer, Float])`.

The program returns an error at compile-time if the result does not match the expectation, e.g.:

> remap error: program error: expected to be infallible, but is not

or

> remap error: program error: expected to resolve to string or float values, but instead resolves to an error, or integer or boolean values

The `fallible` check applies to _all_ (root) expressions in a program (since any failing expression will fail the entire program), whereas the `optional` and `constraint` checks only apply to the last expression (the one that resolves to the final value of the program).

## Expression Type Definitions

To make the above work, every expression now implements:

```rust
fn type_def(&self, state: &state::Compiler) -> TypeDef;
```

There are several rules that apply:

* Path queries (`.foo.bar`) resolve to `Any` (because we don't use any schemas currently, but that could change with #3910), _unless_ a path is assigned a value, in which case the path gets whatever constraint the value has (e.g. `.foo = true` will type check `.foo` as a `Boolean`).
* Literal values type check to their concrete type.
* Variable references type-check to whatever value is assigned to them last (e.g. `$foo = true; $foo = "bar"; $foo` type-checks to a string)
* Some wrapper-expressions type check to their inner expressions (e.g. a `block` expression delegates type checking to the final expression in the block, and an if-else statement merges the if and else type checks together)
* Functions implement their own `type_def`, and have to make sure the contract between implementation and `TypeDef` holds.

## Future Work

While we're currently only using this information on a program-level, we _can_ (and probably will) use this on an expression-level, to reject certain programs.

For example:

```rust
$foo = "bar"
if $foo {
	// ...
}
```

The above will fail at runtime because `"foo"` is of kind `String`, whereas the condition in an if-statement has to resolve to a boolean.

In a future PR, we can (at compile-time) ask the constraints of `$foo`, and know that it'll never resolve to a boolean, and thus return a compile-time error. To resolve this, one could instead write `if to_bool($foo)`. The same applies to certain operators (e.g. `"foo" > 2` would fail to compile).