### PR TITLE
chore(ci): Set DEBIAN_FRONTEND for nightly and release workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ env:
   CHANNEL: nightly
   VERBOSE: true
   CI: true
+  DEBIAN_FRONTEND: noninteractive
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   AUTOINSTALL: true
   VERBOSE: true
   CI: true
+  DEBIAN_FRONTEND: noninteractive
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:


### PR DESCRIPTION
To avoid apt prompting for things like configuring tzdata

Should fix https://github.com/timberio/vector/runs/1620351155?check_suite_focus=true#step:4:594

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
