### PR TITLE
chore(graphql api): async-graphql 2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.1.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddded88c64c85d355f220fd9b886ef8ded92bb700d2efcac8704f20b3933edb"
+checksum = "2c961bdf28cec79b4254c642cf8e55071ec6b7101b3a189ce17a61b909d70951"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.1.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6eb845cc6756bc99d2785202e77a98a667945928caafd364b4bb8df3f683e5d"
+checksum = "87e8975da7722a0f338b3df87214299e5655bba607ce15eeb15d82daf2820333"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-warp"
-version = "2.1.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7e2cd40c7e64a20d0cbf14c896097502719e3740e3a3df1fe9cc12b1bc25bd"
+checksum = "01020b636d5d4be3d93755dd8d279fb4dd1da6565039f2689e8be1ed504889a4"
 dependencies = [
  "async-graphql",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,8 @@ goauth = { version = "0.8.1", optional = true }
 smpl_jwt = { version = "0.5.0", optional = true }
 
 # API
-async-graphql = { version = "2.1.6", optional = true }
-async-graphql-warp = { version = "2.1.6", optional = true }
+async-graphql = { version = "2.2.0", optional = true }
+async-graphql-warp = { version = "2.2.0", optional = true }
 itertools = { version = "0.9.0", optional = true }
 
 # API client


### PR DESCRIPTION
Bump to async-graphql 2.2.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
