### PR TITLE
chore(ci): Restrict self-hosted workflows to specific runners

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,11 +51,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: |
-          env
-          sudo echo "$HOME"
-          sudo echo $GITHUB_PATH
-          sudo bash -c 'echo "$HOME/.cargo/bin" >> $GITHUB_PATH'
-          sudo cat $GITHUB_PATH
+          echo "/root/.cargo/bin" >> $GITHUB_PATH
+          cat $GITHUB_PATH
         shell: bash
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -37,7 +37,7 @@ jobs:
 
   bench:
     name: Bench - Linux
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, benchmarks]
     # Allow benchmarks show regressions until we can refine the thresholds for
     # regression to reduce false positives.
     continue-on-error: true

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -49,6 +49,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -65,7 +65,6 @@ jobs:
           test -f target/criterion.zip || echo "::warning::No master benchmark artifacts could be fetched for comparison."
       - run: unzip target/criterion.zip
         continue-on-error: true
-      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,6 +51,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: |
+          env
+          echo "$HOME"
           echo $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           cat $GITHUB_PATH

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -50,13 +50,11 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: |
-          echo "/root/.cargo/bin" >> $GITHUB_PATH
-          cat $GITHUB_PATH
-        shell: bash
+        # rustup is installed as the root user but for some reason `$HOME` is
+        # not set here on the self-hosted runner and I (Jesse) could not
+        # determine how to get it to be set
+      - run: echo "/root/.cargo/bin" >> $GITHUB_PATH
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -54,7 +54,7 @@ jobs:
           env
           sudo echo "$HOME"
           sudo echo $GITHUB_PATH
-          sudo echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          sudo bash -c 'echo "$HOME/.cargo/bin" >> $GITHUB_PATH'
           sudo cat $GITHUB_PATH
         shell: bash
       - name: Setup tmate session

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -52,10 +52,10 @@ jobs:
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: |
           env
-          echo "$HOME"
-          echo $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          cat $GITHUB_PATH
+          sudo echo "$HOME"
+          sudo echo $GITHUB_PATH
+          sudo echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          sudo cat $GITHUB_PATH
         shell: bash
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Setup tmate session
+      - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -56,6 +56,7 @@ jobs:
           echo $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           cat $GITHUB_PATH
+        shell: bash
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -43,14 +43,12 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
-      - run: make ci-sweep
       - uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,6 +51,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f
         continue-on-error: true
@@ -66,8 +70,6 @@ jobs:
           test -f target/criterion.zip || echo "::warning::No master benchmark artifacts could be fetched for comparison."
       - run: unzip target/criterion.zip
         continue-on-error: true
-      - run: bash scripts/environment/prepare.sh
-      - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - name: Run benchmarks
         run: |

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -50,10 +50,7 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-        # rustup is installed as the root user but for some reason `$HOME` is
-        # not set here on the self-hosted runner and I (Jesse) could not
-        # determine how to get it to be set
-      - run: echo "/root/.cargo/bin" >> $GITHUB_PATH
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Setup tmate session
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Download baseline benchmarks

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -50,7 +50,10 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: |
+          echo $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          cat $GITHUB_PATH
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
   # Then, modify the `cross-linux` job to run `test` instead of `build`.
   test-linux:
     name: Unit - x86_64-unknown-linux-gnu
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, general]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
@@ -187,7 +187,7 @@ jobs:
     # Full CI suites for this platform were only recently introduced.
     # Some failures are permitted until we can properly correct them.
     continue-on-error: true
-    runs-on: [self-hosted, windows, x64]
+    runs-on: [self-hosted, windows, x64, general]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,10 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: |
+          echo $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          cat $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,7 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: |
-          echo $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          cat $GITHUB_PATH
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -28,6 +28,7 @@ apt upgrade --yes
 
 # Deps
 apt install --yes \
+    awscli \
     build-essential \
     cmake \
     pkg-config \


### PR DESCRIPTION
As Github Actions workflow label specifications will let jobs run on runners
that have a superset of the labels, we want to ensure that unit tests don't end
up running on benchmark runners given they are optimized for running
benchmarks where unit tests would likely benefit from hyperthreading and
using all available CPUs.

Admittedly, I'm using labels here to identify runner "roles" rather than
capabilities, as they seem to be intended for, but, for benchmarks, we
really do want to ensure they run on very specific runners that other
tests are not likely to want to run on.

I've applied the labels manually to existing, manually configured,
runners.

Ref: https://docs.github.com/en/free-pro-team@latest/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
