### PR TITLE
chore(remap): add "try_bytes_utf8_lossy" helper method

### DIFF
--- a/lib/remap-functions/src/assert.rs
+++ b/lib/remap-functions/src/assert.rs
@@ -51,10 +51,10 @@ impl Expression for AssertFn {
             Ok(Value::Null)
         } else {
             let message = match self.message.as_ref() {
-                Some(message) => {
-                    let bytes = message.execute(state, object)?.try_bytes()?;
-                    String::from_utf8_lossy(&bytes).into_owned()
-                }
+                Some(message) => message
+                    .execute(state, object)?
+                    .try_bytes_utf8_lossy()?
+                    .into_owned(),
                 None => {
                     // If Expression implemented Display, we could could return the expression here.
                     "evaluated to false".to_string()

--- a/lib/remap-functions/src/contains.rs
+++ b/lib/remap-functions/src/contains.rs
@@ -80,8 +80,8 @@ impl Expression for ContainsFn {
         };
 
         let value = {
-            let bytes = self.value.execute(state, object)?.try_bytes()?;
-            let string = String::from_utf8_lossy(&bytes);
+            let value = self.value.execute(state, object)?;
+            let string = value.try_bytes_utf8_lossy()?;
 
             match case_sensitive {
                 true => string.into_owned(),

--- a/lib/remap-functions/src/ends_with.rs
+++ b/lib/remap-functions/src/ends_with.rs
@@ -80,8 +80,8 @@ impl Expression for EndsWithFn {
         };
 
         let value = {
-            let bytes = self.value.execute(state, object)?.try_bytes()?;
-            let string = String::from_utf8_lossy(&bytes);
+            let value = self.value.execute(state, object)?;
+            let string = value.try_bytes_utf8_lossy()?;
 
             match case_sensitive {
                 true => string.into_owned(),

--- a/lib/remap-functions/src/ip_subnet.rs
+++ b/lib/remap-functions/src/ip_subnet.rs
@@ -53,15 +53,15 @@ impl IpSubnetFn {
 
 impl Expression for IpSubnetFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value: IpAddr = {
-            let bytes = self.value.execute(state, object)?.try_bytes()?;
-            String::from_utf8_lossy(&bytes)
-                .parse()
-                .map_err(|err| format!("unable to parse IP address: {}", err))?
-        };
+        let value: IpAddr = self
+            .value
+            .execute(state, object)?
+            .try_bytes_utf8_lossy()?
+            .parse()
+            .map_err(|err| format!("unable to parse IP address: {}", err))?;
 
-        let bytes = self.subnet.execute(state, object)?.try_bytes()?;
-        let mask = String::from_utf8_lossy(&bytes);
+        let mask = self.subnet.execute(state, object)?;
+        let mask = mask.try_bytes_utf8_lossy()?;
 
         let mask = if mask.starts_with('/') {
             // The parameter is a subnet.

--- a/lib/remap-functions/src/ip_to_ipv6.rs
+++ b/lib/remap-functions/src/ip_to_ipv6.rs
@@ -39,12 +39,12 @@ impl IpToIpv6Fn {
 
 impl Expression for IpToIpv6Fn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let ip = {
-            let bytes = self.value.execute(state, object)?.try_bytes()?;
-            String::from_utf8_lossy(&bytes)
-                .parse()
-                .map_err(|err| format!("unable to parse IP address: {}", err))?
-        };
+        let ip: IpAddr = self
+            .value
+            .execute(state, object)?
+            .try_bytes_utf8_lossy()?
+            .parse()
+            .map_err(|err| format!("unable to parse IP address: {}", err))?;
 
         match ip {
             IpAddr::V4(addr) => Ok(addr.to_ipv6_mapped().to_string().into()),

--- a/lib/remap-functions/src/match.rs
+++ b/lib/remap-functions/src/match.rs
@@ -47,10 +47,10 @@ impl MatchFn {
 
 impl Expression for MatchFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
-        let value = String::from_utf8_lossy(&bytes);
+        let value = self.value.execute(state, object)?;
+        let string = value.try_bytes_utf8_lossy()?;
 
-        Ok(self.pattern.is_match(&value).into())
+        Ok(self.pattern.is_match(&string).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -33,16 +33,15 @@ impl Function for ParseGrok {
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let value = arguments.required("value")?.boxed();
 
-        let patternbytes = arguments
+        let pattern = arguments
             .required_literal("pattern")?
             .as_value()
             .clone()
-            .try_bytes()?;
-
-        let patternstr = String::from_utf8_lossy(&patternbytes).into_owned();
+            .try_bytes_utf8_lossy()?
+            .into_owned();
 
         let mut grok = grok::Grok::with_patterns();
-        let pattern = Arc::new(grok.compile(&patternstr, true).map_err(|e| e.to_string())?);
+        let pattern = Arc::new(grok.compile(&pattern, true).map_err(|e| e.to_string())?);
 
         let remove_empty = arguments.optional("remove_empty").map(Expr::boxed);
 

--- a/lib/remap-functions/src/parse_url.rs
+++ b/lib/remap-functions/src/parse_url.rs
@@ -40,9 +40,10 @@ impl ParseUrlFn {
 
 impl Expression for ParseUrlFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
+        let value = self.value.execute(state, object)?;
+        let string = value.try_bytes_utf8_lossy()?;
 
-        Url::parse(&String::from_utf8_lossy(&bytes))
+        Url::parse(&string)
             .map_err(|e| format!("unable to parse url: {}", e).into())
             .map(url_to_value)
     }

--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -72,8 +72,8 @@ struct RedactFn {
 
 impl Expression for RedactFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
-        let mut input = String::from_utf8_lossy(&bytes).into_owned();
+        let value = self.value.execute(state, object)?;
+        let mut input = value.try_bytes_utf8_lossy()?.into_owned();
 
         for filter in &self.filters {
             match filter {

--- a/lib/remap-functions/src/split.rs
+++ b/lib/remap-functions/src/split.rs
@@ -51,8 +51,8 @@ pub(crate) struct SplitFn {
 
 impl Expression for SplitFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
-        let value = String::from_utf8_lossy(&bytes);
+        let value = self.value.execute(state, object)?;
+        let string = value.try_bytes_utf8_lossy()?;
         let limit: usize = self
             .limit
             .as_ref()
@@ -67,13 +67,13 @@ impl Expression for SplitFn {
             .execute(state, object)
             .and_then(|pattern| match pattern {
                 Value::Regex(pattern) => Ok(pattern
-                    .splitn(value.as_ref(), limit as usize)
+                    .splitn(string.as_ref(), limit as usize)
                     .collect::<Vec<_>>()
                     .into()),
                 Value::Bytes(bytes) => {
                     let pattern = String::from_utf8_lossy(&bytes);
 
-                    Ok(value
+                    Ok(string
                         .splitn(limit, pattern.as_ref())
                         .collect::<Vec<_>>()
                         .into())

--- a/lib/remap-functions/src/tokenize.rs
+++ b/lib/remap-functions/src/tokenize.rs
@@ -38,10 +38,10 @@ impl TokenizeFn {
 
 impl Expression for TokenizeFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
-        let value = String::from_utf8_lossy(&bytes);
+        let value = self.value.execute(state, object)?;
+        let string = value.try_bytes_utf8_lossy()?;
 
-        let tokens: Value = tokenize::parse(&value)
+        let tokens: Value = tokenize::parse(&string)
             .into_iter()
             .map(|token| match token {
                 "" | "-" => Value::Null,

--- a/lib/remap-functions/src/truncate.rs
+++ b/lib/remap-functions/src/truncate.rs
@@ -67,8 +67,11 @@ impl TruncateFn {
 
 impl Expression for TruncateFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let bytes = self.value.execute(state, object)?.try_bytes()?;
-        let mut value = String::from_utf8_lossy(&bytes).into_owned();
+        let mut value = self
+            .value
+            .execute(state, object)?
+            .try_bytes_utf8_lossy()?
+            .into_owned();
 
         let limit = match self.limit.execute(state, object)? {
             Value::Float(f) => f.floor() as i64,

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -174,10 +174,7 @@ impl ArgumentList {
 }
 
 fn literal_to_enum_variant(literal: Literal, variants: &[&'static str]) -> Result<String> {
-    let variant = literal
-        .into_value()
-        .try_bytes()
-        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())?;
+    let variant = literal.into_value().try_bytes_utf8_lossy()?.into_owned();
 
     if variants.contains(&variant.as_str()) {
         Ok(variant)

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -450,6 +450,13 @@ macro_rules! value_impl {
             pub fn unwrap_null(self) -> () {
                 self.try_null().expect("null")
             }
+
+            pub fn try_bytes_utf8_lossy<'a>(&'a self) -> Result<std::borrow::Cow<'a, str>, Error> {
+                match self.as_bytes() {
+                    Some(bytes) => Ok(String::from_utf8_lossy(&bytes)),
+                    None => Err(Error::Expected(Kind::Bytes, self.kind())),
+                }
+            }
         }
     };
 }


### PR DESCRIPTION
This adds a `Value::try_bytes_utf8_lossy` method, which basically merges these steps:

```rust
let value = self.value.execute(state, object)?;
let bytes = value.try_bytes()?;
let string = String::from_utf8_lossy(&bytes);
```

Into:

```rust
let value = self.value.execute(state, object)?;
let string = value.try_bytes_utf8_lossy()?;
```

This pattern is used so much throughout function impls, that I figured it was a worthy helper method to have.

I didn't update all cases yet, but we can do that as we move forward.