### PR TITLE
fix(kubernetes platform): Implement improvements to the Pod recreation on Helm release upgrades

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if not .Values.externalConfigMap }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- end }}
+        {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
         {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
-        {{- include "libvector.valuesChecksumAnnotation" . | nindent 8 }}
-        {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
+        {{- include "libvector.rerollAnnotations" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         {{- if not .Values.externalConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
+        {{- include "libvector.valuesChecksumAnnotation" . | nindent 8 }}
         {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -32,6 +32,12 @@ serviceAccount:
   # template.
   name: ""
 
+# Add an annotation to the `Pod`s managed by `DaemonSet` with a random value,
+# generated at Helm Chart template evaluation time.
+# Enabling this will cause the `Pod`s to be recreated every time the value
+# changes - effectively restarting them on each update.
+podRollmeAnnotation: false
+
 # Annotations to add to the `Pod`s managed by `DaemonSet`.
 podAnnotations: {}
 

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -42,7 +42,7 @@ podRollmeAnnotation: false
 # the Helm release values (as in `values.yaml` content and `--set` flags).
 # Enabling this will cause the `Pod`s to be recreated every time values
 # change.
-podValuesChecksumAnnotation: true
+podValuesChecksumAnnotation: false
 
 # Annotations to add to the `Pod`s managed by `DaemonSet`.
 podAnnotations: {}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -38,6 +38,12 @@ serviceAccount:
 # changes - effectively restarting them on each update.
 podRollmeAnnotation: false
 
+# Add an annotation to the `Pod`s managed by `DaemonSet` with a checksum of
+# the Helm release values (as in `values.yaml` content and `--set` flags).
+# Enabling this will cause the `Pod`s to be recreated every time values
+# change.
+podValuesChecksumAnnotation: true
+
 # Annotations to add to the `Pod`s managed by `DaemonSet`.
 podAnnotations: {}
 

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if not .Values.externalConfigMap }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- end }}
+        {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
         {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
-        {{- include "libvector.valuesChecksumAnnotation" . | nindent 8 }}
-        {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
+        {{- include "libvector.rerollAnnotations" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -17,6 +17,7 @@ spec:
         {{- if not .Values.externalConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         {{- include "libvector.configTemplateChecksumAnnotation" . | nindent 8 }}
+        {{- include "libvector.valuesChecksumAnnotation" . | nindent 8 }}
         {{- include "libvector.rollmeAnnotation" . | nindent 8 }}
         {{- include "libvector.metricsPrometheusPodAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -44,7 +44,7 @@ podRollmeAnnotation: false
 # the Helm release values (as in `values.yaml` content and `--set` flags).
 # Enabling this will cause the `Pod`s to be recreated every time values
 # change.
-podValuesChecksumAnnotation: true
+podValuesChecksumAnnotation: false
 
 # Annotations to add to the `Pod`s managed by `StatefulSet`.
 podAnnotations: {}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -40,6 +40,12 @@ serviceAccount:
 # changes - effectively restarting them on each update.
 podRollmeAnnotation: false
 
+# Add an annotation to the `Pod`s managed by `StatefulSet` with a checksum of
+# the Helm release values (as in `values.yaml` content and `--set` flags).
+# Enabling this will cause the `Pod`s to be recreated every time values
+# change.
+podValuesChecksumAnnotation: true
+
 # Annotations to add to the `Pod`s managed by `StatefulSet`.
 podAnnotations: {}
 

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -34,6 +34,12 @@ serviceAccount:
   # template.
   name: ""
 
+# Add an annotation to the `Pod`s managed by `StatefulSet` with a random value,
+# generated at Helm Chart template evaluation time.
+# Enabling this will cause the `Pod`s to be recreated every time the value
+# changes - effectively restarting them on each update.
+podRollmeAnnotation: false
+
 # Annotations to add to the `Pod`s managed by `StatefulSet`.
 podAnnotations: {}
 

--- a/distribution/helm/vector-shared/templates/_labels.tpl
+++ b/distribution/helm/vector-shared/templates/_labels.tpl
@@ -1,6 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
-Common labels
+Common labels.
 */}}
 {{- define "libvector.labels" -}}
 helm.sh/chart: {{ include "libvector.chart" . }}
@@ -12,7 +13,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels.
 */}}
 {{- define "libvector.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "libvector.name" . }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Rollme annotation.
+*/}}
+{{- define "libvector.rollmeAnnotation" -}}
+{{- $global := default (dict) .Values.global }}
+{{- $global := default (dict) $global.vector }}
+{{- $enabled := default .Values.podRollmeAnnotation $global.podRollmeAnnotation }}
+{{- if $enabled }}
+rollme: {{ randAlphaNum 5 | quote }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -23,3 +23,18 @@ rollme: {{ randAlphaNum 5 | quote }}
 checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
+
+{{/*
+Values checksum annotation.
+*/}}
+{{- define "libvector.valuesChecksumAnnotation" -}}
+{{- $global := default (dict) .Values.global }}
+{{- $global := default (dict) $global.vector }}
+{{- $enabled := .Values.podValuesChecksumAnnotation }}
+{{- if hasKey $global "podValuesChecksumAnnotation" }}
+{{- $enabled = $global.podValuesChecksumAnnotation }}
+{{- end }}
+{{- if $enabled }}
+checksum/values: {{ toJson .Values | sha256sum }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -6,7 +6,10 @@ Rollme annotation.
 {{- define "libvector.rollmeAnnotation" -}}
 {{- $global := default (dict) .Values.global }}
 {{- $global := default (dict) $global.vector }}
-{{- $enabled := default .Values.podRollmeAnnotation $global.podRollmeAnnotation }}
+{{- $enabled := .Values.podRollmeAnnotation }}
+{{- if hasKey $global "podRollmeAnnotation" }}
+{{- $enabled = $global.podRollmeAnnotation }}
+{{- end }}
 {{- if $enabled }}
 rollme: {{ randAlphaNum 5 | quote }}
 {{- end }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -11,3 +11,12 @@ Rollme annotation.
 rollme: {{ randAlphaNum 5 | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+`ConfigMap` template checksum annotation.
+*/}}
+{{- define "libvector.configTemplateChecksumAnnotation" -}}
+{{- if not .Values.externalConfigMap }}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -38,3 +38,12 @@ Values checksum annotation.
 checksum/values: {{ toJson .Values | sha256sum }}
 {{- end }}
 {{- end }}
+
+{{/*
+All reroll annotations.
+*/}}
+{{- define "libvector.rerollAnnotations" -}}
+{{- include "libvector.configTemplateChecksumAnnotation" . }}
+{{- include "libvector.valuesChecksumAnnotation" . }}
+{{- include "libvector.rollmeAnnotation" . }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -20,7 +20,7 @@ rollme: {{ randAlphaNum 5 | quote }}
 */}}
 {{- define "libvector.configTemplateChecksumAnnotation" -}}
 {{- if not .Values.externalConfigMap }}
-checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
 

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -20,6 +20,11 @@
 #     # Sets common environment variables for use in all `Pod`s.
 #     commonEnvKV:
 #       LOG: info
+#     # Add an annotation with a random value generated at Helm Chart template
+#     # evaluation time to the managed `Pod`s.
+#     # Enabling this will cause the `Pod`s to be recreated every time the value
+#     # changes - effectively restarting them on each update.
+#     podRollmeAnnotation: true
 
 vector-agent:
   # See the possible settings at the `vector-agent` chart.

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -29,7 +29,7 @@
 #     in `values.yaml` content and `--set` flags).
 #     # Enabling this will cause the `Pod`s to be recreated every time values
 #     # change.
-#     podValuesChecksumAnnotation: false
+#     podValuesChecksumAnnotation: true
 
 vector-agent:
   # See the possible settings at the `vector-agent` chart.

--- a/distribution/helm/vector/values.yaml
+++ b/distribution/helm/vector/values.yaml
@@ -25,6 +25,11 @@
 #     # Enabling this will cause the `Pod`s to be recreated every time the value
 #     # changes - effectively restarting them on each update.
 #     podRollmeAnnotation: true
+#     # Add an annotation with a checksum of the Helm release values (as
+#     in `values.yaml` content and `--set` flags).
+#     # Enabling this will cause the `Pod`s to be recreated every time values
+#     # change.
+#     podValuesChecksumAnnotation: false
 
 vector-agent:
   # See the possible settings at the `vector-agent` chart.

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -115,9 +115,7 @@ spec:
       annotations:
         
         checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
-        
         checksum/values: 2ab4d24e8daa7b3554d5b79aa6ea15c22a9a9ebb9823ca0e36e15d1351d8f5c4
-        
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -116,6 +116,8 @@ spec:
         
         checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
         
+        checksum/values: 2ab4d24e8daa7b3554d5b79aa6ea15c22a9a9ebb9823ca0e36e15d1351d8f5c4
+        
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -113,6 +113,7 @@ spec:
   template:
     metadata:
       annotations:
+        
         checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
         
         

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -114,8 +114,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
-        checksum/values: 2ab4d24e8daa7b3554d5b79aa6ea15c22a9a9ebb9823ca0e36e15d1351d8f5c4
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -115,6 +115,7 @@ spec:
       annotations:
         checksum/config: 3dac4d3f040851abd23fb5bf6d48a5babbd001e35aaa5465fa23e45816918c14
         
+        
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -125,8 +125,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
-        checksum/values: 69057f1f1d3e3c802d1ea6f0b45113063483d2d50da3f3107864f03b5e577364
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -124,6 +124,7 @@ spec:
   template:
     metadata:
       annotations:
+        
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
         

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -126,9 +126,7 @@ spec:
       annotations:
         
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
-        
         checksum/values: 69057f1f1d3e3c802d1ea6f0b45113063483d2d50da3f3107864f03b5e577364
-        
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -127,6 +127,8 @@ spec:
         
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
+        checksum/values: 69057f1f1d3e3c802d1ea6f0b45113063483d2d50da3f3107864f03b5e577364
+        
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -126,6 +126,7 @@ spec:
       annotations:
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
+        
       labels:
         app.kubernetes.io/name: vector-aggregator
         app.kubernetes.io/instance: vector

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -214,6 +214,7 @@ spec:
   template:
     metadata:
       annotations:
+        
         checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
         
         
@@ -324,6 +325,7 @@ spec:
   template:
     metadata:
       annotations:
+        
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
         
         

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -216,9 +216,7 @@ spec:
       annotations:
         
         checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
-        
         checksum/values: d538f417944766d8932e9b3b8cbed3fa8bca27b630655f9e27af740caa39292e
-        
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -329,9 +327,7 @@ spec:
       annotations:
         
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
-        
         checksum/values: 3188c4cd66595f64f54889630b4d4a8671d021fe91b84f5c627a10466bc82a64
-        
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -217,6 +217,8 @@ spec:
         
         checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
         
+        checksum/values: d538f417944766d8932e9b3b8cbed3fa8bca27b630655f9e27af740caa39292e
+        
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -327,6 +329,8 @@ spec:
       annotations:
         
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
+        
+        checksum/values: 3188c4cd66595f64f54889630b4d4a8671d021fe91b84f5c627a10466bc82a64
         
         
       labels:

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -215,8 +215,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
-        checksum/values: d538f417944766d8932e9b3b8cbed3fa8bca27b630655f9e27af740caa39292e
+        checksum/config: fa3deb906e02ab211d86aa37249d2f7d73dce9e771d68ed0679c7a0cab9eb54c
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -326,8 +325,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
-        checksum/values: 3188c4cd66595f64f54889630b4d4a8671d021fe91b84f5c627a10466bc82a64
+        checksum/config: a67c40b917e758700bf0df9b0719a84da8ee3828ec3a5d651baf78dcb02fb68a
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -216,6 +216,7 @@ spec:
       annotations:
         checksum/config: 4f9264d4d898bb5c5b1070e48a32fc42a233596993e7b9622cc673bd42df9466
         
+        
       labels:
         app.kubernetes.io/name: vector-agent
         app.kubernetes.io/instance: vector
@@ -324,6 +325,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f21e03060de6e60eeda4b7d6cbc3121890b76a4b3618f30fded3a8a4eb226c24
+        
         
       labels:
         app.kubernetes.io/name: vector-aggregator


### PR DESCRIPTION
This PR adds two new parameters to the Helm charts: `podRollmeAnnotation` and `podValuesChecksumAnnotation`. See the diff to learn more about them.

It also restructures the internals of the Helm charts to share the annotation logic.

It also corrects the config checksum calculation logic by switching it to checksumming the evaluated config, rather than some odd behviour. The code we had there came from the official Helm docs, so was a bit surprising to find issues with it.

Closes #5524.