### PR TITLE
chore(performance): Metrics benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7557,6 +7557,7 @@ dependencies = [
  "colored",
  "criterion",
  "crossterm 0.19.0",
+ "dashmap 3.11.10",
  "db-key",
  "derivative 2.1.3",
  "derive_is_enum_variant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -575,6 +575,8 @@ disable-resolv-conf = []
 benches = ["sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
 wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-wasm", "transforms-lua"]
 remap-benches = ["transforms-add_fields", "transforms-remap", "transforms-coercer", "transforms-json_parser"]
+# Separate benching process for metrics due to the nature of the bootstrap procedures.
+metrics-benches = ["sources-socket", "sinks-socket"]
 
 [[bench]]
 name = "default"
@@ -591,6 +593,16 @@ required-features = ["wasm-benches"]
 name = "remap"
 harness = false
 required-features = ["remap-benches"]
+
+[[bench]]
+name = "metrics_on"
+harness = false
+required-features = ["metrics-benches"]
+
+[[bench]]
+name = "metrics_off"
+harness = false
+required-features = ["metrics-benches"]
 
 [patch.'https://github.com/tower-rs/tower']
 tower-layer = "=0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -602,6 +602,11 @@ harness = false
 required-features = ["metrics-benches"]
 
 [[bench]]
+name = "metrics_no_tracing_layer"
+harness = false
+required-features = ["metrics-benches"]
+
+[[bench]]
 name = "metrics_off"
 harness = false
 required-features = ["metrics-benches"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 readme = "README.md"
 publish = false
 default-run = "vector"
+autobenches = false # our benchmarks are not runnable on their own either way
 
 [[bin]]
 name = "graphql-schema"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -602,7 +602,7 @@ harness = false
 required-features = ["metrics-benches"]
 
 [[bench]]
-name = "metrics_no_tracing_layer"
+name = "metrics_no_tracing_integration"
 harness = false
 required-features = ["metrics-benches"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ tokio-postgres = { version = "0.5.5", optional = true, features = ["runtime", "w
 # Indirect dependency; pinning until
 # https://github.com/timberio/vector/issues/6005 is resolved
 thread_local = "= 1.0.1"
+dashmap = "3"
 
 # For WASM
 vector-wasm = { path = "lib/vector-wasm", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -546,10 +546,15 @@ bench-wasm: $(WASM_MODULE_OUTPUTS)  ### Run WASM benches
 	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm wasm ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
+.PHONY: bench-metrics
+bench-metrics: ## Run metrics benches
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "metrics-benches" ${CARGO_BENCH_FLAGS}
+	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
+
 .PHONY: bench-all
 bench-all: ### Run all benches
 bench-all: $(WASM_MODULE_OUTPUTS)
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches wasm-benches" ${CARGO_BENCH_FLAGS}
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches wasm-benches metrics-benches" ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 ##@ Checking

--- a/benches/default.rs
+++ b/benches/default.rs
@@ -8,6 +8,7 @@ mod http;
 mod isolated_buffering;
 mod lookup;
 mod lua;
+mod metrics_snapshot;
 mod regex;
 mod template;
 mod topology;
@@ -21,6 +22,7 @@ criterion_main!(
     isolated_buffering::benches,
     lookup::benches,
     lua::benches,
+    metrics_snapshot::benches,
     regex::benches,
     template::benches,
     topology::benches,

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -1,0 +1,245 @@
+//! This mod contains the benchmarks for metrics.
+//! Due to how metrics are set up, we need isolated process environments to
+//! test with metrics core on and off, so the implemntation is shared but has
+//! two separate entrypoits.
+//!
+//! # Usage
+//!
+//! To run these benches, use the following commands:
+//!
+//!     cargo bench --no-default-features --features "metrics-benches" --bench metrics_on
+//!     cargo bench --no-default-features --features "metrics-benches" --bench metrics_off
+//!
+//! These will run benches with metrics core system on and off respectively.
+
+use criterion::{BatchSize, Criterion, SamplingMode, Throughput};
+use futures::{compat::Future01CompatExt, future, stream, StreamExt};
+use metrics::counter;
+use tracing::{span, Level};
+use vector::{
+    config, sinks, sources,
+    test_util::{
+        next_addr, random_lines, runtime, send_lines, start_topology, wait_for_tcp, CountReceiver,
+    },
+};
+
+#[inline]
+fn disable_metrics() {
+    std::env::set_var("DISABLE_INTERNAL_METRICS_CORE", "true");
+    std::env::set_var("DISABLE_INTERNAL_METRICS_TRACING_LAYER", "true");
+}
+
+#[inline]
+fn boot() {
+    vector::trace::init(false, false, "warn");
+    vector::metrics::init().expect("metrics initialization failed");
+}
+
+/// Due to the nature of how metrics and tracing systems are set up, we need
+/// separate process spaces to measure with and without them being enabled.
+#[inline]
+pub fn benchmark(c: &mut Criterion, metrics_enabled: bool) {
+    if !metrics_enabled {
+        disable_metrics();
+    }
+    boot();
+    assert_eq!(
+        vector::metrics::get_controller().is_ok(),
+        metrics_enabled,
+        "the presence of a controller must correspond to whether metrics are on or off"
+    );
+
+    let bench_name = if metrics_enabled {
+        "metrics_on"
+    } else {
+        "metrics_off"
+    };
+
+    bench_topology(c, bench_name);
+    bench_micro(c, bench_name);
+}
+
+/// Based on the topology benchmarks.
+/// I'm pretty sure criterion used incorrectly here - the bench loops generates
+/// it's own input, and taps into random source and networking - this must not
+/// be working right, as criterion assumptions about the benchmark loop
+/// iteration payload are broken here.
+#[inline]
+fn bench_topology(c: &mut Criterion, bench_name: &'static str) {
+    let num_lines: usize = 10_000;
+    let line_size: usize = 100;
+    let num_writers = 2;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    let mut group = c.benchmark_group(format!("{}/{}", bench_name, "topology"));
+    group.sampling_mode(SamplingMode::Flat);
+
+    group.throughput(Throughput::Bytes(
+        (num_lines * line_size * num_writers) as u64,
+    ));
+    group.bench_function("tcp_socket", |b| {
+        b.iter_batched(
+            || {
+                let mut config = config::Config::builder();
+                config.add_source(
+                    "in",
+                    sources::socket::SocketConfig::make_basic_tcp_config(in_addr),
+                );
+                config.add_sink(
+                    "out",
+                    &["in"],
+                    sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+                );
+
+                let mut rt = runtime();
+                let (output_lines, topology) = rt.block_on(async move {
+                    let output_lines = CountReceiver::receive_lines(out_addr);
+                    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+                    wait_for_tcp(in_addr).await;
+                    (output_lines, topology)
+                });
+                (rt, topology, output_lines)
+            },
+            |(mut rt, topology, output_lines)| {
+                rt.block_on(async move {
+                    let sends = stream::iter(0..num_writers)
+                        .map(|_| {
+                            let lines = random_lines(line_size).take(num_lines);
+                            send_lines(in_addr, lines)
+                        })
+                        .collect::<Vec<_>>()
+                        .await;
+                    future::try_join_all(sends).await.unwrap();
+
+                    topology.stop().compat().await.unwrap();
+
+                    let output_lines = output_lines.await;
+
+                    debug_assert_eq!(num_lines * num_writers, output_lines.len());
+
+                    output_lines
+                });
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+/// Here we perform some microbenchmarks on the metrics.
+#[inline]
+fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
+    let mut group = c.benchmark_group(format!("{}/{}", bench_name, "micro"));
+    group.bench_function("bare_counter", |b| {
+        b.iter(|| {
+            counter!("test", 1);
+        });
+    });
+    group.bench_function("bare_counter_with_static_labels", |b| {
+        b.iter(|| {
+            counter!("test", 1, "my key" => "my value");
+        });
+    });
+    group.bench_function("bare_counter_with_dynamic_labels", |b| {
+        b.iter_batched(
+            || "my value".to_owned(),
+            |my_value| {
+                counter!("test", 1, "my key" => my_value);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    // A span that's not even entered.
+    group.bench_function("ununsed_span", |b| {
+        b.iter_batched_ref(
+            || span!(Level::ERROR, "my span"),
+            |_span| {
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    // A span that's entered but without a counter invocation.
+    group.bench_function("span_enter_without_counter", |b| {
+        b.iter_batched_ref(
+            || span!(Level::ERROR, "my span"),
+            |span| {
+                let _enter = span.enter();
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("span_no_labels", |b| {
+        b.iter_batched_ref(
+            || span!(Level::ERROR, "my span"),
+            |span| {
+                let _enter = span.enter();
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("span_with_1_static_label", |b| {
+        b.iter_batched_ref(
+            || span!(Level::ERROR, "my span", "my key" = "my value"),
+            |span| {
+                let _enter = span.enter();
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("span_with_2_static_labels", |b| {
+        b.iter_batched_ref(
+            || {
+                span!(
+                    Level::ERROR,
+                    "my span",
+                    "my key 1" = "my value 1",
+                    "my key 2" = "my value 2"
+                )
+            },
+            |span| {
+                let _enter = span.enter();
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("span_with_1_dynamic_label", |b| {
+        b.iter_batched_ref(
+            || {
+                let my_value = "my value".to_owned();
+                span!(Level::ERROR, "my span", "my key" = %my_value)
+            },
+            |span| {
+                let _enter = span.enter();
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("span_with_2_dynamic_labels", |b| {
+        b.iter_batched_ref(
+            || {
+                let my_value_1 = "my value 1".to_owned();
+                let my_value_2 = "my value 2".to_owned();
+                span!(
+                    Level::ERROR,
+                    "my span",
+                    "my key 1" = %my_value_1,
+                    "my key 2" = %my_value_2
+                )
+            },
+            |span| {
+                let _enter = span.enter();
+                counter!("test", 1);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -29,8 +29,8 @@ fn disable_metrics() {
 }
 
 #[inline]
-fn disable_metrics_tracing_layer() {
-    std::env::set_var("DISABLE_INTERNAL_METRICS_TRACING_LAYER", "true");
+fn disable_metrics_tracing_integration() {
+    std::env::set_var("DISABLE_INTERNAL_METRICS_TRACING_INTEGRATION", "true");
 }
 
 #[inline]
@@ -43,7 +43,7 @@ fn boot() {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     MetricsOff,
-    MetricsNoTracingLayer,
+    MetricsNoTracingIntegration,
     MetricsOn,
 }
 
@@ -51,7 +51,7 @@ impl Mode {
     fn as_str(&self) -> &'static str {
         match self {
             Mode::MetricsOff => "metrics_off",
-            Mode::MetricsNoTracingLayer => "metrics_no_tracing_layer",
+            Mode::MetricsNoTracingIntegration => "metrics_no_tracing_integration",
             Mode::MetricsOn => "metrics_on",
         }
     }
@@ -64,10 +64,10 @@ pub fn benchmark(c: &mut Criterion, mode: Mode) {
     match mode {
         Mode::MetricsOff => {
             disable_metrics();
-            disable_metrics_tracing_layer();
+            disable_metrics_tracing_integration();
         }
-        Mode::MetricsNoTracingLayer => {
-            disable_metrics_tracing_layer();
+        Mode::MetricsNoTracingIntegration => {
+            disable_metrics_tracing_integration();
         }
         Mode::MetricsOn => {}
     }

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -213,7 +213,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
     group.bench_function("span_enter_without_counter", |b| {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span"),
-            |span| span.enter(),
+            |span| {
+                let _enter = span.enter();
+            },
             BatchSize::SmallInput,
         );
     });
@@ -221,9 +223,8 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span"),
             |span| {
-                let enter = span.enter();
+                let _enter = span.enter();
                 counter!("test", 1);
-                enter
             },
             BatchSize::SmallInput,
         );
@@ -232,9 +233,8 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span", "my key" = "my value"),
             |span| {
-                let enter = span.enter();
+                let _enter = span.enter();
                 counter!("test", 1);
-                enter
             },
             BatchSize::SmallInput,
         );
@@ -250,9 +250,8 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 )
             },
             |span| {
-                let enter = span.enter();
+                let _enter = span.enter();
                 counter!("test", 1);
-                enter
             },
             BatchSize::SmallInput,
         );
@@ -264,9 +263,8 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 span!(Level::ERROR, "my span", "my key" = %my_value)
             },
             |span| {
-                let enter = span.enter();
+                let _enter = span.enter();
                 counter!("test", 1);
-                enter
             },
             BatchSize::SmallInput,
         );
@@ -284,9 +282,8 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 )
             },
             |span| {
-                let enter = span.enter();
+                let _enter = span.enter();
                 counter!("test", 1);
-                enter
             },
             BatchSize::SmallInput,
         );

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -213,9 +213,7 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
     group.bench_function("span_enter_without_counter", |b| {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span"),
-            |span| {
-                let _enter = span.enter();
-            },
+            |span| span.enter(),
             BatchSize::SmallInput,
         );
     });
@@ -223,8 +221,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span"),
             |span| {
-                let _enter = span.enter();
+                let enter = span.enter();
                 counter!("test", 1);
+                enter
             },
             BatchSize::SmallInput,
         );
@@ -233,8 +232,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
         b.iter_batched_ref(
             || span!(Level::ERROR, "my span", "my key" = "my value"),
             |span| {
-                let _enter = span.enter();
+                let enter = span.enter();
                 counter!("test", 1);
+                enter
             },
             BatchSize::SmallInput,
         );
@@ -250,8 +250,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 )
             },
             |span| {
-                let _enter = span.enter();
+                let enter = span.enter();
                 counter!("test", 1);
+                enter
             },
             BatchSize::SmallInput,
         );
@@ -263,8 +264,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 span!(Level::ERROR, "my span", "my key" = %my_value)
             },
             |span| {
-                let _enter = span.enter();
+                let enter = span.enter();
                 counter!("test", 1);
+                enter
             },
             BatchSize::SmallInput,
         );
@@ -282,8 +284,9 @@ fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
                 )
             },
             |span| {
-                let _enter = span.enter();
+                let enter = span.enter();
                 counter!("test", 1);
+                enter
             },
             BatchSize::SmallInput,
         );

--- a/benches/metrics_no_tracing_integration.rs
+++ b/benches/metrics_no_tracing_integration.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 mod metrics_bench_util;
 
 fn benchmark(c: &mut Criterion) {
-    metrics_bench_util::benchmark(c, metrics_bench_util::Mode::MetricsNoTracingLayer)
+    metrics_bench_util::benchmark(c, metrics_bench_util::Mode::MetricsNoTracingIntegration)
 }
 
 criterion_group!(benches, benchmark);

--- a/benches/metrics_no_tracing_layer.rs
+++ b/benches/metrics_no_tracing_layer.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 mod metrics_bench_util;
 
 fn benchmark(c: &mut Criterion) {
-    metrics_bench_util::benchmark(c, metrics_bench_util::Mode::MetricsOff)
+    metrics_bench_util::benchmark(c, metrics_bench_util::Mode::MetricsNoTracingLayer)
 }
 
 criterion_group!(benches, benchmark);

--- a/benches/metrics_off.rs
+++ b/benches/metrics_off.rs
@@ -1,0 +1,10 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+mod metrics_bench_util;
+
+fn benchmark(c: &mut Criterion) {
+    metrics_bench_util::benchmark(c, false)
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/benches/metrics_on.rs
+++ b/benches/metrics_on.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 mod metrics_bench_util;
 
 fn benchmark(c: &mut Criterion) {
-    metrics_bench_util::benchmark(c, true)
+    metrics_bench_util::benchmark(c, metrics_bench_util::Mode::MetricsOn)
 }
 
 criterion_group!(benches, benchmark);

--- a/benches/metrics_on.rs
+++ b/benches/metrics_on.rs
@@ -1,0 +1,10 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+mod metrics_bench_util;
+
+fn benchmark(c: &mut Criterion) {
+    metrics_bench_util::benchmark(c, true)
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -1,0 +1,41 @@
+use criterion::{criterion_group, BenchmarkId, Criterion};
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("metrics_snapshot");
+    for &cardinality in [0, 1, 10, 100, 1000, 10000].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("cardinality", cardinality),
+            &cardinality,
+            |b, &cardinality| {
+                let controller = prepare_metrics(cardinality);
+                b.iter(|| {
+                    let iter = vector::metrics::capture_metrics(controller);
+                    assert_cardinality_matches(&iter, cardinality);
+                    iter
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
+    let _ = vector::metrics::init();
+    let controller = vector::metrics::get_controller().unwrap();
+    vector::metrics::reset(controller);
+
+    for idx in 0..cardinality {
+        metrics::counter!("test", 1, "idx" => format!("{}", idx));
+    }
+
+    assert_cardinality_matches(&vector::metrics::capture_metrics(controller), cardinality);
+
+    controller
+}
+
+fn assert_cardinality_matches(iter: &impl Iterator, cardinality: usize) {
+    assert_eq!(iter.size_hint().0, cardinality);
+    assert_eq!(iter.size_hint().1.unwrap(), cardinality);
+}
+
+criterion_group!(benches, benchmark);

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 
 fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("metrics_snapshot");
@@ -37,6 +37,7 @@ fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
 /// of the benches, however it performs the assertion over the data, effectively
 /// acting as an implicit blackbox.
 fn assert_cardinality_matches(iter: &impl Iterator, cardinality: usize) {
+    let iter = black_box(iter);
     assert_eq!(iter.size_hint().0, cardinality);
     assert_eq!(iter.size_hint().1.unwrap(), cardinality);
 }

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -33,6 +33,9 @@ fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
     controller
 }
 
+/// This call has negligible (and cosistent) performance compared to the rest
+/// of the benches, however it performs the assertion over the data, effectively
+/// acting as an implicit blackbox.
 fn assert_cardinality_matches(iter: &impl Iterator, cardinality: usize) {
     assert_eq!(iter.size_hint().0, cardinality);
     assert_eq!(iter.size_hint().1.unwrap(), cardinality);

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -256,7 +256,7 @@ impl Metric {
 
     /// Convert the metrics_runtime::Measurement value plus the name and
     /// labels from a Key into our internal Metric format.
-    pub fn from_metric_kv(key: metrics::Key, handle: metrics_util::Handle) -> Self {
+    pub fn from_metric_kv(key: &metrics::Key, handle: &metrics_util::Handle) -> Self {
         let value = match handle {
             metrics_util::Handle::Counter(_) => MetricValue::Counter {
                 value: handle.read_counter() as f64,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -213,6 +213,11 @@ fn snapshot(controller: &Controller) -> Vec<Event> {
         .collect()
 }
 
+/// Clear all metrics from the registry.
+pub fn reset(controller: &Controller) {
+    controller.registry.map.clear()
+}
+
 /// Take a snapshot of all gathered metrics and expose them as metric
 /// [`Event`]s.
 pub fn capture_metrics(controller: &Controller) -> impl Iterator<Item = Event> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -88,6 +88,18 @@ pub fn init() -> crate::Result<()> {
 }
 
 /// [`VectorRegistry`] is a vendored version of [`metrics_util::Registry`].
+///
+/// We are removing the generational wrappers that upstream added, as they
+/// might've been the cause of the performance issues on the multi-core systems
+/// under high paralellism.
+///
+/// The suspicion is that the atomics usage in the generational somehow causes
+/// permanent cache invalidation starvation at some scenarios - however, it's
+/// based on the empiric observations, and we currently don't have
+/// a comprehensive mental model to back up this behaviour.
+/// It was decided to just eliminate the generationals - for now.
+/// Maybe in the long term too - we don't need them, so why pay the price?
+/// They're not zero-cost.
 #[derive(Debug)]
 struct VectorRegistry<K, H>
 where

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -33,7 +33,7 @@ pub use tracing_futures::Instrument;
 pub use tracing_tower::{InstrumentableService, InstrumentedService};
 
 fn metrics_layer_enabled() -> bool {
-    !matches!(std::env::var("DISABLE_INTERNAL_METRICS_TRACING_LAYER"), Ok(x) if x == "true")
+    !matches!(std::env::var("DISABLE_INTERNAL_METRICS_TRACING_INTEGRATION"), Ok(x) if x == "true")
 }
 
 pub fn init(color: bool, json: bool, levels: &str) {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -32,8 +32,17 @@ static SENDER: OnceCell<Sender<Event>> = OnceCell::new();
 pub use tracing_futures::Instrument;
 pub use tracing_tower::{InstrumentableService, InstrumentedService};
 
+fn metrics_layer_enabled() -> bool {
+    !matches!(std::env::var("DISABLE_INTERNAL_METRICS_TRACING_LAYER"), Ok(x) if x == "true")
+}
+
 pub fn init(color: bool, json: bool, levels: &str) {
     let _ = BUFFER.set(Mutex::new(Some(Vec::new())));
+
+    // An escape hatch to disable injecting a mertics layer into tracing.
+    // May be used for performance reasons.
+    // This is a hidden and undocumented functionality.
+    let metrics_layer_enabled = metrics_layer_enabled();
 
     let dispatch = if json {
         let formatter = FmtSubscriber::builder()
@@ -41,18 +50,25 @@ pub fn init(color: bool, json: bool, levels: &str) {
             .json()
             .flatten_event(true)
             .finish()
-            .with(Limit::default())
-            .with(MetricsLayer::new());
-
-        Dispatch::new(BroadcastSubscriber { formatter })
+            .with(Limit::default());
+        if metrics_layer_enabled {
+            let formatter = formatter.with(MetricsLayer::new());
+            Dispatch::new(BroadcastSubscriber { formatter })
+        } else {
+            Dispatch::new(BroadcastSubscriber { formatter })
+        }
     } else {
         let formatter = FmtSubscriber::builder()
             .with_ansi(color)
             .with_env_filter(levels)
             .finish()
-            .with(Limit::default())
-            .with(MetricsLayer::new());
-        Dispatch::new(BroadcastSubscriber { formatter })
+            .with(Limit::default());
+        if metrics_layer_enabled {
+            let formatter = formatter.with(MetricsLayer::new());
+            Dispatch::new(BroadcastSubscriber { formatter })
+        } else {
+            Dispatch::new(BroadcastSubscriber { formatter })
+        }
     };
 
     let _ = LogTracer::init();


### PR DESCRIPTION
This PR adds benchmarks to the metrics system.

It also
- introduces some (hidden and undocumented) escape hatches to disable internal metrics subsystem,
- vendors the metrics registry implementation (to allow more flexibility in integrating with our needs),
- optimizes metrics snapshot procedure,
- disables `autobenches` cargo option (with our current configuration it only confuses people),
- adds the ability to reset the metrics registry via a controller.

Closes #5093.

---

Findings from the benches show that the topology of socket source to socket sink performs slower with internal metrics than without them by the order of roughly up to 10-15%, but ultimately the performance change *within the noize tolerance*.

```shell
$ critcmp | grep topology
metrics_no_tracing_layer/topology/tcp_socket/01_writer             1.00     22.9±4.31ms    41.7 MB/sec    1.00     22.9±4.31ms    41.7 MB/sec
metrics_no_tracing_layer/topology/tcp_socket/02_writers            1.00    32.0±11.30ms    59.5 MB/sec    1.00    32.0±11.30ms    59.5 MB/sec
metrics_no_tracing_layer/topology/tcp_socket/04_writers            1.00    68.5±36.47ms    55.7 MB/sec    1.00    68.5±36.47ms    55.7 MB/sec
metrics_no_tracing_layer/topology/tcp_socket/08_writers            1.00    112.0±3.36ms    68.1 MB/sec    1.00    112.0±3.36ms    68.1 MB/sec
metrics_no_tracing_layer/topology/tcp_socket/16_writers            1.00    239.3±4.77ms    63.8 MB/sec    1.00    239.3±4.77ms    63.8 MB/sec
metrics_off/topology/tcp_socket/01_writer                          1.00     20.8±5.73ms    45.9 MB/sec    1.00     20.8±5.73ms    45.9 MB/sec
metrics_off/topology/tcp_socket/02_writers                         1.00    31.1±12.19ms    61.3 MB/sec    1.00    31.1±12.19ms    61.3 MB/sec
metrics_off/topology/tcp_socket/04_writers                         1.00     53.5±8.24ms    71.3 MB/sec    1.00     53.5±8.24ms    71.3 MB/sec
metrics_off/topology/tcp_socket/08_writers                         1.00    114.4±6.01ms    66.7 MB/sec    1.00    114.4±6.01ms    66.7 MB/sec
metrics_off/topology/tcp_socket/16_writers                         1.00    235.5±3.11ms    64.8 MB/sec    1.00    235.5±3.11ms    64.8 MB/sec
metrics_on/topology/tcp_socket/01_writer                           1.00     23.7±5.59ms    40.2 MB/sec    1.00     23.7±5.59ms    40.2 MB/sec
metrics_on/topology/tcp_socket/02_writers                          1.00    32.7±11.48ms    58.3 MB/sec    1.00    32.7±11.48ms    58.3 MB/sec
metrics_on/topology/tcp_socket/04_writers                          1.00    58.8±22.47ms    64.8 MB/sec    1.00    58.8±22.47ms    64.8 MB/sec
metrics_on/topology/tcp_socket/08_writers                          1.00    112.8±5.26ms    67.6 MB/sec    1.00    112.8±5.26ms    67.6 MB/sec
metrics_on/topology/tcp_socket/16_writers                          1.00    240.4±4.67ms    63.5 MB/sec    1.00    240.4±4.67ms    63.5 MB/sec
```