### PR TITLE
chore(remap): remove "optional" from TypeDef

### DIFF
--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -55,7 +55,6 @@ impl Expression for Arithmetic {
 
         TypeDef {
             fallible: true,
-            optional: false,
             kind,
         }
     }
@@ -79,12 +78,11 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes | Kind::Boolean,
             },
         }
 
-        or_any {
+        or_null {
             expr: |_| Arithmetic::new(
                 Box::new(Noop.into()),
                 Box::new(Literal::from(true).into()),
@@ -92,8 +90,7 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
-                kind: Kind::all(),
+                kind: Kind::Boolean | Kind::Null,
             },
         }
 
@@ -105,7 +102,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
             },
         }
@@ -118,7 +114,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
             },
         }
@@ -131,7 +126,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Integer | Kind::Float,
             },
         }
@@ -144,7 +138,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Integer | Kind::Float,
             },
         }
@@ -157,7 +150,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Integer | Kind::Float,
             },
         }
@@ -170,7 +162,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -183,7 +174,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -196,7 +186,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -209,7 +198,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -222,7 +210,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -235,7 +222,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -248,7 +234,6 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -1,4 +1,4 @@
-use crate::{state, Expr, Expression, Object, Result, TypeDef, Value};
+use crate::{state, value, Expr, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Block {
@@ -32,10 +32,9 @@ impl Expression for Block {
         let fallible = type_defs.iter().any(TypeDef::is_fallible);
 
         // The last expression determines the resulting value of the block.
-        let mut type_def = type_defs.pop().unwrap_or(TypeDef {
-            optional: true,
-            ..Default::default()
-        });
+        let mut type_def = type_defs
+            .pop()
+            .unwrap_or_else(|| TypeDef::default().with_constraint(value::Kind::Null));
 
         type_def.fallible = fallible;
         type_def
@@ -55,7 +54,10 @@ mod tests {
     test_type_def![
         no_expression {
             expr: |_| Block::new(vec![]),
-            def: TypeDef { optional: true, ..Default::default() },
+            def: TypeDef {
+                fallible: false,
+                kind: Kind::Null,
+            },
         }
 
         one_expression {
@@ -84,7 +86,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
-                ..Default::default()
             },
         }
 
@@ -101,7 +102,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Array,
-                ..Default::default()
             },
         }
     ];

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -147,8 +147,7 @@ mod tests {
         },
         def: TypeDef {
             fallible: false,
-            optional: true,
-            kind: Kind::all(),
+            kind: Kind::Null,
         },
     }];
 }

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -38,11 +38,12 @@ impl Expression for IfStatement {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.conditional
+        let boolean_condition = self.conditional.type_def(state).kind.is_boolean();
+
+        self.true_expression
             .type_def(state)
-            .fallible_unless(value::Kind::Boolean)
-            .merge(self.true_expression.type_def(state))
             .merge(self.false_expression.type_def(state))
+            .into_fallible(!boolean_condition)
     }
 }
 
@@ -66,12 +67,11 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
 
-        optional_any {
+        optional_null {
             expr: |_| {
                 let conditional = Box::new(Literal::from(true).into());
                 let true_expression = Box::new(Literal::from(true).into());
@@ -81,8 +81,7 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: true,
-                kind: Kind::all(),
+                kind: Kind::Boolean | Kind::Null,
             },
         }
     ];

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -1,4 +1,4 @@
-use crate::{state, Expression, Object, Result, TypeDef, Value};
+use crate::{state, value, Expression, Object, Result, TypeDef, Value};
 
 #[derive(Debug, Clone)]
 pub struct Noop;
@@ -10,8 +10,8 @@ impl Expression for Noop {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            optional: true,
-            ..Default::default()
+            fallible: false,
+            kind: value::Kind::Null,
         }
     }
 }
@@ -24,8 +24,8 @@ mod tests {
     test_type_def![noop {
         expr: |_| Noop,
         def: TypeDef {
-            optional: true,
-            ..Default::default()
+            fallible: false,
+            kind: value::Kind::Null,
         },
     }];
 }

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -27,7 +27,6 @@ impl Expression for Not {
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
             fallible: true,
-            optional: true,
             kind: value::Kind::Boolean,
         }
     }
@@ -71,7 +70,6 @@ mod tests {
         expr: |_| Not::new(Box::new(Noop.into())),
         def: TypeDef {
             fallible: true,
-            optional: true,
             kind: Kind::Boolean,
         },
     }];

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -89,7 +89,6 @@ mod tests {
             expr: |state: &mut state::Compiler| {
                 state.path_query_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
-                    optional: false,
                     kind: Kind::Bytes
                 });
 
@@ -97,7 +96,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -57,7 +57,6 @@ mod tests {
             expr: |state: &mut state::Compiler| {
                 state.variable_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
-                    optional: false,
                     kind: Kind::Bytes
                 });
 
@@ -65,7 +64,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -233,7 +233,6 @@ mod tests {
         for (script, compile_expected, runtime_expected) in cases {
             let accept = TypeDef {
                 fallible: true,
-                optional: true,
                 kind: value::Kind::all(),
             };
 

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -23,7 +23,6 @@ impl ConditionConfig for RemapConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
         let expected_result = TypeDef {
             fallible: true,
-            optional: true,
             kind: value::Kind::Boolean,
         };
 
@@ -119,13 +118,13 @@ mod test {
             (
                 log_event![],
                 "",
-                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to any value"),
+                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to null value"),
                 Ok(()),
             ),
             (
                 log_event!["foo" => "string"],
                 ".foo",
-                Err("remap error: program error: expected to resolve to boolean or no value, but instead resolves to any value"),
+                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to any value"),
                 Ok(()),
             ),
             (

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned()).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned()).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
     ];
 

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -48,7 +48,10 @@ impl Expression for DelFn {
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
-        TypeDef::default().into_optional(true)
+        TypeDef {
+            fallible: false,
+            kind: value::Kind::Null,
+        }
     }
 }
 
@@ -61,8 +64,8 @@ mod tests {
             paths: vec![Path::from("foo")]
         },
         def: TypeDef {
-            optional: true,
-            ..Default::default()
+            fallible: false,
+            kind: value::Kind::Null,
         },
     }];
 }

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -85,7 +85,7 @@ mod tests {
 
         non_string {
             expr: |_| DowncaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
         }
     ];
 }

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -134,7 +134,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         substring_non_string {
@@ -143,7 +143,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         case_sensitive_non_boolean {
@@ -152,7 +152,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
     ];
 

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned()).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned()).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
     ];
 

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -200,7 +200,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_float {
@@ -210,7 +210,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         // TODO(jean): we should update the function to ignore `None` values,
@@ -222,7 +222,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -96,7 +96,7 @@ mod tests {
                 value: Literal::from(chrono::Utc::now()).boxed(),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         optional_value {
@@ -104,7 +104,7 @@ mod tests {
                 value: Box::new(Noop),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -81,7 +81,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         value_optional {
@@ -89,7 +89,7 @@ mod tests {
                 value: Box::new(Noop),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
     ];
 

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -65,12 +65,12 @@ mod tests {
 
         value_non_string {
             expr: |_| Md5Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_optional {
             expr: |_| Md5Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -51,7 +51,10 @@ impl Expression for OnlyFieldsFn {
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
-        TypeDef::default().into_optional(true)
+        TypeDef {
+            fallible: false,
+            kind: value::Kind::Null,
+        }
     }
 }
 
@@ -64,8 +67,8 @@ mod tests {
             paths: vec![Path::from("foo")]
         },
         def: TypeDef {
-            optional: true,
-            ..Default::default()
+            fallible: false,
+            kind: value::Kind::Null,
         },
     }];
 }

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -137,7 +137,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, kind: value::Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Float },
         }
 
         optional_expression {
@@ -145,7 +145,7 @@ mod tests {
                 value: Box::new(Noop),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Float },
+            def: TypeDef { fallible: true, kind: value::Kind::Float },
         }
     ];
 

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -105,7 +105,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
-                ..Default::default()
             },
         }
 
@@ -117,7 +116,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
-                ..Default::default()
             },
         }
 
@@ -129,7 +127,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
-                ..Default::default()
             },
         }
 
@@ -140,7 +137,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
             },
         }

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -131,12 +131,12 @@ mod tests {
 
         value_non_string {
             expr: |_| ParseSyslogFn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Map },
         }
 
         value_optional {
             expr: |_| ParseSyslogFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map },
         }
     ];
 

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -141,7 +141,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Timestamp,
-                ..Default::default()
             },
         }
 
@@ -154,7 +153,6 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Timestamp,
-                ..Default::default()
             },
         }
 

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -96,12 +96,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| ParseUrlFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Map },
         }
 
         value_optional {
             expr: |_| ParseUrlFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map },
         }
     ];
 

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -165,7 +165,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
-                ..Default::default()
             },
         }
 
@@ -192,7 +191,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
-                ..Default::default()
             },
         }
 
@@ -206,7 +204,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
-                ..Default::default()
             },
         }
 
@@ -233,7 +230,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
-                ..Default::default()
             },
         }
     ];

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned()).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned()).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
     ];
 

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -65,12 +65,12 @@ mod tests {
 
         value_non_string {
             expr: |_| Sha1Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_optional {
             expr: |_| Sha1Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -106,7 +106,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_optional {
@@ -114,7 +114,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -97,7 +97,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_optional {
@@ -105,7 +105,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, optional: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -132,7 +132,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         value_array {
@@ -141,7 +141,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Array, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Array },
         }
 
         value_unknown {
@@ -150,7 +150,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes | Kind::Array, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes | Kind::Array },
         }
     ];
 

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -131,7 +131,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
-                ..Default::default()
             },
         }
 
@@ -156,7 +155,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
-                ..Default::default()
             },
         }
 
@@ -181,7 +179,6 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
-                ..Default::default()
             },
         }
     ];

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -132,7 +132,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         substring_non_string {
@@ -141,7 +141,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         case_sensitive_non_boolean {
@@ -150,7 +150,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
     ];
 

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -66,12 +66,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
         }
 
         fallible_expression {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -64,7 +64,7 @@ mod tests {
 
         fallible_expression {
             expr: |_| StripWhitespaceFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -114,29 +114,28 @@ mod tests {
 
         string_fallible {
             expr: |_| ToBoolFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         map_fallible {
             expr: |_| ToBoolFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         array_fallible {
             expr: |_| ToBoolFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         timestamp_fallible {
             expr: |_| ToBoolFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
         fallible_value_without_default {
             expr: |_| ToBoolFn { value: Literal::from("foo".to_owned()).boxed(), default: None },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -148,7 +147,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -160,7 +158,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -172,7 +169,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }
@@ -184,7 +180,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Boolean,
             },
         }

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -114,29 +114,28 @@ mod tests {
 
         string_fallible {
             expr: |_| ToFloatFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float },
         }
 
         map_fallible {
             expr: |_| ToFloatFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float },
         }
 
         array_fallible {
             expr: |_| ToFloatFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float },
         }
 
         timestamp_infallible {
             expr: |_| ToFloatFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Float },
         }
 
         fallible_value_without_default {
             expr: |_| ToFloatFn { value: Variable::new("foo".to_owned()).boxed(), default: None },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Float,
             },
         }
@@ -148,7 +147,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Float,
             },
         }
@@ -160,7 +158,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Float,
             },
         }
@@ -172,7 +169,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Float,
             },
         }
@@ -184,7 +180,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Float,
             },
         }

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -114,29 +114,28 @@ mod tests {
 
         string_fallible {
             expr: |_| ToIntFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
 
         map_fallible {
             expr: |_| ToIntFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
 
         array_fallible {
             expr: |_| ToIntFn { value: Literal::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
 
         timestamp_infallible {
             expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Integer },
         }
 
         fallible_value_without_default {
             expr: |_| ToIntFn { value: Variable::new("foo".to_owned()).boxed(), default: None },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Integer,
             },
         }
@@ -148,7 +147,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Integer,
             },
         }
@@ -160,7 +158,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Integer,
             },
         }
@@ -172,7 +169,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Integer,
             },
         }
@@ -184,7 +180,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Integer,
             },
         }

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -128,7 +128,6 @@ mod tests {
             expr: |_| ToStringFn { value: Variable::new("foo".to_owned()).boxed(), default: None},
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }
@@ -140,7 +139,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }
@@ -152,7 +150,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }
@@ -164,7 +161,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }
@@ -176,7 +172,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Bytes,
             },
         }

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -127,34 +127,33 @@ mod tests {
 
         null_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(()).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp },
         }
 
         string_fallible {
             expr: |_| ToTimestampFn { value: Literal::from("foo").boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp },
         }
 
         map_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp },
         }
 
         array_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(vec![0]).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp },
         }
 
         boolean_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(true).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Timestamp },
         }
 
         fallible_value_without_default {
             expr: |_| ToTimestampFn { value: Variable::new("foo".to_owned()).boxed(), default: None},
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Timestamp,
             },
         }
@@ -166,7 +165,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: true,
-                optional: false,
                 kind: Kind::Timestamp,
             },
         }
@@ -178,7 +176,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Timestamp,
             },
         }
@@ -190,7 +187,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Timestamp,
             },
         }
@@ -202,7 +198,6 @@ mod tests {
             },
             def: TypeDef {
                 fallible: false,
-                optional: false,
                 kind: Kind::Timestamp,
             },
         }

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -75,7 +75,7 @@ mod tests {
 
         value_non_string {
             expr: |_| TokenizeFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Array, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Array },
         }
     ];
 

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -144,7 +144,7 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         limit_float {
@@ -162,7 +162,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
 
         ellipsis_boolean {
@@ -180,7 +180,7 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: Some(Literal::from("baz").boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -67,7 +67,7 @@ mod tests {
 
         non_string {
             expr: |_| UpcaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes },
         }
     ];
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -52,7 +52,6 @@ impl Remap {
     pub fn new(config: RemapConfig) -> crate::Result<Remap> {
         let accepts = TypeDef {
             fallible: true,
-            optional: true,
             kind: value::Kind::all(),
         };
 


### PR DESCRIPTION
This is a follow-up to #5053. In this PR, the `optional` field is removed from `TypeDef`, as expressions can no longer return `None`.