### PR TITLE
chore(ci): Correct the version notation for the nightly Helm charts

### DIFF
--- a/scripts/release-helm.sh
+++ b/scripts/release-helm.sh
@@ -16,7 +16,7 @@ VERSION="${VERSION:-"$(scripts/version.sh)"}"
 if [[ "$CHANNEL" == "nightly" ]]; then
   DATE="${DATE:-"$(date -u +%Y-%m-%d)"}"
   APP_VERSION="nightly-$DATE" # matches the version part of the image tag
-  CHART_VERSION="$VERSION-$DATE"
+  CHART_VERSION="nightly-$VERSION-$DATE"
 else
   APP_VERSION="$VERSION" # matches the version part of the image tag
   CHART_VERSION="$VERSION"

--- a/scripts/release-helm.sh
+++ b/scripts/release-helm.sh
@@ -16,7 +16,7 @@ VERSION="${VERSION:-"$(scripts/version.sh)"}"
 if [[ "$CHANNEL" == "nightly" ]]; then
   DATE="${DATE:-"$(date -u +%Y-%m-%d)"}"
   APP_VERSION="nightly-$DATE" # matches the version part of the image tag
-  CHART_VERSION="nightly-$VERSION-$DATE"
+  CHART_VERSION="$VERSION-nightly-$DATE"
 else
   APP_VERSION="$VERSION" # matches the version part of the image tag
   CHART_VERSION="$VERSION"


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/265507/101069714-6b407c00-35ab-11eb-95f1-fde0630352d4.png)
