### PR TITLE
chore: Bump version to 0.12.0 now that 0.11.0 is released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7118,7 +7118,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

Fixes `make check-version`: https://github.com/timberio/vector/runs/1484814549?check_suite_focus=true

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
