### PR TITLE
chore(ci): Fix hanging splunk_hec source partial test

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1056,7 +1056,7 @@ mod tests {
     async fn partial() {
         trace_init();
 
-        let message = r#"{"event":"first"}{"event":"second""#;
+        let message = r#"{"event":"first"}{"event":"second"}{"event": ""#;
         let (source, address) = source().await;
 
         assert_eq!(


### PR DESCRIPTION
Fixes #5058 

So this fixes the hanging test, but I feel like it isn't the right fix. Seemingly, if only one event is published, `collect_n()` fails to ever poll an event. Pushing this up to get @Hoverbear's thoughts.

The hanging behavior was introduced by #4875 