### PR TITLE
chore: unify metric names

### DIFF
--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -162,13 +162,13 @@ components: sources: internal_metrics: {
 			}
 		}
 		collect_completed_total: {
-			description:       "The total number of MongoDB metrics collections completed."
+			description:       "The total number of metrics collections completed for this component."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
 		collect_duration_nanoseconds: {
-			description:       "The duration spent collecting MongoDB metrics."
+			description:       "The duration spent collecting of metrics for this component."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
@@ -393,7 +393,7 @@ components: sources: internal_metrics: {
 			tags:              _internal_metrics_tags
 		}
 		parse_errors_total: {
-			description:       "The total number of errors parsing Prometheus metrics."
+			description:       "The total number of errors parsing metrics for this component."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
@@ -424,8 +424,8 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		request_error_total: {
-			description:       "The total number of MongoDB request errors."
+		request_errors_total: {
+			description:       "The total number of requests errors for this component."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -418,12 +418,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		request_duration_nanoseconds: {
-			description:       "The request duration for this component (in nanoseconds)."
-			type:              "histogram"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		request_errors_total: {
 			description:       "The total number of requests errors for this component."
 			type:              "counter"

--- a/docs/reference/components/sources/mongodb_metrics.cue
+++ b/docs/reference/components/sources/mongodb_metrics.cue
@@ -103,7 +103,7 @@ components: sources: mongodb_metrics: {
 	telemetry: metrics: {
 		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		request_error_total:          components.sources.internal_metrics.output.metrics.request_error_total
+		request_errors_total:         components.sources.internal_metrics.output.metrics.request_errors_total
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 

--- a/docs/reference/components/sources/nginx_metrics.cue
+++ b/docs/reference/components/sources/nginx_metrics.cue
@@ -110,7 +110,7 @@ components: sources: nginx_metrics: {
 	telemetry: metrics: {
 		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		request_error_total:          components.sources.internal_metrics.output.metrics.request_error_total
+		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 

--- a/docs/reference/components/sources/prometheus_remote_write.cue
+++ b/docs/reference/components/sources/prometheus_remote_write.cue
@@ -76,6 +76,12 @@ components: sources: prometheus_remote_write: {
 		gauge:   output._passthrough_gauge
 	}
 
+	telemetry: metrics: {
+		parse_errors_total:     components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
+	}
+
 	how_it_works: {
 		metric_types: {
 			title: "Metric type interpretation"

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -2,12 +2,12 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
-pub struct ElasticSearchEventReceived {
+pub struct ElasticSearchEventEncoded {
     pub byte_size: usize,
     pub index: String,
 }
 
-impl InternalEvent for ElasticSearchEventReceived {
+impl InternalEvent for ElasticSearchEventEncoded {
     fn emit_logs(&self) {
         trace!(message = "Inserting event.", index = %self.index);
     }

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -31,7 +31,7 @@ impl<'a> InternalEvent for MongoDBMetricsRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_error_total", 1);
+        counter!("request_errors_total", 1);
     }
 }
 

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -16,7 +16,7 @@ impl InternalEvent for MongoDBMetricsCollectCompleted {
 
     fn emit_metrics(&self) {
         counter!("collect_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        histogram!("collect_duration_nanoseconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -16,7 +16,7 @@ impl InternalEvent for NginxMetricsCollectCompleted {
 
     fn emit_metrics(&self) {
         counter!("collect_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        histogram!("collect_duration_nanoseconds", self.end - self.start);
     }
 }
 
@@ -31,7 +31,7 @@ impl<'a> InternalEvent for NginxMetricsRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_errors_total", 1);
+        counter!("http_request_errors_total", 1);
     }
 }
 

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -31,7 +31,7 @@ impl<'a> InternalEvent for NginxMetricsRequestError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("request_error_total", 1);
+        counter!("request_errors_total", 1);
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -139,7 +139,7 @@ impl InternalEvent for PrometheusRemoteWriteReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("events_processed_total", self.count as u64);
+        counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -108,7 +108,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("request_received_total", 1);
+            counter!("requests_received_total", 1);
         }
     }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -3,7 +3,7 @@ use crate::{
     emit,
     event::Event,
     http::{Auth, HttpClient},
-    internal_events::{ElasticSearchEventReceived, ElasticSearchMissingKeys},
+    internal_events::{ElasticSearchEventEncoded, ElasticSearchMissingKeys},
     rusoto::{self, region_from_endpoint, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -196,7 +196,7 @@ impl HttpSink for ElasticSearchCommon {
         serde_json::to_writer(&mut body, &event.into_log()).unwrap();
         body.push(b'\n');
 
-        emit!(ElasticSearchEventReceived {
+        emit!(ElasticSearchEventEncoded {
             byte_size: body.len(),
             index
         });


### PR DESCRIPTION
@jszwedko should we also rename `request_error_total` => `requests_error_total` and `request_read_errors_total` => `requests_read_errors_total` (because we have `requests_completed_total` / `requests_received_total`)?

```
$ grep 'counter!\("request.*?"' -rhoP src/internal_events/ | sort -u
counter!("request_error_total"
counter!("request_read_errors_total"
counter!("requests_completed_total"
counter!("requests_received_total"
```

edit:
**Changes**:
- `events_processed_total` => `processed_events_total` (prometheus)
- `request_received_total` => `requests_received_total` (splunk_hec)
- `request_error_total` => `request_errors_total` (mongo, nginx)