### PR TITLE
chore(kubernetes_logs source): Kubernetes log parsing corrections

### DIFF
--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -219,13 +219,19 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		docker_format_parse_failures_total: {
+		k8s_format_picker_edge_cases_total: {
+			description:       "The total number of edge cases encountered while picking format of the Kubernetes log message."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		k8s_docker_format_parse_failures_total: {
 			description:       "The total number of failures to parse a message as a JSON object."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		event_annotation_failures_total: {
+		k8s_event_annotation_failures_total: {
 			description:       "The total number of failures to annotate Vector events with Kubernetes Pod metadata."
 			type:              "counter"
 			default_namespace: "vector"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -395,7 +395,8 @@ components: sources: kubernetes_logs: {
 	}
 
 	telemetry: metrics: {
-		docker_format_parse_failures_total: components.sources.internal_metrics.output.metrics.docker_format_parse_failures_total
-		event_annotation_failures_total:    components.sources.internal_metrics.output.metrics.event_annotation_failures_total
+		k8s_format_picker_edge_cases_total:     components.sources.internal_metrics.output.metrics.k8s_format_picker_edge_cases_total
+		k8s_docker_format_parse_failures_total: components.sources.internal_metrics.output.metrics.k8s_docker_format_parse_failures_total
+		k8s_event_annotation_failures_total:    components.sources.internal_metrics.output.metrics.k8s_event_annotation_failures_total
 	}
 }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -1,6 +1,5 @@
 use super::InternalEvent;
 use crate::Event;
-use bytes::Bytes;
 use metrics::counter;
 
 #[derive(Debug)]
@@ -43,14 +42,14 @@ impl InternalEvent for KubernetesLogsEventAnnotationFailed<'_> {
 
 #[derive(Debug)]
 pub struct KubernetesLogsDockerFormatParseFailed<'a> {
-    pub message: &'a Bytes,
+    pub error: &'a dyn std::error::Error,
 }
 
 impl InternalEvent for KubernetesLogsDockerFormatParseFailed<'_> {
     fn emit_logs(&self) {
         warn!(
-            message = "Failed to parse message as JSON object.",
-            value = %String::from_utf8_lossy(self.message),
+            message = "Failed to parse log line in docker format.",
+            error = %self.error,
         );
     }
 

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -41,6 +41,24 @@ impl InternalEvent for KubernetesLogsEventAnnotationFailed<'_> {
 }
 
 #[derive(Debug)]
+pub struct KubernetesLogsFormatPickerEdgeCase {
+    pub what: &'static str,
+}
+
+impl InternalEvent for KubernetesLogsFormatPickerEdgeCase {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Encountered format picker edge case.",
+            what = %self.what,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("k8s_format_picker_edge_cases_total", 1);
+    }
+}
+
+#[derive(Debug)]
 pub struct KubernetesLogsDockerFormatParseFailed<'a> {
     pub error: &'a dyn std::error::Error,
 }

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -101,43 +101,43 @@ pub mod tests {
     }
 
     /// Shared test cases.
-    pub fn cases() -> Vec<(String, LogEvent)> {
+    pub fn cases() -> Vec<(String, Vec<LogEvent>)> {
         vec![
             (
                 "2016-10-06T00:17:09.669794202Z stdout F The content of the log entry 1".into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "The content of the log entry 1",
                     "2016-10-06T00:17:09.669794202Z",
                     "stdout",
                     false,
-                ),
+                )],
             ),
             (
                 "2016-10-06T00:17:09.669794202Z stdout P First line of log entry 2".into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "First line of log entry 2",
                     "2016-10-06T00:17:09.669794202Z",
                     "stdout",
                     true,
-                ),
+                )],
             ),
             (
                 "2016-10-06T00:17:09.669794202Z stdout P Second line of the log entry 2".into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "Second line of the log entry 2",
                     "2016-10-06T00:17:09.669794202Z",
                     "stdout",
                     true,
-                ),
+                )],
             ),
             (
                 "2016-10-06T00:17:10.113242941Z stderr F Last line of the log entry 2".into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "Last line of the log entry 2",
                     "2016-10-06T00:17:10.113242941Z",
                     "stderr",
                     false,
-                ),
+                )],
             ),
             // A part of the partial message with a realistic length.
             (
@@ -146,12 +146,12 @@ pub mod tests {
                     make_long_string("very long message ", 16 * 1024).as_str(),
                 ]
                 .join(""),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     make_long_string("very long message ", 16 * 1024).as_str(),
                     "2016-10-06T00:17:10.113242941Z",
                     "stdout",
                     true,
-                ),
+                )],
             ),
         ]
     }

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -94,7 +94,7 @@ enum NormalizationError {
 pub mod tests {
     use super::super::test_util;
     use super::*;
-    use crate::{event::LogEvent, transforms::Transform};
+    use crate::{event::LogEvent, test_util::trace_init, transforms::Transform};
 
     fn make_long_string(base: &str, len: usize) -> String {
         base.chars().cycle().take(len).collect()
@@ -158,6 +158,7 @@ pub mod tests {
 
     #[test]
     fn test_parsing() {
+        trace_init();
         test_util::test_parser(|| Transform::function(Cri::new()), cases());
     }
 }

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -4,6 +4,7 @@ use crate::{
     internal_events::KubernetesLogsDockerFormatParseFailed,
     transforms::FunctionTransform,
 };
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -23,27 +24,41 @@ pub struct Docker;
 impl FunctionTransform for Docker {
     fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
         let log = event.as_mut_log();
-        parse_json(log);
-        normalize_event(log).ok();
+        if let Err(err) = parse_json(log) {
+            emit!(KubernetesLogsDockerFormatParseFailed { error: &err });
+            return;
+        }
+        if let Err(err) = normalize_event(log) {
+            emit!(KubernetesLogsDockerFormatParseFailed { error: &err });
+            return;
+        }
         output.push(event);
     }
 }
 
 /// Parses `message` as json object and removes it.
-fn parse_json(log: &mut LogEvent) -> Option<()> {
-    let to_parse = log.remove(log_schema().message_key())?.as_bytes();
+fn parse_json(log: &mut LogEvent) -> Result<(), ParsingError> {
+    let message = log
+        .remove(log_schema().message_key())
+        .ok_or(ParsingError::NoMessageField)?;
 
-    match serde_json::from_slice(to_parse.as_ref()) {
+    let bytes = match message {
+        Value::Bytes(bytes) => bytes,
+        _ => return Err(ParsingError::MessageFieldNotInBytes),
+    };
+
+    match serde_json::from_slice(bytes.as_ref()) {
         Ok(JsonValue::Object(object)) => {
             for (key, value) in object {
                 log.insert_flat(key, value);
             }
-            Some(())
+            Ok(())
         }
-        Ok(_) | Err(_) => {
-            emit!(KubernetesLogsDockerFormatParseFailed { message: &to_parse });
-            None
-        }
+        Ok(_) => Err(ParsingError::NotAnObject { message: bytes }),
+        Err(err) => Err(ParsingError::InvalidJson {
+            source: err,
+            message: bytes,
+        }),
     }
 }
 
@@ -90,6 +105,19 @@ fn normalize_event(log: &mut LogEvent) -> Result<(), NormalizationError> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Snafu)]
+enum ParsingError {
+    NoMessageField,
+    MessageFieldNotInBytes,
+    InvalidJson {
+        source: serde_json::Error,
+        message: Bytes,
+    },
+    NotAnObject {
+        message: Bytes,
+    },
 }
 
 #[derive(Debug, Snafu)]
@@ -169,5 +197,40 @@ pub mod tests {
     #[test]
     fn test_parsing() {
         test_util::test_parser(|| Transform::function(Docker), cases());
+    }
+
+    #[test]
+    fn test_parsing_invalid() {
+        let cases = vec![
+            // Empty string.
+            r#""#,
+            // Incomplete.
+            r#"{"#,
+            // Random non-JSON text.
+            r#"hello world"#,
+            // Random JSON non-object.
+            r#"123"#,
+            // Empty JSON object.
+            r#"{}"#,
+            // No timestamp.
+            r#"{"log": "Hello world", "stream": "stdout"}"#,
+            // Timestamp not a string.
+            r#"{"log": "Hello world", "stream": "stdout", "time": 123}"#,
+            // Empty timestamp.
+            r#"{"log": "Hello world", "stream": "stdout", "time": ""}"#,
+            // Invalid timestamp.
+            r#"{"log": "Hello world", "stream": "stdout", "time": "qwerty"}"#,
+            // No log field.
+            r#"{"stream": "stderr", "time": "2016-10-05T00:00:30.082640485Z"}"#,
+            // Log is not a string.
+            r#"{"log": 123, "stream": "stderr", "time": "2016-10-05T00:00:30.082640485Z"}"#,
+        ];
+
+        for message in cases {
+            let input = Event::from(message);
+            let mut output = Vec::new();
+            Docker.transform(&mut output, input);
+            assert!(output.is_empty(), "Expected no events: {:?}", output);
+        }
     }
 }

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -111,25 +111,25 @@ pub mod tests {
     }
 
     /// Shared test cases.
-    pub fn cases() -> Vec<(String, LogEvent)> {
+    pub fn cases() -> Vec<(String, Vec<LogEvent>)> {
         vec![
             (
                 r#"{"log": "The actual log line\n", "stream": "stderr", "time": "2016-10-05T00:00:30.082640485Z"}"#.into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "The actual log line",
                     "2016-10-05T00:00:30.082640485Z",
                     "stderr",
                     false,
-                ),
+                )],
             ),
             (
                 r#"{"log": "A line without newline chan at the end", "stream": "stdout", "time": "2016-10-05T00:00:30.082640485Z"}"#.into(),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     "A line without newline chan at the end",
                     "2016-10-05T00:00:30.082640485Z",
                     "stdout",
                     false,
-                ),
+                )],
             ),
             // Partial message due to message length.
             (
@@ -139,12 +139,12 @@ pub mod tests {
                     r#"", "stream": "stdout", "time": "2016-10-05T00:00:30.082640485Z"}"#,
                 ]
                 .join(""),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     make_long_string("partial ",16 * 1024).as_str(),
                     "2016-10-05T00:00:30.082640485Z",
                     "stdout",
                     true,
-                ),
+                )],
             ),
             // Non-partial message, because message length matches but
             // the message also ends with newline.
@@ -156,12 +156,12 @@ pub mod tests {
                     r#"", "stream": "stdout", "time": "2016-10-05T00:00:30.082640485Z"}"#,
                 ]
                 .join(""),
-                test_util::make_log_event(
+                vec![test_util::make_log_event(
                     make_long_string("non-partial ", 16 * 1024 - 1).as_str(),
                     "2016-10-05T00:00:30.082640485Z",
                     "stdout",
                     false,
-                ),
+                )],
             ),
         ]
     }

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -111,10 +111,16 @@ fn normalize_event(log: &mut LogEvent) -> Result<(), NormalizationError> {
 enum ParsingError {
     NoMessageField,
     MessageFieldNotInBytes,
+    #[snafu(display(
+        "Could not parse json: {} in message {:?}",
+        source,
+        String::from_utf8_lossy(message)
+    ))]
     InvalidJson {
         source: serde_json::Error,
         message: Bytes,
     },
+    #[snafu(display("Message was not an object: {:?}", String::from_utf8_lossy(message)))]
     NotAnObject {
         message: Bytes,
     },

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -132,7 +132,7 @@ enum NormalizationError {
 #[cfg(test)]
 pub mod tests {
     use super::{super::test_util, *};
-    use crate::transforms::Transform;
+    use crate::{test_util::trace_init, transforms::Transform};
 
     fn make_long_string(base: &str, len: usize) -> String {
         base.chars().cycle().take(len).collect()
@@ -196,11 +196,15 @@ pub mod tests {
 
     #[test]
     fn test_parsing() {
+        trace_init();
+
         test_util::test_parser(|| Transform::function(Docker), cases());
     }
 
     #[test]
     fn test_parsing_invalid() {
+        trace_init();
+
         let cases = vec![
             // Empty string.
             r#""#,

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -62,7 +62,7 @@ impl FunctionTransform for Picker {
 mod tests {
     use super::super::{cri, docker, test_util};
     use super::*;
-    use crate::{event::LogEvent, transforms::Transform, Event};
+    use crate::{event::LogEvent, test_util::trace_init, transforms::Transform, Event};
 
     /// Picker has to work for all test cases for underlying parsers.
     fn cases() -> Vec<(String, Vec<LogEvent>)> {
@@ -74,11 +74,14 @@ mod tests {
 
     #[test]
     fn test_parsing() {
+        trace_init();
         test_util::test_parser(|| Transform::function(Picker::new()), cases());
     }
 
     #[test]
     fn test_parsing_invalid() {
+        trace_init();
+
         let cases = vec!["", "qwe", "{"];
 
         for message in cases {
@@ -92,6 +95,8 @@ mod tests {
 
     #[test]
     fn test_parsing_invalid_non_standard_events() {
+        trace_init();
+
         let cases = vec![
             // No `message` field.
             Event::new_empty_log(),

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -50,7 +50,7 @@ mod tests {
     use crate::{event::LogEvent, transforms::Transform, Event};
 
     /// Picker has to work for all test cases for underlying parsers.
-    fn cases() -> Vec<(String, LogEvent)> {
+    fn cases() -> Vec<(String, Vec<LogEvent>)> {
         let mut cases = vec![];
         cases.extend(docker::tests::cases());
         cases.extend(cri::tests::cases());
@@ -69,8 +69,9 @@ mod tests {
         for message in cases {
             let input = Event::from(message);
             let mut picker = Picker::new();
-            let output = picker.transform_one(input);
-            assert!(output.is_none(), "Expected none: {:?}", output);
+            let mut output = Vec::new();
+            picker.transform(&mut output, input);
+            assert!(output.is_empty(), "Expected no events: {:?}", output);
         }
     }
 }

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -31,7 +31,7 @@ pub fn make_log_event(message: &str, timestamp: &str, stream: &str, is_partial: 
 /// Shared logic for testing parsers.
 ///
 /// Takes a parser builder and a list of test cases.
-pub fn test_parser<B>(builder: B, cases: Vec<(String, LogEvent)>)
+pub fn test_parser<B>(builder: B, cases: Vec<(String, Vec<LogEvent>)>)
 where
     B: Fn() -> Transform,
 {
@@ -40,9 +40,12 @@ where
         let mut parser = (builder)();
         let parser = parser.as_function();
 
-        let output = parser
-            .transform_one(input)
-            .expect("parser failed to parse the event");
-        assert_eq!(Event::Log(expected), output, "expected left, actual right");
+        let mut output = Vec::new();
+        parser.transform(&mut output, input);
+        assert_eq!(
+            expected.into_iter().map(Event::Log).collect::<Vec<_>>(),
+            output,
+            "expected left, actual right"
+        );
     }
 }


### PR DESCRIPTION
This PR solved some of the issues in the `kubernetes_logs` source that I discovered during my pre-release checking and validation.

Among the changes, it introduces some new metrics in the event parsing and corrects the documentation for the telemetry.