### PR TITLE
enhancement: Set Accept-Encoding to identity for HTTP client

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -87,11 +87,7 @@ where
     ) -> BoxFuture<'static, Result<http::Response<Body>, HttpError>> {
         let _enter = self.span.enter();
 
-        if !request.headers().contains_key("User-Agent") {
-            request
-                .headers_mut()
-                .insert("User-Agent", self.user_agent.clone());
-        }
+        default_request_headers(&mut request, &self.user_agent);
 
         emit!(http_client::AboutToSendHTTPRequest { request: &request });
 
@@ -131,6 +127,22 @@ where
         .instrument(self.span.clone());
 
         Box::pin(fut)
+    }
+}
+
+fn default_request_headers<B>(request: &mut Request<B>, user_agent: &HeaderValue) {
+    if !request.headers().contains_key("User-Agent") {
+        request
+            .headers_mut()
+            .insert("User-Agent", user_agent.clone());
+    }
+
+    if !request.headers().contains_key("Accept-Encoding") {
+        // hardcoding until we support compressed responses:
+        // https://github.com/timberio/vector/issues/5440
+        request
+            .headers_mut()
+            .insert("Accept-Encoding", HeaderValue::from_static("identity"));
     }
 }
 
@@ -242,8 +254,38 @@ impl Auth {
 
 #[cfg(test)]
 mod tests {
-    use super::Auth;
+    use super::*;
     use http::HeaderMap;
+
+    #[test]
+    fn test_default_request_headers_defaults() {
+        let user_agent = HeaderValue::from_static("vector");
+        let mut request = Request::post("http://example.com").body(()).unwrap();
+        default_request_headers(&mut request, &user_agent);
+        assert_eq!(
+            request.headers().get("Accept-Encoding"),
+            Some(&HeaderValue::from_static("identity")),
+        );
+        assert_eq!(request.headers().get("User-Agent"), Some(&user_agent));
+    }
+
+    #[test]
+    fn test_default_request_headers_does_not_overwrite() {
+        let mut request = Request::post("http://example.com")
+            .header("Accept-Encoding", "gzip")
+            .header("User-Agent", "foo")
+            .body(())
+            .unwrap();
+        default_request_headers(&mut request, &HeaderValue::from_static("vector"));
+        assert_eq!(
+            request.headers().get("Accept-Encoding"),
+            Some(&HeaderValue::from_static("gzip")),
+        );
+        assert_eq!(
+            request.headers().get("User-Agent"),
+            Some(&HeaderValue::from_static("foo"))
+        );
+    }
 
     fn test_basic_auth(url: &str) -> (String, Option<String>) {
         let (url, auth) = Auth::get_and_strip_basic_auth(url);


### PR DESCRIPTION
Leaving `Accept-Encoding` out lets the server decide what encoding to
use (very similar to `Accept-Encoding: *`). Currently, we only support
uncompressed responses (ref:
https://github.com/timberio/vector/issues/5440) so this sets
`Accept-Encoding: identity` to indicate this.

Ref: https://tools.ietf.org/html/rfc7231#section-5.3.4

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
