### PR TITLE
enhancement(observability):  allow querying transform outputs on transform components

### DIFF
--- a/src/api/schema/components.rs
+++ b/src/api/schema/components.rs
@@ -142,6 +142,14 @@ impl Transform {
             .collect()
     }
 
+    /// Transform outputs
+    async fn transforms(&self) -> Vec<Transform> {
+        filter_components(|(_name, components)| match components {
+            Component::Transform(t) if t.0.inputs.contains(&self.0.name) => Some(t.clone()),
+            _ => None,
+        })
+    }
+
     /// Sink outputs
     async fn sinks(&self) -> Vec<Sink> {
         filter_components(|(_name, components)| match components {


### PR DESCRIPTION
cc @leebenson 

Small PR to add the transform outputs to transform components.  Transforms can pipe into other transforms so in order to build a complete graph we need to make those available.

@leebenson we talked a little bit about making it easier to get a directed set of links.  After going through this, what we have is actually not bad.  You really just want to query the "output" connections on each component.  My query to get all the nodes and links ended up being like (removing the metrics here)...

```graphql
query NodesAndLinks {
  sources {
    name
    transforms {
      name
    }
    sinks {
      name
    }
  }
  transforms {
    name
    sinks {
      name
    }
    transforms {
      name
    }
  }
  sinks {
    name
  }
}
```

Which in JS you can process pretty efficiently (removing some details here on the metrics):

```ts
const createNodeAndLinks = (data: NodesAndLinksQuery) => {
  const nodes: GraphNodeData[] = [];
  const links: GraphLinkData[] = [];

  const { sources, transforms, sinks } = data;

  sources.forEach((source) => {
    nodes.push(createNodeData(source.name));

    source.transforms.forEach((transform) => {
      links.push({
        source: source.name,
        target: transform.name,
      });
    });
    source.sinks.forEach((sink) => {
      links.push({
        source: source.name,
        target: sink.name,
      });
    });
  });

  transforms.forEach((transform) => {
    nodes.push(createNodeData(transform.name));

    transform.transforms.forEach((nextTransform) => {
      links.push({
        source: transform.name,
        target: nextTransform.name,
      });
    });
    transform.sinks.forEach((sink) => {
      links.push({
        source: transform.name,
        target: sink.name,
      });
    });
  });

  sinks.forEach((sink) => {
    nodes.push(createNodeData(sink.name));
  });

  return {
    links,
    nodes,
  };
};
```

