### PR TITLE
chore(pulsar sink): add metrics to failed encode

### DIFF
--- a/docs/reference/components/sinks/pulsar.cue
+++ b/docs/reference/components/sinks/pulsar.cue
@@ -112,4 +112,8 @@ components: sinks: pulsar: {
 		logs:    true
 		metrics: null
 	}
+
+	telemetry: metrics: {
+		encode_errors_total: components.sources.internal_metrics.output.metrics.encode_errors_total
+	}
 }

--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -159,7 +159,9 @@ components: sinks: splunk_hec: {
 	}
 
 	telemetry: metrics: {
-		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
-		http_requests_total:       components.sources.internal_metrics.output.metrics.http_requests_total
+		encode_errors_total:    components.sources.internal_metrics.output.metrics.encode_errors_total
+		missing_keys_total:     components.sources.internal_metrics.output.metrics.missing_keys_total
+		processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
 	}
 }

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -240,6 +240,12 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		encode_errors_total: {
+			description:       "The total number of errors encountered when encoding an event."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		events_discarded_total: {
 			description:       "The total number of events discarded by this component."
 			type:              "counter"
@@ -380,7 +386,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		missing_keys_total: {
-			description:       "The total number of events dropped due to keys missing from the event."
+			description:       "The total number of failed template renders due to missed keys from the event."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags

--- a/src/internal_events/pulsar.rs
+++ b/src/internal_events/pulsar.rs
@@ -8,7 +8,11 @@ pub struct PulsarEncodeEventFailed<'a> {
 
 impl<'a> InternalEvent for PulsarEncodeEventFailed<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Event encode failed.", error = %self.error);
+        error!(
+            message = "Event encode failed; dropping event.",
+            error = %self.error,
+            rate_limit_secs = 30,
+        );
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/pulsar.rs
+++ b/src/internal_events/pulsar.rs
@@ -1,4 +1,5 @@
 use super::InternalEvent;
+use metrics::counter;
 
 #[derive(Debug)]
 pub struct PulsarEncodeEventFailed<'a> {
@@ -7,6 +8,10 @@ pub struct PulsarEncodeEventFailed<'a> {
 
 impl<'a> InternalEvent for PulsarEncodeEventFailed<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Event encode failed.", error = ?self.error);
+        debug!(message = "Event encode failed.", error = %self.error);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("encode_errors_total", 1);
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -37,40 +37,23 @@ impl InternalEvent for SplunkEventEncodeError {
 }
 
 #[derive(Debug)]
-pub struct SplunkSourceTypeMissingKeys<'a> {
+pub struct SplunkMissingKeys<'a> {
+    pub field: &'static str,
     pub keys: &'a [String],
 }
 
-impl<'a> InternalEvent for SplunkSourceTypeMissingKeys<'a> {
+impl<'a> InternalEvent for SplunkMissingKeys<'a> {
     fn emit_logs(&self) {
         warn!(
-            message = "Failed to render template for sourcetype, leaving empty.",
+            message = "Failed to render template for {}, leaving empty.",
+            self.field,
             missing_keys = ?self.keys,
             rate_limit_secs = 30,
         )
     }
 
     fn emit_metrics(&self) {
-        counter!("sourcetype_missing_keys_total", 1);
-    }
-}
-
-#[derive(Debug)]
-pub struct SplunkSourceMissingKeys<'a> {
-    pub keys: &'a [String],
-}
-
-impl<'a> InternalEvent for SplunkSourceMissingKeys<'a> {
-    fn emit_logs(&self) {
-        warn!(
-            message = "Failed to render template for source, leaving empty.",
-            missing_keys = ?self.keys,
-            rate_limit_secs = 30,
-        )
-    }
-
-    fn emit_metrics(&self) {
-        counter!("source_missing_keys_total", 1);
+        counter!("missing_keys_total", 1);
     }
 }
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -2,10 +2,7 @@ use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::{Event, LogEvent, Value},
     http::HttpClient,
-    internal_events::{
-        SplunkEventEncodeError, SplunkEventSent, SplunkSourceMissingKeys,
-        SplunkSourceTypeMissingKeys,
-    },
+    internal_events::{SplunkEventEncodeError, SplunkEventSent, SplunkMissingKeys},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         http::{BatchedHttpSink, HttpSink},
@@ -147,7 +144,8 @@ impl HttpSink for HecSinkConfig {
             sourcetype
                 .render_string(&event)
                 .map_err(|missing_keys| {
-                    emit!(SplunkSourceTypeMissingKeys {
+                    emit!(SplunkMissingKeys {
+                        field: "sourcetype",
                         keys: &missing_keys
                     });
                 })
@@ -158,7 +156,8 @@ impl HttpSink for HecSinkConfig {
             source
                 .render_string(&event)
                 .map_err(|missing_keys| {
-                    emit!(SplunkSourceMissingKeys {
+                    emit!(SplunkMissingKeys {
+                        field: "source",
                         keys: &missing_keys
                     });
                 })
@@ -169,7 +168,8 @@ impl HttpSink for HecSinkConfig {
             index
                 .render_string(&event)
                 .map_err(|missing_keys| {
-                    emit!(SplunkSourceMissingKeys {
+                    emit!(SplunkMissingKeys {
+                        field: "index",
                         keys: &missing_keys
                     });
                 })
@@ -234,8 +234,8 @@ impl HttpSink for HecSinkConfig {
                 });
                 Some(value)
             }
-            Err(e) => {
-                emit!(SplunkEventEncodeError { error: e });
+            Err(error) => {
+                emit!(SplunkEventEncodeError { error });
                 None
             }
         }


### PR DESCRIPTION
When reviewed #5651 found that `pulsar` do not have metric `encode_errors_total`. Also updated `telemetry` in docs for `pulsar` / `splunk_hec`.