### PR TITLE
chore(external docs): Remap documentation fixes

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -50,7 +50,7 @@ remap: {
 
 			arguments: [...#Argument] // Allow for empty list
 			return: [#RemapReturnTypes, ...#RemapReturnTypes]
-			category:    "coerce" | "object" | "parse" | "text" | "hash" | "event" | "networking"
+			category:    "coerce" | "numeric" | "object" | "parse" | "text" | "hash" | "event" | "networking"
 			description: string
 			examples: [#RemapExample, ...#RemapExample]
 			name: Name

--- a/docs/reference/remap/ceil.cue
+++ b/docs/reference/remap/ceil.cue
@@ -1,0 +1,39 @@
+package metadata
+
+remap: functions: ceil: {
+	arguments: [
+		{
+			name:        "value"
+			description: "The number to round up."
+			required:    true
+			type: ["integer", "float"]
+		},
+		{
+			name:        "precision"
+			description: "The number of decimal places to round to."
+			required:    false
+			default:     0
+			type: ["integer"]
+		},
+	]
+	return: ["timestamp"]
+	category: "numeric"
+	description: #"""
+		Rounds the given number up to the given precision of decimal places.
+		"""#
+	examples: [
+		{
+			title: "Success"
+			input: {
+				number: 4.345
+			}
+			source: #"""
+				.ceil = ceil(.number, precision = 2)
+				"""#
+			output: {
+				number: 4.345
+				ceil:   4.35
+			}
+		},
+	]
+}

--- a/docs/reference/remap/floor.cue
+++ b/docs/reference/remap/floor.cue
@@ -1,0 +1,39 @@
+package metadata
+
+remap: functions: floor: {
+	arguments: [
+		{
+			name:        "value"
+			description: "The number to round down."
+			required:    true
+			type: ["integer", "float"]
+		},
+		{
+			name:        "precision"
+			description: "The number of decimal places to round to."
+			required:    false
+			default:     0
+			type: ["integer"]
+		},
+	]
+	return: ["timestamp"]
+	category: "numeric"
+	description: #"""
+		Rounds the given number down to the given precision of decimal places.
+		"""#
+	examples: [
+		{
+			title: "Success"
+			input: {
+				number: 4.345
+			}
+			source: #"""
+				.floor = floor(.number, precision = 2)
+				"""#
+			output: {
+				number: 4.345
+				floor:  4.34
+			}
+		},
+	]
+}

--- a/docs/reference/remap/format_number.cue
+++ b/docs/reference/remap/format_number.cue
@@ -45,7 +45,7 @@ remap: functions: format_number: {
 				"""#
 			output: {
 				number:    1234567.89
-				formatter: "1,234,567.890"
+				formatted: "1,234,567.890"
 			}
 		},
 		{

--- a/docs/reference/remap/parse_syslog.cue
+++ b/docs/reference/remap/parse_syslog.cue
@@ -1,0 +1,57 @@
+remap: functions: parse_syslog: {
+	arguments: [
+		{
+			name:        "value"
+			description: "The text containing the syslog message to parse."
+			required:    true
+			type: ["string"]
+		},
+	]
+	return: ["map"]
+	category: "parse"
+	description: #"""
+		Parses a syslog message. The function makes a best effort to parse the various Syslog formats out in the wild.
+		This includes [RFC 6587][urls.syslog_6587], [RFC 5424][urls.syslog_5424], [RFC 3164][urls.syslog_3164], and other
+		common variations (such as the Nginx Syslog style). If parsing fails, Vector will include the entire Syslog
+		line in the message field.
+		"""#
+	examples: [
+		{
+			title: "Success"
+			input: {
+				message: """
+					<13>1 2020-03-13T20:45:38.119Z dynamicwireless.name non 2426 ID931 [exampleSDID@32473 iut="3" eventSource= "Application" eventID="1011"] Try to override the THX port, maybe it will reboot the neural interface!
+					"""
+			}
+			source: ".parsed = parse_syslog(.message)"
+			output: {
+				message: """
+					<13>1 2020-03-13T20:45:38.119Z dynamicwireless.name non 2426 ID931 [exampleSDID@32473 iut="3" eventSource= "Application" eventID="1011"] Try to override the THX port, maybe it will reboot the neural interface!
+					"""
+				parsed: {severity: "notice"
+							facility:    "user"
+							timestamp:   "2020-03-13T20:45:38.119Z"
+							hostname:    "dynamicwireless.name"
+							appname:     "non"
+							procid:      "2426"
+							msgid:       "ID931"
+							iut:         "3"
+							eventSource: "Application"
+							eventID:     "1011"
+							message:     "Try to override the THX port, maybe it will reboot the neural interface!"
+				}
+			}
+		},
+		{
+			title: "Invalid Message"
+			input: {
+				message: "A simple message"
+			}
+			source: ".parsed = parse_syslog(.message)"
+			output: {
+				message: "A simple message"
+				parsed: {message: "A simple message"}
+			}
+		},
+	]
+}

--- a/docs/reference/remap/parse_timestamp.cue
+++ b/docs/reference/remap/parse_timestamp.cue
@@ -35,25 +35,25 @@ remap: functions: parse_timestamp: {
 		{
 			title: "Success"
 			input: {
-				".timestamp_bad":  "I am not a timestamp"
-				".timestamp_good": "10-Oct-2020 16:00"
+				"timestamp_bad":  "I am not a timestamp"
+				"timestamp_good": "10-Oct-2020 16:00"
 			}
 			source: #"""
-				.timestamp = parse_timestamp(.timestamp_bad, format="%v %R", default=.timestamp_bad)
+				.timestamp = parse_timestamp(.timestamp_bad, format="%v %R", default=.timestamp_good)
 				"""#
 			output: {
-				".timestamp":      "10-Oct-2020 16:00:00"
-				".timestamp_bad":  "I am not a timestamp"
-				".timestamp_good": "10-Oct-2020 16:00"
+				"timestamp":      "10-Oct-2020 16:00:00"
+				"timestamp_bad":  "I am not a timestamp"
+				"timestamp_good": "10-Oct-2020 16:00"
 			}
 		},
 		{
 			title: "Error"
 			input: {
-				".timestamp_bad": "I am not a timestamp"
+				"timestamp_bad": "I am not a timestamp"
 			}
 			source: #"""
-				.timestamp = parse_timestamp(.timestamp_bad, format="%v %R", default=.timestamp_bad)
+				.timestamp = parse_timestamp(.timestamp_bad, format="%v %R")
 				"""#
 			output: {
 				error: remap.errors.ParseError

--- a/docs/reference/remap/round.cue
+++ b/docs/reference/remap/round.cue
@@ -1,0 +1,53 @@
+package metadata
+
+remap: functions: round: {
+	arguments: [
+		{
+			name:        "value"
+			description: "The number to round."
+			required:    true
+			type: ["integer", "float"]
+		},
+		{
+			name:        "precision"
+			description: "The number of decimal places to round to."
+			required:    false
+			default:     0
+			type: ["integer"]
+		},
+	]
+	return: ["timestamp"]
+	category: "numeric"
+	description: #"""
+		Rounds the given number to the given number of decimal places. Rounds up or down
+		depending on which is nearest. Numbers that are half way (5) are rounded up.
+		"""#
+	examples: [
+		{
+			title: "Round up"
+			input: {
+				number: 4.345
+			}
+			source: #"""
+				.floor = floor(.number, precision = 2)
+				"""#
+			output: {
+				number: 4.345
+				floor:  4.35
+			}
+		},
+		{
+			title: "Round down"
+			input: {
+				number: 4.344
+			}
+			source: #"""
+				.floor = floor(.number, precision = 2)
+				"""#
+			output: {
+				number: 4.344
+				floor:  4.34
+			}
+		},
+	]
+}


### PR DESCRIPTION
This fixes the documentation errors noticed by [Steve](https://discordapp.com/channels/742820443487993987/751109034827972709/782782924541394965).

In the process I noticed that documentation was missing for a number of functions. So this also adds docs for:

- `ceil`
- `floor`
- `round`
- `parse_syslog`

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

