### PR TITLE
chore: Introduce an utility script for CUE

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016
 set -euo pipefail
-shopt -s globstar
 
 # check-docs.sh
 #
@@ -10,38 +8,39 @@ shopt -s globstar
 #   Checks that the contents of /docs folder are valid. This includes:
 #
 #     1. Ensuring the the .cue files can compile.
-#     2. Link validation.
+#     2. In CI, ensuring the the .cue files are properly formatted.
 
-DOCS_PATH="docs"
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-if ! [ -x "$(command -v cue)" ]; then
-  echo 'Error: cue is not installed.' >&2
+read-all-docs() {
+  scripts/cue.sh list | sort | xargs cat -A
+}
+
+if ! cue version >/dev/null; then
+  echo 'Error: cue is not installed'
   exit 1
 fi
 
-if [[ -z "${CI:-}" ]]; then
-  echo "Skipping local formatting - reserved for CI"
+if [[ "${CI:-"false"}" != "true" ]]; then
+  echo "Skipping cue files format validation - reserved for CI"
 else
-  echo "Validating ${DOCS_PATH}/**/*.cue formatting."
+  echo "Validating cue files formatting..."
 
-  cue fmt ${DOCS_PATH}/**/*.cue
-  status="$(git status --porcelain ${DOCS_PATH})"
+  STATE_BEFORE="$(read-all-docs)"
+  scripts/cue.sh fmt
+  STATE_AFTER="$(read-all-docs)"
 
-  [[ -z "$status" ]] || {
-    echo >&2 "Incorrectly formatted Cue files"
-    echo >&2 "$status"
-    git diff ${DOCS_PATH}
+  if [[ "$STATE_BEFORE" != "$STATE_AFTER" ]]; then
+    echo "Incorrectly formatted CUE files"
     exit 1
-  }
+  fi
 fi
 
-echo "Validating ${DOCS_PATH}/**/*.cue..."
+echo "Validating cue files correctness..."
 
-errors=$(cue vet --concrete --all-errors ${DOCS_PATH}/**/*.cue)
-
-if [ -n "$errors" ]; then
-  printf "Failed!\n\n%s\n" "${errors}"
-  exit 1
+if ERRORS="$(scripts/cue.sh vet 2>&1)"; then
+  echo "Success! The contents of the \"docs/\" directory are valid"
 else
-  echo "Success! The contents of the ${DOCS_PATH} directory are valid."
+  printf "Failed!\n\n%s\n" "$ERRORS"
+  exit 1
 fi

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -31,7 +31,8 @@ else
   STATE_AFTER="$(read-all-docs)"
 
   if [[ "$STATE_BEFORE" != "$STATE_AFTER" ]]; then
-    echo "Incorrectly formatted CUE files"
+    printf "Incorrectly formatted CUE files\n\n"
+    diff --unified <(echo "$STATE_BEFORE") <(echo "$STATE_AFTER")
     exit 1
   fi
 fi

--- a/scripts/cue.sh
+++ b/scripts/cue.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cue.sh
+#
+# SUMMARY
+#
+#   CUE utilities.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+list-docs-files() {
+  find docs -name '*.cue'
+}
+
+cmd_list() {
+  list-docs-files
+}
+
+cmd_fmt() {
+  list-docs-files | xargs cue fmt "$@"
+}
+
+cmd_vet() {
+  list-docs-files | xargs cue vet --concrete --all-errors "$@"
+}
+
+cmd_eval() {
+  list-docs-files | xargs cue eval --concrete --all-errors "$@"
+}
+
+cmd_export() {
+  list-docs-files | xargs cue export --all-errors "$@"
+}
+
+usage() {
+  cat >&2 <<-EOF
+Usage: $0 MODE
+
+Modes:
+  list    - list all the documentation files
+  fmt     - format all the documentation files
+  vet     - check the documentation files and print errors
+  eval    - print the evaluated documentation,
+            optionally pass the expression to evaluate via "-e EXPRESSION"
+  export  - export the documentation,
+            optionally pass the expression to evaluate via "-e EXPRESSION"
+
+Examples:
+
+  Print the whole documentation in the JSON format:
+
+    $0 export
+
+  Print the "components.sources.kubernetes_logs" subtree in CUE format:
+
+    $0 eval -e components.sources.kubernetes_logs
+
+  Print the "cli" subtree in JSON format:
+
+    $0 export -e cli
+
+EOF
+  exit 1
+}
+
+MODE="${1:-}"
+case "$MODE" in
+  list|fmt|vet|eval|export)
+    shift
+    "cmd_$MODE" "$@"
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
This PR introduces a utility script for CUE command - `scripts/cue.sh`.
It also rewrites the `check-docs` script using the `scripts/cue.sh`.

The goal of the script is to make it easier to use the cue in the everyday life:

- instead of

  ```shell
  find docs -name '*.cue' | xargs cue eval --all-errors -e 'components.sources.kubernetes_logs' -c`
  ```
- one would simply do

  ```shell
  scripts/cue.sh eval -e components.sources.kubernetes_logs
  ```

This is far less typing.

See `scripts/cue.sh help` for more info.

Supersedes #5184.