### PR TITLE
chore(remap): simplify value type checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,7 @@ checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 name = "remap-lang"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "bytes 0.5.6",
  "chrono",
  "dyn-clone",

--- a/lib/remap-lang/Cargo.toml
+++ b/lib/remap-lang/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 publish = false
 
 [dependencies]
+bitflags = "1"
 bytes = "0.5"
 chrono = "0.4"
+dyn-clone = "1"
 paste = "1"
 pest = "2"
 pest_derive = "2"
 regex = "1"
 thiserror = "1"
-dyn-clone = "1.0.3"

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -145,49 +145,44 @@ expression_dispatch![
 #[cfg(test)]
 mod tests {
     use crate::value;
+    use value::Kind;
 
     #[test]
     fn test_contains() {
-        use value::Constraint::*;
-        use value::Kind::*;
-
         let cases = vec![
-            (true, Any, Any),
-            (true, Any, Exact(String)),
-            (true, Any, Exact(Integer)),
-            (true, Any, OneOf(vec![Float, Boolean])),
-            (true, Any, OneOf(vec![Map])),
-            (true, Exact(String), Exact(String)),
-            (true, Exact(String), OneOf(vec![String])),
-            (false, Exact(String), Exact(Array)),
-            (false, Exact(String), OneOf(vec![Integer])),
-            (false, Exact(String), OneOf(vec![Integer, Float])),
+            (true, Kind::all(), Kind::all()),
+            (true, Kind::all(), Kind::String),
+            (true, Kind::all(), Kind::Integer),
+            (true, Kind::all(), Kind::Float | Kind::Boolean),
+            (true, Kind::all(), Kind::Map),
+            (true, Kind::String, Kind::String),
+            (true, Kind::String, Kind::String),
+            (false, Kind::String, Kind::Array),
+            (false, Kind::String, Kind::Integer),
+            (false, Kind::String, Kind::Integer | Kind::Float),
         ];
 
         for (expect, this, other) in cases {
-            assert_eq!(this.contains(&other), expect);
+            assert_eq!(this.contains(other), expect);
         }
     }
 
     #[test]
     fn test_merge() {
-        use value::Constraint::*;
-        use value::Kind::*;
-
         let cases = vec![
-            (Any, Any, Any),
-            (Any, OneOf(vec![Integer, String]), Any),
-            (OneOf(vec![Integer, Float]), Exact(Integer), Exact(Float)),
-            (Exact(Integer), Exact(Integer), Exact(Integer)),
+            (Kind::all(), Kind::all(), Kind::all()),
+            (Kind::all(), Kind::Integer | Kind::String, Kind::all()),
+            (Kind::Integer | Kind::Float, Kind::Integer, Kind::Float),
+            (Kind::Integer, Kind::Integer, Kind::Integer),
             (
-                OneOf(vec![String, Integer, Float, Boolean]),
-                OneOf(vec![Integer, String]),
-                OneOf(vec![Float, Boolean]),
+                Kind::String | Kind::Integer | Kind::Float | Kind::Boolean,
+                Kind::Integer | Kind::String,
+                Kind::Float | Kind::Boolean,
             ),
         ];
 
         for (expect, this, other) in cases {
-            assert_eq!(this.merge(&other), expect);
+            assert_eq!(this | other, expect);
         }
     }
 }

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -118,8 +118,10 @@ macro_rules! expression_dispatch {
                 type Error = Error;
 
                 fn try_from(expr: Expr) -> std::result::Result<Self, Self::Error> {
+                    #[allow(unreachable_patterns)]
                     match expr {
                         Expr::$expr(v) => Ok(v),
+                        Expr::Argument(v) => $expr::try_from(v.into_expr()),
                         _ => Err(Error::from(ExprError::$expr(expr.as_str()))),
                     }
                 }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -54,26 +54,20 @@ impl Expression for Arithmetic {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::{Constraint::*, Kind::*};
+        use value::Kind;
         use Operator::*;
 
-        let constraint = match self.op {
-            Or => self
-                .lhs
-                .type_def(state)
-                .constraint
-                .merge(&self.rhs.type_def(state).constraint),
-            Multiply | Add => OneOf(vec![String, Integer, Float]),
-            Remainder | Subtract | Divide => OneOf(vec![Integer, Float]),
-            And | Equal | NotEqual | Greater | GreaterOrEqual | Less | LessOrEqual => {
-                Exact(Boolean)
-            }
+        let kind = match self.op {
+            Or => self.lhs.type_def(state).kind | self.rhs.type_def(state).kind,
+            Multiply | Add => Kind::String | Kind::Integer | Kind::Float,
+            Remainder | Subtract | Divide => Kind::Integer | Kind::Float,
+            And | Equal | NotEqual | Greater | GreaterOrEqual | Less | LessOrEqual => Kind::Boolean,
         };
 
         TypeDef {
             fallible: true,
             optional: false,
-            constraint,
+            kind,
         }
     }
 }
@@ -84,8 +78,7 @@ mod tests {
     use crate::{
         expression::{Literal, Noop},
         test_type_def,
-        value::Constraint::*,
-        value::Kind::*,
+        value::Kind,
     };
 
     test_type_def![
@@ -98,7 +91,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![String, Boolean])
+                kind: Kind::String | Kind::Boolean,
             },
         }
 
@@ -111,7 +104,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Any,
+                kind: Kind::all(),
             },
         }
 
@@ -124,7 +117,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![String, Integer, Float]),
+                kind: Kind::String | Kind::Integer | Kind::Float,
             },
         }
 
@@ -137,7 +130,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![String, Integer, Float]),
+                kind: Kind::String | Kind::Integer | Kind::Float,
             },
         }
 
@@ -150,7 +143,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![Integer, Float]),
+                kind: Kind::Integer | Kind::Float,
             },
         }
 
@@ -163,7 +156,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![Integer, Float]),
+                kind: Kind::Integer | Kind::Float,
             },
         }
 
@@ -176,7 +169,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: OneOf(vec![Integer, Float]),
+                kind: Kind::Integer | Kind::Float,
             },
         }
 
@@ -189,7 +182,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -202,7 +195,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -215,7 +208,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -228,7 +221,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -241,7 +234,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -254,7 +247,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -267,7 +260,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
     ];

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -83,7 +83,7 @@ impl Expression for Assignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{expression::Literal, test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{expression::Literal, test_type_def, value::Kind};
 
     test_type_def![
         variable {
@@ -94,7 +94,7 @@ mod tests {
                 Assignment::new(target, value, state)
             },
             def: TypeDef {
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
                 ..Default::default()
             },
         }
@@ -107,7 +107,7 @@ mod tests {
                 Assignment::new(target, value, state)
             },
             def: TypeDef {
-                constraint: Exact(String),
+                kind: Kind::String,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -54,8 +54,7 @@ mod tests {
     use crate::{
         expression::{Arithmetic, Literal},
         test_type_def,
-        value::Constraint::*,
-        value::Kind::*,
+        value::Kind,
         Operator,
     };
 
@@ -67,7 +66,7 @@ mod tests {
 
         one_expression {
             expr: |_| Block::new(vec![Literal::from(true).into()]),
-            def: TypeDef { constraint: Exact(Boolean), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         multiple_expressions {
@@ -76,7 +75,7 @@ mod tests {
                         Literal::from(true).into(),
                         Literal::from(1234).into(),
             ]),
-            def: TypeDef { constraint: Exact(Integer), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         last_one_fallible {
@@ -90,7 +89,7 @@ mod tests {
             ]),
             def: TypeDef {
                 fallible: true,
-                constraint: OneOf(vec![String, Integer, Float]),
+                kind: Kind::String | Kind::Integer | Kind::Float,
                 ..Default::default()
             },
         }
@@ -107,7 +106,7 @@ mod tests {
             ]),
             def: TypeDef {
                 fallible: true,
-                constraint: Exact(Array),
+                kind: Kind::Array,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -142,7 +142,7 @@ impl Expression for Function {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{expression::Noop, test_type_def, value::Constraint::*};
+    use crate::{expression::Noop, test_type_def, value::Kind};
 
     test_type_def![pass_through {
         expr: |_| {
@@ -152,7 +152,7 @@ mod tests {
         def: TypeDef {
             fallible: false,
             optional: true,
-            constraint: Any
+            kind: Kind::all(),
         },
     }];
 }

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -60,8 +60,7 @@ mod tests {
     use crate::{
         expression::{Literal, Noop},
         test_type_def,
-        value::Constraint::*,
-        value::Kind::*,
+        value::Kind,
     };
 
     test_type_def![
@@ -76,7 +75,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Exact(Boolean),
+                kind: Kind::Boolean,
             },
         }
 
@@ -91,7 +90,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: true,
-                constraint: Any,
+                kind: Kind::all(),
             },
         }
     ];

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,4 +1,4 @@
-use crate::{state, value, Expression, Object, Result, TypeDef, Value};
+use crate::{state, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Literal(Value);
@@ -26,7 +26,7 @@ impl Expression for Literal {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            constraint: value::Constraint::Exact(self.0.kind()),
+            kind: self.0.kind(),
             ..Default::default()
         }
     }
@@ -35,48 +35,48 @@ impl Expression for Literal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{test_type_def, value::Kind};
     use std::collections::BTreeMap;
 
     test_type_def![
         boolean {
             expr: |_| Literal::from(true),
-            def: TypeDef { constraint: Exact(Boolean), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         string {
             expr: |_| Literal::from("foo"),
-            def: TypeDef { constraint: Exact(String), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         integer {
             expr: |_| Literal::from(123),
-            def: TypeDef { constraint: Exact(Integer), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         float {
             expr: |_| Literal::from(123.456),
-            def: TypeDef { constraint: Exact(Float), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         array {
             expr: |_| Literal::from(vec!["foo"]),
-            def: TypeDef { constraint: Exact(Array), ..Default::default() },
+            def: TypeDef { kind: Kind::Array, ..Default::default() },
         }
 
         map {
             expr: |_| Literal::from(BTreeMap::default()),
-            def: TypeDef { constraint: Exact(Map), ..Default::default() },
+            def: TypeDef { kind: Kind::Map, ..Default::default() },
         }
 
         timestamp {
             expr: |_| Literal::from(chrono::Utc::now()),
-            def: TypeDef { constraint: Exact(Timestamp), ..Default::default() },
+            def: TypeDef { kind: Kind::Timestamp, ..Default::default() },
         }
 
         null {
             expr: |_| Literal::from(()),
-            def: TypeDef { constraint: Exact(Null), ..Default::default() },
+            def: TypeDef { kind: Kind::Null, ..Default::default() },
         }
     ];
 }

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -41,7 +41,7 @@ impl Expression for Not {
         TypeDef {
             fallible: true,
             optional: true,
-            constraint: value::Constraint::Exact(value::Kind::Boolean),
+            kind: value::Kind::Boolean,
         }
     }
 }
@@ -49,7 +49,7 @@ impl Expression for Not {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{expression::*, test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{expression::*, test_type_def, value::Kind};
 
     #[test]
     fn not() {
@@ -89,7 +89,7 @@ mod tests {
         def: TypeDef {
             fallible: true,
             optional: true,
-            constraint: Exact(Boolean),
+            kind: Kind::Boolean,
         },
     }];
 }

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -73,7 +73,7 @@ impl Expression for Path {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{test_type_def, value::Kind};
 
     test_type_def![
         ident_match {
@@ -89,7 +89,7 @@ mod tests {
                 state.path_query_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
                     optional: false,
-                    constraint: Exact(String)
+                    kind: Kind::String
                 });
 
                 Path::from("foo")
@@ -97,7 +97,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(String),
+                kind: Kind::String,
             },
         }
 

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -51,7 +51,7 @@ impl Expression for Variable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_type_def, value::Constraint::*, value::Kind::*};
+    use crate::{test_type_def, value::Kind};
 
     test_type_def![
         ident_match {
@@ -67,7 +67,7 @@ mod tests {
                 state.variable_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
                     optional: false,
-                    constraint: Exact(String)
+                    kind: Kind::String
                 });
 
                 Variable::new("foo".to_owned())
@@ -75,7 +75,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Exact(String),
+                kind: Kind::String,
             },
         }
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -229,7 +229,7 @@ mod tests {
             let accept = TypeDef {
                 fallible: true,
                 optional: true,
-                constraint: value::Constraint::Any,
+                kind: value::Kind::all(),
             };
 
             let program = Program::new(

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -35,8 +35,8 @@ impl fmt::Display for ResolvesToError {
             }
         }
 
-        want_str.push_str(&want.constraint.to_string());
-        got_str.push_str(&got.constraint.to_string());
+        want_str.push_str(&want.kind.to_string());
+        got_str.push_str(&got.kind.to_string());
 
         if optional_diff {
             if want.is_optional() {
@@ -51,14 +51,14 @@ impl fmt::Display for ResolvesToError {
         want_str.push_str(" value");
         got_str.push_str(" value");
 
-        let want_kinds = want.constraint.value_kinds();
-        let got_kinds = got.constraint.value_kinds();
+        let want_kinds: Vec<_> = want.kind.into_iter().collect();
+        let got_kinds: Vec<_> = got.kind.into_iter().collect();
 
-        if !want.constraint.is_any() && want_kinds.len() > 1 {
+        if !want.kind.is_all() && want_kinds.len() > 1 {
             want_str.push('s');
         }
 
-        if !got.constraint.is_any() && got_kinds.len() > 1 {
+        if !got.kind.is_all() && got_kinds.len() > 1 {
             got_str.push('s');
         }
 
@@ -133,8 +133,7 @@ mod tests {
 
     #[test]
     fn program_test() {
-        use value::Constraint::*;
-        use value::Kind::*;
+        use value::Kind;
 
         let cases = vec![
             (".foo", TypeDef { fallible: true, ..Default::default()}, Ok(())),
@@ -156,7 +155,7 @@ mod tests {
                 TypeDef {
                     fallible: false,
                     optional: false,
-                    constraint: Exact(String),
+                    kind: Kind::String,
                 },
                 Err("expected to resolve to string value, but instead resolves to an error, or any value".to_owned()),
             ),
@@ -166,7 +165,7 @@ mod tests {
                 TypeDef {
                     fallible: false,
                     optional: false,
-                    constraint: OneOf(vec![String, Float]),
+                    kind: Kind::String | Kind::Float,
                 },
                 Err("expected to resolve to string or float values, but instead resolves to an error, or integer or boolean values".to_owned()),
             ),

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -1,4 +1,3 @@
-mod constraint;
 mod kind;
 
 use bytes::Bytes;
@@ -7,7 +6,6 @@ use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::string::String as StdString;
 
-pub use constraint::Constraint;
 pub use kind::Kind;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/lib/remap-lang/src/value/kind.rs
+++ b/lib/remap-lang/src/value/kind.rs
@@ -1,47 +1,117 @@
+#![allow(non_upper_case_globals)]
+
 use super::Value;
 use std::fmt;
 use std::ops::Deref;
 
-#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, Ord, PartialOrd)]
-pub enum Kind {
-    String,
-    Integer,
-    Float,
-    Boolean,
-    Map,
-    Array,
-    Timestamp,
-    Null,
-}
-
-impl fmt::Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self)
+bitflags::bitflags! {
+    pub struct Kind: u16 {
+        const String = 1 << 1;
+        const Integer = 1 << 2;
+        const Float = 1 << 3;
+        const Boolean = 1 << 4;
+        const Map = 1 << 5;
+        const Array = 1 << 6;
+        const Timestamp = 1 << 7;
+        const Null = 1 << 8;
     }
 }
 
 impl Kind {
-    pub fn all() -> Vec<Self> {
-        use Kind::*;
-
-        vec![String, Integer, Float, Boolean, Map, Array, Timestamp, Null]
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        use Kind::*;
-
-        match self {
-            String => "string",
-            Integer => "integer",
-            Float => "float",
-            Boolean => "boolean",
-            Map => "map",
-            Array => "array",
-            Timestamp => "timestamp",
-            Null => "null",
-        }
+    /// Returns `true` if self is more than one, but not all
+    /// [`value::Kind`]s.
+    pub fn is_some(self) -> bool {
+        !self.is_exact() && !self.is_all() && !self.is_empty()
     }
 }
+
+macro_rules! impl_kind {
+    ($(($kind:tt, $name:tt)),+ $(,)*) => {
+        impl fmt::Display for Kind {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if !self.is_some() {
+                    return f.write_str(self)
+                }
+
+                let mut kinds = vec![];
+                $(paste::paste! {
+                if self.[<contains_ $name>]() {
+                    kinds.push(Kind::$kind.as_str())
+                }
+                })+
+
+                let last = kinds.pop();
+                let mut string = kinds.join(", ");
+
+                if let Some(last) = last {
+                    if !string.is_empty() {
+                        string.push_str(" or ")
+                    }
+
+                    string.push_str(last);
+                }
+
+                f.write_str(&string)
+            }
+        }
+
+        impl Kind {
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Kind::$kind => stringify!($name)),+,
+                    _ if self.is_all() => "any",
+                    _ if self.is_empty() => "none",
+                    _ => "some",
+                }
+            }
+
+            pub fn is_exact(self) -> bool {
+                match self {
+                    $(Kind::$kind => true,)+
+                    _ => false,
+                }
+            }
+
+            $(paste::paste! {
+            pub fn [<is_ $name>](self) -> bool {
+                matches!(self, Kind::$kind)
+            }
+
+            pub fn [<contains_ $name>](self) -> bool {
+                self.contains(Kind::$kind)
+            }
+            })+
+        }
+
+
+        impl IntoIterator for Kind {
+            type Item = Self;
+            type IntoIter = std::vec::IntoIter<Self::Item>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                let mut kinds = vec![];
+                $(paste::paste! {
+                if self.[<contains_ $name>]() {
+                    kinds.push(Kind::$kind)
+                }
+                })+
+
+                kinds.into_iter()
+            }
+        }
+    };
+}
+
+impl_kind![
+    (String, string),
+    (Integer, integer),
+    (Float, float),
+    (Boolean, boolean),
+    (Map, map),
+    (Array, array),
+    (Timestamp, timestamp),
+    (Null, null),
+];
 
 impl Deref for Kind {
     type Target = str;
@@ -53,17 +123,15 @@ impl Deref for Kind {
 
 impl From<&Value> for Kind {
     fn from(value: &Value) -> Self {
-        use Kind::*;
-
         match value {
-            Value::String(_) => String,
-            Value::Integer(_) => Integer,
-            Value::Float(_) => Float,
-            Value::Boolean(_) => Boolean,
-            Value::Map(_) => Map,
-            Value::Array(_) => Array,
-            Value::Timestamp(_) => Timestamp,
-            Value::Null => Null,
+            Value::String(_) => Kind::String,
+            Value::Integer(_) => Kind::Integer,
+            Value::Float(_) => Kind::Float,
+            Value::Boolean(_) => Kind::Boolean,
+            Value::Map(_) => Kind::Map,
+            Value::Array(_) => Kind::Array,
+            Value::Timestamp(_) => Kind::Timestamp,
+            Value::Null => Kind::Null,
         }
     }
 }

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -24,7 +24,7 @@ impl ConditionConfig for RemapConfig {
         let expected_result = TypeDef {
             fallible: true,
             optional: true,
-            constraint: value::Constraint::Exact(value::Kind::Boolean),
+            kind: value::Kind::Boolean,
         };
 
         let program = Program::new(&self.source, &crate::remap::FUNCTIONS, expected_result)

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -64,23 +64,23 @@ impl Expression for CeilFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         let value_def = self
             .value
             .type_def(state)
-            .fallible_unless(vec![Integer, Float]);
+            .fallible_unless(Kind::Integer | Kind::Float);
         let precision_def = self
             .precision
             .as_ref()
-            .map(|precision| precision.type_def(state).fallible_unless(Integer));
+            .map(|precision| precision.type_def(state).fallible_unless(Kind::Integer));
 
         value_def
             .clone()
             .merge_optional(precision_def)
-            .with_constraint(match value_def.constraint {
-                v if v.is(Float) || v.is(Integer) => v,
-                _ => vec![Integer, Float].into(),
+            .with_constraint(match value_def.kind {
+                v if v.is_float() || v.is_integer() => v,
+                _ => Kind::Integer | Kind::Float,
             })
     }
 }
@@ -89,7 +89,7 @@ impl Expression for CeilFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_float {
@@ -97,7 +97,7 @@ mod tests {
                 value: Literal::from(1.0).boxed(),
                 precision: None,
             },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         value_integer {
@@ -105,7 +105,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: None,
             },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         value_float_or_integer {
@@ -113,7 +113,7 @@ mod tests {
                 value: Variable::new("foo".to_owned()).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, constraint: vec![Integer, Float].into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
         }
 
         fallible_precision {
@@ -121,7 +121,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned()).boxed()),
             },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -94,12 +94,12 @@ mod tests {
     remap::test_type_def![
         string {
             expr: |_| DowncaseFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: value::Kind::String, ..Default::default() },
         }
 
         non_string {
             expr: |_| DowncaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
         }
     ];
 }

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -111,7 +111,7 @@ impl Expression for EndsWithFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -120,7 +120,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         value_non_string {
@@ -129,7 +129,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         substring_non_string {
@@ -138,7 +138,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         case_sensitive_non_boolean {
@@ -147,7 +147,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -64,23 +64,23 @@ impl Expression for FloorFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         let value_def = self
             .value
             .type_def(state)
-            .fallible_unless(vec![Integer, Float]);
+            .fallible_unless(Kind::Integer | Kind::Float);
         let precision_def = self
             .precision
             .as_ref()
-            .map(|precision| precision.type_def(state).fallible_unless(Integer));
+            .map(|precision| precision.type_def(state).fallible_unless(Kind::Integer));
 
         value_def
             .clone()
             .merge_optional(precision_def)
-            .with_constraint(match value_def.constraint {
-                v if v.is(Float) || v.is(Integer) => v,
-                _ => vec![Integer, Float].into(),
+            .with_constraint(match value_def.kind {
+                v if v.is_float() || v.is_integer() => v,
+                _ => Kind::Integer | Kind::Float,
             })
     }
 }
@@ -89,7 +89,7 @@ impl Expression for FloorFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_float {
@@ -97,7 +97,7 @@ mod tests {
                 value: Literal::from(1.0).boxed(),
                 precision: None,
             },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         value_integer {
@@ -105,7 +105,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: None,
             },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         value_float_or_integer {
@@ -113,7 +113,7 @@ mod tests {
                 value: Variable::new("foo".to_owned()).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, constraint: vec![Integer, Float].into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
         }
 
         fallible_precision {
@@ -121,7 +121,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned()).boxed()),
             },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
     use crate::map;
     use chrono::TimeZone;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_and_format {
@@ -99,7 +99,7 @@ mod tests {
                 value: Literal::from(chrono::Utc::now()).boxed(),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         optional_value {
@@ -107,7 +107,7 @@ mod tests {
                 value: Box::new(Noop),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
         }
     ];
 

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -73,7 +73,7 @@ impl Expression for MatchFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -81,7 +81,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         value_non_string {
@@ -89,7 +89,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         value_optional {
@@ -97,7 +97,7 @@ mod tests {
                 value: Box::new(Noop),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, optional: true, constraint: Boolean.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Boolean },
         }
     ];
 

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -63,22 +63,22 @@ impl Expression for Md5Fn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
             expr: |_| Md5Fn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         value_non_string {
             expr: |_| Md5Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         value_optional {
             expr: |_| Md5Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
         }
     ];
 

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -24,7 +24,7 @@ impl Expression for NowFn {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            constraint: value::Kind::Timestamp.into(),
+            kind: value::Kind::Timestamp,
             ..Default::default()
         }
     }
@@ -37,7 +37,7 @@ mod tests {
     remap::test_type_def![static_def {
         expr: |_| NowFn,
         def: TypeDef {
-            constraint: value::Kind::Timestamp.into(),
+            kind: value::Kind::Timestamp,
             ..Default::default()
         },
     }];

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -143,7 +143,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, constraint: value::Kind::Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Float.into(), ..Default::default() },
         }
 
         optional_expression {
@@ -151,7 +151,7 @@ mod tests {
                 value: Box::new(Noop),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Float.into() },
+            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Float.into() },
         }
     ];
 

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -143,7 +143,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, kind: value::Kind::Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Float, ..Default::default() },
         }
 
         optional_expression {
@@ -151,7 +151,7 @@ mod tests {
                 value: Box::new(Noop),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Float.into() },
+            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Float },
         }
     ];
 

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -70,19 +70,27 @@ impl Expression for ParseJsonFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         let default_def = self
             .default
             .as_ref()
-            .map(|default| default.type_def(state).fallible_unless(String));
+            .map(|default| default.type_def(state).fallible_unless(Kind::String));
 
         self.value
             .type_def(state)
-            .fallible_unless(String)
+            .fallible_unless(Kind::String)
             .merge_with_default_optional(default_def)
             .into_fallible(true) // JSON parsing errors
-            .with_constraint(vec![String, Boolean, Integer, Float, Array, Map, Null])
+            .with_constraint(
+                Kind::String
+                    | Kind::Boolean
+                    | Kind::Integer
+                    | Kind::Float
+                    | Kind::Array
+                    | Kind::Map
+                    | Kind::Null,
+            )
     }
 }
 
@@ -90,7 +98,7 @@ impl Expression for ParseJsonFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -100,7 +108,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -112,7 +120,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -124,7 +132,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -137,7 +145,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: true,
-                constraint: vec![String, Boolean, Integer, Float, Array, Map, Null].into(),
+                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
             },
         }
     ];

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -129,17 +129,17 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| ParseSyslogFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: value::Kind::Map.into(), ..Default::default() },
+            def: TypeDef { kind: value::Kind::Map, ..Default::default() },
         }
 
         value_non_string {
             expr: |_| ParseSyslogFn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::Map.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
 
         value_optional {
             expr: |_| ParseSyslogFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Map.into() },
+            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map },
         }
     ];
 

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -111,9 +111,9 @@ impl Expression for ParseTimestampFn {
         //
         // The `format` type is _always_ fallible, because its string has to be
         // parsed into a valid timestamp format.
-        let format_def = if value_def.constraint.contains(&value::Kind::String.into()) {
+        let format_def = if value_def.kind.contains(value::Kind::String) {
             match &default_def {
-                Some(def) if def.constraint.contains(&value::Kind::String.into()) => {
+                Some(def) if def.kind.contains(value::Kind::String) => {
                     Some(self.format.type_def(state).into_fallible(true))
                 }
                 Some(_) => None,
@@ -145,7 +145,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }
@@ -158,7 +158,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }
@@ -170,7 +170,7 @@ mod tests {
                 default: Some(Literal::from(chrono::Utc::now()).boxed()),
             },
             def: TypeDef {
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }
@@ -182,7 +182,7 @@ mod tests {
                 default: None,
             },
             def: TypeDef {
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }
@@ -194,7 +194,7 @@ mod tests {
                 default: Some(Literal::from("<timestamp>").boxed()),
             },
             def: TypeDef {
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }
@@ -206,7 +206,7 @@ mod tests {
                 default: Some(Literal::from(chrono::Utc::now()).boxed()),
             },
             def: TypeDef {
-                constraint: value::Kind::Timestamp.into(),
+                kind: value::Kind::Timestamp,
                 ..Default::default()
             },
         }

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -101,12 +101,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| ParseUrlFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::Map.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Map.into(), ..Default::default() },
         }
 
         value_optional {
             expr: |_| ParseUrlFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, constraint: value::Kind::Map.into() },
+            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map.into() },
         }
     ];
 

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -101,12 +101,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| ParseUrlFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Map.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
 
         value_optional {
             expr: |_| ParseUrlFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map.into() },
+            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map },
         }
     ];
 

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -108,27 +108,27 @@ impl Expression for ReplaceFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
-        let with_def = self.with.type_def(state).fallible_unless(String);
+        let with_def = self.with.type_def(state).fallible_unless(Kind::String);
 
         let count_def = self
             .count
             .as_ref()
-            .map(|count| count.type_def(state).fallible_unless(Integer));
+            .map(|count| count.type_def(state).fallible_unless(Kind::Integer));
 
         let pattern_def = match &self.pattern {
-            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(String)),
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::String)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
         };
 
         self.value
             .type_def(state)
-            .fallible_unless(String)
+            .fallible_unless(Kind::String)
             .merge(with_def)
             .merge_optional(pattern_def)
             .merge_optional(count_def)
-            .with_constraint(String)
+            .with_constraint(Kind::String)
     }
 }
 
@@ -146,7 +146,7 @@ mod test {
                 count: None,
             },
             def: TypeDef {
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -160,7 +160,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -173,7 +173,7 @@ mod test {
                 count: None,
             },
             def: TypeDef {
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -187,7 +187,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -201,7 +201,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -214,7 +214,7 @@ mod test {
                 count: Some(Literal::from(10).boxed()),
             },
             def: TypeDef {
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }
@@ -228,7 +228,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::String.into(),
+                kind: value::Kind::String,
                 ..Default::default()
             },
         }

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -63,22 +63,22 @@ impl Expression for Sha1Fn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
             expr: |_| Sha1Fn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         value_non_string {
             expr: |_| Sha1Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         value_optional {
             expr: |_| Sha1Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
         }
     ];
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -94,7 +94,7 @@ fn encode<T: Digest>(value: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -102,7 +102,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 variant: None,
             },
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         value_non_string {
@@ -110,7 +110,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         value_optional {
@@ -118,7 +118,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -118,7 +118,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
         }
     ];
 

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -85,7 +85,7 @@ fn encode<T: Digest>(value: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -93,7 +93,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 variant: None,
             },
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         value_non_string {
@@ -101,7 +101,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         value_optional {
@@ -109,7 +109,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, constraint: String.into() },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
         }
     ];
 

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -82,24 +82,25 @@ impl Expression for SplitFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
-        let limit_def = self
-            .limit
-            .as_ref()
-            .map(|limit| limit.type_def(state).fallible_unless(vec![Integer, Float]));
+        let limit_def = self.limit.as_ref().map(|limit| {
+            limit
+                .type_def(state)
+                .fallible_unless(Kind::Integer | Kind::Float)
+        });
 
         let pattern_def = match &self.pattern {
-            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(String)),
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::String)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
         };
 
         self.value
             .type_def(state)
-            .fallible_unless(String)
+            .fallible_unless(Kind::String)
             .merge_optional(limit_def)
             .merge_optional(pattern_def)
-            .with_constraint(Array)
+            .with_constraint(Kind::Array)
     }
 }
 
@@ -115,7 +116,7 @@ mod test {
                 limit: None,
             },
             def: TypeDef {
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }
@@ -128,7 +129,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }
@@ -140,7 +141,7 @@ mod test {
                 limit: None,
             },
             def: TypeDef {
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }
@@ -153,7 +154,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }
@@ -165,7 +166,7 @@ mod test {
                 limit: Some(Literal::from(10).boxed()),
             },
             def: TypeDef {
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }
@@ -178,7 +179,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                constraint: value::Kind::Array.into(),
+                kind: value::Kind::Array,
                 ..Default::default()
             },
         }

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -109,7 +109,7 @@ impl Expression for StartsWithFn {
 mod tests {
     use super::*;
     use crate::map;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
@@ -118,7 +118,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         value_non_string {
@@ -127,7 +127,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         substring_non_string {
@@ -136,7 +136,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         case_sensitive_non_boolean {
@@ -145,7 +145,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -70,12 +70,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
         }
 
         fallible_expression {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -62,12 +62,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| StripWhitespaceFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: value::Kind::String, ..Default::default() },
         }
 
         fallible_expression {
             expr: |_| StripWhitespaceFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -74,17 +74,17 @@ impl Expression for ToBoolFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         self.value
             .type_def(state)
-            .fallible_unless(vec![Boolean, Integer, Float, Null])
+            .fallible_unless(Kind::Boolean | Kind::Integer | Kind::Float | Kind::Null)
             .merge_with_default_optional(self.default.as_ref().map(|default| {
                 default
                     .type_def(state)
-                    .fallible_unless(vec![Boolean, Integer, Float, Null])
+                    .fallible_unless(Kind::Boolean | Kind::Integer | Kind::Float | Kind::Null)
             }))
-            .with_constraint(Boolean)
+            .with_constraint(Kind::Boolean)
     }
 }
 
@@ -93,47 +93,47 @@ mod tests {
     use super::*;
     use crate::map;
     use std::collections::BTreeMap;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         boolean_infallible {
             expr: |_| ToBoolFn { value: Literal::from(true).boxed(), default: None },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToBoolFn { value: Literal::from(1).boxed(), default: None },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToBoolFn { value: Literal::from(1.0).boxed(), default: None },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         null_infallible {
             expr: |_| ToBoolFn { value: Literal::from(()).boxed(), default: None },
-            def: TypeDef { constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Boolean, ..Default::default() },
         }
 
         string_fallible {
             expr: |_| ToBoolFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToBoolFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         array_fallible {
             expr: |_| ToBoolFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         timestamp_fallible {
             expr: |_| ToBoolFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Boolean.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -141,7 +141,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Boolean.into(),
+                kind: Kind::Boolean,
             },
         }
 
@@ -153,7 +153,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Boolean.into(),
+                kind: Kind::Boolean,
             },
         }
 
@@ -165,7 +165,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Boolean.into(),
+                kind: Kind::Boolean,
             },
         }
 
@@ -177,7 +177,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Boolean.into(),
+                kind: Kind::Boolean,
             },
         }
 
@@ -189,7 +189,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Boolean.into(),
+                kind: Kind::Boolean,
             },
         }
     ];

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -74,17 +74,17 @@ impl Expression for ToFloatFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         self.value
             .type_def(state)
-            .fallible_unless(vec![Float, Integer, Boolean, Null])
+            .fallible_unless(Kind::Float | Kind::Integer | Kind::Boolean | Kind::Null)
             .merge_with_default_optional(self.default.as_ref().map(|default| {
                 default
                     .type_def(state)
-                    .fallible_unless(vec![Float, Integer, Boolean, Null])
+                    .fallible_unless(Kind::Float | Kind::Integer | Kind::Boolean | Kind::Null)
             }))
-            .with_constraint(Float)
+            .with_constraint(Kind::Float)
     }
 }
 
@@ -93,47 +93,47 @@ mod tests {
     use super::*;
     use crate::map;
     use std::collections::BTreeMap;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         boolean_infallible {
             expr: |_| ToFloatFn { value: Literal::from(true).boxed(), default: None },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToFloatFn { value: Literal::from(1).boxed(), default: None },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToFloatFn { value: Literal::from(1.0).boxed(), default: None },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         null_infallible {
             expr: |_| ToFloatFn { value: Literal::from(()).boxed(), default: None },
-            def: TypeDef { constraint: Float.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Float, ..Default::default() },
         }
 
         string_fallible {
             expr: |_| ToFloatFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToFloatFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         array_fallible {
             expr: |_| ToFloatFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToFloatFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Float.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -141,7 +141,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Float.into(),
+                kind: Kind::Float,
             },
         }
 
@@ -153,7 +153,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Float.into(),
+                kind: Kind::Float,
             },
         }
 
@@ -165,7 +165,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Float.into(),
+                kind: Kind::Float,
             },
         }
 
@@ -177,7 +177,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Float.into(),
+                kind: Kind::Float,
             },
         }
 
@@ -189,7 +189,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Float.into(),
+                kind: Kind::Float,
             },
         }
     ];

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -74,17 +74,17 @@ impl Expression for ToIntFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         self.value
             .type_def(state)
-            .fallible_unless(vec![Integer, Float, Boolean, Null])
+            .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Null)
             .merge_with_default_optional(self.default.as_ref().map(|default| {
                 default
                     .type_def(state)
-                    .fallible_unless(vec![Integer, Float, Boolean, Null])
+                    .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Null)
             }))
-            .with_constraint(Integer)
+            .with_constraint(Kind::Integer)
     }
 }
 
@@ -93,47 +93,47 @@ mod tests {
     use super::*;
     use crate::map;
     use std::collections::BTreeMap;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         boolean_infallible {
             expr: |_| ToIntFn { value: Literal::from(true).boxed(), default: None },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToIntFn { value: Literal::from(1).boxed(), default: None },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToIntFn { value: Literal::from(1.0).boxed(), default: None },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         null_infallible {
             expr: |_| ToIntFn { value: Literal::from(()).boxed(), default: None },
-            def: TypeDef { constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         string_fallible {
             expr: |_| ToIntFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToIntFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         array_fallible {
             expr: |_| ToIntFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, constraint: Integer.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -141,7 +141,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Integer.into(),
+                kind: Kind::Integer,
             },
         }
 
@@ -153,7 +153,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Integer.into(),
+                kind: Kind::Integer,
             },
         }
 
@@ -165,7 +165,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Integer.into(),
+                kind: Kind::Integer,
             },
         }
 
@@ -177,7 +177,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Integer.into(),
+                kind: Kind::Integer,
             },
         }
 
@@ -189,7 +189,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Integer.into(),
+                kind: Kind::Integer,
             },
         }
     ];

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -78,47 +78,47 @@ mod tests {
     use super::*;
     use crate::map;
     use std::collections::BTreeMap;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         boolean_infallible {
             expr: |_| ToStringFn { value: Literal::from(true).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToStringFn { value: Literal::from(1).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToStringFn { value: Literal::from(1.0).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         null_infallible {
             expr: |_| ToStringFn { value: Literal::from(()).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         string_infallible {
             expr: |_| ToStringFn { value: Literal::from("foo").boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         map_infallible {
             expr: |_| ToStringFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         array_infallible {
             expr: |_| ToStringFn { value: Literal::from(vec![0]).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToStringFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None},
-            def: TypeDef { constraint: String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -126,7 +126,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: String.into(),
+                kind: Kind::String,
             },
         }
 
@@ -138,7 +138,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: String.into(),
+                kind: Kind::String,
             },
         }
 
@@ -150,7 +150,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: String.into(),
+                kind: Kind::String,
             },
         }
 
@@ -162,7 +162,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: String.into(),
+                kind: Kind::String,
             },
         }
 
@@ -174,7 +174,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: String.into(),
+                kind: Kind::String,
             },
         }
     ];

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -92,17 +92,17 @@ impl Expression for ToTimestampFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         self.value
             .type_def(state)
-            .fallible_unless(vec![Timestamp, Integer, Float])
+            .fallible_unless(Kind::Timestamp | Kind::Integer | Kind::Float)
             .merge_with_default_optional(self.default.as_ref().map(|default| {
                 default
                     .type_def(state)
-                    .fallible_unless(vec![Timestamp, Integer, Float])
+                    .fallible_unless(Kind::Timestamp | Kind::Integer | Kind::Float)
             }))
-            .with_constraint(Timestamp)
+            .with_constraint(Kind::Timestamp)
     }
 }
 
@@ -111,47 +111,47 @@ mod tests {
     use super::*;
     use crate::map;
     use std::collections::BTreeMap;
-    use value::Kind::*;
+    use value::Kind;
 
     remap::test_type_def![
         timestamp_infallible {
             expr: |_| ToTimestampFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None},
-            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Timestamp, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToTimestampFn { value: Literal::from(1).boxed(), default: None},
-            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Timestamp, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToTimestampFn { value: Literal::from(1.0).boxed(), default: None},
-            def: TypeDef { constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Timestamp, ..Default::default() },
         }
 
         null_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(()).boxed(), default: None},
-            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
         }
 
         string_fallible {
             expr: |_| ToTimestampFn { value: Literal::from("foo").boxed(), default: None},
-            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
-            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
         }
 
         array_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(vec![0]).boxed(), default: None},
-            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
         }
 
         boolean_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(true).boxed(), default: None},
-            def: TypeDef { fallible: true, constraint: Timestamp.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -159,7 +159,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Timestamp.into(),
+                kind: Kind::Timestamp,
             },
         }
 
@@ -171,7 +171,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                constraint: Timestamp.into(),
+                kind: Kind::Timestamp,
             },
         }
 
@@ -183,7 +183,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Timestamp.into(),
+                kind: Kind::Timestamp,
             },
         }
 
@@ -195,7 +195,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Timestamp.into(),
+                kind: Kind::Timestamp,
             },
         }
 
@@ -207,7 +207,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                constraint: Timestamp.into(),
+                kind: Kind::Timestamp,
             },
         }
     ];

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -71,16 +71,17 @@ impl Expression for TokenizeFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind;
 
     remap::test_type_def![
         value_string {
             expr: |_| TokenizeFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: value::Kind::Array.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::Array, ..Default::default() },
         }
 
         value_non_string {
             expr: |_| TokenizeFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::Array.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Array, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -108,22 +108,22 @@ impl Expression for TruncateFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        use value::Kind::*;
+        use value::Kind;
 
         self.value
             .type_def(state)
-            .fallible_unless(String)
+            .fallible_unless(Kind::String)
             .merge(
                 self.limit
                     .type_def(state)
-                    .fallible_unless(vec![Integer, Float]),
+                    .fallible_unless(Kind::Integer | Kind::Float),
             )
             .merge_optional(
                 self.ellipsis
                     .as_ref()
-                    .map(|ellipsis| ellipsis.type_def(state).fallible_unless(Boolean)),
+                    .map(|ellipsis| ellipsis.type_def(state).fallible_unless(Kind::Boolean)),
             )
-            .with_constraint(String)
+            .with_constraint(Kind::String)
     }
 }
 
@@ -131,6 +131,7 @@ impl Expression for TruncateFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind;
 
     remap::test_type_def![
         infallible {
@@ -139,7 +140,7 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         value_non_string {
@@ -148,7 +149,7 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         limit_float {
@@ -157,7 +158,7 @@ mod tests {
                 limit: Literal::from(1.0).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         limit_non_number {
@@ -166,7 +167,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
 
         ellipsis_boolean {
@@ -175,7 +176,7 @@ mod tests {
                 limit: Literal::from(10).boxed(),
                 ellipsis: Some(Literal::from(true).boxed()),
             },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         ellipsis_non_boolean {
@@ -184,7 +185,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: Some(Literal::from("baz").boxed()),
             },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -64,16 +64,17 @@ impl Expression for UpcaseFn {
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind;
 
     remap::test_type_def![
         string {
             expr: |_| UpcaseFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { kind: Kind::String, ..Default::default() },
         }
 
         non_string {
             expr: |_| UpcaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, constraint: value::Kind::String.into(), ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -27,7 +27,7 @@ impl Expression for UuidV4Fn {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            constraint: value::Kind::String.into(),
+            kind: value::Kind::String,
             ..Default::default()
         }
     }
@@ -42,7 +42,7 @@ mod tests {
     remap::test_type_def![static_def {
         expr: |_| UuidV4Fn,
         def: TypeDef {
-            constraint: value::Kind::String.into(),
+            kind: value::Kind::String,
             ..Default::default()
         },
     }];

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -53,7 +53,7 @@ impl Remap {
         let accepts = TypeDef {
             fallible: true,
             optional: true,
-            constraint: value::Constraint::Any,
+            kind: value::Kind::all(),
         };
 
         let program = Program::new(&config.source, &crate::remap::FUNCTIONS_MUT, accepts)?;

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -104,8 +104,8 @@
   inputs = []
   type = "remap"
   source = """
-    only_fields(".foo", ".bar", ".buz.second")
-    del(".foo.second")
+    only_fields(.foo, .bar, .buz.second)
+    del(.foo.second)
   """
 [[tests]]
   name = "remap_delete_only_fields"


### PR DESCRIPTION
This PR is an enhancement to #4902.

It changes `value::Kind` to support bitwise operations. This in turn simplifies the logic around value constraints and allows us to remove the `value::Constraint` type entirely. It also means `Kind` and `TypeDef` are now `Copy`.