### PR TITLE
fix(config): Avoid alias `in_flight_limit`

### DIFF
--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -426,7 +426,7 @@ impl RequestConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_util::next_addr;
+    use crate::{sinks::util::service::Concurrency, test_util::next_addr};
     use futures::{compat::Future01CompatExt, future::ready};
     use futures01::Stream;
     use hyper::{
@@ -503,5 +503,12 @@ mod test {
 
         let (body, _rest) = rx.into_future().compat().await.unwrap();
         assert_eq!(body.unwrap(), "hello");
+    }
+
+    #[test]
+    fn alias_in_flight_limit_works() {
+        let cfg = toml::from_str::<RequestConfig>("in_flight_limit = 10")
+            .expect("Fixed concurrency failed for in_flight_limit param");
+        assert_eq!(cfg.tower.concurrency(), &Concurrency::Fixed(10));
     }
 }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -219,7 +219,7 @@ impl<T: ConcurrencyOption> TowerRequestConfig<T> {
             (_, false) => &self.concurrency,
             (false, true) => &self.in_flight_limit,
             (true, true) => {
-                warn!("Option `in_flight_limit` has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option");
+                warn!("Option `in_flight_limit` has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option.");
                 &self.concurrency
             }
         }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -129,6 +129,9 @@ impl<'de> Deserialize<'de> for Concurrency {
 pub trait ConcurrencyOption {
     fn parse_concurrency(&self, default: &Self) -> Option<usize>;
     fn is_none(&self) -> bool;
+    fn is_some(&self) -> bool {
+        !self.is_none()
+    }
 }
 
 impl ConcurrencyOption for Option<usize> {
@@ -214,10 +217,10 @@ impl<T: ConcurrencyOption> TowerRequestConfig<T> {
     }
 
     fn concurrency(&self) -> &T {
-        match (self.concurrency.is_none(), self.in_flight_limit.is_none()) {
-            (_, true) => &self.concurrency,
-            (true, false) => &self.in_flight_limit,
-            (false, false) => {
+        match (self.concurrency.is_some(), self.in_flight_limit.is_some()) {
+            (_, false) => &self.concurrency,
+            (false, true) => &self.in_flight_limit,
+            (true, true) => {
                 warn!("`in_flight_limit` option has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option");
                 &self.concurrency
             }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -216,12 +216,12 @@ impl<T: ConcurrencyOption> TowerRequestConfig<T> {
         }
     }
 
-    fn concurrency(&self) -> &T {
+    pub fn concurrency(&self) -> &T {
         match (self.concurrency.is_some(), self.in_flight_limit.is_some()) {
             (_, false) => &self.concurrency,
             (false, true) => &self.in_flight_limit,
             (true, true) => {
-                warn!("`in_flight_limit` option has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option");
+                warn!("Option `in_flight_limit` has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option");
                 &self.concurrency
             }
         }
@@ -463,6 +463,6 @@ mod tests {
 
         let cfg = toml::from_str::<TowerRequestConfigTest>("in_flight_limit = 10")
             .expect("Fixed concurrency failed for in_flight_limit param");
-        assert_eq!(cfg.concurrency, Concurrency::Fixed(10));
+        assert_eq!(cfg.concurrency(), &Concurrency::Fixed(10));
     }
 }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -185,8 +185,6 @@ pub struct TowerRequestConfig<T: ConcurrencyOption = Concurrency> {
 
 impl<T: ConcurrencyOption> TowerRequestConfig<T> {
     pub fn unwrap_with(&self, defaults: &Self) -> TowerRequestSettings {
-        // let concurrency
-
         TowerRequestSettings {
             concurrency: self
                 .concurrency()


### PR DESCRIPTION
Closes #5920 

A case of serde-rs/serde#1504.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
