### PR TITLE
fix(topology): Flush sinks in a couple of more places

### DIFF
--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -244,7 +244,7 @@ mod test {
     use super::*;
     use crate::{event::Metric, test_util::*};
     use bytes::Bytes;
-    use futures::{compat::Sink01CompatExt, TryStreamExt};
+    use futures::{compat::Sink01CompatExt, SinkExt, TryStreamExt};
     use futures01::sync::mpsc;
     use tokio::net::UdpSocket;
     use tokio_util::{codec::BytesCodec, udp::UdpFramed};
@@ -452,15 +452,17 @@ mod test {
 
         let socket = UdpSocket::bind(addr).await.unwrap();
         tokio::spawn(async move {
-            UdpFramed::new(socket, BytesCodec::new())
+            let stream = UdpFramed::new(socket, BytesCodec::new())
                 .map_err(|error| error!(message = "Error reading line.", %error))
-                .map_ok(|(bytes, _addr)| bytes.freeze())
-                .forward(
-                    tx.sink_compat()
-                        .sink_map_err(|error| error!(message = "Error sending event.", %error)),
-                )
-                .await
-                .unwrap()
+                .map_ok(|(bytes, _addr)| bytes.freeze());
+
+            let mut tx = tx
+                .sink_compat()
+                .sink_map_err(|error| error!(message = "Error sending event.", %error));
+
+            stream.forward(&mut tx).await.unwrap();
+
+            tx.flush().await.unwrap();
         });
 
         sink.run(stream::iter(events)).await.unwrap();

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{
-    compat::Sink01CompatExt, executor, FutureExt, StreamExt, TryFutureExt, TryStreamExt,
+    compat::Sink01CompatExt, executor, FutureExt, SinkExt, StreamExt, TryFutureExt, TryStreamExt,
 };
 use futures01::Sink;
 use serde::{Deserialize, Serialize};
@@ -95,20 +95,28 @@ where
         }
     });
 
-    let fut = receiver
-        .take_until(shutdown)
-        .map_err(|error| emit!(StdinReadFailed { error }))
-        .map_ok(move |line| {
-            emit!(StdinEventReceived {
-                byte_size: line.len()
-            });
-            create_event(Bytes::from(line), &host_key, &hostname)
-        })
-        .forward(
-            out.sink_map_err(|error| error!(message = "Unable to send event to out.", %error))
-                .sink_compat(),
-        )
-        .inspect(|_| info!("Finished sending"));
+    let fut = async move {
+        let mut out = out
+            .sink_map_err(|error| error!(message = "Unable to send event to out.", %error))
+            .sink_compat();
+
+        let res = receiver
+            .take_until(shutdown)
+            .map_err(|error| emit!(StdinReadFailed { error }))
+            .map_ok(move |line| {
+                emit!(StdinEventReceived {
+                    byte_size: line.len()
+                });
+                create_event(Bytes::from(line), &host_key, &hostname)
+            })
+            .forward(&mut out)
+            .inspect(|_| info!("Finished sending"))
+            .await;
+
+        let _ = out.flush().await; // error emitted by sink_map_err
+
+        res
+    };
 
     Ok(Box::new(fut.boxed().compat()))
 }

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -110,7 +110,7 @@ where
                 create_event(Bytes::from(line), &host_key, &hostname)
             })
             .forward(&mut out)
-            .inspect(|_| info!("Finished sending"))
+            .inspect(|_| info!("Finished sending."))
             .await;
 
         let _ = out.flush().await; // error emitted by sink_map_err


### PR DESCRIPTION
Fixes #5081

I surveyed the other usages of `Stream.forward` and `Sink.send_all`
looking for other places that should be flushing. I just found these
two, the rest follow two patterns:

* `Sink.send_all` / `Stream.forward` used with streams only containing
  `Ok`s
* Consuming error in stream and returning `None` to end the stream

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
