### PR TITLE
chore(config): Move root level `headers` option to `request.headers` 

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -339,6 +339,7 @@ components: {
 				retry_initial_backoff_secs: uint8
 				retry_max_duration_secs:    uint8
 				timeout_secs:               uint8
+				headers:                    bool
 			}
 		}
 

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -312,7 +312,7 @@ components: sinks: [Name=string]: {
 								}
 							}
 
-							if sinks[Name].features.send.request.headers{
+							if sinks[Name].features.send.request.headers {
 								headers: {
 									common:      false
 									description: "Options for custom headers."
@@ -328,7 +328,7 @@ components: sinks: [Name=string]: {
 										options: {}
 									}
 								}
-							}							
+							}
 						}
 					}
 				}

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -311,6 +311,24 @@ components: sinks: [Name=string]: {
 									unit:    "seconds"
 								}
 							}
+
+							if sinks[Name].features.send.request.headers{
+								headers: {
+									common:      false
+									description: "Options for custom headers."
+									required:    false
+									warnings: []
+									type: object: {
+										examples: [
+											{
+												"Authorization": "${HTTP_TOKEN}"
+												"X-Powered-By":  "Vector"
+											},
+										]
+										options: {}
+									}
+								}
+							}							
 						}
 					}
 				}

--- a/docs/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -45,6 +45,7 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -45,7 +45,7 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/docs/reference/components/sinks/aws_kinesis_firehose.cue
@@ -44,7 +44,7 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/docs/reference/components/sinks/aws_kinesis_firehose.cue
@@ -44,6 +44,7 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_kinesis_streams.cue
+++ b/docs/reference/components/sinks/aws_kinesis_streams.cue
@@ -44,7 +44,7 @@ components: sinks: aws_kinesis_streams: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_kinesis_streams.cue
+++ b/docs/reference/components/sinks/aws_kinesis_streams.cue
@@ -44,6 +44,7 @@ components: sinks: aws_kinesis_streams: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_s3.cue
+++ b/docs/reference/components/sinks/aws_s3.cue
@@ -44,6 +44,7 @@ components: sinks: aws_s3: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_s3.cue
+++ b/docs/reference/components/sinks/aws_s3.cue
@@ -44,7 +44,7 @@ components: sinks: aws_s3: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_sqs.cue
+++ b/docs/reference/components/sinks/aws_sqs.cue
@@ -32,6 +32,7 @@ components: sinks: aws_sqs: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/aws_sqs.cue
+++ b/docs/reference/components/sinks/aws_sqs.cue
@@ -32,7 +32,7 @@ components: sinks: aws_sqs: components._aws & {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -40,7 +40,7 @@ components: sinks: clickhouse: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -40,6 +40,7 @@ components: sinks: clickhouse: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -26,6 +26,7 @@ components: sinks: datadog_metrics: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -26,7 +26,7 @@ components: sinks: datadog_metrics: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -40,6 +40,7 @@ components: sinks: elasticsearch: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -40,7 +40,7 @@ components: sinks: elasticsearch: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:        			true
 			}
 			tls: {
 				enabled:                true
@@ -181,21 +181,6 @@ components: sinks: elasticsearch: {
 			warnings: []
 			type: string: {
 				examples: ["http://10.24.32.122:9000", "https://example.com", "https://user:password@example.com"]
-			}
-		}
-		headers: {
-			common:      false
-			description: "Options for custom headers."
-			required:    false
-			warnings: []
-			type: object: {
-				examples: [
-					{
-						"Authorization": "${ELASTICSEARCH_TOKEN}"
-						"X-Powered-By":  "Vector"
-					},
-				]
-				options: {}
 			}
 		}
 		id_key: {

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -40,7 +40,7 @@ components: sinks: elasticsearch: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			true
+				headers:                    true
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_cloud_storage.cue
+++ b/docs/reference/components/sinks/gcp_cloud_storage.cue
@@ -44,7 +44,7 @@ components: sinks: gcp_cloud_storage: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_cloud_storage.cue
+++ b/docs/reference/components/sinks/gcp_cloud_storage.cue
@@ -44,6 +44,7 @@ components: sinks: gcp_cloud_storage: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_pubsub.cue
+++ b/docs/reference/components/sinks/gcp_pubsub.cue
@@ -35,6 +35,7 @@ components: sinks: gcp_pubsub: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_pubsub.cue
+++ b/docs/reference/components/sinks/gcp_pubsub.cue
@@ -35,7 +35,7 @@ components: sinks: gcp_pubsub: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/docs/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -35,7 +35,7 @@ components: sinks: gcp_stackdriver_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/docs/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -35,6 +35,7 @@ components: sinks: gcp_stackdriver_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/honeycomb.cue
+++ b/docs/reference/components/sinks/honeycomb.cue
@@ -35,7 +35,7 @@ components: sinks: honeycomb: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/honeycomb.cue
+++ b/docs/reference/components/sinks/honeycomb.cue
@@ -35,6 +35,7 @@ components: sinks: honeycomb: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/http.cue
+++ b/docs/reference/components/sinks/http.cue
@@ -44,7 +44,7 @@ components: sinks: http: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			true		
+				headers:                    true		
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/http.cue
+++ b/docs/reference/components/sinks/http.cue
@@ -44,7 +44,7 @@ components: sinks: http: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:                    true		
+				headers:                    true
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/http.cue
+++ b/docs/reference/components/sinks/http.cue
@@ -44,6 +44,7 @@ components: sinks: http: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			true		
 			}
 			tls: {
 				enabled:                true
@@ -91,21 +92,6 @@ components: sinks: http: {
 			password_example: "${HTTP_PASSWORD}"
 			username_example: "${HTTP_USERNAME}"
 		}}
-		headers: {
-			common:      false
-			description: "Options for custom headers."
-			required:    false
-			warnings: []
-			type: object: {
-				examples: [
-					{
-						"Authorization": "${HTTP_TOKEN}"
-						"X-Powered-By":  "Vector"
-					},
-				]
-				options: {}
-			}
-		}
 		uri: {
 			description: """
 				The full URI to make HTTP requests to. This should include the protocol and host,

--- a/docs/reference/components/sinks/humio.cue
+++ b/docs/reference/components/sinks/humio.cue
@@ -57,6 +57,7 @@ components: sinks: _humio: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/humio.cue
+++ b/docs/reference/components/sinks/humio.cue
@@ -57,7 +57,7 @@ components: sinks: _humio: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/influxdb_logs.cue
+++ b/docs/reference/components/sinks/influxdb_logs.cue
@@ -35,6 +35,7 @@ components: sinks: influxdb_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: sinks._influxdb.features.send.tls
 			to:  sinks._influxdb.features.send.to

--- a/docs/reference/components/sinks/influxdb_logs.cue
+++ b/docs/reference/components/sinks/influxdb_logs.cue
@@ -35,7 +35,7 @@ components: sinks: influxdb_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: sinks._influxdb.features.send.tls
 			to:  sinks._influxdb.features.send.to

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -35,7 +35,7 @@ components: sinks: influxdb_metrics: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: sinks._influxdb.features.send.tls
 			to:  sinks._influxdb.features.send.to

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -35,6 +35,7 @@ components: sinks: influxdb_metrics: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: sinks._influxdb.features.send.tls
 			to:  sinks._influxdb.features.send.to

--- a/docs/reference/components/sinks/logdna.cue
+++ b/docs/reference/components/sinks/logdna.cue
@@ -35,6 +35,7 @@ components: sinks: logdna: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/logdna.cue
+++ b/docs/reference/components/sinks/logdna.cue
@@ -35,7 +35,7 @@ components: sinks: logdna: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/loki.cue
+++ b/docs/reference/components/sinks/loki.cue
@@ -39,6 +39,7 @@ components: sinks: loki: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/loki.cue
+++ b/docs/reference/components/sinks/loki.cue
@@ -39,7 +39,7 @@ components: sinks: loki: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/new_relic_logs.cue
+++ b/docs/reference/components/sinks/new_relic_logs.cue
@@ -40,6 +40,7 @@ components: sinks: new_relic_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
+				headers:        			false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/new_relic_logs.cue
+++ b/docs/reference/components/sinks/new_relic_logs.cue
@@ -40,7 +40,7 @@ components: sinks: new_relic_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               30
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: {

--- a/docs/reference/components/sinks/prometheus_remote_write.cue
+++ b/docs/reference/components/sinks/prometheus_remote_write.cue
@@ -33,6 +33,7 @@ components: sinks: prometheus_remote_write: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/prometheus_remote_write.cue
+++ b/docs/reference/components/sinks/prometheus_remote_write.cue
@@ -33,7 +33,7 @@ components: sinks: prometheus_remote_write: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/sematext_logs.cue
+++ b/docs/reference/components/sinks/sematext_logs.cue
@@ -35,6 +35,7 @@ components: sinks: sematext_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: enabled: false
 			to: sinks._sematext.features.send.to

--- a/docs/reference/components/sinks/sematext_logs.cue
+++ b/docs/reference/components/sinks/sematext_logs.cue
@@ -35,7 +35,7 @@ components: sinks: sematext_logs: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: enabled: false
 			to: sinks._sematext.features.send.to

--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -44,7 +44,7 @@ components: sinks: splunk_hec: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
-				headers:        			false
+				headers:                    false
 			}
 			tls: {
 				enabled:                true

--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -44,6 +44,7 @@ components: sinks: splunk_hec: {
 				retry_initial_backoff_secs: 1
 				retry_max_duration_secs:    10
 				timeout_secs:               60
+				headers:        			false
 			}
 			tls: {
 				enabled:                true

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -22,6 +22,7 @@ use http::{
     Request, StatusCode, Uri,
 };
 use hyper::Body;
+use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use rusoto_core::Region;
 use rusoto_credential::{CredentialsError, ProvideAwsCredentials};
@@ -37,7 +38,7 @@ pub struct RequestConfig {
     #[serde(flatten)]
     pub tower: TowerRequestConfig,
     #[serde(default)]
-    pub headers: HashMap<String, String>,
+    pub headers: IndexMap<String, String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -65,7 +66,7 @@ pub struct ElasticSearchConfig {
     pub auth: Option<ElasticSearchAuth>,
 
     // Deprecated, moved to request.
-    pub headers: Option<HashMap<String, String>>,
+    pub headers: Option<IndexMap<String, String>>,
     pub query: Option<HashMap<String, String>>,
 
     pub aws: Option<RegionOrEndpoint>,

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -38,12 +38,22 @@ enum BuildError {
     },
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RequestConfig {
+    #[serde(flatten)]
+    pub tower: TowerRequestConfig,
+    #[serde(default)]
+    pub headers: IndexMap<String, String>,
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct HttpSinkConfig {
     pub uri: UriSerde,
     pub method: Option<HttpMethod>,
     pub auth: Option<Auth>,
+    // Deprecated, moved to request.
     pub headers: Option<IndexMap<String, String>>,
     #[serde(default)]
     pub compression: Compression,
@@ -51,7 +61,7 @@ pub struct HttpSinkConfig {
     #[serde(default)]
     pub batch: BatchConfig,
     #[serde(default)]
-    pub request: TowerRequestConfig,
+    pub request: RequestConfig,
     pub tls: Option<TlsOptions>,
 }
 
@@ -127,18 +137,23 @@ impl SinkConfig for HttpSinkConfig {
             None => future::ok(()).boxed(),
         };
 
-        let config = HttpSinkConfig {
+        let mut config = HttpSinkConfig {
             auth: self.auth.choose_one(&self.uri.auth)?,
             uri: self.uri.with_default_parts(),
             ..self.clone()
         };
-        validate_headers(&config.headers, &config.auth)?;
+
+        config.headers.take().map(|headers| {
+            warn!("`headers` option has been deprecated. Use `request.headers` instead.");
+            config.request.headers.extend(headers);
+        });
+        validate_headers(&config.request.headers, &config.auth)?;
 
         let batch = BatchSettings::default()
             .bytes(bytesize::mib(10u64))
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.tower.unwrap_with(&REQUEST_DEFAULTS);
 
         let sink = BatchedHttpSink::new(
             config,
@@ -244,10 +259,8 @@ impl HttpSink for HttpSinkConfig {
             Compression::None => {}
         }
 
-        if let Some(headers) = &self.headers {
-            for (header, value) in headers.iter() {
-                builder = builder.header(header.as_str(), value.as_str());
-            }
+        for (header, value) in self.request.headers.iter() {
+            builder = builder.header(header.as_str(), value.as_str());
         }
 
         let mut request = builder.body(body).unwrap();
@@ -277,23 +290,16 @@ async fn healthcheck(uri: UriSerde, auth: Option<Auth>, client: HttpClient) -> c
     }
 }
 
-fn validate_headers(
-    headers: &Option<IndexMap<String, String>>,
-    auth: &Option<Auth>,
-) -> crate::Result<()> {
-    if let Some(map) = headers {
-        for (name, value) in map {
-            if auth.is_some() && name.eq_ignore_ascii_case("Authorization") {
-                return Err(
-                    "Authorization header can not be used with defined auth options".into(),
-                );
-            }
-
-            HeaderName::from_bytes(name.as_bytes()).with_context(|| InvalidHeaderName { name })?;
-            HeaderValue::from_bytes(value.as_bytes())
-                .with_context(|| InvalidHeaderValue { value })?;
+fn validate_headers(map: &IndexMap<String, String>, auth: &Option<Auth>) -> crate::Result<()> {
+    for (name, value) in map {
+        if auth.is_some() && name.eq_ignore_ascii_case("Authorization") {
+            return Err("Authorization header can not be used with defined auth options".into());
         }
+
+        HeaderName::from_bytes(name.as_bytes()).with_context(|| InvalidHeaderName { name })?;
+        HeaderValue::from_bytes(value.as_bytes()).with_context(|| InvalidHeaderValue { value })?;
     }
+
     Ok(())
 }
 
@@ -360,13 +366,13 @@ mod tests {
         let config = r#"
         uri = "http://$IN_ADDR/frames"
         encoding = "text"
-        [headers]
+        [request.headers]
         Auth = "token:thing_and-stuff"
         X-Custom-Nonsense = "_%_{}_-_&_._`_|_~_!_#_&_$_"
         "#;
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
-        assert!(super::validate_headers(&config.headers, &None).is_ok());
+        assert!(super::validate_headers(&config.request.headers, &None).is_ok());
     }
 
     #[test]
@@ -374,13 +380,13 @@ mod tests {
         let config = r#"
         uri = "http://$IN_ADDR/frames"
         encoding = "text"
-        [headers]
+        [request.headers]
         "\u0001" = "bad"
         "#;
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         assert_downcast_matches!(
-            super::validate_headers(&config.headers, &None).unwrap_err(),
+            super::validate_headers(&config.request.headers, &None).unwrap_err(),
             BuildError,
             BuildError::InvalidHeaderName{..}
         );
@@ -394,7 +400,7 @@ mod tests {
         let config = r#"
         uri = "http://$IN_ADDR/"
         encoding = "text"
-        [headers]
+        [request.headers]
         Authorization = "Basic base64encodedstring"
         [auth]
         strategy = "basic"
@@ -527,7 +533,7 @@ mod tests {
         uri = "http://$IN_ADDR/frames"
         encoding = "ndjson"
         compression = "gzip"
-        [headers]
+        [request.headers]
         foo = "bar"
         baz = "quux"
     "#

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -1,9 +1,10 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     sinks::{
-        http::{HttpMethod, HttpSinkConfig, RequestConfig},
+        http::{HttpMethod, HttpSinkConfig},
         util::{
-            encoding::EncodingConfig, BatchConfig, Compression, Concurrency, TowerRequestConfig,
+            encoding::EncodingConfig, http::RequestConfig, BatchConfig, Compression, Concurrency,
+            TowerRequestConfig,
         },
     },
 };
@@ -209,8 +210,11 @@ mod tests {
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
         assert_eq!(http_config.batch.max_bytes, Some(MAX_PAYLOAD_SIZE));
-        assert_eq!(http_config.request.concurrency, Concurrency::Fixed(100));
-        assert_eq!(http_config.request.rate_limit_num, Some(100));
+        assert_eq!(
+            http_config.request.tower.concurrency,
+            Concurrency::Fixed(100)
+        );
+        assert_eq!(http_config.request.tower.rate_limit_num, Some(100));
         assert_eq!(
             http_config.headers.unwrap()["X-License-Key"],
             "foo".to_owned()
@@ -237,8 +241,11 @@ mod tests {
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
         assert_eq!(http_config.batch.max_bytes, Some(MAX_PAYLOAD_SIZE));
-        assert_eq!(http_config.request.concurrency, Concurrency::Fixed(12));
-        assert_eq!(http_config.request.rate_limit_num, Some(24));
+        assert_eq!(
+            http_config.request.tower.concurrency,
+            Concurrency::Fixed(12)
+        );
+        assert_eq!(http_config.request.tower.rate_limit_num, Some(24));
         assert_eq!(
             http_config.headers.unwrap()["X-Insert-Key"],
             "foo".to_owned()
@@ -272,8 +279,11 @@ mod tests {
         assert_eq!(http_config.method, Some(HttpMethod::Post));
         assert_eq!(http_config.encoding.codec(), &Encoding::Json.into());
         assert_eq!(http_config.batch.max_bytes, Some(838860));
-        assert_eq!(http_config.request.concurrency, Concurrency::Fixed(12));
-        assert_eq!(http_config.request.rate_limit_num, Some(24));
+        assert_eq!(
+            http_config.request.tower.concurrency,
+            Concurrency::Fixed(12)
+        );
+        assert_eq!(http_config.request.tower.rate_limit_num, Some(24));
         assert_eq!(
             http_config.headers.unwrap()["X-Insert-Key"],
             "foo".to_owned()

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -216,7 +216,7 @@ mod tests {
         );
         assert_eq!(http_config.request.tower.rate_limit_num, Some(100));
         assert_eq!(
-            http_config.headers.unwrap()["X-License-Key"],
+            http_config.request.headers["X-License-Key"],
             "foo".to_owned()
         );
         assert!(http_config.tls.is_none());
@@ -247,7 +247,7 @@ mod tests {
         );
         assert_eq!(http_config.request.tower.rate_limit_num, Some(24));
         assert_eq!(
-            http_config.headers.unwrap()["X-Insert-Key"],
+            http_config.request.headers["X-Insert-Key"],
             "foo".to_owned()
         );
         assert!(http_config.tls.is_none());
@@ -285,7 +285,7 @@ mod tests {
         );
         assert_eq!(http_config.request.tower.rate_limit_num, Some(24));
         assert_eq!(
-            http_config.headers.unwrap()["X-Insert-Key"],
+            http_config.request.headers["X-Insert-Key"],
             "foo".to_owned()
         );
         assert!(http_config.tls.is_none());

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     sinks::{
-        http::{HttpMethod, HttpSinkConfig},
+        http::{HttpMethod, HttpSinkConfig, RequestConfig},
         util::{
             encoding::EncodingConfig, BatchConfig, Compression, Concurrency, TowerRequestConfig,
         },
@@ -136,7 +136,7 @@ impl NewRelicLogsConfig {
             ..batch
         };
 
-        let request = TowerRequestConfig {
+        let tower = TowerRequestConfig {
             // The default throughput ceiling defaults are relatively
             // conservative so we crank them up for New Relic.
             concurrency: (self.request.concurrency).if_none(Concurrency::Fixed(100)),
@@ -144,11 +144,13 @@ impl NewRelicLogsConfig {
             ..self.request
         };
 
+        let request = RequestConfig { tower, headers };
+
         Ok(HttpSinkConfig {
             uri: uri.into(),
             method: Some(HttpMethod::Post),
             auth: None,
-            headers: Some(headers),
+            headers: None,
             compression: self.compression,
             encoding: self.encoding.clone().into_encoding(),
 

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -1,7 +1,7 @@
 use super::Region;
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    sinks::elasticsearch::{ElasticSearchConfig, Encoding},
+    sinks::elasticsearch::{ElasticSearchConfig, Encoding, RequestConfig},
     sinks::util::{
         encoding::EncodingConfigWithDefault, BatchConfig, Compression, TowerRequestConfig,
     },
@@ -69,7 +69,10 @@ impl SinkConfig for SematextLogsConfig {
             doc_type: Some("logs".to_string()),
             index: Some(self.token.clone()),
             batch: self.batch,
-            request: self.request,
+            request: RequestConfig {
+                tower: self.request,
+                ..Default::default()
+            },
             encoding: self.encoding.clone(),
             ..Default::default()
         }

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -1,9 +1,10 @@
 use super::Region;
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    sinks::elasticsearch::{ElasticSearchConfig, Encoding, RequestConfig},
+    sinks::elasticsearch::{ElasticSearchConfig, Encoding},
     sinks::util::{
-        encoding::EncodingConfigWithDefault, BatchConfig, Compression, TowerRequestConfig,
+        encoding::EncodingConfigWithDefault, http::RequestConfig, BatchConfig, Compression,
+        TowerRequestConfig,
     },
     sinks::{Healthcheck, VectorSink},
     Event,

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -416,10 +416,10 @@ pub struct RequestConfig {
 
 impl RequestConfig {
     pub fn add_old_option(&mut self, headers: Option<IndexMap<String, String>>) {
-        headers.map(|headers| {
+        if let Some(headers) = headers {
             warn!("`headers` option has been deprecated. Use `request.headers` instead.");
             self.headers.extend(headers);
-        });
+        }
     }
 }
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -1,13 +1,16 @@
 use super::{
     retries::{RetryAction, RetryLogic},
-    sink, Batch, Partition, TowerBatchedSink, TowerPartitionSink, TowerRequestSettings,
+    sink, Batch, Partition, TowerBatchedSink, TowerPartitionSink, TowerRequestConfig,
+    TowerRequestSettings,
 };
 use crate::{buffers::Acker, http::HttpClient, Event};
 use bytes::{Buf, Bytes};
 use futures::{future::BoxFuture, ready, Sink};
 use http::StatusCode;
 use hyper::{body, Body};
+use indexmap::IndexMap;
 use pin_project::pin_project;
+use serde::{Deserialize, Serialize};
 use std::{
     fmt,
     future::Future,
@@ -398,6 +401,25 @@ impl RetryLogic for HttpRetryLogic {
             _ if status.is_success() => RetryAction::Successful,
             _ => RetryAction::DontRetry(format!("response status: {}", status)),
         }
+    }
+}
+
+/// A helper config struct
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RequestConfig {
+    #[serde(flatten)]
+    pub tower: TowerRequestConfig,
+    #[serde(default)]
+    pub headers: IndexMap<String, String>,
+}
+
+impl RequestConfig {
+    pub fn add_old_option(&mut self, headers: Option<IndexMap<String, String>>) {
+        headers.map(|headers| {
+            warn!("`headers` option has been deprecated. Use `request.headers` instead.");
+            self.headers.extend(headers);
+        });
     }
 }
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -417,7 +417,7 @@ pub struct RequestConfig {
 impl RequestConfig {
     pub fn add_old_option(&mut self, headers: Option<IndexMap<String, String>>) {
         if let Some(headers) = headers {
-            warn!("`headers` option has been deprecated. Use `request.headers` instead.");
+            warn!("Option `headers` has been deprecated. Use `request.headers` instead.");
             self.headers.extend(headers);
         }
     }


### PR DESCRIPTION
Closes #4202 

Moves `headers` option in:
* `http` sink
* `elasticsearch` sink

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
