### PR TITLE
chore(tests): Add missing encoding option to new_relic_logs sink test

### DIFF
--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -298,6 +298,7 @@ mod tests {
         let config = r#"
         insert_key = "foo"
         region = "eu"
+        encoding = "json"
 
         [batch]
         max_size = 8388600


### PR DESCRIPTION
This test is marked as `should_panic` as it is asserting that the
max_size is too big, but was panicking instead because it was missing
the encoding key.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
