### PR TITLE
fix(setup): Default installer script to musl for now

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -128,10 +128,7 @@ install_from_archive() {
         x86_64-apple-darwin)
             _archive_arch=$_arch
             ;;
-        x86_64-*linux*-gnu)
-            _archive_arch="x86_64-unknown-linux-gnu"
-            ;;
-        x86_64-*linux*-musl)
+        x86_64-*linux*)
             _archive_arch="x86_64-unknown-linux-musl"
             ;;
         aarch64-*linux*)


### PR DESCRIPTION
The installer shell script is unaware of versions so for all unknown-linux-gnu OS types it defaults to the gnu archive, which doesn't work on older Linux'es like CentOS 7. This defaults the installer to musl for now.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
