### PR TITLE
chore: update Source type to new futures

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -300,8 +300,7 @@ fn capitalize(s: &str) -> String {
 
 #[cfg(test)]
 mod test {
-    use super::Graph;
-    use crate::config::DataType;
+    use super::*;
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -96,7 +96,7 @@ impl SinkConfig for RemoteWriteConfig {
         Ok((sinks::VectorSink::Sink(Box::new(sink)), healthcheck))
     }
 
-    fn input_type(&self) -> crate::config::DataType {
+    fn input_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -143,119 +143,123 @@ fn apache_metrics(
     let out = out
         .sink_map_err(|error| error!(message = "Error sending metric.", %error))
         .sink_compat();
-    let task = tokio::time::interval(Duration::from_secs(interval))
-        .take_until(shutdown)
-        .map(move |_| stream::iter(urls.clone()))
-        .flatten()
-        .map(move |url| {
-            let client = HttpClient::new(None).expect("HTTPS initialization failed");
-            let sanitized_url = url.to_sanitized_string();
+    Box::pin(
+        tokio::time::interval(Duration::from_secs(interval))
+            .take_until(shutdown)
+            .map(move |_| stream::iter(urls.clone()))
+            .flatten()
+            .map(move |url| {
+                let client = HttpClient::new(None).expect("HTTPS initialization failed");
+                let sanitized_url = url.to_sanitized_string();
 
-            let request = Request::get(&url)
-                .body(Body::empty())
-                .expect("error creating request");
+                let request = Request::get(&url)
+                    .body(Body::empty())
+                    .expect("error creating request");
 
-            let mut tags: BTreeMap<String, String> = BTreeMap::new();
-            tags.insert("endpoint".into(), sanitized_url.to_string());
-            tags.insert("host".into(), url.sanitized_authority());
+                let mut tags: BTreeMap<String, String> = BTreeMap::new();
+                tags.insert("endpoint".into(), sanitized_url.to_string());
+                tags.insert("host".into(), url.sanitized_authority());
 
-            let start = Instant::now();
-            let namespace = namespace.clone();
-            client
-                .send(request)
-                .map_err(crate::Error::from)
-                .and_then(|response| async {
-                    let (header, body) = response.into_parts();
-                    let body = hyper::body::to_bytes(body).await?;
-                    Ok((header, body))
-                })
-                .into_stream()
-                .filter_map(move |response| {
-                    future::ready(match response {
-                        Ok((header, body)) if header.status == hyper::StatusCode::OK => {
-                            emit!(ApacheMetricsRequestCompleted {
-                                start,
-                                end: Instant::now()
-                            });
+                let start = Instant::now();
+                let namespace = namespace.clone();
+                client
+                    .send(request)
+                    .map_err(crate::Error::from)
+                    .and_then(|response| async {
+                        let (header, body) = response.into_parts();
+                        let body = hyper::body::to_bytes(body).await?;
+                        Ok((header, body))
+                    })
+                    .into_stream()
+                    .filter_map(move |response| {
+                        future::ready(match response {
+                            Ok((header, body)) if header.status == hyper::StatusCode::OK => {
+                                emit!(ApacheMetricsRequestCompleted {
+                                    start,
+                                    end: Instant::now()
+                                });
 
-                            let byte_size = body.len();
-                            let body = String::from_utf8_lossy(&body);
+                                let byte_size = body.len();
+                                let body = String::from_utf8_lossy(&body);
 
-                            let results =
-                                parser::parse(&body, namespace.as_deref(), Utc::now(), Some(&tags))
-                                    .chain(vec![Ok(Metric {
-                                        name: "up".into(),
-                                        namespace: namespace.clone(),
-                                        timestamp: Some(Utc::now()),
-                                        tags: Some(tags.clone()),
-                                        kind: MetricKind::Absolute,
-                                        value: MetricValue::Gauge { value: 1.0 },
-                                    })]);
-
-                            let metrics = results
-                                .filter_map(|res| match res {
-                                    Ok(metric) => Some(metric),
-                                    Err(e) => {
-                                        emit!(ApacheMetricsParseError {
-                                            error: e,
-                                            url: &sanitized_url,
-                                        });
-                                        None
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-
-                            emit!(ApacheMetricsEventReceived {
-                                byte_size,
-                                count: metrics.len(),
-                            });
-                            Some(stream::iter(metrics).map(Event::Metric).map(Ok))
-                        }
-                        Ok((header, _)) => {
-                            emit!(ApacheMetricsErrorResponse {
-                                code: header.status,
-                                url: &sanitized_url,
-                            });
-                            Some(
-                                stream::iter(vec![Metric {
+                                let results = parser::parse(
+                                    &body,
+                                    namespace.as_deref(),
+                                    Utc::now(),
+                                    Some(&tags),
+                                )
+                                .chain(vec![Ok(Metric {
                                     name: "up".into(),
                                     namespace: namespace.clone(),
                                     timestamp: Some(Utc::now()),
                                     tags: Some(tags.clone()),
                                     kind: MetricKind::Absolute,
                                     value: MetricValue::Gauge { value: 1.0 },
-                                }])
-                                .map(Event::Metric)
-                                .map(Ok),
-                            )
-                        }
-                        Err(error) => {
-                            emit!(ApacheMetricsHttpError {
-                                error,
-                                url: &sanitized_url
-                            });
-                            Some(
-                                stream::iter(vec![Metric {
-                                    name: "up".into(),
-                                    namespace: namespace.clone(),
-                                    timestamp: Some(Utc::now()),
-                                    tags: Some(tags.clone()),
-                                    kind: MetricKind::Absolute,
-                                    value: MetricValue::Gauge { value: 0.0 },
-                                }])
-                                .map(Event::Metric)
-                                .map(Ok),
-                            )
-                        }
-                    })
-                })
-                .flatten()
-        })
-        .flatten()
-        .forward(out)
-        .inspect(|_| info!("Finished sending."));
+                                })]);
 
-    Box::new(task.boxed().compat())
+                                let metrics = results
+                                    .filter_map(|res| match res {
+                                        Ok(metric) => Some(metric),
+                                        Err(e) => {
+                                            emit!(ApacheMetricsParseError {
+                                                error: e,
+                                                url: &sanitized_url,
+                                            });
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
+
+                                emit!(ApacheMetricsEventReceived {
+                                    byte_size,
+                                    count: metrics.len(),
+                                });
+                                Some(stream::iter(metrics).map(Event::Metric).map(Ok))
+                            }
+                            Ok((header, _)) => {
+                                emit!(ApacheMetricsErrorResponse {
+                                    code: header.status,
+                                    url: &sanitized_url,
+                                });
+                                Some(
+                                    stream::iter(vec![Metric {
+                                        name: "up".into(),
+                                        namespace: namespace.clone(),
+                                        timestamp: Some(Utc::now()),
+                                        tags: Some(tags.clone()),
+                                        kind: MetricKind::Absolute,
+                                        value: MetricValue::Gauge { value: 1.0 },
+                                    }])
+                                    .map(Event::Metric)
+                                    .map(Ok),
+                                )
+                            }
+                            Err(error) => {
+                                emit!(ApacheMetricsHttpError {
+                                    error,
+                                    url: &sanitized_url
+                                });
+                                Some(
+                                    stream::iter(vec![Metric {
+                                        name: "up".into(),
+                                        namespace: namespace.clone(),
+                                        timestamp: Some(Utc::now()),
+                                        tags: Some(tags.clone()),
+                                        kind: MetricKind::Absolute,
+                                        value: MetricValue::Gauge { value: 0.0 },
+                                    }])
+                                    .map(Event::Metric)
+                                    .map(Ok),
+                                )
+                            }
+                        })
+                    })
+                    .flatten()
+            })
+            .flatten()
+            .forward(out)
+            .inspect(|_| info!("Finished sending.")),
+    )
 }
 
 #[cfg(test)]
@@ -266,7 +270,6 @@ mod test {
         test_util::{collect_ready, next_addr, wait_for_tcp},
         Error,
     };
-    use futures::compat::Future01CompatExt;
     use hyper::{
         service::{make_service_fn, service_fn},
         {Body, Response, Server},
@@ -350,8 +353,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             tx,
         )
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         tokio::spawn(source);
 
         delay_for(Duration::from_secs(1)).await;
@@ -418,8 +420,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             tx,
         )
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         tokio::spawn(source);
 
         delay_for(Duration::from_secs(1)).await;
@@ -459,8 +460,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             tx,
         )
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         tokio::spawn(source);
 
         delay_for(Duration::from_secs(1)).await;

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -82,7 +82,7 @@ impl SourceConfig for ApacheMetricsConfig {
         ))
     }
 
-    fn output_type(&self) -> crate::config::DataType {
+    fn output_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     shutdown::ShutdownSignal,
     Event, Pipeline,
 };
-use futures::{compat::Future01CompatExt, FutureExt, StreamExt, TryFutureExt};
+use futures::{compat::Future01CompatExt, StreamExt};
 use futures01::Sink;
 use hyper::{Body, Client, Request};
 use serde::{Deserialize, Serialize};
@@ -104,17 +104,13 @@ impl SourceConfig for AwsEcsMetricsSourceConfig {
     ) -> crate::Result<super::Source> {
         let namespace = Some(self.namespace.clone()).filter(|namespace| !namespace.is_empty());
 
-        Ok(Box::new(
-            aws_ecs_metrics(
-                self.stats_endpoint(),
-                self.scrape_interval_secs,
-                namespace,
-                out,
-                shutdown,
-            )
-            .boxed()
-            .compat(),
-        ))
+        Ok(Box::pin(aws_ecs_metrics(
+            self.stats_endpoint(),
+            self.scrape_interval_secs,
+            namespace,
+            out,
+            shutdown,
+        )))
     }
 
     fn output_type(&self) -> crate::config::DataType {
@@ -545,8 +541,7 @@ mod test {
             tx,
         )
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         tokio::spawn(source);
 
         delay_for(Duration::from_secs(1)).await;
@@ -604,8 +599,7 @@ mod integration_tests {
             tx,
         )
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         tokio::spawn(source);
 
         delay_for(Duration::from_secs(5)).await;

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -113,7 +113,7 @@ impl SourceConfig for AwsEcsMetricsSourceConfig {
         )))
     }
 
-    fn output_type(&self) -> crate::config::DataType {
+    fn output_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -5,11 +5,7 @@ use crate::{
     shutdown::ShutdownSignal,
     Pipeline,
 };
-use futures::{
-    compat::Future01CompatExt,
-    future::{FutureExt, TryFutureExt},
-    stream::StreamExt,
-};
+use futures::{compat::Future01CompatExt, stream::StreamExt};
 use futures01::{stream::iter_ok, Sink};
 use serde::{Deserialize, Serialize};
 use std::task::Poll;
@@ -69,7 +65,7 @@ impl SourceConfig for GeneratorConfig {
 
 impl GeneratorConfig {
     pub(self) fn generator(self, shutdown: ShutdownSignal, out: Pipeline) -> super::Source {
-        Box::new(self.inner(shutdown, out).boxed().compat())
+        Box::pin(self.inner(shutdown, out))
     }
 
     async fn inner(self, mut shutdown: ShutdownSignal, mut out: Pipeline) -> Result<(), ()> {
@@ -116,7 +112,6 @@ impl GeneratorConfig {
 mod tests {
     use super::*;
     use crate::{config::log_schema, shutdown::ShutdownSignal, Pipeline};
-    use futures::compat::Future01CompatExt;
     use futures01::{stream::Stream, sync::mpsc, Async::*};
     use std::time::{Duration, Instant};
 
@@ -128,11 +123,7 @@ mod tests {
     async fn runit(config: &str) -> mpsc::Receiver<Event> {
         let (tx, rx) = Pipeline::new_test();
         let config: GeneratorConfig = toml::from_str(config).unwrap();
-        config
-            .generator(ShutdownSignal::noop(), tx)
-            .compat()
-            .await
-            .unwrap();
+        config.generator(ShutdownSignal::noop(), tx).await.unwrap();
         rx
     }
 

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -11,7 +11,6 @@ use crate::{
 use chrono::{DateTime, Utc};
 use futures::{
     compat::Future01CompatExt,
-    future::{FutureExt, TryFutureExt},
     stream::{self, StreamExt},
 };
 use futures01::Sink;
@@ -131,7 +130,7 @@ impl SourceConfig for HostMetricsConfig {
         let mut config = self.clone();
         config.namespace.0 = config.namespace.0.filter(|namespace| !namespace.is_empty());
 
-        Ok(Box::new(config.run(out, shutdown).boxed().compat()))
+        Ok(Box::pin(config.run(out, shutdown)))
     }
 
     fn output_type(&self) -> DataType {

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -241,7 +241,6 @@ mod tests {
         test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
         Pipeline,
     };
-    use futures::compat::Future01CompatExt;
     use futures01::sync::mpsc;
     use http::HeaderMap;
     use pretty_assertions::assert_eq;
@@ -277,7 +276,6 @@ mod tests {
             )
             .await
             .unwrap()
-            .compat()
             .await
             .unwrap();
         });

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -5,11 +5,7 @@ use crate::{
     shutdown::ShutdownSignal,
     Pipeline,
 };
-use futures::{
-    compat::Future01CompatExt,
-    future::{FutureExt, TryFutureExt},
-    stream::StreamExt,
-};
+use futures::{compat::Future01CompatExt, stream::StreamExt};
 use futures01::Sink;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -50,10 +46,12 @@ impl SourceConfig for InternalMetricsConfig {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> crate::Result<super::Source> {
-        let fut = run(get_controller()?, self.scrape_interval_secs, out, shutdown)
-            .boxed()
-            .compat();
-        Ok(Box::new(fut))
+        Ok(Box::pin(run(
+            get_controller()?,
+            self.scrape_interval_secs,
+            out,
+            shutdown,
+        )))
     }
 
     fn output_type(&self) -> DataType {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -12,7 +12,7 @@ use futures::{
     compat::{Compat01As03Sink, Sink01CompatExt},
     future,
     stream::BoxStream,
-    FutureExt, SinkExt, StreamExt, TryFutureExt,
+    SinkExt, StreamExt,
 };
 use lazy_static::lazy_static;
 use nix::{
@@ -138,7 +138,7 @@ impl SourceConfig for JournaldConfig {
         let start: StartJournalctlFn =
             Box::new(move |cursor| start_journalctl(&journalctl_path, current_boot_only, cursor));
 
-        Ok(Box::new(
+        Ok(Box::pin(
             JournaldSource {
                 include_units,
                 exclude_units,
@@ -148,9 +148,7 @@ impl SourceConfig for JournaldConfig {
                 out: out.sink_compat(),
             }
             .run_shutdown(shutdown, start)
-            .instrument(info_span!("journald-server"))
-            .boxed()
-            .compat(),
+            .instrument(info_span!("journald-server")),
         ))
     }
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -8,10 +8,7 @@ use crate::{
 };
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use futures::{
-    compat::{Compat, Future01CompatExt},
-    FutureExt, StreamExt,
-};
+use futures::{compat::Future01CompatExt, StreamExt};
 use futures01::Sink;
 use rdkafka::{
     config::ClientConfig,
@@ -108,7 +105,7 @@ fn kafka_source(
     let key_field = config.key_field.clone();
     let consumer = Arc::new(create_consumer(config)?);
 
-    let fut = async move {
+    Ok(Box::pin(async move {
         Arc::clone(&consumer)
             .start()
             .take_until(shutdown.clone())
@@ -189,9 +186,7 @@ fn kafka_source(
             })
             .await;
         Ok(())
-    };
-
-    Ok(Box::new(Compat::new(fut.boxed())))
+    }))
 }
 
 fn create_consumer(config: &KafkaSourceConfig) -> crate::Result<StreamConsumer> {
@@ -278,7 +273,6 @@ mod integration_test {
         Pipeline,
     };
     use chrono::Utc;
-    use futures::compat::Future01CompatExt;
     use rdkafka::{
         config::ClientConfig,
         producer::{FutureProducer, FutureRecord},
@@ -337,11 +331,7 @@ mod integration_test {
 
         println!("Receiving event...");
         let (tx, rx) = Pipeline::new_test();
-        tokio::spawn(
-            kafka_source(&config, ShutdownSignal::noop(), tx)
-                .unwrap()
-                .compat(),
-        );
+        tokio::spawn(kafka_source(&config, ShutdownSignal::noop(), tx).unwrap());
         let events = collect_n(rx, 1).await.unwrap();
 
         assert_eq!(

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -207,7 +207,6 @@ mod tests {
         Pipeline,
     };
     use chrono::{DateTime, Utc};
-    use futures::compat::Future01CompatExt;
     use futures01::sync::mpsc;
     use pretty_assertions::assert_eq;
     use std::net::SocketAddr;
@@ -238,7 +237,6 @@ mod tests {
             )
             .await
             .unwrap()
-            .compat()
             .await
             .unwrap()
         });

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,4 +1,4 @@
-use futures01::Future;
+use futures::future::BoxFuture;
 use snafu::Snafu;
 
 #[cfg(feature = "sources-apache_metrics")]
@@ -48,7 +48,7 @@ pub mod vector;
 
 mod util;
 
-pub type Source = Box<dyn Future<Item = (), Error = ()> + Send>;
+pub type Source = BoxFuture<'static, Result<(), ()>>;
 
 /// Common build errors
 #[derive(Debug, Snafu)]

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -167,7 +167,7 @@ impl SourceConfig for MongoDBMetricsConfig {
         ))
     }
 
-    fn output_type(&self) -> crate::config::DataType {
+    fn output_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use futures::{
     compat::Sink01CompatExt,
     future::{join_all, ready, try_join_all},
-    stream, FutureExt, SinkExt, StreamExt, TryFutureExt,
+    stream, FutureExt, SinkExt, StreamExt,
 };
 use futures01::Sink;
 use mongodb::{
@@ -141,7 +141,7 @@ impl SourceConfig for MongoDBMetricsConfig {
             .sink_map_err(|error| error!(message = "Error sending metric.", %error))
             .sink_compat();
 
-        Ok(Box::new(
+        Ok(Box::pin(
             async move {
                 loop {
                     select! {
@@ -163,9 +163,7 @@ impl SourceConfig for MongoDBMetricsConfig {
                     }
                 }
             }
-            .map(Ok)
-            .boxed()
-            .compat(),
+            .map(Ok),
         ))
     }
 
@@ -1059,7 +1057,7 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::{test_util::trace_init, Pipeline};
-    use futures::compat::{Future01CompatExt, Stream01CompatExt};
+    use futures::compat::Stream01CompatExt;
     use tokio::time::{timeout, Duration};
 
     async fn test_instance(endpoint: &'static str) {
@@ -1083,7 +1081,6 @@ mod integration_tests {
             )
             .await
             .unwrap()
-            .compat()
             .await
             .unwrap()
         });

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -78,7 +78,7 @@ impl SourceConfig for PrometheusConfig {
         ))
     }
 
-    fn output_type(&self) -> crate::config::DataType {
+    fn output_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -98,7 +98,8 @@ fn prometheus(
     let out = out
         .sink_map_err(|error| error!(message = "Error sending metric.", %error))
         .sink_compat();
-    let task = tokio::time::interval(Duration::from_secs(interval))
+
+    Box::pin(tokio::time::interval(Duration::from_secs(interval))
         .take_until(shutdown)
         .map(move |_| stream::iter(urls.clone()))
         .flatten()
@@ -185,9 +186,7 @@ fn prometheus(
         })
         .flatten()
         .forward(out)
-        .inspect(|_| info!("Finished sending."));
-
-    Box::new(task.boxed().compat())
+        .inspect(|_| info!("Finished sending.")))
 }
 
 #[cfg(all(test, feature = "sinks-prometheus"))]
@@ -336,7 +335,6 @@ mod integration_tests {
         event::{MetricKind, MetricValue},
         shutdown, test_util, Pipeline,
     };
-    use futures::compat::Future01CompatExt as _;
     use tokio::time::Duration;
 
     #[tokio::test]
@@ -359,7 +357,7 @@ mod integration_tests {
             .await
             .unwrap();
 
-        tokio::spawn(source.compat());
+        tokio::spawn(source);
         tokio::time::delay_for(Duration::from_secs(1)).await;
 
         let events = test_util::collect_ready(rx).await.unwrap();

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -207,8 +207,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         wait_for_tcp(addr).await;
@@ -233,8 +232,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         wait_for_tcp(addr).await;
@@ -266,8 +264,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         let lines = vec![
@@ -314,8 +311,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         let lines = vec![
@@ -364,8 +360,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         let lines = vec![
@@ -410,8 +405,7 @@ mod test {
         let server = SocketConfig::from(TcpConfig::new(addr.into()))
             .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         let source_handle = tokio::spawn(server);
 
         // Send data to Source.
@@ -452,8 +446,7 @@ mod test {
         })
         .build(source_name, &GlobalOptions::default(), shutdown_signal, tx)
         .await
-        .unwrap()
-        .compat();
+        .unwrap();
         let source_handle = tokio::spawn(server);
 
         wait_for_tcp(addr).await;
@@ -550,8 +543,7 @@ mod test {
                 sender,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         let source_handle = tokio::spawn(server);
 
         // Wait for UDP to start listening
@@ -716,8 +708,7 @@ mod test {
                 sender,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
 
         // Wait for server to accept traffic

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -114,7 +114,7 @@ impl SourceConfig for SplunkConfig {
         let tls = MaybeTlsSettings::from_config(&self.tls, true)?;
         let listener = tls.bind(&self.address).await?;
 
-        let fut = async move {
+        Ok(Box::pin(async move {
             let _ = warp::serve(services)
                 .serve_incoming_with_graceful_shutdown(
                     listener.accept_stream(),
@@ -124,8 +124,7 @@ impl SourceConfig for SplunkConfig {
             // We need to drop the last copy of ShutdownSignalToken only after server has shut down.
             drop(shutdown);
             Ok(())
-        };
-        Ok(Box::new(fut.boxed().compat()))
+        }))
     }
 
     fn output_type(&self) -> DataType {
@@ -780,7 +779,7 @@ mod tests {
         Pipeline,
     };
     use chrono::{TimeZone, Utc};
-    use futures::{compat::Future01CompatExt, future, stream, StreamExt};
+    use futures::{future, stream, StreamExt};
     use futures01::sync::mpsc;
     use std::net::SocketAddr;
 
@@ -813,7 +812,6 @@ mod tests {
             )
             .await
             .unwrap()
-            .compat()
             .await
             .unwrap()
         });

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -89,7 +89,7 @@ impl SourceConfig for StatsdConfig {
         }
     }
 
-    fn output_type(&self) -> crate::config::DataType {
+    fn output_type(&self) -> config::DataType {
         config::DataType::Metric
     }
 

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bytes::Bytes;
 use codec::BytesDelimitedCodec;
-use futures::{compat::Sink01CompatExt, stream, FutureExt, SinkExt, StreamExt, TryFutureExt};
+use futures::{compat::Sink01CompatExt, stream, SinkExt, StreamExt, TryFutureExt};
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use tokio::net::UdpSocket;
@@ -73,9 +73,7 @@ impl SourceConfig for StatsdConfig {
         out: Pipeline,
     ) -> crate::Result<super::Source> {
         match self {
-            StatsdConfig::Udp(config) => Ok(Box::new(
-                statsd_udp(config.clone(), shutdown, out).boxed().compat(),
-            )),
+            StatsdConfig::Udp(config) => Ok(Box::pin(statsd_udp(config.clone(), shutdown, out))),
             StatsdConfig::Tcp(config) => {
                 let tls = MaybeTlsSettings::from_config(&config.tls, true)?;
                 StatsdTcpSource.run(

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -144,7 +144,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
     ) -> crate::Result<crate::sources::Source> {
         let tls = MaybeTlsSettings::from_config(tls, true)?;
         let auth = HttpSourceAuth::try_from(auth.as_ref())?;
-        let fut = async move {
+        Ok(Box::pin(async move {
             let span = crate::trace::current_span();
 
             let mut filter: BoxedFilter<()> = warp::post().boxed();
@@ -233,8 +233,6 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
             // We need to drop the last copy of ShutdownSignalToken only after server has shut down.
             drop(shutdown);
             Ok(())
-        };
-
-        Ok(Box::new(fut.boxed().compat()))
+        }))
     }
 }

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -77,7 +77,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
 
         let listenfd = ListenFd::from_env();
 
-        let fut = async move {
+        Ok(Box::pin(async move {
             let listener = match make_listener(addr, listenfd, &tls).await {
                 None => return Err(()),
                 Some(listener) => listener,
@@ -151,9 +151,7 @@ pub trait TcpSource: Clone + Send + Sync + 'static {
                 })
                 .map(Ok)
                 .await
-        };
-
-        Ok(Box::new(fut.boxed().compat()))
+        }))
     }
 }
 

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -8,7 +8,7 @@ use crate::{
     Pipeline,
 };
 use bytes::Bytes;
-use futures::{compat::Sink01CompatExt, future, FutureExt, SinkExt, StreamExt, TryFutureExt};
+use futures::{compat::Sink01CompatExt, future, FutureExt, SinkExt, StreamExt};
 use futures01::Sink;
 use std::path::PathBuf;
 use tokio::net::{UnixListener, UnixStream};
@@ -35,7 +35,7 @@ where
 {
     let out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
 
-    let fut = async move {
+    Box::pin(async move {
         let mut listener =
             UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
         info!(message = "Listening.", path = ?listen_path, r#type = "unix");
@@ -100,7 +100,5 @@ where
         }
 
         Ok(())
-    };
-
-    Box::new(fut.boxed().compat())
+    })
 }

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -121,7 +121,7 @@ mod test {
         tls::{TlsConfig, TlsOptions},
         Event, Pipeline,
     };
-    use futures::{compat::Future01CompatExt, stream};
+    use futures::stream;
     use std::net::SocketAddr;
     use tokio::time::{delay_for, Duration};
 
@@ -141,8 +141,7 @@ mod test {
                 tx,
             )
             .await
-            .unwrap()
-            .compat();
+            .unwrap();
         tokio::spawn(server);
         wait_for_tcp(addr).await;
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1026,7 +1026,7 @@ mod transient_state_tests {
         transforms::json_parser::JsonParserConfig,
         Error, Pipeline,
     };
-    use futures::{future, FutureExt, TryFutureExt};
+    use futures::{future, FutureExt};
     use serde::{Deserialize, Serialize};
     use stream_cancel::{Trigger, Tripwire};
 
@@ -1058,19 +1058,18 @@ mod transient_state_tests {
             shutdown: ShutdownSignal,
             out: Pipeline,
         ) -> Result<Source, Error> {
-            let source = future::select(
-                shutdown.map(|_| ()).boxed(),
-                self.tripwire
-                    .clone()
-                    .unwrap()
-                    .then(crate::stream::tripwire_handler)
-                    .boxed(),
-            )
-            .map(|_| std::mem::drop(out))
-            .unit_error()
-            .boxed()
-            .compat();
-            Ok(Box::new(source))
+            Ok(Box::pin(
+                future::select(
+                    shutdown.map(|_| ()).boxed(),
+                    self.tripwire
+                        .clone()
+                        .unwrap()
+                        .then(crate::stream::tripwire_handler)
+                        .boxed(),
+                )
+                .map(|_| std::mem::drop(out))
+                .unit_error(),
+            ))
         }
 
         fn output_type(&self) -> DataType {

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -204,7 +204,7 @@ impl SourceConfig for ErrorSourceConfig {
         _shutdown: ShutdownSignal,
         _out: Pipeline,
     ) -> Result<sources::Source, vector::Error> {
-        Ok(Box::new(futures01::future::err(())))
+        Ok(Box::pin(future::err(())))
     }
 
     fn output_type(&self) -> config::DataType {
@@ -271,10 +271,7 @@ impl SourceConfig for PanicSourceConfig {
         _shutdown: ShutdownSignal,
         _out: Pipeline,
     ) -> Result<sources::Source, vector::Error> {
-        Ok(Box::new(futures01::future::lazy::<
-            _,
-            futures01::future::FutureResult<(), ()>,
-        >(|| panic!())))
+        Ok(Box::pin(async { panic!() }))
     }
 
     fn output_type(&self) -> config::DataType {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -6,10 +6,12 @@
 
 use async_trait::async_trait;
 use futures::{
-    compat::Sink01CompatExt, future, stream::BoxStream, FutureExt, Sink, SinkExt, StreamExt,
-    TryFutureExt,
+    compat::{Sink01CompatExt, Stream01CompatExt},
+    future,
+    stream::{self, BoxStream},
+    FutureExt, Sink, SinkExt, StreamExt, TryStreamExt,
 };
-use futures01::{sink::Sink as Sink01, stream, sync::mpsc::Receiver, Async, Future, Stream};
+use futures01::{sink::Sink as Sink01, sync::mpsc::Receiver};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::{
@@ -20,6 +22,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     },
+    task::Poll,
 };
 use tracing::{error, info};
 use vector::{
@@ -143,40 +146,37 @@ impl SourceConfig for MockSourceConfig {
     ) -> Result<Source, vector::Error> {
         let wrapped = self.receiver.clone();
         let event_counter = self.event_counter.clone();
-        let mut recv = wrapped.lock().unwrap().take().unwrap();
-        let mut shutdown = Some(shutdown.unit_error().boxed().compat());
+        let mut recv = wrapped.lock().unwrap().take().unwrap().compat();
+        let mut shutdown = Some(shutdown);
         let mut _token = None;
-        let source =
-            futures01::future::lazy(move || {
-                stream::poll_fn(move || {
-                    if let Some(until) = shutdown.as_mut() {
-                        match until.poll() {
-                            Ok(Async::Ready(res)) => {
-                                _token = Some(res);
-                                shutdown.take();
-                                recv.close();
-                            }
-                            Err(_) => {
-                                shutdown.take();
-                            }
-                            Ok(Async::NotReady) => {}
+        Ok(Box::pin(async move {
+            stream::poll_fn(move |cx| {
+                if let Some(until) = shutdown.as_mut() {
+                    match until.poll_unpin(cx) {
+                        Poll::Ready(res) => {
+                            _token = Some(res);
+                            shutdown.take();
+                            recv.get_mut().close();
                         }
+                        Poll::Pending => {}
                     }
+                }
 
-                    recv.poll()
-                })
-                .map(move |x| {
-                    if let Some(counter) = &event_counter {
-                        counter.fetch_add(1, Ordering::Relaxed);
-                    }
-                    x
-                })
-                .forward(out.sink_map_err(
+                recv.poll_next_unpin(cx)
+            })
+            .inspect_ok(move |_| {
+                if let Some(counter) = &event_counter {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+            .forward(
+                out.sink_compat().sink_map_err(
                     |error| error!(message = "Error sending in sink..", error = ?error),
-                ))
-                .map(|_| info!("Finished sending."))
-            });
-        Ok(Box::new(source))
+                ),
+            )
+            .inspect(|_| info!("Finished sending."))
+            .await
+        }))
     }
 
     fn output_type(&self) -> DataType {


### PR DESCRIPTION
Wanted start `nginx` source and found that I need to use `.compat()` :cry: in the same time all sources already use new futures, so quick update.