### PR TITLE
chore(ci): Restrict usage of benchmark runs

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -5,6 +5,18 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/benches.yml"
+      - ".cargo/**"
+      - "benches/**"
+      - "lib/**"
+      - "proto/**"
+      - "src/**"
+      - "tests/**"
+      - "build.rs"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
I noticed in PR #3740, which is a docs-only PR, that the benchmark suite was run. To me, the benchmarks should be run only when truly necessary. This PR adds a `paths` parameter in the benchmark Action definition so that the benchmarks are only run when the Vector sources are updated and excludes everything else, like the `README`, the docs, the `Makefile, the RFCs, etc. The selection of paths was a bit guesswork-y on my part, so please do provide feedback so we don't remove anything that needs to remain.