### PR TITLE
chore(remap): improve test helpers

### DIFF
--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -158,7 +158,12 @@ expression_dispatch![
 
 impl<T: Into<Value>> From<T> for Expr {
     fn from(value: T) -> Self {
-        Literal::from(value.into()).into()
+        let value = value.into();
+
+        match value {
+            Value::Array(array) => Array::from(array).into(),
+            _ => Literal::from(value).into(),
+        }
     }
 }
 

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -54,6 +54,10 @@ impl Path {
     pub(crate) fn new(path: path::Path) -> Self {
         Self { path }
     }
+
+    pub fn boxed(self) -> Box<dyn Expression> {
+        Box::new(self)
+    }
 }
 
 impl Expression for Path {

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -14,4 +14,4 @@ pub use crate::function::{ArgumentList, Parameter};
 pub use crate::generate_param_list;
 
 // test helpers
-pub use crate::{bench_function, func_args, map, test_function, test_type_def};
+pub use crate::{array, bench_function, func_args, test_function, test_type_def};

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -68,15 +68,47 @@ macro_rules! test_function {
 }
 
 #[macro_export]
-macro_rules! map {
-    () => (
-        ::std::collections::BTreeMap::new()
-    );
-    ($($k:tt: $v:expr),+ $(,)?) => {
-        vec![$(($k.into(), $v.into())),+]
+macro_rules! array {
+    () => ({
+        let vec: Vec<$crate::Value> = ::std::vec::Vec::new();
+        $crate::expression::Array::from(vec)
+    });
+    ($($v:expr),+ $(,)?) => ({
+        let vec: Vec<$crate::Value> = vec![$($v.into()),+];
+        $crate::expression::Array::from(vec)
+    })
+}
+
+#[macro_export]
+macro_rules! value {
+    ([]) => ({
+        $crate::Value::Array(vec![])
+    });
+
+    ([$($v:tt),+ $(,)?]) => ({
+        let vec: Vec<$crate::Value> = vec![$($crate::value!($v)),+];
+        $crate::Value::Array(vec)
+    });
+
+    ({}) => ({
+        $crate::Value::Map(::std::collections::BTreeMap::default())
+    });
+
+    ({$($($k1:literal)? $($k2:ident)?: $v:tt),+ $(,)?}) => ({
+        let map = vec![$((String::from($($k1)? $(stringify!($k2))?), $crate::value!($v))),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<_, _>>()
-    };
+            .collect::<::std::collections::BTreeMap<_, $crate::Value>>();
+
+        $crate::Value::Map(map)
+    });
+
+    (null) => ({
+        $crate::Value::Null
+    });
+
+    ($k:expr) => ({
+        $crate::Value::from($k)
+    });
 }
 
 #[doc(hidden)]

--- a/lib/remap-lang/src/value/object.rs
+++ b/lib/remap-lang/src/value/object.rs
@@ -23,50 +23,42 @@ impl Object for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{map, Field::*, Segment::*};
+    use crate::{Field::*, Segment::*};
     use std::str::FromStr;
 
     #[test]
     fn object_get() {
         let cases = vec![
-            (true.into(), vec![], Ok(Some(true.into()))),
+            (value!(true), vec![], Ok(Some(value!(true)))),
             (
-                true.into(),
+                value!(true),
                 vec![Field(Regular("foo".to_string()))],
                 Ok(None),
             ),
-            (map![].into(), vec![], Ok(Some(map![].into()))),
+            (value!({}), vec![], Ok(Some(value!({})))),
+            (value!({foo: "bar"}), vec![], Ok(Some(value!({foo: "bar"})))),
             (
-                map!["foo": "bar"].into(),
-                vec![],
-                Ok(Some(map!["foo": "bar"].into())),
-            ),
-            (
-                map!["foo": "bar"].into(),
+                value!({foo: "bar"}),
                 vec![Field(Regular("foo".to_owned()))],
-                Ok(Some("bar".into())),
+                Ok(Some(value!("bar"))),
             ),
             (
-                map!["foo": "bar"].into(),
+                value!({foo: "bar"}),
                 vec![Field(Regular("bar".to_owned()))],
                 Ok(None),
             ),
+            (value!([1, 2, 3, 4, 5]), vec![Index(1)], Ok(Some(value!(2)))),
             (
-                vec![1, 2, 3, 4, 5].into(),
-                vec![Index(1)],
-                Ok(Some(2.into())),
-            ),
-            (
-                map!["foo": vec![map!["bar": true]]].into(),
+                value!({foo: [{bar: true}]}),
                 vec![
                     Field(Regular("foo".to_owned())),
                     Index(0),
                     Field(Regular("bar".to_owned())),
                 ],
-                Ok(Some(true.into())),
+                Ok(Some(value!(true))),
             ),
             (
-                map!["foo": map!["bar baz": map!["baz": 2]]].into(),
+                value!({foo: {"bar baz": {baz: 2}}}),
                 vec![
                     Field(Regular("foo".to_owned())),
                     Coalesce(vec![
@@ -75,7 +67,7 @@ mod tests {
                     ]),
                     Field(Regular("baz".to_owned())),
                 ],
-                Ok(Some(2.into())),
+                Ok(Some(value!(2))),
             ),
         ];
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -601,7 +601,8 @@ mod test {
 
     #[test]
     fn object_get() {
-        use remap::{map, Field::*, Object, Path, Segment::*};
+        use crate::map;
+        use remap::{Field::*, Object, Path, Segment::*};
 
         let cases = vec![
             (map![], vec![], Ok(Some(map![].into()))),
@@ -654,7 +655,8 @@ mod test {
 
     #[test]
     fn object_insert() {
-        use remap::{map, Field::*, Object, Path, Segment::*};
+        use crate::map;
+        use remap::{Field::*, Object, Path, Segment::*};
 
         let cases = vec![
             (
@@ -760,7 +762,8 @@ mod test {
 
     #[test]
     fn object_remove() {
-        use remap::{map, Field::*, Object, Path, Segment::*};
+        use crate::map;
+        use remap::{Field::*, Object, Path, Segment::*};
 
         let cases = vec![
             (
@@ -836,7 +839,8 @@ mod test {
 
     #[test]
     fn object_paths() {
-        use remap::{map, Object, Path};
+        use crate::map;
+        use remap::{Object, Path};
         use std::str::FromStr;
 
         let cases = vec![

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -84,6 +84,7 @@ impl Expression for ParseJsonFn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::map;
     use value::Kind;
 
     test_function![

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -189,6 +189,8 @@ mod tests {
 
     #[test]
     fn to_bool() {
+        use crate::map;
+
         let cases = vec![
             (
                 map![],

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -189,6 +189,8 @@ mod tests {
 
     #[test]
     fn to_float() {
+        use crate::map;
+
         let cases = vec![
             (
                 map![],

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -189,6 +189,8 @@ mod tests {
 
     #[test]
     fn to_int() {
+        use crate::map;
+
         let cases = vec![
             (
                 map![],

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -180,6 +180,8 @@ mod tests {
 
     #[test]
     fn to_string() {
+        use crate::map;
+
         let cases = vec![
             (
                 map![],

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -205,6 +205,8 @@ mod tests {
 
     #[test]
     fn to_timestamp() {
+        use crate::map;
+
         let cases = vec![
             (
                 map![],

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -539,13 +539,3 @@ macro_rules! map {
             .collect::<::std::collections::BTreeMap<_, _>>()
     };
 }
-
-#[macro_export]
-macro_rules! array {
-    () => (
-        ::std::vec::Vec::new().into()
-    );
-    ($($v:expr),+ $(,)?) => {
-        vec![$($v.into()),+]
-    }
-}


### PR DESCRIPTION
High-level changes:

* Allow function tests to fail individually (this was introduced in an earlier PR, but now applied to the `flatten` function tests as wel)
* Make it easier to work with commonly used remap types in tests (`Value`, `Array`, and soon `Map`)

Specific changes:

* add `value` macro to quickly create `remap::Value` types in tests
* change `array` macro to create an `expression::Array` (again often used in tests)
* remove `map` macro (will be reintroduced in #5279 to create `expression::Map`)
* add a few more `{Try}From` impls to go to/from different wrapper types
* update `flatten` function tests to use new set-up
