### PR TITLE
fix(docker_logs source): Update hyper to work around the docker EOF errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,8 +2672,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+source = "git+https://github.com/timberio/hyper?rev=4ec7442fb74634ea9d128ad58bb741fa1dabefc7#4ec7442fb74634ea9d128ad58bb741fa1dabefc7"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -570,3 +570,6 @@ required-features = ["remap-benches"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "0.3"
+
+[patch.crates-io]
+hyper = { version = "0.13", git = "https://github.com/timberio/hyper", rev = "4ec7442fb74634ea9d128ad58bb741fa1dabefc7" }


### PR DESCRIPTION
This PR fixes (or rather is supposed to be fixing) the issue with docker that was reported earlier today.

Once merged, we'd want to backport it to 0.11 and ship with 0.11.1.

This is a hotfix, a proper resolution will be to simply bump the hyper once they cut a release.