### PR TITLE
chore(ci): Upload criterion benchmarks to criterion.dev

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,9 +1,9 @@
 name: Benchmark Suite
 
 on:
-	pull_request:
+  pull_request:
     branches:
-			-	master
+      - master
   push:
     branches:
       - master
@@ -92,7 +92,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
-			- name: Upload benchmarks to criterion.dev
+      - name: Upload benchmarks to criterion.dev
         run: bash <(curl -s https://criterion.dev/bash)
 
       # note: should run last to flag regressions

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -94,6 +94,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
       - name: Upload benchmarks to criterion.dev
         run: bash <(curl -s https://criterion.dev/bash)
+        env:
+          CRITERION_TOKEN: "${{ secrets.CRITERION_TOKEN }}"
 
       # note: should run last to flag regressions
       - run: cat target/criterion/out | scripts/check-criterion-output.sh

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,7 +1,9 @@
 name: Benchmark Suite
 
 on:
-  pull_request: {}
+	pull_request:
+    branches:
+			-	master
   push:
     branches:
       - master
@@ -54,6 +56,7 @@ jobs:
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+
       - name: Download baseline benchmarks
         uses: dawidd6/action-download-artifact@891cccee4b25d3306cf5edafa174ddc1d969871f
         continue-on-error: true
@@ -69,6 +72,7 @@ jobs:
           test -f target/criterion.zip || echo "::warning::No master benchmark artifacts could be fetched for comparison."
       - run: unzip target/criterion.zip
         continue-on-error: true
+
       - run: make slim-builds
         # build benchmarks on all CPUs, including isolated benchmarking CPU
       - name: Prebuild benchmarks
@@ -78,6 +82,7 @@ jobs:
       - name: Run benchmarks
         run: setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench | tee target/criterion/out
       - run: zip --recurse-paths target/criterion.zip target/criterion
+
       - uses: actions/upload-artifact@v2
         with:
           name: "criterion"
@@ -87,6 +92,9 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
+			- name: Upload benchmarks to criterion.dev
+        run: bash <(curl -s https://criterion.dev/bash)
+
       # note: should run last to flag regressions
       - run: cat target/criterion/out | scripts/check-criterion-output.sh
 


### PR DESCRIPTION
This seems somewhat like a pet project, but I'm curious to see if it
still helpful and/or if we could help support the maintainer if we find
value in it.

I think the benches should end up on https://criterion.dev/ once this CI job runs, but I'm not exactly sure where yet.

I created an account on criterion.dev using vector@timber.io and put the
password in the shared 1password account.

I consider this an experiment that we can run for a week or two and evaluate if it is useful; removing if not.

This also changes the benches suite to only run on PRs to master based
on criterion.dev's example which I found sensible.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
