### PR TITLE
fix(observability): Emit wrapped metrics for reused components

### DIFF
--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -8,6 +8,8 @@ impl InternalEvent for AddFieldsEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -8,6 +8,8 @@ impl InternalEvent for AddTagsEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -8,6 +8,8 @@ impl InternalEvent for ANSIStripperEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -18,6 +18,8 @@ impl InternalEvent for ApacheMetricsEventReceived {
         counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -12,6 +12,8 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/aws_ec2_metadata.rs
+++ b/src/internal_events/aws_ec2_metadata.rs
@@ -12,6 +12,8 @@ impl InternalEvent for AwsEc2MetadataEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -18,6 +18,8 @@ impl InternalEvent for AwsEcsMetricsReceived {
         counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -11,4 +11,6 @@ impl InternalEvent for AwsKinesisStreamsEventSent {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -16,6 +16,8 @@ impl InternalEvent for AwsSqsEventSent<'_> {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/blackhole.rs
+++ b/src/internal_events/blackhole.rs
@@ -11,4 +11,6 @@ impl InternalEvent for BlackholeEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -8,6 +8,8 @@ impl InternalEvent for CoercerEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/concat.rs
+++ b/src/internal_events/concat.rs
@@ -8,6 +8,8 @@ impl InternalEvent for ConcatEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -11,6 +11,8 @@ impl InternalEvent for ConsoleEventProcessed {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -8,6 +8,8 @@ impl InternalEvent for DedupeEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -22,6 +22,8 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -16,6 +16,8 @@ impl InternalEvent for ElasticSearchEventEncoded {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -47,6 +47,8 @@ mod source {
                 "file" => self.file.to_owned(),
             );
         }
+
+        fn emit_metrics_wrapped(&self) {}
     }
 
     #[derive(Debug)]

--- a/src/internal_events/generator.rs
+++ b/src/internal_events/generator.rs
@@ -12,4 +12,6 @@ impl InternalEvent for GeneratorEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/geoip.rs
+++ b/src/internal_events/geoip.rs
@@ -8,6 +8,8 @@ impl InternalEvent for GeoipEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -12,6 +12,8 @@ impl InternalEvent for GrokParserEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/host_metrics.rs
+++ b/src/internal_events/host_metrics.rs
@@ -14,4 +14,6 @@ impl InternalEvent for HostMetricsEventReceived {
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -20,6 +20,8 @@ impl InternalEvent for HTTPEventsReceived {
         counter!("processed_events_total", self.events_count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]
@@ -73,4 +75,6 @@ impl InternalEvent for HTTPEventEncoded {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -15,6 +15,8 @@ impl InternalEvent for JournaldEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -13,6 +13,8 @@ impl InternalEvent for JsonParserEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -15,6 +15,8 @@ impl InternalEvent for KafkaEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/key_value_parser.rs
+++ b/src/internal_events/key_value_parser.rs
@@ -11,6 +11,8 @@ impl InternalEvent for KeyValueEventProcessed {
             "component_type" => "key_value",
         );
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/key_value_parser.rs
+++ b/src/internal_events/key_value_parser.rs
@@ -6,10 +6,7 @@ pub(crate) struct KeyValueEventProcessed;
 
 impl InternalEvent for KeyValueEventProcessed {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1,
-            "component_kind" => "transform",
-            "component_type" => "key_value",
-        );
+        counter!("processed_events_total", 1);
     }
 
     fn emit_metrics_wrapped(&self) {}
@@ -33,8 +30,6 @@ impl InternalEvent for KeyValueParseFailed {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "component_kind" => "transform",
-            "component_type" => "key_value_parser",
             "error_type" => "failed_parse",
         );
     }
@@ -56,8 +51,6 @@ impl<'a> InternalEvent for KeyValueTargetExists<'a> {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "component_kind" => "transform",
-            "component_type" => "key_value_parser",
             "error_type" => "target_field_exists",
         );
     }
@@ -79,8 +72,6 @@ impl InternalEvent for KeyValueFieldDoesNotExist {
 
     fn emit_metrics(&self) {
         counter!("processing_errors_total", 1,
-            "component_kind" => "transform",
-            "component_type" => "key_value_parser",
             "error_type" => "failed_parse",
         );
     }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -20,6 +20,8 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -12,6 +12,8 @@ impl InternalEvent for LogToMetricEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 pub(crate) struct LogToMetricFieldNotFound<'a> {

--- a/src/internal_events/logfmt_parser.rs
+++ b/src/internal_events/logfmt_parser.rs
@@ -12,6 +12,8 @@ impl InternalEvent for LogfmtParserEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -8,6 +8,8 @@ impl InternalEvent for LuaEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -13,6 +13,8 @@ impl InternalEvent for MetricToLogEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -237,8 +237,10 @@ pub trait InternalEvent {
     fn emit_logs(&self) {}
     fn emit_metrics(&self) {}
 
+    /// Called instead of emit_metrics for wrapped emits.
+    ///
     /// Only necessary to implement for certain metrics, like topological ones,
-    /// for componenets that are used inside other componenets.
+    /// and for components that are used inside other components.
     /// Known such metrics:
     /// - `processed_events_total`
     /// - `processed_bytes_total'

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -16,6 +16,8 @@ impl InternalEvent for NatsEventSendSuccess {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -129,18 +129,12 @@ impl InternalEvent for PrometheusRemoteWriteSnapError {
 
 #[derive(Debug)]
 pub struct PrometheusRemoteWriteReceived {
-    pub byte_size: usize,
     pub count: usize,
 }
 
 impl InternalEvent for PrometheusRemoteWriteReceived {
     fn emit_logs(&self) {
         debug!(message = "Received remote_write events.", count = ?self.count);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
-        counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -22,6 +22,8 @@ impl InternalEvent for PrometheusEventReceived {
         counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/reduce.rs
+++ b/src/internal_events/reduce.rs
@@ -8,6 +8,8 @@ impl InternalEvent for ReduceEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -12,6 +12,8 @@ impl InternalEvent for RegexParserEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -8,6 +8,8 @@ impl InternalEvent for RemapEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/remove_fields.rs
+++ b/src/internal_events/remove_fields.rs
@@ -8,6 +8,8 @@ impl InternalEvent for RemoveFieldsEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/remove_tags.rs
+++ b/src/internal_events/remove_tags.rs
@@ -8,4 +8,6 @@ impl InternalEvent for RemoveTagsEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }

--- a/src/internal_events/rename_fields.rs
+++ b/src/internal_events/rename_fields.rs
@@ -8,6 +8,8 @@ impl InternalEvent for RenameFieldsEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/sampler.rs
+++ b/src/internal_events/sampler.rs
@@ -8,6 +8,8 @@ impl InternalEvent for SamplerEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -33,6 +33,8 @@ impl InternalEvent for SocketEventReceived {
         counter!("processed_events_total", 1, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]
@@ -51,6 +53,8 @@ impl InternalEvent for SocketEventsSent {
         counter!("processed_events_total", self.count, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -8,6 +8,8 @@ impl InternalEvent for SplitEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -15,6 +15,8 @@ impl InternalEvent for SplunkEventSent {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]
@@ -91,6 +93,8 @@ mod source {
         fn emit_metrics(&self) {
             counter!("processed_events_total", 1);
         }
+
+        fn emit_metrics_wrapped(&self) {}
     }
 
     #[derive(Debug)]

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -15,6 +15,8 @@ impl InternalEvent for StatsdEventReceived {
         counter!("processed_events_total", 1,);
         counter!("processed_bytes_total", self.byte_size as u64,);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -15,6 +15,8 @@ impl InternalEvent for StdinEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/swimlanes.rs
+++ b/src/internal_events/swimlanes.rs
@@ -8,6 +8,8 @@ impl InternalEvent for SwimlanesEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -15,6 +15,8 @@ impl InternalEvent for SyslogEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -11,6 +11,8 @@ impl InternalEvent for TagCardinalityLimitEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 pub(crate) struct TagCardinalityLimitRejectingEvent<'a> {

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -8,6 +8,8 @@ impl InternalEvent for TokenizerEventProcessed {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -3,18 +3,6 @@ use metrics::counter;
 use prost::DecodeError;
 
 #[derive(Debug)]
-pub struct VectorEventSent {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for VectorEventSent {
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
-    }
-}
-
-#[derive(Debug)]
 pub struct VectorEventReceived {
     pub byte_size: usize,
 }

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -16,6 +16,8 @@ impl InternalEvent for VectorEventReceived {
         counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
+
+    fn emit_metrics_wrapped(&self) {}
 }
 
 #[derive(Debug)]

--- a/src/internal_events/wasm/event_processing.rs
+++ b/src/internal_events/wasm/event_processing.rs
@@ -66,14 +66,21 @@ impl InternalEvent for EventProcessingProgress {
     }
 
     fn emit_metrics(&self) {
+        self.emit_metrics_wrapped();
+        match self.state {
+            State::Completed => counter!("processed_events_total", 1,
+                "component_role" => self.role.as_const_str(),
+            ),
+            _ => (),
+        }
+    }
+
+    fn emit_metrics_wrapped(&self) {
         counter!("wasm_event_processing_total", 1,
             "component_role" => self.role.as_const_str(),
             "state" => self.state.as_const_str(),
         );
         match self.state {
-            State::Completed => counter!("processed_events_total", 1,
-                "component_role" => self.role.as_const_str(),
-            ),
             State::Errored => counter!("processing_errors_total", 1,
                 "component_role" => self.role.as_const_str(),
             ),

--- a/src/internal_events/wrap.rs
+++ b/src/internal_events/wrap.rs
@@ -124,3 +124,23 @@ impl<S: Stream> Stream for StreamEmitWrapper<S> {
         wrap(|| self.0.poll())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unwrapped() {
+        assert!(!is_wrapped());
+    }
+
+    #[test]
+    fn wrapped() {
+        assert!(wrap(|| is_wrapped()));
+    }
+
+    #[test]
+    fn multi_wrap() {
+        assert!(wrap(|| is_wrapped() && wrap(|| is_wrapped())));
+    }
+}

--- a/src/internal_events/wrap.rs
+++ b/src/internal_events/wrap.rs
@@ -1,0 +1,126 @@
+use crate::{
+    transforms::{FunctionTransform, TaskTransform, Transform},
+    Event,
+};
+use futures01::{Poll, Stream};
+use std::cell::Cell;
+
+thread_local!(static WRAPPED: Cell<bool> = Cell::new(false));
+
+struct WrapToken<'a> {
+    cell: &'a Cell<bool>,
+    before: bool,
+}
+
+impl<'a> Drop for WrapToken<'a> {
+    fn drop(&mut self) {
+        self.cell.set(self.before);
+    }
+}
+
+/// Wraps function so that inside of it fn is_wrapped returns true.
+pub fn wrap<R>(f: impl FnOnce() -> R) -> R {
+    WRAPPED.with(|wrapped| {
+        let _token = WrapToken {
+            cell: wrapped,
+            before: wrapped.replace(true),
+        };
+        f()
+    })
+}
+
+/// True if called from inside one or more fn wrap.
+pub fn is_wrapped() -> bool {
+    WRAPPED.with(|wrapped| wrapped.get())
+}
+
+// ****** Convenient wrappers ********* //
+
+pub trait WrapEmit {
+    /// Changes componenet to emit wrapped internal metrics.
+    fn wrap_emit(self) -> Self;
+}
+
+impl WrapEmit for Transform {
+    fn wrap_emit(self) -> Self {
+        match self {
+            Self::Function(t) => Self::Function(t.wrap_emit()),
+            Self::Task(t) => Self::Task(t.wrap_emit()),
+        }
+    }
+}
+
+impl WrapEmit for Box<dyn FunctionTransform> {
+    fn wrap_emit(self) -> Self {
+        Box::new(FunctionTransformEmitWrapper::new(self))
+    }
+}
+
+impl WrapEmit for Box<dyn TaskTransform> {
+    fn wrap_emit(self) -> Self {
+        Box::new(TaskTransformEmitWrapper::new(self))
+    }
+}
+
+impl WrapEmit for Box<dyn Stream<Item = Event, Error = ()> + Send> {
+    fn wrap_emit(self) -> Self {
+        Box::new(StreamEmitWrapper::new(self))
+    }
+}
+
+pub struct FunctionTransformEmitWrapper<F: FunctionTransform + ?Sized>(Box<F>);
+
+impl<F: FunctionTransform + ?Sized> FunctionTransformEmitWrapper<F> {
+    pub fn new(function: Box<F>) -> Self {
+        Self(function)
+    }
+}
+
+impl<F: FunctionTransform + ?Sized> FunctionTransform for FunctionTransformEmitWrapper<F> {
+    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+        wrap(|| self.0.transform(output, event));
+    }
+}
+
+impl<F: FunctionTransform + ?Sized> Clone for FunctionTransformEmitWrapper<F> {
+    fn clone(&self) -> Self {
+        Self(dyn_clone::clone_box(&*self.0))
+    }
+}
+
+pub struct TaskTransformEmitWrapper<F: TaskTransform + ?Sized>(Box<F>);
+
+impl<F: TaskTransform + ?Sized> TaskTransformEmitWrapper<F> {
+    pub fn new(task: Box<F>) -> Self {
+        Self(task)
+    }
+}
+
+impl<F: TaskTransform + ?Sized> TaskTransform for TaskTransformEmitWrapper<F> {
+    fn transform(
+        self: Box<Self>,
+        task: Box<dyn Stream<Item = Event, Error = ()> + Send>,
+    ) -> Box<dyn Stream<Item = Event, Error = ()> + Send>
+    where
+        Self: 'static,
+    {
+        self.0.transform(task).wrap_emit()
+    }
+}
+
+pub struct StreamEmitWrapper<S: Stream>(S);
+
+impl<S: Stream> StreamEmitWrapper<S> {
+    pub fn new(stream: S) -> Self {
+        Self(stream)
+    }
+}
+
+impl<S: Stream> Stream for StreamEmitWrapper<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        wrap(|| self.0.poll())
+    }
+}

--- a/src/internal_events/wrap.rs
+++ b/src/internal_events/wrap.rs
@@ -136,11 +136,11 @@ mod tests {
 
     #[test]
     fn wrapped() {
-        assert!(wrap(|| is_wrapped()));
+        assert!(!is_wrapped() && wrap(is_wrapped) && !is_wrapped());
     }
 
     #[test]
     fn multi_wrap() {
-        assert!(wrap(|| is_wrapped() && wrap(|| is_wrapped())));
+        assert!(wrap(|| is_wrapped() && wrap(is_wrapped) && is_wrapped()));
     }
 }

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -1,6 +1,7 @@
 use super::{default_host_key, logs::HumioLogsConfig, Encoding};
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription, TransformConfig},
+    internal_events::wrap::WrapEmit,
     sinks::util::{
         encoding::EncodingConfigWithDefault, BatchConfig, Compression, TowerRequestConfig,
     },
@@ -69,7 +70,7 @@ impl GenerateConfig for HumioMetricsConfig {
 #[typetag::serde(name = "humio_metrics")]
 impl SinkConfig for HumioMetricsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let mut transform = self.transform.clone().build().await?;
+        let mut transform = self.transform.clone().build().await?.wrap_emit();
         let sink = HumioLogsConfig {
             token: self.token.clone(),
             endpoint: self.endpoint.clone(),

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -1,7 +1,6 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::proto,
-    internal_events::VectorEventSent,
     sinks::util::tcp::TcpSinkConfig,
     tcp::TcpKeepaliveConfig,
     tls::TlsConfig,
@@ -74,10 +73,6 @@ fn encode_event(event: Event) -> Option<Bytes> {
     let event = proto::EventWrapper::from(event);
     let event_len = event.encoded_len();
     let full_len = event_len + 4;
-
-    emit!(VectorEventSent {
-        byte_size: full_len
-    });
 
     let mut out = BytesMut::with_capacity(full_len);
     out.put_u32(event_len as u32);

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -7,7 +7,7 @@
 
 use crate::event::Event;
 use crate::internal_events::{
-    FileSourceInternalEventsEmitter, KubernetesLogsEventAnnotationFailed,
+    wrap::WrapEmit, FileSourceInternalEventsEmitter, KubernetesLogsEventAnnotationFailed,
     KubernetesLogsEventReceived,
 };
 use crate::kubernetes as k8s;
@@ -330,7 +330,7 @@ impl Source {
 
         let event_processing_loop = partial_events_merger.transform(
             Box::new(events.map(Ok).compat())
-        ).map_err(|_| unreachable!("These errors should only happen if our futures compat layer is wrong. If you meet this, please report it.")).compat().forward(out);
+        ).wrap_emit().map_err(|_| unreachable!("These errors should only happen if our futures compat layer is wrong. If you meet this, please report it.")).compat().forward(out);
 
         let mut lifecycle = Lifecycle::new();
         {

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -1,5 +1,6 @@
 use crate::{
     event::{self, Event, LogEvent, Value},
+    internal_events::wrap::WrapEmit,
     transforms::{
         regex_parser::{RegexParser, RegexParserConfig},
         FunctionTransform,
@@ -43,7 +44,7 @@ impl Cri {
 
             let parser = RegexParser::build(&rp_config)
                 .expect("regexp patterns are static, should never fail");
-            parser.into_function()
+            parser.wrap_emit().into_function()
         };
 
         Self { regex_parser }

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -115,10 +115,9 @@ impl HttpSource for RemoteWriteSource {
         _header_map: HeaderMap,
         _query_parameters: HashMap<String, String>,
     ) -> Result<Vec<Event>, ErrorMessage> {
-        let byte_size = body.len();
         let result = self.decode_body(body)?;
         let count = result.len();
-        emit!(PrometheusRemoteWriteReceived { byte_size, count });
+        emit!(PrometheusRemoteWriteReceived { count });
         Ok(result)
     }
 }


### PR DESCRIPTION
Closes #4454 

Replaces previous approach in #5174 which had a flaw. Most relevant comment https://github.com/timberio/vector/pull/5174#issuecomment-738353342. 

Approach of this PR is to wrap reused components with a layer that sets thread local flag on entry, and resets it on exit. Then during emitting we check for this flag and call either `emit_metrics` or `emit_metrics_wrapped` accordingly. With this to reuse a component it should be wrapped with `wrap_emit()`, implementing `trait WrapEmit` if needed.

Shared code can be dealt with in the same way, just a special care of what is running in and outside of wrapped code is needed.

### Tried alternatives
Instead of setting the flag and then checking for it, entering/exiting additional span was tried out but the performance cost was quite severe. @MOZGIII 

### Todo

- [x] Do a more thorough audit of where we are reusing components.

- [x] Should we implement `emit_metrics_wrapped` for all problematic metrics now, or delegate it to when a component gets reused? (EDIT: implemented now since they are just empty functions)

- [ ] Follow up on https://github.com/timberio/vector/pull/5424#discussion_r537414234


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
