### PR TITLE
fix: Fixup version script

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,6 +10,6 @@ set -euo pipefail
 #   An optional "nightly" suffix is added if the build channel
 #   is nightly.
 
-VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
+VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 echo "$VERSION"


### PR DESCRIPTION
On some awks it was failing due to an unnecessary escape! So we removed it.

Fixes https://github.com/timberio/vector/issues/5306