### PR TITLE
chore(ci): Only notify failed nightly builds on master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -551,7 +551,7 @@ jobs:
 
   nightly-failure:
     name: nightly-failure
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/master'
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
@@ -575,4 +575,4 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       uses: Ilshidur/action-discord@0.3.0
       with:
-        args: "Nightly failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"
+        args: "Master nightly failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"


### PR DESCRIPTION
I think the notifications are noisy for adhoc PR runs where the author
is likely checking on it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
