### PR TITLE
chore(deps): bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "68803225a7b13e47191bab76f2687382b60d259e8cf37f6e1893658b84bb9479"
 
 [[package]]
 name = "approx"
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "3abe07af102235a56ac9a6dd904aab1e05483e2e8afdfffec3598be55b1b7606"
 dependencies = [
  "hashbrown",
 ]
@@ -5087,7 +5087,7 @@ dependencies = [
  "remap-lang",
  "rust_decimal",
  "serde_json",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
  "sha2 0.9.2",
  "sha3",
  "shared",
@@ -5833,12 +5833,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -6016,9 +6016,9 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4e6046e4691afe918fd1b603fd6e515bcda5388a1092a9edbada307d159f09"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
  "futures 0.1.30",
@@ -6029,9 +6029,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -6657,9 +6657,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -6945,7 +6945,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
  "url",
  "utf-8",
 ]
@@ -7331,7 +7331,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
  "sha2 0.9.2",
  "sha3",
  "shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
+checksum = "3dc1679af9a1ab4bea16f228b05d18f8363f8327b1fa8db00d2760cfafc6b61e"
 dependencies = [
  "doc-comment",
  "predicates",
@@ -2842,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedd49de24d8c263613701406611410687148ae8c37cd6452650b250f753a0dd"
+checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
 dependencies = [
  "ctor",
  "ghost",
@@ -2853,9 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "inventory-impl"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddead8880bc50f57fcd3b5869a7f6ff92570bb4e8f6870c22e2483272f2256da"
+checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2973,11 +2973,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f95fd36c08ce592e67400a0f1a66f432196997d5a7e9a97e8743c33d8a9312"
+checksum = "dcaa8ea719de24e21fe6fddb2ea996ca4e312d467c119f827551c4768d97dc5c"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes 0.5.6",
  "chrono",
  "http",
@@ -5606,9 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "seahash"
-version = "3.0.7"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f57ca1d128a43733fd71d583e837b1f22239a37ebea09cde11d8d9a9080f47"
+checksum = "39ee459cae272d224928ca09a1df5406da984f263dc544f9f8bde92a8c3dc916"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abe07af102235a56ac9a6dd904aab1e05483e2e8afdfffec3598be55b1b7606"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ structopt = "0.3.21"
 indexmap = {version = "1.5.1", features = ["serde-1"]}
 http = "0.2"
 typetag = "0.1"
-toml = "0.5.7"
+toml = "0.5.8"
 syslog = "5"
 syslog_loose = { version = "0.7.0" }
 derive_is_enum_variant = "0.1.1"
@@ -163,7 +163,7 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 exitcode = "1.1.2"
-snafu = { version = "0.6", features = ["futures-01", "futures"] }
+snafu = { version = "0.6.10", features = ["futures-01", "futures"] }
 url = "2.2.0"
 percent-encoding = "2.1.0"
 base64 = { version = "0.13.0", optional = true }
@@ -179,7 +179,7 @@ logfmt = { version = "0.0.2", optional = true }
 notify = "4.0.14"
 once_cell = "1.3"
 getset = "0.1.1"
-lru = "0.6.1"
+lru = "0.6.2"
 bloom = "0.3.2"
 pulsar = { version = "1.0.0", default-features = false, features = ["tokio-runtime"], optional = true }
 cidr-utils = "0.5.0"
@@ -187,7 +187,7 @@ pin-project = "1.0.1"
 nats = { version = "0.8.6", optional = true }
 k8s-openapi = { version = "0.10.0", features = ["v1_16"], optional = true }
 portpicker = { version = "0.1.0", git = "https://github.com/timberio/portpicker-rs", rev = "d15829e906516720881584ff3301a0dd04218fbb" }
-sha-1 = "0.9"
+sha-1 = "0.9.2"
 sha2 = "0.9"
 sha3 = "0.9"
 md-5 = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ percent-encoding = "2.1.0"
 base64 = { version = "0.13.0", optional = true }
 bollard = { version = "0.9.0", features = ["ssl"], optional = true }
 listenfd = { version = "0.3.3", optional = true }
-inventory = "0.1"
+inventory = "0.1.10"
 maxminddb = { version = "0.15.0", optional = true }
 strip-ansi-escapes = { version = "0.1.0"}
 colored = "2.0"
@@ -179,7 +179,7 @@ logfmt = { version = "0.0.2", optional = true }
 notify = "4.0.14"
 once_cell = "1.3"
 getset = "0.1.1"
-lru = "0.6.2"
+lru = "0.6.3"
 bloom = "0.3.2"
 pulsar = { version = "1.0.0", default-features = false, features = ["tokio-runtime"], optional = true }
 cidr-utils = "0.5.0"
@@ -195,7 +195,7 @@ hex = "0.4.2"
 heim = { version = "0.1.0-rc.1", optional = true, features = ["full"] }
 rust_decimal = "1.8.1"
 mongodb = { version = "1.1.1", optional = true }
-anyhow = { version = "1.0.28" }
+anyhow = { version = "1.0.36" }
 snap = { version = "1.0.2", optional = true }
 dyn-clone = "1.0.3"
 indoc = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ db-key = "0.0.5"
 headers = "0.3"
 rdkafka = { version = "0.24.0", features = ["libz", "ssl", "zstd"], optional = true }
 hostname = "0.3.1"
-seahash = { version = "3.0.6", optional = true }
+seahash = { version = "4.0.1", optional = true }
 semver = { version = "0.11.0", features = ["serde"] }
 jemallocator = { version = "0.3.0", optional = true }
 lazy_static = "1.3.0"
@@ -185,7 +185,7 @@ pulsar = { version = "1.0.0", default-features = false, features = ["tokio-runti
 cidr-utils = "0.5.0"
 pin-project = "1.0.1"
 nats = { version = "0.8.6", optional = true }
-k8s-openapi = { version = "0.9", features = ["v1_16"], optional = true }
+k8s-openapi = { version = "0.10.0", features = ["v1_16"], optional = true }
 portpicker = { version = "0.1.0", git = "https://github.com/timberio/portpicker-rs", rev = "d15829e906516720881584ff3301a0dd04218fbb" }
 sha-1 = "0.9"
 sha2 = "0.9"
@@ -239,7 +239,7 @@ tokio01-test = "0.1.1"
 tower-test = "0.3.0"
 tokio-test = "0.2"
 tokio = { version = "0.2", features = ["test-util"] }
-assert_cmd = "1.0"
+assert_cmd = "1.0.2"
 reqwest = { version = "0.10.9", features = ["json"] }
 rusty-fork = "0.3.0"
 

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }
+k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_16"] }
 k8s-test-framework = { version = "0.1", path = "../k8s-test-framework" }
 regex = "1"
 reqwest = { version = "0.10", features = ["json"] }

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -7,7 +7,7 @@ description = "Kubernetes Test Framework used to test Vector in Kubernetes"
 publish = false
 
 [dependencies]
-k8s-openapi = { version = "0.9", default-features = false, features = ["v1_16"] }
+k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_16"] }
 serde_json = "1"
 tempfile = "3"
 once_cell = "1"


### PR DESCRIPTION
Instead of merging each PR from dependabot separately, I decided to try to join them in one:
- `anyhow: 1.0.32 => 1.0.36`
- `assert_cmd: 1.0.1 => 1.0.2` https://github.com/timberio/vector/pull/5618
- `inventory: 0.1.9 => 0.1.10` https://github.com/timberio/vector/pull/5621
- `k8s-openapi: 0.9.0 => 0.10.0` https://github.com/timberio/vector/pull/5622
- `seahash: 3.0.7 => 4.0.1` https://github.com/timberio/vector/pull/5620
- `sha-1: 0.9.1 => 0.9.2`
- `snafu: 0.6.9 => 0.6.10`
- `toml: 0.5.7 => 0.5.8`