### PR TITLE
chore(ci): Upload criterion output data to S3

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           name: "criterion"
           path: "./target/criterion.zip"
+      - name: Upload criterion data to S3
+        run: scripts/upload-benchmarks-s3.sh
+      # note: should run last to flag regressions
       - run: cat target/criterion/out | scripts/check-criterion-output.sh
 
   master-failure:

--- a/scripts/upload-benchmarks-s3.sh
+++ b/scripts/upload-benchmarks-s3.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci-upload-benchmarks-s3.sh
+#
+# SUMMARY
+#
+#   This uploads raw criterion benchmark results to S3 for later analysis via
+#   Athena.
+#
+#   It should only be run in CI as we want to ensure that the benchmark
+#   environment is consistent.
+
+if !(${CI:-false}); then
+  echo "Aborted: this script is for use in CI, bencmark analysis depends on a consistent bench environment" >&2
+  exit 1
+fi
+
+escape() {
+  # /s mess up Athena partitioning
+  echo $1 | sed "s#/#_#"
+}
+
+S3_BUCKET=${S3_BUCKET:-test-artifacts.vector.dev}
+BENCHES_VERSION="1" # bump if S3 schema changes
+ENVIRONMENT_VERSION="1" # bump if bench environment changes
+VECTOR_THREADS=${VECTOR_THREADS:-$(nproc)}
+LIBC="gnu"
+
+git_branch=$(git branch --show-current)
+git_rev_count=$(git rev-list --count HEAD)
+git_sha=$(git rev-parse HEAD)
+machine=$(uname --machine)
+operating_system=$(uname --kernel-name)
+year=$(date +"%Y")
+month=$(date +"%m")
+day=$(date +"%d")
+timestamp=$(date +"%s")
+
+object_name="$(echo "s3://$S3_BUCKET/benches/\
+benches_version=${BENCHES_VERSION}/\
+environment_version=${ENVIRONMENT_VERSION}/\
+branch=${git_branch}/\
+machine=${machine}/\
+operating_system=${operating_system}/\
+libc=${LIBC}/\
+threads=${VECTOR_THREADS}/\
+year=${year}/\
+month=${month}/\
+day=${day}/\
+rev_count=${git_rev_count}/\
+sha=${git_sha}/\
+timestamp=${timestamp}/\
+raw.csv" | tr '[:upper:]' '[:lower:]'
+)"
+
+(
+  echo 'group,function,value,throughput_num,throughput_type,sample_measured_value,unit,iteration_count' ;
+  find target/criterion -type f -path '*/new/*' -name raw.csv -exec bash -c "cat '{}' | tail --lines +2" \;
+) | aws s3 cp - $object_name
+
+echo "wrote $object_name"


### PR DESCRIPTION
This will allow us to analyze it with Athena.

I originally included group, function, and value in the object path to
be used for partitioning the data in Athena, but ran into issues with
the maximum partition length of 256. Instead all benchmark data for
a given run is concatted together (which includes the group, function,
and value).

The partitioning scheme was chosen to allow for comparisons across:

* Time for a given configuration (OS, allocator, etc.) for a given
  benchmark
* Across configurations (e.g. comparing different allocators) for
  a given benchmark

Corresponding Terraform PR for the AWS Glue Database bits: https://github.com/timberio/resources/pull/10

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
