### PR TITLE
chore(remap): remove required! and optional! macros

### DIFF
--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -1,4 +1,3 @@
-use super::Error as E;
 use crate::{state, value, Expr, Expression, Object, Result, TypeDef, Value};
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -30,14 +29,11 @@ impl IfStatement {
 
 impl Expression for IfStatement {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        match self.conditional.execute(state, object)? {
-            Value::Boolean(true) => self.true_expression.execute(state, object),
-            Value::Boolean(false) => self.false_expression.execute(state, object),
-            v => Err(E::from(Error::from(value::Error::Expected(
-                value::Kind::Boolean,
-                v.kind(),
-            )))
-            .into()),
+        let condition = self.conditional.execute(state, object)?.try_boolean()?;
+
+        match condition {
+            true => self.true_expression.execute(state, object),
+            false => self.false_expression.execute(state, object),
         }
     }
 

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -1,4 +1,3 @@
-use super::Error as E;
 use crate::{state, value, Expr, Expression, Object, Result, TypeDef, Value};
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -20,16 +19,9 @@ impl Not {
 
 impl Expression for Not {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        self.expression
-            .execute(state, object)
-            .and_then(|v| match v {
-                Value::Boolean(b) => Ok(Value::Boolean(!b)),
-                _ => Err(E::from(Error::from(value::Error::Expected(
-                    value::Kind::Boolean,
-                    v.kind(),
-                )))
-                .into()),
-            })
+        let boolean = self.expression.execute(state, object)?.try_boolean()?;
+
+        Ok((!boolean).into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -62,7 +54,7 @@ mod tests {
                 Not::new(Box::new(Literal::from(false).into())),
             ),
             (
-                Err("not operation error".to_string()),
+                Err("value error".to_string()),
                 Not::new(Box::new(Literal::from("not a bool").into())),
             ),
         ];

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -2,6 +2,7 @@ mod kind;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::string::String as StdString;
@@ -86,6 +87,12 @@ impl From<Bytes> for Value {
     }
 }
 
+impl From<Cow<'_, str>> for Value {
+    fn from(v: Cow<'_, str>) -> Self {
+        v.as_ref().into()
+    }
+}
+
 impl From<Vec<u8>> for Value {
     fn from(v: Vec<u8>) -> Self {
         v.as_slice().into()
@@ -118,7 +125,7 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
 
 impl From<&str> for Value {
     fn from(v: &str) -> Self {
-        Value::String(Vec::from(v.as_bytes()).into())
+        Value::String(Bytes::copy_from_slice(v.as_bytes()))
     }
 }
 

--- a/src/remap/function.rs
+++ b/src/remap/function.rs
@@ -1,26 +1,5 @@
 #![macro_use]
 
-macro_rules! required {
-    ($state:expr, $object:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
-        match $fn.execute($state, $object)? {
-            $($pattern $(if $if)? => $then,)+
-            v => panic!(v),
-        }
-    }
-}
-
-macro_rules! optional {
-    ($state:expr, $object:expr, $fn:expr, $($pattern:pat $(if $if:expr)? => $then:expr),+ $(,)?) => {
-        $fn.as_ref()
-            .map(|v| v.execute($state, $object))
-            .transpose()?
-            .map(|value| match value {
-                $($pattern $(if $if)? => $then,)+
-                v => panic!(v),
-            })
-    }
-}
-
 mod ceil;
 mod contains;
 mod del;

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -47,16 +47,16 @@ impl CeilFn {
 
 impl Expression for CeilFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let precision =
-            optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
-        let res = required!(state, object, self.value,
-                            Value::Float(f) => {
-                                Value::Float(round_to_precision(f, precision, f64::ceil))
-                            },
-                            v@Value::Integer(_) => v
-        );
+        let precision = match &self.precision {
+            Some(expr) => expr.execute(state, object)?.try_integer()?,
+            None => 0,
+        };
 
-        Ok(res)
+        match self.value.execute(state, object)? {
+            Value::Float(f) => Ok(round_to_precision(f, precision, f64::ceil).into()),
+            v @ Value::Integer(_) => Ok(v),
+            _ => unreachable!(),
+        }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -64,23 +64,32 @@ impl EndsWithFn {
 
 impl Expression for EndsWithFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let case_sensitive = match &self.case_sensitive {
+            Some(expr) => expr.execute(state, object)?.try_boolean()?,
+            None => false,
+        };
+
         let substring = {
-            let bytes = required!(state, object, self.substring, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
+            let bytes = self.substring.execute(state, object)?.try_string()?;
+            let string = String::from_utf8_lossy(&bytes);
+
+            match case_sensitive {
+                true => string.into_owned(),
+                false => string.to_lowercase(),
+            }
         };
 
         let value = {
-            let bytes = required!(state, object, self.value, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
+            let bytes = self.value.execute(state, object)?.try_string()?;
+            let string = String::from_utf8_lossy(&bytes);
+
+            match case_sensitive {
+                true => string.into_owned(),
+                false => string.to_lowercase(),
+            }
         };
 
-        let ends_with = value.ends_with(&substring)
-            || optional!(state, object, self.case_sensitive, Value::Boolean(b) => b)
-                .iter()
-                .filter(|&case_sensitive| !case_sensitive)
-                .any(|_| value.to_lowercase().ends_with(&substring.to_lowercase()));
-
-        Ok(ends_with.into())
+        Ok(value.ends_with(&substring).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -47,16 +47,16 @@ impl FloorFn {
 
 impl Expression for FloorFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let precision =
-            optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
-        let res = required!(state, object, self.value,
-                            Value::Float(f) => {
-                                Value::Float(round_to_precision(f, precision, f64::floor))
-                            },
-                            v@Value::Integer(_) => v
-        );
+        let precision = match &self.precision {
+            Some(expr) => expr.execute(state, object)?.try_integer()?,
+            None => 0,
+        };
 
-        Ok(res)
+        match self.value.execute(state, object)? {
+            Value::Float(f) => Ok(round_to_precision(f, precision, f64::floor).into()),
+            v @ Value::Integer(_) => Ok(v),
+            _ => unreachable!(),
+        }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -50,8 +50,9 @@ impl FormatTimestampFn {
 
 impl Expression for FormatTimestampFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let format = required!(state, object, self.format, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
-        let ts = required!(state, object, self.value, Value::Timestamp(ts) => ts);
+        let bytes = self.format.execute(state, object)?.try_string()?;
+        let format = String::from_utf8_lossy(&bytes);
+        let ts = self.value.execute(state, object)?.try_timestamp()?;
 
         try_format(&ts, &format).map(Into::into)
     }

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -47,14 +47,10 @@ impl MatchFn {
 
 impl Expression for MatchFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        required!(
-            state, object, self.value,
+        let bytes = self.value.execute(state, object)?.try_string()?;
+        let value = String::from_utf8_lossy(&bytes);
 
-            Value::String(b) => {
-                let value = String::from_utf8_lossy(&b);
-                Ok(self.pattern.is_match(&value).into())
-            }
-        )
+        Ok(self.pattern.is_match(&value).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -1,3 +1,4 @@
+use md5::Digest;
 use remap::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
@@ -37,14 +38,9 @@ impl Md5Fn {
 
 impl Expression for Md5Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        use md5::{Digest, Md5};
+        let value = self.value.execute(state, object)?.try_string()?;
 
-        self.value
-            .execute(state, object)
-            .map(|v| match v.as_string_lossy() {
-                Value::String(b) => Value::String(hex::encode(Md5::digest(&b)).into()),
-                _ => unreachable!(),
-            })
+        Ok(hex::encode(md5::Md5::digest(&value)).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -80,18 +80,16 @@ impl ParseDurationFn {
 
 impl Expression for ParseDurationFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = {
-            let bytes = required!(state, object, self.value, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
-        };
+        let bytes = self.value.execute(state, object)?.try_string()?;
+        let value = String::from_utf8_lossy(&bytes);
 
         let conversion_factor = {
-            let bytes = required!(state, object, self.output, Value::String(v) => v);
-            let output = String::from_utf8_lossy(&bytes).into_owned();
+            let bytes = self.output.execute(state, object)?.try_string()?;
+            let string = String::from_utf8_lossy(&bytes);
 
             UNITS
-                .get(&output)
-                .ok_or(format!("unknown output format: '{}'", output))?
+                .get(string.as_ref())
+                .ok_or(format!("unknown output format: '{}'", string))?
         };
 
         let captures = RE

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -101,7 +101,8 @@ fn message_to_value(message: Message<&str>) -> Value {
 
 impl Expression for ParseSyslogFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let message = required!(state, object, self.value, Value::String(v) => String::from_utf8_lossy(&v).into_owned());
+        let bytes = self.value.execute(state, object)?.try_string()?;
+        let message = String::from_utf8_lossy(&bytes);
 
         let parsed = syslog_loose::parse_message_with_year(&message, resolve_year);
 

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -41,7 +41,7 @@ impl ParseUrlFn {
 
 impl Expression for ParseUrlFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = required!(state, object, self.value, Value::String(v) => v);
+        let bytes = self.value.execute(state, object)?.try_string()?;
 
         Url::parse(&String::from_utf8_lossy(&bytes))
             .map_err(|e| format!("unable to parse url: {}", e).into())

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -1,3 +1,4 @@
+use ::sha1::Digest;
 use remap::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
@@ -37,14 +38,9 @@ impl Sha1Fn {
 
 impl Expression for Sha1Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        use ::sha1::{Digest, Sha1};
+        let value = self.value.execute(state, object)?.try_string()?;
 
-        self.value
-            .execute(state, object)
-            .map(|v| match v.as_string_lossy() {
-                Value::String(b) => Value::String(hex::encode(Sha1::digest(&b)).into()),
-                _ => unreachable!(),
-            })
+        Ok(hex::encode(sha1::Sha1::digest(&value)).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -58,7 +58,7 @@ impl Sha2Fn {
 
 impl Expression for Sha2Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = required!(state, object, self.value, Value::String(v) => v);
+        let value = self.value.execute(state, object)?.try_string()?;
 
         let hash = match self.variant.as_deref() {
             Some("SHA-224") => encode::<Sha224>(&value),

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -51,7 +51,7 @@ impl Sha3Fn {
 
 impl Expression for Sha3Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = required!(state, object, self.value, Value::String(v) => v);
+        let value = self.value.execute(state, object)?.try_string()?;
 
         let hash = match self.variant.as_deref() {
             Some("SHA3-224") => encode::<Sha3_224>(&value),

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -64,23 +64,32 @@ impl StartsWithFn {
 
 impl Expression for StartsWithFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let case_sensitive = match &self.case_sensitive {
+            Some(expr) => expr.execute(state, object)?.try_boolean()?,
+            None => false,
+        };
+
         let substring = {
-            let bytes = required!(state, object, self.substring, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
+            let bytes = self.substring.execute(state, object)?.try_string()?;
+            let string = String::from_utf8_lossy(&bytes);
+
+            match case_sensitive {
+                true => string.into_owned(),
+                false => string.to_lowercase(),
+            }
         };
 
         let value = {
-            let bytes = required!(state, object, self.value, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
+            let bytes = self.value.execute(state, object)?.try_string()?;
+            let string = String::from_utf8_lossy(&bytes);
+
+            match case_sensitive {
+                true => string.into_owned(),
+                false => string.to_lowercase(),
+            }
         };
 
-        let starts_with = value.starts_with(&substring)
-            || optional!(state, object, self.case_sensitive, Value::Boolean(b) => b)
-                .iter()
-                .filter(|&case_sensitive| !case_sensitive)
-                .any(|_| value.to_lowercase().starts_with(&substring.to_lowercase()));
-
-        Ok(starts_with.into())
+        Ok(value.starts_with(&substring).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -38,7 +38,7 @@ impl StripAnsiEscapeCodesFn {
 
 impl Expression for StripAnsiEscapeCodesFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = required!(state, object, self.value, Value::String(v) => v);
+        let bytes = self.value.execute(state, object)?.try_string()?;
 
         strip_ansi_escapes::strip(&bytes)
             .map(Bytes::from)

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -37,7 +37,8 @@ impl StripWhitespaceFn {
 
 impl Expression for StripWhitespaceFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
+        let bytes = self.value.execute(state, object)?.try_string()?;
+        let value = String::from_utf8_lossy(&bytes);
 
         Ok(value.trim().into())
     }

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -38,10 +38,8 @@ impl TokenizeFn {
 
 impl Expression for TokenizeFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = {
-            let bytes = required!(state, object, self.value, Value::String(v) => v);
-            String::from_utf8_lossy(&bytes).into_owned()
-        };
+        let bytes = self.value.execute(state, object)?.try_string()?;
+        let value = String::from_utf8_lossy(&bytes);
 
         let tokens: Value = tokenize::parse(&value)
             .into_iter()


### PR DESCRIPTION
With the Expression trait updated to remove `None` results in #5053, the usage of the `required!` and `optional!` macro's made functions more difficult to parse as a reader than not using them.

They hid so little implementation detail, and code within them wasn't being formatted by rustfmt, which made me decide to remove them entirely.

I think this improves readability of expressions, at the cost of sometimes one or two more lines of code within the expressions themselves.

Additionally, a few PRs back, helper functions were added to the `Value` type, which makes it easier to get a specific value kind through `{as,as_mut,try,unwrap}_{string,integer,...}`, that the resulting code is often easier to write and understand than with the macros.

Another added benefit is that we were kind of fast-and-loose with resolving `Cow<str>` to an owned string, as it made using the macros easier (due to lifetime issues). Without the macros, I felt more pushed toward only cloning the string if needed, which removed extra allocations in quite a few function implementations.

_note that in a few places I use `let bytes = ...try_string()?;`, which is obviously awkward. @FungusHumungus has requested this on multiple occasions, so in a follow-up PR I'll be renaming `Value::String` to `Value::Bytes`._

