### PR TITLE
chore(external docs): Cleanup Remap categories

### DIFF
--- a/docs/reference/components/transforms/remap.cue
+++ b/docs/reference/components/transforms/remap.cue
@@ -4,7 +4,7 @@ components: transforms: remap: {
 	title: "Remap"
 
 	description: """
-		Transforms events using the [Vector Remap Language](\(urls.vector_remap_language_reference)),
+		Transforms events using the [Vector Remap Language](\(urls.vector_remap_language_reference)) (VRL),
 		a fast, safe, self-documenting data mapping language.
 		"""
 
@@ -41,16 +41,22 @@ components: transforms: remap: {
 
 	configuration: {
 		source: {
-			description: "The remap source/instruction set to execute for each event"
+			description: """
+				The [Vector Remap Language](\(urls.vector_remap_language_reference)) (VRL)
+				expression to execute for each event. Please refer to the
+				[Vector Remap Language reference](\(urls.vector_remap_language_reference))
+				for a list of operations and functions.
+				"""
 			required:    true
 			type: string: {
 				examples: [
 					"""
 						. = parse_json(.message)
+						.new_field = "new value"
 						.status = to_int(.status)
 						.duration = parse_duration(.duration, "s")
-						.new_field = .old_field
-						del(.old_field)
+						.new_name = .old_name
+						del(.old_name)
 						""",
 				]
 			}
@@ -338,18 +344,18 @@ components: transforms: remap: {
 
 	how_it_works: {
 		remap_language: {
-			title: "Remap Language"
+			title: "Vector Remap Language"
 			body: #"""
-				The remap language is a restrictive, fast, and safe language we
-				designed specifically for mapping data. It avoids the need to chain
-				together many fundamental transforms to accomplish rudimentary
+				The Vector Remap Language (VRL) is a restrictive, fast, and safe language we
+				designed specifically for mapping observability data. It avoids the need to
+				chain together many fundamental Vector transforms to accomplish rudimentary
 				reshaping of data.
 
-				The intent is to offer the same robustness of full language runtime
+				The intent is to offer the same robustness of full language runtime (ex: Lua)
 				without paying the performance or safety penalty.
 
-				Learn more about Vector's remap syntax in
-				[the docs](/docs/reference/remap).
+				Learn more about Vector's Remap Language in the
+				[Vector Remap Language reference](\(urls.vector_remap_language_reference)).
 				"""#
 		}
 	}

--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -49,7 +49,7 @@ remap: {
 
 			arguments: [...#Argument] // Allow for empty list
 			return: [#RemapReturnTypes, ...#RemapReturnTypes]
-			category:    "coerce" | "numeric" | "object" | "parse" | "text" | "hash" | "event" | "networking" | "encode"
+			category:    "Coerce" | "Encode" | "Enumerable" | "Event" | "Hash" | "IP" | "Map" | "Numeric" | "Parse" | "Random" | "String" | "Test" | "Timestamp"
 			description: string
 			examples?: [#RemapExample, ...#RemapExample]
 			name: Name

--- a/docs/reference/remap/assert.cue
+++ b/docs/reference/remap/assert.cue
@@ -16,7 +16,7 @@ remap: functions: assert: {
 		},
 	]
 	return: ["null"]
-	category: "event"
+	category: "Test"
 	description: #"""
 			Checks a given condition. If that condition evaluates to false the event is aborted with
 			an error message provided.

--- a/docs/reference/remap/ceil.cue
+++ b/docs/reference/remap/ceil.cue
@@ -17,7 +17,7 @@ remap: functions: ceil: {
 		},
 	]
 	return: ["timestamp"]
-	category: "numeric"
+	category: "Numeric"
 	description: #"""
 		Rounds the given number up to the given precision of decimal places.
 		"""#

--- a/docs/reference/remap/compact.cue
+++ b/docs/reference/remap/compact.cue
@@ -45,7 +45,7 @@ remap: functions: compact: {
 		},
 	]
 	return: ["array", "map"]
-	category: "text"
+	category: "Enumerable"
 	description: #"""
 		Compacts an `Array` or `Map` by removing empty values. What is considered an
 		empty value can be specified with the parameters, `null`, `string`, `map`, and

--- a/docs/reference/remap/contains.cue
+++ b/docs/reference/remap/contains.cue
@@ -23,7 +23,7 @@ remap: functions: contains: {
 		},
 	]
 	return: ["boolean"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Searches a string, `value` to determine if it contains a given `substring`.
 		The search can be optionally case insensitive.

--- a/docs/reference/remap/del.cue
+++ b/docs/reference/remap/del.cue
@@ -11,7 +11,7 @@ remap: functions: del: {
 		},
 	]
 	return: ["null"]
-	category: "event"
+	category: "Event"
 	description: #"""
 		Removed the fields specified by the given paths from the root `event` object. Multiple fields can be specified.
 		"""#

--- a/docs/reference/remap/downcase.cue
+++ b/docs/reference/remap/downcase.cue
@@ -10,7 +10,7 @@ remap: functions: downcase: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Returns a copy of `string` that has been converted into lowercase.
 		"""#

--- a/docs/reference/remap/encode_json.cue
+++ b/docs/reference/remap/encode_json.cue
@@ -12,7 +12,7 @@ remap: functions: encode_json: {
 		},
 	]
 	return: ["string"]
-	category: "encode"
+	category: "Encode"
 
 	description: "Returns the JSON representation of the argument."
 	examples: [

--- a/docs/reference/remap/ends_with.cue
+++ b/docs/reference/remap/ends_with.cue
@@ -23,7 +23,7 @@ remap: functions: ends_with: {
 		},
 	]
 	return: ["boolean"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Determines if a given string ends with a given `substring`.
 		The search can be optionally case insensitive.

--- a/docs/reference/remap/exists.cue
+++ b/docs/reference/remap/exists.cue
@@ -11,7 +11,7 @@ remap: functions: exists: {
 		},
 	]
 	return: ["boolean"]
-	category: "event"
+	category: "Event"
 	description: #"""
 		Checks if the given path exists. Nested paths and arrays can also be checked.
 		"""#

--- a/docs/reference/remap/flatten.cue
+++ b/docs/reference/remap/flatten.cue
@@ -10,7 +10,7 @@ remap: functions: flatten: {
 		},
 	]
 	return: ["array", "map"]
-	category: "object"
+	category: "Enumerable"
 	description: #"""
 		Returns a nested array or map that has been flattened to a single level.
 		"""#

--- a/docs/reference/remap/floor.cue
+++ b/docs/reference/remap/floor.cue
@@ -17,7 +17,7 @@ remap: functions: floor: {
 		},
 	]
 	return: ["timestamp"]
-	category: "numeric"
+	category: "Numeric"
 	description: #"""
 		Rounds the given number down to the given precision of decimal places.
 		"""#

--- a/docs/reference/remap/format_number.cue
+++ b/docs/reference/remap/format_number.cue
@@ -30,7 +30,7 @@ remap: functions: format_number: {
 		},
 	]
 	return: ["string"]
-	category: "coerce"
+	category: "Numeric"
 	description: #"""
 		Returns a string representation of the given number.
 		"""#

--- a/docs/reference/remap/format_timestamp.cue
+++ b/docs/reference/remap/format_timestamp.cue
@@ -16,7 +16,7 @@ remap: functions: format_timestamp: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "Timestamp"
 	description: #"""
 		Formats a `timestamp` as a given string.
 		The format string used is specified by the [Chrono library](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).

--- a/docs/reference/remap/includes.cue
+++ b/docs/reference/remap/includes.cue
@@ -16,7 +16,7 @@ remap: functions: includes: {
 		},
 	]
 	return: ["boolean"]
-	category: "parse"
+	category: "Enumerable"
 	description: """
 		Determines whether an item is contained in an array. The item can be of any type and arrays
 		can be of mixed types.

--- a/docs/reference/remap/ip_cidr_contains.cue
+++ b/docs/reference/remap/ip_cidr_contains.cue
@@ -16,7 +16,7 @@ remap: functions: ip_cidr_contains: {
 		},
 	]
 	return: ["boolean"]
-	category: "networking"
+	category: "IP"
 	description: #"""
 		Returns `true` if the given ip address is contained within the block referenced
 		by the given CIDR mask.

--- a/docs/reference/remap/ip_subnet.cue
+++ b/docs/reference/remap/ip_subnet.cue
@@ -19,7 +19,7 @@ remap: functions: ip_subnet: {
 		},
 	]
 	return: ["string"]
-	category: "networking"
+	category: "IP"
 	description: #"""
 		Extracts the subnet address from a given IP address using a supplied subnet mask or prefix length.
 		Works with both IPv4 and IPv6 addresses. The IP version for the mask must be the same as the

--- a/docs/reference/remap/ip_to_ipv6.cue
+++ b/docs/reference/remap/ip_to_ipv6.cue
@@ -10,7 +10,7 @@ remap: functions: ip_to_ipv6: {
 		},
 	]
 	return: ["string"]
-	category: "networking"
+	category: "IP"
 	description: #"""
 		Converts an address to an IPv6 address.
 		If the parameter is already an IPv6 address it is passed through

--- a/docs/reference/remap/ipv6_to_ipv4.cue
+++ b/docs/reference/remap/ipv6_to_ipv4.cue
@@ -10,7 +10,7 @@ remap: functions: ipv6_to_ipv4: {
 		},
 	]
 	return: ["string"]
-	category: "networking"
+	category: "IP"
 	description: #"""
 		Converts an IPv4 mapped IPv6 address to an IPv4 address.
 		This function will raise an error if the input address is not a compatible address.

--- a/docs/reference/remap/match.cue
+++ b/docs/reference/remap/match.cue
@@ -16,7 +16,7 @@ remap: functions: match: {
 		},
 	]
 	return: ["boolean"]
-	category: "text"
+	category: "String"
 	description: """
 		Determines whether a string matches the provided pattern.
 		"""
@@ -29,16 +29,18 @@ remap: functions: match: {
 			source: ".has_teapot = match(.phrase, /teapot/)"
 			output: {
 				has_teapot: true
+				phrase:     "I'm a little teapot"
 			}
 		},
 		{
 			title: "Unsuccessful match"
 			input: {
-				phrase: "life is but a dream"
+				phrase: "Life is but a dream"
 			}
 			source: ".has_teapot = match(.phrase, /teapot/)"
 			output: {
 				has_teapot: false
+				phrase:     "Life is but a dream"
 			}
 		},
 	]

--- a/docs/reference/remap/md5.cue
+++ b/docs/reference/remap/md5.cue
@@ -10,7 +10,7 @@ remap: functions: md5: {
 		},
 	]
 	return: ["string"]
-	category: "hash"
+	category: "Hash"
 	description: #"""
 		Calculates an md5 hash of a given string.
 		"""#

--- a/docs/reference/remap/merge.cue
+++ b/docs/reference/remap/merge.cue
@@ -23,7 +23,7 @@ remap: functions: merge: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "Map"
 	description: #"""
 		Merges the `from` map provided into the `to` path specified, which must specify an existing map.
 		If a key exists in both maps, the field from the `from` map is chosen.

--- a/docs/reference/remap/now.cue
+++ b/docs/reference/remap/now.cue
@@ -2,7 +2,7 @@ package metadata
 
 remap: functions: now: {
 	arguments: []
-	category: "text"
+	category: "Timestamp"
 	return: ["timestamp"]
 	description: #"""
 		Returns the current timestamp in the Utc timezone.

--- a/docs/reference/remap/only_fields.cue
+++ b/docs/reference/remap/only_fields.cue
@@ -11,7 +11,7 @@ remap: functions: only_fields: {
 		},
 	]
 	return: ["null"]
-	category: "event"
+	category: "Event"
 	description: #"""
 		Remove any fields that are *not* specified by the given paths from the root `event` object. Multiple fields can be specified.
 		"""#

--- a/docs/reference/remap/parse_aws_alb_log.cue
+++ b/docs/reference/remap/parse_aws_alb_log.cue
@@ -10,7 +10,7 @@ remap: functions: parse_aws_alb_log: {
 		},
 	]
 	return: ["map"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a Elastic Load Balancer Access log into it's constituent components.
 		"""#

--- a/docs/reference/remap/parse_aws_vpc_flow_log.cue
+++ b/docs/reference/remap/parse_aws_vpc_flow_log.cue
@@ -16,7 +16,7 @@ remap: functions: parse_aws_vpc_flow_log: {
 		},
 	]
 	return: ["map"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a [VPC Flow Logs]\(urls.aws_vpc_flow_logs\) into it's constituent components.
 		"""#

--- a/docs/reference/remap/parse_duration.cue
+++ b/docs/reference/remap/parse_duration.cue
@@ -16,7 +16,7 @@ remap: functions: parse_duration: {
 		},
 	]
 	return: ["float"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a string representing a duration and returns a number of this duration in another specified unit.
 

--- a/docs/reference/remap/parse_grok.cue
+++ b/docs/reference/remap/parse_grok.cue
@@ -23,7 +23,7 @@ remap: functions: parse_grok: {
 		},
 	]
 	return: ["map"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a string using the Rust [`grok` library](https://github.com/daschl/grok). All patterns
 		[listed here](https://github.com/daschl/grok/tree/master/patterns) are supported. It is recommended

--- a/docs/reference/remap/parse_json.cue
+++ b/docs/reference/remap/parse_json.cue
@@ -10,7 +10,7 @@ remap: functions: parse_json: {
 		},
 	]
 	return: ["boolean", "integer", "float", "string", "map", "array", "null"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Returns an `object` whose text representation is a JSON
 		payload in `string` form.

--- a/docs/reference/remap/parse_syslog.cue
+++ b/docs/reference/remap/parse_syslog.cue
@@ -8,7 +8,7 @@ remap: functions: parse_syslog: {
 		},
 	]
 	return: ["map"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a syslog message. The function makes a best effort to parse the various Syslog formats out in the wild.
 		This includes [RFC 6587][urls.syslog_6587], [RFC 5424][urls.syslog_5424], [RFC 3164][urls.syslog_3164], and other

--- a/docs/reference/remap/parse_timestamp.cue
+++ b/docs/reference/remap/parse_timestamp.cue
@@ -23,7 +23,7 @@ remap: functions: parse_timestamp: {
 
 	]
 	return: ["timestamp"]
-	category: "coerce"
+	category: "Parse"
 	description: #"""
 		Parses a string representing a timestamp using a provided format string. If the string is unable to be parsed, and a `default` is specified,
 		use this. `default` can be either a `string` or a `timestamp`. If a `string`, it is parsed and the result returned. If a `timestamp`, this

--- a/docs/reference/remap/parse_url.cue
+++ b/docs/reference/remap/parse_url.cue
@@ -10,7 +10,7 @@ remap: functions: parse_url: {
 		},
 	]
 	return: ["map"]
-	category: "parse"
+	category: "Parse"
 	description: #"""
 		Parses a url into it's constituent components.
 		"""#

--- a/docs/reference/remap/redact.cue
+++ b/docs/reference/remap/redact.cue
@@ -37,7 +37,7 @@ remap: functions: redact: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: """
 		Obscures sensitive data, such as personal identification numbers or credit card numbers, in
 		Vector event data.

--- a/docs/reference/remap/replace.cue
+++ b/docs/reference/remap/replace.cue
@@ -30,7 +30,7 @@ remap: functions: replace: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Replaces any matches of pattern with the provided string. Pattern can be either a fixed string or a regular expression.
 

--- a/docs/reference/remap/round.cue
+++ b/docs/reference/remap/round.cue
@@ -17,7 +17,7 @@ remap: functions: round: {
 		},
 	]
 	return: ["timestamp"]
-	category: "numeric"
+	category: "Numeric"
 	description: #"""
 		Rounds the given number to the given number of decimal places. Rounds up or down
 		depending on which is nearest. Numbers that are half way (5) are rounded up.

--- a/docs/reference/remap/sha1.cue
+++ b/docs/reference/remap/sha1.cue
@@ -10,7 +10,7 @@ remap: functions: sha1: {
 		},
 	]
 	return: ["string"]
-	category: "hash"
+	category: "Hash"
 	description: #"""
 		Calculates a sha1 hash of a given string.
 		"""#

--- a/docs/reference/remap/sha2.cue
+++ b/docs/reference/remap/sha2.cue
@@ -26,7 +26,7 @@ remap: functions: sha2: {
 		},
 	]
 	return: ["string"]
-	category: "hash"
+	category: "Hash"
 	description: #"""
 		Calculates a sha2 hash of a given string.
 		"""#

--- a/docs/reference/remap/sha3.cue
+++ b/docs/reference/remap/sha3.cue
@@ -24,7 +24,7 @@ remap: functions: sha3: {
 		},
 	]
 	return: ["string"]
-	category: "hash"
+	category: "Hash"
 	description: #"""
 		Calculates a sha3 hash of a given string.
 		"""#

--- a/docs/reference/remap/slice.cue
+++ b/docs/reference/remap/slice.cue
@@ -23,7 +23,7 @@ remap: functions: slice: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Returns a slice of the provided string or array between the `start` and `end` positions specified.
 

--- a/docs/reference/remap/split.cue
+++ b/docs/reference/remap/split.cue
@@ -22,7 +22,7 @@ remap: functions: split: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Splits the given string whenever a given pattern is matched. If `limit` is specified, after `limit` has been reached
 		the remainder of the string is returned unsplit.

--- a/docs/reference/remap/starts_with.cue
+++ b/docs/reference/remap/starts_with.cue
@@ -23,7 +23,7 @@ remap: functions: starts_with: {
 		},
 	]
 	return: ["boolean"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Determines if a given string begins with a given `substring`.
 		The search can be optionally case insensitive.

--- a/docs/reference/remap/strip_ansi_escape_codes.cue
+++ b/docs/reference/remap/strip_ansi_escape_codes.cue
@@ -10,7 +10,7 @@ remap: functions: strip_ansi_escape_codes: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Removes the any ANSI escape codes from the provided string.
 		"""#

--- a/docs/reference/remap/strip_whitespace.cue
+++ b/docs/reference/remap/strip_whitespace.cue
@@ -10,7 +10,7 @@ remap: functions: strip_whitespace: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Trims the whitespace from the start and end of the string. [Whitespace](https://en.wikipedia.org/wiki/Unicode_character_property#Whitespace) is any unicode character with the property `"WSpace=yes"`.
 		"""#

--- a/docs/reference/remap/to_float.cue
+++ b/docs/reference/remap/to_float.cue
@@ -8,7 +8,7 @@ remap: functions: to_float: {
 		},
 	]
 	return: ["float"]
-	category: "coerce"
+	category: "Coerce"
 	description: #"""
 		Returns a `float` whose text representation is `string`.
 		"""#

--- a/docs/reference/remap/to_int.cue
+++ b/docs/reference/remap/to_int.cue
@@ -8,7 +8,7 @@ remap: functions: to_int: {
 		},
 	]
 	return: ["integer"]
-	category: "coerce"
+	category: "Coerce"
 	description: #"""
 		Returns an `integer` whose text representation is `string`.
 		"""#

--- a/docs/reference/remap/to_string.cue
+++ b/docs/reference/remap/to_string.cue
@@ -18,8 +18,7 @@ remap: functions: to_string: {
 		},
 	]
 	return: ["string"]
-	category: "coerce"
-
+	category: "Coerce"
 	description: #"""
 		Returns the string representation of the first parameter. If this parameter is an error, then
 		the second parameter is returned.

--- a/docs/reference/remap/to_syslog_level.cue
+++ b/docs/reference/remap/to_syslog_level.cue
@@ -10,7 +10,7 @@ remap: functions: to_syslog_level: {
 		},
 	]
 	return: ["string"]
-	category:    "parse"
+	category:    "Coerce"
 	description: """
 		Converts a Syslog [severity level](\(urls.syslog_levels)) into its corresponding keyword,
 		i.e. 0 into `"emerg"`, 1 into `"alert", etc.

--- a/docs/reference/remap/to_syslog_severity.cue
+++ b/docs/reference/remap/to_syslog_severity.cue
@@ -11,7 +11,7 @@ remap: functions: to_syslog_severity: {
 	]
 
 	return: ["integer"]
-	category:    "parse"
+	category:    "Coerce"
 	description: """
 		Converts a Syslog [log level keyword](\(urls.syslog_levels)) into an integer severity level
 		(0 to 7). Throws an error if the level isn't recognized. The now-deprecated keywords

--- a/docs/reference/remap/to_timestamp.cue
+++ b/docs/reference/remap/to_timestamp.cue
@@ -14,7 +14,7 @@ remap: functions: to_timestamp: {
 		},
 	]
 	return: ["timestamp"]
-	category: "coerce"
+	category: "Coerce"
 	description: #"""
 		Returns a `timestamp` from the parameters. If parameter is `string`, the timestamp is parsed in these formats.
 		If parameter is `integer`, the timestamp is takes as that number of seconds after January 1st 1970.

--- a/docs/reference/remap/tokenize.cue
+++ b/docs/reference/remap/tokenize.cue
@@ -10,7 +10,7 @@ remap: functions: tokenize: {
 		},
 	]
 	return: ["array"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Splits the string up into an array of tokens. A token is considered to be:
 		- A word surrounded by whitespace.

--- a/docs/reference/remap/truncate.cue
+++ b/docs/reference/remap/truncate.cue
@@ -22,7 +22,7 @@ remap: functions: truncate: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Truncates a string after a given number of characters. If `limit` is larger than the length of the string,
 		the string is returned unchanged.

--- a/docs/reference/remap/upcase.cue
+++ b/docs/reference/remap/upcase.cue
@@ -10,7 +10,7 @@ remap: functions: upcase: {
 		},
 	]
 	return: ["string"]
-	category: "text"
+	category: "String"
 	description: #"""
 		Returns a copy of `string` that has been converted into uppercase.
 		"""#

--- a/docs/reference/remap/uuid_v4.cue
+++ b/docs/reference/remap/uuid_v4.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: uuid_v4: {
 	arguments: []
 	return: ["string"]
-	category: "text"
+	category: "Random"
 	description: #"""
 		Returns a random UUID (Universally Unique Identifier).
 		"""#


### PR DESCRIPTION
This cleans up the Remap doc's categories. Some were mis classified and I tried to align them with Remap's types where possible.