### PR TITLE
chore: Fix release-github.sh VERSION interpolation

### DIFF
--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -11,5 +11,5 @@ VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 
 grease --debug create-release timberio/vector v${VERSION} ${SHA1} \
   --assets './target/artifacts/*' \
-  --notes '[View release notes](https://vector.dev/releases/${VERSION}/)' \
+  --notes "[View release notes](https://vector.dev/releases/${VERSION}/)" \
   --name v${VERSION}

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 
-grease --debug create-release timberio/vector v${VERSION} ${SHA1} \
+grease --debug create-release timberio/vector "v${VERSION}" "${SHA1}" \
   --assets './target/artifacts/*' \
   --notes "[View release notes](https://vector.dev/releases/${VERSION}/)" \
-  --name v${VERSION}
+  --name "v${VERSION}"


### PR DESCRIPTION
This interpolation didn't work, I assume it's due to the use if `'`.