### PR TITLE
chore(remap): update syslog_loose version in remap-functions

### DIFF
--- a/lib/remap-functions/Cargo.toml
+++ b/lib/remap-functions/Cargo.toml
@@ -24,7 +24,7 @@ sha-2 = { package = "sha2", version = "0.9", optional = true }
 sha-3 = { package = "sha3", version = "0.9", optional = true }
 shared = { path = "../shared", default-features = false, optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.5", optional = true }
+syslog_loose = { version = "0.7", optional = true }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }


### PR DESCRIPTION
The `syslog_loose` crate is now specified in two places. `vector/Cargo.toml` and `vector/lib/remap-functions/Cargo.toml`.

#5452 updated the version in `vector`, but not in `remap-functions`. This should bring them back into line and fix the failing test on master.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

