### PR TITLE
chore: Remove unused `use`

### DIFF
--- a/benches/topology.rs
+++ b/benches/topology.rs
@@ -4,7 +4,7 @@ use futures::{compat::Future01CompatExt, future, stream, StreamExt};
 use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
 
 use vector::{
-    conditions, config, sinks, sources,
+    config, sinks, sources,
     test_util::{
         next_addr, random_lines, runtime, send_lines, start_topology, wait_for_tcp, CountReceiver,
     },

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -7,7 +7,6 @@
 use approx::assert_relative_eq;
 use futures::compat::Future01CompatExt;
 use vector::{
-    conditions::CheckFieldsConfig,
     config, sinks, sources,
     test_util::{
         next_addr, random_lines, send_lines, start_topology, trace_init, wait_for_tcp,


### PR DESCRIPTION
Removes unused `use` that clippy reported. Introduced with #4918.

This PR is just a small fix for master so I'll be merging it as soon as the relevant check passes.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
