### PR TITLE
chore(ci): Always pass benches workflow

### DIFF
--- a/scripts/check-criterion-output.sh
+++ b/scripts/check-criterion-output.sh
@@ -10,10 +10,12 @@ set -euo pipefail
 
 DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+# Always exit 0 until we resolve
+# https://github.com/timberio/vector/issues/5394
 (
   echo -e "name\ttime\ttime change\tthroughput\tthroughput change\tchange";
   awk --file "$DIR/parse-criterion-output.awk" |
     jq --slurp --raw-output '.[] | [.name, .time, .time_change, .throughput, .throughput_change, .change] | @tsv'
 ) |
   column -s $'\t' -t  |
-  awk -v rc=0 '/regressed/ { rc=1 } 1; END { if (rc == 1) { print "\nRegression detected. Note that any regressions should be verified."; exit rc }}'
+  (awk -v rc=0 '/regressed/ { rc=1 } 1; END { if (rc == 1) { print "\nRegression detected. Note that any regressions should be verified."; exit rc }}' || true)


### PR DESCRIPTION
Until we can reduce measurement noise as part of
https://github.com/timberio/vector/issues/5394 as, even if the workflow is marked to allow failures, it still marks the suite of checks as failing.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
