### PR TITLE
chore(ci): Refactor Docker build and release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -279,6 +279,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
+          install: true
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,6 +206,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - run: |
           apt-get update && \
           apt-get install -y \
@@ -273,11 +275,19 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
+          name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v2
+        with:
           name: vector-${{ env.VECTOR_VERSION }}-amd64.deb
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v2
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-armhf.deb
           path: target/artifacts
       - env:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -257,6 +257,8 @@ jobs:
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+      - build-armv7-unknown-linux-gnueabihf-packages
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,8 +206,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - run: |
           apt-get update && \
           apt-get install -y \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -259,6 +259,7 @@ jobs:
       - build-x86_64-unknown-linux-musl-packages
       - build-armv7-unknown-linux-musleabihf-packages
       - build-armv7-unknown-linux-gnueabihf-packages
+      - deb-verify
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -269,7 +269,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.CI_DOCKER_USERNAME }}
-          password: ${{ secrets.CI_DOCKER_PASSWORD }
+          password: ${{ secrets.CI_DOCKER_PASSWORD }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -265,6 +265,20 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.CI_DOCKER_USERNAME }}
+          password: ${{ secrets.CI_DOCKER_PASSWORD }
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz
@@ -290,11 +304,8 @@ jobs:
           name: vector-${{ env.VECTOR_VERSION }}-armhf.deb
           path: target/artifacts
       - env:
-          DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
-          DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
           PLATFORM: "linux/amd64,linux/arm64,linux/arm/v7"
         run: |
-          ./scripts/upgrade-docker.sh
           make release-docker
 
   release-s3:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,6 @@ jobs:
           path: target/artifacts
       - run: |
           rpm -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
-
   release-docker:
     runs-on: ubuntu-latest
     needs:
@@ -274,11 +273,19 @@ jobs:
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
+          name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-musleabihf.tar.gz
+          path: target/artifacts
+      - uses: actions/download-artifact@v2
+        with:
           name: vector-${{ env.VECTOR_VERSION }}-amd64.deb
           path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
+          path: target/artifacts
+      - uses: actions/download-artifact@v2
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-armhf.deb
           path: target/artifacts
       - env:
           DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,7 @@ jobs:
           path: target/artifacts
       - run: |
           rpm -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
+
   release-docker:
     runs-on: ubuntu-latest
     needs:
@@ -263,6 +264,21 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.CI_DOCKER_USERNAME }}
+          password: ${{ secrets.CI_DOCKER_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz
@@ -288,11 +304,8 @@ jobs:
           name: vector-${{ env.VECTOR_VERSION }}-armhf.deb
           path: target/artifacts
       - env:
-          DOCKER_USERNAME: "${{ secrets.CI_DOCKER_USERNAME }}"
-          DOCKER_PASSWORD: "${{ secrets.CI_DOCKER_PASSWORD }}"
           PLATFORM: "linux/amd64,linux/arm64,linux/arm/v7"
         run: |
-          ./scripts/upgrade-docker.sh
           make release-docker
 
   release-s3:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,8 @@ jobs:
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
+      - build-armv7-unknown-linux-musleabihf-packages
+      - build-armv7-unknown-linux-gnueabihf-packages
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,6 @@ jobs:
           name: vector-${{ env.VECTOR_VERSION }}-x64.msi
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x64.msi"
 
-
   deb-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
@@ -261,6 +260,7 @@ jobs:
       - build-x86_64-unknown-linux-musl-packages
       - build-armv7-unknown-linux-musleabihf-packages
       - build-armv7-unknown-linux-gnueabihf-packages
+      - deb-verify
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -1081,7 +1081,7 @@ release-commit: ## Commits release changes
 
 .PHONY: release-docker
 release-docker: ## Release to Docker Hub
-	@scripts/release-docker.sh
+	@scripts/build-docker.sh
 
 .PHONY: release-github
 release-github: ## Release to Github

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.12 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl.tar.gz --strip-components=2
+RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
 FROM alpine:3.12
 RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,14 +1,13 @@
-FROM alpine:3.12 AS builder
+FROM debian:buster-slim AS builder
 
-WORKDIR /vector
-
-COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
+COPY vector-*.deb ./
+RUN dpkg -i vector-*-$(dpkg --print-architecture).deb
 
 FROM gcr.io/distroless/cc-debian10
 
-COPY --from=builder /vector/bin/vector /usr/bin/vector
-COPY --from=builder /vector/config /etc/vector
+COPY --from=builder /usr/bin/vector /usr/bin/vector
+COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
+COPY --from=builder /etc/vector /etc/vector
 VOLUME /var/lib/vector/
 
 # Smoke test

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,13 +1,14 @@
-FROM debian:buster-slim AS builder
+FROM alpine:3.12 AS builder
 
-COPY vector-*.deb ./
-RUN dpkg -i vector-*-$(dpkg --print-architecture).deb
+WORKDIR /vector
+
+COPY vector-*-unknown-linux-musl*.tar.gz ./
+RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
 FROM gcr.io/distroless/cc-debian10
 
-COPY --from=builder /usr/bin/vector /usr/bin/vector
-COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
-COPY --from=builder /etc/vector /etc/vector
+COPY --from=builder /vector/bin/vector /usr/bin/vector
+COPY --from=builder /vector/config /etc/vector
 VOLUME /var/lib/vector/
 
 # Smoke test

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -7,11 +7,11 @@ RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-c
 
 FROM gcr.io/distroless/static
 
-COPY --from=builder /vector/bin/vector /usr/bin/vector
-COPY --from=builder /vector/config /etc/vector
+COPY --from=builder /vector/bin/* /usr/local/bin/
+COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
 VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]
 
-ENTRYPOINT ["/usr/bin/vector"]
+ENTRYPOINT ["/usr/local/bin/vector"]

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -1,17 +1,17 @@
-FROM debian:buster-slim AS builder
+FROM alpine:3.12 AS builder
 
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf vector-0*-$(dpkg --print-architecture)-unknown-linux-musl*.tar.gz --strip-components=2
+RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
 FROM gcr.io/distroless/static
 
-COPY --from=builder /vector/bin/* /usr/local/bin/
-COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
+COPY --from=builder /vector/bin/vector /usr/bin/vector
+COPY --from=builder /vector/config /etc/vector
 VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]
 
-ENTRYPOINT ["/usr/local/bin/vector"]
+ENTRYPOINT ["/usr/bin/vector"]

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:buster-slim AS builder
 
 WORKDIR /vector
 
-COPY vector-*-x86_64-unknown-linux-musl.tar.gz ./
-RUN tar -xvf vector-*-x86_64-unknown-linux-musl.tar.gz --strip-components=2
+COPY vector-*-unknown-linux-musl*.tar.gz ./
+RUN tar -xvf vector-0*-$(dpkg --print-architecture)-unknown-linux-musl*.tar.gz --strip-components=2
 
 FROM gcr.io/distroless/static
 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -13,7 +13,6 @@ set -x
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 DATE="${DATE:-"$(date -u +%Y-%m-%d)"}"
-PUSH="${PUSH:-}"
 PLATFORM="${PLATFORM:-}"
 REPO="${REPO:-"timberio/vector"}"
 
@@ -29,31 +28,17 @@ build() {
   local DOCKERFILE="distribution/docker/$BASE/Dockerfile"
 
   if [ -n "$PLATFORM" ]; then
-    export DOCKER_CLI_EXPERIMENTAL=enabled
-    docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
-    docker buildx rm vector-builder || true
-    docker buildx create --use --name vector-builder
-    docker buildx install
-
-    ARGS=()
-    if [[ -n "${PUSH:-}" ]]; then
-      ARGS+=(--push)
-    fi
-
     docker buildx build \
       --platform="$PLATFORM" \
       --tag "$TAG" \
       target/artifacts \
-      -f "$DOCKERFILE" "${ARGS[@]}"
+      -f "$DOCKERFILE" --push
   else
     docker build \
       --tag "$TAG" \
       target/artifacts \
       -f "$DOCKERFILE"
-
-    if [ -n "$PUSH" ]; then
       docker push "$TAG"
-    fi
   fi
 }
 

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-PUSH=1 ./scripts/build-docker.sh

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -104,7 +104,6 @@ if [[ -z "${CONTAINER_IMAGE:-}" ]]; then
       CHANNEL="test" \
       BASE="$BASE_TAG" \
       TAG="$VERSION_TAG" \
-      PUSH="" \
       scripts/build-docker.sh
 
     # Prepare the container image for the deployment command.


### PR DESCRIPTION
Our Docker build and release process relies on a twisty-path of shell scripts. This removes several pieces from the shell scripts and puts them into GitHub Actions actions inside our nightly and release workflow. Specifically, we remove the qemu and buildx steps from the script and replace them with actions. 

Signed-off-by: James Turnbull <james@lovedthanlost.net>