### PR TITLE
chore(performance): Disable jemallocator background threads on OSX

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -176,6 +176,8 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
+      - run: uname -s
+      - run: uname
       - run: make test
       - run: make test-behavior
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ headers = "0.3"
 rdkafka = { version = "0.24.0", features = ["libz", "ssl", "zstd"], optional = true }
 hostname = "0.3.1"
 seahash = { version = "3.0.6", optional = true }
-jemallocator = { version = "0.3.2", optional = true, features = ["background_threads"] }
+jemallocator = { version = "0.3.2", optional = true }
 semver = { version = "0.11.0", features = ["serde"] }
 lazy_static = "1.3.0"
 rlua = { git = "https://github.com/kyren/rlua", optional = true }
@@ -235,6 +235,7 @@ reqwest = { version = "0.10.6", features = ["json"] }
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
+default-macos = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "macos", "leveldb", "rdkafka-plain"]
 default-musl = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-cmake"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-cmake"]
@@ -254,8 +255,10 @@ target-aarch64-unknown-linux-musl = ["api", "api-client", "sources", "transforms
 target-armv7-unknown-linux-musleabihf = ["api", "api-client", "sources", "transforms", "sinks", "vendor-openssl", "vendor-libz", "rdkafka-cmake"]
 target-armv7-unknown-linux-gnueabihf = ["api", "api-client", "sources", "transforms", "sinks", "vendor-openssl", "vendor-libz", "unix", "leveldb", "rdkafka-cmake"]
 
-# Enables features that work only on systems providing `cfg(unix)`
-unix = ["jemallocator"]
+# Enables features that work only on systems providing `cfg(target_os = "macos")`
+macos = ["jemallocator-plain"]
+# Enables features that work only on systems providing `cfg(target_os = "linux")`
+unix = ["jemallocator-background_threads"]
 # These are **very** useful on Cross compilations!
 vendor-all = ["vendor-sasl", "vendor-openssl", "vendor-libz"]
 vendor-sasl = ["rdkafka/gssapi-vendored"]
@@ -270,6 +273,10 @@ rdkafka-plain = ["rdkafka"]
 rdkafka-cmake = ["rdkafka", "rdkafka/cmake_build"]
 # This feature enables the WASM foreign module support.
 wasm = ["lucetc", "lucet-runtime", "lucet-wasi", "vector-wasm"]
+# OSX doesn't support background-threads
+# https://github.com/jemalloc/jemalloc/issues/843
+jemallocator-plain = ["jemallocator"]
+jemallocator-background_threads = ["jemallocator", "jemallocator/background_threads"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@
 # Begin OS detection
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
     export OPERATING_SYSTEM := Windows
-	export RUST_TARGET ?= "x86_64-unknown-windows-msvc"
     export DEFAULT_FEATURES = default-msvc
 else
-    export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
-	export RUST_TARGET ?= "x86_64-unknown-linux-gnu"
+  export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
+  ifeq ($(UNAME_S),Darwin)
+    export DEFAULT_FEATURES = default-macos
+  else
     export DEFAULT_FEATURES = default
+  endif
 endif
 
 # Override this with any scopes for testing/benching.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
     export DEFAULT_FEATURES = default-msvc
 else
   export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
-  ifeq ($(UNAME_S),Darwin)
+  ifeq ($(OPERATING_SYSTEM),Darwin)
     export DEFAULT_FEATURES = default-macos
   else
     export DEFAULT_FEATURES = default

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@
 
 # Begin OS detection
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
-    export OPERATING_SYSTEM := Windows
     export DEFAULT_FEATURES = default-msvc
 else
-  export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
+  OPERATING_SYSTEM := $(shell uname -s)
   ifeq ($(OPERATING_SYSTEM),Darwin)
     export DEFAULT_FEATURES = default-macos
   else

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ test-aarch64-unknown-linux-gnu: cross-test-aarch64-unknown-linux-gnu ## Runs uni
 
 .PHONY: test-behavior
 test-behavior: ## Runs behaviorial test
-	${MAYBE_ENVIRONMENT_EXEC} cargo run -- test tests/behavior/**/*.toml
+	${MAYBE_ENVIRONMENT_EXEC} cargo run --no-default-features --features "${DEFAULT_FEATURES}" -- test tests/behavior/**/*.toml
 
 .PHONY: test-integration
 test-integration: ## Runs all integration tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ extern crate derivative;
 #[macro_use]
 extern crate pest_derive;
 
-#[cfg(feature = "jemallocator")]
+#[cfg(any(
+    feature = "jemallocator-plain",
+    feature = "jemallocator-background_threads"
+))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
These appear to be unsupported:
https://github.com/jemalloc/jemalloc/issues/843

Build failure: https://github.com/timberio/vector/runs/1428614738

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
