### PR TITLE
chore: add clippy rule trivially_copy_pass_by_ref

### DIFF
--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -57,7 +57,7 @@ fn value_eq(this: &Value, other: &Value) -> bool {
         (Value::Timestamp(this), Value::Timestamp(other)) => this.eq(other),
         (Value::Null, Value::Null) => true,
         // Non-trivial.
-        (Value::Float(this), Value::Float(other)) => f64_eq(this, other),
+        (Value::Float(this), Value::Float(other)) => f64_eq(*this, *other),
         (Value::Array(this), Value::Array(other)) => array_eq(&this, &other),
         (Value::Map(this), Value::Map(other)) => map_eq(this, other),
         // Type mismatch.
@@ -66,7 +66,7 @@ fn value_eq(this: &Value, other: &Value) -> bool {
 }
 
 // Does an f64 comparison that is suitable for discriminant purposes.
-fn f64_eq(this: &f64, other: &f64) -> bool {
+fn f64_eq(this: f64, other: f64) -> bool {
     if this.is_nan() && other.is_nan() {
         return true;
     }
@@ -124,7 +124,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &Value) {
         Value::Integer(val) => val.hash(hasher),
         Value::Timestamp(val) => val.hash(hasher),
         // Non-trivial.
-        Value::Float(val) => hash_f64(hasher, val),
+        Value::Float(val) => hash_f64(hasher, *val),
         Value::Array(val) => hash_array(hasher, &val),
         Value::Map(val) => hash_map(hasher, val),
         Value::Null => hash_null(hasher),
@@ -132,7 +132,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &Value) {
 }
 
 // Does f64 hashing that is suitable for discriminant purposes.
-fn hash_f64<H: Hasher>(hasher: &mut H, value: &f64) {
+fn hash_f64<H: Hasher>(hasher: &mut H, value: f64) {
     hasher.write(&value.to_ne_bytes());
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -9,7 +9,7 @@ pub(crate) enum SocketMode {
 }
 
 impl SocketMode {
-    fn as_str(&self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             Self::Tcp => "tcp",
             Self::Udp => "udp",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
 #![deny(clippy::clone_on_ref_ptr)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 extern crate tracing;

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -209,14 +209,14 @@ fn query_arithmetic_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Functio
 fn query_function_from_pairs(mut pairs: Pairs<Rule>) -> Result<Box<dyn query::Function>> {
     let name = pairs.next().ok_or(TOKEN_ERR)?.as_span().as_str();
     let signature = FunctionSignature::from_str(name)?;
-    let arguments = function_arguments_from_pairs(pairs, &signature)?;
+    let arguments = function_arguments_from_pairs(pairs, signature)?;
 
     signature.into_boxed_function(arguments)
 }
 
 fn function_arguments_from_pairs(
     mut pairs: Pairs<Rule>,
-    signature: &FunctionSignature,
+    signature: FunctionSignature,
 ) -> Result<ArgumentList> {
     let mut arguments = ArgumentList::new();
 
@@ -288,7 +288,7 @@ fn positional_item_from_pair(
     pair: Pair<Rule>,
     list: &mut ArgumentList,
     index: usize,
-    signature: &FunctionSignature,
+    signature: FunctionSignature,
 ) -> Result<()> {
     let parameter = signature.parameters().get(index).cloned().ok_or(format!(
         "unknown positional argument '{}' for function: '{}'",
@@ -346,7 +346,7 @@ fn regex_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>> {
 fn keyword_item_from_pair(
     pair: Pair<Rule>,
     list: &mut ArgumentList,
-    signature: &FunctionSignature,
+    signature: FunctionSignature,
 ) -> Result<()> {
     let mut pairs = pair.into_inner();
     let keyword = pairs.next().ok_or(TOKEN_ERR)?.as_span().as_str();

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -6,7 +6,7 @@ pub mod proto {
     pub use metric_metadata::MetricType;
 
     impl MetricType {
-        pub fn as_str(&self) -> &'static str {
+        pub fn as_str(self) -> &'static str {
             match self {
                 MetricType::Counter => "counter",
                 MetricType::Gauge => "gauge",

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -132,7 +132,7 @@ enum Encoding {
 }
 
 impl Encoding {
-    fn content_type(&self) -> &'static str {
+    fn content_type(self) -> &'static str {
         match self {
             Self::Text => "text/plain",
             Self::Ndjson => "application/x-ndjson",


### PR DESCRIPTION
While checked [needless_lifetime](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes) rule in https://github.com/timberio/vector/pull/5771#discussion_r550790780 found that [trivially_copy_pass_by_ref](https://rust-lang.github.io/rust-clippy/master/#trivially_copy_pass_by_ref) can be useful.