### PR TITLE
enhancement(remap): Enable casting timestamps into integers

### DIFF
--- a/docs/reference/remap/to_int.cue
+++ b/docs/reference/remap/to_int.cue
@@ -8,7 +8,7 @@ remap: functions: to_int: {
 				* If a string, it must be the string representation of an integer or else an error
 					is raised.
 				* If a Boolean, returns `0` for `false` and `1` for `true`.
-				* If a timestamp, returns the [Unix timestamp](\(urls.unix_timestamp)).
+				* If a timestamp, returns the [Unix timestamp](\(urls.unix_timestamp)) in seconds.
 				"""
 			required:    true
 			type: ["integer", "float", "boolean", "string", "timestamp"]

--- a/docs/reference/remap/to_int.cue
+++ b/docs/reference/remap/to_int.cue
@@ -2,9 +2,16 @@ remap: functions: to_int: {
 	arguments: [
 		{
 			name:        "value"
-			description: "The string that is to be converted to an int. Must be the string representation of an `int`, otherwise, an `ArgumentError` will be raised."
+			description: """
+				The value to convert to an integer.
+
+				* If a string, it must be the string representation of an integer or else an error
+					is raised.
+				* If a Boolean, returns `0` for `false` and `1` for `true`.
+				* If a timestamp, returns the [Unix timestamp](\(urls.unix_timestamp)).
+				"""
 			required:    true
-			type: ["integer", "float", "boolean", "string"]
+			type: ["integer", "float", "boolean", "string", "timestamp"]
 		},
 	]
 	return: ["integer"]
@@ -31,6 +38,16 @@ remap: functions: to_int: {
 			source: ".integer = to_int(.integer)"
 			output: {
 				error: remap.errors.ArgumentError
+			}
+		},
+		{
+			title: "Timestamp"
+			input: {
+				timestamp: "2020-12-30 22:20:53.824727 UTC"
+			}
+			source: ".timestamp = to_int(.timestamp)"
+			output: {
+				timestamp: 1609366853
 			}
 		},
 	]

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -51,9 +51,7 @@ impl Expression for ToIntFn {
                 .convert(v)
                 .map_err(|e| e.to_string().into()),
             Timestamp(v) => Ok(v.timestamp().into()),
-            Array(_) | Map(_) | Regex(_) => {
-                Err("unable to convert value to integer".into())
-            }
+            Array(_) | Map(_) | Regex(_) => Err("unable to convert value to integer".into()),
         }
     }
 
@@ -62,7 +60,9 @@ impl Expression for ToIntFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Timestamp | Kind::Null)
+            .fallible_unless(
+                Kind::Integer | Kind::Float | Kind::Boolean | Kind::Timestamp | Kind::Null,
+            )
             .with_constraint(Kind::Integer)
     }
 }
@@ -70,8 +70,8 @@ impl Expression for ToIntFn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use value::Kind;
     use chrono::{DateTime, Utc};
+    use value::Kind;
 
     remap::test_type_def![
         boolean_infallible {
@@ -138,7 +138,7 @@ mod tests {
                 ],
                 Ok(Value::Integer(1571227200)),
                 ToIntFn::new(Box::new(Path::from("foo"))),
-            )
+            ),
         ];
 
         let mut state = state::Program::default();

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -10,39 +10,29 @@ impl Function for ToInt {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[
-            Parameter {
-                keyword: "value",
-                accepts: crate::util::is_scalar_value,
-                required: true,
-            },
-            Parameter {
-                keyword: "default",
-                accepts: crate::util::is_scalar_value,
-                required: false,
-            },
-        ]
+        &[Parameter {
+            keyword: "value",
+            accepts: crate::util::is_scalar_value,
+            required: true,
+        }]
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let value = arguments.required("value")?.boxed();
-        let default = arguments.optional("default").map(Expr::boxed);
 
-        Ok(Box::new(ToIntFn { value, default }))
+        Ok(Box::new(ToIntFn { value }))
     }
 }
 
 #[derive(Debug, Clone)]
 struct ToIntFn {
     value: Box<dyn Expression>,
-    default: Option<Box<dyn Expression>>,
 }
 
 impl ToIntFn {
     #[cfg(test)]
-    fn new(value: Box<dyn Expression>, default: Option<Value>) -> Self {
-        let default = default.map(|v| Box::new(Literal::from(v)) as _);
-        Self { value, default }
+    fn new(value: Box<dyn Expression>) -> Self {
+        Self { value }
     }
 }
 
@@ -50,7 +40,9 @@ impl Expression for ToIntFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Value::*;
 
-        let to_int = |value| match value {
+        let value = self.value.execute(state, object)?;
+
+        match value {
             Integer(_) => Ok(value),
             Float(v) => Ok(Integer(v as i64)),
             Boolean(v) => Ok(Integer(if v { 1 } else { 0 })),
@@ -58,16 +50,11 @@ impl Expression for ToIntFn {
             Bytes(v) => Conversion::Integer
                 .convert(v)
                 .map_err(|e| e.to_string().into()),
-            Array(_) | Map(_) | Timestamp(_) | Regex(_) => {
+            Timestamp(v) => Ok(v.timestamp().into()),
+            Array(_) | Map(_) | Regex(_) => {
                 Err("unable to convert value to integer".into())
             }
-        };
-
-        crate::util::convert_value_or_default(
-            self.value.execute(state, object),
-            self.default.as_ref().map(|v| v.execute(state, object)),
-            to_int,
-        )
+        }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -75,12 +62,7 @@ impl Expression for ToIntFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Null)
-            .merge_with_default_optional(self.default.as_ref().map(|default| {
-                default
-                    .type_def(state)
-                    .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Null)
-            }))
+            .fallible_unless(Kind::Integer | Kind::Float | Kind::Boolean | Kind::Timestamp | Kind::Null)
             .with_constraint(Kind::Integer)
     }
 }
@@ -89,103 +71,47 @@ impl Expression for ToIntFn {
 mod tests {
     use super::*;
     use value::Kind;
+    use chrono::{DateTime, Utc};
 
     remap::test_type_def![
         boolean_infallible {
-            expr: |_| ToIntFn { value: Literal::from(true).boxed(), default: None },
+            expr: |_| ToIntFn { value: Literal::from(true).boxed() },
             def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         integer_infallible {
-            expr: |_| ToIntFn { value: Literal::from(1).boxed(), default: None },
+            expr: |_| ToIntFn { value: Literal::from(1).boxed() },
             def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         float_infallible {
-            expr: |_| ToIntFn { value: Literal::from(1.0).boxed(), default: None },
+            expr: |_| ToIntFn { value: Literal::from(1.0).boxed() },
             def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         null_infallible {
-            expr: |_| ToIntFn { value: Literal::from(()).boxed(), default: None },
+            expr: |_| ToIntFn { value: Literal::from(()).boxed() },
             def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         string_fallible {
-            expr: |_| ToIntFn { value: Literal::from("foo").boxed(), default: None },
+            expr: |_| ToIntFn { value: Literal::from("foo").boxed() },
             def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         map_fallible {
-            expr: |_| ToIntFn { value: map!{}.boxed(), default: None },
+            expr: |_| ToIntFn { value: map!{}.boxed() },
             def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         array_fallible {
-            expr: |_| ToIntFn { value: array![].boxed(), default: None },
+            expr: |_| ToIntFn { value: array![].boxed() },
             def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         timestamp_infallible {
-            expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
-        }
-
-        fallible_value_without_default {
-            expr: |_| ToIntFn { value: Variable::new("foo".to_owned(), None).boxed(), default: None },
-            def: TypeDef {
-                fallible: true,
-                kind: Kind::Integer,
-                ..Default::default()
-            },
-        }
-
-       fallible_value_with_fallible_default {
-            expr: |_| ToIntFn {
-                value: array![].boxed(),
-                default: Some(array![].boxed()),
-            },
-            def: TypeDef {
-                fallible: true,
-                kind: Kind::Integer,
-                ..Default::default()
-            },
-        }
-
-       fallible_value_with_infallible_default {
-            expr: |_| ToIntFn {
-                value: array![].boxed(),
-                default: Some(Literal::from(1).boxed()),
-            },
-            def: TypeDef {
-                fallible: false,
-                kind: Kind::Integer,
-                ..Default::default()
-            },
-        }
-
-        infallible_value_with_fallible_default {
-            expr: |_| ToIntFn {
-                value: Literal::from(1).boxed(),
-                default: Some(array![].boxed()),
-            },
-            def: TypeDef {
-                fallible: false,
-                kind: Kind::Integer,
-                ..Default::default()
-            },
-        }
-
-        infallible_value_with_infallible_default {
-            expr: |_| ToIntFn {
-                value: Literal::from(1).boxed(),
-                default: Some(Literal::from(1).boxed()),
-            },
-            def: TypeDef {
-                fallible: false,
-                kind: Kind::Integer,
-                ..Default::default()
-            },
+            expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed() },
+            def: TypeDef { fallible: false, kind: Kind::Integer, ..Default::default() },
         }
     ];
 
@@ -195,20 +121,24 @@ mod tests {
 
         let cases = vec![
             (
-                map![],
-                Ok(Value::Integer(10)),
-                ToIntFn::new(Array::from(vec![0]).boxed(), Some(10.into())),
-            ),
-            (
                 map!["foo": "20"],
                 Ok(Value::Integer(20)),
-                ToIntFn::new(Box::new(Path::from("foo")), None),
+                ToIntFn::new(Box::new(Path::from("foo"))),
             ),
             (
                 map!["foo": 20.5],
                 Ok(Value::Integer(20)),
-                ToIntFn::new(Box::new(Path::from("foo")), None),
+                ToIntFn::new(Box::new(Path::from("foo"))),
             ),
+            (
+                map![
+                    "foo": DateTime::parse_from_rfc2822("Wed, 16 Oct 2019 12:00:00 +0000")
+                            .unwrap()
+                            .with_timezone(&Utc),
+                ],
+                Ok(Value::Integer(1571227200)),
+                ToIntFn::new(Box::new(Path::from("foo"))),
+            )
         ];
 
         let mut state = state::Program::default();

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -12,7 +12,7 @@ impl Function for ToInt {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: crate::util::is_scalar_value,
+            accepts: |v| matches!(v, Value::Integer(_) | Value::Float(_) | Value::Bytes(_) | Value::Boolean(_) | Value::Timestamp(_) | Value::Null),
             required: true,
         }]
     }

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -61,7 +61,12 @@ impl Expression for ToIntFn {
         self.value
             .type_def(state)
             .fallible_unless(
-                Kind::Integer | Kind::Float | Kind::Bytes | Kind::Boolean | Kind::Timestamp | Kind::Null,
+                Kind::Integer
+                    | Kind::Float
+                    | Kind::Bytes
+                    | Kind::Boolean
+                    | Kind::Timestamp
+                    | Kind::Null,
             )
             .with_constraint(Kind::Integer)
     }

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -61,7 +61,7 @@ impl Expression for ToIntFn {
         self.value
             .type_def(state)
             .fallible_unless(
-                Kind::Integer | Kind::Float | Kind::Boolean | Kind::Timestamp | Kind::Null,
+                Kind::Integer | Kind::Float | Kind::Bytes | Kind::Boolean | Kind::Timestamp | Kind::Null,
             )
             .with_constraint(Kind::Integer)
     }

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -101,7 +101,12 @@ mod tests {
 
         string_fallible {
             expr: |_| ToIntFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
+        }
+
+        timestamp_infallible {
+            expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed() },
+            def: TypeDef { kind: Kind::Integer, ..Default::default() },
         }
 
         map_fallible {
@@ -112,11 +117,6 @@ mod tests {
         array_fallible {
             expr: |_| ToIntFn { value: array![].boxed() },
             def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
-        }
-
-        timestamp_infallible {
-            expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed() },
-            def: TypeDef { fallible: false, kind: Kind::Integer, ..Default::default() },
         }
     ];
 


### PR DESCRIPTION
Closes #5730.

Enables users to pass timestamps to the `to_int` function to get the Unix time elapsed rather than needing to use `format_timestamp` and pass in `%s` as the format. The discussion around this appears to be a bit unsettled so I'm happy to defer to others on the desired end state here.