### PR TITLE
enhancement(kubernetes platform): Allow passing component configs as YAML in Helm charts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@ scripts/* linguist-detectable=false
 Makefile linguist-detectable=false
 
 distribution/helm/*/charts/*.tgz filter=lfs diff=lfs merge=lfs -text
+
+tests/helm-snapshots/**/snapshot.yaml linguist-generated=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,9 @@ jobs:
       - name: Check helm lint
         if: needs.changes.outputs.helm == 'true'
         run: make check-helm-lint
+      - name: Check that Helm template snapshots don't diverge from Helm
+        if: needs.changes.outputs.helm == 'true'
+        run: make check-helm-snapshots
       - name: Check that generated Kubernetes YAMLs don't diverge from Helm
         if: needs.changes.outputs.helm == 'true'
         run: make check-kubernetes-yaml

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,8 @@ check-all: ## Check everything
 check-all: check-fmt check-clippy check-style check-markdown check-docs
 check-all: check-version check-examples check-component-features
 check-all: check-scripts
-check-all: check-helm-lint check-helm-dependencies check-kubernetes-yaml
+check-all: check-helm-lint check-helm-dependencies check-helm-snapshots
+check-all: check-kubernetes-yaml
 
 .PHONY: check-component-features
 check-component-features: ## Check that all component features are setup properly
@@ -595,6 +596,10 @@ check-helm-lint: ## Check that Helm charts pass helm lint
 .PHONY: check-helm-dependencies
 check-helm-dependencies: ## Check that Helm charts have up-to-date dependencies
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/helm-dependencies.sh validate
+
+.PHONY: check-helm-snapshots
+check-helm-snapshots: ## Check that the Helm template snapshots do not diverge from the Helm charts
+	${MAYBE_ENVIRONMENT_EXEC} ./scripts/helm-template-snapshot.sh check
 
 .PHONY: check-kubernetes-yaml
 check-kubernetes-yaml: ## Check that the generated Kubernetes YAML configs are up to date
@@ -786,6 +791,10 @@ git-hooks: ## Add Vector-local git hooks for commit sign-off
 .PHONY: update-helm-dependencies
 update-helm-dependencies: ## Recursively update the dependencies of the Helm charts in the proper order
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/helm-dependencies.sh update
+
+.PHONY: update-helm-snapshots
+update-helm-snapshots: ## Update the Helm template snapshots from the Helm charts
+	${MAYBE_ENVIRONMENT_EXEC} ./scripts/helm-template-snapshot.sh update
 
 .PHONY: update-kubernetes-yaml
 update-kubernetes-yaml: ## Regenerate the Kubernetes YAML configs

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -9,40 +9,28 @@ data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |
-    # Configuration for vector.
-    # Docs: https://vector.dev/docs/
+    {{- include "libvector.vectorConfigHeader" . | nindent 4 -}}
 
-    # Data dir is location controlled at the `DaemonSet`.
-    data_dir = "{{ .Values.globalOptions.dataDir }}"
-
-    {{- with .Values.logSchema }}
-    [log_schema]
-      host_key = "{{ .hostKey }}"
-      message_key = "{{ .messageKey }}"
-      source_type_key = "{{ .sourceTypeKey }}"
-      timestamp_key = "{{ .timestampKey }}"
-    {{- end }}
-
-    {{- if .Values.kubernetesLogsSource.enabled }}
+    {{- with .Values.kubernetesLogsSource }}
+    {{- if .enabled }}
     # Ingest logs from Kubernetes.
-    [sources.{{ .Values.kubernetesLogsSource.sourceId }}]
-      type = "kubernetes_logs"
-
-      {{- with .Values.kubernetesLogsSource.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "kubernetes_logs" -}}
+    {{- $_ := set $value "rawConfig" .rawConfig -}}
+    {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.vectorSink.enabled }}
+    {{- with .Values.vectorSink -}}
+    {{- if .enabled }}
     # Send logs to the aggregator.
-    [sinks.{{ .Values.vectorSink.sinkId }}]
-      type = "vector"
-      inputs = {{ required "You must specify the `inputs` for the built-in vector sink" .Values.vectorSink.inputs | toJson }}
-      address = "{{ include "vector-agent.vectorSinkAddress" . }}"
-
-      {{- with .Values.vectorSink.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "vector" -}}
+    {{- $_ := set $value "inputs" (required "You must specify the `inputs` for the built-in vector sink" .inputs) -}}
+    {{- $_ := set $value "address" (include "vector-agent.vectorSinkAddress" $) -}}
+    {{- $_ := set $value "rawConfig" .rawConfig -}}
+    {{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 4 -}}
+    {{- end }}
     {{- end }}
 
     {{- $prometheusInputs := (list) -}}
@@ -50,44 +38,15 @@ data:
     {{- if .enabled }}
     {{- $prometheusInputs = prepend $prometheusInputs .sourceId }}
     # Capture the metrics from the host.
-    [sources.{{ .sourceId }}]
-      type = "host_metrics"
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "host_metrics" -}}
+    {{- $_ := set $value "rawConfig" .rawConfig -}}
+    {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
+    {{- end -}}
+    {{- end -}}
 
-      {{- with .rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
-    {{- end }}
+    {{- merge . (dict "prometheusInputs" $prometheusInputs) | include "libvector.metricsConfigPartial" | nindent 4 -}}
 
-    {{- merge . (dict "prometheusInputs" $prometheusInputs) | include "libvector.metricsConfigPartial" | nindent 4  }}
-
-    {{- range $sourceId, $source := .Values.sources }}
-    [sources.{{ $sourceId }}]
-      type = "{{ $source.type }}"
-
-      {{- with $source.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
-
-    {{- range $transformId, $transform := .Values.transforms }}
-    [transforms.{{ $transformId }}]
-      type = "{{ $transform.type }}"
-      inputs = {{ $transform.inputs | toJson }}
-
-      {{- with $transform.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
-
-    {{- range $sinkId, $sink := .Values.sinks }}
-    [sinks.{{ $sinkId }}]
-      type = "{{ $sink.type }}"
-      inputs = {{ $sink.inputs | toJson }}
-
-      {{- with $sink.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
+    {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
 
 {{- end }}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -126,7 +126,10 @@ kubernetesLogsSource:
   enabled: true
   # The name to use for the "built-in" kubernetes logs source.
   sourceId: kubernetes_logs
-  # Raw TOML config to embed at the kubernetes logs source.
+  # Additional config to embed at the kubernetes logs source.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the kubernetes logs source (deprecated).
   rawConfig: null
 
 # The "built-in" vector sink, to send the logs to the vector aggregator.
@@ -143,7 +146,10 @@ vectorSink:
   host: null  # "vector.internal"
   # The port of the Vector to send the data to.
   port: null  # 9000
-  # Raw TOML config to embed at the vector sink.
+  # Additional config to embed at the vector sink.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the vector sink (deprecated).
   rawConfig: null
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
@@ -153,7 +159,10 @@ internalMetricsSource:
   enabled: true
   # The name to use for the "built-in" internal metrics source.
   sourceId: internal_metrics
-  # Raw TOML config to embed at the internal metrics source.
+  # Additional config to embed at the internal metrics source.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the internal metrics source (deprecated).
   rawConfig: null
 
 # The "built-in" host metrics source emitting the metrics gathered from the node
@@ -163,7 +172,10 @@ hostMetricsSource:
   enabled: true
   # The name to use for the "built-in" host metrics source.
   sourceId: host_metrics
-  # Raw TOML config to embed at the host metrics source.
+  # Additional config to embed at the host metrics source.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the host metrics source (deprecated).
   rawConfig: null
 
 # The "built-in" prometheus sink exposing metrics in the Prometheus scraping
@@ -189,7 +201,10 @@ prometheusSink:
   listenAddress: "0.0.0.0"
   # The port to listen at.
   listenPort: "9090"
-  # Raw TOML config to embed at the vector source.
+  # Additional config to embed at the prometheus sink.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the prometheus sink (deprecated).
   rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
   # To be used in clusters that rely on Pod annotations in the form of
@@ -212,6 +227,7 @@ prometheusSink:
 sources: {}
   # source_name:
   #   type: "source_type"
+  #   option: "value"
   #   rawConfig: |
   #     option = "value"
 
@@ -220,6 +236,7 @@ transforms: {}
   # transform_name:
   #   type: "transform_type"
   #   inputs: ["input1", "input2"]
+  #   option: "value"
   #   rawConfig: |
   #     option = "value"
 
@@ -228,5 +245,6 @@ sinks: {}
   # sink_name:
   #   type: "sink_type"
   #   inputs: ["input1", "input2"]
+  #   option: "value"
   #   rawConfig: |
   #     option = "value"

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -9,60 +9,21 @@ data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |
-    # Configuration for vector.
-    # Docs: https://vector.dev/docs/
+    {{- include "libvector.vectorConfigHeader" . | nindent 4 -}}
 
-    # Data dir is location controlled at the `StatefulSet`.
-    data_dir = "{{ .Values.globalOptions.dataDir }}"
-
-    {{- with .Values.logSchema }}
-    [log_schema]
-      host_key = "{{ .hostKey }}"
-      message_key = "{{ .messageKey }}"
-      source_type_key = "{{ .sourceTypeKey }}"
-      timestamp_key = "{{ .timestampKey }}"
-    {{- end }}
-
-    {{- if .Values.vectorSource.enabled }}
+    {{- with .Values.vectorSource }}
+    {{- if .enabled }}
     # Accept logs from Vector agents.
-    [sources.{{ .Values.vectorSource.sourceId }}]
-      type = "vector"
-      address = "{{ .Values.vectorSource.listenAddress }}:{{ .Values.vectorSource.listenPort }}"
-
-      {{- with .Values.vectorSource.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "vector" -}}
+    {{- $_ := set $value "address" (printf "%v:%v" .listenAddress .listenPort) -}}
+    {{- $_ := set $value "rawConfig" .rawConfig -}}
+    {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
+    {{- end }}
     {{- end }}
 
     {{- include "libvector.metricsConfigPartial" . | nindent 4  }}
 
-    {{- range $sourceId, $source := .Values.sources }}
-    [sources.{{ $sourceId }}]
-      type = "{{ $source.type }}"
-
-      {{- with $source.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
-
-    {{- range $transformId, $transform := .Values.transforms }}
-    [transforms.{{ $transformId }}]
-      type = "{{ $transform.type }}"
-      inputs = {{ $transform.inputs | toJson }}
-
-      {{- with $transform.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
-
-    {{- range $sinkId, $sink := .Values.sinks }}
-    [sinks.{{ $sinkId }}]
-      type = "{{ $sink.type }}"
-      inputs = {{ $sink.inputs | toJson }}
-
-      {{- with $sink.rawConfig }}
-      {{- . | nindent 6 }}
-      {{- end }}
-    {{- end }}
+    {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
 
 {{- end }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -186,7 +186,10 @@ vectorSource:
   listenAddress: "0.0.0.0"
   # The port to listen at.
   listenPort: "9000"
-  # Raw TOML config to embed at the vector source.
+  # Additional config to embed at the vector source.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the vector source (deprecated).
   rawConfig: null
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
@@ -196,7 +199,10 @@ internalMetricsSource:
   enabled: true
   # The name to use for the "built-in" internal metrics source.
   sourceId: internal_metrics
-  # Raw TOML config to embed at the internal metrics source.
+  # Additional config to embed at the internal metrics source.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the internal metrics source (deprecated).
   rawConfig: null
 
 # The "built-in" prometheus sink exposing metrics in the Prometheus scraping
@@ -222,7 +228,10 @@ prometheusSink:
   listenAddress: "0.0.0.0"
   # The port to listen at.
   listenPort: "9090"
-  # Raw TOML config to embed at the vector source.
+  # Additional config to embed at the prometheus sink.
+  config: {}
+    # option: "value"
+  # Raw TOML config to embed at the prometheus sink (deprecated).
   rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
   # To be used in clusters that rely on Pod annotations in the form of

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -5,40 +5,40 @@ Common Vector configuration partial containing built-in metrics pipeline.
 Internal metrics are common, so we share and reuse the definition.
 */}}
 {{- define "libvector.metricsConfigPartial" -}}
+
 {{- $values := .Values -}}
+
 {{- $prometheusInputs := .prometheusInputs -}}
 {{- with $values.internalMetricsSource }}
 {{- if .enabled }}
 # Emit internal Vector metrics.
-[sources.{{ .sourceId }}]
-  type = "internal_metrics"
-
-  {{- with .rawConfig }}
-  {{- . | nindent 6 }}
-  {{- end }}
+{{- $value := merge (dict) .config -}}
+{{- $_ := set $value "type" "internal_metrics" -}}
+{{- $_ := set $value "rawConfig" .rawConfig -}}
+{{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 0 -}}
 {{- end }}
 {{- end }}
 
 {{- with $values.prometheusSink }}
 {{- if .enabled }}
+
 {{- $inputs := .inputs }}
 {{- if $prometheusInputs -}}
-{{- $inputs = concat $inputs $prometheusInputs }}
+{{-   $inputs = concat $inputs $prometheusInputs }}
 {{- end }}
 {{- if and $values.internalMetricsSource.enabled (not .excludeInternalMetrics) -}}
-{{- $inputs = prepend $inputs $values.internalMetricsSource.sourceId }}
+{{-   $inputs = prepend $inputs $values.internalMetricsSource.sourceId }}
 {{- end }}
 # Expose metrics for scraping in the Prometheus format.
-[sinks.{{ .sinkId }}]
-  type = "prometheus"
-  inputs = {{ $inputs | toJson }}
-  address = "{{ .listenAddress }}:{{ .listenPort }}"
+{{- $value := merge (dict) .config -}}
+{{- $_ := set $value "type" "prometheus" -}}
+{{- $_ := set $value "inputs" $inputs -}}
+{{- $_ := set $value "address" (printf "%v:%v" .listenAddress .listenPort) -}}
+{{- $_ := set $value "rawConfig" .rawConfig -}}
+{{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 0 -}}
+{{- end }}
+{{- end }}
 
-  {{- with .rawConfig }}
-  {{- . | nindent 6 }}
-  {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -25,8 +25,14 @@ Serialize the passed Vector component configuration bits as TOML.
 {{- $toml -}}
 
 {{- with $rawConfig -}}
-{{- /* Ensure raw config section is put under the component-level section. */ -}}
+{{- /* Here is a poor attempt to ensure raw config section is put under the */ -}}
+{{- /* component-level section. What we're trying to do here is prohibited */ -}}
+{{- /* in the TOML spec, but it may work in the simple case - and this is */ -}}
+{{- /* what we have to support for the backward compatibility. */ -}}
+{{- if contains (printf "[%s.%s." $componentGroup $componentId) $toml -}}
 {{- $header| nindent 0 -}}
+{{- end -}}
+{{- /* Print the raw config. */ -}}
   {{- $rawConfig | nindent 2 -}}
 {{- end }}
 

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -1,0 +1,99 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Serialize the passed Vector component configuration bits as TOML.
+*/}}
+{{- define "libvector.vectorComponentConfig" -}}
+{{- $componentGroup := index . 0 -}}
+{{- $componentId := index . 1 -}}
+{{- $value := index . 2 -}}
+
+{{- $rawConfig := $value.rawConfig -}}
+{{- $value = unset $value "rawConfig" -}}
+
+{{- $header := printf "[%s.%s]" $componentGroup $componentId -}}
+
+{{- /* Build the right hierarchy and evaluate the TOML. */ -}}
+{{- $toml := toToml (dict $componentGroup (dict $componentId $value)) -}}
+{{- /* Cut the root-level key containing the component kind name (i.e. `[sink]`). */ -}}
+{{- $toml = $toml | trimPrefix (printf "[%s]\n" $componentGroup) -}}
+{{- /* Remove one level of indentation. */ -}}
+{{- $toml = regexReplaceAllLiteral "(?m)^  " $toml "" -}}
+{{- /* Cut tailing newline. */ -}}
+{{- $toml = $toml | trimSuffix "\n" -}}
+{{- /* Print the value. */ -}}
+{{- $toml -}}
+
+{{- with $rawConfig -}}
+{{- /* Ensure raw config section is put under the component-level section. */ -}}
+{{- $header| nindent 0 -}}
+  {{- $rawConfig | nindent 2 -}}
+{{- end }}
+
+{{- printf "\n" -}}
+{{- end }}
+
+{{/*
+Serialize the passed Vector source configuration bits as TOML.
+*/}}
+{{- define "libvector.vectorSourceConfig" -}}
+{{- $componentId := index . 0 -}}
+{{- $value := index . 1 -}}
+{{- tuple "sources" $componentId $value | include "libvector.vectorComponentConfig" -}}
+{{- end }}
+
+{{/*
+Serialize the passed Vector transform configuration bits as TOML.
+*/}}
+{{- define "libvector.vectorTransformConfig" -}}
+{{- $componentId := index . 0 -}}
+{{- $value := index . 1 -}}
+{{- tuple "transforms" $componentId $value | include "libvector.vectorComponentConfig" -}}
+{{- end }}
+
+{{/*
+Serialize the passed Vector sink configuration bits as TOML.
+*/}}
+{{- define "libvector.vectorSinkConfig" -}}
+{{- $componentId := index . 0 -}}
+{{- $value := index . 1 -}}
+{{- tuple "sinks" $componentId $value | include "libvector.vectorComponentConfig" -}}
+{{- end }}
+
+{{/*
+Serialize the passed Vector topology configuration bits as TOML.
+*/}}
+{{- define "libvector.vectorTopology" -}}
+{{- range $componentId, $value := .sources }}
+{{- tuple $componentId $value | include "libvector.vectorSourceConfig" | nindent 0 -}}
+{{- end }}
+
+{{- range $componentId, $value := .transforms }}
+{{- tuple $componentId $value | include "libvector.vectorTransformConfig" | nindent 0 -}}
+{{- end }}
+
+{{- range $componentId, $value := .sinks }}
+{{- tuple $componentId $value | include "libvector.vectorSinkConfig" | nindent 0 -}}
+{{- end }}
+{{- end }}
+
+{{/*
+The common header for Vector ConfigMaps.
+*/}}
+{{- define "libvector.vectorConfigHeader" -}}
+# Configuration for vector.
+# Docs: https://vector.dev/docs/
+
+# Data dir is location controlled at the `DaemonSet`.
+data_dir = "{{ .Values.globalOptions.dataDir }}"
+{{- printf "\n" -}}
+
+{{- with .Values.logSchema }}
+[log_schema]
+  host_key = "{{ .hostKey }}"
+  message_key = "{{ .messageKey }}"
+  source_type_key = "{{ .sourceTypeKey }}"
+  timestamp_key = "{{ .timestampKey }}"
+  {{- printf "\n" -}}
+{{- end }}
+{{- end }}

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -84,7 +84,6 @@ The common header for Vector ConfigMaps.
 # Configuration for vector.
 # Docs: https://vector.dev/docs/
 
-# Data dir is location controlled at the `DaemonSet`.
 data_dir = "{{ .Values.globalOptions.dataDir }}"
 {{- printf "\n" -}}
 

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -15,7 +15,7 @@ Serialize the passed Vector component configuration bits as TOML.
 
 {{- /* Build the right hierarchy and evaluate the TOML. */ -}}
 {{- $toml := toToml (dict $componentGroup (dict $componentId $value)) -}}
-{{- /* Cut the root-level key containing the component kind name (i.e. `[sink]`). */ -}}
+{{- /* Cut the root-level key containing the component kind name (i.e. `[sinks]`). */ -}}
 {{- $toml = $toml | trimPrefix (printf "[%s]\n" $componentGroup) -}}
 {{- /* Remove one level of indentation. */ -}}
 {{- $toml = regexReplaceAllLiteral "(?m)^  " $toml "" -}}

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -36,7 +36,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -35,29 +35,34 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-
+    
     # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
+    
     [log_schema]
       host_key = "host"
       message_key = "message"
       source_type_key = "source_type"
       timestamp_key = "timestamp"
+    
     # Ingest logs from Kubernetes.
     [sources.kubernetes_logs]
       type = "kubernetes_logs"
+    
     # Capture the metrics from the host.
     [sources.host_metrics]
       type = "host_metrics"
     
+    
     # Emit internal Vector metrics.
     [sources.internal_metrics]
       type = "internal_metrics"
+    
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
-      type = "prometheus"
-      inputs = ["internal_metrics","host_metrics"]
       address = "0.0.0.0:9090"
+      inputs = ["internal_metrics", "host_metrics"]
+      type = "prometheus"
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -36,7 +36,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -35,27 +35,31 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-
-    # Data dir is location controlled at the `StatefulSet`.
+    
+    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
+    
     [log_schema]
       host_key = "host"
       message_key = "message"
       source_type_key = "source_type"
       timestamp_key = "timestamp"
+    
     # Accept logs from Vector agents.
     [sources.vector]
-      type = "vector"
       address = "0.0.0.0:9000"
+      type = "vector"
+    
     
     # Emit internal Vector metrics.
     [sources.internal_metrics]
       type = "internal_metrics"
+    
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
-      type = "prometheus"
-      inputs = ["internal_metrics"]
       address = "0.0.0.0:9090"
+      inputs = ["internal_metrics"]
+      type = "prometheus"
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -47,34 +47,40 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-
+    
     # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
+    
     [log_schema]
       host_key = "host"
       message_key = "message"
       source_type_key = "source_type"
       timestamp_key = "timestamp"
+    
     # Ingest logs from Kubernetes.
     [sources.kubernetes_logs]
       type = "kubernetes_logs"
+    
     # Send logs to the aggregator.
     [sinks.vector_sink]
-      type = "vector"
-      inputs = ["kubernetes_logs"]
       address = "vector-aggregator:9000"
+      inputs = ["kubernetes_logs"]
+      type = "vector"
+    
     # Capture the metrics from the host.
     [sources.host_metrics]
       type = "host_metrics"
     
+    
     # Emit internal Vector metrics.
     [sources.internal_metrics]
       type = "internal_metrics"
+    
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
-      type = "prometheus"
-      inputs = ["internal_metrics","host_metrics"]
       address = "0.0.0.0:9090"
+      inputs = ["internal_metrics", "host_metrics"]
+      type = "prometheus"
 ---
 # Source: vector/charts/vector-aggregator/templates/configmap.yaml
 apiVersion: v1
@@ -93,27 +99,31 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-
-    # Data dir is location controlled at the `StatefulSet`.
+    
+    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
+    
     [log_schema]
       host_key = "host"
       message_key = "message"
       source_type_key = "source_type"
       timestamp_key = "timestamp"
+    
     # Accept logs from Vector agents.
     [sources.vector]
-      type = "vector"
       address = "0.0.0.0:9000"
+      type = "vector"
+    
     
     # Emit internal Vector metrics.
     [sources.internal_metrics]
       type = "internal_metrics"
+    
     # Expose metrics for scraping in the Prometheus format.
     [sinks.prometheus_sink]
-      type = "prometheus"
-      inputs = ["internal_metrics"]
       address = "0.0.0.0:9090"
+      inputs = ["internal_metrics"]
+      type = "prometheus"
 ---
 # Source: vector/charts/vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -48,7 +48,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]
@@ -100,7 +99,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -13,6 +13,15 @@ sinks:
   stdout:
     type: "console"
     inputs: ["kubernetes_logs"]
+    target: "stdout"
+    encoding: "json"
+"#;
+
+const HELM_VALUES_STDOUT_SINK_RAW_CONFIG: &str = r#"
+sinks:
+  stdout:
+    type: "console"
+    inputs: ["kubernetes_logs"]
     rawConfig: |
       target = "stdout"
       encoding = "json"
@@ -52,6 +61,90 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                ..Default::default()
+            },
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            "test-vector",
+            "daemonset/vector-agent",
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod(
+            "test-vector-test-pod",
+            "test-pod",
+            "echo MARKER",
+            vec![],
+            vec![],
+        ))?)
+        .await?;
+    framework
+        .wait(
+            "test-vector-test-pod",
+            vec!["pods/test-pod"],
+            WaitFor::Condition("initialized"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the rest of the log lines.
+    let mut got_marker = false;
+    look_for_log_line(&mut log_reader, |val| {
+        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+            // A log from something other than our test pod, pretend we don't
+            // see it.
+            return FlowControlCommand::GoOn;
+        }
+
+        // Ensure we got the marker.
+        assert_eq!(val["message"], "MARKER");
+
+        if got_marker {
+            // We've already seen one marker! This is not good, we only emitted
+            // one.
+            panic!("Marker seen more than once");
+        }
+
+        // If we did, remember it.
+        got_marker = true;
+
+        // Request to stop the flow.
+        FlowControlCommand::Terminate
+    })
+    .await?;
+
+    assert!(got_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(vector);
+    Ok(())
+}
+
+/// This test validates that vector-agent picks up logs at the simplest case
+/// possible - a new pod is deployed and prints to stdout, and we assert that
+/// vector picks that up - but with the legacy `rawConfig` way of passing the
+/// sink configuration.
+#[tokio::test]
+async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let framework = make_framework();
+
+    let vector = framework
+        .vector(
+            "test-vector",
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: HELM_VALUES_STDOUT_SINK_RAW_CONFIG,
                 ..Default::default()
             },
         )

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -7,18 +7,16 @@ const HELM_VALUES_DUMMY_TOPOLOGY: &str = r#"
 sources:
   dummy:
     type: "generator"
-    rawConfig: |
-      format = "shuffle"
-      lines = ["Hello world"]
-      interval = 60 # once a minute
+    format: "shuffle"
+    lines: ["Hello world"]
+    interval: 60 # once a minute
 
 sinks:
   stdout:
     type: "console"
     inputs: ["dummy"]
-    rawConfig: |
-      target = "stdout"
-      encoding = "json"
+    target: "stdout"
+    encoding: "json"
 "#;
 
 /// This test validates that vector-aggregator can deploy with the default

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -14,9 +14,8 @@ vector-aggregator:
     stdout:
       type: "console"
       inputs: ["vector"]
-      rawConfig: |
-        target = "stdout"
-        encoding = "json"
+      target: "stdout"
+      encoding: "json"
 "#;
 
 /// This test validates that vector picks up logs with an agent and

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -34,6 +34,7 @@ for FILE in $(git ls-files); do
     *sig) continue;;
     tests/data*) continue;;
     distribution/kubernetes/*/*.yaml) continue;;
+    tests/helm-snapshots/*/snapshot.yaml) continue;;
   esac
 
   # Skip all directories (usually theis only happens when we have symlinks).

--- a/scripts/helm-template-snapshot.sh
+++ b/scripts/helm-template-snapshot.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# helm-template-snapshot.sh
+#
+# SUMMARY
+#
+#   Manages the Helm template snapshots.
+#   See usage function in the code or run without arguments.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+CONFIGURATIONS_DIR="tests/helm-snapshots"
+
+generate() {
+  local RELEASE_NAME="$1"
+  local CHART="$2"
+  local VALUES_FILE="$3"
+
+  # Print header.
+  cat <<EOF
+# Do not edit!
+# This file is generated
+# - by "scripts/helm-snapshot-tests.sh"
+# - for the chart at "$CHART"
+# - with the values from "$VALUES_FILE"
+EOF
+
+  # Generate template.
+  # TODO: use app-version when https://github.com/helm/helm/issues/8670 is solved
+  helm template \
+    "$RELEASE_NAME" \
+    "$CHART" \
+    --namespace vector \
+    --create-namespace \
+    --values "$VALUES_FILE" \
+    --version master
+}
+
+update() {
+  for CONFIG_FILE in "$CONFIGURATIONS_DIR"/*/config.sh; do
+    VALUES_FILE="$(dirname "$CONFIG_FILE")/values.yaml"
+    TARGET_FILE="$(dirname "$CONFIG_FILE")/snapshot.yaml"
+    (
+      # shellcheck disable=SC1090
+      source "$CONFIG_FILE"
+      generate "$RELEASE_NAME" "$CHART" "$VALUES_FILE" >"$TARGET_FILE"
+    )
+  done
+}
+
+check() {
+  for CONFIG_FILE in "$CONFIGURATIONS_DIR"/*/config.sh; do
+    VALUES_FILE="$(dirname "$CONFIG_FILE")/values.yaml"
+    TARGET_FILE="$(dirname "$CONFIG_FILE")/snapshot.yaml"
+    (
+      # shellcheck disable=SC1090
+      source "$CONFIG_FILE"
+      GENERATED="$(generate "$RELEASE_NAME" "$CHART" "$VALUES_FILE")"
+      FILE="$(cat "$TARGET_FILE")"
+
+      if [[ "$GENERATED" != "$FILE" ]]; then
+        echo "Error: snapshot ($TARGET_FILE) does not match the generated version" >&2
+        exit 1
+      fi
+    )
+  done
+}
+
+usage() {
+  cat >&2 <<-EOF
+Usage: $0 MODE
+
+Modes:
+  check  - run the tests, compare the generated outputs with snapshots and
+           exit with non-zero exit code if the outputs do not match
+  update - run the tests and update the snapshots from the generated output
+EOF
+  exit 1
+}
+
+MODE="${1:-}"
+case "$MODE" in
+update | check)
+  "$MODE"
+  ;;
+*)
+  usage
+  ;;
+esac

--- a/scripts/helm-template-snapshot.sh
+++ b/scripts/helm-template-snapshot.sh
@@ -34,7 +34,8 @@ EOF
     --namespace vector \
     --create-namespace \
     --values "$VALUES_FILE" \
-    --version master
+    --version master \
+    --debug
 }
 
 list-config-files() {

--- a/tests/helm-snapshots/README.md
+++ b/tests/helm-snapshots/README.md
@@ -1,0 +1,5 @@
+# Snapshot Tests for Helm Charts
+
+This directory contains snapshot tests for Helm charts.
+
+Snapshot tests are yet another layer of QA that we apply to Helm charts.

--- a/tests/helm-snapshots/builtin_configs/vector-agent/config.sh
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+CHART="distribution/helm/vector-agent"
+RELEASE_NAME="vector"

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -1,0 +1,246 @@
+# Do not edit!
+# This file is generated
+# - by "scripts/helm-snapshot-tests.sh"
+# - for the chart at "distribution/helm/vector-agent"
+# - with the values from "tests/helm-snapshots/builtin_configs/vector-agent/values.yaml"
+---
+# Source: vector-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vector-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # We leave `vector.toml` file name available to let externally managed config
+  # maps to provide it.
+  managed.toml: |
+    # Configuration for vector.
+    # Docs: https://vector.dev/docs/
+    
+    # Data dir is location controlled at the `DaemonSet`.
+    data_dir = "/vector-data-dir"
+    
+    [log_schema]
+      host_key = "host"
+      message_key = "message"
+      source_type_key = "source_type"
+      timestamp_key = "timestamp"
+    
+    # Ingest logs from Kubernetes.
+    [sources.kubernetes_logs]
+      option1 = "value1"
+      option2 = "value2"
+      type = "kubernetes_logs"
+    [sources.kubernetes_logs]
+      arbitrary text 1
+    
+    # Send logs to the aggregator.
+    [sinks.vector_sink]
+      address = "vector.internal:9000"
+      inputs = ["my_input_1", "my_input_2"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "vector"
+    [sinks.vector_sink]
+      arbitrary text 1
+    
+    # Capture the metrics from the host.
+    [sources.host_metrics]
+      option1 = "value1"
+      option2 = "value2"
+      type = "host_metrics"
+    [sources.host_metrics]
+      arbitrary text 1
+    
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      option1 = "value1"
+      option2 = "value2"
+      type = "internal_metrics"
+    [sources.internal_metrics]
+      arbitrary text 1
+    
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      address = "0.0.0.0:9090"
+      inputs = ["internal_metrics", "host_metrics"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "prometheus"
+    [sinks.prometheus_sink]
+      arbitrary text 1
+---
+# Source: vector-agent/templates/rbac.yaml
+# Permissions to use Kubernetes API.
+# Requires that RBAC authorization is enabled.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - watch
+---
+# Source: vector-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector-agent
+subjects:
+  - kind: ServiceAccount
+    name: vector-agent
+    namespace: vector
+---
+# Source: vector-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-agent
+      app.kubernetes.io/instance: vector
+  minReadySeconds: 1
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
+        
+      labels:
+        app.kubernetes.io/name: vector-agent
+        app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
+    spec:
+      serviceAccountName: vector-agent
+      securityContext:
+        {}
+      containers:
+        - name: vector
+          securityContext:
+            {}
+          image: "timberio/vector:0.0.0-debian"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --config
+            - /etc/vector/*.toml
+          env:
+            - name: VECTOR_SELF_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: VECTOR_SELF_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VECTOR_SELF_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PROCFS_ROOT
+              value: /host/proc
+            - name: SYSFS_ROOT
+              value: /host/sys
+            
+          ports:
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          resources:
+            {}
+          volumeMounts:
+            # Host log directory mount.
+            - name: var-log
+              mountPath: /var/log/
+              readOnly: true
+            # Host mount for docker and containerd log file symlinks.
+            - name: var-lib
+              mountPath: /var/lib
+              readOnly: true
+            # Vector data dir mount.
+            - name: data-dir
+              mountPath: "/vector-data-dir"
+            # Vector config dir mount.
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            # Host procsfs mount.
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            # Host sysfs mount.
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+      terminationGracePeriodSeconds: 60
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      volumes:
+        # Log directory.
+        - name: var-log
+          hostPath:
+            path: /var/log/
+        # Docker and containerd log files in Kubernetes are symlinks to this folder.
+        - name: var-lib
+          hostPath:
+            path: /var/lib/
+        # Vector will store it's data here.
+        - name: data-dir
+          hostPath:
+            path: /var/lib/vector/
+        # Vector config dir.
+        - name: config-dir
+          projected:
+            sources:
+              - configMap:
+                  name: vector-agent
+        # Host procsfs.
+        - name: procfs
+          hostPath:
+            path: /proc
+        # Host sysfs.
+        - name: sysfs
+          hostPath:
+            path: /sys

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -34,7 +34,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -47,7 +47,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "kubernetes_logs"
-    [sources.kubernetes_logs]
       arbitrary text 1
     
     # Send logs to the aggregator.
@@ -57,7 +56,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "vector"
-    [sinks.vector_sink]
       arbitrary text 1
     
     # Capture the metrics from the host.
@@ -65,7 +63,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "host_metrics"
-    [sources.host_metrics]
       arbitrary text 1
     
     
@@ -74,7 +71,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "internal_metrics"
-    [sources.internal_metrics]
       arbitrary text 1
     
     # Expose metrics for scraping in the Prometheus format.
@@ -84,7 +80,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "prometheus"
-    [sinks.prometheus_sink]
       arbitrary text 1
 ---
 # Source: vector-agent/templates/rbac.yaml

--- a/tests/helm-snapshots/builtin_configs/vector-agent/values.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/values.yaml
@@ -1,0 +1,38 @@
+kubernetesLogsSource:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+vectorSink:
+  enabled: true
+  inputs: ["my_input_1", "my_input_2"]
+  host: "vector.internal"
+  port: 9000
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+internalMetricsSource:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+hostMetricsSource:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+prometheusSink:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/config.sh
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+CHART="distribution/helm/vector-aggregator"
+RELEASE_NAME="vector"

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -34,7 +34,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -1,0 +1,193 @@
+# Do not edit!
+# This file is generated
+# - by "scripts/helm-snapshot-tests.sh"
+# - for the chart at "distribution/helm/vector-aggregator"
+# - with the values from "tests/helm-snapshots/builtin_configs/vector-aggregator/values.yaml"
+---
+# Source: vector-aggregator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vector-aggregator/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # We leave `vector.toml` file name available to let externally managed config
+  # maps to provide it.
+  managed.toml: |
+    # Configuration for vector.
+    # Docs: https://vector.dev/docs/
+    
+    # Data dir is location controlled at the `DaemonSet`.
+    data_dir = "/vector-data-dir"
+    
+    [log_schema]
+      host_key = "host"
+      message_key = "message"
+      source_type_key = "source_type"
+      timestamp_key = "timestamp"
+    
+    # Accept logs from Vector agents.
+    [sources.vector]
+      address = "0.0.0.0:9000"
+      option1 = "value1"
+      option2 = "value2"
+      type = "vector"
+    [sources.vector]
+      arbitrary text 1
+    
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      option1 = "value1"
+      option2 = "value2"
+      type = "internal_metrics"
+    [sources.internal_metrics]
+      arbitrary text 1
+    
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      address = "0.0.0.0:9090"
+      inputs = ["internal_metrics"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "prometheus"
+    [sinks.prometheus_sink]
+      arbitrary text 1
+---
+# Source: vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: None
+  ports:
+    
+    - name: vector
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+---
+# Source: vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ports:
+    
+    - name: vector
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+---
+# Source: vector-aggregator/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: vector-aggregator-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-aggregator
+      app.kubernetes.io/instance: vector
+  podManagementPolicy: "Parallel"
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
+        
+      labels:
+        app.kubernetes.io/name: vector-aggregator
+        app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
+    spec:
+      serviceAccountName: vector-aggregator
+      securityContext:
+        {}
+      containers:
+        - name: vector
+          securityContext:
+            {}
+          image: "timberio/vector:0.0.0-debian"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --config
+            - /etc/vector/*.toml
+          env:
+            
+          ports:
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          resources:
+            {}
+          volumeMounts:
+            # Vector data dir mount.
+            - name: data-dir
+              mountPath: "/vector-data-dir"
+            # Vector config dir mount.
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            # Extra volumes.
+      terminationGracePeriodSeconds: 60
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      volumes:
+        # Vector will store it's data here.
+        - name: data-dir
+          emptyDir: {}
+        # Vector config dir.
+        - name: config-dir
+          projected:
+            sources:
+              - configMap:
+                  name: vector-aggregator
+                  optional: true
+  volumeClaimTemplates:

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -48,7 +48,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "vector"
-    [sources.vector]
       arbitrary text 1
     
     
@@ -57,7 +56,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "internal_metrics"
-    [sources.internal_metrics]
       arbitrary text 1
     
     # Expose metrics for scraping in the Prometheus format.
@@ -67,7 +65,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "prometheus"
-    [sinks.prometheus_sink]
       arbitrary text 1
 ---
 # Source: vector-aggregator/templates/service-headless.yaml

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/values.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/values.yaml
@@ -1,0 +1,20 @@
+vectorSource:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+internalMetricsSource:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1
+
+prometheusSink:
+  config:
+    option1: value1
+    option2: value2
+  rawConfig: |-
+    arbitrary text 1

--- a/tests/helm-snapshots/topology_config/vector-agent/config.sh
+++ b/tests/helm-snapshots/topology_config/vector-agent/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+CHART="distribution/helm/vector-agent"
+RELEASE_NAME="vector"

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -34,7 +34,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -66,7 +66,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [sources.source1]
       option = "value"
       arbitrary text
     
@@ -86,7 +85,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [transforms.transform1]
       option = "value"
       arbitrary text
     
@@ -108,7 +106,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [sinks.sink1]
       option = "value"
       arbitrary text
     

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -1,0 +1,284 @@
+# Do not edit!
+# This file is generated
+# - by "scripts/helm-snapshot-tests.sh"
+# - for the chart at "distribution/helm/vector-agent"
+# - with the values from "tests/helm-snapshots/topology_config/vector-agent/values.yaml"
+---
+# Source: vector-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vector-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # We leave `vector.toml` file name available to let externally managed config
+  # maps to provide it.
+  managed.toml: |
+    # Configuration for vector.
+    # Docs: https://vector.dev/docs/
+    
+    # Data dir is location controlled at the `DaemonSet`.
+    data_dir = "/vector-data-dir"
+    
+    [log_schema]
+      host_key = "host"
+      message_key = "message"
+      source_type_key = "source_type"
+      timestamp_key = "timestamp"
+    
+    # Ingest logs from Kubernetes.
+    [sources.kubernetes_logs]
+      type = "kubernetes_logs"
+    
+    # Capture the metrics from the host.
+    [sources.host_metrics]
+      type = "host_metrics"
+    
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      address = "0.0.0.0:9090"
+      inputs = ["internal_metrics", "host_metrics"]
+      type = "prometheus"
+    
+    
+    [sources.source1]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [sources.source1]
+      option = "value"
+      arbitrary text
+    
+    [sources.source2]
+      optionA = "valueA"
+      type = "type2"
+      [sources.source2.optionB]
+        suboption = "valueB"
+    [sources.source2]
+      arbitrary text 2
+    
+    [sources.source3]
+      type = "type3"
+    
+    [transforms.transform1]
+      inputs = ["input1", "input2"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [transforms.transform1]
+      option = "value"
+      arbitrary text
+    
+    [transforms.transform2]
+      inputs = ["input2", "input1"]
+      optionA = "valueA"
+      type = "type2"
+      [transforms.transform2.optionB]
+        suboption = "valueB"
+    [transforms.transform2]
+      arbitrary text 2
+    
+    [transforms.transform3]
+      inputs = []
+      type = "type3"
+    
+    [sinks.sink1]
+      inputs = ["input1", "input2"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [sinks.sink1]
+      option = "value"
+      arbitrary text
+    
+    [sinks.sink2]
+      inputs = ["input2", "input1"]
+      optionA = "valueA"
+      type = "type2"
+      [sinks.sink2.optionB]
+        suboption = "valueB"
+    [sinks.sink2]
+      arbitrary text 2
+    
+    [sinks.sink3]
+      inputs = []
+      type = "type3"
+---
+# Source: vector-agent/templates/rbac.yaml
+# Permissions to use Kubernetes API.
+# Requires that RBAC authorization is enabled.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - watch
+---
+# Source: vector-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector-agent
+subjects:
+  - kind: ServiceAccount
+    name: vector-agent
+    namespace: vector
+---
+# Source: vector-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector-agent
+  labels:
+    helm.sh/chart: vector-agent-0.0.0
+    app.kubernetes.io/name: vector-agent
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-agent
+      app.kubernetes.io/instance: vector
+  minReadySeconds: 1
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
+        
+      labels:
+        app.kubernetes.io/name: vector-agent
+        app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
+    spec:
+      serviceAccountName: vector-agent
+      securityContext:
+        {}
+      containers:
+        - name: vector
+          securityContext:
+            {}
+          image: "timberio/vector:0.0.0-debian"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --config
+            - /etc/vector/*.toml
+          env:
+            - name: VECTOR_SELF_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: VECTOR_SELF_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VECTOR_SELF_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PROCFS_ROOT
+              value: /host/proc
+            - name: SYSFS_ROOT
+              value: /host/sys
+            
+          ports:
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          resources:
+            {}
+          volumeMounts:
+            # Host log directory mount.
+            - name: var-log
+              mountPath: /var/log/
+              readOnly: true
+            # Host mount for docker and containerd log file symlinks.
+            - name: var-lib
+              mountPath: /var/lib
+              readOnly: true
+            # Vector data dir mount.
+            - name: data-dir
+              mountPath: "/vector-data-dir"
+            # Vector config dir mount.
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            # Host procsfs mount.
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            # Host sysfs mount.
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+      terminationGracePeriodSeconds: 60
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      volumes:
+        # Log directory.
+        - name: var-log
+          hostPath:
+            path: /var/log/
+        # Docker and containerd log files in Kubernetes are symlinks to this folder.
+        - name: var-lib
+          hostPath:
+            path: /var/lib/
+        # Vector will store it's data here.
+        - name: data-dir
+          hostPath:
+            path: /var/lib/vector/
+        # Vector config dir.
+        - name: config-dir
+          projected:
+            sources:
+              - configMap:
+                  name: vector-agent
+        # Host procsfs.
+        - name: procfs
+          hostPath:
+            path: /proc
+        # Host sysfs.
+        - name: sysfs
+          hostPath:
+            path: /sys

--- a/tests/helm-snapshots/topology_config/vector-agent/values.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/values.yaml
@@ -1,0 +1,59 @@
+sources:
+  source1:
+    type: "type1"
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  source2:
+    type: "type2"
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  source3:
+    type: "type3"
+
+transforms:
+  transform1:
+    type: "type1"
+    inputs: ["input1", "input2"]
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  transform2:
+    type: "type2"
+    inputs: ["input2", "input1"]
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  transform3:
+    type: "type3"
+    inputs: []
+
+sinks:
+  sink1:
+    type: "type1"
+    inputs: ["input1", "input2"]
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  sink2:
+    type: "type2"
+    inputs: ["input2", "input1"]
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  sink3:
+    type: "type3"
+    inputs: []

--- a/tests/helm-snapshots/topology_config/vector-aggregator/config.sh
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+CHART="distribution/helm/vector-aggregator"
+RELEASE_NAME="vector"

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -34,7 +34,6 @@ data:
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    # Data dir is location controlled at the `DaemonSet`.
     data_dir = "/vector-data-dir"
     
     [log_schema]

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -63,7 +63,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [sources.source1]
       option = "value"
       arbitrary text
     
@@ -83,7 +82,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [transforms.transform1]
       option = "value"
       arbitrary text
     
@@ -105,7 +103,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-    [sinks.sink1]
       option = "value"
       arbitrary text
     

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -1,0 +1,245 @@
+# Do not edit!
+# This file is generated
+# - by "scripts/helm-snapshot-tests.sh"
+# - for the chart at "distribution/helm/vector-aggregator"
+# - with the values from "tests/helm-snapshots/topology_config/vector-aggregator/values.yaml"
+---
+# Source: vector-aggregator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: vector-aggregator/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # We leave `vector.toml` file name available to let externally managed config
+  # maps to provide it.
+  managed.toml: |
+    # Configuration for vector.
+    # Docs: https://vector.dev/docs/
+    
+    # Data dir is location controlled at the `DaemonSet`.
+    data_dir = "/vector-data-dir"
+    
+    [log_schema]
+      host_key = "host"
+      message_key = "message"
+      source_type_key = "source_type"
+      timestamp_key = "timestamp"
+    
+    # Accept logs from Vector agents.
+    [sources.vector]
+      address = "0.0.0.0:9000"
+      type = "vector"
+    
+    
+    # Emit internal Vector metrics.
+    [sources.internal_metrics]
+      type = "internal_metrics"
+    
+    # Expose metrics for scraping in the Prometheus format.
+    [sinks.prometheus_sink]
+      address = "0.0.0.0:9090"
+      inputs = ["internal_metrics"]
+      type = "prometheus"
+    
+    
+    [sources.source1]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [sources.source1]
+      option = "value"
+      arbitrary text
+    
+    [sources.source2]
+      optionA = "valueA"
+      type = "type2"
+      [sources.source2.optionB]
+        suboption = "valueB"
+    [sources.source2]
+      arbitrary text 2
+    
+    [sources.source3]
+      type = "type3"
+    
+    [transforms.transform1]
+      inputs = ["input1", "input2"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [transforms.transform1]
+      option = "value"
+      arbitrary text
+    
+    [transforms.transform2]
+      inputs = ["input2", "input1"]
+      optionA = "valueA"
+      type = "type2"
+      [transforms.transform2.optionB]
+        suboption = "valueB"
+    [transforms.transform2]
+      arbitrary text 2
+    
+    [transforms.transform3]
+      inputs = []
+      type = "type3"
+    
+    [sinks.sink1]
+      inputs = ["input1", "input2"]
+      option1 = "value1"
+      option2 = "value2"
+      type = "type1"
+    [sinks.sink1]
+      option = "value"
+      arbitrary text
+    
+    [sinks.sink2]
+      inputs = ["input2", "input1"]
+      optionA = "valueA"
+      type = "type2"
+      [sinks.sink2.optionB]
+        suboption = "valueB"
+    [sinks.sink2]
+      arbitrary text 2
+    
+    [sinks.sink3]
+      inputs = []
+      type = "type3"
+---
+# Source: vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: None
+  ports:
+    
+    - name: vector
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+---
+# Source: vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ports:
+    
+    - name: vector
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+---
+# Source: vector-aggregator/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: vector-aggregator-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-aggregator
+      app.kubernetes.io/instance: vector
+  podManagementPolicy: "Parallel"
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
+        
+      labels:
+        app.kubernetes.io/name: vector-aggregator
+        app.kubernetes.io/instance: vector
+        vector.dev/exclude: "true"
+    spec:
+      serviceAccountName: vector-aggregator
+      securityContext:
+        {}
+      containers:
+        - name: vector
+          securityContext:
+            {}
+          image: "timberio/vector:0.0.0-debian"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --config
+            - /etc/vector/*.toml
+          env:
+            
+          ports:
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          resources:
+            {}
+          volumeMounts:
+            # Vector data dir mount.
+            - name: data-dir
+              mountPath: "/vector-data-dir"
+            # Vector config dir mount.
+            - name: config-dir
+              mountPath: /etc/vector
+              readOnly: true
+            # Extra volumes.
+      terminationGracePeriodSeconds: 60
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      volumes:
+        # Vector will store it's data here.
+        - name: data-dir
+          emptyDir: {}
+        # Vector config dir.
+        - name: config-dir
+          projected:
+            sources:
+              - configMap:
+                  name: vector-aggregator
+                  optional: true
+  volumeClaimTemplates:

--- a/tests/helm-snapshots/topology_config/vector-aggregator/values.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/values.yaml
@@ -1,0 +1,59 @@
+sources:
+  source1:
+    type: "type1"
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  source2:
+    type: "type2"
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  source3:
+    type: "type3"
+
+transforms:
+  transform1:
+    type: "type1"
+    inputs: ["input1", "input2"]
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  transform2:
+    type: "type2"
+    inputs: ["input2", "input1"]
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  transform3:
+    type: "type3"
+    inputs: []
+
+sinks:
+  sink1:
+    type: "type1"
+    inputs: ["input1", "input2"]
+    option1: "value1"
+    option2: "value2"
+    rawConfig: |-
+      option = "value"
+      arbitrary text
+  sink2:
+    type: "type2"
+    inputs: ["input2", "input1"]
+    optionA: "valueA"
+    optionB:
+      suboption: "valueB"
+    rawConfig: |-
+      arbitrary text 2
+  sink3:
+    type: "type3"
+    inputs: []


### PR DESCRIPTION
This PR adds the ability to pass values to the `sources`, `transforms` and `sinks` defined in Helm charts as an inline YAML, rather than as a TOML string in `rawConfig`.

It also adds snapshot testing mechanism to Helm templates - we generate and snapshot YAML files in various interesting configurations.

This new testing mechanism allows us to achieve the following goals:
- if some complicated configuration snapshot changes unintentionally we'll know, and will be able to fix it in time;
- when doing the development of the Helm charts, it easy to work on supporting more complicated configurations - you can prepare the snapshot config upfront, and then assert that it's working;
- core review for the changes in Helm charts becomes easier because the snapshots show how the effective configurations will change.

Overall, this is a step up in Helm charts maintainability.

Closes #4932.

To do:

- [x] add Helm snapshot tests to CI
- [x] fix table redefinition issue