### PR TITLE
chore(journald source): Deprecate `remap_priority` option

### DIFF
--- a/docs/reference/components/sources/journald.cue
+++ b/docs/reference/components/sources/journald.cue
@@ -93,13 +93,6 @@ components: sources: journald: {
 				examples: ["/usr/local/bin/journalctl"]
 			}
 		}
-		remap_priority: {
-			common:      false
-			description: "If the record from journald contains a `PRIORITY` field, it will be remapped into the equivalent syslog priority level name using the standard (abbreviated) all-capitals names such as `EMERG` or `ERR`."
-			required:    false
-			warnings: []
-			type: bool: default: false
-		}
 	}
 
 	output: logs: {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -75,8 +75,9 @@ pub struct JournaldConfig {
     pub data_dir: Option<PathBuf>,
     pub batch_size: Option<usize>,
     pub journalctl_path: Option<PathBuf>,
+    /// Deprecated
     #[serde(default)]
-    pub remap_priority: bool,
+    remap_priority: bool,
 }
 
 inventory::submit! {
@@ -97,6 +98,10 @@ impl SourceConfig for JournaldConfig {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> crate::Result<super::Source> {
+        if self.remap_priority {
+            warn!("Option `remap_priority` has been deprecated. Please use the `remap` transform and function `to_syslog_level` instead.");
+        }
+
         let data_dir = globals.resolve_and_make_data_subdir(self.data_dir.as_ref(), name)?;
 
         let include_units = match (!self.units.is_empty(), !self.include_units.is_empty()) {


### PR DESCRIPTION
Ref #4414 

~~The functionality and the docs are removed, but the option remains to detect it's usage and error with a helpful message.~~

EDIT:
Removes the docs and adds a warning with a message to use `remap` instead.

The plan is to deprecate first and then to remove the functionality and turn the warning into an error in a later release.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
