### PR TITLE
chore: Adjust privacy policy language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -961,7 +961,8 @@ If you have additional questions, please [contact us](#contact).
 Vector requires all contributors to agree to the DCO. DCO stands for Developer
 Certificate of Origin and is maintained by the
 [Linux Foundation](https://www.linuxfoundation.org). It is an attestation
-attached to every commit made by every developer.
+attached to every commit made by every developer. All contributions are covered
+by, and fall under, the DCO.
 
 #### Trivial changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ expanding into more specifics.
       1. [Directory Structure](#directory-structure)
       1. [Makefile](#makefile)
       1. [Code Style](#code-style)
+         1. [Logging style](#logging-style)
       1. [Feature flags](#feature-flags)
       1. [Dependencies](#dependencies)
    1. [Guidelines](#guidelines)
@@ -960,8 +961,7 @@ If you have additional questions, please [contact us](#contact).
 Vector requires all contributors to agree to the DCO. DCO stands for Developer
 Certificate of Origin and is maintained by the
 [Linux Foundation](https://www.linuxfoundation.org). It is an attestation
-attached to every commit made by every developer. All contributions are covered
-by, and fall under, the DCO.
+attached to every commit made by every developer.
 
 #### Trivial changes
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,10 +1,10 @@
 # Privacy Policy
 
 It should go without saying, but Vector takes the privacy of your data,
-including how you use Vector, very seriously. Vector is used to collect and
-route some of your most sensitive data and we want you to know that we do not
-take that lightly. This document clarifies how the Vector project thinks about
-privacy now and in the future.
+including how you use Vector, very seriously. Vector collects and routes some
+of your most sensitive data, and therefore, Vector strives to be as transparent
+as possible with our privacy efforts. This document clarifies how the Vector
+project thinks about privacy now and in the future.
 
 <!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
 
@@ -15,7 +15,6 @@ privacy now and in the future.
 1. [Vector Community](#vector-community)
    1. [Vector Repository](#vector-repository)
    1. [Vector Chat](#vector-chat)
-   1. [Vector Mailing List](#vector-mailing-list)
 
 <!-- /MarkdownTOC -->
 
@@ -23,25 +22,24 @@ privacy now and in the future.
 
 ### Downloads
 
-Vector uses Amazon S3, Github assets, and Docker Hub to host release artifacts.
+Vector uses AWS S3, Github assets, and Docker Hub to host release artifacts.
 Vector does track download counts in aggregate. For Github and Docker this data
-is anonymous, but for S3 IP addresses are logged. There is no way to disable IP
-address tracking within the S3 logs. If you are concerned about sharing your IP
-address we recommend using a proxy or downloading Vector from a different
-channel.
+is anonymous, but for AWS S3 IP addresses are logged. There is no way to disable
+IP address tracking within the AWS S3 logs. If you are concerned about sharing
+your IP address we recommend using a proxy, or downloading Vector from a
+different channel.
 
 ### Phoning Home
 
-Vector, under no circumstances, now and in the future, will "phone home" and
-communicate with an external service that you did not explicitly configure as
-part of setting up Vector. This includes grey-area tactics such as version
+Vector will not "phone home" or communicate with an external service that you
+did not explicitly configure. This includes grey-area tactics such as version
 checks, capturing diagnostic information, and sharing crash reports.
 
 ## Vector Website & Docs
 
-The Vector website does not implement any front-end trackers. Aggregated
-analytics data is derived from backend server logs which are anonymized.
-Vector uses [Netlify analytics][netlify_analytics] for this.
+The Vector website does collect various analytics. Aggregated analytics data is
+derived from backend server logs which are anonymized. Vector uses
+[Netlify analytics][netlify_analytics] for this.
 
 ## Vector Community
 
@@ -57,12 +55,6 @@ ways Vector can improve.
 
 The Vector chat uses Discord; you can review their
 privacy policy [here][discord_pp].
-
-### Vector Mailing List
-
-The Vector mailing list uses Vero; you can review their privacy policy
-[here][vero_pp]. Additionally, Vector will never share your email with 3rd party
-for any reason, and Vector will not send you spam email.
 
 [github_pp]: https://help.github.com/en/github/site-policy/github-privacy-statement
 [discord_pp]: https://discord.com/privacy/

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,11 +22,11 @@ project thinks about privacy now and in the future.
 
 ### Downloads
 
-Vector uses AWS S3, Github assets, and Docker Hub to host release artifacts.
-Vector does track download counts in aggregate. For Github and Docker this data
-is anonymous, but for AWS S3 IP addresses are logged. There is no way to disable
-IP address tracking within the AWS S3 logs. If you are concerned about sharing
-your IP address we recommend using a proxy, or downloading Vector from a
+Vector uses AWS S3, Github assets, [Cloudsmith][cloudsmith], and Docker Hub to host
+release artifacts. Vector does track download counts in aggregate. For Github, Cloudsmith,
+and Docker this data is anonymous, but for AWS S3 IP addresses are logged. There is no
+way to disable IP address tracking within the AWS S3 logs. If you are concerned about
+sharing your IP address we recommend using a proxy, or downloading Vector from a
 different channel.
 
 ### Phoning Home
@@ -60,3 +60,5 @@ privacy policy [here][discord_pp].
 [discord_pp]: https://discord.com/privacy/
 [netlify_analytics]: https://www.netlify.com/products/analytics/
 [vero_pp]: https://www.getvero.com/privacy/
+[cloudsmith]: https://cloudsmith.com/
+


### PR DESCRIPTION
I did a quick review of our contributing and privacy policy language and tried to remove any ambiguity.

1. I relaxed the privacy language about the website since this is likely to change as more people work on the website, run A/B tests, and so on. The data will always be anonymous though.
2. I shortened the "phone home" language but did not change its intent.
3. Removed the mailing list since we do not maintain that anymore.