### PR TITLE
chore(ci): Configure criterion noise thresholds

### DIFF
--- a/benches/batch.rs
+++ b/benches/batch.rs
@@ -93,7 +93,13 @@ fn benchmark_batching(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_batching);
+criterion_group!(
+    name = benches;
+    // noisy benchmarks; 10% encapsulates what we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.10);
+    targets = benchmark_batching
+);
 
 pub struct PartitionedBuffer {
     inner: Buffer,

--- a/benches/buffering.rs
+++ b/benches/buffering.rs
@@ -157,4 +157,10 @@ fn benchmark_buffers(c: &mut Criterion) {
     //});
 }
 
-criterion_group!(benches, benchmark_buffers);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = benchmark_buffers
+);

--- a/benches/event.rs
+++ b/benches/event.rs
@@ -98,4 +98,10 @@ fn create_event(json: Value) -> LogEvent {
     output.into_iter().next().unwrap().into_log()
 }
 
-criterion_group!(benches, benchmark_event);
+criterion_group!(
+    name = benches;
+    // encapsulates inherent CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = benchmark_event
+);

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -92,4 +92,10 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchmark_files_without_partitions);
+criterion_group!(
+    name = benches;
+    // encapsulates inherent CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = benchmark_files_without_partitions
+);

--- a/benches/isolated_buffering.rs
+++ b/benches/isolated_buffering.rs
@@ -192,4 +192,10 @@ fn random_events(size: usize) -> impl Stream<Item = Event, Error = ()> {
     stream::iter_ok(random_lines(size)).map(Event::from)
 }
 
-criterion_group!(benches, benchmark_buffers);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = benchmark_buffers
+);

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -55,6 +55,8 @@ fn lookup_to_string(c: &mut Criterion) {
     group_from_elem.finish();
 
     let mut group_to_string = c.benchmark_group("to_string");
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
     for (_path, fixture) in fixtures.iter() {
         group_to_string.throughput(Throughput::Bytes(fixture.clone().into_bytes().len() as u64));
         group_to_string.bench_with_input(
@@ -91,6 +93,8 @@ fn lookup_to_string(c: &mut Criterion) {
     group_serialize.finish();
 
     let mut group_deserialize = c.benchmark_group("deserialize");
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
     for (_path, fixture) in fixtures.iter() {
         group_deserialize.throughput(Throughput::Bytes(fixture.clone().into_bytes().len() as u64));
         group_deserialize.bench_with_input(
@@ -109,4 +113,10 @@ fn lookup_to_string(c: &mut Criterion) {
     group_deserialize.finish();
 }
 
-criterion_group!(benches, lookup_to_string);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = lookup_to_string
+);

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -188,4 +188,10 @@ end
     group.finish();
 }
 
-criterion_group!(benches, bench_add_fields, bench_field_filter);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = bench_field_filter
+);

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -193,5 +193,5 @@ criterion_group!(
     // encapsulates CI noise we saw in
     // https://github.com/timberio/vector/issues/5394
     config = Criterion::default().noise_threshold(0.05);
-    targets = bench_field_filter
+    targets = bench_add_fields, bench_field_filter
 );

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -74,4 +74,10 @@ fn http_access_log_lines() -> impl Iterator<Item = String> {
     })
 }
 
-criterion_group!(benches, benchmark_regex);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.07);
+    targets = benchmark_regex
+);

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -15,7 +15,13 @@ use vector::{
     test_util::runtime,
 };
 
-criterion_group!(benches, benchmark_remap, upcase, downcase, parse_json);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.02);
+    targets = benchmark_remap, upcase, downcase, parse_json
+);
 criterion_main!(benches);
 
 bench_function! {

--- a/benches/template.rs
+++ b/benches/template.rs
@@ -41,4 +41,10 @@ fn bench_elasticsearch_index(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_elasticsearch_index);
+criterion_group!(
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.20);
+    targets = bench_elasticsearch_index
+);

--- a/benches/topology.rs
+++ b/benches/topology.rs
@@ -436,9 +436,9 @@ fn benchmark_complex(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    benchmark_simple_pipes,
-    benchmark_interconnected,
-    benchmark_transforms,
-    benchmark_complex,
+    name = benches;
+    // encapsulates CI noise we saw in
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.20);
+    targets = benchmark_simple_pipes, benchmark_interconnected, benchmark_transforms, benchmark_complex
 );

--- a/benches/wasm/mod.rs
+++ b/benches/wasm/mod.rs
@@ -168,7 +168,13 @@ fn bench_group_transforms_over_parameterized_event_sizes(
     group.finish();
 }
 
-criterion_group!(benches, protobuf, add_fields);
+criterion_group!(
+    name = benches;
+    // We've seen CI noise commonly be 5% so configure here
+    // https://github.com/timberio/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = protobuf, add_fields
+);
 criterion_main! {
     benches,
 }


### PR DESCRIPTION
Configure the noise thresholds for various benchmark groups based on the
findings in https://github.com/timberio/vector/issues/5394 when we ran
8 runs in parallel, 50 times, on our benchmark runner.

I didn't actually run the wasm benches as part of that test so just
configuring to 0.05 for now, but we can see.

Should merge after #5850 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
