### PR TITLE
fix(remap): Make the redact function fallible

### DIFF
--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -264,7 +264,7 @@ mod test {
             expr: |_| RedactFn {
                 value: lit!("1111222233334444").boxed(),
                 filters: vec![Filter::Pattern],
-                patterns: Some(vec![Literal::from(Regex::new("foo").unwrap()).into()]),
+                patterns: Some(vec![Literal::from(Regex::new(r"/[0-9]{16}/").unwrap()).into()]),
                 redactor: Redactor::Full,
             },
             def: TypeDef {

--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -119,7 +119,7 @@ impl Expression for RedactFn {
         match &self.patterns {
             Some(patterns) => {
                 for p in patterns {
-                    typedef = typedef.merge(p.type_def(state).with_constraint(Kind::Regex));
+                    typedef = typedef.merge(p.type_def(state).fallible_unless(Kind::Regex));
                 }
             }
             None => (),

--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -210,3 +210,37 @@ impl FromStr for Redactor {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    test_type_def![
+        string_infallible {
+            expr: |_| RedactFn {
+                value: lit!("foo").boxed(),
+                filters: vec![Filter::Pattern],
+                patterns: None,
+                redactor: Redactor::Full,
+            },
+            def: TypeDef {
+                kind: value::Kind::Bytes,
+                ..Default::default()
+            },
+        }
+
+        non_string_fallible {
+            expr: |_| RedactFn {
+                value: lit!(27).boxed(),
+                filters: vec![Filter::Pattern],
+                patterns: None,
+                redactor: Redactor::Full,
+            },
+            def: TypeDef {
+                fallible: true,
+                kind: value::Kind::Bytes,
+                ..Default::default()
+            },
+        }
+    ];
+}

--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -108,9 +108,12 @@ impl Expression for RedactFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        use value::Kind;
+
         self.value
             .type_def(state)
-            .with_constraint(value::Kind::Bytes)
+            .fallible_unless(Kind::Bytes)
+            .with_constraint(Kind::Bytes)
     }
 }
 

--- a/lib/remap-functions/src/redact.rs
+++ b/lib/remap-functions/src/redact.rs
@@ -110,10 +110,22 @@ impl Expression for RedactFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         use value::Kind;
 
-        self.value
+        let mut typedef = self
+            .value
             .type_def(state)
             .fallible_unless(Kind::Bytes)
-            .with_constraint(Kind::Bytes)
+            .with_constraint(Kind::Bytes);
+
+        match &self.patterns {
+            Some(patterns) => {
+                for p in patterns {
+                    typedef = typedef.merge(p.type_def(state).with_constraint(Kind::Regex));
+                }
+            }
+            None => (),
+        }
+
+        typedef
     }
 }
 


### PR DESCRIPTION
This PR fixes the type definition for the `redact` function to indicate its fallibility. Going over this function, though, raised the following question for me.

In several functions, including `redact`, the work of handling non-required arguments happens during the `compile` step, which allows for a "cleaner" function struct that isn't just a placeholder for multiple `Box<dyn Expression>` values:

```rust
struct RedactFn {
    value: Box<dyn Expression>,
    filters: Vec<Filter>,
    redactor: Redactor,
    patterns: Option<Vec<Expr>>,
}
```

The problem I see, though, is that this doesn't allow for accurate `type_def`s. I believe you need either the original `Box<dyn Expression>` or `Option<Box<dyn Expression>>` to properly compute the type definition. In the case of the `redact` function, the type def doesn't account for `filters`, `redactor`, or `patterns` and is thus incorrect.

If this is indeed a problem, I'll update this PR to fix that in the `redact` function and a separate PR for the other functions that do this (`sha2` and `sha3` come to mind).