### PR TITLE
fix(kubernetes platform): Add exclusion label at vector-aggregator

### DIFF
--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "libvector.selectorLabels" . | nindent 8 }}
+        vector.dev/exclude: "true"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -129,6 +129,7 @@ spec:
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
     spec:
       serviceAccountName: vector-aggregator
       securityContext:

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -328,6 +328,7 @@ spec:
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
     spec:
       serviceAccountName: vector-aggregator
       securityContext:


### PR DESCRIPTION
Fixes logging feedback loop between vector-aggregator and vector-agent.
Ref: https://github.com/timberio/vector/runs/1498792526