### PR TITLE
enhancement(remap transform): docs for remap transform metrics

### DIFF
--- a/docs/reference/components/transforms/remap.cue
+++ b/docs/reference/components/transforms/remap.cue
@@ -54,7 +54,7 @@ components: transforms: remap: {
 
 	input: {
 		logs:    true
-		metrics: null
+		metrics: true
 	}
 
 	examples: [

--- a/docs/reference/components/transforms/remap.cue
+++ b/docs/reference/components/transforms/remap.cue
@@ -53,8 +53,15 @@ components: transforms: remap: {
 	}
 
 	input: {
-		logs:    true
-		metrics: true
+		logs: true
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			set:          true
+			summary:      true
+		}
 	}
 
 	examples: [


### PR DESCRIPTION
Remap works with Metrics data now, but the docs need updating.

We need to document somewhere that Remap for metrics will only work with the following paths:

- `.name` - Read and Write
- `.namespace` - Read and Write
- `.timestamp` - Read and Write
- `.kind` - Read and Write - must be either "absolute" or "incremental"
- `.tags` - Read and Write - tags are specified by adding an extra segment, eg. `.tags.host`, `.tags.foo`
- `.type` - Read only - the type of the metric (will be "counter", "gauge", "set", "distribution", "aggregated histogram" or "aggregated summary")


I'm not sure of the right place in the docs to put this, any ideas?



Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

