### PR TITLE
fix(file source): clean up file format and fix features

### DIFF
--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = {version = "1.5.1", features = ["serde-1"]}
 flate2 = "1.0.19"
 winapi = { version = "0.3", features = ["winioctl"] }
 libc =  "0.2"
-tokio = { version = "0.2.13", features = ["time"] }
+tokio = { version = "0.2.13", features = ["rt-core", "blocking", "time"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.33"
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -25,6 +25,7 @@ enum State {
 /// A simple JSON-friendly struct of the fingerprint/position pair, since fingerprints as objects
 /// cannot be keys in a plain JSON map.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 struct Checkpoint {
     fingerprint: FileFingerprint,
     position: FilePosition,

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -27,6 +27,7 @@ pub enum FingerprintStrategy {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FileFingerprint {
     Checksum(u64),
     FirstLineChecksum(u64),


### PR DESCRIPTION
This is just a couple of small tweaks to clean up the file source:

1. We were missing the features for the new tokio usage, but generally got away with it because we use them in the top-level crate. This fixes the `file-source` crate itself.
2. We weren't consistently `snake_case`-ing everything in the new checkpoints json file. This fixes that.