### PR TITLE
enhancement(file source): unify checksum methods

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -114,7 +114,18 @@ where
 
         let checkpoints = checkpointer.view();
 
+        let needs_checksum_upgrade = checkpoints.contains_bytes_checksums();
+
         for (path, file_id) in existing_files {
+            if needs_checksum_upgrade {
+                if let Ok(Some(old_checksum)) = self
+                    .fingerprinter
+                    .get_bytes_checksum(&path, &mut fingerprint_buffer)
+                {
+                    checkpoints.update_key(old_checksum, file_id)
+                }
+            }
+
             self.watch_new_file(
                 path,
                 file_id,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -210,6 +210,7 @@ pub fn file_source(
         glob_minimum_cooldown,
         fingerprinter: Fingerprinter {
             strategy: config.fingerprint.clone().into(),
+            max_line_length: config.max_line_bytes,
             ignore_not_found: false,
         },
         oldest_first: config.oldest_first,
@@ -1450,6 +1451,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let config = file::FileConfig {
             include: vec![PathBuf::from("tests/data/gzipped.log")],
+            // TODO: remove this once files are fingerprinted after decompression
+            //
+            // Currently, this needs to be smaller than the total size of the compressed file
+            // because the fingerprinter tries to read until a newline, which it's not going to see
+            // in the compressed data, or this number of bytes. If it hits EOF before that, it
+            // can't return a fingerprint because the value would change once more data is written.
+            max_line_bytes: 100,
             ..test_default_file_config(&dir)
         };
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -283,9 +283,9 @@ impl Source {
                 strategy: FingerprintStrategy::FirstLineChecksum {
                     // Max line length to expect during fingerprinting, see the
                     // explanation above.
-                    max_line_length: max_line_bytes,
                     ignored_header_bytes: 0,
                 },
+                max_line_length: max_line_bytes,
                 ignore_not_found: true,
             },
             // We expect the files distribution to not be a concern because of


### PR DESCRIPTION
Closes #5088

This change makes the file source use checksums of the first line of the file no matter which checksum strategy is configured. The old configuration is left in place for now to facilitate an automated migration on startup that upgrades existing bytes-based checksums to the new line-based version.

The one gotcha at this stage is around compressed files. If a gzipped file is smaller than the maximum allowed line length (default 100kb), we will currently not return a checksum and not read the file. This is because we need some fixed stopping point to make the checksum stable, and EOF is not that. This will be fixed by #5085.