### PR TITLE
chore(deps): update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg 0.1.2",
+ "rand_pcg",
  "rand_xorshift",
  "winapi 0.3.9",
 ]
@@ -4835,7 +4835,18 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76330fb486679b4ace3670f117bbc9e16204005c4bde9c4bd372f45bed34f12"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.0",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -4856,6 +4867,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.0",
 ]
 
 [[package]]
@@ -4883,13 +4904,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.3.0"
+name = "rand_core"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
+checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
+dependencies = [
+ "getrandom 0.2.0",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9e8f32ad24fb80d07d2323a9a2ce8b30d68a62b8cb4df88119ff49a698f038"
 dependencies = [
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.0",
 ]
 
 [[package]]
@@ -4908,6 +4938,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.0",
 ]
 
 [[package]]
@@ -4952,15 +4991,6 @@ checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
  "autocfg 0.1.7",
  "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7364,7 +7394,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "pulsar",
- "rand 0.7.3",
+ "rand 0.8.0",
  "rand_distr",
  "rdkafka",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "approx"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,6 +2977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7353,7 +7362,7 @@ dependencies = [
  "indexmap",
  "indoc",
  "inventory",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "jemallocator",
  "k8s-openapi",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.1",
  "lazy_static",
  "proc-macro-hack",
  "tiny-keccak",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "derivative"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+checksum = "eaed5874effa6cde088c644ddcdcb4ffd1511391c5be4fdd7a5ccd02c7e4a183"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -2224,13 +2224,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -3539,9 +3539,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maxminddb"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfc54d66f57716c4bf6611403b89d6428b742fc422616b1b5a32220cee1834"
+checksum = "46e726b02f46b503921729f640c8e9b98167b87f7b640ce44fbd879ed23bc4b7"
 dependencies = [
  "log",
  "serde",
@@ -3683,7 +3683,7 @@ version = "0.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80db40007b46085d83469f71912d95526791038200e1c00afc6a5494d7dc8a4f"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.1",
  "rpassword",
  "scrypt",
 ]
@@ -3798,7 +3798,7 @@ dependencies = [
  "bitflags",
  "bson",
  "chrono",
- "derivative 2.1.1",
+ "derivative 2.1.3",
  "err-derive",
  "futures 0.3.8",
  "futures-intrusive",
@@ -4128,7 +4128,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
 dependencies = [
- "derivative 2.1.1",
+ "derivative 2.1.3",
  "num_enum_derive",
 ]
 
@@ -4918,7 +4918,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -6565,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",
@@ -7337,7 +7337,7 @@ dependencies = [
  "criterion",
  "crossterm 0.19.0",
  "db-key",
- "derivative 2.1.1",
+ "derivative 2.1.3",
  "derive_is_enum_variant",
  "dirs-next 2.0.0",
  "dyn-clone",
@@ -7966,9 +7966,9 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
  "bytes 0.5.6",
  "chrono",
  "ct-logs",
- "dirs-next",
+ "dirs-next 1.0.2",
  "futures-core",
  "futures-util",
  "hex",
@@ -1646,6 +1646,16 @@ name = "dirs-next"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -7290,7 +7300,7 @@ dependencies = [
  "db-key",
  "derivative 2.1.1",
  "derive_is_enum_variant",
- "dirs-next",
+ "dirs-next 2.0.0",
  "dyn-clone",
  "evmap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ snap = { version = "1.0.3", optional = true }
 dyn-clone = "1.0.3"
 indoc = "1.0.3"
 avro-rs = { version = "0.12.0", optional = true }
-dirs-next = { version = "1", optional = true }
+dirs-next = { version = "2.0.0", optional = true }
 fakedata_generator = "0.2.4"
 
 # For WASM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ built = { version = "0.4.4", features = ["git2", "chrono"] }
 
 [dev-dependencies]
 base64 = "0.13"
-approx = "0.3.0"
+approx = "0.4.0"
 criterion = "0.3"
 tempfile = "3.0.6"
 libc = "0.2.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,8 @@ remap-functions = { path = "lib/remap-functions" }
 # External libs
 derivative = "2.1.1"
 chrono = { version = "0.4.19", features = ["serde"] }
-rand = { version = "0.7.3", features = ["small_rng"] }
-rand_distr = "0.3.0"
+rand = { version = "0.8.0", features = ["small_rng"] }
+rand_distr = "0.4.0"
 regex = "1.3.9"
 bytes = { version = "0.5.6", features = ["serde"] }
 stream-cancel = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ smpl_jwt = { version = "0.5.0", optional = true }
 # API
 async-graphql = { version = "2.4.3", optional = true }
 async-graphql-warp = { version = "2.4.3", optional = true }
-itertools = { version = "0.9.0", optional = true }
+itertools = { version = "0.10.0", optional = true }
 
 # API client
 num-format = { version = "0.4.0", optional = true }

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -67,9 +67,9 @@ fn http_access_log_lines() -> impl Iterator<Item = String> {
                 rng.gen::<u8>(), rng.gen::<u8>(), rng.gen::<u8>(), rng.gen::<u8>(), // IP
                 year.sample(&mut rng), mday.sample(&mut rng), // date
                 hour.sample(&mut rng), minsec.sample(&mut rng), minsec.sample(&mut rng), // time
-                (&mut rng).sample_iter(&Alphanumeric).take(url_size).collect::<String>(), // URL
+                (&mut rng).sample_iter(&Alphanumeric).take(url_size).map(char::from).collect::<String>(), // URL
                 code.sample(&mut rng), size.sample(&mut rng),
-                (&mut rng).sample_iter(&Alphanumeric).take(browser_size).collect::<String>(),
+                (&mut rng).sample_iter(&Alphanumeric).take(browser_size).map(char::from).collect::<String>(),
         )
     })
 }

--- a/src/sources/util/fake.rs
+++ b/src/sources/util/fake.rs
@@ -212,9 +212,9 @@ fn syslog_version() -> String {
 
 // Helper functions
 fn random_in_range(min: usize, max: usize) -> String {
-    thread_rng().gen_range(min, max).to_string()
+    thread_rng().gen_range(min..max).to_string()
 }
 
 fn random_from_array<T: Copy>(v: &[T]) -> T {
-    v[thread_rng().gen_range(0, v.len())]
+    v[thread_rng().gen_range(0..v.len())]
 }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -203,6 +203,7 @@ pub fn random_string(len: usize) -> String {
     thread_rng()
         .sample_iter(&Alphanumeric)
         .take(len)
+        .map(char::from)
         .collect::<String>()
 }
 
@@ -211,7 +212,7 @@ pub fn random_lines(len: usize) -> impl Iterator<Item = String> {
 }
 
 pub fn random_map(max_size: usize, field_len: usize) -> HashMap<String, String> {
-    let size = thread_rng().gen_range(0, max_size);
+    let size = thread_rng().gen_range(0..max_size);
 
     (0..size)
         .map(move |_| (random_string(field_len), random_string(field_len)))

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -236,7 +236,7 @@ impl SyslogMessageRFC5424 {
             host: "hogwarts".to_owned(),
             source_type: "syslog".to_owned(),
             appname: "harry".to_owned(),
-            procid: thread_rng().gen_range(0, 32768),
+            procid: thread_rng().gen_range(0..32768),
             structured_data,
             message: msg,
         }
@@ -306,7 +306,7 @@ fn random_structured_data(
     max_children: usize,
     field_len: usize,
 ) -> StructuredData {
-    let amount = thread_rng().gen_range(0, max_children);
+    let amount = thread_rng().gen_range(0..max_children);
 
     random_maps(max_map_size, field_len)
         .filter(|m| !m.is_empty()) //syslog_rfc5424 ignores empty maps, tested separately


### PR DESCRIPTION
Looks like #5811 trigger `dependabot` update. This PR includes:
- `approx` #5818
- `dirs-next` #5815 
- `itertools`
- `rand`
- `rand_distr`
- `cargo update --aggressive`

I leaved `tui` not updated for @leebenson (https://github.com/timberio/vector/issues/5289)