### PR TITLE
fix(external docs): Specify that the filter transform takes metric inputs

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -377,12 +377,12 @@ components: {
 	})
 
 	#MetricInput: {
-		counter:      bool
-		distribution: bool
-		gauge:        bool
-		histogram:    bool
-		summary:      bool
-		set:          bool
+		counter:      *false | bool
+		distribution: *false | bool
+		gauge:        *false | bool
+		histogram:    *false | bool
+		set:          *false | bool
+		summary:      *false | bool
 	}
 
 	#MetricOutput: [Name=string]: close({

--- a/docs/reference/components/transforms/filter.cue
+++ b/docs/reference/components/transforms/filter.cue
@@ -39,7 +39,7 @@ components: transforms: filter: {
 
 	input: {
 		logs:    true
-		metrics: null
+		metrics: true
 	}
 
 	examples: [

--- a/docs/reference/components/transforms/filter.cue
+++ b/docs/reference/components/transforms/filter.cue
@@ -38,8 +38,15 @@ components: transforms: filter: {
 	}
 
 	input: {
-		logs:    true
-		metrics: true
+		logs: true
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			set:          true
+			summary:      true
+		}
 	}
 
 	examples: [


### PR DESCRIPTION
Addresses #5495 by updating the filter transform docs to correctly indicate that metrics can be used as inputs.