### PR TITLE
chore(ci): Run benchmarks on isolated CPU

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -70,14 +70,13 @@ jobs:
       - run: unzip target/criterion.zip
         continue-on-error: true
       - run: make slim-builds
+        # build benchmarks on all CPUs, including isolated benchmarking CPU
+      - name: Prebuild benchmarks
+        run: taskset -c "0-$(nproc)" make bench CARGO_BENCH_FLAGS="--no-run"
+        # run benchmarks on isolated CPU and with address randomization
+        # disabled
       - name: Run benchmarks
-        run: |
-          mkdir -p target/criterion
-          # build benchmarks on all CPUs, including isolated benchmarking CPU
-          taskset -c "0-$(nproc)" make bench CARGO_BENCH_FLAGS="--no-run"
-          # run benchmarks on isolated CPU and with address randomization
-          # disabled
-          setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench | tee target/criterion/out
+        run: setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench | tee target/criterion/out
       - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -75,7 +75,10 @@ jobs:
       - name: Run benchmarks
         run: |
           mkdir -p target/criterion
-          make bench | tee target/criterion/out
+          # build benchmarks on all CPUs, including isolated benchmarking CPU
+          taskset -c "0-$(nproc)" make bench CARGO_BENCH_FLAGS="--no-run"
+          # run benchmarks on isolated CPU
+          setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench | tee target/criterion/out
       - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -77,7 +77,8 @@ jobs:
           mkdir -p target/criterion
           # build benchmarks on all CPUs, including isolated benchmarking CPU
           taskset -c "0-$(nproc)" make bench CARGO_BENCH_FLAGS="--no-run"
-          # run benchmarks on isolated CPU
+          # run benchmarks on isolated CPU and with address randomization
+          # disabled
           setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench | tee target/criterion/out
       - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ endif
 
 # Override this with any scopes for testing/benching.
 export SCOPE ?= ""
+# Override this with any extra flags for cargo bench
+export CARGO_BENCH_FLAGS ?= ""
 # Override to false to disable autospawning services on integration tests.
 export AUTOSPAWN ?= true
 # Override to control if services are turned off after integration tests.
@@ -899,23 +901,23 @@ test-wasm: $(WASM_MODULE_OUTPUTS)  ### Run engine tests
 
 .PHONY: bench
 bench: ## Run benchmarks in /benches
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches"
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches" ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 .PHONY: bench-remap
 bench-remap: ## Run benchmarks in /benches
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "remap-benches" --bench remap
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "remap-benches" --bench remap ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 .PHONY: bench-wasm
 bench-wasm: $(WASM_MODULE_OUTPUTS)  ### Run WASM benches
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm wasm
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm wasm ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 .PHONY: bench-all
 bench-all: ### Run default and WASM benches
 bench-all: $(WASM_MODULE_OUTPUTS)
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches wasm-benches"
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches wasm-benches" ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 ##@ Checking


### PR DESCRIPTION
Build benchmarks on all CPUs first, and then run on the isolated CPU
(always 0).

Should be merged after https://github.com/timberio/vector/pull/5850

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
