### PR TITLE
chore(ci): Fix remap benches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ test: ## Run the unit test suite
 test-components: ## Test with all components enabled
 # TODO(jesse) add `wasm-benches` when https://github.com/timberio/vector/issues/5106 is fixed
 # test-components: $(WASM_MODULE_OUTPUTS)
-test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches"
+test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches remap-benches"
 test-components: test
 
 .PHONY: test-all
@@ -899,14 +899,21 @@ bench: ## Run benchmarks in /benches
 	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches"
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
-.PHONY: bench-all
-bench-all: ### Run default and WASM benches
-bench-all: $(WASM_MODULE_OUTPUTS)
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches wasm-benches"
+.PHONY: bench-remap
+bench-remap: ## Run benchmarks in /benches
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "remap-benches" --bench remap
+	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 .PHONY: bench-wasm
 bench-wasm: $(WASM_MODULE_OUTPUTS)  ### Run WASM benches
 	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm wasm
+	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
+
+.PHONY: bench-all
+bench-all: ### Run default and WASM benches
+bench-all: $(WASM_MODULE_OUTPUTS)
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches wasm-benches"
+	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 ##@ Checking
 

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -41,7 +41,7 @@ bench_function! {
 
     literal_value {
         args: func_args![value: r#"{"key": "value"}"#],
-        want: Ok(map!["key": "value"]),
+        want: Ok(value!({"key": "value"})),
     }
 
     invalid_json_with_default {
@@ -49,7 +49,7 @@ bench_function! {
             value: r#"{"key": INVALID}"#,
             default: r#"{"key": "default"}"#,
         ],
-        want: Ok(map!["key": "default"]),
+        want: Ok(value!({"key": "default"})),
     }
 }
 

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -19,7 +19,7 @@ criterion_group!(benches, benchmark_remap, upcase, downcase, parse_json);
 criterion_main!(benches);
 
 bench_function! {
-    upcase => vector::remap::Upcase;
+    upcase => remap_functions::Upcase;
 
     literal_value {
         args: func_args![value: "foo"],
@@ -28,7 +28,7 @@ bench_function! {
 }
 
 bench_function! {
-    downcase => vector::remap::Downcase;
+    downcase => remap_functions::Downcase;
 
     literal_value {
         args: func_args![value: "FOO"],
@@ -37,7 +37,7 @@ bench_function! {
 }
 
 bench_function! {
-    parse_json => vector::remap::ParseJson;
+    parse_json => remap_functions::ParseJson;
 
     literal_value {
         args: func_args![value: r#"{"key": "value"}"#],

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -72,12 +72,15 @@ macro_rules! test_function {
 #[macro_export]
 macro_rules! map {
     () => ({
-        ::std::collections::BTreeMap::<String, $crate::Value>::new()
+        let map = ::std::collections::BTreeMap::<String, $crate::Expr>::new();
+        $crate::expression::Map::new(map)
     });
     ($($k:tt: $v:expr),+ $(,)?) => ({
-        vec![$(($k.into(), $v.into())),+]
+        let map: ::std::collections::BTreeMap<String, $crate::Expr> = vec![$(($k.into(), $v.into())),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<String, $crate::Value>>()
+            .collect::<::std::collections::BTreeMap<_, _>>();
+
+        $crate::expression::Map::new(map)
     });
 }
 

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -72,15 +72,12 @@ macro_rules! test_function {
 #[macro_export]
 macro_rules! map {
     () => ({
-        let map = ::std::collections::BTreeMap::<String, $crate::Expr>::new();
-        $crate::expression::Map::new(map)
+        ::std::collections::BTreeMap::<String, $crate::Value>::new()
     });
     ($($k:tt: $v:expr),+ $(,)?) => ({
-        let map: ::std::collections::BTreeMap<String, $crate::Expr> = vec![$(($k.into(), $v.into())),+]
+        vec![$(($k.into(), $v.into())),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<_, _>>();
-
-        $crate::expression::Map::new(map)
+            .collect::<::std::collections::BTreeMap<String, $crate::Value>>()
     });
 }
 


### PR DESCRIPTION
Also adds them to CI so that we should catch it if they break again.

@FungusHumungus I'm not super confident with my fix to the `map` macro here. I'd appreciate your :eyes: 

The error I was resolving was:

```
error[E0277]: the trait bound `remap_lang::Value: From<remap_lang::expression::Map>` is not satisfied                                                                         
  --> benches/remap.rs:39:1                                                                                                                                                      |                                                                                   
39 | / bench_function! {                                                               
40 | |     parse_json => remap_functions::ParseJson;                                   
41 | |                                                                                                                                                                        
42 | |     literal_value {                                                             
...  |                                                                                 
53 | |     }                                                                                                                                                                  54 | | }                                                                               
   | |_^ the trait `From<remap_lang::expression::Map>` is not implemented for `remap_lang::Value`                                                                             
   |                                                                                   
   = help: the following implementations were found:                                   
             <remap_lang::Value as From<&[u8]>>                                                                                                                               
             <remap_lang::Value as From<&str>>                                                                                                                                
             <remap_lang::Value as From<()>>                                                                                                                                               <remap_lang::Value as From<BTreeMap<std::string::String, remap_lang::Value>>>                                                                                    
           and 15 others                                                               
   = note: required by `from`                                                                                                                                                 
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info) 
```

Since `<remap_lang::Value as From<BTreeMap<std::string::String, remap_lang::Value>>>` was defined, I figured I'd just return that in the macro.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
