### PR TITLE
fix(remap): Remove errant VRL benchmark

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -49,14 +49,6 @@ bench_function! {
         args: func_args![value: r#"{"key": "value"}"#],
         want: Ok(value!({"key": "value"})),
     }
-
-    invalid_json_with_default {
-        args: func_args![
-            value: r#"{"key": INVALID}"#,
-            default: r#"{"key": "default"}"#,
-        ],
-        want: Ok(value!({"key": "default"})),
-    }
 }
 
 fn benchmark_remap(c: &mut Criterion) {


### PR DESCRIPTION
This PR removes a benchmark function that is bound to fail given changes introduced in #5745, specifically the removal of all `default` args in VRL functions.