### PR TITLE
chore(observability): API disabled log

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -202,6 +202,7 @@ impl Application {
 
                 Some(api::Server::start(topology.config()))
             } else {
+                info!(message="API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.");
                 None
             };
 


### PR DESCRIPTION
Dumps an info-level log when the API is disabled:

```
Nov 23 12:31:12.985  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
```

Closes #5156

Signed-off-by: Lee Benson <lee@leebenson.com>
