### PR TITLE
fix(remap): Fix type definition for `includes()`

### DIFF
--- a/lib/remap-functions/src/includes.rs
+++ b/lib/remap-functions/src/includes.rs
@@ -52,16 +52,17 @@ impl Expression for IncludesFn {
 
         let value_type_def = self.value.type_def(state).fallible_unless(Kind::Array);
 
+        let value_fallible = value_type_def.is_fallible();
+
         let inner_kind = value_type_def
             .inner_type_def
-            .clone()
             .unwrap_or_default()
             .scalar_kind();
 
         let item_type_def = self.item.type_def(state).fallible_unless(inner_kind);
 
         TypeDef {
-            fallible: value_type_def.is_fallible() || item_type_def.is_fallible(),
+            fallible: value_fallible || item_type_def.is_fallible(),
             kind: Kind::Boolean,
             ..Default::default()
         }

--- a/lib/remap-functions/src/includes.rs
+++ b/lib/remap-functions/src/includes.rs
@@ -50,11 +50,21 @@ impl Expression for IncludesFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         use value::Kind;
 
-        self.value
-            .type_def(state)
-            .fallible_unless(Kind::Array)
-            .merge(self.item.type_def(state))
-            .with_constraint(Kind::Boolean)
+        let value_type_def = self.value.type_def(state).fallible_unless(Kind::Array);
+
+        let inner_kind = value_type_def
+            .inner_type_def
+            .clone()
+            .unwrap_or_default()
+            .scalar_kind();
+
+        let item_type_def = self.item.type_def(state).fallible_unless(inner_kind);
+
+        TypeDef {
+            fallible: value_type_def.is_fallible() || item_type_def.is_fallible(),
+            kind: Kind::Boolean,
+            ..Default::default()
+        }
     }
 }
 
@@ -76,6 +86,14 @@ mod tests {
             expr: |_| IncludesFn {
                 value: Literal::from("foo").boxed(), // Must be an array, hence fallible
                 item: Literal::from("foo").boxed(),
+            },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
+        }
+
+        value_item_mismatched_types_fallible {
+            expr: |_| IncludesFn {
+                value: Array::from(vec!["foo", "bar", "baz"]).boxed(),
+                item: Literal::from(1).boxed(), // Type doesn't match array, hence fallible
             },
             def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -171,6 +171,11 @@ impl TypeDef {
         self
     }
 
+    pub fn with_inner_type(mut self, inner_type: impl Into<Option<Box<Self>>>) -> Self {
+        self.inner_type_def = inner_type.into();
+        self
+    }
+
     pub fn merge(self, other: Self) -> Self {
         self | other
     }


### PR DESCRIPTION
Introduced by https://github.com/timberio/vector/pull/5541. It currently causes a failing test on master: https://github.com/timberio/vector/runs/1580208153#step:9:740 . The test was correct, but the implementation didn't satisfy it.

Previously it was merging the type definitions of an array and a scalar
resulting in the type def, though the kind was Boolean, still having an
inner_type_def defined as the inner_type_def of the array.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
