### PR TITLE
feat: New Redis source and sink

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -313,6 +313,24 @@ jobs:
       - run: make slim-builds
       - run: make test-integration-splunk
 
+  test-integration-redis:
+    name: Integration - Linux, Redis
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: make ci-sweep
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: make slim-builds
+      - run: make test-integration-redis
+
   master-failure:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'
@@ -329,6 +347,7 @@ jobs:
       - test-integration-loki
       - test-integration-pulsar
       - test-integration-splunk
+      - test-integration-redis
     runs-on: ubuntu-20.04
     steps:
     - name: Discord notification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,7 +779,7 @@ dependencies = [
  "serde_urlencoded 0.6.1",
  "thiserror",
  "tokio 0.2.25",
- "tokio-util",
+ "tokio-util 0.3.1",
  "url",
  "webpki-roots 0.20.0",
  "winapi 0.3.9",
@@ -1044,7 +1050,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.6",
  "serde_json",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tracing 0.1.23",
 ]
 
@@ -1080,6 +1086,19 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "combine"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -2566,7 +2585,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c55b7ac37895bd6e4ca0b357c074248358c95e20cf1cf2b462603121f7b87"
 dependencies = [
- "arc-swap",
+ "arc-swap 0.4.8",
  "futures 0.3.12",
  "log",
  "reqwest",
@@ -2594,7 +2613,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
 dependencies = [
- "combine",
+ "combine 3.8.1",
  "failure",
 ]
 
@@ -2665,7 +2684,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.25",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tracing 0.1.23",
  "tracing-futures 0.2.5",
 ]
@@ -5327,7 +5346,7 @@ dependencies = [
  "regex",
  "tokio 0.2.25",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.3.1",
  "url",
 ]
 
@@ -5709,6 +5728,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redis"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8f8d059ead7805e171fc22de8348a3d611c0f985aaa4f5cf6c0dfc7645407"
+dependencies = [
+ "arc-swap 1.2.0",
+ "async-std",
+ "async-trait",
+ "bytes 1.0.1",
+ "combine 4.5.2",
+ "dtoa",
+ "futures 0.3.12",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite 0.2.4",
+ "sha1",
+ "tokio 1.2.0",
+ "tokio-util 0.6.3",
+ "url",
 ]
 
 [[package]]
@@ -7285,7 +7327,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg 1.0.1",
+ "bytes 1.0.1",
  "libc",
+ "memchr",
  "mio 0.7.7",
  "num_cpus",
  "pin-project-lite 0.2.4",
@@ -7374,7 +7418,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "tokio 0.2.25",
- "tokio-util",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -7461,6 +7505,20 @@ dependencies = [
  "log",
  "pin-project-lite 0.1.11",
  "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.4",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -8131,6 +8189,7 @@ dependencies = [
  "rand 0.8.3",
  "rand_distr",
  "rdkafka",
+ "redis",
  "regex",
  "reqwest",
  "rlua",
@@ -8169,7 +8228,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-postgres",
  "tokio-test",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tokio01-test",
  "toml",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ typetag = "0.1.6"
 url = "2.2.0"
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
 warp = { version = "0.2.5", default-features = false, optional = true }
+redis = { version = "0.20.0", features = ["connection-manager","async-std-comp"], optional = true }
 
 # For WASM
 async-stream = "0.3.0"
@@ -361,6 +362,7 @@ sources-metrics = [
   "sources-prometheus",
   "sources-statsd",
   "sources-vector",
+  "sources-redis",
 ]
 
 sources-apache_metrics = []
@@ -394,6 +396,7 @@ sources-utils-tls = []
 sources-utils-udp = ["socket2"]
 sources-utils-unix = []
 sources-vector = ["listenfd", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls"]
+sources-redis = ["redis"]
 
 # Transforms
 transforms = ["transforms-logs", "transforms-metrics"]
@@ -512,7 +515,8 @@ sinks-metrics = [
   "sinks-prometheus",
   "sinks-sematext",
   "sinks-statsd",
-  "sinks-vector"
+  "sinks-vector",
+  "sinks-redis",
 ]
 
 sinks-aws_cloudwatch_logs = ["rusoto", "rusoto_logs"]
@@ -547,6 +551,7 @@ sinks-splunk_hec = ["bytesize"]
 sinks-statsd = ["sinks-utils-udp", "tokio-util/udp"]
 sinks-utils-udp = ["socket2"]
 sinks-vector = ["sinks-utils-udp"]
+sinks-redis = ["redis"]
 
 # Identifies that the build is a nightly build
 nightly = []
@@ -571,6 +576,7 @@ all-integration-tests = [
   "prometheus-integration-tests",
   "pulsar-integration-tests",
   "splunk-integration-tests",
+  "redis-integration-tests",
 ]
 
 aws-integration-tests = [
@@ -609,6 +615,7 @@ postgresql_metrics-integration-tests = ["sources-postgresql_metrics"]
 prometheus-integration-tests = ["bytesize", "sinks-prometheus", "sources-prometheus"]
 pulsar-integration-tests = ["sinks-pulsar"]
 splunk-integration-tests = ["sinks-splunk_hec", "warp"]
+redis-integration-tests = ["sources-redis", "sinks-redis"]
 
 disable-resolv-conf = []
 shutdown-tests = ["rdkafka", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "unix"]

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ test-behavior: ## Runs behaviorial test
 
 .PHONY: test-integration
 test-integration: ## Runs all integration tests
-test-integration: test-integration-aws test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
+test-integration: test-integration-aws  test-integration-docker-logs test-integration-elasticsearch
 test-integration: test-integration-gcp test-integration-humio test-integration-influxdb test-integration-kafka
 test-integration: test-integration-loki test-integration-mongodb_metrics test-integration-nats
 test-integration: test-integration-nginx test-integration-postgresql_metrics test-integration-prometheus test-integration-pulsar
@@ -317,7 +317,7 @@ ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh aws stop
 endif
 
-.PHONY: test-integration-clickhouse
+.PHONY:
 test-integration-clickhouse: ## Runs Clickhouse integration tests
 ifeq ($(AUTOSPAWN), true)
 	@scripts/setup_integration_env.sh clickhouse stop
@@ -490,6 +490,18 @@ endif
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features splunk-integration-tests --lib ::splunk_hec:: -- --nocapture
 ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh splunk stop
+endif
+
+.PHONY: test-integration-redis
+test-integration-redis: ## Runs Redis integration tests
+ifeq ($(AUTOSPAWN), true)
+	@scripts/setup_integration_env.sh redis stop
+	@scripts/setup_integration_env.sh redis start
+	sleep 10 # Many services are very slow... Give them a sec..
+endif
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features redis-integration-tests --lib ::redis:: -- --nocapture
+ifeq ($(AUTODESPAWN), true)
+	@scripts/setup_integration_env.sh redis stop
 endif
 
 .PHONY: test-e2e-kubernetes

--- a/docs/reference/components/sinks/redis.cue
+++ b/docs/reference/components/sinks/redis.cue
@@ -1,0 +1,121 @@
+package metadata
+
+components: sinks: redis: {
+	title:       "Redis"
+	description: "[Redis](\(urls.redis)) is an open source (BSD licensed), in-memory data structure store, used as a database, cache, and message broker."
+	classes: {
+		commonly_used: false
+		delivery:      "best_effort"
+		development:   "beta"
+		egress_method: "stream"
+		service_providers: []
+		stateful: false
+	}
+	features: {
+		buffer: enabled:      false
+		healthcheck: enabled: true
+		send: {
+			compression: enabled: false
+			encoding: {
+				enabled: true
+				codec: {
+					enabled: true
+					default: null
+					enum: ["json", "text"]
+				}
+			}
+			request: enabled: false
+			tls: enabled:     false
+			to: {
+				service: services.redis
+				interface: {
+					socket: {
+						direction: "outgoing"
+						protocols: ["tcp"]
+						ssl: "disabled"
+					}
+				}
+			}
+		}
+	}
+
+	support: {
+		targets: {
+			"aarch64-unknown-linux-gnu":      true
+			"aarch64-unknown-linux-musl":     true
+			"armv7-unknown-linux-gnueabihf":  true
+			"armv7-unknown-linux-musleabihf": true
+			"x86_64-apple-darwin":            true
+			"x86_64-pc-windows-msv":          true
+			"x86_64-unknown-linux-gnu":       true
+			"x86_64-unknown-linux-musl":      true
+		}
+
+		requirements: []
+		warnings: []
+		notices: []
+	}
+
+	configuration: {
+		url: {
+			description: "The Redis URL to connect to. The url _must_ take the form of `redis://server:port/db`."
+			groups: ["tcp"]
+			required: true
+			warnings: []
+			type: string: {
+				examples: ["redis://127.0.0.1:6379/0"]
+				syntax: "literal"
+			}
+		}
+		key: {
+			description: "The Redis key to publish messages to."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["syslog:{{ app }}", "vector"]
+				syntax: "template"
+			}
+		}
+		data_type: {
+			common:      false
+			description: "The Redis Data Type(list or channel) to use."
+			required:    false
+			type: string: {
+				enum: {
+					list:    "Use list"
+					channel: "Use channel"
+				}
+				syntax: "literal"
+			}
+		}
+		method: {
+			common:      false
+			description: "The Method(lpush or rpush) to publish messages when data_type is list."
+			required:    false
+			type: string: {
+				enum: {
+					lpush: "Use lpush"
+					rpush: "Use rpush"
+				}
+				syntax: "literal"
+			}
+		}
+	}
+
+	input: {
+		logs:    true
+		metrics: null
+	}
+
+	how_it_works: {
+		redis_rs: {
+			title: "redis-rs"
+			body:  """
+				The `redis` sink uses [`redis-rs`](\(urls.redis_rs)) under the hood. This
+				is a is a high level redis library for Rust. It provides convenient access to all Redis functionality through a very flexible but low-level API.
+				It uses a customizable type conversion trait so that any operation can return results in just the type you are expecting.
+				This makes for a very pleasant development experience.
+				"""
+		}
+	}
+}

--- a/docs/reference/components/sources/redis.cue
+++ b/docs/reference/components/sources/redis.cue
@@ -1,0 +1,137 @@
+package metadata
+
+components: sources: redis: {
+	title:       "Redis"
+	description: "[Redis](\(urls.redis)) is an open source (BSD licensed), in-memory data structure store, used as a database, cache, and message broker."
+	features: {
+		collect: {
+			checkpoint: enabled: false
+			tls: {
+				enabled:                true
+				can_enable:             true
+				can_verify_certificate: false
+				can_verify_hostname:    false
+				enabled_default:        false
+			}
+			from: {
+				service: services.redis
+				interface: {
+					socket: {
+						direction: "incoming"
+						port:      6379
+						protocols: ["tcp"]
+						ssl: "disabled"
+					}
+				}
+			}
+		}
+		multiline: enabled: false
+	}
+
+	classes: {
+		commonly_used: false
+		delivery:      "best_effort"
+		deployment_roles: ["daemon", "sidecar"]
+		development:   "beta"
+		egress_method: "stream"
+		stateful:      false
+	}
+
+	support: {
+		targets: {
+			"aarch64-unknown-linux-gnu":      true
+			"aarch64-unknown-linux-musl":     true
+			"armv7-unknown-linux-gnueabihf":  true
+			"armv7-unknown-linux-musleabihf": true
+			"x86_64-apple-darwin":            true
+			"x86_64-pc-windows-msv":          true
+			"x86_64-unknown-linux-gnu":       true
+			"x86_64-unknown-linux-musl":      true
+		}
+
+		requirements: []
+		warnings: []
+		notices: []
+	}
+
+	installation: {
+		platform_name: null
+	}
+
+	configuration: {
+		url: {
+			description: "The Redis URL to connect to. The url _must_ take the form of `redis://server:port/db`."
+			groups: ["tcp"]
+			required: true
+			warnings: []
+			type: string: {
+				examples: ["redis://127.0.0.1:6379/0"]
+				syntax: "literal"
+			}
+		}
+		key: {
+			description: "The Redis key to read messages from."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["vector"]
+				syntax: "literal"
+			}
+		}
+		data_type: {
+			common:      false
+			description: "The Redis Data Type(list or channel) to use."
+			required:    false
+			type: string: {
+				enum: {
+					list:    "Use list"
+					channel: "Use channel"
+				}
+				syntax: "literal"
+			}
+		}
+		method: {
+			common:      false
+			description: "The Method(brpop or blpop) to pop messages when data_type is list."
+			required:    false
+			type: string: {
+				enum: {
+					brpop: "Use brpop."
+					blpop: "Use blpop."
+				}
+				syntax: "literal"
+			}
+		}
+		redis_key: {
+			common:      false
+			description: "The log field name to use for the redis key. If unspecified, the key would not be added to the log event."
+			required:    false
+			warnings: []
+			type: string: {
+				examples: ["redis_key"]
+				syntax: "literal"
+			}
+		}
+	}
+
+	output: logs: record: {
+		description: "An individual Redis record"
+		fields: {
+			host:      fields._local_host
+			message:   fields._raw_line
+			timestamp: fields._current_timestamp
+		}
+	}
+
+	how_it_works: {
+		redis_rs: {
+			title: "redis-rs"
+			body:  """
+				The `redis` source uses [`redis-rs`](\(urls.redis_rs)) under the hood. This
+				is a is a high level redis library for Rust. It provides convenient access to all Redis functionality through a very flexible but low-level API.
+				It uses a customizable type conversion trait so that any operation can return results in just the type you are expecting.
+				This makes for a very pleasant development experience.
+				"""
+		}
+	}
+}

--- a/docs/reference/services/redis.cue
+++ b/docs/reference/services/redis.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: redis: {
+	name:     "Redis"
+	thing:    "a \(name) database"
+	url:      urls.redis
+	versions: null
+
+	description: "[Redis](\(urls.redis)) is an open source (BSD licensed), in-memory data structure store, used as a database, cache, and message broker."
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -511,4 +511,6 @@ urls: {
 	yum:                                                      "\(wikipedia)/wiki/Yum_(software)"
 	zlib:                                                     "https://www.zlib.net"
 	zstd:                                                     "https://zstd.net"
+	redis:                                                    "https://redis.io"
+	redis_rs:                                                 "https://github.com/mitsuhiko/redis-rs"
 }

--- a/scripts/setup_integration/redis_integration_env.sh
+++ b/scripts/setup_integration/redis_integration_env.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+# redis_integration_env.sh
+#
+# SUMMARY
+#
+#   Builds and pulls down the Vector Redis Integration test environment
+
+if [ $# -ne 1 ]
+then
+    echo "Usage: $0 {stop|start}" 1>&2; exit 1;
+    exit 1
+fi
+ACTION=$1
+
+#
+# Functions
+#
+
+start_podman () {
+  podman pod create --replace --name vector-test-integration-redis -p 6379:6379
+  podman run -d --pod=vector-test-integration-redis  --name vector_redis \
+	 redis
+}
+
+start_docker () {
+  docker network create vector-test-integration-redis
+  docker run -d --network=vector-test-integration-redis -p 6379:6379 --name vector_redis \
+	 redis
+}
+
+stop_podman () {
+  podman rm --force vector_redis 2>/dev/null; true
+  podman pod stop vector-test-integration-redis 2>/dev/null; true
+  podman pod rm --force vector-test-integration-redis 2>/dev/null; true
+}
+
+stop_docker () {
+  docker rm --force vector_redis 2>/dev/null; true
+  docker network rm vector-test-integration-redis 2>/dev/null; true
+}
+
+echo "Running $ACTION action for Redis integration tests environment"
+
+"${ACTION}"_"${CONTAINER_TOOL}"

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -80,6 +80,8 @@ mod process;
 #[cfg(any(feature = "sources-prometheus", feature = "sinks-prometheus"))]
 mod prometheus;
 mod pulsar;
+#[cfg(any(feature = "sources-redis", feature = "sinks-redis"))]
+mod redis;
 #[cfg(feature = "transforms-reduce")]
 mod reduce;
 #[cfg(feature = "transforms-regex_parser")]
@@ -200,6 +202,8 @@ pub use self::process::*;
 #[cfg(any(feature = "sources-prometheus", feature = "sinks-prometheus"))]
 pub(crate) use self::prometheus::*;
 pub use self::pulsar::*;
+#[cfg(any(feature = "sources-redis", feature = "sinks-redis"))]
+pub use self::redis::*;
 #[cfg(feature = "transforms-reduce")]
 pub(crate) use self::reduce::*;
 #[cfg(feature = "transforms-regex_parser")]

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -1,0 +1,109 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct RedisEventReceived {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for RedisEventReceived {
+    fn emit_logs(&self) {
+        trace!(message = "Received one event.", rate_limit_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processed_events_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
+pub struct RedisEventReceivedFail {
+    pub error: redis::RedisError,
+}
+
+impl InternalEvent for RedisEventReceivedFail {
+    fn emit_logs(&self) {
+        error!(
+            message = "Failed to read message.",
+            error = ?self.error ,
+            rate_limit_secs = 30,
+        );
+    }
+    fn emit_metrics(&self) {
+        counter!("events_failed_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct RedisEventSend {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for RedisEventSend {
+    fn emit_logs(&self) {
+        trace!(message = "Processed one event.", rate_limit_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processed_events_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
+pub struct RedisEventSendFail {
+    pub error: redis::RedisError,
+}
+
+impl InternalEvent for RedisEventSendFail {
+    fn emit_logs(&self) {
+        error!(
+            message = "Failed to send message.",
+            error = %self.error,
+            rate_limit_secs = 30,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("send_errors_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RedisEventEncodeError {
+    pub error: serde_json::Error,
+}
+
+impl InternalEvent for RedisEventEncodeError {
+    fn emit_logs(&self) {
+        error!(
+            message = "Error encoding redis event to JSON.",
+            error = ?self.error,
+            rate_limit_secs = 30,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("encode_errors_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct RedisMissingKeys<'a> {
+    pub keys: &'a [String],
+}
+
+impl<'a> InternalEvent for RedisMissingKeys<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Keys do not exist on the event; dropping event.",
+            missing_keys = ?self.keys,
+            rate_limit_secs = 30,
+        )
+    }
+
+    fn emit_metrics(&self) {
+        counter!("missing_keys_total", 1);
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -57,6 +57,8 @@ pub mod papertrail;
 pub mod prometheus;
 #[cfg(feature = "sinks-pulsar")]
 pub mod pulsar;
+#[cfg(feature = "sinks-redis")]
+pub mod redis;
 #[cfg(feature = "sinks-sematext")]
 pub mod sematext;
 #[cfg(feature = "sinks-socket")]

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -1,0 +1,551 @@
+use crate::{
+    buffers::Acker,
+    config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
+    internal_events::{
+        RedisEventEncodeError, RedisEventSend, RedisEventSendFail, RedisMissingKeys,
+    },
+    sinks::util::encoding::{EncodingConfig, EncodingConfigWithDefault, EncodingConfiguration},
+    template::{Template, TemplateError},
+};
+
+use futures::{future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, Sink, Stream};
+use redis::{aio::ConnectionManager, AsyncCommands, RedisError, RedisResult};
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use std::{
+    collections::HashSet,
+    convert::TryFrom,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+#[derive(Debug, Snafu)]
+enum BuildError {
+    #[snafu(display("creating redis producer failed: {}", source))]
+    RedisCreateFailed { source: RedisError },
+    #[snafu(display("invalid key template: {}", source))]
+    KeyTemplate { source: TemplateError },
+}
+
+#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
+    #[derivative(Default)]
+    List,
+    Channel,
+}
+
+#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize, Eq, PartialEq)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Method {
+    #[derivative(Default)]
+    LPUSH,
+    RPUSH,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedisSinkConfig {
+    #[serde(default)]
+    pub data_type: Type,
+    pub method: Option<Method>,
+    pub encoding: EncodingConfigWithDefault<Encoding>,
+    pub url: String,
+    pub key: String,
+}
+
+#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize, Eq, PartialEq)]
+#[derivative(Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Encoding {
+    #[derivative(Default)]
+    Json,
+    Text,
+}
+
+enum RedisSinkState {
+    None,
+    Ready(ConnectionManager),
+    Sending(BoxFuture<'static, (ConnectionManager, Result<i32, RedisError>)>),
+}
+
+pub struct RedisSink {
+    key: Template,
+    data_type: Type,
+    method: Option<Method>,
+    encoding: EncodingConfig<Encoding>,
+    state: RedisSinkState,
+    in_flight: FuturesUnordered<BoxFuture<'static, (usize, Result<i32, RedisError>)>>,
+    acker: Acker,
+    seq_head: usize,
+    seq_tail: usize,
+    pending_acks: HashSet<usize>,
+}
+
+inventory::submit! {
+    SinkDescription::new::<RedisSinkConfig>("redis")
+}
+
+impl GenerateConfig for RedisSinkConfig {
+    fn generate_config() -> toml::Value {
+        toml::Value::try_from(&Self {
+            url: "redis://127.0.0.1:6379/0".to_owned(),
+            key: "vector".to_owned(),
+            encoding: Encoding::Json.into(),
+            data_type: Type::List,
+            method: Option::from(Method::LPUSH),
+        })
+        .unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "redis")]
+impl SinkConfig for RedisSinkConfig {
+    async fn build(
+        &self,
+        cx: SinkContext,
+    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
+        if self.key.is_empty() {
+            return Err("`key` cannot be empty.".into());
+        } else if let Type::List = self.data_type {
+            if self.method.is_none() {
+                return Err("When `data_type` is `list`, `method` cannot be empty.".into());
+            }
+        }
+
+        let sink = RedisSink::new(self.clone(), cx.acker()).await?;
+
+        let conn = match &(sink.state) {
+            RedisSinkState::Ready(conn) => conn.clone(),
+            _ => unreachable!(),
+        };
+        let healthcheck = healthcheck(conn).boxed();
+
+        Ok((super::VectorSink::Sink(Box::new(sink)), healthcheck))
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "redis"
+    }
+}
+
+impl RedisSinkConfig {
+    async fn build_client(&self) -> RedisResult<ConnectionManager> {
+        trace!("Open redis client.");
+        let client = redis::Client::open(self.url.as_str())?;
+        trace!("Open redis client success.");
+        trace!("Get redis connection.");
+        let conn = client.get_tokio_connection_manager().await;
+        trace!("Get redis connection success.");
+        conn
+    }
+}
+
+impl RedisSink {
+    async fn new(config: RedisSinkConfig, acker: Acker) -> crate::Result<Self> {
+        let res = config.build_client().await.context(RedisCreateFailed);
+
+        let key_tmpl = Template::try_from(config.key).context(KeyTemplate)?;
+
+        match res {
+            Ok(conn) => Ok(RedisSink {
+                data_type: config.data_type,
+                method: config.method,
+                key: key_tmpl,
+                encoding: config.encoding.into(),
+                acker,
+                seq_head: 0,
+                seq_tail: 0,
+                pending_acks: HashSet::new(),
+                in_flight: FuturesUnordered::new(),
+                state: RedisSinkState::Ready(conn),
+            }),
+            Err(error) => {
+                error!(message = "Redis sink init generated an error.", %error);
+                Err(error.to_string().into())
+            }
+        }
+    }
+    fn poll_in_flight_prepare(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if let RedisSinkState::Sending(fut) = &mut self.state {
+            let (conn, result) = ready!(fut.as_mut().poll(cx));
+
+            let seqno = self.seq_head;
+            self.seq_head += 1;
+
+            self.state = RedisSinkState::Ready(conn);
+            self.in_flight
+                .push(Box::pin(async move { (seqno, result) }));
+        }
+        Poll::Ready(())
+    }
+}
+
+impl Sink<Event> for RedisSink {
+    type Error = ();
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_in_flight_prepare(cx));
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, event: Event) -> Result<(), Self::Error> {
+        assert!(
+            matches!(self.state, RedisSinkState::Ready(_)),
+            "expected `poll_ready` to be called first."
+        );
+
+        let conn = match std::mem::replace(&mut self.state, RedisSinkState::None) {
+            RedisSinkState::Ready(conn) => conn,
+            _ => unreachable!(),
+        };
+
+        let key = self.key.render_string(&event).map_err(|missing_keys| {
+            emit!(RedisMissingKeys {
+                keys: &missing_keys
+            });
+        })?;
+
+        let encoded = encode_event(event, &self.encoding);
+        let message_len = encoded.len();
+
+        match self.data_type {
+            Type::List => match self.method {
+                Some(Method::LPUSH) => {
+                    let _ = std::mem::replace(
+                        &mut self.state,
+                        RedisSinkState::Sending(Box::pin(async move {
+                            let result = lpush(conn.clone(), key.clone(), encoded.clone()).await;
+                            if result.is_ok() {
+                                emit!(RedisEventSend {
+                                    byte_size: message_len,
+                                });
+                            }
+                            (conn, result)
+                        })),
+                    );
+                }
+                Some(Method::RPUSH) => {
+                    let _ = std::mem::replace(
+                        &mut self.state,
+                        RedisSinkState::Sending(Box::pin(async move {
+                            let result = rpush(conn.clone(), key.clone(), encoded.clone()).await;
+                            if result.is_ok() {
+                                emit!(RedisEventSend {
+                                    byte_size: message_len,
+                                });
+                            }
+                            (conn, result)
+                        })),
+                    );
+                }
+                None => {
+                    panic!("When `data_type` is `list`, `method` cannot be empty.")
+                }
+            },
+            Type::Channel => {
+                let _ = std::mem::replace(
+                    &mut self.state,
+                    RedisSinkState::Sending(Box::pin(async move {
+                        let result = publish(conn.clone(), key.clone(), encoded.clone()).await;
+                        if result.is_ok() {
+                            emit!(RedisEventSend {
+                                byte_size: message_len,
+                            });
+                        }
+                        (conn, result)
+                    })),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_in_flight_prepare(cx));
+
+        let this = Pin::into_inner(self);
+        while !this.in_flight.is_empty() {
+            match ready!(Pin::new(&mut this.in_flight).poll_next(cx)) {
+                Some((seqno, Ok(result))) => {
+                    trace!(
+                        message = "Redis sink produced message.",
+                        length = ?result,
+                    );
+                    this.pending_acks.insert(seqno);
+                    let mut num_to_ack = 0;
+                    while this.pending_acks.remove(&this.seq_tail) {
+                        num_to_ack += 1;
+                        this.seq_tail += 1
+                    }
+                    this.acker.ack(num_to_ack);
+                }
+                Some((_, Err(error))) => {
+                    error!(message = "Redis sink generated an error.", %error);
+                    emit!(RedisEventSendFail { error });
+                    return Poll::Ready(Err(()));
+                }
+                None => break,
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_flush(cx)
+    }
+}
+
+async fn lpush(mut conn: ConnectionManager, key: String, value: String) -> Result<i32, RedisError> {
+    let res: RedisResult<i32> = conn.lpush(key, value).await;
+    match res {
+        Ok(len) => Ok(len),
+        Err(e) => Err(e),
+    }
+}
+
+async fn rpush(mut conn: ConnectionManager, key: String, value: String) -> Result<i32, RedisError> {
+    let res: RedisResult<i32> = conn.rpush(key, value).await;
+    match res {
+        Ok(len) => Ok(len),
+        Err(e) => Err(e),
+    }
+}
+
+async fn publish(
+    mut conn: ConnectionManager,
+    key: String,
+    value: String,
+) -> Result<i32, RedisError> {
+    let res: RedisResult<i32> = conn.publish(key, value).await;
+    match res {
+        Ok(len) => Ok(len),
+        Err(e) => Err(e),
+    }
+}
+
+async fn healthcheck(mut conn: ConnectionManager) -> crate::Result<()> {
+    redis::cmd("PING")
+        .query_async(&mut conn)
+        .await
+        .map_err(Into::into)
+}
+
+fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> String {
+    encoding.apply_rules(&mut event);
+
+    match encoding.codec() {
+        Encoding::Json => serde_json::to_string(event.as_log())
+            .map_err(|error| emit!(RedisEventEncodeError { error }))
+            .unwrap_or_default(),
+        Encoding::Text => event
+            .as_log()
+            .get(log_schema().message_key())
+            .map(|v| v.to_string_lossy())
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<RedisSinkConfig>();
+    }
+
+    #[test]
+    fn redis_event_json() {
+        let msg = "hello_world".to_owned();
+        let mut evt = Event::from(msg.clone());
+        evt.as_mut_log().insert("key", "value");
+        let result = encode_event(evt, &EncodingConfig::from(Encoding::Json));
+        let map: HashMap<String, String> = serde_json::from_str(result.as_str()).unwrap();
+        assert_eq!(msg, map[&log_schema().message_key().to_string()]);
+    }
+
+    #[test]
+    fn redis_event_text() {
+        let msg = "hello_world".to_owned();
+        let evt = Event::from(msg.clone());
+        let event = encode_event(evt, &EncodingConfig::from(Encoding::Text));
+        assert_eq!(event, msg);
+    }
+
+    #[test]
+    fn redis_encode_event() {
+        let msg = "hello_world";
+        let mut evt = Event::from(msg);
+        evt.as_mut_log().insert("key", "value");
+
+        let event = encode_event(
+            evt,
+            &EncodingConfigWithDefault {
+                codec: Encoding::Json,
+                except_fields: Some(vec!["key".into()]),
+                ..Default::default()
+            }
+            .into(),
+        );
+
+        let map: HashMap<String, String> = serde_json::from_str(event.as_str()).unwrap();
+        assert!(!map.contains_key("key"));
+    }
+}
+
+#[cfg(feature = "redis-integration-tests")]
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::test_util::{random_lines_with_stream, random_string, trace_init};
+    use futures::StreamExt;
+    use rand::Rng;
+
+    const REDIS_SERVER: &str = "redis://127.0.0.1:6379/0";
+
+    #[tokio::test]
+    async fn redis_sink_list_lpush() {
+        trace_init();
+
+        let key = format!("test-{}", random_string(10));
+        debug!("Test key name: {}.", key);
+        let mut rng = rand::thread_rng();
+        let num_events = rng.gen_range(1000..2000);
+        debug!("Test events num: {}.", num_events);
+
+        let cnf = RedisSinkConfig {
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            encoding: Encoding::Json.into(),
+            data_type: Type::List,
+            method: Option::from(Method::LPUSH),
+        };
+
+        // Publish events.
+        let (acker, ack_counter) = Acker::new_for_testing();
+        let sink = RedisSink::new(cnf.clone(), acker).await.unwrap();
+        let (_input, events) = random_lines_with_stream(1000, num_events);
+        events.map(Ok).forward(sink).await.unwrap();
+
+        assert_eq!(
+            ack_counter.load(std::sync::atomic::Ordering::Relaxed),
+            num_events
+        );
+
+        let mut conn = cnf.build_client().await.unwrap();
+
+        let key_exists: bool = conn.exists(key.clone()).await.unwrap();
+        debug!("Test key: {} exists: {}.", key, key_exists);
+        assert_eq!(key_exists, true);
+        let llen: usize = conn.llen(key.clone()).await.unwrap();
+        debug!("Test key: {} len: {}.", key, llen);
+        assert_eq!(llen, num_events);
+    }
+
+    #[tokio::test]
+    async fn redis_sink_list_rpush() {
+        trace_init();
+
+        let key = format!("test-{}", random_string(10));
+        debug!("Test key name: {}.", key);
+        let mut rng = rand::thread_rng();
+        let num_events = rng.gen_range(1000..2000);
+        debug!("Test events num: {}.", num_events);
+
+        let cnf = RedisSinkConfig {
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            encoding: Encoding::Json.into(),
+            data_type: Type::List,
+            method: Option::from(Method::RPUSH),
+        };
+
+        // Publish events.
+        let (acker, ack_counter) = Acker::new_for_testing();
+        let sink = RedisSink::new(cnf.clone(), acker).await.unwrap();
+        let (_input, events) = random_lines_with_stream(100, num_events);
+        events.map(Ok).forward(sink).await.unwrap();
+
+        assert_eq!(
+            ack_counter.load(std::sync::atomic::Ordering::Relaxed),
+            num_events
+        );
+
+        let mut conn = cnf.build_client().await.unwrap();
+
+        let key_exists: bool = conn.exists(key.clone()).await.unwrap();
+        debug!("Test key: {} exists: {}.", key, key_exists);
+        assert_eq!(key_exists, true);
+        let llen: usize = conn.llen(key.clone()).await.unwrap();
+        debug!("Test key: {} len: {}.", key, llen);
+        assert_eq!(llen, num_events);
+    }
+
+    #[tokio::test]
+    async fn redis_sink_channel() {
+        trace_init();
+
+        let key = format!("test-{}", random_string(10));
+        debug!("Test key name: {}.", key);
+        let mut rng = rand::thread_rng();
+        let num_events = rng.gen_range(1000..2000);
+        debug!("Test events num: {}.", num_events);
+
+        let client = redis::Client::open(REDIS_SERVER).unwrap();
+        debug!("Get redis async connection.");
+        let conn = client
+            .get_async_connection()
+            .await
+            .expect("Failed to get redis async connection.");
+        debug!("Get redis async connection success.");
+        let mut pubsub_conn = conn.into_pubsub();
+        debug!("Subscrib channel:{}.", key.as_str());
+        pubsub_conn
+            .subscribe(key.as_str())
+            .await
+            .unwrap_or_else(|_| panic!("Failed to subscribe channel:{}.", key.as_str()));
+        debug!("Subscribed to channel:{}.", key.as_str());
+        let mut pubsub_stream = pubsub_conn.on_message();
+
+        let cnf = RedisSinkConfig {
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            encoding: Encoding::Json.into(),
+            data_type: Type::Channel,
+            method: None,
+        };
+
+        // Publish events.
+        let (acker, ack_counter) = Acker::new_for_testing();
+        let sink = RedisSink::new(cnf.clone(), acker).await.unwrap();
+        let (_input, events) = random_lines_with_stream(100, num_events);
+        events.map(Ok).forward(sink).await.unwrap();
+
+        assert_eq!(
+            ack_counter.load(std::sync::atomic::Ordering::Relaxed),
+            num_events
+        );
+
+        // Receive events.
+        let mut received_msg_num = 0;
+        loop {
+            let _msg = pubsub_stream.next().await.unwrap();
+            received_msg_num += 1;
+            debug!("Received msg num:{}.", received_msg_num);
+            if received_msg_num == num_events {
+                assert_eq!(received_msg_num, num_events);
+                break;
+            }
+        }
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -52,6 +52,9 @@ pub mod syslog;
 #[cfg(feature = "sources-vector")]
 pub mod vector;
 
+#[cfg(feature = "sources-redis")]
+pub mod redis;
+
 mod util;
 
 pub type Source = BoxFuture<'static, Result<(), ()>>;

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -1,0 +1,54 @@
+use futures::{SinkExt, StreamExt};
+
+use crate::{
+    internal_events::{RedisEventReceived, RedisEventReceivedFail},
+    shutdown::ShutdownSignal,
+    sources::redis::create_event,
+    sources::Source,
+    Pipeline,
+};
+
+pub fn subscribe(
+    client: redis::Client,
+    key: String,
+    redis_key: Option<String>,
+    mut shutdown: ShutdownSignal,
+    out: Pipeline,
+) -> Source {
+    let mut out = out.sink_map_err(|error| error!(message="Error sending event.", %error));
+    let fut = async move {
+        trace!("Get redis async connection.");
+        let conn = client
+            .get_async_connection()
+            .await
+            .expect("Failed to get redis async connection.");
+        trace!("Get redis async connection success.");
+        let mut pubsub_conn = conn.into_pubsub();
+        trace!("Subscrib channel:{}.", key.as_str());
+        pubsub_conn
+            .subscribe(key.as_str())
+            .await
+            .unwrap_or_else(|_| panic!("Failed to subscribe channel:{}.", key.as_str()));
+        trace!("Subscribed to channel:{}.", key.as_str());
+        let mut pubsub_stream = pubsub_conn.on_message();
+        loop {
+            let msg = pubsub_stream.next().await.unwrap();
+            let line = msg
+                .get_payload::<String>()
+                .map_err(|error| emit!(RedisEventReceivedFail { error }))
+                .unwrap_or_default();
+            emit!(RedisEventReceived {
+                byte_size: line.len()
+            });
+            let event = create_event(line.as_str(), key.clone(), &redis_key);
+            tokio::select! {
+                result = out.send(event) => {match result {
+                    Ok(()) => { },
+                    Err(()) => return Ok(()),
+                }}
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    };
+    Box::pin(fut)
+}

--- a/src/sources/redis/list.rs
+++ b/src/sources/redis/list.rs
@@ -1,0 +1,115 @@
+use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, RedisResult};
+
+use crate::{
+    internal_events::{RedisEventReceived, RedisEventReceivedFail},
+    shutdown::ShutdownSignal,
+    sources::redis::{create_event, Method},
+    sources::Source,
+    Pipeline,
+};
+use futures::SinkExt;
+
+pub fn watch(
+    client: redis::Client,
+    key: String,
+    redis_key: Option<String>,
+    method: Method,
+    mut shutdown: ShutdownSignal,
+    out: Pipeline,
+) -> Source {
+    let mut out = out.sink_map_err(|error| error!(message="Error sending event.", %error));
+    match method {
+        Method::BRPOP => {
+            let fut = async move {
+                trace!("Get redis connection manager.");
+                let mut conn = client
+                    .get_tokio_connection_manager()
+                    .await
+                    .expect("Failed to get redis async connection.");
+                trace!("Get redis connection manager success.");
+                loop {
+                    tokio::select! {
+                        res = brpop(&mut conn,key.as_str()) => {
+                            match res {
+                                Ok(line) => {
+                                    emit!(RedisEventReceived {
+                                        byte_size: line.len()
+                                    });
+                                    let event = create_event(line.as_str(),key.clone(),&redis_key);
+                                    tokio::select!{
+                                        result = out.send(event) => {match result {
+                                            Ok(()) => { },
+                                            Err(()) => return Ok(()),
+                                        }}
+                                        _ = &mut shutdown => return Ok(()),
+                                    }
+                                }
+                                Err(error) => {
+                                    error!(message = "Redis source generated an error.", %error);
+                                    emit!(RedisEventReceivedFail { error });
+                                }
+                            }
+                        }
+                        _ = &mut shutdown => return Ok(()),
+                    }
+                }
+            };
+            Box::pin(fut)
+        }
+        Method::BLPOP => {
+            let fut = async move {
+                trace!("Get redis connection manager.");
+                let mut conn = client
+                    .get_tokio_connection_manager()
+                    .await
+                    .expect("Failed to get redis async connection.");
+                trace!("Get redis connection manager success.");
+                loop {
+                    tokio::select! {
+                        res = blpop(&mut conn,key.as_str()) => {
+                            match res {
+                                Ok(line) => {
+                                    emit!(RedisEventReceived {
+                                        byte_size: line.len()
+                                    });
+                                    let event = create_event(line.as_str(),key.clone(),&redis_key);
+                                    tokio::select!{
+                                        result = out.send(event) => {match result {
+                                            Ok(()) => { },
+                                            Err(()) => return Ok(()),
+                                        }}
+                                        _ = &mut shutdown => return Ok(()),
+                                    }
+                                }
+                                Err(error) => {
+                                    emit!(RedisEventReceivedFail {
+                                        error
+                                    });
+                                }
+                            }
+                        }
+                        _ = &mut shutdown => return Ok(()),
+                    }
+                }
+            };
+            Box::pin(fut)
+        }
+    }
+}
+
+async fn brpop(conn: &mut ConnectionManager, key: &str) -> RedisResult<String> {
+    let res: RedisResult<(String, String)> = conn.brpop(key, 0).await;
+    match res {
+        Ok(payload) => Ok(payload.1),
+        Err(error) => Err(error),
+    }
+}
+
+async fn blpop(conn: &mut ConnectionManager, key: &str) -> RedisResult<String> {
+    let res: RedisResult<(String, String)> = conn.blpop(key, 0).await;
+    match res {
+        Ok(payload) => Ok(payload.1),
+        Err(error) => Err(error),
+    }
+}

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -1,0 +1,308 @@
+use crate::{
+    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    event::Event,
+    shutdown::ShutdownSignal,
+    Pipeline,
+};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+mod channel;
+mod list;
+
+#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
+    #[derivative(Default)]
+    List,
+    Channel,
+}
+
+#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize, Eq, PartialEq)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Method {
+    #[derivative(Default)]
+    BRPOP,
+    BLPOP,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedisSourceConfig {
+    #[serde(default)]
+    pub data_type: Type,
+    pub method: Option<Method>,
+    pub url: String,
+    pub key: String,
+    pub redis_key: Option<String>,
+}
+
+impl Default for RedisSourceConfig {
+    fn default() -> Self {
+        RedisSourceConfig {
+            data_type: Type::List,
+            url: String::from("redis://127.0.0.1:6379/0"),
+            key: String::from("vector"),
+            method: Some(Method::BRPOP),
+            redis_key: Some("redis_key".to_owned()),
+        }
+    }
+}
+
+inventory::submit! {
+    SourceDescription::new::<RedisSourceConfig>("redis")
+}
+
+impl_generate_config_from_default!(RedisSourceConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "redis")]
+impl SourceConfig for RedisSourceConfig {
+    async fn build(
+        &self,
+        _name: &str,
+        _globals: &GlobalOptions,
+        shutdown: ShutdownSignal,
+        out: Pipeline,
+    ) -> crate::Result<super::Source> {
+        redis_source(self, shutdown, out)
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn source_type(&self) -> &'static str {
+        "redis"
+    }
+}
+
+fn redis_source(
+    config: &RedisSourceConfig,
+    shutdown: ShutdownSignal,
+    out: Pipeline,
+) -> crate::Result<super::Source> {
+    if config.key.is_empty() {
+        return Err("`key` cannot be empty.".into());
+    } else if let Type::List = config.data_type {
+        if config.method.is_none() {
+            return Err("When `data_type` is `list`, `method` cannot be empty.".into());
+        }
+    }
+
+    let client = build_client(config).expect("Failed to open redis client.");
+    let key = config.key.clone();
+    let redis_key = config.redis_key.clone();
+
+    match config.data_type {
+        Type::List => match config.method {
+            Some(method) => Ok(list::watch(client, key, redis_key, method, shutdown, out)),
+            None => {
+                panic!("When `data_type` is `list`, `method` cannot be empty.")
+            }
+        },
+        Type::Channel => Ok(channel::subscribe(client, key, redis_key, shutdown, out)),
+    }
+}
+
+fn build_client(config: &RedisSourceConfig) -> crate::Result<redis::Client> {
+    trace!("Open redis client.");
+    let client = redis::Client::open(config.url.as_str())?;
+    trace!("Open redis client successed.");
+    Ok(client)
+}
+
+fn create_event(line: &str, key: String, redis_key: &Option<String>) -> Event {
+    let mut event = Event::from(line);
+    event
+        .as_mut_log()
+        .insert(log_schema().source_type_key(), Bytes::from("redis"));
+    if let Some(redis_key) = &redis_key {
+        event.as_mut_log().insert(redis_key.clone(), key);
+    }
+    event
+}
+
+#[cfg(test)]
+mod test {
+    use super::{redis_source, RedisSourceConfig};
+    use crate::sources::redis::{Method, Type};
+    use crate::{shutdown::ShutdownSignal, Pipeline};
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<RedisSourceConfig>();
+    }
+
+    fn make_config(t: Type) -> RedisSourceConfig {
+        RedisSourceConfig {
+            data_type: t,
+            url: String::from("redis://127.0.0.1:6379/0"),
+            key: String::from("vector"),
+            method: Option::from(Method::BRPOP),
+            redis_key: None,
+        }
+    }
+
+    #[test]
+    fn redis_list_source_create_ok() {
+        let config = make_config(Type::List);
+        assert!(redis_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_ok());
+    }
+
+    #[test]
+    fn redis_channel_source_create_ok() {
+        let config = make_config(Type::Channel);
+        assert!(redis_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_ok());
+    }
+}
+
+#[cfg(feature = "redis-integration-tests")]
+#[cfg(test)]
+mod integration_test {
+    use super::*;
+    use crate::config::log_schema;
+    use crate::{
+        shutdown::ShutdownSignal,
+        test_util::{collect_n, random_string},
+        Pipeline,
+    };
+    use redis::{AsyncCommands, RedisResult};
+
+    const REDIS_SERVER: &str = "redis://127.0.0.1:6379/0";
+
+    async fn send_event_by_list(key: String, text: &str) {
+        let client = redis::Client::open(REDIS_SERVER).unwrap();
+        trace!("Get redis connection manager.");
+        let mut conn = client
+            .get_tokio_connection_manager()
+            .await
+            .expect("Failed to get redis async connection.");
+        trace!("Get redis connection manager success.");
+        let res: RedisResult<i32> = conn.lpush(key, text).await;
+        match res {
+            Ok(len) => {
+                debug!("Send event for list success, len: {:?}.", len);
+            }
+            Err(err) => {
+                panic!("Send event for list error: {:?}.", err);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn redis_source_list_brpop() {
+        let key = format!("test-key-{}", random_string(10));
+        debug!("Test key name: {}.", key);
+
+        let config = RedisSourceConfig {
+            data_type: Type::List,
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            method: Option::from(Method::BRPOP),
+            redis_key: None,
+        };
+
+        debug!("Sending event.");
+        send_event_by_list(key.clone(), "test message for list(brpop)").await;
+
+        debug!("Receiving event.");
+        let (tx, rx) = Pipeline::new_test();
+        tokio::spawn(redis_source(&config, ShutdownSignal::noop(), tx).unwrap());
+        let events = collect_n(rx, 1).await;
+
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key()],
+            "test message for list(brpop)".into()
+        );
+        assert_eq!(
+            events[0].as_log()[log_schema().source_type_key()],
+            "redis".into()
+        );
+    }
+
+    #[tokio::test]
+    async fn redis_source_list_blpop() {
+        let key = format!("test-key-{}", random_string(10));
+        debug!("Test key name: {}.", key);
+
+        let config = RedisSourceConfig {
+            data_type: Type::List,
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            method: Option::from(Method::BLPOP),
+            redis_key: None,
+        };
+
+        debug!("Sending event.");
+        send_event_by_list(key.clone(), "test message for list(blpop)").await;
+
+        debug!("Receiving event.");
+        let (tx, rx) = Pipeline::new_test();
+        tokio::spawn(redis_source(&config, ShutdownSignal::noop(), tx).unwrap());
+        let events = collect_n(rx, 1).await;
+
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key()],
+            "test message for list(blpop)".into()
+        );
+        assert_eq!(
+            events[0].as_log()[log_schema().source_type_key()],
+            "redis".into()
+        );
+    }
+
+    #[tokio::test]
+    async fn redis_source_channel_consume_event() {
+        let key = "test-channel".to_owned();
+        debug!("Test key name: {}.", key);
+
+        let config = RedisSourceConfig {
+            data_type: Type::Channel,
+            method: None,
+            url: REDIS_SERVER.to_owned(),
+            key: key.clone(),
+            redis_key: None,
+        };
+
+        debug!("Receiving event.");
+        let (tx, rx) = Pipeline::new_test();
+        tokio::spawn(redis_source(&config, ShutdownSignal::noop(), tx).unwrap());
+        let events = collect_n(rx, 1).await;
+
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key()],
+            "test message for channel".into()
+        );
+        assert_eq!(
+            events[0].as_log()[log_schema().source_type_key()],
+            "redis".into()
+        );
+    }
+
+    #[tokio::test]
+    async fn redis_source_channel_product_event() {
+        debug!("Sending event by channel.");
+        let key = "test-channel".to_owned();
+        debug!("Test key name: {}.", key);
+        let client = redis::Client::open(REDIS_SERVER).unwrap();
+        trace!("Get redis async connection.");
+        let mut conn = client
+            .get_async_connection()
+            .await
+            .expect("Failed to get redis async connection.");
+        trace!("Get redis async connection success.");
+        let res: RedisResult<i32> = conn.publish(key, "test message for channel").await;
+        match res {
+            Ok(len) => {
+                debug!("Send event by channel success, len: {:?}.", len);
+                assert_eq!(len, 1);
+            }
+            Err(err) => {
+                panic!("Send event by channel error: {:?}.", err);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I creat a plugin to support redis(list、channel) as a data source and sink 

Context Issue: #3319 

the example config:
```toml
[sources.in]
type = "redis"
url = "redis://127.0.0.1:6379/0"
data_type = "list"
key = "vector"
method = "brpop"
redis_key = "redis_key"


[sinks.out]
type = "redis"
url = "redis://127.0.0.1:6379/0"
data_type = "list"
key = "vector"
method = "lpush"
healthcheck = true
inputs = ["in"]
encoding.codec = "json"
```