### PR TITLE
fix(internal_metrics source): Rework defaults and a minimal scraping interval value

### DIFF
--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -13,8 +13,8 @@ use tokio::time;
 #[derivative(Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct InternalMetricsConfig {
-    #[derivative(Default(value = "2.0"))]
-    scrape_interval_secs: f64,
+    #[derivative(Default(value = "2"))]
+    scrape_interval_secs: u64,
 }
 
 inventory::submit! {
@@ -33,7 +33,7 @@ impl SourceConfig for InternalMetricsConfig {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> crate::Result<super::Source> {
-        let interval = time::Duration::from_secs_f64(self.scrape_interval_secs);
+        let interval = time::Duration::from_secs(self.scrape_interval_secs);
         if interval < time::Duration::from_millis(500) {
             return Err(format!(
                 "interval set too low ({} secs), use interval >= 0.5 secs",

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -33,13 +33,12 @@ impl SourceConfig for InternalMetricsConfig {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> crate::Result<super::Source> {
-        let interval = time::Duration::from_secs(self.scrape_interval_secs);
-        if interval < time::Duration::from_millis(500) {
+        if self.scrape_interval_secs == 0 {
             warn!(
                 "Interval set to 0 secs, this could result in high CPU utilization. It is suggested to use interval >= 1 secs.",
             );
         }
-
+        let interval = time::Duration::from_secs(self.scrape_interval_secs);
         Ok(Box::pin(run(get_controller()?, interval, out, shutdown)))
     }
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -35,11 +35,10 @@ impl SourceConfig for InternalMetricsConfig {
     ) -> crate::Result<super::Source> {
         let interval = time::Duration::from_secs(self.scrape_interval_secs);
         if interval < time::Duration::from_millis(500) {
-            return Err(format!(
-                "interval set too low ({} secs), use interval >= 0.5 secs",
+            warn!(
+                "Interval set too low ({} secs), use interval >= 0.5 secs.",
                 interval.as_secs_f64()
-            )
-            .into());
+            );
         }
 
         Ok(Box::pin(run(get_controller()?, interval, out, shutdown)))

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -36,8 +36,7 @@ impl SourceConfig for InternalMetricsConfig {
         let interval = time::Duration::from_secs(self.scrape_interval_secs);
         if interval < time::Duration::from_millis(500) {
             warn!(
-                "Interval set too low ({} secs), use interval >= 0.5 secs.",
-                interval.as_secs_f64()
+                "Interval set to 0 secs, this could result in high CPU utilization. It is suggested to use interval >= 1 secs.",
             );
         }
 


### PR DESCRIPTION
This PR fixes a bug with the scarping interval being 0 if the setting is omitted in the config file.

It also adds a lower limit to the interval value.

Closes #5680.