### PR TITLE
chore(ci): Disable jemalloc background_thread

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -176,8 +176,6 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
-      - run: uname -s
-      - run: uname
       - run: make test
       - run: make test-behavior
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,8 @@ headers = "0.3"
 rdkafka = { version = "0.24.0", features = ["libz", "ssl", "zstd"], optional = true }
 hostname = "0.3.1"
 seahash = { version = "3.0.6", optional = true }
-jemallocator = { version = "0.3.2", optional = true }
 semver = { version = "0.11.0", features = ["serde"] }
+jemallocator = { version = "0.3.0", optional = true }
 lazy_static = "1.3.0"
 rlua = { git = "https://github.com/kyren/rlua", optional = true }
 num_cpus = "1.10.0"
@@ -235,7 +235,6 @@ reqwest = { version = "0.10.6", features = ["json"] }
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
-default-macos = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "macos", "leveldb", "rdkafka-plain"]
 default-musl = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-cmake"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-cmake"]
@@ -255,10 +254,8 @@ target-aarch64-unknown-linux-musl = ["api", "api-client", "sources", "transforms
 target-armv7-unknown-linux-musleabihf = ["api", "api-client", "sources", "transforms", "sinks", "vendor-openssl", "vendor-libz", "rdkafka-cmake"]
 target-armv7-unknown-linux-gnueabihf = ["api", "api-client", "sources", "transforms", "sinks", "vendor-openssl", "vendor-libz", "unix", "leveldb", "rdkafka-cmake"]
 
-# Enables features that work only on systems providing `cfg(target_os = "macos")`
-macos = ["jemallocator-plain"]
-# Enables features that work only on systems providing `cfg(target_os = "linux")`
-unix = ["jemallocator-background_threads"]
+# Enables features that work only on systems providing `cfg(unix)`
+unix = ["jemallocator"]
 # These are **very** useful on Cross compilations!
 vendor-all = ["vendor-sasl", "vendor-openssl", "vendor-libz"]
 vendor-sasl = ["rdkafka/gssapi-vendored"]
@@ -273,10 +270,6 @@ rdkafka-plain = ["rdkafka"]
 rdkafka-cmake = ["rdkafka", "rdkafka/cmake_build"]
 # This feature enables the WASM foreign module support.
 wasm = ["lucetc", "lucet-runtime", "lucet-wasi", "vector-wasm"]
-# OSX doesn't support background-threads
-# https://github.com/jemalloc/jemalloc/issues/843
-jemallocator-plain = ["jemallocator"]
-jemallocator-background_threads = ["jemallocator", "jemallocator/background_threads"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,13 @@
 
 # Begin OS detection
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
+    export OPERATING_SYSTEM := Windows
+	export RUST_TARGET ?= "x86_64-unknown-windows-msvc"
     export DEFAULT_FEATURES = default-msvc
 else
-  OPERATING_SYSTEM := $(shell uname -s)
-  ifeq ($(OPERATING_SYSTEM),Darwin)
-    export DEFAULT_FEATURES = default-macos
-  else
+    export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
+	export RUST_TARGET ?= "x86_64-unknown-linux-gnu"
     export DEFAULT_FEATURES = default
-  endif
 endif
 
 # Override this with any scopes for testing/benching.
@@ -295,7 +294,7 @@ test-aarch64-unknown-linux-gnu: cross-test-aarch64-unknown-linux-gnu ## Runs uni
 
 .PHONY: test-behavior
 test-behavior: ## Runs behaviorial test
-	${MAYBE_ENVIRONMENT_EXEC} cargo run --no-default-features --features "${DEFAULT_FEATURES}" -- test tests/behavior/**/*.toml
+	${MAYBE_ENVIRONMENT_EXEC} cargo run -- test tests/behavior/**/*.toml
 
 .PHONY: test-integration
 test-integration: ## Runs all integration tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,7 @@ extern crate derivative;
 #[macro_use]
 extern crate pest_derive;
 
-#[cfg(any(
-    feature = "jemallocator-plain",
-    feature = "jemallocator-background_threads"
-))]
+#[cfg(feature = "jemallocator")]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
This ended up causing a couple of more issues:

It looks like we might need to disable the background threads for alpine as well:

```
 #22 [linux/amd64 stage-1 5/5] RUN ["vector", "--version"]
#22 0.097 <jemalloc>: Error in dlsym(RTLD_NEXT, "pthread_create")
#22 ERROR: executor failed running [vector --version]: buildkit-runc did not terminate successfully
```

(re: the nightly failure https://github.com/timberio/vector/actions/runs/375637227)

I see the OSX build is still failing on master with the jemalloc background_thread issue due the benches feature as well: https://github.com/timberio/vector/runs/1435646011?check_suite_focus=true

I'd sill like to have this, but wanted to get master back to green. We can re-add this week, after resolving these.

Originally enabled in #4845 and an attempted fix for some issues in #5148 