### PR TITLE
fix(metrics): Address metric naming discrepancy

### DIFF
--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -144,7 +144,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("request_errors_total", 1);
+            counter!("http_request_errors_total", 1);
         }
     }
 }


### PR DESCRIPTION
This PR addresses a small metric naming discrepancy I encountered in my work for #4820.