### PR TITLE
chore: Add global options

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -442,9 +442,10 @@ _values: {
 
 #Unit: "bytes" | "events" | "milliseconds" | "requests" | "seconds"
 
-components:   _
-data_model:   _
-installation: _
-process:      _
-releases:     _
-remap:        _
+components:    _
+configuration: _
+data_model:    _
+installation:  _
+process:       _
+releases:      _
+remap:         _

--- a/docs/reference/configuration.cue
+++ b/docs/reference/configuration.cue
@@ -1,0 +1,20 @@
+package metadata
+
+configuration: #Schema
+
+configuration: {
+	data_dir: {
+		common: false
+		description: """
+			The directory used for persisting Vector state, such
+			as on-disk buffers, file checkpoints, and more.
+			Please make sure the Vector project has write
+			permissions to this directory.
+			"""
+		required: false
+		type: string: {
+			default: "/var/lib/vector/"
+			examples: ["/var/lib/vector", "/var/local/lib/vector/", "/home/user/vector/"]
+		}
+	}
+}


### PR DESCRIPTION
This adds the `data_dir` global option. A case could be made to copy over all of the component options as well, but I'd like to wait on that since it'll significantly increase the resulting file size.