### PR TITLE
chore(tests): Enable test `sources::file::tests::remove_file` for Mac OS

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1467,9 +1467,6 @@ mod tests {
         );
     }
 
-    // TODO: Renable test for Mac after https://github.com/timberio/vector/issues/4196 has been resolved
-    // TODO: and check if the original issue has been resolved https://github.com/timberio/vector/issues/3780.
-    #[cfg(not(target_os = "macos"))]
     #[tokio::test]
     async fn remove_file() {
         let n = 5;


### PR DESCRIPTION
Closes #3780 

It seams #4196 happened less in recent weeks so we can verify if the test has been fixed for Mac OS.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
