### PR TITLE
chore(dev): Fix docker installation in dev environment on arm64

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -85,7 +85,7 @@ if ! [ -x "$(command -v docker)" ]; then
     # Docker
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
     add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+        "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu \
         xenial \
         stable"
     # Install those new things

--- a/scripts/upgrade-docker.sh
+++ b/scripts/upgrade-docker.sh
@@ -12,7 +12,7 @@ sudo apt-get install \
   software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository \
- "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+ "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu \
  $(lsb_release -cs) \
  stable"
 sudo apt-get update


### PR DESCRIPTION
Small fix to the bootstrap / installation scripts which break on the Docker installation when running on an arm64 host / container.

Ran this on a machine with Apple's M1 chip and the [Docker Apple M1 Tech Preview](https://docs.docker.com/docker-for-mac/apple-m1/).