### PR TITLE
fix(observability): Fix bytes processed total query

### DIFF
--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -211,7 +211,7 @@ pub fn component_bytes_processed_total(component_name: &str) -> Option<BytesProc
     capture_metrics(&GLOBAL_CONTROLLER)
         .find(|ev| match ev {
             Event::Metric(m)
-                if m.name.as_str().eq("bytes_processed_total")
+                if m.name.as_str().eq("processed_bytes_total")
                     && m.tag_matches("component_name", &component_name) =>
             {
                 true


### PR DESCRIPTION
ping @leebenson 'Ello Guv'na! 😄

Attempting to fix an issue where the bytes processed always comes back as null on queries (not subscriptions).  Believe it's a typo in the API that's causing it.  This is **not** noticeable on the `vector top` because the initial query is immediately updated by the subscriptions.  The typo is understandable given that events goes the other way with `events_processed_total`.

If you run a query against master like this you will always get null even if there are results:

```gql
query {
  sinks {
    name
    bytesProcessedTotal {
      bytesProcessedTotal
    }
  }
}
```


