### PR TITLE
enhancement(external docs): Allow components to have aliases

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -49,6 +49,10 @@ components: {
 
 		env_vars: #EnvVars
 
+		// `alias` is used to register a component's former name when it
+		// undergoes a name change.
+		alias?: !=""
+
 		// `type` is the component identifier. This is set automatically.
 		type: string
 

--- a/docs/reference/components/sources/docker_logs.cue
+++ b/docs/reference/components/sources/docker_logs.cue
@@ -12,6 +12,8 @@ components: sources: docker_logs: {
 		production.
 		"""
 
+	alias: "docker"
+
 	classes: {
 		commonly_used: false
 		delivery:      "best_effort"


### PR DESCRIPTION
PR #5039 alerted me to the need to allow components to have aliases in the docs, i.e. names that still work in a particular version but are deprecated.