### PR TITLE
fix(config): update log for TaskTransform to be WARN

### DIFF
--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -126,7 +126,7 @@ fn walk(
                 transforms.insert(key, target);
             }
             Transform::Task(t) => {
-                error!("Using a recently refactored `TaskTransform` in a unit test. You may experience limited support for multiple inputs.");
+                warn!("Using a recently refactored `TaskTransform` in a unit test. You may experience limited support for multiple inputs.");
                 use futures::compat::Stream01CompatExt;
                 let in_stream = futures01::stream::iter_ok(inputs.clone());
                 let out_stream = t.transform(Box::new(in_stream)).compat();


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
Currently vector generates the following ERROR message, which seems inaccurate since it doesn't actually fail the test. A WARN message seems more appropriate given the context.
```
Dec 21 15:33:46.930 ERROR vector::config::unit_test: Using a recently refactored `TaskTransform` in a unit test. You may experience limited support for multiple inputs.
```
