### PR TITLE
enhancement(elasticsearch sink): add support for data streams

### DIFF
--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -78,7 +78,7 @@ components: sinks: elasticsearch: {
 
 		requirements: [
 			#"""
-				Elasticsearch's Data streams feature require Vector to be configured with the `create` `bulk_action`. *This is not enabled by default.*
+				Elasticsearch's Data streams feature requires Vector to be configured with the `create` `bulk_action`. *This is not enabled by default.*
 				"""#,
 		]
 		warnings: []
@@ -157,7 +157,7 @@ components: sinks: elasticsearch: {
 		}
 		bulk_action: {
 			common:      false
-			description: "Action to use when making requests to the Bulk API. Supports `index` and `create`."
+			description: "Action to use when making requests to the [Elasticsearch Bulk API](elasticsearch_bulk). Supports `index` and `create`."
 			required:    false
 			warnings: []
 			type: string: {
@@ -249,11 +249,11 @@ components: sinks: elasticsearch: {
 		conflicts: {
 			title: "Conflicts"
 			body: """
-				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's
-				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are inserted
-				via the `index` action. In the case of a conflict, such as a document with the
-				same `id`, Vector will add or _replace_ the document as necessary. If `bulk_action` is
-				configured with `create`, Elasticsearch will _not_ replace an existing document.
+				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's 
+				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are 
+				inserted via the `index` action which will update documents if an existing 
+				one has the same `id`. If `bulk_action` is configured with `create`, Elasticsearch 
+				will _not_ replace an existing document and instead return a conflict error.
 				"""
 		}
 

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -249,10 +249,10 @@ components: sinks: elasticsearch: {
 		conflicts: {
 			title: "Conflicts"
 			body: """
-				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's 
-				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are 
-				inserted via the `index` action which will update documents if an existing 
-				one has the same `id`. If `bulk_action` is configured with `create`, Elasticsearch 
+				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's
+				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are
+				inserted via the `index` action which will update documents if an existing
+				one has the same `id`. If `bulk_action` is configured with `create`, Elasticsearch
 				will _not_ replace an existing document and instead return a conflict error.
 				"""
 		}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -76,7 +76,11 @@ components: sinks: elasticsearch: {
 			"x86_64-unknown-linux-musl":  true
 		}
 
-		requirements: []
+		requirements: [
+			#"""
+				Elasticsearch's Data streams feature require Vector to be configured with the `create` `bulk_action`. *This is not enabled by default.*
+				"""#,
+		]
 		warnings: []
 		notices: []
 	}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -246,9 +246,19 @@ components: sinks: elasticsearch: {
 			title: "Conflicts"
 			body: """
 				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's
-				[`_bulk` API endpoint][urls.elasticsearch_bulk]. All events are inserted
+				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are inserted
 				via the `index` action. In the case of an conflict, such as a document with the
-				same `id`, Vector will add or _replace_ the document as necessary.
+				same `id`, Vector will add or _replace_ the document as necessary. If `bulk_action` is
+				configured with `create`, Elasticsearch will _not_ replace an existing document.
+				"""
+		}
+
+		data_streams: {
+			title: "Data streams"
+			body: """
+				By default, Vector will use the `index` action with Elasticsearch's Bulk API.
+				To use [Data streams][urls.elasticsearch_data_streams], `bulk_action` must be configured
+				with the `create` option.
 				"""
 		}
 

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -156,9 +156,8 @@ components: sinks: elasticsearch: {
 			description: "Action to use when making requests to the Bulk API. Supports `index` and `create`."
 			required:    false
 			warnings: []
-			type: object: {
+			type: string: {
 				examples: ["index", "create"]
-				options: {}
 			}
 		}
 		doc_type: {

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -157,6 +157,7 @@ components: sinks: elasticsearch: {
 			required:    false
 			warnings: []
 			type: string: {
+				default: "index"
 				examples: ["index", "create"]
 			}
 		}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -151,6 +151,16 @@ components: sinks: elasticsearch: {
 				}
 			}
 		}
+		bulk_action: {
+			common:      false
+			description: "Action to use when making requests to the Bulk API. Supports `index` and `create`."
+			required:    false
+			warnings: []
+			type: object: {
+				examples: ["index", "create"]
+				options: {}
+			}
+		}
 		doc_type: {
 			common:      false
 			description: "The `doc_type` for your index data. This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to set this option since Elasticsearch has removed it."

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -251,7 +251,7 @@ components: sinks: elasticsearch: {
 			body: """
 				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's
 				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are inserted
-				via the `index` action. In the case of an conflict, such as a document with the
+				via the `index` action. In the case of a conflict, such as a document with the
 				same `id`, Vector will add or _replace_ the document as necessary. If `bulk_action` is
 				configured with `create`, Elasticsearch will _not_ replace an existing document.
 				"""

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -122,6 +122,7 @@ urls: {
 	cidr:                                                     "https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
 	elasticsearch:                                            "https://www.elastic.co/products/elasticsearch"
 	elasticsearch_bulk:                                       "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
+	elasticsearch_data_streams:                               "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html"
 	elasticsearch_id_field:                                   "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html"
 	elasticsearch_id_performance:                             "https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#_use_auto_generated_ids"
 	elasticsearch_ignore_malformed:                           "https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-malformed.html"

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -561,8 +561,8 @@ mod tests {
 
     #[test]
     fn sets_create_action_when_configured() {
-        use chrono::{Utc, TimeZone};
         use crate::config::log_schema;
+        use chrono::{TimeZone, Utc};
 
         let config = ElasticSearchConfig {
             bulk_action: BulkAction::Create,
@@ -573,7 +573,10 @@ mod tests {
         let es = ElasticSearchCommon::parse_config(&config).unwrap();
 
         let mut event = Event::from("hello there");
-        event.as_mut_log().insert(log_schema().timestamp_key(), Utc.ymd(2020, 12, 1).and_hms(1, 2, 3));
+        event.as_mut_log().insert(
+            log_schema().timestamp_key(),
+            Utc.ymd(2020, 12, 1).and_hms(1, 2, 3),
+        );
         let encoded = es.encode_event(event).unwrap();
         let expected = r#"{"create":{"_index":"vector","_type":"_doc"}}
 {"message":"hello there","timestamp":"2020-12-01T01:02:03Z"}

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -116,7 +116,7 @@ impl BulkAction {
         }
     }
 
-    pub fn as_path(&self) -> &'static str {
+    pub fn as_json_pointer(&self) -> &'static str {
         match *self {
             BulkAction::Index => "/index",
             BulkAction::Create => "/create",
@@ -225,7 +225,7 @@ impl HttpSink for ElasticSearchCommon {
         });
         maybe_set_id(
             self.config.id_key.as_ref(),
-            action.pointer_mut(self.bulk_action.as_path()).unwrap(),
+            action.pointer_mut(self.bulk_action.as_json_pointer()).unwrap(),
             &mut event,
         );
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -86,16 +86,6 @@ pub enum ElasticSearchAuth {
     Aws { assume_role: Option<String> },
 }
 
-impl ElasticSearchAuth {
-    pub fn apply<B>(&self, req: &mut Request<B>) {
-        if let Self::Basic { user, password } = &self {
-            use headers::{Authorization, HeaderMapExt};
-            let auth = Authorization::basic(&user, &password);
-            req.headers_mut().typed_insert(auth);
-        }
-    }
-}
-
 #[derive(Derivative, Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 #[derivative(Default)]

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -96,7 +96,7 @@ impl ElasticSearchAuth {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub enum BulkAction {
     Index,
     Create,

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -61,6 +61,7 @@ pub struct ElasticSearchConfig {
 
     pub aws: Option<RegionOrEndpoint>,
     pub tls: Option<TlsOptions>,
+    #[serde(default)]
     pub bulk_action: BulkAction,
 }
 
@@ -96,7 +97,7 @@ impl ElasticSearchAuth {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum BulkAction {
     Index,
     Create,

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -570,6 +570,29 @@ mod tests {
     }
 
     #[test]
+    fn sets_insert_action_when_configured() {
+        let config = ElasticSearchConfig {
+            bulk_action: BulkAction::Create,
+            index: Some(String::from("vector")),
+            encoding: EncodingConfigWithDefault {
+                codec: Encoding::Default,
+                except_fields: Some(vec!["timestamp".to_string()]),
+                ..Default::default()
+            },
+            endpoint: String::from("https://example.com"),
+            ..Default::default()
+        };
+        let es = ElasticSearchCommon::parse_config(&config).unwrap();
+
+        let event = Event::from("hello there");
+        let encoded = es.encode_event(event).unwrap();
+        let expected = r#"{"create":{"_index":"vector","_type":"_doc"}}
+{"message":"hello there"}
+"#;
+        assert_eq!(std::str::from_utf8(&encoded).unwrap(), &expected[..]);
+    }
+
+    #[test]
     fn handles_error_response() {
         let json = "{\"took\":185,\"errors\":true,\"items\":[{\"index\":{\"_index\":\"test-hgw28jv10u\",\"_type\":\"log_lines\",\"_id\":\"3GhQLXEBE62DvOOUKdFH\",\"status\":400,\"error\":{\"type\":\"illegal_argument_exception\",\"reason\":\"mapper [message] of different type, current_type [long], merged_type [text]\"}}}]}";
         let response = Response::builder()

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -96,17 +96,13 @@ impl ElasticSearchAuth {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Derivative, Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[derivative(Default)]
 pub enum BulkAction {
+    #[derivative(Default)]
     Index,
     Create,
-}
-
-impl Default for BulkAction {
-    fn default() -> Self {
-        BulkAction::Index
-    }
 }
 
 impl BulkAction {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -226,7 +226,9 @@ impl HttpSink for ElasticSearchCommon {
         });
         maybe_set_id(
             self.config.id_key.as_ref(),
-            action.pointer_mut(self.bulk_action.as_json_pointer()).unwrap(),
+            action
+                .pointer_mut(self.bulk_action.as_json_pointer())
+                .unwrap(),
             &mut event,
         );
 


### PR DESCRIPTION
Adds a configuration option to specify 'index' (default) or 'create' (for data streams)

Related: https://github.com/timberio/vector/issues/4939

Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
