### PR TITLE
chore(graphql api): Standardize metric names

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -921,7 +921,7 @@ components: {
 
 		telemetry: metrics: {
 			// Default metrics for each component
-			events_processed_total: components.sources.internal_metrics.output.metrics.events_processed_total
+			processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
 			processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		}
 	}}

--- a/docs/reference/components/sources/docker_logs.cue
+++ b/docs/reference/components/sources/docker_logs.cue
@@ -261,7 +261,7 @@ components: sources: docker_logs: {
 
 	telemetry: metrics: {
 		communication_errors_total:            components.sources.internal_metrics.output.metrics.communication_errors_total
-		container_events_processed_total:      components.sources.internal_metrics.output.metrics.container_events_processed_total
+		container_processed_events_total:      components.sources.internal_metrics.output.metrics.container_processed_events_total
 		container_metadata_fetch_errors_total: components.sources.internal_metrics.output.metrics.container_metadata_fetch_errors_total
 		containers_unwatched_total:            components.sources.internal_metrics.output.metrics.containers_unwatched_total
 		containers_watched_total:              components.sources.internal_metrics.output.metrics.containers_watched_total

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -195,7 +195,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		container_events_processed_total: {
+		container_processed_events_total: {
 			description:       "The total number of container events processed."
 			type:              "counter"
 			default_namespace: "vector"
@@ -243,7 +243,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		events_processed_total: {
+		processed_events_total: {
 			description:       "The total number of events processed by this component."
 			type:              "counter"
 			default_namespace: "vector"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -366,7 +366,7 @@ components: sources: kubernetes_logs: {
 
 		kubernetes_api_access_control: {
 			title: "Kubernetes API access control"
-			body: """
+			body:  """
 				Vector requires access to the Kubernetes API.
 				Specifically, the [`kubernetes_logs` source](\(urls.vector_kubernetes_logs_source))
 				uses the `/api/v1/pods` endpoint to "watch" the pods from

--- a/lib/vector-api-client/graphql/queries/components.graphql
+++ b/lib/vector-api-client/graphql/queries/components.graphql
@@ -3,11 +3,11 @@ query ComponentsQuery {
     __typename
     name
     componentType
-    eventsProcessedTotal {
-      eventsProcessedTotal
+    processedEventsTotal {
+      processedEventsTotal
     }
-    bytesProcessedTotal {
-      bytesProcessedTotal
+    processedBytesTotal {
+      processedBytesTotal
     }
   }
 }

--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -86,51 +86,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
-              "name": "timestamp",
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total number of bytes processed",
-              "isDeprecated": false,
-              "name": "bytesProcessedTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "MetricType",
-              "ofType": null
-            }
-          ],
-          "kind": "OBJECT",
-          "name": "BytesProcessedTotal",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "name",
@@ -165,10 +120,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "eventsProcessedTotal",
+              "name": "processedEventsTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "EventsProcessedTotal",
+                "name": "ProcessedEventsTotal",
                 "ofType": null
               }
             },
@@ -177,10 +132,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "bytesProcessedTotal",
+              "name": "processedBytesTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "BytesProcessedTotal",
+                "name": "ProcessedBytesTotal",
                 "ofType": null
               }
             }
@@ -206,92 +161,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component name",
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed throughput",
-              "isDeprecated": false,
-              "name": "throughput",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentBytesProcessedThroughput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component name",
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed total metric",
-              "isDeprecated": false,
-              "name": "metric",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "BytesProcessedTotal",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentBytesProcessedTotal",
-          "possibleTypes": null
         },
         {
           "description": null,
@@ -359,6 +228,92 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Bytes processed throughput",
+              "isDeprecated": false,
+              "name": "throughput",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ComponentProcessedBytesThroughput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Component name",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Bytes processed total metric",
+              "isDeprecated": false,
+              "name": "metric",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProcessedBytesTotal",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ComponentProcessedBytesTotal",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Component name",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Events processed throughput",
               "isDeprecated": false,
               "name": "throughput",
@@ -376,7 +331,7 @@
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "ComponentEventsProcessedThroughput",
+          "name": "ComponentProcessedEventsThroughput",
           "possibleTypes": null
         },
         {
@@ -410,7 +365,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "EventsProcessedTotal",
+                  "name": "ProcessedEventsTotal",
                   "ofType": null
                 }
               }
@@ -419,7 +374,7 @@
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "ComponentEventsProcessedTotal",
+          "name": "ComponentProcessedEventsTotal",
           "possibleTypes": null
         },
         {
@@ -571,51 +526,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "ErrorsTotal",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
-              "name": "timestamp",
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total number of events processed",
-              "isDeprecated": false,
-              "name": "eventsProcessedTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "MetricType",
-              "ofType": null
-            }
-          ],
-          "kind": "OBJECT",
-          "name": "EventsProcessedTotal",
           "possibleTypes": null
         },
         {
@@ -1123,12 +1033,12 @@
             },
             {
               "kind": "OBJECT",
-              "name": "EventsProcessedTotal",
+              "name": "ProcessedEventsTotal",
               "ofType": null
             },
             {
               "kind": "OBJECT",
-              "name": "BytesProcessedTotal",
+              "name": "ProcessedBytesTotal",
               "ofType": null
             }
           ]
@@ -1246,6 +1156,96 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "NetworkMetrics",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Metric timestamp",
+              "isDeprecated": false,
+              "name": "timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total number of bytes processed",
+              "isDeprecated": false,
+              "name": "processedBytesTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "MetricType",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "ProcessedBytesTotal",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Metric timestamp",
+              "isDeprecated": false,
+              "name": "timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total number of events processed",
+              "isDeprecated": false,
+              "name": "processedEventsTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "MetricType",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "ProcessedEventsTotal",
           "possibleTypes": null
         },
         {
@@ -1492,10 +1492,10 @@
               "deprecationReason": null,
               "description": "Metric indicating events processed for the current sink",
               "isDeprecated": false,
-              "name": "eventsProcessedTotal",
+              "name": "processedEventsTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "EventsProcessedTotal",
+                "name": "ProcessedEventsTotal",
                 "ofType": null
               }
             },
@@ -1504,10 +1504,10 @@
               "deprecationReason": null,
               "description": "Metric indicating bytes processed for the current sink",
               "isDeprecated": false,
-              "name": "bytesProcessedTotal",
+              "name": "processedBytesTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "BytesProcessedTotal",
+                "name": "ProcessedBytesTotal",
                 "ofType": null
               }
             }
@@ -1629,10 +1629,10 @@
               "deprecationReason": null,
               "description": "Metric indicating events processed for the current source",
               "isDeprecated": false,
-              "name": "eventsProcessedTotal",
+              "name": "processedEventsTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "EventsProcessedTotal",
+                "name": "ProcessedEventsTotal",
                 "ofType": null
               }
             },
@@ -1641,10 +1641,10 @@
               "deprecationReason": null,
               "description": "Metric indicating bytes processed for the current source",
               "isDeprecated": false,
-              "name": "bytesProcessedTotal",
+              "name": "processedBytesTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "BytesProcessedTotal",
+                "name": "ProcessedBytesTotal",
                 "ofType": null
               }
             }
@@ -1787,13 +1787,13 @@
               "deprecationReason": null,
               "description": "Events processed metrics.",
               "isDeprecated": false,
-              "name": "eventsProcessedTotal",
+              "name": "processedEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "EventsProcessedTotal",
+                  "name": "ProcessedEventsTotal",
                   "ofType": null
                 }
               }
@@ -1818,7 +1818,7 @@
               "deprecationReason": null,
               "description": "Events processed throughput, sampled over a provided millisecond `interval`.",
               "isDeprecated": false,
-              "name": "eventsProcessedThroughput",
+              "name": "processedEventsThroughput",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1849,7 +1849,7 @@
               "deprecationReason": null,
               "description": "Component events processed throughputs over `interval`.",
               "isDeprecated": false,
-              "name": "componentEventsProcessedThroughputs",
+              "name": "componentProcessedEventsThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1861,7 +1861,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "ComponentEventsProcessedThroughput",
+                      "name": "ComponentProcessedEventsThroughput",
                       "ofType": null
                     }
                   }
@@ -1888,7 +1888,7 @@
               "deprecationReason": null,
               "description": "Component events processed metrics over `interval`.",
               "isDeprecated": false,
-              "name": "componentEventsProcessedTotals",
+              "name": "componentProcessedEventsTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1900,7 +1900,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "ComponentEventsProcessedTotal",
+                      "name": "ComponentProcessedEventsTotal",
                       "ofType": null
                     }
                   }
@@ -1927,13 +1927,13 @@
               "deprecationReason": null,
               "description": "Bytes processed metrics.",
               "isDeprecated": false,
-              "name": "bytesProcessedTotal",
+              "name": "processedBytesTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "BytesProcessedTotal",
+                  "name": "ProcessedBytesTotal",
                   "ofType": null
                 }
               }
@@ -1958,7 +1958,7 @@
               "deprecationReason": null,
               "description": "Bytes processed throughput, sampled over a provided millisecond `interval`.",
               "isDeprecated": false,
-              "name": "bytesProcessedThroughput",
+              "name": "processedBytesThroughput",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1989,7 +1989,7 @@
               "deprecationReason": null,
               "description": "Component bytes processed metrics, over `interval`.",
               "isDeprecated": false,
-              "name": "componentBytesProcessedTotals",
+              "name": "componentProcessedBytesTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2001,7 +2001,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "ComponentBytesProcessedTotal",
+                      "name": "ComponentProcessedBytesTotal",
                       "ofType": null
                     }
                   }
@@ -2028,7 +2028,7 @@
               "deprecationReason": null,
               "description": "Component bytes processed throughputs, over `interval`",
               "isDeprecated": false,
-              "name": "componentBytesProcessedThroughputs",
+              "name": "componentProcessedBytesThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2040,7 +2040,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "ComponentBytesProcessedThroughput",
+                      "name": "ComponentProcessedBytesThroughput",
                       "ofType": null
                     }
                   }
@@ -2382,10 +2382,10 @@
               "deprecationReason": null,
               "description": "Metric indicating events processed for the current transform",
               "isDeprecated": false,
-              "name": "eventsProcessedTotal",
+              "name": "processedEventsTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "EventsProcessedTotal",
+                "name": "ProcessedEventsTotal",
                 "ofType": null
               }
             },
@@ -2394,10 +2394,10 @@
               "deprecationReason": null,
               "description": "Metric indicating bytes processed for the current transform",
               "isDeprecated": false,
-              "name": "bytesProcessedTotal",
+              "name": "processedBytesTotal",
               "type": {
                 "kind": "OBJECT",
-                "name": "BytesProcessedTotal",
+                "name": "ProcessedBytesTotal",
                 "ofType": null
               }
             }

--- a/lib/vector-api-client/graphql/subscriptions/bytes_processed_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/bytes_processed_throughput.graphql
@@ -1,3 +1,0 @@
-subscription BytesProcessedThroughputSubscription($interval: Int!) {
-    bytesProcessedThroughput(interval: $interval)
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_throughputs.graphql
@@ -1,6 +1,0 @@
-subscription ComponentBytesProcessedThroughputsSubscription($interval: Int!) {
-    componentBytesProcessedThroughputs(interval: $interval) {
-        name
-        throughput
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_totals.graphql
@@ -1,8 +1,0 @@
-subscription ComponentBytesProcessedTotalsSubscription($interval: Int!) {
-    componentBytesProcessedTotals(interval: $interval) {
-        name
-        metric {
-            bytesProcessedTotal
-        }
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_events_processed_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_events_processed_throughputs.graphql
@@ -1,6 +1,0 @@
-subscription ComponentEventsProcessedThroughputsSubscription($interval: Int!) {
-    componentEventsProcessedThroughputs(interval: $interval) {
-        name
-        throughput
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_events_processed_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_events_processed_totals.graphql
@@ -1,8 +1,0 @@
-subscription ComponentEventsProcessedTotalsSubscription($interval: Int!) {
-    componentEventsProcessedTotals(interval: $interval) {
-        name
-        metric {
-            eventsProcessedTotal
-        }
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_processed_bytes_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_processed_bytes_throughputs.graphql
@@ -1,0 +1,6 @@
+subscription ComponentProcessedBytesThroughputsSubscription($interval: Int!) {
+    componentProcessedBytesThroughputs(interval: $interval) {
+        name
+        throughput
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/component_processed_bytes_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_processed_bytes_totals.graphql
@@ -1,0 +1,8 @@
+subscription ComponentProcessedBytesTotalsSubscription($interval: Int!) {
+    componentProcessedBytesTotals(interval: $interval) {
+        name
+        metric {
+            processedBytesTotal
+        }
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/component_processed_events_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_processed_events_throughputs.graphql
@@ -1,0 +1,6 @@
+subscription ComponentProcessedEventsThroughputsSubscription($interval: Int!) {
+    componentProcessedEventsThroughputs(interval: $interval) {
+        name
+        throughput
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/component_processed_events_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_processed_events_totals.graphql
@@ -1,0 +1,8 @@
+subscription ComponentProcessedEventsTotalsSubscription($interval: Int!) {
+    componentProcessedEventsTotals(interval: $interval) {
+        name
+        metric {
+            processedEventsTotal
+        }
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/events_processed_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/events_processed_throughput.graphql
@@ -1,3 +1,0 @@
-subscription EventsProcessedThroughputSubscription($interval: Int!) {
-    eventsProcessedThroughput(interval: $interval)
-}

--- a/lib/vector-api-client/graphql/subscriptions/events_processed_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/events_processed_total.graphql
@@ -1,5 +1,0 @@
-subscription EventsProcessedTotalSubscription($interval: Int!) {
-  eventsProcessedTotal(interval: $interval) {
-    eventsProcessedTotal
-  }
-}

--- a/lib/vector-api-client/graphql/subscriptions/processed_bytes_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/processed_bytes_throughput.graphql
@@ -1,0 +1,3 @@
+subscription ProcessedBytesThroughputSubscription($interval: Int!) {
+    processedBytesThroughput(interval: $interval)
+}

--- a/lib/vector-api-client/graphql/subscriptions/processed_events_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/processed_events_throughput.graphql
@@ -1,0 +1,3 @@
+subscription ProcessedEventsThroughputSubscription($interval: Int!) {
+    processedEventsThroughput(interval: $interval)
+}

--- a/lib/vector-api-client/graphql/subscriptions/processed_events_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/processed_events_total.graphql
@@ -1,0 +1,5 @@
+subscription ProcessedEventsTotalSubscription($interval: Int!) {
+  processedEventsTotal(interval: $interval) {
+    processedEventsTotal
+  }
+}

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -13,75 +13,75 @@ use graphql_client::GraphQLQuery;
 )]
 pub struct UptimeSubscription;
 
-/// EventsProcessedTotalSubscription contains metrics on the number of events
+/// ProcessedEventsTotalSubscription contains metrics on the number of events
 /// that have been processed by a Vector instance
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/events_processed_total.graphql",
+    query_path = "graphql/subscriptions/processed_events_total.graphql",
     response_derives = "Debug"
 )]
-pub struct EventsProcessedTotalSubscription;
+pub struct ProcessedEventsTotalSubscription;
 
-/// EventsProcessedThroughputSubscription contains metrics on the number of events
+/// ProcessedEventsThroughputSubscription contains metrics on the number of events
 /// that have been processed between `interval` samples
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/events_processed_throughput.graphql",
+    query_path = "graphql/subscriptions/processed_events_throughput.graphql",
     response_derives = "Debug"
 )]
-pub struct EventsProcessedThroughputSubscription;
+pub struct ProcessedEventsThroughputSubscription;
 
-/// BytesProcessedThroughputSubscription contains metrics on the number of bytes
+/// ProcessedBytesThroughputSubscription contains metrics on the number of bytes
 /// that have been processed between `interval` samples
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/bytes_processed_throughput.graphql",
+    query_path = "graphql/subscriptions/processed_bytes_throughput.graphql",
     response_derives = "Debug"
 )]
-pub struct BytesProcessedThroughputSubscription;
+pub struct ProcessedBytesThroughputSubscription;
 
-/// ComponentEventsProcessedThroughputsSubscription contains metrics on the number of events
+/// ComponentProcessedEventsThroughputsSubscription contains metrics on the number of events
 /// that have been processed between `interval` samples, against specific components
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_events_processed_throughputs.graphql",
+    query_path = "graphql/subscriptions/component_processed_events_throughputs.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentEventsProcessedThroughputsSubscription;
+pub struct ComponentProcessedEventsThroughputsSubscription;
 
-/// ComponentEventsProcessedTotalsSubscription contains metrics on the number of events
+/// ComponentProcessedEventsTotalsSubscription contains metrics on the number of events
 /// that have been processed by a Vector instance, against specific components
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_events_processed_totals.graphql",
+    query_path = "graphql/subscriptions/component_processed_events_totals.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentEventsProcessedTotalsSubscription;
+pub struct ComponentProcessedEventsTotalsSubscription;
 
-/// ComponentBytesProcessedThroughputsSubscription contains metrics on the number of bytes
+/// ComponentProcessedBytesThroughputsSubscription contains metrics on the number of bytes
 /// that have been processed between `interval` samples, against specific components
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_bytes_processed_throughputs.graphql",
+    query_path = "graphql/subscriptions/component_processed_bytes_throughputs.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentBytesProcessedThroughputsSubscription;
+pub struct ComponentProcessedBytesThroughputsSubscription;
 
-/// ComponentBytesProcessedTotalsSubscription contains metrics on the number of bytes
+/// ComponentProcessedBytesTotalsSubscription contains metrics on the number of bytes
 /// that have been processed by a Vector instance, against a specific component
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_bytes_processed_totals.graphql",
+    query_path = "graphql/subscriptions/component_processed_bytes_totals.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentBytesProcessedTotalsSubscription;
+pub struct ComponentProcessedBytesTotalsSubscription;
 
 /// Extension methods for metrics subscriptions
 pub trait MetricsSubscriptionExt {
@@ -89,46 +89,46 @@ pub trait MetricsSubscriptionExt {
     fn uptime_subscription(&self) -> crate::BoxedSubscription<UptimeSubscription>;
 
     /// Executes an events processed metrics subscription
-    fn events_processed_total_subscription(
+    fn processed_events_total_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<EventsProcessedTotalSubscription>;
+    ) -> crate::BoxedSubscription<ProcessedEventsTotalSubscription>;
 
     /// Executes an events processed throughput subscription
-    fn events_processed_throughput_subscription(
+    fn processed_events_throughput_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<EventsProcessedThroughputSubscription>;
+    ) -> crate::BoxedSubscription<ProcessedEventsThroughputSubscription>;
 
     /// Executes a bytes processed throughput subscription
-    fn bytes_processed_throughput_subscription(
+    fn processed_bytes_throughput_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<BytesProcessedThroughputSubscription>;
+    ) -> crate::BoxedSubscription<ProcessedBytesThroughputSubscription>;
 
     /// Executes an component events processed totals subscription
-    fn component_events_processed_totals_subscription(
+    fn component_processed_events_totals_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentEventsProcessedTotalsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentProcessedEventsTotalsSubscription>;
 
     /// Executes an component events processed throughputs subscription
-    fn component_events_processed_throughputs_subscription(
+    fn component_processed_events_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentEventsProcessedThroughputsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentProcessedEventsThroughputsSubscription>;
 
     /// Executes an component bytes processed totals subscription
-    fn component_bytes_processed_totals_subscription(
+    fn component_processed_bytes_totals_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentBytesProcessedTotalsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentProcessedBytesTotalsSubscription>;
 
     /// Executes an component bytes processed throughputs subscription
-    fn component_bytes_processed_throughputs_subscription(
+    fn component_processed_bytes_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentBytesProcessedThroughputsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentProcessedBytesThroughputsSubscription>;
 }
 
 impl MetricsSubscriptionExt for crate::SubscriptionClient {
@@ -140,86 +140,86 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
     }
 
     /// Executes an events processed metrics subscription
-    fn events_processed_total_subscription(
+    fn processed_events_total_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<EventsProcessedTotalSubscription> {
-        let request_body = EventsProcessedTotalSubscription::build_query(
-            events_processed_total_subscription::Variables { interval },
+    ) -> BoxedSubscription<ProcessedEventsTotalSubscription> {
+        let request_body = ProcessedEventsTotalSubscription::build_query(
+            processed_events_total_subscription::Variables { interval },
         );
 
-        self.start::<EventsProcessedTotalSubscription>(&request_body)
+        self.start::<ProcessedEventsTotalSubscription>(&request_body)
     }
 
     /// Executes an events processed throughput subscription
-    fn events_processed_throughput_subscription(
+    fn processed_events_throughput_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<EventsProcessedThroughputSubscription> {
-        let request_body = EventsProcessedThroughputSubscription::build_query(
-            events_processed_throughput_subscription::Variables { interval },
+    ) -> BoxedSubscription<ProcessedEventsThroughputSubscription> {
+        let request_body = ProcessedEventsThroughputSubscription::build_query(
+            processed_events_throughput_subscription::Variables { interval },
         );
 
-        self.start::<EventsProcessedThroughputSubscription>(&request_body)
+        self.start::<ProcessedEventsThroughputSubscription>(&request_body)
     }
 
     /// Executes a bytes processed throughput subscription
-    fn bytes_processed_throughput_subscription(
+    fn processed_bytes_throughput_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<BytesProcessedThroughputSubscription> {
-        let request_body = BytesProcessedThroughputSubscription::build_query(
-            bytes_processed_throughput_subscription::Variables { interval },
+    ) -> BoxedSubscription<ProcessedBytesThroughputSubscription> {
+        let request_body = ProcessedBytesThroughputSubscription::build_query(
+            processed_bytes_throughput_subscription::Variables { interval },
         );
 
-        self.start::<BytesProcessedThroughputSubscription>(&request_body)
+        self.start::<ProcessedBytesThroughputSubscription>(&request_body)
     }
 
     /// Executes an all component events processed totals subscription
-    fn component_events_processed_totals_subscription(
+    fn component_processed_events_totals_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentEventsProcessedTotalsSubscription> {
-        let request_body = ComponentEventsProcessedTotalsSubscription::build_query(
-            component_events_processed_totals_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentProcessedEventsTotalsSubscription> {
+        let request_body = ComponentProcessedEventsTotalsSubscription::build_query(
+            component_processed_events_totals_subscription::Variables { interval },
         );
 
-        self.start::<ComponentEventsProcessedTotalsSubscription>(&request_body)
+        self.start::<ComponentProcessedEventsTotalsSubscription>(&request_body)
     }
 
     /// Executes an all component events processed throughputs subscription
-    fn component_events_processed_throughputs_subscription(
+    fn component_processed_events_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentEventsProcessedThroughputsSubscription> {
-        let request_body = ComponentEventsProcessedThroughputsSubscription::build_query(
-            component_events_processed_throughputs_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentProcessedEventsThroughputsSubscription> {
+        let request_body = ComponentProcessedEventsThroughputsSubscription::build_query(
+            component_processed_events_throughputs_subscription::Variables { interval },
         );
 
-        self.start::<ComponentEventsProcessedThroughputsSubscription>(&request_body)
+        self.start::<ComponentProcessedEventsThroughputsSubscription>(&request_body)
     }
 
     /// Executes an all component bytes processed totals subscription
-    fn component_bytes_processed_totals_subscription(
+    fn component_processed_bytes_totals_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentBytesProcessedTotalsSubscription> {
-        let request_body = ComponentBytesProcessedTotalsSubscription::build_query(
-            component_bytes_processed_totals_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentProcessedBytesTotalsSubscription> {
+        let request_body = ComponentProcessedBytesTotalsSubscription::build_query(
+            component_processed_bytes_totals_subscription::Variables { interval },
         );
 
-        self.start::<ComponentBytesProcessedTotalsSubscription>(&request_body)
+        self.start::<ComponentProcessedBytesTotalsSubscription>(&request_body)
     }
 
     /// Executes an all component bytes processed throughputs subscription
-    fn component_bytes_processed_throughputs_subscription(
+    fn component_processed_bytes_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentBytesProcessedThroughputsSubscription> {
-        let request_body = ComponentBytesProcessedThroughputsSubscription::build_query(
-            component_bytes_processed_throughputs_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentProcessedBytesThroughputsSubscription> {
+        let request_body = ComponentProcessedBytesThroughputsSubscription::build_query(
+            component_processed_bytes_throughputs_subscription::Variables { interval },
         );
 
-        self.start::<ComponentBytesProcessedThroughputsSubscription>(&request_body)
+        self.start::<ComponentProcessedBytesThroughputsSubscription>(&request_body)
     }
 }

--- a/src/api/schema/components.rs
+++ b/src/api/schema/components.rs
@@ -20,12 +20,12 @@ lazy_static! {
     field(name = "name", type = "String"),
     field(name = "component_type", type = "String"),
     field(
-        name = "events_processed_total",
-        type = "Option<metrics::EventsProcessedTotal>"
+        name = "processed_events_total",
+        type = "Option<metrics::ProcessedEventsTotal>"
     ),
     field(
-        name = "bytes_processed_total",
-        type = "Option<metrics::BytesProcessedTotal>"
+        name = "processed_bytes_total",
+        type = "Option<metrics::ProcessedBytesTotal>"
     )
 )]
 pub enum Component {
@@ -95,13 +95,13 @@ impl Source {
     }
 
     /// Metric indicating events processed for the current source
-    async fn events_processed_total(&self) -> Option<metrics::EventsProcessedTotal> {
-        metrics::component_events_processed_total(&self.0.name)
+    async fn processed_events_total(&self) -> Option<metrics::ProcessedEventsTotal> {
+        metrics::component_processed_events_total(&self.0.name)
     }
 
     /// Metric indicating bytes processed for the current source
-    async fn bytes_processed_total(&self) -> Option<metrics::BytesProcessedTotal> {
-        metrics::component_bytes_processed_total(&self.0.name)
+    async fn processed_bytes_total(&self) -> Option<metrics::ProcessedBytesTotal> {
+        metrics::component_processed_bytes_total(&self.0.name)
     }
 }
 
@@ -159,13 +159,13 @@ impl Transform {
     }
 
     /// Metric indicating events processed for the current transform
-    async fn events_processed_total(&self) -> Option<metrics::EventsProcessedTotal> {
-        metrics::component_events_processed_total(&self.0.name)
+    async fn processed_events_total(&self) -> Option<metrics::ProcessedEventsTotal> {
+        metrics::component_processed_events_total(&self.0.name)
     }
 
     /// Metric indicating bytes processed for the current transform
-    async fn bytes_processed_total(&self) -> Option<metrics::BytesProcessedTotal> {
-        metrics::component_bytes_processed_total(&self.0.name)
+    async fn processed_bytes_total(&self) -> Option<metrics::ProcessedBytesTotal> {
+        metrics::component_processed_bytes_total(&self.0.name)
     }
 }
 
@@ -222,13 +222,13 @@ impl Sink {
     }
 
     /// Metric indicating events processed for the current sink
-    async fn events_processed_total(&self) -> Option<metrics::EventsProcessedTotal> {
-        metrics::component_events_processed_total(&self.0.name)
+    async fn processed_events_total(&self) -> Option<metrics::ProcessedEventsTotal> {
+        metrics::component_processed_events_total(&self.0.name)
     }
 
     /// Metric indicating bytes processed for the current sink
-    async fn bytes_processed_total(&self) -> Option<metrics::BytesProcessedTotal> {
-        metrics::component_bytes_processed_total(&self.0.name)
+    async fn processed_bytes_total(&self) -> Option<metrics::ProcessedBytesTotal> {
+        metrics::component_processed_bytes_total(&self.0.name)
     }
 }
 #[derive(Default)]

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -70,7 +70,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Events processed metrics.
+    /// Event processing metrics.
     async fn processed_events_total(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -81,7 +81,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Events processed throughput, sampled over a provided millisecond `interval`.
+    /// Event processing throughput sampled over the provided millisecond `interval`.
     async fn processed_events_throughput(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -90,7 +90,7 @@ impl MetricsSubscription {
             .map(|(_, throughput)| throughput as i64)
     }
 
-    /// Component events processed throughputs over `interval`.
+    /// Component event processing throughput metrics over `interval`.
     async fn component_processed_events_throughputs(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -107,7 +107,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Component events processed metrics over `interval`.
+    /// Component event processing metrics over `interval`.
     async fn component_processed_events_totals(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -119,7 +119,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Bytes processed metrics.
+    /// Byte processing metrics.
     async fn processed_bytes_total(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -130,7 +130,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Bytes processed throughput, sampled over a provided millisecond `interval`.
+    /// Byte processing throughput sampled over a provided millisecond `interval`.
     async fn processed_bytes_throughput(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -139,7 +139,7 @@ impl MetricsSubscription {
             .map(|(_, throughput)| throughput as i64)
     }
 
-    /// Component bytes processed metrics, over `interval`.
+    /// Component byte processing metrics over `interval`.
     async fn component_processed_bytes_totals(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -151,7 +151,7 @@ impl MetricsSubscription {
         })
     }
 
-    /// Component bytes processed throughputs, over `interval`
+    /// Component byte processing throughput over `interval`
     async fn component_processed_bytes_throughputs(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -178,7 +178,7 @@ impl MetricsSubscription {
             .map(ErrorsTotal::new)
     }
 
-    /// Component errors metrics, over `interval`.
+    /// Component error metrics over `interval`.
     async fn component_errors_totals(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,

--- a/src/api/schema/metrics/processed_bytes.rs
+++ b/src/api/schema/metrics/processed_bytes.rs
@@ -2,23 +2,23 @@ use crate::event::{Metric, MetricValue};
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 
-pub struct EventsProcessedTotal(Metric);
+pub struct ProcessedBytesTotal(Metric);
 
-impl EventsProcessedTotal {
+impl ProcessedBytesTotal {
     pub fn new(m: Metric) -> Self {
         Self(m)
     }
 }
 
 #[Object]
-impl EventsProcessedTotal {
+impl ProcessedBytesTotal {
     /// Metric timestamp
     pub async fn timestamp(&self) -> Option<DateTime<Utc>> {
         self.0.timestamp
     }
 
-    /// Total number of events processed
-    pub async fn events_processed_total(&self) -> f64 {
+    /// Total number of bytes processed
+    pub async fn processed_bytes_total(&self) -> f64 {
         match self.0.value {
             MetricValue::Counter { value } => value,
             _ => 0.00,
@@ -26,19 +26,19 @@ impl EventsProcessedTotal {
     }
 }
 
-impl From<Metric> for EventsProcessedTotal {
+impl From<Metric> for ProcessedBytesTotal {
     fn from(m: Metric) -> Self {
         Self(m)
     }
 }
 
-pub struct ComponentEventsProcessedTotal {
+pub struct ComponentProcessedBytesTotal {
     name: String,
     metric: Metric,
 }
 
-impl ComponentEventsProcessedTotal {
-    /// Returns a new `ComponentEventsProcessedTotal` struct, which is a GraphQL type. The
+impl ComponentProcessedBytesTotal {
+    /// Returns a new `ComponentProcessedBytesTotal` struct, which is a GraphQL type. The
     /// component name is hoisted for clear field resolution in the resulting payload
     pub fn new(metric: Metric) -> Self {
         let name = metric.tag_value("component_name").expect(
@@ -50,38 +50,38 @@ impl ComponentEventsProcessedTotal {
 }
 
 #[Object]
-impl ComponentEventsProcessedTotal {
+impl ComponentProcessedBytesTotal {
     /// Component name
     async fn name(&self) -> &str {
         &self.name
     }
 
-    /// Events processed total metric
-    async fn metric(&self) -> EventsProcessedTotal {
-        EventsProcessedTotal::new(self.metric.clone())
+    /// Bytes processed total metric
+    async fn metric(&self) -> ProcessedBytesTotal {
+        ProcessedBytesTotal::new(self.metric.clone())
     }
 }
 
-pub struct ComponentEventsProcessedThroughput {
+pub struct ComponentProcessedBytesThroughput {
     name: String,
     throughput: i64,
 }
 
-impl ComponentEventsProcessedThroughput {
-    /// Returns a new `ComponentEventsProcessedThroughput`, set to the provided name/throughput values
+impl ComponentProcessedBytesThroughput {
+    /// Returns a new `ComponentProcessedBytesThroughput`, set to the provided name/throughput values
     pub fn new(name: String, throughput: i64) -> Self {
         Self { name, throughput }
     }
 }
 
 #[Object]
-impl ComponentEventsProcessedThroughput {
+impl ComponentProcessedBytesThroughput {
     /// Component name
     async fn name(&self) -> &str {
         &self.name
     }
 
-    /// Events processed throughput
+    /// Bytes processed throughput
     async fn throughput(&self) -> i64 {
         self.throughput
     }

--- a/src/api/schema/metrics/processed_events.rs
+++ b/src/api/schema/metrics/processed_events.rs
@@ -2,23 +2,23 @@ use crate::event::{Metric, MetricValue};
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 
-pub struct BytesProcessedTotal(Metric);
+pub struct ProcessedEventsTotal(Metric);
 
-impl BytesProcessedTotal {
+impl ProcessedEventsTotal {
     pub fn new(m: Metric) -> Self {
         Self(m)
     }
 }
 
 #[Object]
-impl BytesProcessedTotal {
+impl ProcessedEventsTotal {
     /// Metric timestamp
     pub async fn timestamp(&self) -> Option<DateTime<Utc>> {
         self.0.timestamp
     }
 
-    /// Total number of bytes processed
-    pub async fn bytes_processed_total(&self) -> f64 {
+    /// Total number of events processed
+    pub async fn processed_events_total(&self) -> f64 {
         match self.0.value {
             MetricValue::Counter { value } => value,
             _ => 0.00,
@@ -26,19 +26,19 @@ impl BytesProcessedTotal {
     }
 }
 
-impl From<Metric> for BytesProcessedTotal {
+impl From<Metric> for ProcessedEventsTotal {
     fn from(m: Metric) -> Self {
         Self(m)
     }
 }
 
-pub struct ComponentBytesProcessedTotal {
+pub struct ComponentProcessedEventsTotal {
     name: String,
     metric: Metric,
 }
 
-impl ComponentBytesProcessedTotal {
-    /// Returns a new `ComponentBytesProcessedTotal` struct, which is a GraphQL type. The
+impl ComponentProcessedEventsTotal {
+    /// Returns a new `ComponentProcessedEventsTotal` struct, which is a GraphQL type. The
     /// component name is hoisted for clear field resolution in the resulting payload
     pub fn new(metric: Metric) -> Self {
         let name = metric.tag_value("component_name").expect(
@@ -50,38 +50,38 @@ impl ComponentBytesProcessedTotal {
 }
 
 #[Object]
-impl ComponentBytesProcessedTotal {
+impl ComponentProcessedEventsTotal {
     /// Component name
     async fn name(&self) -> &str {
         &self.name
     }
 
-    /// Bytes processed total metric
-    async fn metric(&self) -> BytesProcessedTotal {
-        BytesProcessedTotal::new(self.metric.clone())
+    /// Events processed total metric
+    async fn metric(&self) -> ProcessedEventsTotal {
+        ProcessedEventsTotal::new(self.metric.clone())
     }
 }
 
-pub struct ComponentBytesProcessedThroughput {
+pub struct ComponentProcessedEventsThroughput {
     name: String,
     throughput: i64,
 }
 
-impl ComponentBytesProcessedThroughput {
-    /// Returns a new `ComponentBytesProcessedThroughput`, set to the provided name/throughput values
+impl ComponentProcessedEventsThroughput {
+    /// Returns a new `ComponentProcessedEventsThroughput`, set to the provided name/throughput values
     pub fn new(name: String, throughput: i64) -> Self {
         Self { name, throughput }
     }
 }
 
 #[Object]
-impl ComponentBytesProcessedThroughput {
+impl ComponentProcessedEventsThroughput {
     /// Component name
     async fn name(&self) -> &str {
         &self.name
     }
 
-    /// Bytes processed throughput
+    /// Events processed throughput
     async fn throughput(&self) -> i64 {
         self.throughput
     }

--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -6,7 +6,7 @@ pub struct AddFieldsEventProcessed;
 
 impl InternalEvent for AddFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -6,7 +6,7 @@ pub struct AddTagsEventProcessed;
 
 impl InternalEvent for AddTagsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -6,7 +6,7 @@ pub struct ANSIStripperEventProcessed;
 
 impl InternalEvent for ANSIStripperEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -15,7 +15,7 @@ impl InternalEvent for ApacheMetricsEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/aws_ec2_metadata.rs
+++ b/src/internal_events/aws_ec2_metadata.rs
@@ -10,7 +10,7 @@ impl InternalEvent for AwsEc2MetadataEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -15,7 +15,7 @@ impl InternalEvent for AwsEcsMetricsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -8,7 +8,7 @@ pub struct AwsKinesisStreamsEventSent {
 
 impl InternalEvent for AwsKinesisStreamsEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -13,8 +13,8 @@ impl InternalEvent for AwsSqsEventSent<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
-        counter!("bytes_processed_total", self.byte_size as u64);
+        counter!("processed_events_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
 

--- a/src/internal_events/blackhole.rs
+++ b/src/internal_events/blackhole.rs
@@ -8,7 +8,7 @@ pub struct BlackholeEventReceived {
 
 impl InternalEvent for BlackholeEventReceived {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -6,7 +6,7 @@ pub struct CoercerEventProcessed;
 
 impl InternalEvent for CoercerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/concat.rs
+++ b/src/internal_events/concat.rs
@@ -6,7 +6,7 @@ pub struct ConcatEventProcessed;
 
 impl InternalEvent for ConcatEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -8,7 +8,7 @@ pub struct ConsoleEventProcessed {
 
 impl InternalEvent for ConsoleEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -6,7 +6,7 @@ pub(crate) struct DedupeEventProcessed;
 
 impl InternalEvent for DedupeEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -19,7 +19,7 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
@@ -40,7 +40,7 @@ impl<'a> InternalEvent for DockerLogsContainerEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("container_events_processed_total", 1);
+        counter!("container_processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -13,7 +13,7 @@ impl InternalEvent for ElasticSearchEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -39,7 +39,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "events_processed_total", 1,
+                "processed_events_total", 1,
                 "file" => self.file.to_owned(),
             );
             counter!(

--- a/src/internal_events/generator.rs
+++ b/src/internal_events/generator.rs
@@ -10,6 +10,6 @@ impl InternalEvent for GeneratorEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }

--- a/src/internal_events/geoip.rs
+++ b/src/internal_events/geoip.rs
@@ -6,7 +6,7 @@ pub struct GeoipEventProcessed;
 
 impl InternalEvent for GeoipEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for GrokParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/host_metrics.rs
+++ b/src/internal_events/host_metrics.rs
@@ -12,6 +12,6 @@ impl InternalEvent for HostMetricsEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("processed_events_total", self.count as u64);
     }
 }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -17,7 +17,7 @@ impl InternalEvent for HTTPEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.events_count as u64);
+        counter!("processed_events_total", self.events_count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -12,7 +12,7 @@ impl InternalEvent for JournaldEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -11,7 +11,7 @@ impl InternalEvent for JsonParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -12,7 +12,7 @@ impl InternalEvent for KafkaEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/key_value_parser.rs
+++ b/src/internal_events/key_value_parser.rs
@@ -6,7 +6,7 @@ pub(crate) struct KeyValueEventProcessed;
 
 impl InternalEvent for KeyValueEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1,
+        counter!("processed_events_total", 1,
             "component_kind" => "transform",
             "component_type" => "key_value",
         );

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -18,7 +18,7 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -10,7 +10,7 @@ impl InternalEvent for LogToMetricEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/logfmt_parser.rs
+++ b/src/internal_events/logfmt_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for LogfmtParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -6,7 +6,7 @@ pub struct LuaEventProcessed;
 
 impl InternalEvent for LuaEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -11,7 +11,7 @@ impl InternalEvent for MetricToLogEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -13,7 +13,7 @@ impl InternalEvent for NatsEventSendSuccess {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -16,7 +16,7 @@ impl InternalEvent for PrometheusEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/reduce.rs
+++ b/src/internal_events/reduce.rs
@@ -6,7 +6,7 @@ pub(crate) struct ReduceEventProcessed;
 
 impl InternalEvent for ReduceEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -10,7 +10,7 @@ impl InternalEvent for RegexParserEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -6,7 +6,7 @@ pub struct RemapEventProcessed;
 
 impl InternalEvent for RemapEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/remove_fields.rs
+++ b/src/internal_events/remove_fields.rs
@@ -6,7 +6,7 @@ pub struct RemoveFieldsEventProcessed;
 
 impl InternalEvent for RemoveFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/remove_tags.rs
+++ b/src/internal_events/remove_tags.rs
@@ -6,6 +6,6 @@ pub struct RemoveTagsEventProcessed;
 
 impl InternalEvent for RemoveTagsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }

--- a/src/internal_events/rename_fields.rs
+++ b/src/internal_events/rename_fields.rs
@@ -6,7 +6,7 @@ pub struct RenameFieldsEventProcessed;
 
 impl InternalEvent for RenameFieldsEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/sampler.rs
+++ b/src/internal_events/sampler.rs
@@ -6,7 +6,7 @@ pub struct SamplerEventProcessed;
 
 impl InternalEvent for SamplerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -30,7 +30,7 @@ impl InternalEvent for SocketEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1, "mode" => self.mode.as_str());
+        counter!("processed_events_total", 1, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }
@@ -48,7 +48,7 @@ impl InternalEvent for SocketEventsSent {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count, "mode" => self.mode.as_str());
+        counter!("processed_events_total", self.count, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -6,7 +6,7 @@ pub struct SplitEventProcessed;
 
 impl InternalEvent for SplitEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -12,7 +12,7 @@ pub(crate) struct SplunkEventSent {
 
 impl InternalEvent for SplunkEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
@@ -89,7 +89,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("events_processed_total", 1);
+            counter!("processed_events_total", 1);
         }
     }
 

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -12,7 +12,7 @@ impl InternalEvent for StatsdEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1,);
+        counter!("processed_events_total", 1,);
         counter!("processed_bytes_total", self.byte_size as u64,);
     }
 }

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -12,7 +12,7 @@ impl InternalEvent for StdinEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/swimlanes.rs
+++ b/src/internal_events/swimlanes.rs
@@ -6,7 +6,7 @@ pub struct SwimlanesEventProcessed;
 
 impl InternalEvent for SwimlanesEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -12,7 +12,7 @@ impl InternalEvent for SyslogEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -9,7 +9,7 @@ impl InternalEvent for TagCardinalityLimitEventProcessed {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -6,7 +6,7 @@ pub(crate) struct TokenizerEventProcessed;
 
 impl InternalEvent for TokenizerEventProcessed {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
     }
 }
 

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -9,7 +9,7 @@ pub struct VectorEventSent {
 
 impl InternalEvent for VectorEventSent {
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
@@ -25,7 +25,7 @@ impl InternalEvent for VectorEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", 1);
+        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/wasm/event_processing.rs
+++ b/src/internal_events/wasm/event_processing.rs
@@ -71,7 +71,7 @@ impl InternalEvent for EventProcessingProgress {
             "state" => self.state.as_const_str(),
         );
         match self.state {
-            State::Completed => counter!("events_processed_total", 1,
+            State::Completed => counter!("processed_events_total", 1,
                 "component_role" => self.role.as_const_str(),
             ),
             State::Errored => counter!("processing_errors_total", 1,

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -139,18 +139,18 @@ impl<'a> Widgets<'a> {
             // Build metric stats
             let formatted_metrics = if self.opts.human_metrics {
                 [
-                    r.events_processed_total.human_format(),
-                    r.events_processed_throughput.human_format(),
-                    r.bytes_processed_total.human_format_bytes(),
-                    r.bytes_processed_throughput.human_format_bytes(),
+                    r.processed_events_total.human_format(),
+                    r.processed_events_throughput.human_format(),
+                    r.processed_bytes_total.human_format_bytes(),
+                    r.processed_bytes_throughput.human_format_bytes(),
                     r.errors.human_format(),
                 ]
             } else {
                 [
-                    r.events_processed_total.thousands_format(),
-                    r.events_processed_throughput.thousands_format(),
-                    r.bytes_processed_total.thousands_format(),
-                    r.bytes_processed_throughput.thousands_format(),
+                    r.processed_events_total.thousands_format(),
+                    r.processed_events_throughput.thousands_format(),
+                    r.processed_bytes_total.thousands_format(),
+                    r.processed_bytes_throughput.thousands_format(),
                     r.errors.thousands_format(),
                 ]
             };

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -5,10 +5,10 @@ type NamedMetric = (String, i64);
 
 #[derive(Debug)]
 pub enum EventType {
-    EventsProcessedTotals(Vec<NamedMetric>),
-    EventsProcessedThroughputs(Vec<NamedMetric>),
-    BytesProcessedTotals(Vec<NamedMetric>),
-    BytesProcessedThroughputs(Vec<NamedMetric>),
+    ProcessedEventsTotals(Vec<NamedMetric>),
+    ProcessedEventsThroughputs(Vec<NamedMetric>),
+    ProcessedBytesTotals(Vec<NamedMetric>),
+    ProcessedBytesThroughputs(Vec<NamedMetric>),
     ComponentAdded(ComponentRow),
     ComponentRemoved(String),
 }
@@ -23,10 +23,10 @@ pub struct ComponentRow {
     pub name: String,
     pub kind: String,
     pub component_type: String,
-    pub events_processed_total: i64,
-    pub events_processed_throughput: i64,
-    pub bytes_processed_total: i64,
-    pub bytes_processed_throughput: i64,
+    pub processed_events_total: i64,
+    pub processed_events_throughput: i64,
+    pub processed_bytes_total: i64,
+    pub processed_bytes_throughput: i64,
     pub errors: i64,
 }
 
@@ -43,31 +43,31 @@ pub async fn updater(mut state: State, mut event_rx: EventRx) -> StateRx {
         loop {
             if let Some(event_type) = event_rx.recv().await {
                 match event_type {
-                    EventType::EventsProcessedTotals(rows) => {
+                    EventType::ProcessedEventsTotals(rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.events_processed_total = v;
+                                r.processed_events_total = v;
                             }
                         }
                     }
-                    EventType::EventsProcessedThroughputs(rows) => {
+                    EventType::ProcessedEventsThroughputs(rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.events_processed_throughput = v;
+                                r.processed_events_throughput = v;
                             }
                         }
                     }
-                    EventType::BytesProcessedTotals(rows) => {
+                    EventType::ProcessedBytesTotals(rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.bytes_processed_total = v;
+                                r.processed_bytes_total = v;
                             }
                         }
                     }
-                    EventType::BytesProcessedThroughputs(rows) => {
+                    EventType::ProcessedBytesThroughputs(rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.bytes_processed_throughput = v;
+                                r.processed_bytes_throughput = v;
                             }
                         }
                     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -194,7 +194,7 @@ mod tests {
         )
     }
 
-    async fn new_events_processed_total_subscription(
+    async fn new_processed_events_total_subscription(
         client: &SubscriptionClient,
         num_results: usize,
         interval: i64,
@@ -202,24 +202,24 @@ mod tests {
         // Emit events for the duration of the test
         let _shutdown = emit_fake_generator_events();
 
-        let subscription = client.events_processed_total_subscription(interval);
+        let subscription = client.processed_events_total_subscription(interval);
 
         tokio::pin! {
-            let events_processed_total = subscription.stream().take(num_results);
+            let processed_events_total = subscription.stream().take(num_results);
         }
 
         let mut last_result = 0.0;
 
         for _ in 0..num_results {
-            let ep = events_processed_total
+            let ep = processed_events_total
                 .next()
                 .await
                 .unwrap()
                 .unwrap()
                 .data
                 .unwrap()
-                .events_processed_total
-                .events_processed_total;
+                .processed_events_total
+                .processed_events_total;
 
             assert!(ep > last_result);
             last_result = ep
@@ -311,7 +311,7 @@ mod tests {
 
         let _metrics = init_metrics();
 
-        new_events_processed_total_subscription(&client, 3, 100).await;
+        new_processed_events_total_subscription(&client, 3, 100).await;
     }
 
     #[tokio::test]
@@ -331,9 +331,9 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)]
     #[ignore]
-    /// Tests componentEventsProcessedTotals returns increasing metrics, ordered by
+    /// Tests componentProcessedEventsTotals returns increasing metrics, ordered by
     /// source -> transform -> sink
-    async fn api_graphql_component_events_processed_totals() {
+    async fn api_graphql_component_processed_events_totals() {
         init_metrics();
 
         let topology = from_str_config(
@@ -341,15 +341,15 @@ mod tests {
             [api]
               enabled = true
 
-            [sources.events_processed_total_batch_source]
+            [sources.processed_events_total_batch_source]
               type = "generator"
               lines = ["Random line", "And another"]
               batch_interval = 0.1
 
-            [sinks.events_processed_total_batch_sink]
+            [sinks.processed_events_total_batch_sink]
               # General
               type = "blackhole"
-              inputs = ["events_processed_total_batch_source"]
+              inputs = ["processed_events_total_batch_source"]
               print_amount = 100000
         "#,
         )
@@ -357,7 +357,7 @@ mod tests {
 
         let server = api::Server::start(topology.config());
         let client = new_subscription_client(server.addr()).await;
-        let subscription = client.component_events_processed_totals_subscription(500);
+        let subscription = client.component_processed_events_totals_subscription(500);
 
         tokio::pin! {
             let stream = subscription.stream();
@@ -370,23 +370,23 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .component_events_processed_totals;
+            .component_processed_events_totals;
 
-        assert_eq!(data[0].name, "events_processed_total_batch_source");
-        assert_eq!(data[1].name, "events_processed_total_batch_sink");
+        assert_eq!(data[0].name, "processed_events_total_batch_source");
+        assert_eq!(data[1].name, "processed_events_total_batch_sink");
 
         assert_eq!(
-            data[0].metric.events_processed_total,
-            data[1].metric.events_processed_total
+            data[0].metric.processed_events_total,
+            data[1].metric.processed_events_total
         );
     }
 
     #[tokio::test]
     #[allow(clippy::float_cmp)]
     #[ignore]
-    /// Tests componentBytesProcessedTotals returns increasing metrics, ordered by
+    /// Tests componentProcessedBytesTotals returns increasing metrics, ordered by
     /// source -> transform -> sink
-    async fn api_graphql_component_bytes_processed_totals() {
+    async fn api_graphql_component_processed_bytes_totals() {
         init_metrics();
 
         let topology = from_str_config(
@@ -394,15 +394,15 @@ mod tests {
             [api]
               enabled = true
 
-            [sources.bytes_processed_total_batch_source]
+            [sources.processed_bytes_total_batch_source]
               type = "generator"
               lines = ["Random line", "And another"]
               batch_interval = 0.1
 
-            [sinks.bytes_processed_total_batch_sink]
+            [sinks.processed_bytes_total_batch_sink]
               # General
               type = "blackhole"
-              inputs = ["bytes_processed_total_batch_source"]
+              inputs = ["processed_bytes_total_batch_source"]
               print_amount = 100000
         "#,
         )
@@ -410,7 +410,7 @@ mod tests {
 
         let server = api::Server::start(topology.config());
         let client = new_subscription_client(server.addr()).await;
-        let subscription = client.component_bytes_processed_totals_subscription(500);
+        let subscription = client.component_processed_bytes_totals_subscription(500);
 
         tokio::pin! {
             let stream = subscription.stream();
@@ -423,11 +423,11 @@ mod tests {
             .unwrap()
             .data
             .unwrap()
-            .component_bytes_processed_totals;
+            .component_processed_bytes_totals;
 
         // Bytes are currently only relevant on sinks
-        assert_eq!(data[0].name, "bytes_processed_total_batch_sink");
-        assert!(data[0].metric.bytes_processed_total > 0.00);
+        assert_eq!(data[0].name, "processed_bytes_total_batch_sink");
+        assert!(data[0].metric.processed_bytes_total > 0.00);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR updates the metric names exposed via the GraphQL API to be in line with their Prometheus equivalents (and consistent with [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/)):

* `bytesProcessedTotal` => `processedBytesTotal` (in line with `processed_bytes_total`)
* `eventsProcessedTotal` => `processedEventsTotal` (in line with `processed_events_total`)

I also took the liberty of updating underlying code and filenames to reflect this, although that may have been overreach. If so, I'm happy to revert and change only user-facing names.