### PR TITLE
chore(metrics): More metric renaming to match conventions

### DIFF
--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -521,13 +521,13 @@ components: sources: file: {
 	telemetry: metrics: {
 		checkpoint_write_errors_total: components.sources.internal_metrics.output.metrics.checkpoint_write_errors_total
 		checkpoints_total:             components.sources.internal_metrics.output.metrics.checkpoints_total
-		checksum_errors:               components.sources.internal_metrics.output.metrics.checksum_errors
-		file_delete_errors:            components.sources.internal_metrics.output.metrics.file_delete_errors
-		file_watch_errors:             components.sources.internal_metrics.output.metrics.file_watch_errors
-		files_added:                   components.sources.internal_metrics.output.metrics.files_added
-		files_deleted:                 components.sources.internal_metrics.output.metrics.files_deleted
-		files_resumed:                 components.sources.internal_metrics.output.metrics.files_resumed
-		files_unwatched:               components.sources.internal_metrics.output.metrics.files_unwatched
-		fingerprint_read_errors:       components.sources.internal_metrics.output.metrics.fingerprint_read_errors
+		checksum_errors_total:         components.sources.internal_metrics.output.metrics.checksum_errors_total
+		file_delete_errors_total:      components.sources.internal_metrics.output.metrics.file_delete_errors_total
+		file_watch_errors_total:       components.sources.internal_metrics.output.metrics.file_watch_errors_total
+		files_added_total:             components.sources.internal_metrics.output.metrics.files_added_total
+		files_deleted_total:           components.sources.internal_metrics.output.metrics.files_deleted_total
+		files_resumed_total:           components.sources.internal_metrics.output.metrics.files_resumed_total
+		files_unwatched_total:         components.sources.internal_metrics.output.metrics.files_unwatched_total
+		fingerprint_read_errors_total: components.sources.internal_metrics.output.metrics.fingerprint_read_errors_total
 	}
 }

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -149,7 +149,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
-		checksum_errors: {
+		checksum_errors_total: {
 			description:       "The total number of errors identifying files via checksum."
 			type:              "counter"
 			default_namespace: "vector"
@@ -257,7 +257,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		file_delete_errors: {
+		file_delete_errors_total: {
 			description:       "The total number of failures to delete a file."
 			type:              "counter"
 			default_namespace: "vector"
@@ -265,7 +265,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		file_watch_errors: {
+		file_watch_errors_total: {
 			description:       "The total number of errors encountered when watching files."
 			type:              "counter"
 			default_namespace: "vector"
@@ -273,7 +273,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		files_added: {
+		files_added_total: {
 			description:       "The total number of files Vector has found to watch."
 			type:              "counter"
 			default_namespace: "vector"
@@ -281,7 +281,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		files_deleted: {
+		files_deleted_total: {
 			description:       "The total number of files deleted."
 			type:              "counter"
 			default_namespace: "vector"
@@ -289,7 +289,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		files_resumed: {
+		files_resumed_total: {
 			description:       "The total number of times Vector has resumed watching a file."
 			type:              "counter"
 			default_namespace: "vector"
@@ -297,7 +297,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		files_unwatched: {
+		files_unwatched_total: {
 			description:       "The total number of times Vector has stopped watching a file."
 			type:              "counter"
 			default_namespace: "vector"
@@ -305,7 +305,7 @@ components: sources: internal_metrics: {
 				file: _file
 			}
 		}
-		fingerprint_read_errors: {
+		fingerprint_read_errors_total: {
 			description:       "The total number of times Vector failed to read a file for fingerprinting."
 			type:              "counter"
 			default_namespace: "vector"
@@ -358,7 +358,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		memory_used: {
+		memory_used_bytes: {
 			description:       "The total memory currently being used by Vector (in bytes)."
 			type:              "gauge"
 			default_namespace: "vector"
@@ -468,7 +468,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-
 		sqs_message_receive_failed_total: {
 			description:       "The total number of failures to receive SQS messages."
 			type:              "counter"

--- a/docs/reference/components/transforms/lua.cue
+++ b/docs/reference/components/transforms/lua.cue
@@ -472,7 +472,7 @@ components: transforms: lua: {
 	}
 
 	telemetry: metrics: {
-		memory_used:             components.sources.internal_metrics.output.metrics.memory_used
+		memory_used_bytes:       components.sources.internal_metrics.output.metrics.memory_used_bytes
 		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -64,7 +64,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "checksum_errors", 1,
+                "checksum_errors_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -87,7 +87,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "fingerprint_read_errors", 1,
+                "fingerprint_read_errors_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -111,7 +111,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "file_delete_errors", 1,
+                "file_delete_errors_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -132,7 +132,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "files_deleted", 1,
+                "files_deleted_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -153,7 +153,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "files_unwatched", 1,
+                "files_unwatched_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -176,7 +176,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "file_watch_errors", 1,
+                "file_watch_errors_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -199,7 +199,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "files_resumed", 1,
+                "files_resumed_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }
@@ -220,7 +220,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "files_added", 1,
+                "files_added_total", 1,
                 "file" => self.path.to_string_lossy().into_owned(),
             );
         }

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -17,7 +17,7 @@ pub struct LuaGcTriggered {
 
 impl InternalEvent for LuaGcTriggered {
     fn emit_metrics(&self) {
-        gauge!("memory_used", self.used_memory as f64);
+        gauge!("memory_used_bytes", self.used_memory as f64);
     }
 }
 


### PR DESCRIPTION
This PR is basically just another run through the metric names to bring them in line with established conventions, namely:

* All counters should end in `_total`
* Gauges should specify units when applicable