### PR TITLE
enhancement(kubernetes platform): Expose host metrics in our Helm charts out of the box

### DIFF
--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -45,7 +45,21 @@ data:
       {{- end }}
     {{- end }}
 
-    {{- include "libvector.metricsConfigPartial" . | nindent 4  }}
+    {{- $prometheusInputs := (list) -}}
+    {{- with .Values.hostMetricsSource -}}
+    {{- if .enabled }}
+    {{- $prometheusInputs = prepend $prometheusInputs .sourceId }}
+    # Capture the metrics from the host.
+    [sources.{{ .sourceId }}]
+      type = "host_metrics"
+
+      {{- with .rawConfig }}
+      {{- . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+
+    {{- merge . (dict "prometheusInputs" $prometheusInputs) | include "libvector.metricsConfigPartial" | nindent 4  }}
 
     {{- range $sourceId, $source := .Values.sources }}
     [sources.{{ $sourceId }}]

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -55,6 +55,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.hostMetricsSource.enabled }}
+            - name: PROCFS_ROOT
+              value: /host/proc
+            - name: SYSFS_ROOT
+              value: /host/sys
+            {{- end }}
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -82,6 +88,16 @@ spec:
             - name: config-dir
               mountPath: /etc/vector
               readOnly: true
+            {{- if .Values.hostMetricsSource.enabled }}
+            # Host procsfs mount.
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            # Host sysfs mount.
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             # Extra volumes.
             {{- toYaml . | nindent 12 }}
@@ -121,6 +137,16 @@ spec:
               {{- with .Values.extraConfigDirSources }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
+        {{- if .Values.hostMetricsSource.enabled }}
+        # Host procsfs.
+        - name: procfs
+          hostPath:
+            path: /proc
+        # Host sysfs.
+        - name: sysfs
+          hostPath:
+            path: /sys
+        {{- end }}
         {{- with .Values.extraVolumes }}
         # Extra volumes.
         {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -156,6 +156,16 @@ internalMetricsSource:
   # Raw TOML config to embed at the internal metrics source.
   rawConfig: null
 
+# The "built-in" host metrics source emitting the metrics gathered from the node
+# that Vector is executing on.
+hostMetricsSource:
+  # Disable to omit the host metrics source from being added.
+  enabled: true
+  # The name to use for the "built-in" host metrics source.
+  sourceId: host_metrics
+  # Raw TOML config to embed at the host metrics source.
+  rawConfig: null
+
 # The "built-in" prometheus sink exposing metrics in the Prometheus scraping
 # format.
 # When using this "built-in" sink, we automatically configure container ports,

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -5,7 +5,9 @@ Common Vector configuration partial containing built-in metrics pipeline.
 Internal metrics are common, so we share and reuse the definition.
 */}}
 {{- define "libvector.metricsConfigPartial" -}}
-{{- with .Values.internalMetricsSource }}
+{{- $values := .Values -}}
+{{- $prometheusInputs := .prometheusInputs -}}
+{{- with $values.internalMetricsSource }}
 {{- if .enabled }}
 # Emit internal Vector metrics.
 [sources.{{ .sourceId }}]
@@ -17,11 +19,14 @@ Internal metrics are common, so we share and reuse the definition.
 {{- end }}
 {{- end }}
 
-{{- with .Values.prometheusSink }}
+{{- with $values.prometheusSink }}
 {{- if .enabled }}
 {{- $inputs := .inputs }}
-{{- if and $.Values.internalMetricsSource.enabled (not .excludeInternalMetrics) -}}
-{{- $inputs = prepend $inputs $.Values.internalMetricsSource.sourceId }}
+{{- if $prometheusInputs -}}
+{{- $inputs = concat $inputs $prometheusInputs }}
+{{- end }}
+{{- if and $values.internalMetricsSource.enabled (not .excludeInternalMetrics) -}}
+{{- $inputs = prepend $inputs $values.internalMetricsSource.sourceId }}
 {{- end }}
 # Expose metrics for scraping in the Prometheus format.
 [sinks.{{ .sinkId }}]

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -149,6 +149,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PROCFS_ROOT
+              value: /host/proc
+            - name: SYSFS_ROOT
+              value: /host/sys
             
             - name: LOG
               value: info
@@ -173,6 +177,14 @@ spec:
             # Vector config dir mount.
             - name: config-dir
               mountPath: /etc/vector
+              readOnly: true
+            # Host procsfs mount.
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            # Host sysfs mount.
+            - name: sysfs
+              mountPath: /host/sys
               readOnly: true
       terminationGracePeriodSeconds: 60
       tolerations:
@@ -203,3 +215,11 @@ spec:
               - secret:
                   name: vector-agent-config
                   optional: true
+        # Host procsfs.
+        - name: procfs
+          hostPath:
+            path: /proc
+        # Host sysfs.
+        - name: sysfs
+          hostPath:
+            path: /sys

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -46,6 +46,9 @@ data:
     # Ingest logs from Kubernetes.
     [sources.kubernetes_logs]
       type = "kubernetes_logs"
+    # Capture the metrics from the host.
+    [sources.host_metrics]
+      type = "host_metrics"
     
     # Emit internal Vector metrics.
     [sources.internal_metrics]
@@ -53,7 +56,7 @@ data:
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
       type = "prometheus"
-      inputs = ["internal_metrics"]
+      inputs = ["internal_metrics","host_metrics"]
       address = "0.0.0.0:9090"
 ---
 # Source: vector-agent/templates/rbac.yaml

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -63,6 +63,9 @@ data:
       type = "vector"
       inputs = ["kubernetes_logs"]
       address = "vector-aggregator:9000"
+    # Capture the metrics from the host.
+    [sources.host_metrics]
+      type = "host_metrics"
     
     # Emit internal Vector metrics.
     [sources.internal_metrics]
@@ -70,7 +73,7 @@ data:
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
       type = "prometheus"
-      inputs = ["internal_metrics"]
+      inputs = ["internal_metrics","host_metrics"]
       address = "0.0.0.0:9090"
 ---
 # Source: vector/charts/vector-aggregator/templates/configmap.yaml

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -250,6 +250,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PROCFS_ROOT
+              value: /host/proc
+            - name: SYSFS_ROOT
+              value: /host/sys
             
             - name: "LOG"
               value: "info"
@@ -274,6 +278,14 @@ spec:
             # Vector config dir mount.
             - name: config-dir
               mountPath: /etc/vector
+              readOnly: true
+            # Host procsfs mount.
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            # Host sysfs mount.
+            - name: sysfs
+              mountPath: /host/sys
               readOnly: true
       terminationGracePeriodSeconds: 60
       tolerations:
@@ -304,6 +316,14 @@ spec:
               - secret:
                   name: vector-agent-config
                   optional: true
+        # Host procsfs.
+        - name: procfs
+          hostPath:
+            path: /proc
+        # Host sysfs.
+        - name: sysfs
+          hostPath:
+            path: /sys
 ---
 # Source: vector/charts/vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
This PR adds a built-in host metrics source to our Helm charts and exposes it via the built-in Prometheus sink. It also applies other necessary changes to make host metrics work in the Kubernetes environment.

Closes #4163.

To do:

- [x] make heim work in the container environment (#5264 covers that for pending use cases (cgroup metrics), this can be merged in later)
- [x] E2E tests
- [ ] docs (will be covered by #5043, can be skipped in this PR)