### PR TITLE
fix(humio_metrics sink): dont use flatten for logs config fields

### DIFF
--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -1,6 +1,7 @@
+use super::{default_host_key, Encoding};
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
-    sinks::splunk_hec::{self, HecSinkConfig},
+    sinks::splunk_hec::HecSinkConfig,
     sinks::util::{
         encoding::EncodingConfigWithDefault, BatchConfig, Compression, TowerRequestConfig,
     },
@@ -13,34 +14,30 @@ const HOST: &str = "https://cloud.humio.com";
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct HumioLogsConfig {
-    token: String,
+    pub(in crate::sinks::humio) token: String,
     // Deprecated name
     #[serde(alias = "host")]
     pub(in crate::sinks::humio) endpoint: Option<String>,
-    source: Option<Template>,
+    pub(in crate::sinks::humio) source: Option<Template>,
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
     )]
-    encoding: EncodingConfigWithDefault<Encoding>,
+    pub(in crate::sinks::humio) encoding: EncodingConfigWithDefault<Encoding>,
 
-    event_type: Option<Template>,
+    pub(in crate::sinks::humio) event_type: Option<Template>,
 
     #[serde(default = "default_host_key")]
-    host_key: String,
+    pub(in crate::sinks::humio) host_key: String,
 
     #[serde(default)]
-    compression: Compression,
+    pub(in crate::sinks::humio) compression: Compression,
 
     #[serde(default)]
-    request: TowerRequestConfig,
+    pub(in crate::sinks::humio) request: TowerRequestConfig,
 
     #[serde(default)]
-    batch: BatchConfig,
-}
-
-fn default_host_key() -> String {
-    crate::config::LogSchema::default().host_key().to_string()
+    pub(in crate::sinks::humio) batch: BatchConfig,
 }
 
 inventory::submit! {
@@ -48,24 +45,6 @@ inventory::submit! {
 }
 
 impl_generate_config_from_default!(HumioLogsConfig);
-
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
-#[serde(rename_all = "snake_case")]
-#[derivative(Default)]
-pub enum Encoding {
-    #[derivative(Default)]
-    Json,
-    Text,
-}
-
-impl From<Encoding> for splunk_hec::Encoding {
-    fn from(v: Encoding) -> Self {
-        match v {
-            Encoding::Json => splunk_hec::Encoding::Json,
-            Encoding::Text => splunk_hec::Encoding::Text,
-        }
-    }
-}
 
 #[async_trait::async_trait]
 #[typetag::serde(name = "humio_logs")]

--- a/src/sinks/humio/mod.rs
+++ b/src/sinks/humio/mod.rs
@@ -1,2 +1,28 @@
 pub mod logs;
 pub mod metrics;
+
+
+use crate::sinks::splunk_hec;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
+#[serde(rename_all = "snake_case")]
+#[derivative(Default)]
+pub enum Encoding {
+    #[derivative(Default)]
+    Json,
+    Text,
+}
+
+impl From<Encoding> for splunk_hec::Encoding {
+    fn from(v: Encoding) -> Self {
+        match v {
+            Encoding::Json => splunk_hec::Encoding::Json,
+            Encoding::Text => splunk_hec::Encoding::Text,
+        }
+    }
+}
+
+fn default_host_key() -> String {
+    crate::config::LogSchema::default().host_key().to_string()
+}

--- a/src/sinks/humio/mod.rs
+++ b/src/sinks/humio/mod.rs
@@ -1,7 +1,6 @@
 pub mod logs;
 pub mod metrics;
 
-
 use crate::sinks::splunk_hec;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Closes #4903 

There is a bug in Serde ([here](https://github.com/serde-rs/serde/issues/1504)) whereby if you flatten fields from another struct it will not alias any fields from that struct. 

So, I have had to copy the field from the Humio logs config rather that flatten them. The code is not as elegant, but until Serde fix that issue, there isn't much else to do. By the sounds of it, it is quite a hard bug to fix.