### PR TITLE
chore(observability): Enable API by default

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -23,7 +23,7 @@ impl Server {
 
         let (_shutdown, rx) = oneshot::channel();
         let (addr, server) = warp::serve(routes).bind_with_graceful_shutdown(
-            config.api.bind.expect("Invalid socket address"),
+            config.api.address.expect("Invalid socket address"),
             async {
                 rx.await.ok();
             },

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,7 +200,7 @@ impl Application {
             // assigned to prevent the API terminating when falling out of scope
             let api_server = if api_config.enabled {
                 emit!(ApiStarted {
-                    addr: api_config.bind.unwrap(),
+                    addr: api_config.address.unwrap(),
                     playground: api_config.playground
                 });
 

--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -8,7 +8,7 @@ pub struct Options {
     pub enabled: bool,
 
     #[serde(default = "default_bind")]
-    pub bind: Option<SocketAddr>,
+    pub address: Option<SocketAddr>,
 
     #[serde(default = "default_playground")]
     pub playground: bool,
@@ -19,19 +19,19 @@ impl Default for Options {
         Self {
             enabled: default_enabled(),
             playground: default_playground(),
-            bind: default_bind(),
+            address: default_address(),
         }
     }
 }
 
 fn default_enabled() -> bool {
-    false
+    true
 }
 
 /// By default, the API binds to 127.0.0.1:8686. This function should remain public;
 /// `vector top`  will use it to determine which to connect to by default, if no URL
 /// override is provided
-pub fn default_bind() -> Option<SocketAddr> {
+pub fn default_address() -> Option<SocketAddr> {
     Some(SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 8686))
 }
 
@@ -44,22 +44,24 @@ impl Options {
         // Merge options
 
         // Try to merge bind
-        let bind = match (self.bind, other.bind) {
+        let bind = match (self.address, other.address) {
             (None, b) => b,
             (Some(a), None) => Some(a),
             (Some(a), Some(b)) if a == b => Some(a),
             // Prefer non default bind
-            (Some(a), Some(b)) => match (Some(a) == default_bind(), Some(b) == default_bind()) {
-                (false, false) => {
-                    return Err(format!("Conflicting `api` bindings: {}, {} .", a, b))
+            (Some(a), Some(b)) => {
+                match (Some(a) == default_address(), Some(b) == default_address()) {
+                    (false, false) => {
+                        return Err(format!("Conflicting `api` bindings: {}, {} .", a, b))
+                    }
+                    (false, true) => Some(a),
+                    (true, _) => Some(b),
                 }
-                (false, true) => Some(a),
-                (true, _) => Some(b),
-            },
+            }
         };
 
         let options = Options {
-            bind,
+            address: bind,
             enabled: self.enabled | other.enabled,
             playground: self.playground & other.playground,
         };
@@ -73,7 +75,7 @@ impl Options {
 fn bool_merge() {
     let mut a = Options {
         enabled: true,
-        bind: None,
+        address: None,
         playground: false,
     };
 
@@ -83,7 +85,7 @@ fn bool_merge() {
         a,
         Options {
             enabled: true,
-            bind: default_bind(),
+            address: default_address(),
             playground: false,
         }
     );
@@ -94,7 +96,7 @@ fn bind_merge() {
     let address = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 9000);
     let mut a = Options {
         enabled: true,
-        bind: Some(address),
+        address: Some(address),
         playground: true,
     };
 
@@ -104,7 +106,7 @@ fn bind_merge() {
         a,
         Options {
             enabled: true,
-            bind: Some(address),
+            address: Some(address),
             playground: true,
         }
     );
@@ -113,12 +115,12 @@ fn bind_merge() {
 #[test]
 fn bind_conflict() {
     let mut a = Options {
-        bind: Some(SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 9000)),
+        address: Some(SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 9000)),
         ..Options::default()
     };
 
     let b = Options {
-        bind: Some(SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 9001)),
+        address: Some(SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 9001)),
         ..Options::default()
     };
 

--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -7,7 +7,7 @@ pub struct Options {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
-    #[serde(default = "default_bind")]
+    #[serde(default = "default_address")]
     pub address: Option<SocketAddr>,
 
     #[serde(default = "default_playground")]

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -19,7 +19,7 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
     // provided by the API config. This will work despite `api` and `api-client` being distinct
     // features; the config is available even if `api` is disabled
     let url = opts.url.clone().unwrap_or_else(|| {
-        let addr = config::api::default_bind().unwrap();
+        let addr = config::api::default_address().unwrap();
         Url::parse(&*format!("http://{}/graphql", addr))
             .expect("Couldn't parse default API URL. Please report this.")
     });

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -66,14 +66,14 @@ mod tests {
         config.add_source("in1", source_with_event_counter().1);
         config.add_sink("out1", &["in1"], sink(10).1);
         config.api.enabled = true;
-        config.api.bind = Some(next_addr());
+        config.api.address = Some(next_addr());
 
         config.build().unwrap()
     }
 
     async fn from_str_config(conf: &str) -> vector::topology::RunningTopology {
         let mut c = config::load_from_str(conf).unwrap();
-        c.api.bind = Some(next_addr());
+        c.api.address = Some(next_addr());
 
         let diff = config::ConfigDiff::initial(&c);
         let pieces = vector::topology::build_or_log_errors(&c, &diff)
@@ -101,7 +101,7 @@ mod tests {
     // Returns the result of a URL test against the API. Wraps the test in retry_until
     // to guard against the race condition of the TCP listener not being ready
     async fn url_test(config: Config, url: &'static str) -> reqwest::Response {
-        let addr = config.api.bind.unwrap();
+        let addr = config.api.address.unwrap();
         let url = format!("http://{}:{}/{}", addr.ip(), addr.port(), url);
 
         let _server = api::Server::start(&config);


### PR DESCRIPTION
Small PR on the road to #5083. Enables the API by default. This was already bound to 127.0.0.1:8686 by default, so it should be relatively safe.

Renames `bind` -> `address` to follow the precedent set elsewhere in the config.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
