### PR TITLE
chore(ci): Run checks in master

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -414,6 +414,51 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
 
+  checks:
+    name: Checks
+    runs-on: ubuntu-20.04
+    container: timberio/ci_image
+    needs: changes
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # check-version needs tags
+          fetch-depth: 0 # fetch everything
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Enable Rust matcher
+        run: echo "::add-matcher::.github/matchers/rust.json"
+      - name: Make slim-builds
+        run: make slim-builds
+      - name: Check markdown
+        run: make check-markdown
+      - name: Check Cue docs
+        run: make check-docs
+      - name: Check code format
+        run: make check-fmt
+      - name: Check clippy
+        run: make check-clippy
+      - name: Check version
+        run: make check-version
+      - name: Check scripts
+        run: make check-scripts
+      - name: Check helm dependencies
+        run: make check-helm-dependencies
+      - name: Check helm lint
+        run: make check-helm-lint
+      - name: Check that generated Kubernetes YAML doesn't diverge from Helm
+        run: make check-kubernetes-yaml
+      - name: Check events
+        run: make check-events
+      - name: Check cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check advisories
+
   master-failure:
     name: master-failure
     if: failure()
@@ -436,6 +481,7 @@ jobs:
       - test-integration-pulsar
       - test-integration-splunk
       - check-component-features
+      - checks
     runs-on: ubuntu-latest
     steps:
     - name: Discord notification


### PR DESCRIPTION
Makes it easier to catch regressions merged in by PRs to see where they
were introduced.

Example: https://github.com/timberio/vector/runs/1435709845

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
