### PR TITLE
chore(gcp_stackdriver sink): Make `resource` required in docs

### DIFF
--- a/docs/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/docs/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -135,9 +135,8 @@ components: sinks: gcp_stackdriver_logs: {
 			}
 		}
 		resource: {
-			common:      false
 			description: "Options for describing the logging resource."
-			required:    false
+			required:    true
 			warnings: []
 			type: object: {
 				examples: [


### PR DESCRIPTION
Closes #5929