### PR TITLE
enhancement(remap): added remove_empty parameter to parse_grok

### DIFF
--- a/docs/reference/remap/parse_grok.cue
+++ b/docs/reference/remap/parse_grok.cue
@@ -14,6 +14,13 @@ remap: functions: parse_grok: {
 			required:    true
 			type: ["string"]
 		},
+		{
+			name:        "remove_empty"
+			description: "If set to true, any patterns that resolve to an empty value will be removed from the result."
+			required:    false
+			default:     true
+			type: ["boolean"]
+		},
 	]
 	return: ["map"]
 	category: "parse"

--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -22,6 +22,11 @@ impl Function for ParseGrok {
                 accepts: |v| matches!(v, Value::Bytes(_)),
                 required: true,
             },
+            Parameter {
+                keyword: "remove_empty",
+                accepts: |v| matches!(v, Value::Boolean(_)),
+                required: false,
+            },
         ]
     }
 
@@ -39,7 +44,13 @@ impl Function for ParseGrok {
         let mut grok = grok::Grok::with_patterns();
         let pattern = Arc::new(grok.compile(&patternstr, true).map_err(|e| e.to_string())?);
 
-        Ok(Box::new(ParseGrokFn { value, pattern }))
+        let remove_empty = arguments.optional("remove_empty").map(Expr::boxed);
+
+        Ok(Box::new(ParseGrokFn {
+            value,
+            pattern,
+            remove_empty,
+        }))
     }
 }
 
@@ -48,18 +59,27 @@ struct ParseGrokFn {
     value: Box<dyn Expression>,
     // Wrapping pattern in an Arc, as cloning the pattern could otherwise be expensive.
     pattern: Arc<grok::Pattern>,
+    remove_empty: Option<Box<dyn Expression>>,
 }
 
 impl ParseGrokFn {
     #[cfg(test)]
-    fn new(value: Box<dyn Expression>, pattern: String) -> Result<Self> {
+    fn new(
+        value: Box<dyn Expression>,
+        pattern: String,
+        remove_empty: Option<Box<dyn Expression>>,
+    ) -> Result<Self> {
         let mut grok = grok::Grok::with_patterns();
         let pattern = Arc::new(
             grok.compile(&pattern, true)
                 .map_err(|e| Error::from(e.to_string()))?,
         );
 
-        Ok(Self { value, pattern })
+        Ok(Self {
+            value,
+            pattern,
+            remove_empty,
+        })
     }
 }
 
@@ -67,13 +87,19 @@ impl Expression for ParseGrokFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let bytes = self.value.execute(state, object)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
+        let remove_empty = match &self.remove_empty {
+            Some(expr) => expr.execute(state, object)?.try_boolean()?,
+            None => false,
+        };
 
         match self.pattern.match_against(&value) {
             Some(matches) => {
                 let mut result = BTreeMap::new();
 
                 for (name, value) in matches.iter() {
-                    result.insert(name.to_string(), Value::from(value));
+                    if !remove_empty || !value.is_empty() {
+                        result.insert(name.to_string(), Value::from(value));
+                    }
                 }
 
                 Ok(Value::from(result))
@@ -102,7 +128,8 @@ mod test {
                 grok::Grok::with_patterns()
                     .compile("%{LOGLEVEL:level}", true)
                     .unwrap()
-            )
+            ),
+            remove_empty: Some(Literal::from(false).boxed()),
         },
         def: TypeDef {
             kind: value::Kind::Array,
@@ -149,6 +176,7 @@ mod test {
                     Box::new(Path::from("message")),
                     "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
                         .to_string(),
+                    None,
                 )
                 .unwrap(),
             ),
@@ -159,6 +187,7 @@ mod test {
                     Box::new(Path::from("message")),
                     "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
                         .to_string(),
+                    None,
                 )
                 .unwrap(),
             ),
@@ -173,6 +202,34 @@ mod test {
                     Box::new(Path::from("message")),
                     "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
                         .to_string(),
+                    None,
+                )
+                .unwrap(),
+            ),
+            (
+                map!["message": "2020-10-02T23:22:12.223222Z"],
+                Ok(Value::from(
+                    map!["timestamp": "2020-10-02T23:22:12.223222Z",
+                         "level": ""
+                    ],
+                )),
+                ParseGrokFn::new(
+                    Box::new(Path::from("message")),
+                    "(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})".to_string(),
+                    None,
+                )
+                .unwrap(),
+            ),
+            (
+                map!["message": "2020-10-02T23:22:12.223222Z"],
+                Ok(Value::from(
+                    map!["timestamp": "2020-10-02T23:22:12.223222Z",
+                    ],
+                )),
+                ParseGrokFn::new(
+                    Box::new(Path::from("message")),
+                    "(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})".to_string(),
+                    Some(Literal::from(true).boxed()),
                 )
                 .unwrap(),
             ),

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -908,7 +908,8 @@
   inputs = []
   type = "remap"
   source = """
-    .grokked = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
+    .grokked = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} (%{EMAILADDRESS:email}|%{LOGLEVEL:level}) %{GREEDYDATA:message}")
+    .grokked2 = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} (%{EMAILADDRESS:email}|%{LOGLEVEL:level}) %{GREEDYDATA:message}", remove_empty = true)
     """
 [[tests]]
   name = "remap_function_parse_grok"
@@ -923,6 +924,11 @@
     "grokked.timestamp.equals" = "2020-10-02T23:22:12.223222Z"
     "grokked.level.equals" = "info"
     "grokked.message.equals" = "Hello world"
+    "grokked.email.equals" = ""
+    "grokked2.timestamp.equals" = "2020-10-02T23:22:12.223222Z"
+    "grokked2.level.equals" = "info"
+    "grokked2.email.exists" = false
+    "grokked2.message.equals" = "Hello world"
 
 [transforms.remap_function_ip_subnet]
   inputs = []


### PR DESCRIPTION
Closes #4482 

Added a new `remove_empty` parameter to `parse_grok` - defaulting to false, that if set will remove any empty matches from the result.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>