### PR TITLE
chore(config): Rename `api.bind` -> `api.address`

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -23,7 +23,7 @@ impl Server {
 
         let (_shutdown, rx) = oneshot::channel();
         let (addr, server) = warp::serve(routes).bind_with_graceful_shutdown(
-            config.api.bind.expect("Invalid socket address"),
+            config.api.address.expect("Invalid socket address"),
             async {
                 rx.await.ok();
             },

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -23,7 +23,7 @@ impl Server {
 
         let (_shutdown, rx) = oneshot::channel();
         let (addr, server) = warp::serve(routes).bind_with_graceful_shutdown(
-            config.api.address.expect("Invalid socket address"),
+            config.api.address.expect("No socket address"),
             async {
                 rx.await.ok();
             },

--- a/src/app.rs
+++ b/src/app.rs
@@ -196,7 +196,7 @@ impl Application {
             // assigned to prevent the API terminating when falling out of scope
             let api_server = if api_config.enabled {
                 emit!(ApiStarted {
-                    addr: api_config.bind.unwrap(),
+                    addr: api_config.address.unwrap(),
                     playground: api_config.playground
                 });
 

--- a/src/internal_events/api.rs
+++ b/src/internal_events/api.rs
@@ -13,7 +13,7 @@ impl InternalEvent for ApiStarted {
         let playground = &*format!("http://{}:{}/playground", self.addr.ip(), self.addr.port());
         info!(
             message="API server running.",
-            bind = ?self.addr,
+            address = ?self.addr,
             playground = %if self.playground { playground } else { "off" }
         );
     }

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -20,7 +20,7 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
     // provided by the API config. This will work despite `api` and `api-client` being distinct
     // features; the config is available even if `api` is disabled
     let url = opts.url.clone().unwrap_or_else(|| {
-        let addr = config::api::default_bind().unwrap();
+        let addr = config::api::default_address().unwrap();
         Url::parse(&*format!("http://{}/graphql", addr))
             .expect("Couldn't parse default API URL. Please report this.")
     });

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -60,14 +60,14 @@ mod tests {
         config.add_source("in1", source_with_event_counter().1);
         config.add_sink("out1", &["in1"], sink(10).1);
         config.api.enabled = true;
-        config.api.bind = Some(next_addr());
+        config.api.address = Some(next_addr());
 
         config.build().unwrap()
     }
 
     async fn from_str_config(conf: &str) -> vector::topology::RunningTopology {
         let mut c = config::load_from_str(conf).unwrap();
-        c.api.bind = Some(next_addr());
+        c.api.address = Some(next_addr());
 
         let diff = config::ConfigDiff::initial(&c);
         let pieces = vector::topology::build_or_log_errors(&c, &diff)
@@ -95,7 +95,7 @@ mod tests {
     // Returns the result of a URL test against the API. Wraps the test in retry_until
     // to guard against the race condition of the TCP listener not being ready
     async fn url_test(config: Config, url: &'static str) -> reqwest::Response {
-        let addr = config.api.bind.unwrap();
+        let addr = config.api.address.unwrap();
         let url = format!("http://{}:{}/{}", addr.ip(), addr.port(), url);
 
         let _server = api::Server::start(&config);


### PR DESCRIPTION
Renames `api.bind` -> `api.address` to match other parts of our config.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
