### PR TITLE
chore(ci): Fix whitespace in Kubernetes YAMLs (2)

### DIFF
--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -135,7 +135,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-
+            
             - name: LOG
               value: info
           ports:

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -135,7 +135,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-
+            
             - name: LOG
               value: info
           ports:

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -25,7 +25,7 @@ ised() {
 
 EXIT_CODE=0
 for FILE in $(git ls-files); do
-  # ignore binary files
+  # Ignore binary files and generated files.
   case "$FILE" in
     *png) continue;;
     *svg) continue;;
@@ -33,7 +33,7 @@ for FILE in $(git ls-files); do
     *ico) continue;;
     *sig) continue;;
     tests/data*) continue;;
-    distribution/kubernetes/vector.yaml) continue;;
+    distribution/kubernetes/*/*.yaml) continue;;
   esac
 
   # check that the file contains trailing newline

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -36,6 +36,11 @@ for FILE in $(git ls-files); do
     distribution/kubernetes/*/*.yaml) continue;;
   esac
 
+  # Skip all directories (usually theis only happens when we have symlinks).
+  if [[ -d "$FILE" ]]; then
+    continue
+  fi
+
   # check that the file contains trailing newline
   if [ -n "$(tail -c1 "$FILE" | tr -d $'\n')" ]; then
     case "$MODE" in


### PR DESCRIPTION
This PR corrects the #5192.

The YAML files are generated and previously were excluded from the style checks. We just correct the ignore list, and regenerate the files.