### PR TITLE
enhancement(external docs): Add Cue sources for GraphQL API

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -238,7 +238,7 @@ _values: {
 		category: strings.ToTitle(name)
 	}
 
-	// `desription` describes the option in a succinct fashion. Usually 1 to
+	// `description` describes the option in a succinct fashion. Usually 1 to
 	// 2 sentences.
 	description: string
 

--- a/docs/reference/api.cue
+++ b/docs/reference/api.cue
@@ -3,14 +3,14 @@ package metadata
 // These sources produce JSON providing a structured representation of the
 // Vector GraphQL API
 
-#GraphQLAPI: {
+api: {
 	description:     !=""
 	playground_url:  !=""
 	schema_json_url: !=""
 	configuration:   #Schema
 }
 
-api: #GraphQLAPI & {
+api: {
 	description:     """
 		The [GraphQL](\(urls.graphql)) API exposed by Vector for configuration,
 		monitoring, and topology visualization.

--- a/docs/reference/api.cue
+++ b/docs/reference/api.cue
@@ -24,7 +24,7 @@ api: #GraphQLAPI & {
 			required:    false
 			description: "Whether the GraphQL API is enabled for this Vector instance."
 		}
-		bind: {
+		address: {
 			common:   true
 			required: false
 			type: string: {

--- a/docs/reference/api.cue
+++ b/docs/reference/api.cue
@@ -1,0 +1,51 @@
+package metadata
+
+// These sources produce JSON providing a structured representation of the
+// Vector GraphQL API
+
+#GraphQLAPI: {
+	description:     !=""
+	playground_url:  !=""
+	schema_json_url: !=""
+	configuration:   #Schema
+}
+
+api: #GraphQLAPI & {
+	description:     """
+		The [GraphQL](\(urls.graphql)) API exposed by Vector for configuration,
+		monitoring, and topology visualization.
+		"""
+	playground_url:  "https://playground.vector.dev:8686/playground"
+	schema_json_url: "https://github.com/timberio/vector/blob/master/lib/vector-api-client/graphql/schema.json"
+	configuration: {
+		enabled: {
+			common: true
+			type: bool: default: false
+			required:    false
+			description: "Whether the GraphQL API is enabled for this Vector instance."
+		}
+		bind: {
+			common:   true
+			required: false
+			type: string: {
+				default: "127.0.0.1:8686"
+				examples: ["0.0.0.0:8686", "localhost:1234"]
+			}
+			description: """
+				The network address to which the API should bind. If you're running
+				Vector in a Docker container, make sure to bind to `0.0.0.0`. Otherwise
+				the API will not be exposed outside the container.
+				"""
+		}
+		playground: {
+			common:   false
+			required: false
+			type: bool: default: true
+			description: """
+				Whether the [GraphQL Playground](\(urls.graphql_playground)) is enabled
+				for the API. The Playground is accessible via the `/playground` endpoint
+				of the address set using the `bind` parameter.
+				"""
+		}
+	}
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -136,6 +136,8 @@ urls: {
 	github_protected_branches:                                "https://help.github.com/en/github/administering-a-repository/about-protected-branches"
 	github_sign_commits:                                      "https://help.github.com/en/github/authenticating-to-github/signing-commits"
 	globbing:                                                 "https://en.wikipedia.org/wiki/Glob_(programming)"
+	graphql:                                                  "https://graphql.org"
+	graphql_playground:                                       "https://github.com/graphql/graphql-playground"
 	grok:                                                     "https://grokdebug.herokuapp.com/"
 	grok_debugger:                                            "https://grokdebug.herokuapp.com/"
 	grok_patterns:                                            "https://github.com/daschl/grok/tree/master/patterns"


### PR DESCRIPTION
This PR adds some basic metadata about the GraphQL API that can be used for the docs site. The structure will likely change over time but I wanted to start schematizing things.