### PR TITLE
enhancement(file source): expire checkpoints

### DIFF
--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -76,7 +76,7 @@ impl CheckpointsView {
                 let duration = now - *ts;
                 duration >= chrono::Duration::seconds(60)
             })
-            .map(|entry| entry.key().clone())
+            .map(|entry| *entry.key())
             .collect::<Vec<FileFingerprint>>();
 
         for fng in to_remove {

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -45,16 +45,45 @@ pub struct Checkpointer {
 pub struct CheckpointsView {
     checkpoints: DashMap<FileFingerprint, FilePosition>,
     modified_times: DashMap<FileFingerprint, DateTime<Utc>>,
+    removed_times: DashMap<FileFingerprint, DateTime<Utc>>,
 }
 
 impl CheckpointsView {
     pub fn update(&self, fng: FileFingerprint, pos: FilePosition) {
         self.checkpoints.insert(fng, pos);
         self.modified_times.insert(fng, Utc::now());
+        self.removed_times.remove(&fng);
     }
 
     pub fn get(&self, fng: FileFingerprint) -> Option<FilePosition> {
         self.checkpoints.get(&fng).map(|r| *r.value())
+    }
+
+    pub fn set_dead(&self, fng: FileFingerprint) {
+        self.removed_times.insert(fng, Utc::now());
+    }
+
+    pub fn remove_expired(&self) {
+        let now = Utc::now();
+
+        // Collect all of the expired keys. Removing them while iterating can lead to deadlocks,
+        // the set should be small, and this is not a performance-sensitive path.
+        let to_remove = self
+            .removed_times
+            .iter()
+            .filter(|entry| {
+                let ts = entry.value();
+                let duration = now - *ts;
+                duration >= chrono::Duration::seconds(60)
+            })
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<FileFingerprint>>();
+
+        for fng in to_remove {
+            self.checkpoints.remove(&fng);
+            self.modified_times.remove(&fng);
+            self.removed_times.remove(&fng);
+        }
     }
 
     fn load(&self, checkpoint: Checkpoint) {
@@ -202,7 +231,12 @@ impl Checkpointer {
     /// Persist the current checkpoints state to disk, making our best effort to do so in an atomic
     /// way that allow for recovering the previous state in the event of a crash.
     pub fn write_checkpoints(&self) -> Result<usize, io::Error> {
-        // First write the new checkpoints to a tmp file and flush it fully to disk. If vector
+        // First drop any checkpoints for files that were removed more than 60 seconds ago. This
+        // keeps our working set as small as possible and makes sure we don't spend time and IO
+        // writing checkpoints that don't matter anymore.
+        self.checkpoints.remove_expired();
+
+        // Write the new checkpoints to a tmp file and flush it fully to disk. If vector
         // dies anywhere during this section, the existing stable file will still be in its current
         // valid state and we'll be able to recover.
         let mut f = io::BufWriter::new(fs::File::create(&self.tmp_file_path)?);
@@ -338,7 +372,7 @@ mod test {
     }
 
     #[test]
-    fn test_checkpointer_expiration() {
+    fn test_checkpointer_ignore_before() {
         let newer = (
             FileFingerprint::DevInode(1, 2),
             Utc::now() - Duration::seconds(5),
@@ -479,5 +513,42 @@ mod test {
             chkptr.read_checkpoints(None);
             assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
         }
+    }
+
+    #[test]
+    fn test_checkpointer_expiration() {
+        let cases = vec![
+            // (checkpoint, position, seconds since removed)
+            (FileFingerprint::Checksum(123), 0, 30),
+            (FileFingerprint::Checksum(456), 1, 60),
+            (FileFingerprint::Checksum(789), 2, 90),
+            (FileFingerprint::Checksum(101112), 3, 120),
+        ];
+
+        let data_dir = tempdir().unwrap();
+        let mut chkptr = Checkpointer::new(&data_dir.path());
+
+        for (fingerprint, position, removed) in cases.clone() {
+            chkptr.update_checkpoint(fingerprint, position);
+
+            // slide these in manually so we don't have to sleep for a long time
+            chkptr
+                .checkpoints
+                .removed_times
+                .insert(fingerprint, Utc::now() - chrono::Duration::seconds(removed));
+
+            assert_eq!(chkptr.get_checkpoint(fingerprint), Some(position));
+        }
+
+        // Update one that would otherwise be expired to ensure it sticks around
+        chkptr.update_checkpoint(cases[2].0, 42);
+
+        // Expiration is piggybacked on the persistence interval, so do a write to trigger it
+        chkptr.write_checkpoints().unwrap();
+
+        assert_eq!(chkptr.get_checkpoint(cases[0].0), Some(0));
+        assert_eq!(chkptr.get_checkpoint(cases[1].0), None);
+        assert_eq!(chkptr.get_checkpoint(cases[2].0), Some(42));
+        assert_eq!(chkptr.get_checkpoint(cases[3].0), None);
     }
 }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -299,7 +299,6 @@ where
                                 Ok(()) => {
                                     self.emitter.emit_file_deleted(&watcher.path);
                                     watcher.set_dead();
-                                    checkpoints.set_dead(file_id);
                                 }
                                 Err(error) => {
                                     // We will try again after some time.

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -148,11 +148,11 @@ where
                 let emitter = emitter.clone();
                 let checkpointer = Arc::clone(&checkpointer);
                 tokio::task::spawn_blocking(move || {
-                    checkpointer
-                        .write_checkpoints()
-                        .map_err(|error| emitter.emit_file_checkpoint_write_failed(error))
-                        .map(|count| emitter.emit_file_checkpointed(count))
-                        .ok()
+                    let start = time::Instant::now();
+                    match checkpointer.write_checkpoints() {
+                        Ok(count) => emitter.emit_file_checkpointed(count, start.elapsed()),
+                        Err(error) => emitter.emit_file_checkpoint_write_failed(error),
+                    }
                 })
                 .await
                 .ok();
@@ -299,6 +299,7 @@ where
                                 Ok(()) => {
                                     self.emitter.emit_file_deleted(&watcher.path);
                                     watcher.set_dead();
+                                    checkpoints.set_dead(file_id);
                                 }
                                 Err(error) => {
                                     // We will try again after some time.
@@ -317,9 +318,10 @@ where
 
             // A FileWatcher is dead when the underlying file has disappeared.
             // If the FileWatcher is dead we don't retain it; it will be deallocated.
-            fp_map.retain(|_file_id, watcher| {
+            fp_map.retain(|file_id, watcher| {
                 if watcher.dead() {
                     self.emitter.emit_file_unwatched(&watcher.path);
+                    checkpoints.set_dead(*file_id);
                     false
                 } else {
                     true

--- a/lib/file-source/src/internal_events.rs
+++ b/lib/file-source/src/internal_events.rs
@@ -1,5 +1,4 @@
-use std::io::Error;
-use std::path::Path;
+use std::{io::Error, path::Path, time::Duration};
 
 /// Every internal event in this crate has a corresponding
 /// method in this trait which should emit the event.
@@ -18,7 +17,7 @@ pub trait FileSourceInternalEvents: Send + Sync + Clone + 'static {
 
     fn emit_file_fingerprint_read_failed(&self, path: &Path, error: Error);
 
-    fn emit_file_checkpointed(&self, count: usize);
+    fn emit_file_checkpointed(&self, count: usize, duration: Duration);
 
     fn emit_file_checksum_failed(&self, path: &Path);
 

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -20,8 +20,7 @@ mod source {
     use super::{FileOpen, InternalEvent};
     use file_source::FileSourceInternalEvents;
     use metrics::counter;
-    use std::io::Error;
-    use std::path::Path;
+    use std::{io::Error, path::Path, time::Duration};
 
     #[derive(Debug)]
     pub struct FileEventReceived<'a> {
@@ -230,11 +229,16 @@ mod source {
     #[derive(Debug)]
     pub struct FileCheckpointed {
         pub count: usize,
+        pub duration: Duration,
     }
 
     impl InternalEvent for FileCheckpointed {
         fn emit_logs(&self) {
-            debug!(message = "Files checkpointed.", count = %self.count);
+            debug!(
+                message = "Files checkpointed.",
+                count = %self.count,
+                duration_ms = self.duration.as_millis() as u64,
+            );
         }
 
         fn emit_metrics(&self) {
@@ -296,8 +300,8 @@ mod source {
             emit!(FileChecksumFailed { path });
         }
 
-        fn emit_file_checkpointed(&self, count: usize) {
-            emit!(FileCheckpointed { count });
+        fn emit_file_checkpointed(&self, count: usize, duration: Duration) {
+            emit!(FileCheckpointed { count, duration });
         }
 
         fn emit_file_checkpoint_write_failed(&self, error: Error) {


### PR DESCRIPTION
Closes #5137

This clears out old checkpoints before writing to disk and adds some instrumentation around write timing. Checkpoints are considered old when the file they refer to was deleted more than 60 seconds ago, and any updates after "removal" will cancel the expiration.