### PR TITLE
enhancement(remap): added reverse_dns remap function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093d88961fd18c4ecacb8c80cd0b356463ba941ba11e0e01f9cf5271380b79dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5090,7 @@ dependencies = [
  "bytes 0.5.6",
  "chrono",
  "cidr-utils",
+ "dns-lookup",
  "grok",
  "hex",
  "lazy_static",

--- a/docs/reference/remap/reverse_dns.cue
+++ b/docs/reference/remap/reverse_dns.cue
@@ -1,0 +1,33 @@
+package metadata
+
+remap: functions: reverse_dns: {
+	arguments: [
+		{
+			name:        "ip"
+			description: "The ip address to look up."
+			required:    true
+			type: ["string"]
+		},
+	]
+	return: ["string"]
+	category: "networking"
+	description: #"""
+		Performs a reverse DNS lookup on the given IP address. Note this function has the potential to reduce
+		performance as it may have to perform a network call each time.
+		"""#
+	examples: [
+		{
+			title: "Google"
+			input: {
+				ip: "8.8.8.8"
+			}
+			source: #"""
+				.host = reverse_dns(ip = .ip)
+				"""#
+			output: {
+				ip: "8.8.8.8"
+				host: "dns.google"
+			}
+		},
+	]
+}

--- a/lib/remap-functions/Cargo.toml
+++ b/lib/remap-functions/Cargo.toml
@@ -11,6 +11,7 @@ remap = { package = "remap-lang", path = "../remap-lang" }
 bytes = { version = "0.5.6", optional = true }
 chrono = { version = "0.4", optional = true }
 cidr-utils = { version = "0.5", optional = true }
+dns-lookup = { version = "1.0.5", optional = true }
 grok = { version = "1", optional = true }
 hex = { version = "0.4", optional = true }
 lazy_static = { version = "1", optional = true }
@@ -69,6 +70,7 @@ default = [
     "parse_url",
     "redact",
     "replace",
+    "reverse_dns",
     "round",
     "sha1",
     "sha2",
@@ -123,6 +125,7 @@ parse_timestamp = ["shared/conversion"]
 parse_url = ["url"]
 redact = []
 replace = []
+reverse_dns = ["dns-lookup"]
 round = []
 sha1 = ["sha-1", "hex"]
 sha2 = ["sha-2", "hex"]

--- a/lib/remap-functions/src/lib.rs
+++ b/lib/remap-functions/src/lib.rs
@@ -68,6 +68,8 @@ mod parse_url;
 mod redact;
 #[cfg(feature = "replace")]
 mod replace;
+#[cfg(feature = "reverse_dns")]
+mod reverse_dns;
 #[cfg(feature = "round")]
 mod round;
 #[cfg(feature = "sha1")]
@@ -177,6 +179,8 @@ pub use r#match::Match;
 pub use redact::Redact;
 #[cfg(feature = "replace")]
 pub use replace::Replace;
+#[cfg(feature = "reverse_dns")]
+pub use reverse_dns::ReverseDns;
 #[cfg(feature = "round")]
 pub use round::Round;
 #[cfg(feature = "sha2")]
@@ -284,6 +288,8 @@ pub fn all() -> Vec<Box<dyn remap::Function>> {
         Box::new(Redact),
         #[cfg(feature = "replace")]
         Box::new(Replace),
+        #[cfg(feature = "reverse_dns")]
+        Box::new(ReverseDns),
         #[cfg(feature = "round")]
         Box::new(Round),
         #[cfg(feature = "sha2")]

--- a/lib/remap-functions/src/reverse_dns.rs
+++ b/lib/remap-functions/src/reverse_dns.rs
@@ -1,0 +1,82 @@
+use dns_lookup::lookup_addr;
+use std::net::IpAddr;
+
+use remap::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReverseDns;
+
+impl Function for ReverseDns {
+    fn identifier(&self) -> &'static str {
+        "reverse_dns"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "ip",
+            accepts: |v| matches!(v, Value::Bytes(_)),
+            required: true,
+        }]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+        let ip = arguments.required("ip")?.boxed();
+
+        Ok(Box::new(ReverseDnsFn { ip }))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReverseDnsFn {
+    ip: Box<dyn Expression>,
+}
+
+impl Expression for ReverseDnsFn {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let bytes = self.ip.execute(state, object)?.try_bytes()?;
+        let value = String::from_utf8_lossy(&bytes);
+        let ip: IpAddr = value
+            .parse()
+            .map_err(|err| format!("unable to parse IP address: {}", err))?;
+        let host =
+            lookup_addr(&ip).map_err(|err| format!("unable to perform a lookup : {}", err))?;
+
+        Ok(host.into())
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.ip
+            .type_def(state)
+            .fallible_unless(value::Kind::Bytes)
+            .with_constraint(value::Kind::Bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    remap::test_type_def![value_string {
+        expr: |_| ReverseDnsFn {
+            ip: Literal::from("192.168.0.1").boxed()
+        },
+        def: TypeDef {
+            kind: value::Kind::Bytes,
+            ..Default::default()
+        },
+    }];
+
+    test_function![
+        reverse_dns => ReverseDns;
+
+        invalid_ip {
+            args: func_args![ip: value!("999.999.999.999")],
+            want: Err("function call error: unable to parse IP address: invalid IP address syntax".to_string())
+        }
+
+        localhost {
+            args: func_args![ip: value!("127.0.0.1")],
+            want: Ok(value!("localhost"))
+        }
+    ];
+}

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1365,3 +1365,21 @@
       "namespace.equals" = "zork"
       "host.equals" = "ook"
       "type.equals" = "counter"
+
+[transforms.remap_function_reverse_dns]
+  inputs = []
+  type = "remap"
+  source = """
+    .host = reverse_dns(.ip)
+  """
+[[tests]]
+  name = "remap_function_reverse_dns"
+  [tests.input]
+    insert_at = "remap_function_reverse_dns"
+    type = "log"
+    [tests.input.log_fields]
+      ip = "127.0.0.1"
+  [[tests.outputs]]
+    extract_from = "remap_function_reverse_dns"
+    [[tests.outputs.conditions]]
+      "host.equals" = "localhost"


### PR DESCRIPTION
Closes #4517 

This adds the `reverse_dns` remap function. It returns a hostname when given an ip address.

It should be noted that this function could degrade performance fairly significantly as it has to perform a network request to do the lookup. I could add some caching to this function if needed, but that may have other repercussions and we would need to choose the caching strategy carefully. 

There may be ways to setup the local dns resolver to do this caching. It didn't seem to do this on my local machine, but can investigate further if necessary.



Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
