### PR TITLE
chore(external docs): Add keepalive docs

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -214,6 +214,16 @@ components: {
 	#FeaturesGenerate: {
 	}
 
+	#FeaturesKeepalive: {
+		enabled: bool
+
+		if enabled {
+			time:     uint
+			interval: uint
+			retries:  uint
+		}
+	}
+
 	#FeaturesMultiline: {
 		enabled: bool
 	}
@@ -231,8 +241,9 @@ components: {
 	}
 
 	#FeaturesReceive: {
-		from?: #Service
-		tls:   #FeaturesTLS & {_args: {mode: "accept"}}
+		from?:      #Service
+		keepalive?: #FeaturesKeepalive
+		tls:        #FeaturesTLS & {_args: {mode: "accept"}}
 	}
 
 	#FeaturesReduce: {
@@ -292,6 +303,8 @@ components: {
 				}
 			}
 		}
+
+		keepalive?: #FeaturesKeepalive
 
 		// `request` describes how the component issues and manages external
 		// requests.
@@ -796,6 +809,10 @@ components: {
 						receive_context: "Enriches data with useful \(features.receive.from.name) context."
 					}
 
+					if features.receive.keepalive.enabled != _|_ {
+						keepalive: "Supports keepalive connections for bandwidth efficiency."
+					}
+
 					if features.receive.tls.enabled != _|_ {
 						tls_receive: "Securely receives data via Transport Layer Security (TLS)."
 					}
@@ -810,6 +827,10 @@ components: {
 
 					if features.send.compression.enabled != _|_ {
 						compress: "Compresses data to optimize bandwidth."
+					}
+
+					if features.receive.keepalive.enabled != _|_ {
+						keepalive: "Supports keepalive connections for bandwidth efficiency."
 					}
 
 					if features.send.request.enabled != _|_ {

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -306,6 +306,46 @@ components: sinks: [Name=string]: {
 		}
 
 		if sinks[Name].features.send != _|_ {
+			if sinks[Name].features.send.keepalive != _|_ {
+				keepalive: {
+					common:      false
+					description: "Configures the sink keepalive behavior."
+					required:    false
+					type: object: {
+						examples: []
+						options: {
+							time: {
+								common:      false
+								description: "The connection life time."
+								required:    false
+								type: uint: {
+									default: sinks[Name].features.send.keepalive.time
+									unit:    "seconds"
+								}
+							}
+							interval: {
+								common:      false
+								description: "The connection life time."
+								required:    false
+								type: uint: {
+									default: sinks[Name].features.send.keepalive.interval
+									unit:    "seconds"
+								}
+							}
+							retries: {
+								common:      false
+								description: "The number of times to retry a connection."
+								required:    false
+								type: uint: {
+									default: sinks[Name].features.send.keepalive.retries
+									unit:    "seconds"
+								}
+							}
+						}
+					}
+				}
+			}
+
 			if sinks[Name].features.send.tls.enabled {
 				tls: configuration._tls_connect & {_args: {
 					can_enable:             sinks[Name].features.send.tls.can_enable

--- a/docs/reference/components/sinks/socket.cue
+++ b/docs/reference/components/sinks/socket.cue
@@ -24,6 +24,12 @@ components: sinks: socket: {
 					enum: ["json", "text"]
 				}
 			}
+			keepalive: {
+				enabled:  true
+				time:     7200
+				interval: 75
+				retries:  5
+			}
 			request: enabled: false
 			tls: {
 				enabled:                true


### PR DESCRIPTION
Cue docs for https://github.com/timberio/vector/pull/5157. See the `sinks/socket.cue` changes.

cc @pablosichert for finishing off the details here.