### PR TITLE
feat(remap): add error coalescing operator

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -40,7 +40,7 @@ not            = { operator_not* ~ (call | primary) }
 
 // Operators -------------------------------------------------------------------
 
-operator_boolean_expr   = { "||" | "&&" }
+operator_boolean_expr   = { "??" | "||" | "&&" }
 operator_equality       = { "!=" | "==" }
 operator_comparison     = { ">=" | ">" | "<=" | "<" }
 operator_addition       = { "-" | "+" }

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -18,6 +18,13 @@ impl Expression for Arithmetic {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Operator::*;
 
+        if matches!(self.op, ErrorOr) {
+            return self
+                .lhs
+                .execute(state, object)
+                .or_else(|_| self.rhs.execute(state, object));
+        }
+
         let lhs = self.lhs.execute(state, object)?;
         let rhs = self.rhs.execute(state, object)?;
 
@@ -36,6 +43,7 @@ impl Expression for Arithmetic {
             GreaterOrEqual => lhs.try_ge(rhs),
             Less => lhs.try_lt(rhs),
             LessOrEqual => lhs.try_le(rhs),
+            ErrorOr => unreachable!(),
         }
         .map_err(Into::into)
     }
@@ -52,6 +60,9 @@ impl Expression for Arithmetic {
             Or if lhs_def.kind.is_null() => rhs_def,
             Or if !lhs_def.kind.is_boolean() => lhs_def,
             Or => type_def,
+            ErrorOr if !lhs_def.is_fallible() => lhs_def,
+            ErrorOr if !rhs_def.is_fallible() => rhs_def,
+            ErrorOr => type_def,
             And if lhs_def.kind.is_null() => lhs_def.with_constraint(Kind::Boolean),
             And => type_def
                 .fallible_unless(Kind::Null | Kind::Boolean)
@@ -78,7 +89,7 @@ mod tests {
     use super::*;
     use crate::{
         expression::{Literal, Noop},
-        test_type_def,
+        lit, test_type_def,
         value::Kind,
     };
 
@@ -269,6 +280,83 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
+            },
+        }
+
+        error_or_lhs_infallible {
+            expr: |_| Arithmetic::new(
+                Box::new(Expr::from(lit!("foo"))),
+                Box::new(Arithmetic::new(
+                    Box::new(Expr::from(lit!("foo"))),
+                    Box::new(Expr::from(lit!(1))),
+                    Operator::Divide,
+                ).into()),
+                Operator::ErrorOr,
+            ),
+            def: TypeDef {
+                kind: Kind::Bytes,
+                ..Default::default()
+            },
+        }
+
+        error_or_rhs_infallible {
+            expr: |_| Arithmetic::new(
+                Box::new(Arithmetic::new(
+                    Box::new(Expr::from(lit!("foo"))),
+                    Box::new(Expr::from(lit!(1))),
+                    Operator::Divide,
+                ).into()),
+                Box::new(Expr::from(lit!(true))),
+                Operator::ErrorOr,
+            ),
+            def: TypeDef {
+                kind: Kind::Boolean,
+                ..Default::default()
+            },
+        }
+
+        error_or_fallible {
+            expr: |_| Arithmetic::new(
+                Box::new(Arithmetic::new(
+                    Box::new(Expr::from(lit!("foo"))),
+                    Box::new(Expr::from(lit!(1))),
+                    Operator::Divide,
+                ).into()),
+                Box::new(Arithmetic::new(
+                    Box::new(Expr::from(lit!(true))),
+                    Box::new(Expr::from(lit!(1))),
+                    Operator::Divide,
+                ).into()),
+                Operator::ErrorOr,
+            ),
+            def: TypeDef {
+                kind: Kind::Integer | Kind::Float,
+                fallible: true,
+                ..Default::default()
+            },
+        }
+
+        error_or_nested_infallible {
+            expr: |_| Arithmetic::new(
+                Box::new(Arithmetic::new(
+                    Box::new(Expr::from(lit!("foo"))),
+                    Box::new(Expr::from(lit!(1))),
+                    Operator::Divide,
+                ).into()),
+                Box::new(Arithmetic::new(
+                    Box::new(Arithmetic::new(
+                        Box::new(Expr::from(lit!(true))),
+                        Box::new(Expr::from(lit!(1))),
+                        Operator::Divide,
+                    ).into()),
+                    Box::new(Expr::from(lit!("foo"))),
+                    Operator::ErrorOr,
+                ).into()),
+                Operator::ErrorOr,
+            ),
+            def: TypeDef {
+                kind: Kind::Bytes,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -281,6 +281,12 @@ mod tests {
                     "g": r#"{"1": Integer(1), "true": Boolean(true)}"#,
                 })),
             ),
+            ("true * 5 ?? 5 * 5", Ok(()), Ok(value!(25))),
+            ("5 * 5 ?? true * 5", Ok(()), Ok(value!(25))),
+            ("false * 5 ?? true * 5 ?? 5 * 5", Ok(()), Ok(value!(25))),
+            ("false * 5 ?? 5 * 5 ?? true * 5", Ok(()), Ok(value!(25))),
+            ("false * 5 ?? true * 5", Ok(()), Err("remap error: value error: unable to multiply value type boolean by integer")),
+            ("5 + (true * 5 ?? 0)", Ok(()), Ok(value!(5))),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {

--- a/lib/remap-lang/src/operator.rs
+++ b/lib/remap-lang/src/operator.rs
@@ -17,6 +17,7 @@ pub enum Operator {
     LessOrEqual,
     And,
     Or,
+    ErrorOr,
 }
 
 impl FromStr for Operator {
@@ -40,6 +41,7 @@ impl FromStr for Operator {
             "<=" => LessOrEqual,
             "&&" => And,
             "||" => Or,
+            "??" => ErrorOr,
             _ => return Err("unknown operator"),
         })
     }
@@ -64,6 +66,7 @@ impl AsRef<str> for Operator {
             LessOrEqual => "<=",
             And => "&&",
             Or => "||",
+            ErrorOr => "??",
         }
     }
 }

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -641,7 +641,7 @@ impl<'a> Parser<'a> {
         }
 
         boolean_expr => {
-            op: [And, Or],
+            op: [ErrorOr, And, Or],
             next: equality,
         }
     }


### PR DESCRIPTION
This PR adds support for the error coalescing operator `??`:

```rust
<lhs exp> ?? <rhs expr>
```

`rhs` is evaluated if `lhs` returns an error. This operator can be chained to try multiple expressions until one succeeds (or returning the error of the most rightward expression):

```rust
<expr 1> ?? <expr 2> ?? <expr 3>
```

It allows you to handle error-cases of expressions in a succinct way.

For example, trying to parse a message value using multiple regex patterns:

```rust
. = parse_regex(.message, /^(?P<timestamp>[^\\]]+) \\[(?P<level>\\w+)\\] (?P<pid>[0-9]+)#(?P<tid>[0-9]+): \\*(?P<cid>[0-9]+) (?P<message>.*)$/) \
  ?? parse_regex(.message, /client: (?P<client>[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})/) \
  ?? parse_regex(.message, /server: (?P<server>[^,]+)/) \
  ?? .
```

This expression is infallible because the last expression (`.`) is infallible, and thus requires no extra error handling.

It's possible, but tedious, to do the same without this operator:

```rust
. = if ok($v) = parse_regex(.message, /^(?P<timestamp>[^\\]]+) \\[(?P<level>\\w+)\\] (?P<pid>[0-9]+)#(?P<tid>[0-9]+): \\*(?P<cid>[0-9]+) (?P<message>.*)$/) {
	$v
} else if ok($v) = parse_regex(.message, /client: (?P<client>[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})/) {
	$v
} else if ok($v) = parse_regex(.message, /server: (?P<server>[^,]+)/) {
	$v
} else {
	.
}
```

The alternative of using the logical OR operator for this was discussed before, but rejected as it prevents you from easily distinguishing between errors and false/null values.

The operator has the lowest precedence level, allowing you to chain operations such as `5 * true ?? 5 * 5`.

closes #5726
closes #5781
closes #5782
closes #5864