### PR TITLE
enhancement(kafka source): include kafka metadata as optional keys

### DIFF
--- a/docs/reference/components/sources/kafka.cue
+++ b/docs/reference/components/sources/kafka.cue
@@ -83,6 +83,36 @@ components: sources: kafka: {
 				examples: ["message_key"]
 			}
 		}
+		topic_key: {
+			common:      true
+			description: "The log field name to use for the Kafka topic key. If unspecified, the key would not be added to the log event."
+			required:    false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["topic_key"]
+			}
+		}
+		partition_key: {
+			common:      true
+			description: "The log field name to use for the Kafka partition key. If unspecified, the key would not be added to the log event."
+			required:    false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["partition_key"]
+			}
+		}
+		offset_key: {
+			common:      true
+			description: "The log field name to use for the Kafka offset key. If unspecified, the key would not be added to the log event."
+			required:    false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["offset_key"]
+			}
+		}
 		librdkafka_options: components._kafka.configuration.librdkafka_options
 		sasl: {
 			common:      false

--- a/docs/reference/components/sources/kafka.cue
+++ b/docs/reference/components/sources/kafka.cue
@@ -90,7 +90,7 @@ components: sources: kafka: {
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["topic_key"]
+				examples: ["topic"]
 			}
 		}
 		partition_key: {
@@ -100,7 +100,7 @@ components: sources: kafka: {
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["partition_key"]
+				examples: ["partition"]
 			}
 		}
 		offset_key: {
@@ -110,7 +110,7 @@ components: sources: kafka: {
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["offset_key"]
+				examples: ["offset"]
 			}
 		}
 		librdkafka_options: components._kafka.configuration.librdkafka_options

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -369,7 +369,10 @@ mod integration_test {
             events[0].as_log()[log_schema().source_type_key()],
             "kafka".into()
         );
-        assert_eq!(events[0].as_log()[log_schema().timestamp_key()], now.trunc_subsecs(3).into());
+        assert_eq!(
+            events[0].as_log()[log_schema().timestamp_key()],
+            now.trunc_subsecs(3).into()
+        );
         assert_eq!(events[0].as_log()["topic"], topic.into());
         assert!(events[0].as_log().contains("partition"));
         assert!(events[0].as_log().contains("offset"));

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -172,24 +172,15 @@ fn kafka_source(
                             }
 
                             if let Some(topic_key) = &topic_key {
-                                log.insert(
-                                    topic_key,
-                                    Value::from(msg.topic().to_string()),
-                                );
+                                log.insert(topic_key, Value::from(msg.topic().to_string()));
                             }
 
                             if let Some(partition_key) = &partition_key {
-                                log.insert(
-                                    partition_key,
-                                    Value::from(msg.partition()),
-                                );
+                                log.insert(partition_key, Value::from(msg.partition()));
                             }
 
                             if let Some(offset_key) = &offset_key {
-                                log.insert(
-                                    offset_key,
-                                    Value::from(msg.offset()),
-                                );
+                                log.insert(offset_key, Value::from(msg.offset()));
                             }
 
                             consumer.store_offset(&msg).map_err(|error| {


### PR DESCRIPTION
Fixes: #1150
Fixes: #5143 
Fixes: #800

Modelled after the existing `key_field` configuration I inserted the topic, partition, and offset provided by rdkafka into events when configured. These should be opt-in and not affect users unless explicitly configured.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
