### PR TITLE
fix(ci): Adds docker push guard back into CI scripts

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -14,6 +14,7 @@ CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 DATE="${DATE:-"$(date -u +%Y-%m-%d)"}"
 PLATFORM="${PLATFORM:-}"
+PUSH="${PUSH:-}"
 REPO="${REPO:-"timberio/vector"}"
 
 #
@@ -38,7 +39,10 @@ build() {
       --tag "$TAG" \
       target/artifacts \
       -f "$DOCKERFILE"
-      docker push "$TAG"
+
+      if [ -n "$PUSH" ]; then
+        docker push "$TAG"
+      fi
   fi
 }
 

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -104,6 +104,7 @@ if [[ -z "${CONTAINER_IMAGE:-}" ]]; then
       CHANNEL="test" \
       BASE="$BASE_TAG" \
       TAG="$VERSION_TAG" \
+      PUSH="" \
       scripts/build-docker.sh
 
     # Prepare the container image for the deployment command.


### PR DESCRIPTION
Adds the docker push guard back into our CI scripts to fix k8s e2e test failure
Signed-off-by: Ian Henry <ianjhenry00@gmail.com>
