### PR TITLE
fix(elasticsearch sink): Add Accept-Encoding header when compression is enabled

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -214,6 +214,7 @@ impl HttpSink for ElasticSearchCommon {
 
             if let Some(ce) = self.compression.content_encoding() {
                 request.add_header("Content-Encoding", ce);
+                request.add_header("Accept-Encoding", ce);
             }
 
             if let Some(headers) = &self.config.headers {
@@ -241,6 +242,7 @@ impl HttpSink for ElasticSearchCommon {
 
             if let Some(ce) = self.compression.content_encoding() {
                 builder = builder.header("Content-Encoding", ce);
+                builder = builder.header("Accept-Encoding", ce);
             }
 
             if let Some(headers) = &self.config.headers {


### PR DESCRIPTION
So that responses from ES are compressed as well (traffic and costs are saved) we need to set the "Accept-Encoding" header as well.