### PR TITLE
chore(observability): Top throughput

### DIFF
--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -73,14 +73,7 @@ impl HumanFormatter for i64 {
     }
 }
 
-static COMPONENT_HEADERS: [&str; 6] = [
-    "Name",
-    "Kind",
-    "Type",
-    "Events (Total/Sec)",
-    "Bytes (Total/Sec)",
-    "Errors",
-];
+static COMPONENT_HEADERS: [&str; 6] = ["Name", "Kind", "Type", "Events", "Bytes", "Errors"];
 
 struct Widgets<'a> {
     constraints: Vec<Constraint>,

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -73,11 +73,19 @@ impl HumanFormatter for i64 {
     }
 }
 
+static COMPONENT_HEADERS: [&str; 6] = [
+    "Name",
+    "Kind",
+    "Type",
+    "Events (Total/Sec)",
+    "Bytes (Total/Sec)",
+    "Errors",
+];
+
 struct Widgets<'a> {
     constraints: Vec<Constraint>,
     url_string: &'a str,
     opts: &'a super::Opts,
-    component_headers: [String; 8],
 }
 
 impl<'a> Widgets<'a> {
@@ -89,23 +97,10 @@ impl<'a> Widgets<'a> {
             Constraint::Length(3),
         ];
 
-        // Create component headers
-        let component_headers = [
-            "Name".to_string(),
-            "Kind".to_string(),
-            "Type".to_string(),
-            "Events".to_string(),
-            format!("I/O @ {}ms", opts.interval),
-            "Bytes".to_string(),
-            format!("I/O @ {}ms", opts.interval),
-            "Errors".to_string(),
-        ];
-
         Self {
             constraints,
             url_string,
             opts,
-            component_headers,
         }
     }
 
@@ -136,30 +131,43 @@ impl<'a> Widgets<'a> {
         let items = state.iter().map(|(_, r)| {
             let mut data = vec![r.name.clone(), r.kind.clone(), r.component_type.clone()];
 
-            // Build metric stats
-            let formatted_metrics = if self.opts.human_metrics {
-                [
-                    r.processed_events_total.human_format(),
-                    r.processed_events_throughput.human_format(),
-                    r.processed_bytes_total.human_format_bytes(),
-                    r.processed_bytes_throughput.human_format_bytes(),
-                    r.errors.human_format(),
-                ]
-            } else {
-                [
-                    r.processed_events_total.thousands_format(),
-                    r.processed_events_throughput.thousands_format(),
-                    r.processed_bytes_total.thousands_format(),
-                    r.processed_bytes_throughput.thousands_format(),
-                    r.errors.thousands_format(),
-                ]
-            };
+            let formatted_metrics = [
+                match r.processed_events_total {
+                    0 => "N/A".to_string(),
+                    v => format!(
+                        "{} ({}/s)",
+                        if self.opts.human_metrics {
+                            v.human_format()
+                        } else {
+                            v.thousands_format()
+                        },
+                        r.processed_events_throughput_sec.human_format()
+                    ),
+                },
+                match r.processed_bytes_total {
+                    0 => "N/A".to_string(),
+                    v => format!(
+                        "{} ({}/s)",
+                        if self.opts.human_metrics {
+                            v.human_format()
+                        } else {
+                            v.thousands_format()
+                        },
+                        r.processed_bytes_throughput_sec.human_format_bytes()
+                    ),
+                },
+                if self.opts.human_metrics {
+                    r.errors.human_format()
+                } else {
+                    r.errors.thousands_format()
+                },
+            ];
 
             data.extend_from_slice(&formatted_metrics);
             Row::StyledData(data.into_iter(), Style::default().fg(Color::White))
         });
 
-        let w = Table::new(self.component_headers.iter(), items)
+        let w = Table::new(COMPONENT_HEADERS.iter(), items)
             .block(Block::default().borders(Borders::ALL).title("Components"))
             .header_gap(1)
             .column_spacing(2)
@@ -167,10 +175,8 @@ impl<'a> Widgets<'a> {
                 Constraint::Percentage(20),
                 Constraint::Percentage(10),
                 Constraint::Percentage(10),
-                Constraint::Percentage(10),
-                Constraint::Percentage(10),
-                Constraint::Percentage(10),
-                Constraint::Percentage(10),
+                Constraint::Percentage(20),
+                Constraint::Percentage(20),
                 Constraint::Percentage(10),
             ]);
 

--- a/src/top/metrics.rs
+++ b/src/top/metrics.rs
@@ -23,9 +23,9 @@ async fn component_added(client: Arc<SubscriptionClient>, mut tx: state::EventTx
                     kind: c.on.to_string(),
                     component_type: c.component_type,
                     processed_events_total: 0,
-                    processed_events_throughput: 0,
+                    processed_events_throughput_sec: 0,
                     processed_bytes_total: 0,
-                    processed_bytes_throughput: 0,
+                    processed_bytes_throughput_sec: 0,
                     errors: 0,
                 }))
                 .await;
@@ -90,6 +90,7 @@ async fn processed_events_throughputs(
             let c = d.component_processed_events_throughputs;
             let _ = tx
                 .send(state::EventType::ProcessedEventsThroughputs(
+                    interval,
                     c.into_iter().map(|c| (c.name, c.throughput)).collect(),
                 ))
                 .await;
@@ -138,6 +139,7 @@ async fn processed_bytes_throughputs(
             let c = d.component_processed_bytes_throughputs;
             let _ = tx
                 .send(state::EventType::ProcessedBytesThroughputs(
+                    interval,
                     c.into_iter().map(|c| (c.name, c.throughput)).collect(),
                 ))
                 .await;
@@ -198,13 +200,13 @@ pub async fn init_components(client: &Client) -> Result<state::State, ()> {
                         .as_ref()
                         .map(|ep| ep.processed_events_total as i64)
                         .unwrap_or(0),
-                    processed_events_throughput: 0,
+                    processed_events_throughput_sec: 0,
                     processed_bytes_total: d
                         .processed_bytes_total
                         .as_ref()
                         .map(|ep| ep.processed_bytes_total as i64)
                         .unwrap_or(0),
-                    processed_bytes_throughput: 0,
+                    processed_bytes_throughput_sec: 0,
                     errors: 0,
                 },
             )

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -6,9 +6,11 @@ type NamedMetric = (String, i64);
 #[derive(Debug)]
 pub enum EventType {
     ProcessedEventsTotals(Vec<NamedMetric>),
-    ProcessedEventsThroughputs(Vec<NamedMetric>),
+    /// Interval + named metric
+    ProcessedEventsThroughputs(i64, Vec<NamedMetric>),
     ProcessedBytesTotals(Vec<NamedMetric>),
-    ProcessedBytesThroughputs(Vec<NamedMetric>),
+    /// Interval + named metric
+    ProcessedBytesThroughputs(i64, Vec<NamedMetric>),
     ComponentAdded(ComponentRow),
     ComponentRemoved(String),
 }
@@ -24,9 +26,9 @@ pub struct ComponentRow {
     pub kind: String,
     pub component_type: String,
     pub processed_events_total: i64,
-    pub processed_events_throughput: i64,
+    pub processed_events_throughput_sec: i64,
     pub processed_bytes_total: i64,
-    pub processed_bytes_throughput: i64,
+    pub processed_bytes_throughput_sec: i64,
     pub errors: i64,
 }
 
@@ -50,10 +52,11 @@ pub async fn updater(mut state: State, mut event_rx: EventRx) -> StateRx {
                             }
                         }
                     }
-                    EventType::ProcessedEventsThroughputs(rows) => {
+                    EventType::ProcessedEventsThroughputs(interval, rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.processed_events_throughput = v;
+                                r.processed_events_throughput_sec =
+                                    (v as f64 * (1000.0 / interval as f64)) as i64;
                             }
                         }
                     }
@@ -64,10 +67,11 @@ pub async fn updater(mut state: State, mut event_rx: EventRx) -> StateRx {
                             }
                         }
                     }
-                    EventType::ProcessedBytesThroughputs(rows) => {
+                    EventType::ProcessedBytesThroughputs(interval, rows) => {
                         for (name, v) in rows {
                             if let Some(r) = state.get_mut(&name) {
-                                r.processed_bytes_throughput = v;
+                                r.processed_bytes_throughput_sec =
+                                    (v as f64 * (1000.0 / interval as f64)) as i64;
                             }
                         }
                     }


### PR DESCRIPTION
Refactors `vector top` columns, to group events/byte counts and throughput.

Throughput is now displayed per second, irrespective of sample interval.

Updates columns without metrics to `N/A` to make it clearer that no metrics have been raised. Retains `--` where metrics are available but the sample interval hasn't elapsed.

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/719722/100356350-030dfb00-2feb-11eb-854c-df2712f68685.png">


Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
