### PR TITLE
chore(external docs): Fix field name examples in Remap docs

### DIFF
--- a/docs/reference/remap/del.cue
+++ b/docs/reference/remap/del.cue
@@ -24,7 +24,7 @@ remap: functions: del: {
 				"field3": 3
 			}
 			source: #"""
-				del(".field1", ".field3")
+				del(.field1, .field3)
 				"""#
 			output: {
 				"field2": 2

--- a/docs/reference/remap/only_fields.cue
+++ b/docs/reference/remap/only_fields.cue
@@ -24,7 +24,7 @@ remap: functions: only_fields: {
 				"field3": 3
 			}
 			source: #"""
-				only_fields(".field1", ".field3")
+				only_fields(.field1, .field3)
 				"""#
 			output: {
 				"field1": 1


### PR DESCRIPTION
Field names can be of the form `."foo"` but not `".foo"`.
