### PR TITLE
fix(setup): Add support for detecting glibc version to installer script

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -208,7 +208,9 @@ add_to_path() {
 # ------------------------------------------------------------------------------
 
 get_gnu_musl_glibc() {
-  need_cmd head
+  need_cmd ldd
+  need_cmd bc
+  need_cmd awk
   # Detect both gnu and musl
   # Also detect glibc versions older than 2.18 and return musl for these
   local _ldd_version

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -213,6 +213,7 @@ get_gnu_musl_glibc() {
   need_cmd awk
   # Detect both gnu and musl
   # Also detect glibc versions older than 2.18 and return musl for these
+  # Required until we address https://github.com/timberio/vector/issues/5412.
   local _ldd_version
   local _glibc_version
   _ldd_version=$(ldd --version)
@@ -226,7 +227,7 @@ get_gnu_musl_glibc() {
 elif [[ $_ldd_version =~ "musl" ]]; then
   echo "musl"
 else
-  err "Unknown architecture from ldd"
+  err "Unknown architecture from ldd: ${_ldd_version}"
 fi
 }
 

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -215,11 +215,12 @@ get_gnu_musl_glibc() {
   local _glibc_version
   _ldd_version=$(ldd --version)
   if [[ $_ldd_version =~ "GNU" ]]; then
-    _glibc_version=$(echo "$ldd_version" | awk '/ldd/{print $NF}')
+    _glibc_version=$(echo "$_ldd_version" | awk '/ldd/{print $NF}')
     if [ 1 -eq "$(echo "${_glibc_version} < 2.18" | bc)" ]; then
       echo "musl"
     else
       echo "gnu"
+    fi
 elif [[ $_ldd_version =~ "musl" ]]; then
   echo "musl"
 else


### PR DESCRIPTION
Closes #5415 

Signed-off-by: James Turnbull <james@lovedthanlost.net>

This is going to need careful eyes over. Basically:

1. Replaced ldd -version check with a function (get_gnu_musl_glibc)
2. This command runs ldd --version
3. If GNU then extracts glibc version and compares (using bc because bash doesn't speak float) to 2.18. If earlier it returns 'musl' otherwise returns 'gnu'
4. If musl then returns 'musl'.
