### PR TITLE
chore(ci): Show p value for criterion benchmark table output

### DIFF
--- a/scripts/check-criterion-output.sh
+++ b/scripts/check-criterion-output.sh
@@ -13,9 +13,9 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 # Always exit 0 until we resolve
 # https://github.com/timberio/vector/issues/5394
 (
-  echo -e "name\ttime\ttime change\tthroughput\tthroughput change\tchange";
+  echo -e "name\ttime\ttime change\tthroughput\tthroughput change\tp\tchange";
   awk --file "$DIR/parse-criterion-output.awk" |
-    jq --slurp --raw-output '.[] | [.name, .time, .time_change, .throughput, .throughput_change, .change] | @tsv'
+    jq --slurp --raw-output '.[] | [.name, .time, .time_change, (.throughput // "unknown"), (.throughput_change // "unknown"), .p, .change] | @tsv'
 ) |
   column -s $'\t' -t  |
   (awk -v rc=0 '/regressed/ { rc=1 } 1; END { if (rc == 1) { print "\nRegression detected. Note that any regressions should be verified."; exit rc }}' || true)

--- a/scripts/parse-criterion-output.awk
+++ b/scripts/parse-criterion-output.awk
@@ -46,8 +46,9 @@
 BEGIN {
   # match time:   [1.8272 s 1.8391 s 1.8498 s]
   measurement_regex = "\\[(.+ .+) (.+ .+) (.+ .+)\\]"
-  # match change: [+0.1481% +0.8758% +1.5410%] (p = 0.01 < 0.05)
+  # match time change: [+0.1481% +0.8758% +1.5410%] (p = 0.01 < 0.05)
   time_change_regex = "\\[(.+) (.+) (.+)\\] \\(p = (.+) [<>] .+\\)"
+  # match thrpt change: [+0.1481% +0.8758% +1.5410%]
   thrpt_change_regex = "\\[(.+) (.+) (.+)\\]"
 }
 

--- a/scripts/parse-criterion-output.awk
+++ b/scripts/parse-criterion-output.awk
@@ -38,8 +38,8 @@
 #
 # To output records like:
 # ```
-# { "throughput": "32.852 MiB/s",  "change": "none",  "throughput_change": "-1.0800%",  "name": "transforms/transforms",  "time_change": "+1.0918%",  "time": "31.932 ms"}
-# { "throughput": null,  "change": "none",  "throughput_change": null,  "name": "complex/complex",  "time_change": "+0.8758%",  "time": "1.8391 s"}
+# { "throughput": "32.852 MiB/s",  "change": "none",  "throughput_change": "-1.0800%",  "name": "transforms/transforms",  "time_change": "+1.0918%",  "time": "31.932 ms", "p": "0.0"}
+# { "throughput": null,  "change": "none",  "throughput_change": null,  "name": "complex/complex",  "time_change": "+0.8758%",  "time": "1.8391 s", "p": "0,2"}
 # ```
 ###
 
@@ -47,7 +47,8 @@ BEGIN {
   # match time:   [1.8272 s 1.8391 s 1.8498 s]
   measurement_regex = "\\[(.+ .+) (.+ .+) (.+ .+)\\]"
   # match change: [+0.1481% +0.8758% +1.5410%] (p = 0.01 < 0.05)
-  change_regex = "\\[(.+) (.+) (.+)\\]"
+  time_change_regex = "\\[(.+) (.+) (.+)\\] \\(p = (.+) [<>] .+\\)"
+  thrpt_change_regex = "\\[(.+) (.+) (.+)\\]"
 }
 
 function finish_benchmark(benchmark, change)
@@ -74,7 +75,7 @@ function finish_benchmark(benchmark, change)
 
 /^Benchmarking .*: Analyzing$/ {
   match($0, /^Benchmarking (.*): Analyzing$/, arr)
-  num_fields = split("name time time_change throughput throughput_change change", fields)
+  num_fields = split("name time time_change throughput throughput_change p change", fields)
   for (i=1; i<=num_fields; i++) benchmark[fields[i]] = "null"
   benchmark["name"] = arr[1]
   benchmark["change"] = "unknown"
@@ -84,12 +85,13 @@ function finish_benchmark(benchmark, change)
 in_bench && /change:$/ { in_change = 1 }
 
 in_change && /time: / {
-  match($0, change_regex, arr)
+  match($0, time_change_regex, arr)
   benchmark["time_change"] = arr[2]
+  benchmark["p"] = arr[4]
 }
 
 in_change && /\s+thrpt: / {
-  match($0, change_regex, arr)
+  match($0, thrpt_change_regex, arr)
   benchmark["throughput_change"] = arr[2]
 }
 
@@ -104,8 +106,9 @@ in_change && /\s+thrpt: / {
 }
 
 !in_change && /change: / {
-  match($0, change_regex, arr)
+  match($0, time_change_regex, arr)
   benchmark["time_change"] = arr[2]
+  benchmark["p"] = arr[4]
 }
 
 in_bench && /Performance has improved./ { finish_benchmark(benchmark, "improved") }

--- a/scripts/parse-criterion-output.awk
+++ b/scripts/parse-criterion-output.awk
@@ -38,18 +38,18 @@
 #
 # To output records like:
 # ```
-# { "throughput": "32.852 MiB/s",  "change": "none",  "throughput_change": "-1.0800%",  "name": "transforms/transforms",  "time_change": "+1.0918%",  "time": "31.932 ms", "p": "0.0"}
-# { "throughput": null,  "change": "none",  "throughput_change": null,  "name": "complex/complex",  "time_change": "+0.8758%",  "time": "1.8391 s", "p": "0,2"}
+# { "throughput": "32.852 MiB/s",  "change": "none",  "throughput_change": "-1.0800%",  "name": "transforms/transforms",  "time_change": "+1.0918%",  "time": "31.932 ms", "p": "0.00"}
+# { "throughput": null,  "change": "none",  "throughput_change": null,  "name": "complex/complex",  "time_change": "+0.8758%",  "time": "1.8391 s", "p": "0.02"}
 # ```
 ###
 
 BEGIN {
   # match time:   [1.8272 s 1.8391 s 1.8498 s]
-  measurement_regex = "\\[(.+ .+) (.+ .+) (.+ .+)\\]"
+  measurement_regex = "\\[(\\S+ \\S+) (\\S+ \\S+) (\\S+ \\S+)\\]"
   # match time change: [+0.1481% +0.8758% +1.5410%] (p = 0.01 < 0.05)
-  time_change_regex = "\\[(.+) (.+) (.+)\\] \\(p = (.+) [<>] .+\\)"
+  time_change_regex = "\\[(\\S+) (\\S+) (\\S+)\\] \\(p = (\\S+) [<>] \\S+\\)"
   # match thrpt change: [+0.1481% +0.8758% +1.5410%]
-  thrpt_change_regex = "\\[(.+) (.+) (.+)\\]"
+  thrpt_change_regex = "\\[(\\S+) (\\S+) (\\S+)\\]"
 }
 
 function finish_benchmark(benchmark, change)


### PR DESCRIPTION
I found this useful to look at.

Also default throughput values to "unknown" given they are sometimes null to align the table columns when they are missing.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
