### PR TITLE
enhancement(observability): Enable TLS subscription connections in vector top

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6395,8 +6395,10 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "pin-project 0.4.27",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -6713,6 +6715,7 @@ dependencies = [
  "httparse",
  "input_buffer",
  "log",
+ "native-tls",
  "rand 0.7.3",
  "sha-1 0.9.1",
  "url",

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -24,7 +24,7 @@ graphql_client = "0.9.0"
 
 # HTTP / WebSockets
 reqwest = { version = "0.10.6", features = ["json"] }
-tokio-tungstenite = "0.11.0"
+tokio-tungstenite = { version = "0.11.0", features = ["tls"] }
 
 # External libs
 weak-table = "0.3.0"

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -71,8 +71,8 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
 
     let subscription_client = match connect_subscription_client(ws_url).await {
         Ok(c) => c,
-        _ => {
-            eprintln!("Couldn't connect to Vector API via WebSockets.");
+        Err(e) => {
+            eprintln!("Couldn't connect to Vector API via WebSockets: {:?}", e);
             return exitcode::UNAVAILABLE;
         }
     };


### PR DESCRIPTION
ping @leebenson 

This PR enables TLS subscription connections and allows users to get the error message on connection failures. 

I noticed that I could not connect to a remote instance using secure sockets in `vector top --url <some url>`.    I first added a log of the actual error which showed like this:

```
Couldn't connect to Vector API via WebSockets: Url("TLS support not compiled in.")
```

I think we should keep that so users can get a little more info when something goes wrong (optional).  We could also, use the same strategy for the other errors in this file (glad to add here).   So the fix was to enable the TLS feature in `tokio-tungstenite` and it now works against the remote instance.
