### PR TITLE
chore(ci): Fix conditions::remap::test::check_remap null check

### DIFF
--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -120,8 +120,8 @@ mod test {
             ),
             (
                 log_event![],
-                "",
-                Err("remap error: program error: expected to resolve to boolean value, but instead resolves to null value"),
+                "null",
+                Err("remap error: program error: expected to resolve to an error, or boolean value, but instead resolves to null value"),
                 Ok(()),
             ),
             (


### PR DESCRIPTION
Broken in master: https://github.com/timberio/vector/runs/1547837589#step:9:1063

It is a bit odd that the error message differs from the tests below it in that includes "to an error", but this fixes it at least.