### PR TITLE
chore(ci): Archive bench artifacts before uploading

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -42,9 +42,9 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: benches.yml
           branch: master
-          name: vector-benches
+          name: criterion
           path: target/criterion
-      - run: zip --recurse-paths target/criterion.zip target/criterion
+      - run: unzip target/criterion.zip
         continue-on-error: true
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
@@ -54,7 +54,7 @@ jobs:
       - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2
         with:
-          name: "vector-benches"
+          name: "criterion"
           path: "./target/criterion.zip"
 
   master-failure:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -44,15 +44,18 @@ jobs:
           branch: master
           name: vector-benches
           path: target/criterion
+      - run: zip --recurse-paths target/criterion.zip target/criterion
+        continue-on-error: true
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make bench
+      - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2
         with:
           name: "vector-benches"
-          path: "./target/criterion/*"
+          path: "./target/criterion.zip"
 
   master-failure:
     name: master-failure


### PR DESCRIPTION
Uploading many small files in GA seems to be resulting in some number of
them failing: https://github.com/timberio/vector/actions/runs/395559899

This change archives them first using zip and uploads this artifact.
This is how Github stores them anyway.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
