### PR TITLE
chore(external docs): Correct the Kubernetes installation docs

### DIFF
--- a/docs/reference/installation/_interfaces/helm3.cue
+++ b/docs/reference/installation/_interfaces/helm3.cue
@@ -21,9 +21,13 @@ installation: _interfaces: "helm3": {
 
 	roles: [Name=string]: {
 		commands: {
-			_name:                     string
+			_repo_name:                string | *"timberio"
+			_chart_name:               string
+			_namespace:                string | *"vector"
+			_release_name:             string | *"vector"
 			_controller_resource_type: string
-			add_repo:                  #"helm repo add timberio https://packages.timber.io/helm/latest"#
+			_controller_resource_name: string | *_chart_name
+			add_repo:                  #"helm repo add \#(_repo_name) https://packages.timber.io/helm/latest"#
 			configure: #"""
 				cat <<-'VALUES' > values.yaml
 				// The Vector Kubernetes integration automatically defines a
@@ -41,15 +45,15 @@ installation: _interfaces: "helm3": {
 				    encoding = "json"
 				VALUES
 				"""#
-			install:   #"helm install --namespace vector --create-namespace \#(_name) timberio/\#(_name) --values values.yaml"#
-			logs:      #"kubectl logs --namespace vector \#(_controller_resource_type)/\#(_name)"#
+			install:   #"helm install --namespace \#(_namespace) --create-namespace \#(_release_name) \#(_repo_name)/\#(_chart_name) --values values.yaml"#
+			logs:      #"kubectl logs --namespace \#(_namespace) \#(_controller_resource_type)/\#(_controller_resource_name)"#
 			reload:    null
-			restart:   #"kubectl rollout restart --namespace vector \#(_controller_resource_type)/\#(_name)"#
+			restart:   #"kubectl rollout restart --namespace \#(_namespace) \#(_controller_resource_type)/\#(_controller_resource_name)"#
 			start:     null
 			stop:      null
 			top:       null
-			uninstall: "helm uninstall \(_name) --namespace vector"
-			upgrade:   "helm repo update && helm upgrade vector --namespace vector timberio/\(_name) --reuse-values"
+			uninstall: #"helm uninstall --namespace \#(_namespace) \#(_release_name)"#
+			upgrade:   #"helm repo update && helm upgrade --namespace \#(_namespace) \#(_release_name) \#(_repo_name)/\#(_chart_name) --reuse-values"#
 		}
 	}
 
@@ -71,7 +75,7 @@ installation: _interfaces: "helm3": {
 						"""#
 
 			commands: {
-				_name:                     "vector-agent"
+				_chart_name:               "vector-agent"
 				_controller_resource_type: "daemonset"
 			}
 			tutorials: installation: [
@@ -106,7 +110,7 @@ installation: _interfaces: "helm3": {
 		//      """#
 
 		//  commands: {
-		//   _name:          "vector-aggregator"
+		//   _chart_name:               "vector-aggregator"
 		//   _controller_resource_type: "statefulset"
 		//  }
 		//  tutorials: installation: [

--- a/docs/reference/installation/_interfaces/helm3.cue
+++ b/docs/reference/installation/_interfaces/helm3.cue
@@ -41,15 +41,15 @@ installation: _interfaces: "helm3": {
 				    encoding = "json"
 				VALUES
 				"""#
-			install:   #"helm install \#(_name) timberio/\#(_name) --devel --values values.yaml --namespace vector --create-namespace"#
-			logs:      #"kubectl logs -n vector \#(_controller_resource_type)/\#(_name)"#
+			install:   #"helm install --namespace vector --create-namespace \#(_name) timberio/\#(_name) --devel --values values.yaml"#
+			logs:      #"kubectl logs --namespace vector \#(_controller_resource_type)/\#(_name)"#
 			reload:    null
-			restart:   #"kubectl rollout restart \#(_controller_resource_type)/\#(_name)"#
+			restart:   #"kubectl rollout restart --namespace vector \#(_controller_resource_type)/\#(_name)"#
 			start:     null
 			stop:      null
 			top:       null
 			uninstall: "helm uninstall \(_name) --namespace vector"
-			upgrade:   "helm repo update && helm upgrade vector timberio/\(_name) --namespace vector --reuse-values"
+			upgrade:   "helm repo update && helm upgrade vector --namespace vector timberio/\(_name) --reuse-values"
 		}
 	}
 

--- a/docs/reference/installation/_interfaces/helm3.cue
+++ b/docs/reference/installation/_interfaces/helm3.cue
@@ -41,7 +41,7 @@ installation: _interfaces: "helm3": {
 				    encoding = "json"
 				VALUES
 				"""#
-			install:   #"helm install --namespace vector --create-namespace \#(_name) timberio/\#(_name) --devel --values values.yaml"#
+			install:   #"helm install --namespace vector --create-namespace \#(_name) timberio/\#(_name) --values values.yaml"#
 			logs:      #"kubectl logs --namespace vector \#(_controller_resource_type)/\#(_name)"#
 			reload:    null
 			restart:   #"kubectl rollout restart --namespace vector \#(_controller_resource_type)/\#(_name)"#

--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -23,7 +23,7 @@ installation: _interfaces: kubectl: {
 			install:                   "kubectl apply -k ."
 			logs:                      "kubectl logs -n vector \(_controller_resource_type)/\(_controller_resource_name)"
 			reload:                    null
-			restart:                   "kubectl rollout restart \(_controller_resource_type)/\(_controller_resource_name)"
+			restart:                   "kubectl rollout restart -n vector \(_controller_resource_type)/\(_controller_resource_name)"
 			start:                     null
 			stop:                      null
 			top:                       null


### PR DESCRIPTION
This PR fixes some issues with the Kubernetes installation docs, in both `helm` and `kubectl` installation methods.

It also establishes some internal structure in the `helm` documentation, so the logic there is easier to follow.