### PR TITLE
fix(external docs): Correct the kustomization instructions

### DIFF
--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -19,7 +19,7 @@ installation: _interfaces: kubectl: {
 	roles: [Name=string]: {
 		commands: {
 			_deployment_variant:       string
-			_vector_version:           "0.10"
+			_vector_version:           "0.11"
 			_namespace:                string | *"vector"
 			_controller_resource_type: string
 			_controller_resource_name: string | *_deployment_variant

--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -52,7 +52,7 @@ installation: _interfaces: kubectl: {
 				  - \#(_kustomization_base)
 
 				images:
-				  # Override the Vector image tag to avoid using sliding release.
+				  # Override the Vector image to avoid use of the sliding tag.
 				  - name: timberio/vector
 				    newName: timberio/vector
 				    newTag: #\(_vector_image_tag)

--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -38,16 +38,27 @@ installation: _interfaces: kubectl: {
 			verify_config:             "kubectl kustomize"
 			prepare_namespace:         "kubectl create namespace --dry-run=client -oyaml \(_namespace) > namespace.yaml"
 			prepare_kustomization:     #"""
-				cat <<-KUSTOMIZATION > kustomization.yaml
+				cat <<-'KUSTOMIZATION' > kustomization.yaml
+				# Override the namespace of all of the resources we manage.
 				namespace: \#(_namespace)
+
 				bases:
+				  # Include Vector recommended base (from git).
 				  - \#(_kustomization_base)
+
 				resources:
+				  # A namespace to keep the resources at.
 				  - namespace.yaml
+
 				configMapGenerator:
+				  # Provide a custom `ConfigMap` for Vector.
 				  - name: \#(_configmap_name)
 				    files:
 				      - \#(_configmap_file_name)
+
+				generatorOptions:
+				  # We do not want a suffix at the `ConfigMap` name.
+				  disableNameSuffixHash: true
 				KUSTOMIZATION
 				"""#
 			configure:                 #"""

--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -26,6 +26,9 @@ installation: _interfaces: kubectl: {
 			_configmap_name:           string | *"\(_controller_resource_name)-config"
 			_configmap_file_name:      string | *"\(_controller_resource_name).toml"
 			_config_header:            string | *""
+			_vector_image_version:     "0.10.X"
+			_vector_image_flavor:      "debian"
+			_vector_image_tag:         "\(_vector_image_version)-\(_vector_image_flavor)"
 			install:                   "kubectl apply -k ."
 			logs:                      "kubectl logs -n \(_namespace) \(_controller_resource_type)/\(_controller_resource_name)"
 			reload:                    null
@@ -45,6 +48,12 @@ installation: _interfaces: kubectl: {
 				bases:
 				  # Include Vector recommended base (from git).
 				  - \#(_kustomization_base)
+
+				images:
+				  # Override the Vector image tag to avoid using sliding release.
+				  - name: timberio/vector
+				    newName: timberio/vector
+				    newTag: #\(_vector_image_tag)
 
 				resources:
 				  # A namespace to keep the resources at.

--- a/docs/reference/installation/_interfaces/kubectl.cue
+++ b/docs/reference/installation/_interfaces/kubectl.cue
@@ -19,14 +19,16 @@ installation: _interfaces: kubectl: {
 	roles: [Name=string]: {
 		commands: {
 			_deployment_variant:       string
+			_vector_version:           "0.10"
 			_namespace:                string | *"vector"
 			_controller_resource_type: string
 			_controller_resource_name: string | *_deployment_variant
-			_kustomization_base:       string | *"github.com/timberio/vector/distribution/kubernetes/\(_deployment_variant)"
+			_kustomization_ref:        "v\(_vector_version)"
+			_kustomization_base:       string | *"github.com/timberio/vector/distribution/kubernetes/\(_deployment_variant)?ref=\(_kustomization_ref)"
 			_configmap_name:           string | *"\(_controller_resource_name)-config"
 			_configmap_file_name:      string | *"\(_controller_resource_name).toml"
 			_config_header:            string | *""
-			_vector_image_version:     "0.10.X"
+			_vector_image_version:     "\(_vector_version).X"
 			_vector_image_flavor:      "debian"
 			_vector_image_tag:         "\(_vector_image_version)-\(_vector_image_flavor)"
 			install:                   "kubectl apply -k ."


### PR DESCRIPTION
This PR corrects some functional issues with the existing kustomization instructions.
It also introduces proper version locking at the recommended `kustomization.yaml`, so that users can reliably refer to a particular Vector version, and upgrade as they need (contrary to us pushing a new release).