### PR TITLE
chore(tests): Register signal handler before causing signal

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -128,10 +128,10 @@ mod tests {
     use tokio::signal::unix::{signal, SignalKind};
 
     async fn test(file: &mut File, timeout: Duration) -> bool {
+        let mut signal = signal(SignalKind::hangup()).expect("Signal handlers should not panic.");
+
         file.write_all(&[0]).unwrap();
         file.sync_all().unwrap();
-
-        let mut signal = signal(SignalKind::hangup()).expect("Signal handlers should not panic.");
 
         tokio::time::timeout(timeout, signal.recv()).await.is_ok()
     }


### PR DESCRIPTION
The `file_update` test was flaky on mac https://github.com/timberio/vector/pull/5821/checks?check_run_id=1644393968 hopefully this was the cause.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
