### PR TITLE
chore(ci): Removed musl scaffolding and harden Debian packaging

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb"
 
   build-x86_64-unknown-linux-gnu-packages:
     runs-on: ubuntu-latest
@@ -321,14 +313,6 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
           name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
           path: target/artifacts
       - uses: actions/download-artifact@v2
@@ -364,14 +348,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
@@ -433,32 +409,6 @@ jobs:
           release: "any-version"
           republish: "true"
           file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
-      - name: Push x86_64 musl RPM
-        id: push-rpm-x86_64-musl
-        uses: cloudsmith-io/action@master
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "rpm"
-          owner: "timber"
-          repo: "vector-nightly"
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm"
-      - name: Push amd64 musl deb
-        id: push-deb-amd64-musl
-        uses: cloudsmith-io/action@master
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "timber"
-          repo: "vector-nightly"
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb"
       - name: Push aarch64 RPM
         id: push-rpm-aarch64
         uses: cloudsmith-io/action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,6 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb"
 
   build-x86_64-unknown-linux-gnu-packages:
     runs-on: ubuntu-latest
@@ -322,14 +314,6 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
           name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
           path: target/artifacts
       - uses: actions/download-artifact@v2
@@ -400,14 +384,6 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
           name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
           path: target/artifacts
       - uses: actions/download-artifact@v2
@@ -469,14 +445,6 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb
-          path: target/artifacts
-      - uses: actions/download-artifact@v2
-        with:
           name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
           path: target/artifacts
       - uses: actions/download-artifact@v2
@@ -535,32 +503,6 @@ jobs:
           release: "any-version"
           republish: "true"
           file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
-      - name: Push x86_64 musl RPM
-        id: push-rpm-x86_64-musl
-        uses: cloudsmith-io/action@master
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "rpm"
-          owner: "timber"
-          repo: "vector"
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1-musl.x86_64.rpm"
-      - name: Push amd64 musl deb
-        id: push-deb-amd64-musl
-        uses: cloudsmith-io/action@master
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "timber"
-          repo: "vector"
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-musl-amd64.deb"
       - name: Push aarch64 RPM
         id: push-rpm-aarch64
         uses: cloudsmith-io/action@master

--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ package: build ## Build the Vector archive
 package-x86_64-unknown-linux-gnu-all: package-x86_64-unknown-linux-gnu package-deb-x86_64-unknown-linux-gnu package-rpm-x86_64-unknown-linux-gnu # Build all x86_64 GNU packages
 
 .PHONY: package-x86_64-unknown-linux-musl-all
-package-x86_64-unknown-linux-musl-all: package-x86_64-unknown-linux-musl package-rpm-x86_64-unknown-linux-musl package-deb-x86_64-unknown-linux-musl # Build all x86_64 MUSL packages
+package-x86_64-unknown-linux-musl-all: package-x86_64-unknown-linux-musl # Build all x86_64 MUSL packages
 
 .PHONY: package-aarch64-unknown-linux-musl-all
 package-aarch64-unknown-linux-musl-all: package-aarch64-unknown-linux-musl package-deb-aarch64 package-rpm-aarch64  # Build all aarch64 MUSL packages

--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -4,11 +4,11 @@ set -e
 # Add Vector to adm group to read /var/logs
 usermod --append --groups adm vector || true
 
-# Add Vector to systemd-journal to read journald logs
-usermod --append --groups systemd-journal vector || true
-
-# Reload the daemon to reflect new group membership
-if command -v systemctl >/dev/null 2>&1
+# If the systemd-journal group is present
+if getent group | grep 'systemd-journald'
 then
+  # Add Vector to systemd-journal to read journald logs
+  usermod --append --groups systemd-journal vector || true
+  # Reload the daemon to reflect new group membership
   systemctl daemon-reload
 fi

--- a/distribution/debian/scripts/preinst
+++ b/distribution/debian/scripts/preinst
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --no-create-home --quiet vector
+# Add vector:vector user & group
+useradd -M --system --user-group vector
 
+# Create default Vector data directory
 mkdir -p /var/lib/vector
+
+# Make vector:vector the owner of the Vector data directory
 chown -R vector:vector /var/lib/vector

--- a/docs/reference/installation/downloads.cue
+++ b/docs/reference/installation/downloads.cue
@@ -91,18 +91,6 @@ installation: downloads: {
 		type:                 "package"
 	}
 
-	"amd64-musl-deb": {
-		available_on_latest:  true
-		available_on_nightly: true
-		arch:                 "x86_64"
-		file_name:            "vector-{version}-musl-amd64.deb"
-		file_type:            "deb"
-		library:              "gnu"
-		os:                   "Linux"
-		package_manager:      installation.package_managers.dpkg.name
-		type:                 "package"
-	}
-
 	"arm64-deb": {
 		available_on_latest:  true
 		available_on_nightly: true
@@ -132,18 +120,6 @@ installation: downloads: {
 		available_on_nightly: true
 		arch:                 "x86_64"
 		file_name:            "vector-{version}-1.x86_64.rpm"
-		file_type:            "rpm"
-		library:              "gnu"
-		os:                   "Linux"
-		package_manager:      installation.package_managers.rpm.name
-		type:                 "package"
-	}
-
-	"x86_64-musl-rpm": {
-		available_on_latest:  true
-		available_on_nightly: true
-		arch:                 "x86_64"
-		file_name:            "vector-{version}-1.musl.x86_64.rpm"
 		file_type:            "rpm"
 		library:              "gnu"
 		os:                   "Linux"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -73,22 +73,12 @@ cat LICENSE NOTICE > "$PROJECT_ROOT/target/debian-license.txt"
 
 cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --no-build --no-strip
 
-# If the TARGET is musl populate the TYPE variable
-if [ "${TARGET}" = "x86_64-unknown-linux-musl" ]; then
-  TYPE="musl"
-else
-  TYPE=""
-fi
-
 # Rename the resulting .deb file to use - instead of _ since this
 # is consistent with our package naming scheme.
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
   nbase=${base//_/-}
-  if [ "${TYPE}" = 'musl' ]; then
-    nbase=${nbase//amd64.deb/musl-amd64.deb}
-  fi
-    mv "${file}" target/"${TARGET}"/debian/"${nbase}";
+  mv "${file}" target/"${TARGET}"/debian/"${nbase}";
 done
 
 #

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -73,18 +73,8 @@ rpmbuild \
   -ba distribution/rpm/vector.spec
 
 #
-# Set the type of RPM - gnu or musl
-#
-
-if [ "${TARGET}" = "x86_64-unknown-linux-musl" ]; then
-  TYPE="-musl"
-else
-  TYPE=""
-fi
-
-#
 # Move the RPM into the artifacts dir
 #
 
 ls "$RPMBUILD_DIR/RPMS/$ARCH"
-mv -v "$RPMBUILD_DIR/RPMS/$ARCH/vector-$CLEANED_VERSION-$RELEASE.$ARCH.rpm" "target/artifacts/vector-${CLEANED_VERSION}-${RELEASE}${TYPE}.${ARCH}.rpm"
+mv -v "$RPMBUILD_DIR/RPMS/$ARCH/vector-$CLEANED_VERSION-$RELEASE.$ARCH.rpm" "target/artifacts/vector-${CLEANED_VERSION}-${RELEASE}.${ARCH}.rpm"


### PR DESCRIPTION
This PR.

1. Removes the extra musl-scaffolding we put in place until Cross supported glibc builds earlier than 2.18.

2. Hardens up the Debian pre and post inst scripts to cater for some edge cases with earlier versions of Debian and Ubuntu. Also I hate systemd.