### PR TITLE
enhancement(remap): add integer division

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -42,7 +42,7 @@ operator_boolean_expr   = { "||" | "&&" }
 operator_equality       = { "!=" | "==" }
 operator_comparison     = { ">=" | ">" | "<=" | "<" }
 operator_addition       = { "-" | "+" }
-operator_multiplication = { "/" | "*" | "%" }
+operator_multiplication = { "//" | "/" | "*" | "%" }
 operator_not            = { "!" }
 
 // Paths -----------------------------------------------------------------------

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -24,6 +24,7 @@ impl Expression for Arithmetic {
         match self.op {
             Multiply => lhs.try_mul(rhs),
             Divide => lhs.try_div(rhs),
+            IntegerDivide => lhs.try_int_div(rhs),
             Add => lhs.try_add(rhs),
             Subtract => lhs.try_sub(rhs),
             Or => Ok(lhs.or(rhs)),
@@ -62,6 +63,9 @@ impl Expression for Arithmetic {
             Subtract | Divide | Remainder => type_def
                 .fallible_unless(Kind::Integer | Kind::Float)
                 .with_constraint(Kind::Integer | Kind::Float),
+            IntegerDivide => type_def
+                .fallible_unless(Kind::Integer)
+                .with_constraint(Kind::Integer),
             Multiply | Add => type_def
                 .fallible_unless(Kind::Bytes | Kind::Integer | Kind::Float)
                 .with_constraint(Kind::Bytes | Kind::Integer | Kind::Float),
@@ -160,6 +164,18 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer | Kind::Float,
+            },
+        }
+
+        integer_divide {
+            expr: |_| Arithmetic::new(
+                Box::new(Noop.into()),
+                Box::new(Noop.into()),
+                Operator::IntegerDivide,
+            ),
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Integer
             },
         }
 

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -64,7 +64,7 @@ impl Expression for Arithmetic {
                 .fallible_unless(Kind::Integer | Kind::Float)
                 .with_constraint(Kind::Integer | Kind::Float),
             IntegerDivide => type_def
-                .fallible_unless(Kind::Integer)
+                .fallible_unless(Kind::Integer | Kind::Float)
                 .with_constraint(Kind::Integer),
             Multiply | Add => type_def
                 .fallible_unless(Kind::Bytes | Kind::Integer | Kind::Float)

--- a/lib/remap-lang/src/operator.rs
+++ b/lib/remap-lang/src/operator.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 pub enum Operator {
     Multiply,
     Divide,
+    IntegerDivide,
     Remainder,
     Add,
     Subtract,
@@ -27,6 +28,7 @@ impl FromStr for Operator {
         Ok(match s {
             "*" => Multiply,
             "/" => Divide,
+            "//" => IntegerDivide,
             "%" => Remainder,
             "+" => Add,
             "-" => Subtract,
@@ -50,6 +52,7 @@ impl AsRef<str> for Operator {
         match self {
             Multiply => "*",
             Divide => "/",
+            IntegerDivide => "//",
             Remainder => "%",
             Add => "+",
             Subtract => "-",

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -501,7 +501,7 @@ impl Parser<'_> {
     // The order of `op` operations defines operator precedence.
     operation_fns! {
         multiplication => {
-            op: [Multiply, Divide, Remainder],
+            op: [Multiply, Divide, IntegerDivide, Remainder],
             next: not,
         }
 

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("unable to divide value type {0} by {1}")]
     Div(Kind, Kind),
 
+    #[error("unable to integer divide value type {0} by {1}")]
+    IntDiv(Kind, Kind),
+
     #[error("unable to add value type {1} to {0}")]
     Add(Kind, Kind),
 
@@ -315,8 +318,19 @@ impl Value {
         let err = || Error::Div(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) => (lhv / i64::try_from(&rhs).map_err(|_| err())?).into(),
+            Value::Integer(lhv) => (lhv as f64 / f64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv / f64::try_from(&rhs).map_err(|_| err())?).into(),
+            _ => return Err(err()),
+        };
+
+        Ok(value)
+    }
+
+    pub fn try_int_div(self, rhs: Self) -> Result<Self, Error> {
+        let err = || Error::IntDiv(self.kind(), rhs.kind());
+
+        let value = match (&self, &rhs) {
+            (Value::Integer(lhv), Value::Integer(rhs)) => (lhv / rhs).into(),
             _ => return Err(err()),
         };
 

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -331,7 +331,7 @@ impl Value {
 
         let value = match &self {
             Value::Integer(lhv) => (lhv / i64::try_from(&rhs).map_err(|_| err())?).into(),
-            Value::Float(lhv) => (*lhv as i64/ i64::try_from(&rhs).map_err(|_| err())?).into(),
+            Value::Float(lhv) => (*lhv as i64 / i64::try_from(&rhs).map_err(|_| err())?).into(),
             _ => return Err(err()),
         };
 

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -329,8 +329,9 @@ impl Value {
     pub fn try_int_div(self, rhs: Self) -> Result<Self, Error> {
         let err = || Error::IntDiv(self.kind(), rhs.kind());
 
-        let value = match (&self, &rhs) {
-            (Value::Integer(lhv), Value::Integer(rhs)) => (lhv / rhs).into(),
+        let value = match &self {
+            Value::Integer(lhv) => (lhv / i64::try_from(&rhs).map_err(|_| err())?).into(),
+            Value::Float(lhv) => (*lhv as i64/ i64::try_from(&rhs).map_err(|_| err())?).into(),
             _ => return Err(err()),
         };
 

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -54,6 +54,8 @@
     .result_b = .a * (.b + .c) - .d
     .result_c = .a + .b * .c / .d
     .result_d = (.a + .b) * (.c / .d)
+    .result_e = .e / .c
+    .result_f = .e // .c
   """
 [[tests]]
   name = "remap_arithmetic"
@@ -65,6 +67,7 @@
       b = 7
       c = 12
       d = 6
+      e = 9
   [[tests.outputs]]
     extract_from = "remap_arithmetic"
     [[tests.outputs.conditions]]
@@ -72,6 +75,8 @@
       "result_b.equals" = 51
       "result_c.equals" = 17
       "result_d.equals" = 20
+      "result_e.equals" = 0.75
+      "result_f.equals" = 0
 
 [transforms.remap_boolean_arithmetic]
   inputs = []


### PR DESCRIPTION
Closes #3729 

Discussion in that issue stalled, so I have moved forward to try to satisfy all the issues raised there..

This PR makes two changes. 

 - Ordinary division is now always float division. Before, if the first parameter was an Integer it would be Integer division. So `9 / 12 == 0`. Now it will be `9 / 12 == 0.75`. It does mean that even if the result is a whole number it will be a float - `4 / 2 == 2.0` 

 - There is a new integer division operator - `//`. So `9 // 12 == 0`. Float parameters are cast to an integer.
 


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

