### PR TITLE
chore(ci): `cargo clean` before using cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1160,7 +1160,7 @@ update-kubernetes-yaml: ## Regenerate the Kubernetes YAML config
 .PHONY: cargo-install-%
 cargo-install-%: override TOOL = $(@:cargo-install-%=%)
 cargo-install-%:
-	$(if $(findstring true,$(AUTOINSTALL)),cargo install ${TOOL} --quiet,)
+	$(if $(findstring true,$(AUTOINSTALL)),cargo install ${TOOL} --quiet; cargo clean,)
 
 .PHONY: ensure-has-wasm-toolchain ### Configures a wasm toolchain for test artifact building, if required
 ensure-has-wasm-toolchain: target/wasm32-wasi/.obtained


### PR DESCRIPTION
it is a known `cross` issue/limitation (but perhaps not well documented) that running `cargo build --target $T`-like commands and then `cross build --target $T`-like commands (where `$T` is the target triple of the host) can cause runtime errors like "GLIBC symbol not found".

This is because the first `cargo build` (which runs outside docker) may produce build script artifacts (binaries / ELFs) that depend on a recent glibc; invoking `cross build` after that makes Cargo reuses those build scripts and run them *inside* the docker container, which (intentionally) has an old glibc. The issue is avoid by invoking `cargo clean` before using `cross`.

in the CI of this repo, this is only a potential issue for the `cross-build-x86_64-unknown-linux-gnu` target because `cargo install` (which does `cargo build` with implicit target = `x86_64-unknown-linux-gnu`) is invoked before `cross build`. My Makefile-fu is a bit rusty so I'm running `cargo clean` on *all* the `cross-build-*` targets to avoid the issue.

the CI of this repo will run into this issue soon because cross has lowered its glibc version (when target = x86_64-linux) to support LTS distributions like centos 7 (see rust-embedded/cross#501; the PR has landed and the corresponding image has already been updated at the time of writing)

cc @jamtur01 @Hoverbear 

Signed-off-by: Jorge Aparicio <jorge.aparicio@ferrous-systems.com>

