### PR TITLE
chore(remap): add benchmark and test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4976,6 +4976,7 @@ dependencies = [
  "bitflags",
  "bytes 0.5.6",
  "chrono",
+ "criterion",
  "dyn-clone",
  "paste",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,6 +543,7 @@ disable-resolv-conf = []
 # excluing API client due to running out of memory during linking in Github Actions
 benches = ["sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
 wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-wasm", "transforms-lua"]
+remap-benches = ["transforms-add_fields", "transforms-remap", "transforms-coercer", "transforms-json_parser"]
 
 [[bench]]
 name = "default"
@@ -554,6 +555,11 @@ name = "wasm"
 path = "benches/wasm/mod.rs"
 harness = false
 required-features = ["wasm-benches"]
+
+[[bench]]
+name = "remap"
+harness = false
+required-features = ["remap-benches"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"

--- a/benches/default.rs
+++ b/benches/default.rs
@@ -8,7 +8,6 @@ mod http;
 mod isolated_buffering;
 mod lua;
 mod regex;
-mod remap;
 mod template;
 mod topology;
 
@@ -21,7 +20,6 @@ criterion_main!(
     isolated_buffering::benches,
     lua::benches,
     regex::benches,
-    remap::benches,
     template::benches,
     topology::benches,
 );

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -1,8 +1,7 @@
-use criterion::{criterion_group, BatchSize, Criterion};
-
 use chrono::{DateTime, Utc};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use indexmap::IndexMap;
-
+use remap::prelude::*;
 use vector::transforms::{
     add_fields::AddFields,
     coercer::CoercerConfig,
@@ -15,6 +14,43 @@ use vector::{
     event::{Event, Value},
     test_util::runtime,
 };
+
+criterion_group!(benches, benchmark_remap, upcase, downcase, parse_json);
+
+bench_function! {
+    upcase => vector::remap::Upcase;
+
+    literal_value {
+        args: func_args![value: "foo"],
+        want: Ok("FOO")
+    }
+}
+
+bench_function! {
+    downcase => vector::remap::Downcase;
+
+    literal_value {
+        args: func_args![value: "FOO"],
+        want: Ok("foo")
+    }
+}
+
+bench_function! {
+    parse_json => vector::remap::ParseJson;
+
+    literal_value {
+        args: func_args![value: r#"{"key": "value"}"#],
+        want: Ok(map!["key": "value"]),
+    }
+
+    invalid_json_with_default {
+        args: func_args![
+            value: r#"{"key": INVALID}"#,
+            default: r#"{"key": "default"}"#,
+        ],
+        want: Ok(map!["key": "default"]),
+    }
+}
 
 fn benchmark_remap(c: &mut Criterion) {
     let mut rt = runtime();
@@ -231,5 +267,3 @@ fn benchmark_remap(c: &mut Criterion) {
         );
     });
 }
-
-criterion_group!(benches, benchmark_remap);

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use criterion::{criterion_group, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use indexmap::IndexMap;
 use remap::prelude::*;
 use vector::transforms::{
@@ -16,6 +16,7 @@ use vector::{
 };
 
 criterion_group!(benches, benchmark_remap, upcase, downcase, parse_json);
+criterion_main!(benches);
 
 bench_function! {
     upcase => vector::remap::Upcase;

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 use indexmap::IndexMap;
 use remap::prelude::*;
 use vector::transforms::{

--- a/lib/remap-lang/Cargo.toml
+++ b/lib/remap-lang/Cargo.toml
@@ -15,3 +15,6 @@ pest = "2"
 pest_derive = "2"
 regex = "1"
 thiserror = "1"
+
+[dev-dependencies]
+criterion = "0.3"

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -137,6 +137,12 @@ expression_dispatch![
     Argument,
 ];
 
+impl<T: Into<Value>> From<T> for Expr {
+    fn from(value: T) -> Self {
+        Literal::from(value.into()).into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::value;

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -14,4 +14,4 @@ pub use crate::function::{Argument, ArgumentList, Parameter};
 pub use crate::generate_param_list;
 
 // test helpers
-pub use crate::test_type_def;
+pub use crate::{bench_function, func_args, map, test_function, test_type_def};

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -41,7 +41,8 @@ macro_rules! bench_function {
 
                     b.iter(|| {
                         let got = expression.execute(&mut state, &mut object).map_err(|e| e.to_string());
-                        assert_eq!(got, want);
+                        debug_assert_eq!(got, want);
+                        got
                     })
                 });
             )+

--- a/src/remap/function.rs
+++ b/src/remap/function.rs
@@ -76,6 +76,7 @@ pub use uuid_v4::UuidV4;
 
 use remap::{Result, Value};
 
+#[inline]
 fn convert_value_or_default(
     value: Result<Value>,
     default: Option<Result<Value>>,
@@ -86,6 +87,7 @@ fn convert_value_or_default(
         .or_else(|err| default.ok_or(err)?.and_then(|value| convert(value)))
 }
 
+#[inline]
 fn is_scalar_value(value: &Value) -> bool {
     use Value::*;
 
@@ -98,6 +100,7 @@ fn is_scalar_value(value: &Value) -> bool {
 /// Rounds the given number to the given precision.
 /// Takes a function parameter so the exact rounding function (ceil, floor or round)
 /// can be specified.
+#[inline]
 fn round_to_precision<F>(num: f64, precision: i64, fun: F) -> f64
 where
     F: Fn(f64) -> f64,

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -37,15 +37,6 @@ struct ParseJsonFn {
     default: Option<Box<dyn Expression>>,
 }
 
-impl ParseJsonFn {
-    #[cfg(test)]
-    fn new(value: Box<dyn Expression>, default: Option<Value>) -> Self {
-        let default = default.map(|v| Box::new(Literal::from(v)) as _);
-
-        Self { value, default }
-    }
-}
-
 impl Expression for ParseJsonFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let to_json = |value| match value {
@@ -93,10 +84,49 @@ impl Expression for ParseJsonFn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::map;
     use value::Kind;
 
-    remap::test_type_def![
+    test_function![
+        parse_json => ParseJson;
+
+        number {
+            args: func_args![value: "42"],
+            want: Ok(42),
+        }
+
+        string {
+            args: func_args![value: r#""hello""#],
+            want: Ok("hello"),
+        }
+
+        json {
+            args: func_args![value: r#"{"field":"value"}"#],
+            want: Ok(map!["field": "value"]),
+        }
+
+        default {
+            args: func_args![
+                value: r#"{ INVALID }"#,
+                default: "42",
+            ],
+            want: Ok(42),
+        }
+
+        invalid_value {
+            args: func_args![value: r#"{ INVALID }"#],
+            want: Err("function call error: unable to parse json: key must be a string at line 1 column 3"),
+        }
+
+        invalid_value_and_default {
+            args: func_args![
+                value: r#"{ INVALID }"#,
+                default: r#"{ INVALID }"#,
+            ],
+            want: Err("function call error: unable to parse json: key must be a string at line 1 column 3"),
+        }
+    ];
+
+    test_type_def![
         value_string {
             expr: |_| ParseJsonFn {
                 value: Literal::from("foo").boxed(),
@@ -141,50 +171,4 @@ mod tests {
             },
         }
     ];
-
-    #[test]
-    fn parse_json() {
-        let cases = vec![
-            (
-                map!["foo": "42"],
-                Ok(42.into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map!["foo": "\"hello\""],
-                Ok("hello".into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map!["foo": r#"{"field":"value"}"#],
-                Ok(map!["field": "value"].into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map!["foo": r#"{ INVALID }"#],
-                Ok(42.into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), Some("42".into())),
-            ),
-            (
-                map!["foo": r#"{ INVALID }"#],
-                Err("function call error: unable to parse json key must be a string at line 1 column 3".into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map!["foo": r#"{ INVALID }"#],
-                Err("function call error: unable to parse json key must be a string at line 1 column 3".into()),
-                ParseJsonFn::new(Box::new(Path::from("foo")), Some("{ INVALID }".into())),
-            ),
-        ];
-
-        let mut state = state::Program::default();
-
-        for (mut object, exp, func) in cases {
-            let got = func
-                .execute(&mut state, &mut object)
-                .map_err(|e| format!("{:#}", anyhow::anyhow!(e)));
-
-            assert_eq!(got, exp);
-        }
-    }
 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -5,7 +5,7 @@ use crate::{
     transforms::{FunctionTransform, Transform},
     Result,
 };
-use remap::{value, Program, Runtime, TypeDef};
+use remap::{value, Program, Runtime, TypeConstraint, TypeDef};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
@@ -50,12 +50,15 @@ pub struct Remap {
 
 impl Remap {
     pub fn new(config: RemapConfig) -> crate::Result<Remap> {
-        let accepts = TypeDef {
-            fallible: true,
-            kind: value::Kind::all(),
+        let accepts = TypeConstraint {
+            allow_any: true,
+            type_def: TypeDef {
+                fallible: true,
+                kind: value::Kind::all(),
+            },
         };
 
-        let program = Program::new(&config.source, &crate::remap::FUNCTIONS_MUT, accepts)?;
+        let program = Program::new(&config.source, &crate::remap::FUNCTIONS_MUT, Some(accepts))?;
 
         Ok(Remap {
             program,


### PR DESCRIPTION
This PR introduces a few convenient macros to the `remap-lang` crate to quickly add tests and benchmarks for individual functions.

It also adds a few benchmarks and tests to get started.

I'll add more in follow-up PRs, but with this merged, everyone can use the new set-up to put more of our functions under test coverage.

Built-in expressions also aren't properly tested/benched yet, these will be tackled in a follow-up PR. This also doesn't cover testing complete remap programs (or the parser specifically), again, these will be tackled separately.