### PR TITLE
fix(external docs): Fix timestamp info table syntax error

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -813,7 +813,7 @@ components: {
 					:------|:------------|:-------
 					`%F %T` | `YYYY-MM-DD HH:MM:SS` | `2020-12-01 02:37:54`
 					`%v %T` | `DD-Mmm-YYYY HH:MM:SS` | `01-Dec-2020 02:37:54`
-					`%FT%T` | [ISO 8601](\(urls.iso_8601))/[RFC 3339](\(urls.rfc_3339)) format without time zone | `2020-12-01T02:37:54`
+					`%FT%T` | [ISO 8601](\(urls.iso_8601))\\[RFC 3339](\(urls.rfc_3339)) format without time zone | `2020-12-01T02:37:54`
 					`%a, %d %b %Y %T` | [RFC 822](\(urls.rfc_822))/[2822](\(urls.rfc_2822)) without time zone | `Tue, 01 Dec 2020 02:37:54`
 					`%a %d %b %T %Y` | [`date`](\(urls.date)) command output without time zone | `Tue 01 Dec 02:37:54 2020`
 					`%a %b %e %T %Y` | [ctime](\(urls.ctime)) format | `Tue Dec  1 02:37:54 2020`


### PR DESCRIPTION
The table of timestamp options seen in docs like the [grok_parser](https://vector.dev/docs/reference/transforms/grok_parser) docs has a small syntax error involving a non-escaped slash.