### PR TITLE
chore(remap): improve regex handling

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -17,7 +17,7 @@ if_statement = { "if" ~ boolean_expr ~ block ~ ("else if" ~ boolean_expr ~ block
 // Primary ---------------------------------------------------------------------
 
 primary  =  { value | variable | path | group }
-value    =  { string | float | integer | boolean | null | array }
+value    =  { string | float | integer | boolean | null | array | regex }
 variable = ${ "$" ~ ident ~ path_index* ~ ("." ~ path_segments)?  }
 group    =  { "(" ~ expression ~ ")" }
 

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -25,11 +25,7 @@ group    =  { "(" ~ expression ~ ")" }
 
 call           = ${ ident ~ "(" ~ arguments? ~ ")"  }
 arguments      = !{ argument ~ ("," ~ argument)* }
-argument       =  { (ident ~ "=")? ~ (argument_array | argument_value) }
-argument_value = _{ (expression | regex) }
-
-// Similar to `array`, but also accepts regex patterns.
-argument_array =  { "[" ~ NEWLINE* ~ (argument_value ~ "," ~ NEWLINE*)* ~ argument_value? ~ NEWLINE* ~ "]" }
+argument       =  { (ident ~ "=")? ~ expression }
 
 // Operations ------------------------------------------------------------------
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -76,8 +76,6 @@ impl fmt::Display for Rule {
         rules_str![
             addition,
             argument,
-            argument_array,
-            argument_value,
             arguments,
             array,
             assignment,

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -1,12 +1,15 @@
-use crate::{expression, function, parser::Rule, path, program, value};
-use pest::error::Error as PestError;
+use crate::{
+    expression, function,
+    parser::{self, Rule},
+    path, program, value,
+};
 use std::error::Error as StdError;
 use std::fmt;
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
-    #[error("parser error: {0}")]
-    Parser(String),
+    #[error("parser error")]
+    Parser(#[from] parser::Error),
 
     #[error("program error")]
     Program(#[from] program::Error),
@@ -19,9 +22,6 @@ pub enum Error {
 
     #[error("function error")]
     Function(#[from] function::Error),
-
-    #[error("regex error")]
-    Regex(#[from] regex::Error),
 
     #[error("value error")]
     Value(#[from] value::Error),
@@ -48,12 +48,6 @@ impl From<String> for Error {
 impl From<&str> for Error {
     fn from(s: &str) -> Self {
         Error::Call(s.to_owned())
-    }
-}
-
-impl From<PestError<Rule>> for Error {
-    fn from(err: PestError<Rule>) -> Self {
-        Error::Parser(err.to_string())
     }
 }
 
@@ -129,7 +123,7 @@ impl fmt::Display for Rule {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct RemapError(pub(crate) Error);
+pub struct RemapError(Error);
 
 impl StdError for RemapError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {

--- a/lib/remap-lang/src/expression/argument.rs
+++ b/lib/remap-lang/src/expression/argument.rs
@@ -32,7 +32,6 @@ impl std::fmt::Debug for Argument {
 impl PartialEq for Argument {
     fn eq(&self, other: &Self) -> bool {
         self.expression == other.expression
-            && self.ident == other.ident
             && self.keyword == other.keyword
             && self.function_ident == other.function_ident
     }

--- a/lib/remap-lang/src/expression/argument.rs
+++ b/lib/remap-lang/src/expression/argument.rs
@@ -12,10 +12,10 @@ pub enum Error {
 #[derive(Clone)]
 pub struct Argument {
     expression: Box<Expr>,
-    keyword: &'static str,
     validator: fn(&Value) -> bool,
 
     // used for error messages
+    keyword: &'static str,
     function_ident: &'static str,
 }
 
@@ -23,8 +23,9 @@ impl std::fmt::Debug for Argument {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Argument")
             .field("expression", &self.expression)
-            .field("keyword", &self.keyword)
             .field("validator", &"fn(&Value) -> bool".to_owned())
+            .field("keyword", &self.keyword)
+            .field("function_ident", &self.function_ident)
             .finish()
     }
 }
@@ -40,14 +41,14 @@ impl PartialEq for Argument {
 impl Argument {
     pub fn new(
         expression: Box<Expr>,
-        keyword: &'static str,
         validator: fn(&Value) -> bool,
+        keyword: &'static str,
         function_ident: &'static str,
     ) -> Self {
         Self {
             expression,
-            keyword,
             validator,
+            keyword,
             function_ident,
         }
     }

--- a/lib/remap-lang/src/expression/argument.rs
+++ b/lib/remap-lang/src/expression/argument.rs
@@ -12,7 +12,6 @@ pub enum Error {
 #[derive(Clone)]
 pub struct Argument {
     expression: Box<Expr>,
-    ident: &'static str,
     keyword: &'static str,
     validator: fn(&Value) -> bool,
 
@@ -24,7 +23,6 @@ impl std::fmt::Debug for Argument {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Argument")
             .field("expression", &self.expression)
-            .field("ident", &self.ident)
             .field("keyword", &self.keyword)
             .field("validator", &"fn(&Value) -> bool".to_owned())
             .finish()
@@ -43,14 +41,12 @@ impl PartialEq for Argument {
 impl Argument {
     pub fn new(
         expression: Box<Expr>,
-        ident: &'static str,
         keyword: &'static str,
         validator: fn(&Value) -> bool,
         function_ident: &'static str,
     ) -> Self {
         Self {
             expression,
-            ident,
             keyword,
             validator,
             function_ident,

--- a/lib/remap-lang/src/expression/array.rs
+++ b/lib/remap-lang/src/expression/array.rs
@@ -15,6 +15,10 @@ impl Array {
     pub(crate) fn expressions(&self) -> &[Expr] {
         &self.expressions
     }
+
+    pub fn boxed(self) -> Box<dyn Expression> {
+        Box::new(self)
+    }
 }
 
 impl fmt::Debug for Array {

--- a/lib/remap-lang/src/expression/array.rs
+++ b/lib/remap-lang/src/expression/array.rs
@@ -19,6 +19,24 @@ impl fmt::Debug for Array {
     }
 }
 
+impl From<Array> for Vec<Expr> {
+    fn from(array: Array) -> Self {
+        array.expressions
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Array {
+    fn from(values: Vec<T>) -> Self {
+        Self::new(
+            values
+                .into_iter()
+                .map(Into::into)
+                .map(Expr::from)
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
 impl IntoIterator for Array {
     type Item = Expr;
     type IntoIter = std::vec::IntoIter<Self::Item>;
@@ -107,7 +125,7 @@ mod tests {
                           Box::new(Literal::from(true).into()),
                           Operator::Multiply,
                         ).into(),
-                        Literal::from(vec![1]).into(),
+                        Array::from(vec![1]).into(),
             ]),
             def: TypeDef {
                 fallible: true,

--- a/lib/remap-lang/src/expression/array.rs
+++ b/lib/remap-lang/src/expression/array.rs
@@ -11,6 +11,10 @@ impl Array {
     pub fn new(expressions: Vec<Expr>) -> Self {
         Self { expressions }
     }
+
+    pub(crate) fn expressions(&self) -> &[Expr] {
+        &self.expressions
+    }
 }
 
 impl fmt::Debug for Array {

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -45,7 +45,7 @@ impl Expression for Block {
 mod tests {
     use super::*;
     use crate::{
-        expression::{Arithmetic, Literal},
+        expression::{Arithmetic, Array, Literal},
         test_type_def,
         value::Kind,
         Operator,
@@ -97,7 +97,7 @@ mod tests {
                           Box::new(Literal::from(true).into()),
                           Operator::Multiply,
                         ).into(),
-                        Literal::from(vec![1]).into(),
+                        Array::from(vec![1]).into(),
             ]),
             def: TypeDef {
                 fallible: true,

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -1,8 +1,7 @@
 use super::Error as E;
 use crate::{
-    expression,
-    function::{Argument, ArgumentList},
-    state, Expression, Function as Fn, Object, Result, TypeDef, Value,
+    expression, function::ArgumentList, state, Expr, Expression, Function as Fn, Object, Result,
+    TypeDef, Value,
 };
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -43,7 +42,7 @@ impl PartialEq for Function {
 impl Function {
     pub fn new(
         ident: String,
-        arguments: Vec<(Option<String>, Argument)>,
+        arguments: Vec<(Option<String>, Expr)>,
         definitions: &[Box<dyn Fn>],
     ) -> Result<Self> {
         let definition = definitions
@@ -99,15 +98,9 @@ impl Function {
                 )
             })?;
 
-            let argument = match argument {
-                // Wrap expression argument to validate its value type at
-                // runtime.
-                Argument::Expression(expr) => Argument::Expression(
-                    expression::Argument::new(Box::new(expr), param.keyword, param.accepts, ident)
-                        .into(),
-                ),
-                Argument::Regex(_) | Argument::Array(_) => argument,
-            };
+            let argument =
+                expression::Argument::new(Box::new(argument), param.keyword, param.accepts, ident)
+                    .into();
 
             list.insert(param.keyword, argument);
         }

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -103,14 +103,8 @@ impl Function {
                 // Wrap expression argument to validate its value type at
                 // runtime.
                 Argument::Expression(expr) => Argument::Expression(
-                    expression::Argument::new(
-                        Box::new(expr),
-                        definition.identifier(),
-                        param.keyword,
-                        param.accepts,
-                        ident,
-                    )
-                    .into(),
+                    expression::Argument::new(Box::new(expr), param.keyword, param.accepts, ident)
+                        .into(),
                 ),
                 Argument::Regex(_) | Argument::Array(_) => argument,
             };

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -99,7 +99,7 @@ impl Function {
             })?;
 
             let argument =
-                expression::Argument::new(Box::new(argument), param.keyword, param.accepts, ident)
+                expression::Argument::new(Box::new(argument), param.accepts, param.keyword, ident)
                     .into();
 
             list.insert(param.keyword, argument);

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -11,6 +11,16 @@ impl fmt::Debug for Literal {
 }
 
 impl Literal {
+    pub fn new(value: Value) -> Self {
+        debug_assert!(
+            !matches!(value, Value::Array(_)),
+            "{} must use expression::Array instead of expression::Literal",
+            value.kind()
+        );
+
+        Self(value)
+    }
+
     pub fn boxed(self) -> Box<dyn Expression> {
         Box::new(self)
     }
@@ -26,7 +36,7 @@ impl Literal {
 
 impl<T: Into<Value>> From<T> for Literal {
     fn from(value: T) -> Self {
-        Self(value.into())
+        Self::new(value.into())
     }
 }
 
@@ -68,11 +78,6 @@ mod tests {
         float {
             expr: |_| Literal::from(123.456),
             def: TypeDef { kind: Kind::Float, ..Default::default() },
-        }
-
-        array {
-            expr: |_| Literal::from(vec!["foo"]),
-            def: TypeDef { kind: Kind::Array, ..Default::default() },
         }
 
         map {

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,14 +1,9 @@
 use crate::{state, Expression, Object, Result, TypeDef, Value};
 use std::fmt;
+use std::ops::Deref;
 
 #[derive(Clone, PartialEq)]
 pub struct Literal(Value);
-
-impl fmt::Debug for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 impl Literal {
     pub fn new(value: Value) -> Self {
@@ -31,6 +26,20 @@ impl Literal {
 
     pub fn into_value(self) -> Value {
         self.0
+    }
+}
+
+impl fmt::Debug for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for Literal {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -252,12 +252,6 @@ impl<T: Into<Expr>> From<T> for Argument {
     }
 }
 
-impl From<regex::Regex> for Argument {
-    fn from(regex: regex::Regex) -> Self {
-        Argument::Regex(regex)
-    }
-}
-
 impl From<Vec<Argument>> for Argument {
     fn from(args: Vec<Argument>) -> Self {
         Argument::Array(args)

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -198,11 +198,11 @@ mod tests {
                 Ok(()),
                 Ok(vec![
                     r#"Expression(Bytes(b"foo"))"#,
-                    r#"Regex(bar)"#,
+                    r#"Expression(Regex(bar))"#,
                     r#"Expression(Integer(5))"#,
                     r#"Expression([Bytes(b"baz"), Float(4.2)])"#,
                     r#"Expression(Boolean(true))"#,
-                    r#"Regex(qu+x)"#,
+                    r#"Expression(Regex(qu+x))"#,
                 ].into()),
             ),
             (
@@ -326,7 +326,12 @@ mod tests {
             }
 
             fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-                Ok(Box::new(RegexPrinterFn(arguments.required_regex("value")?)))
+                Ok(Box::new(RegexPrinterFn(
+                    arguments
+                        .required_literal("value")?
+                        .into_value()
+                        .try_regex()?,
+                )))
             }
 
             fn parameters(&self) -> &'static [Parameter] {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -177,7 +177,7 @@ mod tests {
             ("$foo = .foo.qux\n$foo[2].quux", Ok(()), Ok(true.into())),
             (
                 "$foo[0] = true",
-                Err(r#"remap error: parser error: paths in variable assignment not supported. Use "$foo" without ".[0]""#),
+                Err(r#"remap error: parser error: path in variable assignment unsupported, use "$foo" without ".[0]""#),
                 Ok(().into()),
             ),
             (r#"["foo", "bar", "baz"]"#, Ok(()), Ok(vec!["foo", "bar", "baz"].into())),

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -32,7 +32,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::function::{Argument, ArgumentList};
+    use crate::function::ArgumentList;
     use crate::map;
 
     #[test]
@@ -197,12 +197,12 @@ mod tests {
                 r#"array_printer(["foo", /bar/, 5, ["baz", 4.2], true, /qu+x/])"#,
                 Ok(()),
                 Ok(vec![
-                    r#"Expression(Bytes(b"foo"))"#,
-                    r#"Expression(Regex(bar))"#,
-                    r#"Expression(Integer(5))"#,
-                    r#"Expression([Bytes(b"baz"), Float(4.2)])"#,
-                    r#"Expression(Boolean(true))"#,
-                    r#"Expression(Regex(qu+x))"#,
+                    r#"Bytes(b"foo")"#,
+                    r#"Regex(bar)"#,
+                    r#"Integer(5)"#,
+                    r#"[Bytes(b"baz"), Float(4.2)]"#,
+                    r#"Boolean(true)"#,
+                    r#"Regex(qu+x)"#,
                 ].into()),
             ),
             (
@@ -210,7 +210,7 @@ mod tests {
                     .foo = ["foo", "bar"]
                     array_printer(.foo)
                 "#,
-                Err("remap error: function error: expected array literal argument, got expression"),
+                Err("remap error: unexpected expression: expected Array, got Path"),
                 Ok(().into()),
             ),
             (
@@ -230,7 +230,7 @@ mod tests {
             ),
             (
                 r#"enum_list_validator("qux")"#,
-                Err("remap error: function error: expected array literal argument, got expression"),
+                Err("remap error: unexpected expression: expected Array, got Literal"),
                 Ok(().into()),
             ),
         ];
@@ -283,6 +283,7 @@ mod tests {
 
     mod test_functions {
         use super::*;
+        use crate::expression::Array;
 
         #[derive(Debug, Clone)]
         pub(super) struct EnumValidator;
@@ -376,12 +377,13 @@ mod tests {
         }
 
         #[derive(Debug, Clone)]
-        struct ArrayPrinterFn(Vec<Argument>);
+        struct ArrayPrinterFn(Array);
         impl Expression for ArrayPrinterFn {
             fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
                 Ok(self
                     .0
-                    .iter()
+                    .clone()
+                    .into_iter()
                     .map(|v| format!("{:?}", v))
                     .collect::<Vec<_>>()
                     .into())

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -321,8 +321,6 @@ impl Parser<'_> {
             match pair.as_rule() {
                 // This matches first, if a keyword is provided.
                 R::ident => ident = Some(pair.as_str().to_owned()),
-                R::regex => return Ok((ident, Argument::Regex(self.regex_from_pair(pair)?))),
-                R::argument_array => return Ok((ident, self.argument_array_from_pair(pair)?)),
                 _ => {
                     let expr = self.expression_from_pair(pair)?;
                     return Ok((ident, Argument::Expression(expr)));
@@ -331,16 +329,6 @@ impl Parser<'_> {
         }
 
         Err(e(R::argument))
-    }
-
-    fn argument_array_from_pair(&mut self, pair: Pair<R>) -> Result<Argument> {
-        pair.into_inner()
-            .map(|pair| match pair.as_rule() {
-                R::regex => self.regex_from_pair(pair).map(Argument::Regex),
-                _ => self.expression_from_pair(pair).map(Argument::Expression),
-            })
-            .collect::<Result<Vec<_>>>()
-            .map(Argument::Array)
     }
 
     /// Parse a [`Regex`] value

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -278,6 +278,7 @@ impl Parser<'_> {
                 Literal::from(pair.as_str().parse::<f64>().map_err(|_| e(R::float))?).into()
             }
             R::array => self.array_from_pair(pair)?.into(),
+            R::regex => Literal::from(self.regex_from_pair(pair)?).into(),
             _ => return Err(e(R::value)),
         })
     }
@@ -720,14 +721,9 @@ mod tests {
                 vec![" 1:23\n", "= expected assignment, if_statement, not, or block"],
             ),
             (
-                // We cannot assign a regular expression to a field.
-                r#".foo = /ab/i"#,
-                vec![" 1:8\n", "= expected assignment, if_statement, not, or block"],
-            ),
-            (
                 // We cannot assign to a regular expression.
                 r#"/ab/ = .foo"#,
-                vec![" 1:1\n", "= expected EOI, assignment, if_statement, not, or block"],
+                vec![" 1:6\n", "= expected EOI, assignment, if_statement, not, operator_boolean_expr, operator_equality, operator_comparison, operator_addition, operator_multiplication, or block"],
             ),
         ];
 

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -5,7 +5,6 @@ use crate::{
         self, Arithmetic, Array, Assignment, Block, Function, IfStatement, Literal, Noop, Not,
         Path, Target, Variable,
     },
-    function::Argument,
     path, state, Error, Expr, Function as Fn, Operator, Result, Value,
 };
 use pest::iterators::{Pair, Pairs};
@@ -307,24 +306,21 @@ impl Parser<'_> {
     }
 
     /// Parse into a vector of argument properties.
-    fn arguments_from_pair(&mut self, pair: Pair<R>) -> Result<Vec<(Option<String>, Argument)>> {
+    fn arguments_from_pair(&mut self, pair: Pair<R>) -> Result<Vec<(Option<String>, Expr)>> {
         pair.into_inner()
             .map(|pair| self.argument_from_pair(pair))
             .collect::<Result<_>>()
     }
 
     /// Parse optional argument keyword and [`Argument`] value.
-    fn argument_from_pair(&mut self, pair: Pair<R>) -> Result<(Option<String>, Argument)> {
+    fn argument_from_pair(&mut self, pair: Pair<R>) -> Result<(Option<String>, Expr)> {
         let mut ident = None;
 
         for pair in pair.into_inner() {
             match pair.as_rule() {
                 // This matches first, if a keyword is provided.
                 R::ident => ident = Some(pair.as_str().to_owned()),
-                _ => {
-                    let expr = self.expression_from_pair(pair)?;
-                    return Ok((ident, Argument::Expression(expr)));
-                }
+                _ => return Ok((ident, self.expression_from_pair(pair)?)),
             }
         }
 

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -5,7 +5,7 @@ use crate::{
         self, Arithmetic, Array, Assignment, Block, Function, IfStatement, Literal, Noop, Not,
         Path, Target, Variable,
     },
-    path, state, Error as E, Expr, Function as Fn, Operator, Result, Value,
+    path, state, Error as E, Expr, Expression, Function as Fn, Operator, Result, Value,
 };
 use pest::iterators::{Pair, Pairs};
 use regex::{Regex, RegexBuilder};
@@ -24,6 +24,9 @@ type R = Rule;
 pub enum Error {
     #[error("cannot assign regex to object")]
     RegexAssignment,
+
+    #[error("cannot return regex from program")]
+    RegexResult,
 
     #[error(r#"path in variable assignment unsupported, use "${0}" without "{1}""#)]
     VariableAssignmentPath(String, String),
@@ -139,6 +142,14 @@ impl<'a> Parser<'a> {
                 }
                 R::EOI => (),
                 _ => return Err(e(R::expression)),
+            }
+        }
+
+        if let Some(expression) = expressions.last() {
+            let type_def = expression.type_def(&self.compiler_state);
+
+            if !type_def.kind.is_all() && type_def.kind.contains_regex() {
+                return Err(Error::RegexResult.into());
             }
         }
 

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{expression, function, state, value};
 pub use crate::{Error, Expr, Expression, Function, Object, Result, TypeDef, Value};
 
 // commonly used expressions
-pub use crate::expression::{Literal, Noop, Path, Variable};
+pub use crate::expression::{Array, Literal, Noop, Path, Variable};
 
 // commonly used function types
 pub use crate::function::{ArgumentList, Parameter};

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::{Error, Expr, Expression, Function, Object, Result, TypeDef, Valu
 pub use crate::expression::{Literal, Noop, Path, Variable};
 
 // commonly used function types
-pub use crate::function::{Argument, ArgumentList, Parameter};
+pub use crate::function::{ArgumentList, Parameter};
 
 // commonly used macros
 pub use crate::generate_param_list;

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -1,5 +1,4 @@
-use crate::{parser, state, value, Error as E, Expr, Expression, Function, RemapError, TypeDef};
-use pest::Parser;
+use crate::{parser::Parser, value, Error as E, Expr, Expression, Function, RemapError, TypeDef};
 use std::fmt;
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -91,16 +90,8 @@ impl Program {
         function_definitions: &[Box<dyn Function>],
         constraint: Option<TypeConstraint>,
     ) -> Result<Self, RemapError> {
-        let pairs = parser::Parser::parse(parser::Rule::program, source).map_err(E::from)?;
-
-        let compiler_state = state::Compiler::default();
-
-        let mut parser = parser::Parser {
-            function_definitions,
-            compiler_state,
-        };
-
-        let expressions = parser.pairs_to_expressions(pairs).map_err(RemapError)?;
+        let mut parser = Parser::new(function_definitions);
+        let expressions = parser.program_from_str(source)?;
 
         // optional type constraint checking
         if let Some(constraint) = constraint {

--- a/lib/remap-lang/src/runtime.rs
+++ b/lib/remap-lang/src/runtime.rs
@@ -21,8 +21,7 @@ impl Runtime {
             .expressions
             .iter()
             .map(|expression| expression.execute(&mut self.state, object))
-            .collect::<crate::Result<Vec<Value>>>()
-            .map_err(RemapError)?;
+            .collect::<crate::Result<Vec<Value>>>()?;
 
         Ok(values.pop().unwrap_or(Value::Null))
     }

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -20,12 +20,12 @@ macro_rules! test_type_def {
 #[macro_export]
 macro_rules! func_args {
     () => (
-        ::std::collections::HashMap::<&'static str, $crate::function::Argument>::default()
+        ::std::collections::HashMap::<&'static str, $crate::Expr>::default()
     );
     ($($k:tt: $v:expr),+ $(,)?) => {
         vec![$((stringify!($k), $v.into())),+]
             .into_iter()
-            .collect::<::std::collections::HashMap<&'static str, $crate::function::Argument>>()
+            .collect::<::std::collections::HashMap<&'static str, $crate::Expr>>()
     };
 }
 
@@ -83,7 +83,7 @@ macro_rules! map {
 #[macro_export]
 macro_rules! __prep_bench_or_test {
     ($func:path, $args:expr, $want:expr) => {{
-        let args: ::std::collections::HashMap<&str, $crate::function::Argument> = $args;
+        let args: ::std::collections::HashMap<&str, $crate::Expr> = $args;
 
         let mut arguments = $crate::function::ArgumentList::default();
         for (k, v) in args {

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -954,6 +954,7 @@ impl fmt::Display for Value {
                 write!(f, "[{}]", joined)
             }
             Value::Timestamp(val) => write!(f, "{}", val.to_string()),
+            Value::Regex(regex) => write!(f, "{}", regex.to_string()),
             Value::Null => write!(f, "Null"),
         }
     }

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -49,7 +49,14 @@ impl PartialEq for Value {
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
-    #[error(r#"expected "{0}", got "{1}""#)]
+    #[error(
+        r#"expected {}, got "{1}""#,
+        if .0.is_some() {
+            format!(r#"{}"#, .0)
+        } else {
+            format!(r#""{}""#, .0)
+        }
+    )]
     Expected(Kind, Kind),
 
     #[error(r#"unable to coerce "{0}" into "{1}""#)]

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -38,7 +38,7 @@ impl PartialEq for Value {
             Map(v1) => other.as_map().map(|v2| v1 == v2).unwrap_or_default(),
             Array(v1) => other.as_array().map(|v2| v1 == v2).unwrap_or_default(),
             Timestamp(v1) => other.as_timestamp().map(|v2| v1 == v2).unwrap_or_default(),
-            Null => other.as_null().map(|_| true).unwrap_or_default(),
+            Null => other.is_null(),
             Regex(v1) => match other {
                 Regex(v2) => v1.as_str() == v2.as_str(),
                 _ => false,
@@ -258,6 +258,10 @@ macro_rules! value_impl {
     ($(($func:expr, $variant:expr, $ret:ty)),+ $(,)*) => {
         impl Value {
             $(paste::paste! {
+            pub fn [<is $func>](&self) -> bool {
+                matches!(self, Value::$variant(_))
+            }
+
             pub fn [<as_ $func>](&self) -> Option<&$ret> {
                 match self {
                     Value::$variant(v) => Some(v),
@@ -283,6 +287,10 @@ macro_rules! value_impl {
                 self.[<try_ $func>]().expect(stringify!($func))
             }
             })+
+
+            pub fn is_null(&self) -> bool {
+                matches!(self, Value::Null)
+            }
 
             pub fn as_null(&self) -> Option<()> {
                 match self {

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 pub use kind::Kind;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Value {
     Bytes(Bytes),
     Integer(i64),
@@ -22,7 +22,29 @@ pub enum Value {
     Map(BTreeMap<String, Value>),
     Array(Vec<Value>),
     Timestamp(DateTime<Utc>),
+    Regex(regex::Regex),
     Null,
+}
+
+impl PartialEq for Value {
+    fn eq(&self, other: &Self) -> bool {
+        use Value::*;
+
+        match self {
+            Bytes(v1) => other.as_bytes().map(|v2| v1 == v2).unwrap_or_default(),
+            Integer(v1) => other.as_integer().map(|v2| v1 == v2).unwrap_or_default(),
+            Float(v1) => other.as_float().map(|v2| v1 == v2).unwrap_or_default(),
+            Boolean(v1) => other.as_boolean().map(|v2| v1 == v2).unwrap_or_default(),
+            Map(v1) => other.as_map().map(|v2| v1 == v2).unwrap_or_default(),
+            Array(v1) => other.as_array().map(|v2| v1 == v2).unwrap_or_default(),
+            Timestamp(v1) => other.as_timestamp().map(|v2| v1 == v2).unwrap_or_default(),
+            Null => other.as_null().map(|_| true).unwrap_or_default(),
+            Regex(v1) => match other {
+                Regex(v2) => v1.as_str() == v2.as_str(),
+                _ => false,
+            },
+        }
+    }
 }
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -124,6 +146,12 @@ impl From<String> for Value {
 impl From<bool> for Value {
     fn from(v: bool) -> Self {
         Value::Boolean(v)
+    }
+}
+
+impl From<regex::Regex> for Value {
+    fn from(v: regex::Regex) -> Self {
+        Value::Regex(v)
     }
 }
 
@@ -285,6 +313,7 @@ value_impl! {
     (map, Map, BTreeMap<String, Value>),
     (array, Array, Vec<Value>),
     (timestamp, Timestamp, DateTime<Utc>),
+    (regex, Regex, regex::Regex),
     // manually implemented due to no variant value
     // (null, Null, ()),
 }

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -258,7 +258,7 @@ macro_rules! value_impl {
     ($(($func:expr, $variant:expr, $ret:ty)),+ $(,)*) => {
         impl Value {
             $(paste::paste! {
-            pub fn [<is $func>](&self) -> bool {
+            pub fn [<is_ $func>](&self) -> bool {
                 matches!(self, Value::$variant(_))
             }
 

--- a/lib/remap-lang/src/value/kind.rs
+++ b/lib/remap-lang/src/value/kind.rs
@@ -13,7 +13,8 @@ bitflags::bitflags! {
         const Map = 1 << 5;
         const Array = 1 << 6;
         const Timestamp = 1 << 7;
-        const Null = 1 << 8;
+        const Regex = 1 << 8;
+        const Null = 1 << 9;
     }
 }
 
@@ -112,6 +113,7 @@ impl_kind![
     (Map, map),
     (Array, array),
     (Timestamp, timestamp),
+    (Regex, regex),
     (Null, null),
 ];
 
@@ -133,6 +135,7 @@ impl From<&Value> for Kind {
             Value::Map(_) => Kind::Map,
             Value::Array(_) => Kind::Array,
             Value::Timestamp(_) => Kind::Timestamp,
+            Value::Regex(_) => Kind::Regex,
             Value::Null => Kind::Null,
         }
     }

--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -214,6 +214,7 @@ impl From<remap::Value> for Value {
             Map(v) => Value::Map(v.into_iter().map(|(k, v)| (k, v.into())).collect()),
             Array(v) => Value::Array(v.into_iter().map(Into::into).collect()),
             Timestamp(v) => Value::Timestamp(v),
+            Regex(v) => Value::Bytes(bytes::Bytes::copy_from_slice(v.to_string().as_bytes())),
             Null => Value::Null,
         }
     }

--- a/src/remap/function.rs
+++ b/src/remap/function.rs
@@ -117,7 +117,7 @@ fn is_scalar_value(value: &Value) -> bool {
 
     match value {
         Integer(_) | Float(_) | Bytes(_) | Boolean(_) | Null => true,
-        Timestamp(_) | Map(_) | Array(_) => false,
+        Timestamp(_) | Map(_) | Array(_) | Regex(_) => false,
     }
 }
 

--- a/src/remap/function/assert.rs
+++ b/src/remap/function/assert.rs
@@ -24,8 +24,8 @@ impl Function for Assert {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let condition = arguments.required_expr("condition")?;
-        let message = arguments.optional_expr("message")?;
+        let condition = arguments.required("condition")?.boxed();
+        let message = arguments.optional("message").map(Expr::boxed);
 
         Ok(Box::new(AssertFn { condition, message }))
     }

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -25,8 +25,8 @@ impl Function for Ceil {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let precision = arguments.optional_expr("precision")?;
+        let value = arguments.required("value")?.boxed();
+        let precision = arguments.optional("precision").map(Expr::boxed);
 
         Ok(Box::new(CeilFn { value, precision }))
     }

--- a/src/remap/function/compact.rs
+++ b/src/remap/function/compact.rs
@@ -45,12 +45,12 @@ impl Function for Compact {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let recursive = arguments.optional_expr("recursive")?;
-        let null = arguments.optional_expr("null")?;
-        let string = arguments.optional_expr("string")?;
-        let map = arguments.optional_expr("map")?;
-        let array = arguments.optional_expr("array")?;
+        let value = arguments.required("value")?.boxed();
+        let recursive = arguments.optional("recursive").map(Expr::boxed);
+        let null = arguments.optional("null").map(Expr::boxed);
+        let string = arguments.optional("string").map(Expr::boxed);
+        let map = arguments.optional("map").map(Expr::boxed);
+        let array = arguments.optional("array").map(Expr::boxed);
 
         Ok(Box::new(CompactFn {
             value,

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -29,9 +29,9 @@ impl Function for Contains {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let substring = arguments.required_expr("substring")?;
-        let case_sensitive = arguments.optional_expr("case_sensitive")?;
+        let value = arguments.required("value")?.boxed();
+        let substring = arguments.required("substring")?.boxed();
+        let case_sensitive = arguments.optional("case_sensitive").map(Expr::boxed);
 
         Ok(Box::new(ContainsFn {
             value,

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -18,7 +18,7 @@ impl Function for Downcase {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(DowncaseFn { value }))
     }

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -29,9 +29,9 @@ impl Function for EndsWith {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let substring = arguments.required_expr("substring")?;
-        let case_sensitive = arguments.optional_expr("case_sensitive")?;
+        let value = arguments.required("value")?.boxed();
+        let substring = arguments.required("substring")?.boxed();
+        let case_sensitive = arguments.optional("case_sensitive").map(Expr::boxed);
 
         Ok(Box::new(EndsWithFn {
             value,

--- a/src/remap/function/flatten.rs
+++ b/src/remap/function/flatten.rs
@@ -18,7 +18,7 @@ impl Function for Flatten {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
         Ok(Box::new(FlattenFn { value }))
     }
 }

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -25,8 +25,8 @@ impl Function for Floor {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let precision = arguments.optional_expr("precision")?;
+        let value = arguments.required("value")?.boxed();
+        let precision = arguments.optional("precision").map(Expr::boxed);
 
         Ok(Box::new(FloorFn { value, precision }))
     }

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -35,10 +35,10 @@ impl Function for FormatNumber {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let scale = arguments.optional_expr("scale")?;
-        let decimal_separator = arguments.optional_expr("decimal_separator")?;
-        let grouping_separator = arguments.optional_expr("grouping_separator")?;
+        let value = arguments.required("value")?.boxed();
+        let scale = arguments.optional("scale").map(Expr::boxed);
+        let decimal_separator = arguments.optional("decimal_separator").map(Expr::boxed);
+        let grouping_separator = arguments.optional("grouping_separator").map(Expr::boxed);
 
         Ok(Box::new(FormatNumberFn {
             value,

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -26,8 +26,8 @@ impl Function for FormatTimestamp {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let format = arguments.required_expr("format")?;
+        let value = arguments.required("value")?.boxed();
+        let format = arguments.required("format")?.boxed();
 
         Ok(Box::new(FormatTimestampFn { value, format }))
     }

--- a/src/remap/function/ip_cidr_contains.rs
+++ b/src/remap/function/ip_cidr_contains.rs
@@ -25,8 +25,8 @@ impl Function for IpCidrContains {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let cidr = arguments.required_expr("cidr")?;
-        let value = arguments.required_expr("value")?;
+        let cidr = arguments.required("cidr")?.boxed();
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(IpCidrContainsFn { cidr, value }))
     }

--- a/src/remap/function/ip_subnet.rs
+++ b/src/remap/function/ip_subnet.rs
@@ -31,8 +31,8 @@ impl Function for IpSubnet {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let subnet = arguments.required_expr("subnet")?;
+        let value = arguments.required("value")?.boxed();
+        let subnet = arguments.required("subnet")?.boxed();
 
         Ok(Box::new(IpSubnetFn { value, subnet }))
     }

--- a/src/remap/function/ip_to_ipv6.rs
+++ b/src/remap/function/ip_to_ipv6.rs
@@ -19,7 +19,7 @@ impl Function for IpToIpv6 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(IpToIpv6Fn { value }))
     }

--- a/src/remap/function/ipv6_to_ipv4.rs
+++ b/src/remap/function/ipv6_to_ipv4.rs
@@ -19,7 +19,7 @@ impl Function for Ipv6ToIpV4 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(Ipv6ToIpV4Fn { value }))
     }

--- a/src/remap/function/log.rs
+++ b/src/remap/function/log.rs
@@ -26,7 +26,7 @@ impl Function for Log {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
         let level = arguments
             .optional_enum("level", &LEVELS)?
             .unwrap_or_else(|| "info".to_string());
@@ -80,7 +80,7 @@ mod tests {
         // This is largely just a smoke test to ensure it doesn't crash as there isn't really much to test.
         let mut state = state::Program::default();
         let func = LogFn::new(
-            Box::new(Literal::from(Value::Array(vec![Value::from(42)]))),
+            Box::new(Array::from(vec![Value::from(42)])),
             "warn".to_string(),
         );
         let mut object = Value::Map(map![]);

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -25,7 +25,7 @@ impl Function for Match {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
         let pattern = arguments.required_regex("pattern")?;
 
         Ok(Box::new(MatchFn { value, pattern }))

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -18,7 +18,7 @@ impl Function for Md5 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(Md5Fn { value }))
     }

--- a/src/remap/function/merge.rs
+++ b/src/remap/function/merge.rs
@@ -32,8 +32,8 @@ impl Function for Merge {
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let to = arguments.required_path("to")?;
-        let from = arguments.required_expr("from")?;
-        let deep = arguments.optional_expr("deep")?;
+        let from = arguments.required("from")?.boxed();
+        let deep = arguments.optional("deep").map(Expr::boxed);
 
         Ok(Box::new(MergeFn { to, from, deep }))
     }

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -56,8 +56,8 @@ impl Function for ParseDuration {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let output = arguments.required_expr("output")?;
+        let value = arguments.required("value")?.boxed();
+        let output = arguments.required("output")?.boxed();
 
         Ok(Box::new(ParseDurationFn { value, output }))
     }

--- a/src/remap/function/parse_grok.rs
+++ b/src/remap/function/parse_grok.rs
@@ -26,7 +26,7 @@ impl Function for ParseGrok {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         let patternbytes = arguments
             .required_literal("pattern")?
@@ -115,24 +115,20 @@ mod test {
         let mut arguments = ArgumentList::default();
         arguments.insert(
             "value",
-            Argument::Expression(
-                expression::Argument::new(
-                    Box::new(Literal::from("foo").into()),
-                    "value",
-                    "value",
-                    |_| true,
-                    "parse_grok",
-                )
-                .into(),
-            ),
+            expression::Argument::new(
+                Box::new(Literal::from("foo").into()),
+                |_| true,
+                "value",
+                "parse_grok",
+            )
+            .into(),
         );
         arguments.insert(
             "pattern",
             expression::Argument::new(
                 Box::new(Literal::from("%{NOG}").into()),
-                "pattern",
-                "pattern",
                 |_| true,
+                "pattern",
                 "parse_grok",
             )
             .into(),

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -25,8 +25,8 @@ impl Function for ParseJson {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let default = arguments.optional_expr("default")?;
+        let value = arguments.required("value")?.boxed();
+        let default = arguments.optional("default").map(Expr::boxed);
 
         Ok(Box::new(ParseJsonFn { value, default }))
     }

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -20,7 +20,7 @@ impl Function for ParseSyslog {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(ParseSyslogFn { value }))
     }

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -30,9 +30,9 @@ impl Function for ParseTimestamp {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let format = arguments.required_expr("format")?;
-        let default = arguments.optional_expr("default")?;
+        let value = arguments.required("value")?.boxed();
+        let format = arguments.required("format")?.boxed();
+        let default = arguments.optional("default").map(Expr::boxed);
 
         Ok(Box::new(ParseTimestampFn {
             value,

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -21,7 +21,7 @@ impl Function for ParseUrl {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(ParseUrlFn { value }))
     }

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -25,8 +25,8 @@ impl Function for Round {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let precision = arguments.optional_expr("precision")?;
+        let value = arguments.required("value")?.boxed();
+        let precision = arguments.optional("precision").map(Expr::boxed);
 
         Ok(Box::new(RoundFn { value, precision }))
     }

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -18,7 +18,7 @@ impl Function for Sha1 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(Sha1Fn { value }))
     }

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -34,7 +34,7 @@ impl Function for Sha2 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
         let variant = arguments.optional_enum("variant", &VARIANTS)?;
 
         Ok(Box::new(Sha2Fn { value, variant }))

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -27,7 +27,7 @@ impl Function for Sha3 {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
         let variant = arguments.optional_enum("variant", &VARIANTS)?;
 
         Ok(Box::new(Sha3Fn { value, variant }))

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -29,9 +29,9 @@ impl Function for Slice {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let start = arguments.required_expr("start")?;
-        let end = arguments.optional_expr("end")?;
+        let value = arguments.required("value")?.boxed();
+        let start = arguments.required("start")?.boxed();
+        let end = arguments.optional("end").map(Expr::boxed);
 
         Ok(Box::new(SliceFn { value, start, end }))
     }
@@ -137,7 +137,7 @@ mod tests {
 
         value_array {
             expr: |_| SliceFn {
-                value: Literal::from(vec!["foo"]).boxed(),
+                value: Array::from(vec!["foo"]).boxed(),
                 start: Literal::from(0).boxed(),
                 end: None,
             },
@@ -235,17 +235,17 @@ mod tests {
             (
                 map![],
                 Ok(vec![0, 1, 2].into()),
-                SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), 0, None),
+                SliceFn::new(Array::from(vec![0, 1, 2]).boxed(), 0, None),
             ),
             (
                 map![],
                 Ok(vec![1, 2].into()),
-                SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), 1, None),
+                SliceFn::new(Array::from(vec![0, 1, 2]).boxed(), 1, None),
             ),
             (
                 map![],
                 Ok(vec![1, 2].into()),
-                SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), -2, None),
+                SliceFn::new(Array::from(vec![0, 1, 2]).boxed(), -2, None),
             ),
             (
                 map![],

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -29,9 +29,9 @@ impl Function for StartsWith {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let substring = arguments.required_expr("substring")?;
-        let case_sensitive = arguments.optional_expr("case_sensitive")?;
+        let value = arguments.required("value")?.boxed();
+        let substring = arguments.required("substring")?.boxed();
+        let case_sensitive = arguments.optional("case_sensitive").map(Expr::boxed);
 
         Ok(Box::new(StartsWithFn {
             value,

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -18,7 +18,7 @@ impl Function for StripAnsiEscapeCodes {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(StripAnsiEscapeCodesFn { value }))
     }

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -17,7 +17,7 @@ impl Function for StripWhitespace {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(StripWhitespaceFn { value }))
     }

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -25,8 +25,8 @@ impl Function for ToBool {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let default = arguments.optional_expr("default")?;
+        let value = arguments.required("value")?.boxed();
+        let default = arguments.optional("default").map(Expr::boxed);
 
         Ok(Box::new(ToBoolFn { value, default }))
     }
@@ -59,7 +59,9 @@ impl Expression for ToBoolFn {
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            Array(_) | Map(_) | Timestamp(_) => Err("unable to convert value to boolean".into()),
+            Array(_) | Map(_) | Timestamp(_) | Regex(_) => {
+                Err("unable to convert value to boolean".into())
+            }
         };
 
         super::convert_value_or_default(
@@ -123,7 +125,7 @@ mod tests {
         }
 
         array_fallible {
-            expr: |_| ToBoolFn { value: Literal::from(vec![0]).boxed(), default: None },
+            expr: |_| ToBoolFn { value: Array::from(vec![0]).boxed(), default: None },
             def: TypeDef { fallible: true, kind: Kind::Boolean },
         }
 
@@ -142,8 +144,8 @@ mod tests {
 
        fallible_value_with_fallible_default {
             expr: |_| ToBoolFn {
-                value: Literal::from(vec![0]).boxed(),
-                default: Some(Literal::from(vec![0]).boxed()),
+                value: Array::from(vec![0]).boxed(),
+                default: Some(Array::from(vec![0]).boxed()),
             },
             def: TypeDef {
                 fallible: true,
@@ -153,7 +155,7 @@ mod tests {
 
        fallible_value_with_infallible_default {
             expr: |_| ToBoolFn {
-                value: Literal::from(vec![0]).boxed(),
+                value: Array::from(vec![0]).boxed(),
                 default: Some(Literal::from(true).boxed()),
             },
             def: TypeDef {
@@ -165,7 +167,7 @@ mod tests {
         infallible_value_with_fallible_default {
             expr: |_| ToBoolFn {
                 value: Literal::from(true).boxed(),
-                default: Some(Literal::from(vec![0]).boxed()),
+                default: Some(Array::from(vec![0]).boxed()),
             },
             def: TypeDef {
                 fallible: false,
@@ -191,7 +193,7 @@ mod tests {
             (
                 map![],
                 Ok(Value::Boolean(true)),
-                ToBoolFn::new(Literal::from(vec![0]).boxed(), Some(true.into())),
+                ToBoolFn::new(Array::from(vec![0]).boxed(), Some(true.into())),
             ),
             (
                 map!["foo": "true"],

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -25,8 +25,8 @@ impl Function for ToFloat {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let default = arguments.optional_expr("default")?;
+        let value = arguments.required("value")?.boxed();
+        let default = arguments.optional("default").map(Expr::boxed);
 
         Ok(Box::new(ToFloatFn { value, default }))
     }
@@ -59,7 +59,9 @@ impl Expression for ToFloatFn {
                 .convert(value.into())
                 .map(Into::into)
                 .map_err(|e| e.to_string().into()),
-            Array(_) | Map(_) | Timestamp(_) => Err("unable to convert value to float".into()),
+            Array(_) | Map(_) | Timestamp(_) | Regex(_) => {
+                Err("unable to convert value to float".into())
+            }
         };
 
         super::convert_value_or_default(
@@ -123,7 +125,7 @@ mod tests {
         }
 
         array_fallible {
-            expr: |_| ToFloatFn { value: Literal::from(vec![0]).boxed(), default: None },
+            expr: |_| ToFloatFn { value: Array::from(vec![0]).boxed(), default: None },
             def: TypeDef { fallible: true, kind: Kind::Float },
         }
 
@@ -142,8 +144,8 @@ mod tests {
 
        fallible_value_with_fallible_default {
             expr: |_| ToFloatFn {
-                value: Literal::from(vec![0]).boxed(),
-                default: Some(Literal::from(vec![0]).boxed()),
+                value: Array::from(vec![0]).boxed(),
+                default: Some(Array::from(vec![0]).boxed()),
             },
             def: TypeDef {
                 fallible: true,
@@ -153,7 +155,7 @@ mod tests {
 
        fallible_value_with_infallible_default {
             expr: |_| ToFloatFn {
-                value: Literal::from(vec![0]).boxed(),
+                value: Array::from(vec![0]).boxed(),
                 default: Some(Literal::from(1).boxed()),
             },
             def: TypeDef {
@@ -165,7 +167,7 @@ mod tests {
         infallible_value_with_fallible_default {
             expr: |_| ToFloatFn {
                 value: Literal::from(1).boxed(),
-                default: Some(Literal::from(vec![0]).boxed()),
+                default: Some(Array::from(vec![0]).boxed()),
             },
             def: TypeDef {
                 fallible: false,
@@ -191,7 +193,7 @@ mod tests {
             (
                 map![],
                 Ok(Value::Float(10.0)),
-                ToFloatFn::new(Literal::from(vec![0]).boxed(), Some(10.0.into())),
+                ToFloatFn::new(Array::from(vec![0]).boxed(), Some(10.0.into())),
             ),
             (
                 map!["foo": "20.5"],

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -18,7 +18,7 @@ impl Function for Tokenize {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(TokenizeFn { value }))
     }

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -29,9 +29,9 @@ impl Function for Truncate {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
-        let limit = arguments.required_expr("limit")?;
-        let ellipsis = arguments.optional_expr("ellipsis")?;
+        let value = arguments.required("value")?.boxed();
+        let limit = arguments.required("limit")?.boxed();
+        let ellipsis = arguments.optional("ellipsis").map(Expr::boxed);
 
         Ok(Box::new(TruncateFn {
             value,

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -18,7 +18,7 @@ impl Function for Upcase {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let value = arguments.required_expr("value")?;
+        let value = arguments.required("value")?.boxed();
 
         Ok(Box::new(UpcaseFn { value }))
     }

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1205,3 +1205,23 @@
     "c.equals" = "hello ****, hello ****"
     "d.equals" = "hello world, hello universe"
     "e.equals" = "**** w****rld, **** ****n****v****rs****"
+
+[transforms.remap_function_replace]
+  inputs = []
+  type = "remap"
+  source = """
+    .a = replace("foo", pattern = "o", with = "bar", 1)
+    .b = replace("foo", pattern = /o/, with = "bar")
+  """
+[[tests]]
+  name = "remap_function_replace"
+  [tests.input]
+    insert_at = "remap_function_replace"
+    type = "log"
+    [tests.input.log_fields]
+      input = "hello world, hello universe"
+  [[tests.outputs]]
+    extract_from = "remap_function_replace"
+    [[tests.outputs.conditions]]
+    "a.equals" = "fbaro"
+    "b.equals" = "fbarbar"


### PR DESCRIPTION
_PR is best reviewed per commit_

Regex support has some history in Remap (even in its short lifetime).

We discussed the implementation in #4091, then had an initial implementation in #4290, a refactor of that implementation in #4695, and added support for arrays with regexps in #5283.

Since the start, regexps have been treated in a special way, compared to other expressions. That is to say, there is no easy/correct way to represent a regexp as an `event::Value`, and so we didn't model regexps as a `remap::Value` (and thus we couldn't treat them as expressions), instead opting to add special parsing rules that allow regexps in argument positions, but nowhere else.

This "works", but it came with a bag full of special/edge-cases that need to be handled, and an entire set of infrastructure to handle function arguments differently from other expressions in Remap.

After adding arrays, it became clear to me this was 1) becoming more difficult to work with, and 2) didn't scale well to container types (such as arrays, but also maps, eventually).

This PR proposes a way to address those issues.

After this PR:

* A new `Value::Regex` variant is added to Remap (not Vector!).
* Remap now _symantically_ supports regexp expressions, but _syntactically_ rejects assigning regexp values to paths, or to return regexp values as a root expression (i.e. the `Value::Regex` type is self-contained within Remap and cannot leak out to Vector or other users of Remap).
* There is **no† difference in behaviour to the end-user**.
* Functions no longer take `Argument`s, but `Expression` types, removing a host of special-casing logic in the process.
* An `expression::Literal` no longer stores `Value::Array`, instead this is handled by `expression::Array` (there is a debug assert to make sure this invariant is upheld).
* It is now **allowed** to assign a regexp (or an array containing regexps) to a variable.

†: the only noticeable difference is a slightly updated compiler error when using regexps inappropriately

---

Here's an example of what now works and doesn't work:

```rust
$foo = /foo/ 	// ok
.foo = /foo/ 	// remap error: parser error: cannot assign regex to object
.foo = [/foo/] 	// remap error: parser error: cannot assign regex to object
my_func(/foo/) 	// ok
my_func($foo) 	// ok
// etc...
```

---

There is still some work to do in a follow-up PR. Namely, we should extend our `TypeDef` infrastructure to also encode which types are embedded in a container type.

If we did this, we can always statically know if there is a chance of a regexp being returned in an expression, which would make our checks to disallow regexps in path assignments or as root expressions more robust.

I left this out of this PR, but will follow up on this in the next iteration.