### PR TITLE
chore: Add `namespace` alias for `default_namespace`

### DIFF
--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -34,6 +34,7 @@ pub struct CloudWatchMetricsSvc {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CloudWatchMetricsSinkConfig {
+    #[serde(alias = "namespace")]
     pub default_namespace: String,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -40,6 +40,7 @@ struct DatadogState {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DatadogConfig {
+    #[serde(alias = "namespace")]
     pub default_namespace: Option<String>,
     // Deprecated name
     #[serde(alias = "host")]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -38,6 +38,7 @@ struct InfluxDBSvc {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct InfluxDBConfig {
+    #[serde(alias = "namespace")]
     pub default_namespace: Option<String>,
     pub endpoint: String,
     #[serde(flatten)]

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -41,6 +41,7 @@ enum BuildError {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusExporterConfig {
+    #[serde(alias = "namespace")]
     pub default_namespace: Option<String>,
     #[serde(default = "default_address")]
     pub address: SocketAddr,

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -30,6 +30,7 @@ pub struct StatsdSvc {
 // TODO: add back when serde-rs/serde#1358 is addressed
 // #[serde(deny_unknown_fields)]
 pub struct StatsdSinkConfig {
+    #[serde(alias = "namespace")]
     pub default_namespace: Option<String>,
     #[serde(flatten)]
     pub mode: Mode,


### PR DESCRIPTION
Adds `namespace` alias to `default_namespace` options that replaced `namespace` options in #4806. 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
