### PR TITLE
fix(vector sink): remove duplicated event

### DIFF
--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -3,18 +3,6 @@ use metrics::counter;
 use prost::DecodeError;
 
 #[derive(Debug)]
-pub struct VectorEventSent {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for VectorEventSent {
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
-    }
-}
-
-#[derive(Debug)]
 pub struct VectorEventReceived {
     pub byte_size: usize,
 }

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -1,7 +1,6 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::proto,
-    internal_events::VectorEventSent,
     sinks::util::tcp::TcpSinkConfig,
     tcp::TcpKeepaliveConfig,
     tls::TlsConfig,
@@ -74,10 +73,6 @@ fn encode_event(event: Event) -> Option<Bytes> {
     let event = proto::EventWrapper::from(event);
     let event_len = event.encoded_len();
     let full_len = event_len + 4;
-
-    emit!(VectorEventSent {
-        byte_size: full_len
-    });
 
     let mut out = BytesMut::with_capacity(full_len);
     out.put_u32(event_len as u32);


### PR DESCRIPTION
While checked internal events in sinks I noticed that we duplicate events/bytes for vector sink. Vector sink uses TcpSink from util which emit event internally:
https://github.com/timberio/vector/blob/ed31012bdf8fcf11b4862b49eaf28c55d306f02a/src/sinks/util/socket_bytes_sink.rs#L70-L74