### PR TITLE
chore(deps): Add some initial allowed licenses to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,21 @@
+[licenses]
+allow = [
+  "MIT",
+  "CC0-1.0",
+  "ISC",
+  "Unlicense",
+]
+
+private = { ignore = true }
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
 [advisories]
 ignore = [
     # `net2` crate has been deprecated; use `socket2` instead

--- a/lib/codec/Cargo.toml
+++ b/lib/codec/Cargo.toml
@@ -3,6 +3,7 @@ name = "codec"
 version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 bytes = "0.5"

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "End-to-end tests of Vector in the Kubernetes environment"
+publish = false
 
 [dependencies]
 futures = "0.3"

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "Kubernetes Test Framework used to test Vector in Kubernetes"
+publish = false
 
 [dependencies]
 k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -3,6 +3,7 @@ name = "prometheus-parser"
 version = "0.1.0"
 authors = ["Duy Do <juchiast@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -3,6 +3,7 @@ name = "tracing-limit"
 version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 tracing-core = "0.1"

--- a/lib/vector-wasm/Cargo.toml
+++ b/lib/vector-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "vector-wasm"
 version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Advances toward https://github.com/timberio/vector/issues/5129 by adding
the permissive licenses that don't seem to have any additional
requirements.

Also clarifies the license for ring which has multiple and marks internal packages as not published.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
