### PR TITLE
chore(remap): rename Value::String to Value::Bytes

### DIFF
--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -149,15 +149,15 @@ mod tests {
     fn test_contains() {
         let cases = vec![
             (true, Kind::all(), Kind::all()),
-            (true, Kind::all(), Kind::String),
+            (true, Kind::all(), Kind::Bytes),
             (true, Kind::all(), Kind::Integer),
             (true, Kind::all(), Kind::Float | Kind::Boolean),
             (true, Kind::all(), Kind::Map),
-            (true, Kind::String, Kind::String),
-            (true, Kind::String, Kind::String),
-            (false, Kind::String, Kind::Array),
-            (false, Kind::String, Kind::Integer),
-            (false, Kind::String, Kind::Integer | Kind::Float),
+            (true, Kind::Bytes, Kind::Bytes),
+            (true, Kind::Bytes, Kind::Bytes),
+            (false, Kind::Bytes, Kind::Array),
+            (false, Kind::Bytes, Kind::Integer),
+            (false, Kind::Bytes, Kind::Integer | Kind::Float),
         ];
 
         for (expect, this, other) in cases {
@@ -169,12 +169,12 @@ mod tests {
     fn test_merge() {
         let cases = vec![
             (Kind::all(), Kind::all(), Kind::all()),
-            (Kind::all(), Kind::Integer | Kind::String, Kind::all()),
+            (Kind::all(), Kind::Integer | Kind::Bytes, Kind::all()),
             (Kind::Integer | Kind::Float, Kind::Integer, Kind::Float),
             (Kind::Integer, Kind::Integer, Kind::Integer),
             (
-                Kind::String | Kind::Integer | Kind::Float | Kind::Boolean,
-                Kind::Integer | Kind::String,
+                Kind::Bytes | Kind::Integer | Kind::Float | Kind::Boolean,
+                Kind::Integer | Kind::Bytes,
                 Kind::Float | Kind::Boolean,
             ),
         ];

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -48,7 +48,7 @@ impl Expression for Arithmetic {
 
         let kind = match self.op {
             Or => self.lhs.type_def(state).kind | self.rhs.type_def(state).kind,
-            Multiply | Add => Kind::String | Kind::Integer | Kind::Float,
+            Multiply | Add => Kind::Bytes | Kind::Integer | Kind::Float,
             Remainder | Subtract | Divide => Kind::Integer | Kind::Float,
             And | Equal | NotEqual | Greater | GreaterOrEqual | Less | LessOrEqual => Kind::Boolean,
         };
@@ -80,7 +80,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String | Kind::Boolean,
+                kind: Kind::Bytes | Kind::Boolean,
             },
         }
 
@@ -106,7 +106,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String | Kind::Integer | Kind::Float,
+                kind: Kind::Bytes | Kind::Integer | Kind::Float,
             },
         }
 
@@ -119,7 +119,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String | Kind::Integer | Kind::Float,
+                kind: Kind::Bytes | Kind::Integer | Kind::Float,
             },
         }
 

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -98,7 +98,7 @@ mod tests {
                 Assignment::new(target, value, state)
             },
             def: TypeDef {
-                kind: Kind::String,
+                kind: Kind::Bytes,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -83,7 +83,7 @@ mod tests {
             ]),
             def: TypeDef {
                 fallible: true,
-                kind: Kind::String | Kind::Integer | Kind::Float,
+                kind: Kind::Bytes | Kind::Integer | Kind::Float,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -46,7 +46,7 @@ mod tests {
 
         string {
             expr: |_| Literal::from("foo"),
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         integer {

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -88,7 +88,7 @@ mod tests {
                 state.path_query_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
                     optional: false,
-                    kind: Kind::String
+                    kind: Kind::Bytes
                 });
 
                 Path::from("foo")
@@ -96,7 +96,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -66,7 +66,7 @@ mod tests {
                 state.variable_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
                     optional: false,
-                    kind: Kind::String
+                    kind: Kind::Bytes
                 });
 
                 Variable::new("foo".to_owned())
@@ -74,7 +74,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -116,7 +116,7 @@ impl ArgumentList {
         let variant = expression::Literal::try_from(argument.into_expr())?
             .as_value()
             .clone()
-            .try_string()
+            .try_bytes()
             .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())?;
 
         if variants.contains(&variant.as_str()) {

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -155,7 +155,7 @@ mod tests {
                 TypeDef {
                     fallible: false,
                     optional: false,
-                    kind: Kind::String,
+                    kind: Kind::Bytes,
                 },
                 Err("expected to resolve to string value, but instead resolves to an error, or any value".to_owned()),
             ),
@@ -165,7 +165,7 @@ mod tests {
                 TypeDef {
                     fallible: false,
                     optional: false,
-                    kind: Kind::String | Kind::Float,
+                    kind: Kind::Bytes | Kind::Float,
                 },
                 Err("expected to resolve to string or float values, but instead resolves to an error, or integer or boolean values".to_owned()),
             ),

--- a/lib/remap-lang/src/value/kind.rs
+++ b/lib/remap-lang/src/value/kind.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 bitflags::bitflags! {
     pub struct Kind: u16 {
-        const String = 1 << 1;
+        const Bytes = 1 << 1;
         const Integer = 1 << 2;
         const Float = 1 << 3;
         const Boolean = 1 << 4;
@@ -57,7 +57,9 @@ macro_rules! impl_kind {
 
         impl Kind {
             pub fn as_str(self) -> &'static str {
+                #[allow(unreachable_patterns)]
                 match self {
+                    Kind::Bytes => "string", // special-cased
                     $(Kind::$kind => stringify!($name)),+,
                     _ if self.is_all() => "any",
                     _ if self.is_empty() => "none",
@@ -103,7 +105,7 @@ macro_rules! impl_kind {
 }
 
 impl_kind![
-    (String, string),
+    (Bytes, bytes),
     (Integer, integer),
     (Float, float),
     (Boolean, boolean),
@@ -124,7 +126,7 @@ impl Deref for Kind {
 impl From<&Value> for Kind {
     fn from(value: &Value) -> Self {
         match value {
-            Value::String(_) => Kind::String,
+            Value::Bytes(_) => Kind::Bytes,
             Value::Integer(_) => Kind::Integer,
             Value::Float(_) => Kind::Float,
             Value::Boolean(_) => Kind::Boolean,

--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -207,7 +207,7 @@ impl From<remap::Value> for Value {
         use remap::Value::*;
 
         match v {
-            String(v) => Value::Bytes(v),
+            Bytes(v) => Value::Bytes(v),
             Integer(v) => Value::Integer(v),
             Float(v) => Value::Float(v),
             Boolean(v) => Value::Boolean(v),
@@ -224,7 +224,7 @@ impl From<Value> for remap::Value {
         use remap::Value::*;
 
         match v {
-            Value::Bytes(v) => String(v),
+            Value::Bytes(v) => Bytes(v),
             Value::Integer(v) => Integer(v),
             Value::Float(v) => Float(v),
             Value::Boolean(v) => Boolean(v),

--- a/src/remap/function.rs
+++ b/src/remap/function.rs
@@ -90,7 +90,7 @@ fn is_scalar_value(value: &Value) -> bool {
     use Value::*;
 
     match value {
-        Integer(_) | Float(_) | String(_) | Boolean(_) | Null => true,
+        Integer(_) | Float(_) | Bytes(_) | Boolean(_) | Null => true,
         Timestamp(_) | Map(_) | Array(_) => false,
     }
 }

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -12,12 +12,12 @@ impl Function for Contains {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "substring",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -70,7 +70,7 @@ impl Expression for ContainsFn {
         };
 
         let substring = {
-            let bytes = self.substring.execute(state, object)?.try_string()?;
+            let bytes = self.substring.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -80,7 +80,7 @@ impl Expression for ContainsFn {
         };
 
         let value = {
-            let bytes = self.value.execute(state, object)?.try_string()?;
+            let bytes = self.value.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -95,11 +95,11 @@ impl Expression for ContainsFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .merge(
                 self.substring
                     .type_def(state)
-                    .fallible_unless(value::Kind::String),
+                    .fallible_unless(value::Kind::Bytes),
             )
             .merge_optional(self.case_sensitive.as_ref().map(|case_sensitive| {
                 case_sensitive

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -12,7 +12,7 @@ impl Function for Downcase {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -48,8 +48,8 @@ impl Expression for DowncaseFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -87,12 +87,12 @@ mod tests {
     remap::test_type_def![
         string {
             expr: |_| DowncaseFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { kind: value::Kind::String, ..Default::default() },
+            def: TypeDef { kind: value::Kind::Bytes, ..Default::default() },
         }
 
         non_string {
             expr: |_| DowncaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
     ];
 }

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -12,12 +12,12 @@ impl Function for EndsWith {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "substring",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -70,7 +70,7 @@ impl Expression for EndsWithFn {
         };
 
         let substring = {
-            let bytes = self.substring.execute(state, object)?.try_string()?;
+            let bytes = self.substring.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -80,7 +80,7 @@ impl Expression for EndsWithFn {
         };
 
         let value = {
-            let bytes = self.value.execute(state, object)?.try_string()?;
+            let bytes = self.value.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -96,7 +96,7 @@ impl Expression for EndsWithFn {
         let substring_def = self
             .substring
             .type_def(state)
-            .fallible_unless(value::Kind::String);
+            .fallible_unless(value::Kind::Bytes);
 
         let case_sensitive_def = self
             .case_sensitive
@@ -105,7 +105,7 @@ impl Expression for EndsWithFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .merge(substring_def)
             .merge_optional(case_sensitive_def)
             .with_constraint(value::Kind::Boolean)

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -23,12 +23,12 @@ impl Function for FormatNumber {
             },
             Parameter {
                 keyword: "decimal_separator",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: false,
             },
             Parameter {
                 keyword: "grouping_separator",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: false,
             },
         ]
@@ -92,12 +92,12 @@ impl Expression for FormatNumberFn {
         };
 
         let grouping_separator = match &self.grouping_separator {
-            Some(expr) => Some(expr.execute(state, object)?.try_string()?),
+            Some(expr) => Some(expr.execute(state, object)?.try_bytes()?),
             None => None,
         };
 
         let decimal_separator = match &self.decimal_separator {
-            Some(expr) => expr.execute(state, object)?.try_string()?,
+            Some(expr) => expr.execute(state, object)?.try_bytes()?,
             None => ".".into(),
         };
 
@@ -166,13 +166,13 @@ impl Expression for FormatNumberFn {
         let decimal_separator_def = self.decimal_separator.as_ref().map(|decimal_separator| {
             decimal_separator
                 .type_def(state)
-                .fallible_unless(Kind::String)
+                .fallible_unless(Kind::Bytes)
         });
 
         let grouping_separator_def = self.grouping_separator.as_ref().map(|grouping_separator| {
             grouping_separator
                 .type_def(state)
-                .fallible_unless(Kind::String)
+                .fallible_unless(Kind::Bytes)
         });
 
         self.value
@@ -182,7 +182,7 @@ impl Expression for FormatNumberFn {
             .merge_optional(decimal_separator_def)
             .merge_optional(grouping_separator_def)
             .into_fallible(true) // `Decimal::from` can theoretically fail.
-            .with_constraint(Kind::String)
+            .with_constraint(Kind::Bytes)
     }
 }
 
@@ -200,7 +200,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_float {
@@ -210,7 +210,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         // TODO(jean): we should update the function to ignore `None` values,
@@ -222,7 +222,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -19,7 +19,7 @@ impl Function for FormatTimestamp {
             },
             Parameter {
                 keyword: "format",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
         ]
@@ -50,7 +50,7 @@ impl FormatTimestampFn {
 
 impl Expression for FormatTimestampFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.format.execute(state, object)?.try_string()?;
+        let bytes = self.format.execute(state, object)?.try_bytes()?;
         let format = String::from_utf8_lossy(&bytes);
         let ts = self.value.execute(state, object)?.try_timestamp()?;
 
@@ -61,14 +61,14 @@ impl Expression for FormatTimestampFn {
         let format_def = self
             .format
             .type_def(state)
-            .fallible_unless(value::Kind::String);
+            .fallible_unless(value::Kind::Bytes);
 
         self.value
             .type_def(state)
             .fallible_unless(value::Kind::Timestamp)
             .merge(format_def)
             .into_fallible(true) // due to `try_format`
-            .with_constraint(value::Kind::String)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -96,7 +96,7 @@ mod tests {
                 value: Literal::from(chrono::Utc::now()).boxed(),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         optional_value {
@@ -104,7 +104,7 @@ mod tests {
                 value: Box::new(Noop),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -13,7 +13,7 @@ impl Function for Match {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -47,7 +47,7 @@ impl MatchFn {
 
 impl Expression for MatchFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         Ok(self.pattern.is_match(&value).into())
@@ -56,7 +56,7 @@ impl Expression for MatchFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .with_constraint(value::Kind::Boolean)
     }
 }

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -12,7 +12,7 @@ impl Function for Md5 {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -38,7 +38,7 @@ impl Md5Fn {
 
 impl Expression for Md5Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = self.value.execute(state, object)?.try_string()?;
+        let value = self.value.execute(state, object)?.try_bytes()?;
 
         Ok(hex::encode(md5::Md5::digest(&value)).into())
     }
@@ -46,8 +46,8 @@ impl Expression for Md5Fn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -60,17 +60,17 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| Md5Fn { value: Literal::from("foo").boxed() },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         value_non_string {
             expr: |_| Md5Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
             expr: |_| Md5Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -44,12 +44,12 @@ impl Function for ParseDuration {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "output",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
         ]
@@ -80,11 +80,11 @@ impl ParseDurationFn {
 
 impl Expression for ParseDurationFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         let conversion_factor = {
-            let bytes = self.output.execute(state, object)?.try_string()?;
+            let bytes = self.output.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             UNITS
@@ -115,11 +115,11 @@ impl Expression for ParseDurationFn {
         let output_def = self
             .output
             .type_def(state)
-            .fallible_unless(value::Kind::String);
+            .fallible_unless(value::Kind::Bytes);
 
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .merge(output_def)
             .into_fallible(true) // parsing errors
             .with_constraint(value::Kind::Float)

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -12,12 +12,12 @@ impl Function for ParseJson {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "default",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: false,
             },
         ]
@@ -49,7 +49,7 @@ impl ParseJsonFn {
 impl Expression for ParseJsonFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let to_json = |value| match value {
-            Value::String(bytes) => serde_json::from_slice(&bytes)
+            Value::Bytes(bytes) => serde_json::from_slice(&bytes)
                 .map(|v: serde_json::Value| {
                     let v: crate::event::Value = v.into();
                     v.into()
@@ -71,15 +71,15 @@ impl Expression for ParseJsonFn {
         let default_def = self
             .default
             .as_ref()
-            .map(|default| default.type_def(state).fallible_unless(Kind::String));
+            .map(|default| default.type_def(state).fallible_unless(Kind::Bytes));
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::String)
+            .fallible_unless(Kind::Bytes)
             .merge_with_default_optional(default_def)
             .into_fallible(true) // JSON parsing errors
             .with_constraint(
-                Kind::String
+                Kind::Bytes
                     | Kind::Boolean
                     | Kind::Integer
                     | Kind::Float
@@ -104,7 +104,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -116,7 +116,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -128,7 +128,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
                 ..Default::default()
             },
         }
@@ -141,7 +141,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: true,
-                kind: Kind::String | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
             },
         }
     ];

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -14,7 +14,7 @@ impl Function for ParseSyslog {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -101,7 +101,7 @@ fn message_to_value(message: Message<&str>) -> Value {
 
 impl Expression for ParseSyslogFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let message = String::from_utf8_lossy(&bytes);
 
         let parsed = syslog_loose::parse_message_with_year(&message, resolve_year);
@@ -112,7 +112,7 @@ impl Expression for ParseSyslogFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .with_constraint(value::Kind::Map)
     }
 }

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -13,17 +13,17 @@ impl Function for ParseTimestamp {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_) | Value::Timestamp(_)),
+                accepts: |v| matches!(v, Value::Bytes(_) | Value::Timestamp(_)),
                 required: true,
             },
             Parameter {
                 keyword: "format",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "default",
-                accepts: |v| matches!(v, Value::String(_) | Value::Timestamp(_)),
+                accepts: |v| matches!(v, Value::Bytes(_) | Value::Timestamp(_)),
                 required: false,
             },
         ]
@@ -68,9 +68,9 @@ impl Expression for ParseTimestampFn {
         let format = self.format.execute(state, object);
 
         let to_timestamp = |value| match value {
-            Value::String(_) => format
+            Value::Bytes(_) => format
                 .clone()
-                .map(|v| format!("timestamp|{}", String::from_utf8_lossy(&v.unwrap_string())))?
+                .map(|v| format!("timestamp|{}", String::from_utf8_lossy(&v.unwrap_bytes())))?
                 .parse::<Conversion>()
                 .map_err(|e| format!("{}", e))?
                 .convert(value.into())
@@ -106,9 +106,9 @@ impl Expression for ParseTimestampFn {
         //
         // The `format` type is _always_ fallible, because its string has to be
         // parsed into a valid timestamp format.
-        let format_def = if value_def.kind.contains(value::Kind::String) {
+        let format_def = if value_def.kind.contains(value::Kind::Bytes) {
             match &default_def {
-                Some(def) if def.kind.contains(value::Kind::String) => {
+                Some(def) if def.kind.contains(value::Kind::Bytes) => {
                     Some(self.format.type_def(state).into_fallible(true))
                 }
                 Some(_) => None,

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -15,7 +15,7 @@ impl Function for ParseUrl {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -41,7 +41,7 @@ impl ParseUrlFn {
 
 impl Expression for ParseUrlFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
 
         Url::parse(&String::from_utf8_lossy(&bytes))
             .map_err(|e| format!("unable to parse url: {}", e).into())
@@ -52,7 +52,7 @@ impl Expression for ParseUrlFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .into_fallible(true) // URL parsing error
             .with_constraint(value::Kind::Map)
     }

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -12,17 +12,17 @@ impl Function for Replace {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "pattern",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "with",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -73,10 +73,10 @@ impl ReplaceFn {
 
 impl Expression for ReplaceFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value_bytes = self.value.execute(state, object)?.try_string()?;
+        let value_bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&value_bytes);
 
-        let with_bytes = self.with.execute(state, object)?.try_string()?;
+        let with_bytes = self.with.execute(state, object)?.try_bytes()?;
         let with = String::from_utf8_lossy(&with_bytes);
 
         let count = match &self.count {
@@ -86,7 +86,7 @@ impl Expression for ReplaceFn {
 
         match &self.pattern {
             Argument::Expression(expr) => {
-                let bytes = expr.execute(state, object)?.try_string()?;
+                let bytes = expr.execute(state, object)?.try_bytes()?;
                 let pattern = String::from_utf8_lossy(&bytes);
                 let replaced = match count {
                     i if i > 0 => value.replacen(pattern.as_ref(), &with, i as usize),
@@ -114,7 +114,7 @@ impl Expression for ReplaceFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         use value::Kind;
 
-        let with_def = self.with.type_def(state).fallible_unless(Kind::String);
+        let with_def = self.with.type_def(state).fallible_unless(Kind::Bytes);
 
         let count_def = self
             .count
@@ -122,17 +122,17 @@ impl Expression for ReplaceFn {
             .map(|count| count.type_def(state).fallible_unless(Kind::Integer));
 
         let pattern_def = match &self.pattern {
-            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::String)),
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::Bytes)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
         };
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::String)
+            .fallible_unless(Kind::Bytes)
             .merge(with_def)
             .merge_optional(pattern_def)
             .merge_optional(count_def)
-            .with_constraint(Kind::String)
+            .with_constraint(Kind::Bytes)
     }
 }
 
@@ -150,7 +150,7 @@ mod test {
                 count: None,
             },
             def: TypeDef {
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -164,7 +164,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -177,7 +177,7 @@ mod test {
                 count: None,
             },
             def: TypeDef {
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -191,7 +191,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -205,7 +205,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -218,7 +218,7 @@ mod test {
                 count: Some(Literal::from(10).boxed()),
             },
             def: TypeDef {
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }
@@ -232,7 +232,7 @@ mod test {
             },
             def: TypeDef {
                 fallible: true,
-                kind: value::Kind::String,
+                kind: value::Kind::Bytes,
                 ..Default::default()
             },
         }

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -114,7 +114,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -22,12 +22,12 @@ impl Function for Sha2 {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "variant",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: false,
             },
         ]
@@ -58,7 +58,7 @@ impl Sha2Fn {
 
 impl Expression for Sha2Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = self.value.execute(state, object)?.try_string()?;
+        let value = self.value.execute(state, object)?.try_bytes()?;
 
         let hash = match self.variant.as_deref() {
             Some("SHA-224") => encode::<Sha224>(&value),
@@ -76,8 +76,8 @@ impl Expression for Sha2Fn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -98,7 +98,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 variant: None,
             },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         value_non_string {
@@ -106,7 +106,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -15,12 +15,12 @@ impl Function for Sha3 {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "variant",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: false,
             },
         ]
@@ -51,7 +51,7 @@ impl Sha3Fn {
 
 impl Expression for Sha3Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = self.value.execute(state, object)?.try_string()?;
+        let value = self.value.execute(state, object)?.try_bytes()?;
 
         let hash = match self.variant.as_deref() {
             Some("SHA3-224") => encode::<Sha3_224>(&value),
@@ -67,8 +67,8 @@ impl Expression for Sha3Fn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -89,7 +89,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 variant: None,
             },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         value_non_string {
@@ -97,7 +97,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
@@ -105,7 +105,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::String },
+            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -12,7 +12,7 @@ impl Function for Slice {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_) | Value::Array(_)),
+                accepts: |v| matches!(v, Value::Bytes(_) | Value::Array(_)),
                 required: true,
             },
             Parameter {
@@ -85,7 +85,7 @@ impl Expression for SliceFn {
         };
 
         match self.value.execute(state, object)? {
-            Value::String(v) => range(v.len() as i64)
+            Value::Bytes(v) => range(v.len() as i64)
                 .map(|range| v.slice(range))
                 .map(Value::from),
             Value::Array(mut v) => range(v.len() as i64)
@@ -101,7 +101,7 @@ impl Expression for SliceFn {
         let value_def = self
             .value
             .type_def(state)
-            .fallible_unless(Kind::String | Kind::Array);
+            .fallible_unless(Kind::Bytes | Kind::Array);
         let end_def = self
             .end
             .as_ref()
@@ -112,8 +112,8 @@ impl Expression for SliceFn {
             .merge(self.start.type_def(state).fallible_unless(Kind::Integer))
             .merge_optional(end_def)
             .with_constraint(match value_def.kind {
-                v if v.is_string() || v.is_array() => v,
-                _ => Kind::String | Kind::Array,
+                v if v.is_bytes() || v.is_array() => v,
+                _ => Kind::Bytes | Kind::Array,
             })
             .into_fallible(true) // can fail for invalid start..end ranges
     }
@@ -132,7 +132,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_array {
@@ -150,7 +150,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String | Kind::Array, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes | Kind::Array, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -13,12 +13,12 @@ impl Function for Split {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "pattern",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -51,7 +51,7 @@ pub(crate) struct SplitFn {
 
 impl Expression for SplitFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
         let limit: usize = self
             .limit
@@ -69,7 +69,7 @@ impl Expression for SplitFn {
                 .collect::<Vec<_>>()
                 .into(),
             Argument::Expression(expr) => {
-                let bytes = expr.execute(state, object)?.try_string()?;
+                let bytes = expr.execute(state, object)?.try_bytes()?;
                 let pattern = String::from_utf8_lossy(&bytes);
 
                 value
@@ -92,13 +92,13 @@ impl Expression for SplitFn {
         });
 
         let pattern_def = match &self.pattern {
-            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::String)),
+            Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::Bytes)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
         };
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::String)
+            .fallible_unless(Kind::Bytes)
             .merge_optional(limit_def)
             .merge_optional(pattern_def)
             .with_constraint(Kind::Array)

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -12,12 +12,12 @@ impl Function for StartsWith {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
                 keyword: "substring",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -70,7 +70,7 @@ impl Expression for StartsWithFn {
         };
 
         let substring = {
-            let bytes = self.substring.execute(state, object)?.try_string()?;
+            let bytes = self.substring.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -80,7 +80,7 @@ impl Expression for StartsWithFn {
         };
 
         let value = {
-            let bytes = self.value.execute(state, object)?.try_string()?;
+            let bytes = self.value.execute(state, object)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             match case_sensitive {
@@ -95,11 +95,11 @@ impl Expression for StartsWithFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .merge(
                 self.substring
                     .type_def(state)
-                    .fallible_unless(value::Kind::String),
+                    .fallible_unless(value::Kind::Bytes),
             )
             .merge_optional(self.case_sensitive.as_ref().map(|case_sensitive| {
                 case_sensitive

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -11,7 +11,7 @@ impl Function for StripWhitespace {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -37,7 +37,7 @@ impl StripWhitespaceFn {
 
 impl Expression for StripWhitespaceFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         Ok(value.trim().into())
@@ -46,8 +46,8 @@ impl Expression for StripWhitespaceFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -59,12 +59,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| StripWhitespaceFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { kind: value::Kind::String, ..Default::default() },
+            def: TypeDef { kind: value::Kind::Bytes, ..Default::default() },
         }
 
         fallible_expression {
             expr: |_| StripWhitespaceFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -55,7 +55,7 @@ impl Expression for ToBoolFn {
             Integer(v) => Ok(Boolean(v != 0)),
             Float(v) => Ok(Boolean(v != 0.0)),
             Null => Ok(Boolean(false)),
-            String(_) => Conversion::Boolean
+            Bytes(_) => Conversion::Boolean
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -55,7 +55,7 @@ impl Expression for ToFloatFn {
             Integer(v) => Ok(Float(v as f64)),
             Boolean(v) => Ok(Float(if v { 1.0 } else { 0.0 })),
             Null => Ok(0.0.into()),
-            String(_) => Conversion::Float
+            Bytes(_) => Conversion::Float
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -55,7 +55,7 @@ impl Expression for ToIntFn {
             Float(v) => Ok(Integer(v as i64)),
             Boolean(v) => Ok(Integer(if v { 1 } else { 0 })),
             Null => Ok(0.into()),
-            String(_) => Conversion::Integer
+            Bytes(_) => Conversion::Integer
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -48,7 +48,7 @@ impl ToStringFn {
 impl Expression for ToStringFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let to_string = |value| match value {
-            Value::String(_) => Ok(value),
+            Value::Bytes(_) => Ok(value),
             _ => Ok(value.as_string_lossy()),
         };
 
@@ -65,7 +65,7 @@ impl Expression for ToStringFn {
             .merge_with_default_optional(
                 self.default.as_ref().map(|default| default.type_def(state)),
             )
-            .with_constraint(value::Kind::String)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -79,42 +79,42 @@ mod tests {
     remap::test_type_def![
         boolean_infallible {
             expr: |_| ToStringFn { value: Literal::from(true).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         integer_infallible {
             expr: |_| ToStringFn { value: Literal::from(1).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         float_infallible {
             expr: |_| ToStringFn { value: Literal::from(1.0).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         null_infallible {
             expr: |_| ToStringFn { value: Literal::from(()).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         string_infallible {
             expr: |_| ToStringFn { value: Literal::from("foo").boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         map_infallible {
             expr: |_| ToStringFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         array_infallible {
             expr: |_| ToStringFn { value: Literal::from(vec![0]).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToStringFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None},
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -122,7 +122,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 
@@ -134,7 +134,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 
@@ -146,7 +146,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 
@@ -158,7 +158,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
 
@@ -170,7 +170,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 optional: false,
-                kind: Kind::String,
+                kind: Kind::Bytes,
             },
         }
     ];

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -19,7 +19,7 @@ impl Function for ToTimestamp {
                         v,
                         Value::Integer(_) |
                         Value::Float(_) |
-                        Value::String(_) |
+                        Value::Bytes(_) |
                         Value::Timestamp(_)
                     )
                 },
@@ -32,7 +32,7 @@ impl Function for ToTimestamp {
                         v,
                         Value::Integer(_) |
                         Value::Float(_) |
-                        Value::String(_) |
+                        Value::Bytes(_) |
                         Value::Timestamp(_)
                     )
                 },
@@ -71,7 +71,7 @@ impl Expression for ToTimestampFn {
             Timestamp(_) => Ok(value),
             Integer(v) => Ok(Timestamp(Utc.timestamp(v, 0))),
             Float(v) => Ok(Timestamp(Utc.timestamp(v.round() as i64, 0))),
-            String(_) => Conversion::Timestamp
+            Bytes(_) => Conversion::Timestamp
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -12,7 +12,7 @@ impl Function for Tokenize {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -38,7 +38,7 @@ impl TokenizeFn {
 
 impl Expression for TokenizeFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         let tokens: Value = tokenize::parse(&value)
@@ -56,7 +56,7 @@ impl Expression for TokenizeFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
             .with_constraint(value::Kind::Array)
     }
 }

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -12,7 +12,7 @@ impl Function for Truncate {
         &[
             Parameter {
                 keyword: "value",
-                accepts: |v| matches!(v, Value::String(_)),
+                accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
             Parameter {
@@ -67,7 +67,7 @@ impl TruncateFn {
 
 impl Expression for TruncateFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_string()?;
+        let bytes = self.value.execute(state, object)?.try_bytes()?;
         let mut value = String::from_utf8_lossy(&bytes).into_owned();
 
         let limit = match self.limit.execute(state, object)? {
@@ -107,7 +107,7 @@ impl Expression for TruncateFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::String)
+            .fallible_unless(Kind::Bytes)
             .merge(
                 self.limit
                     .type_def(state)
@@ -118,7 +118,7 @@ impl Expression for TruncateFn {
                     .as_ref()
                     .map(|ellipsis| ellipsis.type_def(state).fallible_unless(Kind::Boolean)),
             )
-            .with_constraint(Kind::String)
+            .with_constraint(Kind::Bytes)
     }
 }
 
@@ -135,7 +135,7 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         value_non_string {
@@ -144,7 +144,7 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         limit_float {
@@ -153,7 +153,7 @@ mod tests {
                 limit: Literal::from(1.0).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         limit_non_number {
@@ -162,7 +162,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         ellipsis_boolean {
@@ -171,7 +171,7 @@ mod tests {
                 limit: Literal::from(10).boxed(),
                 ellipsis: Some(Literal::from(true).boxed()),
             },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         ellipsis_non_boolean {
@@ -180,7 +180,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: Some(Literal::from("baz").boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -12,7 +12,7 @@ impl Function for Upcase {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
+            accepts: |v| matches!(v, Value::Bytes(_)),
             required: true,
         }]
     }
@@ -48,8 +48,8 @@ impl Expression for UpcaseFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::String)
-            .with_constraint(value::Kind::String)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
     }
 }
 
@@ -62,12 +62,12 @@ mod tests {
     remap::test_type_def![
         string {
             expr: |_| UpcaseFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { kind: Kind::String, ..Default::default() },
+            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
         non_string {
             expr: |_| UpcaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::String, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -27,7 +27,7 @@ impl Expression for UuidV4Fn {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            kind: value::Kind::String,
+            kind: value::Kind::Bytes,
             ..Default::default()
         }
     }
@@ -42,7 +42,7 @@ mod tests {
     remap::test_type_def![static_def {
         expr: |_| UuidV4Fn,
         def: TypeDef {
-            kind: value::Kind::String,
+            kind: value::Kind::Bytes,
             ..Default::default()
         },
     }];
@@ -53,7 +53,7 @@ mod tests {
         let mut object = map![];
         let value = UuidV4Fn.execute(&mut state, &mut object).unwrap();
 
-        assert!(matches!(&value, Value::String(_)));
+        assert!(matches!(&value, Value::Bytes(_)));
 
         uuid::Uuid::parse_str(&String::try_from(value).unwrap()).expect("valid UUID V4");
     }


### PR DESCRIPTION
As noted in #5054, and as requested a few times by @FungusHumungus, this PR renames `Value::String` to `Value::Bytes` (and `Kind::String` to `Kind::Bytes`).

This makes sense, as functions such as `try_string()` didn't actually return a string, but the `Bytes` type.

I special-cased the `fmt` implementation of `Kind::Bytes` since in error messages it makes more sense to see _"expected boolean, got string"_, than _"expected boolean, got bytes"_.