### PR TITLE
chore(remap transform): update events for remap transform

### DIFF
--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -1,7 +1,7 @@
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription},
     emit,
-    internal_events::RemapConditionExecutionFailed,
+    internal_events::RemapConditionExecutionError,
     Event,
 };
 use remap::{value, Program, RemapError, Runtime, TypeConstraint, TypeDef, Value};
@@ -69,7 +69,7 @@ impl Condition for Remap {
                 _ => unreachable!("boolean type constraint set"),
             })
             .unwrap_or_else(|_| {
-                emit!(RemapConditionExecutionFailed);
+                emit!(RemapConditionExecutionError);
                 false
             })
     }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -6,19 +6,22 @@ pub struct RemapEventProcessed;
 
 impl InternalEvent for RemapEventProcessed {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
+        counter!("processed_events_total", 1,
+                 "component_kind" => "transform",
+                 "component_type" => "remap",
+        );
     }
 }
 
 #[derive(Debug)]
-pub struct RemapFailedMapping {
+pub struct RemapMappingError {
     /// If set to true, the remap transform has dropped the event after a failed
     /// mapping. This internal event will reflect that in its messaging.
     pub event_dropped: bool,
     pub error: String,
 }
 
-impl InternalEvent for RemapFailedMapping {
+impl InternalEvent for RemapMappingError {
     fn emit_logs(&self) {
         let message = if self.event_dropped {
             "Mapping failed with event; discarding event."
@@ -34,18 +37,29 @@ impl InternalEvent for RemapFailedMapping {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "failed_mapping");
+        counter!("processing_errors_total", 1,
+                 "error_type" => "failed_mapping",
+                 "component_kind" => "transform",
+                 "component_type" => "remap",
+        );
     }
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct RemapConditionExecutionFailed;
+pub struct RemapConditionExecutionError;
 
-impl InternalEvent for RemapConditionExecutionFailed {
+impl InternalEvent for RemapConditionExecutionError {
     fn emit_logs(&self) {
         warn!(
             message = "Remap condition execution failed.",
             rate_limit_secs = 120
         )
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processing_errors_total", 1,
+                 "component_kind" => "condition",
+                 "component_type" => "mapping",
+        );
     }
 }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -6,10 +6,7 @@ pub struct RemapEventProcessed;
 
 impl InternalEvent for RemapEventProcessed {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1,
-                 "component_kind" => "transform",
-                 "component_type" => "remap",
-        );
+        counter!("processed_events_total", 1);
     }
 }
 
@@ -38,10 +35,7 @@ impl InternalEvent for RemapMappingError {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-                 "error_type" => "failed_mapping",
-                 "component_kind" => "transform",
-                 "component_type" => "remap",
-        );
+                 "error_type" => "failed_mapping");
     }
 }
 
@@ -57,9 +51,6 @@ impl InternalEvent for RemapConditionExecutionError {
     }
 
     fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1,
-                 "component_kind" => "condition",
-                 "component_type" => "mapping",
-        );
+        counter!("processing_errors_total", 1);
     }
 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{DataType, TransformConfig, TransformDescription},
     event::Event,
-    internal_events::{RemapEventProcessed, RemapFailedMapping},
+    internal_events::{RemapEventProcessed, RemapMappingError},
     transforms::{FunctionTransform, Transform},
     Result,
 };
@@ -74,9 +74,9 @@ impl FunctionTransform for Remap {
         let mut runtime = Runtime::default();
 
         if let Err(error) = runtime.execute(&mut event, &self.program) {
-            emit!(RemapFailedMapping {
-                event_dropped: self.drop_on_err,
+            emit!(RemapMappingError {
                 error: error.to_string(),
+                event_dropped: self.drop_on_err,
             });
 
             if self.drop_on_err {


### PR DESCRIPTION
Closes #4000 

Note it seems these events do not update the errors column in `vector top`. It is possible there is an error here, or in `vector top` which may be surfaced in  #5329.

@leebenson  does it look like these have been defined correctly?

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

