### PR TITLE
fix(remap): Remap should error on divide by zero

### DIFF
--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -78,6 +78,23 @@
       "result_e.equals" = 0.75
       "result_f.equals" = 0
 
+[transforms.remap_arithmetic_error]
+  inputs = []
+  type = "remap"
+  drop_on_err = true
+  source = """
+    .a / .b
+  """
+[[tests]]
+  name = "remap_arithmetic_error"
+  no_outputs_from = ["remap_arithmetic_error"]
+  [tests.input]
+    insert_at = "remap_arithmetic_error"
+    type = "log"
+    [tests.input.log_fields]
+      a = 10
+      b = 0
+
 [transforms.remap_boolean_arithmetic]
   inputs = []
   type = "remap"


### PR DESCRIPTION
Closes #5523 

This raises an error if you try to divide by zero in Remap.
 
Previously, if you do integer division, it would panic Vector. With float division it would not panic, but would return Infinity, which could contribute to strange results (see #5530).


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

