### PR TITLE
enhancement(external docs): Add docs for redact function for TRL

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -39,6 +39,7 @@ remap: {
 				multiple:    bool | *false
 				default?:    bool | string | int
 				type: [#RemapParameterTypes, ...#RemapParameterTypes]
+				enum?: [_description=string]: string
 			}
 			#RemapExample: {
 				title: string

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -1,0 +1,61 @@
+package metadata
+
+remap: functions: redact: {
+	arguments: [
+		{
+			name:        "value"
+			description: "The value that you want to redact."
+			required:    true
+			type: ["string"]
+		},
+		{
+			name:        "filters"
+			description: "A list of filters to apply"
+			required:    false
+			type: ["array"]
+			enum: {
+				pattern: "Filter based on a supplied regular expression."
+			}
+		},
+		{
+			name:        "redactor"
+			description: "The redaction method to be applied, with multiple options available."
+			required:    false
+			type: ["string"]
+			enum: {
+				full: "Replace the entire content with `****`."
+			}
+		},
+		{
+			name: "patterns"
+			description: """
+				A list of patterns to apply. Patterns can be strings or regular expressions; if a
+				string is supplied, Vector searches for exact matches when redacting.
+				"""
+			required: false
+			type: ["array"]
+		},
+	]
+	return: ["string"]
+	category: "text"
+	description: """
+		Obscures sensitive data.
+		"""
+	examples: [
+		{
+			title: "Redact credit card number"
+			input: {
+				credit_card: "9876123454320123"
+				filters: ["pattern"]
+				redactor: "full"
+				patterns: ["[0-9]{16}"]
+			}
+			source: """
+				.credit_card = redact(.credit_card, filters = ["pattern"], redactor = "full", patterns = ["[0-9]{16}"])
+				"""
+			output: {
+				credit_card: "****"
+			}
+		},
+	]
+}

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -47,9 +47,6 @@ remap: functions: redact: {
 			title: "Redact credit card number"
 			input: {
 				credit_card: "9876123454320123"
-				filters: ["pattern"]
-				redactor: "full"
-				patterns: ["[0-9]{16}"]
 			}
 			source: """
 				.credit_card = redact(.credit_card, filters = ["pattern"], redactor = "full", patterns = ["[0-9]{16}"])

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -62,14 +62,14 @@ remap: functions: redact: {
 			input: {
 				email: "ana@booper.com"
 			}
-			source: """
+			source: #"""
 				$email_pattern = /^\S+@\S+$/
 
 				.email = redact(.email, filters = ["pattern"], redactor = "full", patterns = [$email_pattern])
-				"""
+				"""#
 			output: {
 				email: "****"
 			}
-		}
+		},
 	]
 }

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -49,11 +49,27 @@ remap: functions: redact: {
 				credit_card: "9876123454320123"
 			}
 			source: """
-				.credit_card = redact(.credit_card, filters = ["pattern"], redactor = "full", patterns = ["[0-9]{16}"])
+				$cc_pattern = /[0-9]{16}/
+
+				.credit_card = redact(.credit_card, filters = ["pattern"], redactor = "full", patterns = [$cc_pattern])
 				"""
 			output: {
 				credit_card: "****"
 			}
 		},
+		{
+			title: "Redact email address"
+			input: {
+				email: "ana@booper.com"
+			}
+			source: """
+				$email_pattern = /^\S+@\S+$/
+
+				.email = redact(.email, filters = ["pattern"], redactor = "full", patterns = [$email_pattern])
+				"""
+			output: {
+				email: "****"
+			}
+		}
 	]
 }

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -10,7 +10,7 @@ remap: functions: redact: {
 		},
 		{
 			name:        "filters"
-			description: "A list of filters to apply"
+			description: "A list of filters to apply to the input value."
 			required:    false
 			type: ["array"]
 			enum: {
@@ -30,7 +30,7 @@ remap: functions: redact: {
 			name: "patterns"
 			description: """
 				A list of patterns to apply. Patterns can be strings or regular expressions; if a
-				string is supplied, Vector searches for exact matches when redacting.
+				string is supplied, Vector searches for exact matches to redact.
 				"""
 			required: false
 			type: ["array"]
@@ -39,7 +39,8 @@ remap: functions: redact: {
 	return: ["string"]
 	category: "text"
 	description: """
-		Obscures sensitive data.
+		Obscures sensitive data, such as personal identification numbers or credit card numbers, in
+		Vector event data.
 		"""
 	examples: [
 		{


### PR DESCRIPTION
This PR adds CUE sources for the `redact` function in Remap. I am aware that this function will likely change in the near term but I think it'd be beneficial to have this initial doc in place.
