### PR TITLE
enhancement(remap): allow multiple statements in boolean conditional

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -12,7 +12,8 @@ rule_string_inner = _{ SOI ~ string_inner ~ EOI }
 // Statements ------------------------------------------------------------------
 
 assignment   = { target ~ "=" ~ expression }
-if_statement = { "if" ~ boolean_expr ~ block ~ ("else if" ~ boolean_expr ~ block)* ~ ("else" ~ block)? }
+if_statement = { "if" ~ (boolean_expr | conditional_expr) ~ block ~ ("else if" ~ (boolean_expr | conditional_expr ) ~ block)* ~ ("else" ~ block)? }
+
 
 // Primary ---------------------------------------------------------------------
 
@@ -80,6 +81,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 
 // Other ----------------------------------------------------------------------
 
+conditional_expr = { "(" ~ NEWLINE* ~ (expression ~ (NEWLINE+ | ";"))* ~ boolean_expr ~ NEWLINE* ~ ")" }
 ident  = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 target = _{ variable | path }
 block  =  { "{" ~ NEWLINE* ~ (expression ~ (NEWLINE+ ~ expression)*) ~ NEWLINE* ~ "}" }

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -79,6 +79,7 @@ impl fmt::Display for Rule {
             call,
             char,
             comparison,
+            conditional_expr,
             EOI,
             equality,
             expression,

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -105,6 +105,19 @@ mod tests {
                 Ok(()), Ok(4.into()),
             ),
             (
+                r#"if ($foo = true; $foo) { $foo } else { false }"#,
+                Ok(()), Ok(true.into())
+            ),
+            (
+                r#"if ($foo = "sproink"
+                       $foo == "sproink") {
+                      $foo
+                   } else {
+                     false
+                   }"#,
+                Ok(()), Ok("sproink".into())
+            ),
+            (
                 r#"regex_printer(/escaped\/forward slash/)"#,
                 Ok(()), Ok("regex: escaped/forward slash".into()),
             ),


### PR DESCRIPTION
Closes #5382 

Implements [rfc 2020-10-29-3736-remap-chain-parsing](https://github.com/timberio/vector/blob/master/rfcs/2020-10-29-3736-remap-chain-parsing.md).

This allows if conditionals to contain multiple statements - the last statement of which has to be a boolean expression.  The expressions can be separated by a semicolon (`;`) or a newline.

This allows us to cleanly chain a number of parsing expressions like the following:

```
if ($match = matches(.message, /^Started (?P<method>[^\s]*) for (?P<remote_addr>[^\s]*)/)
    !is_empty($match)) {
  .method = $match.method
  .remote_addr = $match.remote_addr
  .source = "nginx"
} else if ($match = matches(.message, /^(?P<remote_addr>[^\s]*).*"(?P<method>[^\s]*).*"$/)
           !is_empty($match)) {
  .method = $match.method
  .remote_addr = $match.remote_addr
  .source = "haproxy"
} else {
  .source = "none"
}
```

(note: `matches` hasn't been implemented yet.)

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
