### PR TITLE
fix(syslog source): priority now defaults to 13, so is never missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6301,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc84750f2634660415240f7ab6c67022b79d3eccdd9c8f6b969d95e5e409a2c5"
+checksum = "59105a46f64e6e0c60a07061ffd07ef42d137735b5d9796572fe969b21342772"
 dependencies = [
  "chrono",
  "nom 5.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ http = "0.2"
 typetag = "0.1"
 toml = "0.5.7"
 syslog = "5"
-syslog_loose = { version = "0.5.0" }
+syslog_loose = { version = "0.7.0" }
 derive_is_enum_variant = "0.1.1"
 leveldb = { version = "0.8", optional = true, default-features = false }
 db-key = "0.0.5"

--- a/lib/remap-functions/src/parse_syslog.rs
+++ b/lib/remap-functions/src/parse_syslog.rs
@@ -183,6 +183,18 @@ mod tests {
                     r#"<133>Jun 13 16:33:35 haproxy[73411]: Proxy sticky-servers started."#,
                 ))),
             ),
+            (
+                map![],
+                Ok(map![
+                        "message": "I am missing a pri.",
+                        "timestamp": DateTime::<Utc>::from(chrono::Local.ymd(Utc::now().year(), 6, 13).and_hms_milli(16, 33, 35, 0)),
+                        "appname": "haproxy",
+                        "procid": 73411
+                ]),
+                ParseSyslogFn::new(Box::new(Literal::from(
+                    r#"Jun 13 16:33:35 haproxy[73411]: I am missing a pri."#,
+                ))),
+            ),
         ];
 
         let mut state = state::Program::default();


### PR DESCRIPTION
Closes #5441 

Updates `syslog_loose` to v0.6.0 which handles missing priority fields. Now if that field is missing or invalid it defaults to 13 - `LOG_USER` and `SEV_NOTICE`. As a result, these fields are now always present in every message.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

