### PR TITLE
fix(tests): Set `core_threads` for `merge_and_fork`

### DIFF
--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -158,7 +158,7 @@ async fn fork() {
     assert_eq!(input_lines, output_lines2);
 }
 
-#[tokio::test]
+#[tokio::test(core_threads = 2)]
 async fn merge_and_fork() {
     trace_init();
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -158,6 +158,10 @@ async fn fork() {
     assert_eq!(input_lines, output_lines2);
 }
 
+// In cpu constrained environments at least two threads
+// are needed to finish processing all the events before
+// sources are forcefully shutted down.
+// Although that's still not a guarantee.
 #[tokio::test(core_threads = 2)]
 async fn merge_and_fork() {
     trace_init();


### PR DESCRIPTION
Closes #4714

In short, the test didn't have enough cpu time to finish in time.

The fix isn't guaranteed to help, since this is more of CI hardware issue.

The most damning evidence is the lack of 
```
INFO vector::topology: Shutting down... Waiting on: out2, in1, in2, out1. 41 seconds left
```
logs which should happen every 5 seconds but only happened twice in span of 35 seconds.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
