### PR TITLE
chore(deps): put `portpicker` and `is_derive_enum` to lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,8 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "derive_is_enum_variant"
-version = "0.1.1"
-source = "git+https://github.com/timberio/derive_is_enum_variant?rev=e4550f8ca1366823b8366f0126a7d00ee8ffb080#e4550f8ca1366823b8366f0126a7d00ee8ffb080"
+version = "1.0.0"
 dependencies = [
  "heck",
  "proc-macro2 1.0.24",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,10 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "portpicker"
-version = "0.1.0"
-source = "git+https://github.com/timberio/portpicker-rs?rev=d15829e906516720881584ff3301a0dd04218fbb#d15829e906516720881584ff3301a0dd04218fbb"
+version = "1.0.0"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ depends = ""
 [workspace]
 members = [
   ".",
+  "lib/codec",
   "lib/file-source",
   "lib/k8s-e2e-tests",
   "lib/k8s-test-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ depends = ""
 members = [
   ".",
   "lib/codec",
+  "lib/derive_is_enum_variant",
   "lib/file-source",
   "lib/k8s-e2e-tests",
   "lib/k8s-test-framework",
@@ -53,6 +54,7 @@ members = [
 [dependencies]
 # Internal libs
 codec = { path = "lib/codec" }
+derive_is_enum_variant = { path = "lib/derive_is_enum_variant" }
 file-source = { path = "lib/file-source", optional = true }
 portpicker = { path = "lib/portpicker" }
 prometheus-parser = { path = "lib/prometheus-parser", optional = true }
@@ -146,7 +148,6 @@ typetag = "0.1.6"
 toml = "0.5.8"
 syslog = "5"
 syslog_loose = "0.7.0"
-derive_is_enum_variant = "0.1.1"
 leveldb = { version = "0.8", optional = true, default-features = false }
 db-key = "0.0.5"
 headers = "0.3"
@@ -582,7 +583,5 @@ tower-layer = "0.3"
 [patch.crates-io]
 # TODO: update to next 0.12.x (after 0.12.0, if any)
 avro-rs = { version = "0.12.0", git = "https://github.com/flavray/avro-rs", rev = "f28acbbb9860bd62cb24ead83878d7526d075454", optional = true }
-# Not maintained, our branch update `sync` and `quote` crates: https://github.com/fitzgen/derive_is_enum_variant/pull/3
-derive_is_enum_variant = { version = "0.1.1", git = "https://github.com/timberio/derive_is_enum_variant", rev = "e4550f8ca1366823b8366f0126a7d00ee8ffb080" }
 # TODO: update to the next 0.13.x (after 0.13.9, if any) or 0.14 (or higher)
 hyper = { version = "0.13", git = "https://github.com/hyperium/hyper", rev = "a00cc20afc597cb55cbc62c70b0b25b46c82a0a6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "lib/file-source",
   "lib/k8s-e2e-tests",
   "lib/k8s-test-framework",
+  "lib/portpicker",
   "lib/prometheus-parser",
   "lib/remap-cli",
   "lib/remap-functions",
@@ -52,6 +53,7 @@ members = [
 # Internal libs
 codec = { path = "lib/codec" }
 file-source = { path = "lib/file-source", optional = true }
+portpicker = { path = "lib/portpicker" }
 prometheus-parser = { path = "lib/prometheus-parser", optional = true }
 shared = { path = "lib/shared" }
 tracing-limit = { path = "lib/tracing-limit" }
@@ -186,7 +188,6 @@ cidr-utils = "0.5.0"
 pin-project = "1.0.1"
 nats = { version = "0.8.6", optional = true }
 k8s-openapi = { version = "0.10.0", features = ["v1_16"], optional = true }
-portpicker = "0.1.0"
 sha-1 = "0.9.2"
 sha2 = "0.9"
 sha3 = "0.9"
@@ -584,5 +585,3 @@ avro-rs = { version = "0.12.0", git = "https://github.com/flavray/avro-rs", rev 
 derive_is_enum_variant = { version = "0.1.1", git = "https://github.com/timberio/derive_is_enum_variant", rev = "e4550f8ca1366823b8366f0126a7d00ee8ffb080" }
 # TODO: update to the next 0.13.x (after 0.13.9, if any) or 0.14 (or higher)
 hyper = { version = "0.13", git = "https://github.com/hyperium/hyper", rev = "a00cc20afc597cb55cbc62c70b0b25b46c82a0a6" }
-# Not maintained, our branch update `rand` crate: https://github.com/Dentosal/portpicker-rs/pull/3
-portpicker = { version = "0.1.0", git = "https://github.com/timberio/portpicker-rs", rev = "d15829e906516720881584ff3301a0dd04218fbb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,26 +35,26 @@ depends = ""
 [workspace]
 members = [
   ".",
-  "lib/shared",
   "lib/file-source",
-  "lib/tracing-limit",
-  "lib/vector-wasm",
-  "lib/k8s-test-framework",
   "lib/k8s-e2e-tests",
+  "lib/k8s-test-framework",
   "lib/prometheus-parser",
-  "lib/vector-api-client",
-  "lib/remap-lang",
   "lib/remap-cli",
   "lib/remap-functions",
+  "lib/remap-lang",
+  "lib/shared",
+  "lib/tracing-limit",
+  "lib/vector-api-client",
+  "lib/vector-wasm",
 ]
 
 [dependencies]
 # Internal libs
-shared = { path = "lib/shared" }
 codec = { path = "lib/codec" }
 file-source = { path = "lib/file-source", optional = true }
-tracing-limit = { path = "lib/tracing-limit" }
 prometheus-parser = { path = "lib/prometheus-parser", optional = true }
+shared = { path = "lib/shared" }
+tracing-limit = { path = "lib/tracing-limit" }
 vector-api-client = { path = "lib/vector-api-client", optional = true }
 
 # Tokio / Futures

--- a/lib/derive_is_enum_variant/Cargo.toml
+++ b/lib/derive_is_enum_variant/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "derive_is_enum_variant"
+version = "1.0.0"
+authors = ["Vector Contributors <vector@timber.io>", "Nick Fitzgerald <fitzgen@gmail.com>"]
+edition = "2018"
+description = "Automatically derives `is_dog` and `is_cat` methods for `enum Pet { Dog, Cat }`."
+publish = false
+
+[dependencies]
+heck = "0.3.0"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["extra-traits"] }
+
+[lib]
+proc_macro = true

--- a/lib/derive_is_enum_variant/src/lib.rs
+++ b/lib/derive_is_enum_variant/src/lib.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2021 Vector Contributors <vector@timber.io>
+// Copyright (c) 2015 The Rust Project Developers
+
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! ### Add `#[derive(is_enum_variant)]` to your `enum` definitions:
+//!
+//! ```rust
+//! #[macro_use]
+//! extern crate derive_is_enum_variant;
+//!
+//! #[derive(is_enum_variant)]
+//! pub enum Pet {
+//!     Doggo,
+//!     Kitteh,
+//! }
+//!
+//! fn main() {
+//!     let pet = Pet::Doggo;
+//!
+//!     assert!(pet.is_doggo());
+//!     assert!(!pet.is_kitteh());
+//! }
+//! ```
+//!
+//! ### Customizing Predicate Names
+//!
+//! By default, the predicates are named `is_snake_case_of_variant_name`. You can
+//! use any name you want instead with `#[is_enum_variant(name = "..")]`:
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate derive_is_enum_variant;
+//!
+//! #[derive(is_enum_variant)]
+//! pub enum Pet {
+//!     #[is_enum_variant(name = "is_real_good_boy")]
+//!     Doggo,
+//!     Kitteh,
+//! }
+//!
+//! # fn main() {
+//! let pet = Pet::Doggo;
+//! assert!(pet.is_real_good_boy());
+//! # }
+//! ```
+//!
+//! ### Skipping Predicates for Certain Variants
+//!
+//! If you don't want to generate a predicate for a certain variant, you can use
+//! `#[is_enum_variant(skip)]`:
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate derive_is_enum_variant;
+//!
+//! #[derive(is_enum_variant)]
+//! pub enum Errors {
+//!     Io(::std::io::Error),
+//!
+//!     #[doc(hidden)]
+//!     #[is_enum_variant(skip)]
+//!     __NonExhaustive,
+//! }
+//!
+//! # fn main() {}
+//! ```
+
+#[macro_use]
+extern crate quote;
+
+use heck::SnakeCase;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(is_enum_variant, attributes(is_enum_variant))]
+pub fn derive_is_enum_variant(tokens: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(tokens).expect("should parse input tokens into AST");
+
+    let name = ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let data_enum = match ast.data {
+        syn::Data::Enum(data_enum) => data_enum,
+        _ => panic!("#[derive(is_enum_variant)] can only be used with enums"),
+    };
+    let predicates = data_enum.variants.into_iter().map(
+        |syn::Variant {
+             attrs,
+             ident,
+             fields,
+             ..
+         }| {
+            let cfg = attrs.into();
+            if let PredicateConfig::Skip = cfg {
+                return quote! {};
+            }
+
+            let variant_name = ident.to_string();
+            let doc = format!("Is this `{}` a `{}`?", name, variant_name);
+
+            let predicate_name = if let PredicateConfig::Name(name) = cfg {
+                name
+            } else {
+                format!("is_{}", variant_name.to_snake_case())
+            };
+            let fn_name = syn::Ident::new(&predicate_name, proc_macro2::Span::call_site());
+
+            let data_tokens = match fields {
+                syn::Fields::Named(..) => quote! { { .. } },
+                syn::Fields::Unnamed(..) => quote! { (..) },
+                syn::Fields::Unit => quote! {},
+            };
+
+            quote! {
+                #[doc = #doc]
+                #[inline]
+                #[allow(unreachable_patterns)]
+                #[allow(dead_code)]
+                pub fn #fn_name(&self) -> bool {
+                    matches!(*self, #name :: #ident #data_tokens)
+                }
+            }
+        },
+    );
+
+    TokenStream::from(quote! {
+        /// # `enum` Variant Predicates
+        impl #impl_generics #name #ty_generics #where_clause {
+            #(
+                #predicates
+            )*
+        }
+    })
+}
+
+enum PredicateConfig {
+    None,
+    Skip,
+    Name(String),
+}
+
+impl PredicateConfig {
+    fn join(self, meta: syn::Meta) -> Self {
+        match meta {
+            syn::Meta::Path(path) if path.is_ident("skip") => match self {
+                PredicateConfig::None | PredicateConfig::Skip => PredicateConfig::Skip,
+                PredicateConfig::Name(_) => panic!(
+                    "Cannot both `#[is_enum_variant(skip)]` and \
+                     `#[is_enum_variant(name = \"..\")]`"
+                ),
+            },
+            syn::Meta::NameValue(syn::MetaNameValue {
+                path,
+                lit: syn::Lit::Str(s),
+                ..
+            }) if path.is_ident("name") => {
+                let value = s.value();
+                if !value
+                    .chars()
+                    .all(|c| matches!(c, '_' | 'a'..='z' | 'A'..='Z' | '0'..='9'))
+                {
+                    panic!(
+                        "#[is_enum_variant(name = \"..\")] must be provided \
+                         a valid identifier"
+                    )
+                }
+                match self {
+                    PredicateConfig::None => PredicateConfig::Name(value),
+                    PredicateConfig::Skip => panic!(
+                        "Cannot both `#[is_enum_variant(skip)]` and \
+                         `#[is_enum_variant(name = \"..\")]`"
+                    ),
+                    PredicateConfig::Name(_) => panic!(
+                        "Cannot provide more than one \
+                         `#[is_enum_variant(name = \"..\")]`"
+                    ),
+                }
+            }
+            otherwise => panic!(
+                "Unknown item inside `#[is_enum_variant(..)]`: {:?}",
+                otherwise
+            ),
+        }
+    }
+}
+
+impl From<Vec<syn::Attribute>> for PredicateConfig {
+    fn from(attrs: Vec<syn::Attribute>) -> Self {
+        let our_attr = attrs
+            .into_iter()
+            .find(|attr| attr.path.is_ident("is_enum_variant"));
+        our_attr.map_or(PredicateConfig::None, |attr| {
+            match attr.parse_meta().expect("unable to parse Meta") {
+                syn::Meta::List(list) => list
+                    .nested
+                    .into_iter()
+                    .map(|meta| match meta {
+                        syn::NestedMeta::Meta(meta) => meta,
+                        syn::NestedMeta::Lit(_) => {
+                            panic!("Invalid #[is_enum_variant] item")
+                        }
+                    })
+                    .fold(PredicateConfig::None, PredicateConfig::join),
+                _ => panic!(
+                    "#[is_enum_variant] must be used with name/value pairs, like \
+                    #[is_enum_variant(name = \"..\")]"
+                ),
+            }
+        })
+    }
+}

--- a/lib/derive_is_enum_variant/tests/tests.rs
+++ b/lib/derive_is_enum_variant/tests/tests.rs
@@ -1,0 +1,107 @@
+#[macro_use]
+extern crate derive_is_enum_variant;
+
+/// A kind of pet.
+#[derive(is_enum_variant)]
+pub enum Pet {
+    /// A dog.
+    Doggo,
+    /// A cat.
+    Kitteh,
+    /// A flying squirrel.
+    FlyingSquirrel,
+}
+
+#[test]
+fn basic_enum_predicates() {
+    let doggo = Pet::Doggo;
+    assert!(doggo.is_doggo());
+    assert!(!doggo.is_kitteh());
+    assert!(!doggo.is_flying_squirrel());
+
+    let kitteh = Pet::Kitteh;
+    assert!(!kitteh.is_doggo());
+    assert!(kitteh.is_kitteh());
+    assert!(!kitteh.is_flying_squirrel());
+
+    let squirrel = Pet::FlyingSquirrel;
+    assert!(!squirrel.is_doggo());
+    assert!(!squirrel.is_kitteh());
+    assert!(squirrel.is_flying_squirrel());
+}
+
+/// Different kinds of enum variants.
+#[derive(is_enum_variant)]
+pub enum VariantKinds {
+    Struct { x: usize, y: usize },
+    Tuple(usize, usize),
+    Unit,
+}
+
+#[test]
+fn variant_kinds() {
+    assert!(VariantKinds::Struct { x: 1, y: 2 }.is_struct());
+    assert!(VariantKinds::Tuple(1, 2).is_tuple());
+    assert!(VariantKinds::Unit.is_unit());
+}
+
+/// Various funky case names.
+#[allow(non_camel_case_types)]
+#[derive(is_enum_variant)]
+pub enum Funky {
+    /// doc
+    CAPS,
+    /// doc
+    SHOUTING_SNAKE,
+    /// doc
+    snake_case,
+    /// doc
+    littleCamel,
+    /// doc
+    WithACRONYM,
+}
+
+#[test]
+fn funky_variant_names() {
+    assert!(Funky::CAPS.is_caps());
+    assert!(Funky::SHOUTING_SNAKE.is_shouting_snake());
+    assert!(Funky::snake_case.is_snake_case());
+    assert!(Funky::littleCamel.is_little_camel());
+    assert!(Funky::WithACRONYM.is_with_acronym());
+}
+
+/// Test providing custom predicate names.
+#[derive(is_enum_variant)]
+pub enum CustomNames {
+    #[is_enum_variant(name = "i_dont_know_why_you_say")]
+    Goodbye,
+    #[is_enum_variant(name = "i_say")]
+    Hello,
+}
+
+#[test]
+fn custom_predicate_names() {
+    assert!(CustomNames::Goodbye.i_dont_know_why_you_say());
+    assert!(CustomNames::Hello.i_say());
+}
+
+/// This doesn't get a predicate for every variant
+#[derive(is_enum_variant)]
+pub enum Skip {
+    #[is_enum_variant(skip)]
+    NoPredicate,
+    YesPredicate,
+}
+
+#[test]
+fn skip_variants() {
+    assert!(Skip::YesPredicate.is_yes_predicate());
+}
+
+/// Because there is only one variant, the generated match's `_` pattern is
+/// unreachable. This better not create a compilation error due to our
+/// `deny(unreachable_patterns)`.
+#[derive(is_enum_variant)]
+pub enum GeneratedCodeHasNoWarnings {
+    OnlyOneVariant,
+}

--- a/lib/portpicker/Cargo.toml
+++ b/lib/portpicker/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "portpicker"
+version = "1.0.0"
+authors = ["Vector Contributors <vector@timber.io>", "Hannes Karppila <hannes.karppila@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+rand = "0.8.0"

--- a/lib/portpicker/src/lib.rs
+++ b/lib/portpicker/src/lib.rs
@@ -1,0 +1,112 @@
+// Modified by `Vector Contributors <vector@timber.io>`.
+// Based on `https://github.com/Dentosal/portpicker-rs` by `Hannes Karppila <hannes.karppila@gmail.com>`.
+// `portpicker-rs` LICENSE:
+// This is free and unencumbered software released into the public domain.
+
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+// For more information, please refer to <http://unlicense.org>
+
+use rand::{thread_rng, Rng};
+use std::net::{
+    Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, TcpListener, ToSocketAddrs, UdpSocket,
+};
+
+pub type Port = u16;
+
+// Try to bind to a socket using UDP
+fn test_bind_udp<A: ToSocketAddrs>(addr: A) -> Option<Port> {
+    Some(UdpSocket::bind(addr).ok()?.local_addr().ok()?.port())
+}
+
+// Try to bind to a socket using TCP
+fn test_bind_tcp<A: ToSocketAddrs>(addr: A) -> Option<Port> {
+    Some(TcpListener::bind(addr).ok()?.local_addr().ok()?.port())
+}
+
+/// Check if a port is free on UDP
+pub fn is_free_udp(port: Port) -> bool {
+    let ipv4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    let ipv6 = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
+
+    test_bind_udp(ipv6).is_some() && test_bind_udp(ipv4).is_some()
+}
+
+/// Check if a port is free on TCP
+pub fn is_free_tcp(port: Port) -> bool {
+    let ipv4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    let ipv6 = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
+
+    test_bind_tcp(ipv6).is_some() && test_bind_tcp(ipv4).is_some()
+}
+
+/// Check if a port is free on both TCP and UDP
+pub fn is_free(port: Port) -> bool {
+    is_free_tcp(port) && is_free_udp(port)
+}
+
+/// Asks the OS for a free port
+fn ask_free_tcp_port() -> Option<Port> {
+    let ipv4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+    let ipv6 = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0);
+
+    test_bind_tcp(ipv6).or_else(|| test_bind_tcp(ipv4))
+}
+
+/// Picks an available port that is available on both TCP and UDP
+/// ```rust
+/// use portpicker::pick_unused_port;
+/// let port: u16 = pick_unused_port();
+/// ```
+pub fn pick_unused_port() -> Port {
+    let mut rng = thread_rng();
+
+    loop {
+        // Try random port first
+        for _ in 0..10 {
+            let port = rng.gen_range(15000..25000);
+            if is_free(port) {
+                return port;
+            }
+        }
+
+        // Ask the OS for a port
+        for _ in 0..10 {
+            if let Some(port) = ask_free_tcp_port() {
+                // Test that the udp port is free as well
+                if is_free_udp(port) {
+                    return port;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_unused_port;
+
+    #[test]
+    fn it_works() {
+        pick_unused_port();
+    }
+}

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -84,12 +84,12 @@ pub fn open_fixture(path: impl AsRef<Path>) -> crate::Result<serde_json::Value> 
 }
 
 pub fn next_addr() -> SocketAddr {
-    let port = pick_unused_port().unwrap();
+    let port = pick_unused_port();
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
 }
 
 pub fn next_addr_v6() -> SocketAddr {
-    let port = pick_unused_port().unwrap();
+    let port = pick_unused_port();
     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), port)
 }
 


### PR DESCRIPTION
Part of #5738 

This PR add [portpicker-rs](https://github.com/Dentosal/portpicker-rs) and [is_enum_variant](https://github.com/fitzgen/derive_is_enum_variant) abandoned crates to `lib`.