### PR TITLE
enhancement(config)!: remove the check_fields default for conditions

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,6 +1,5 @@
 use crate::config::component::ComponentDescription;
 use crate::Event;
-use serde::{Deserialize, Serialize};
 
 pub mod check_fields;
 pub mod is_log;
@@ -35,19 +34,3 @@ dyn_clone::clone_trait_object!(ConditionConfig);
 pub type ConditionDescription = ComponentDescription<Box<dyn ConditionConfig>>;
 
 inventory::collect!(ConditionDescription);
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(untagged)]
-pub enum AnyCondition {
-    FromType(Box<dyn ConditionConfig>),
-    NoTypeCondition(CheckFieldsConfig),
-}
-
-impl AnyCondition {
-    pub fn build(&self) -> crate::Result<Box<dyn Condition>> {
-        match self {
-            Self::FromType(c) => c.build(),
-            Self::NoTypeCondition(c) => c.build(),
-        }
-    }
-}

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{AnyCondition, Condition},
+    conditions::{Condition, ConditionConfig},
     config::{DataType, GenerateConfig, TransformConfig, TransformDescription},
     event::Event,
     internal_events::{FilterEventDiscarded, FilterEventProcessed},
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 struct FilterConfig {
-    condition: AnyCondition,
+    condition: Box<dyn ConditionConfig>,
 }
 
 inventory::submit! {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{AnyCondition, Condition},
+    conditions::{Condition, ConditionConfig},
     config::{DataType, TransformConfig, TransformDescription},
     event::discriminant::Discriminant,
     event::{Event, LogEvent},
@@ -39,8 +39,8 @@ pub struct ReduceConfig {
 
     /// An optional condition that determines when an event is the end of a
     /// reduce.
-    pub ends_when: Option<AnyCondition>,
-    pub starts_when: Option<AnyCondition>,
+    pub ends_when: Option<Box<dyn ConditionConfig>>,
+    pub starts_when: Option<Box<dyn ConditionConfig>>,
 }
 
 inventory::submit! {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -310,6 +310,7 @@ mod test {
 group_by = [ "request_id" ]
 
 [ends_when]
+  type = "check_fields"
   "test_end.exists" = true
 "#,
         )
@@ -367,6 +368,7 @@ merge_strategies.bar = "array"
 merge_strategies.baz = "max"
 
 [ends_when]
+  type = "check_fields"
   "test_end.exists" = true
 "#,
         )
@@ -416,6 +418,7 @@ merge_strategies.baz = "max"
 group_by = [ "request_id" ]
 
 [ends_when]
+  type = "check_fields"
   "test_end.exists" = true
 "#,
         )
@@ -472,6 +475,7 @@ merge_strategies.foo = "array"
 merge_strategies.bar = "concat"
 
 [ends_when]
+  type = "check_fields"
   "test_end.exists" = true
 "#,
         )

--- a/src/transforms/swimlanes.rs
+++ b/src/transforms/swimlanes.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{AnyCondition, Condition},
+    conditions::{Condition, ConditionConfig},
     config::{DataType, GenerateConfig, TransformConfig, TransformDescription},
     event::Event,
     internal_events::SwimlanesEventDiscarded,
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct SwimlaneConfig {
     #[serde(flatten)]
-    condition: AnyCondition,
+    condition: Box<dyn ConditionConfig>,
 }
 
 #[async_trait::async_trait]
@@ -65,7 +65,7 @@ impl FunctionTransform for Swimlane {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SwimlanesConfig {
-    lanes: IndexMap<String, AnyCondition>,
+    lanes: IndexMap<String, Box<dyn ConditionConfig>>,
 }
 
 inventory::submit! {

--- a/tests/behavior/transforms/filter.toml
+++ b/tests/behavior/transforms/filter.toml
@@ -2,6 +2,7 @@
   inputs = ["ignored"]
   type = "filter"
   [transforms.filter_a.condition]
+    type = "check_fields"
     "message.eq" = "test filter 1"
 [transforms.filter_b]
   inputs = ["ignored"]
@@ -25,6 +26,7 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test filter 1"
 
 [[tests]]
@@ -57,6 +59,7 @@
   [[tests.outputs]]
     extract_from = "filter_b"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test filter 2"
 
 [[tests]]
@@ -78,4 +81,5 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test filter 1"

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -3,6 +3,7 @@
   type = "reduce"
   group_by = [ "request_id" ]
   [transforms.reduce.ends_when]
+    type = "check_fields"
     "test_end_message.exists" = true
 
 [[tests]]
@@ -67,12 +68,14 @@
   [[tests.outputs]]
     extract_from = "reduce"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "first message value"
       "host.equals" = "host1"
       "request_id.equals" = "1"
       "counter.equals" = 21
       "timestamp_end.exists" = true
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "other reduce one"
       "host.equals" = "host3"
       "request_id.equals" = "2"
@@ -93,6 +96,7 @@
     "concat_array" = "concat"
 
   [transforms.reduce_strats.ends_when]
+    type = "check_fields"
     "test_end_message.exists" = true
 
 [[tests]]
@@ -167,6 +171,7 @@
   [[tests.outputs]]
     extract_from = "reduce_strats"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "first message value second message value third message value"
       "another.equals" = "foo\nbar baz\nqux\nquux"
       "host.equals" = "host1"
@@ -174,6 +179,7 @@
       "counter.equals" = 21
       "timestamp_end.exists" = true
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "other reduce one other reduce two other reduce three"
       "concat_array[0].equals" = "foo"
       "concat_array[1].equals" = "bar"
@@ -194,6 +200,7 @@
     "maxs" = "max"
 
   [transforms.reduce_numbers.ends_when]
+    type = "check_fields"
     "test_end_message.exists" = true
 
 [[tests]]
@@ -224,6 +231,7 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "mins.equals" = 5.1
       "maxs.equals" = 7.2
       "timestamp_end.exists" = true
@@ -256,6 +264,7 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "mins.equals" = 5
       "maxs.equals" = 7
       "timestamp_end.exists" = true
@@ -331,14 +340,17 @@
   [[tests.outputs]]
     extract_from = "ends_when_remap"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "request_id.equals" = "1"
       "counter.equals" = 6
       "timestamp_end.exists" = true
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "request_id.equals" = "2"
       "counter.equals" = 7
       "test_end_message.exists" = true
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "request_id.equals" = "3"
       "counter.equals" = 5
       "test_end_message.exists" = true
@@ -394,8 +406,10 @@
   [[tests.outputs]]
     extract_from = "ruby_exception"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
 
 ##------------------------------------------------------------------------------
@@ -443,10 +457,13 @@
   [[tests.outputs]]
     extract_from = "line_continuation"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "First-line"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "Second line\\ more second line\\      end of second line"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "third line"
 
 ##------------------------------------------------------------------------------
@@ -494,10 +511,13 @@
   [[tests.outputs]]
     extract_from = "line_termination"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "first line;"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "second line more of the second line end of second line;         "
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "third line;"
 
 ##------------------------------------------------------------------------------
@@ -545,10 +565,13 @@
   [[tests.outputs]]
     extract_from = "log_stream"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "<12> first line   more of the first line"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "<22> second line"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "<17> third line"
 
 ##------------------------------------------------------------------------------
@@ -626,5 +649,6 @@
   [[tests.outputs]]
     extract_from = "java_exception"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.starts_with" = "2020-10-19 04:34:15,389"
       "message.ends_with" = "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]"

--- a/tests/behavior/transforms/swimlanes.toml
+++ b/tests/behavior/transforms/swimlanes.toml
@@ -2,8 +2,10 @@
   inputs = ["ignored"]
   type = "swimlanes"
   [transforms.foo.lanes.first]
+    type = "check_fields"
     "message.eq" = "test swimlane 1"
   [transforms.foo.lanes.second]
+    type = "check_fields"
     "message.eq" = "test swimlane 2"
   [transforms.foo.lanes.third]
     type = "is_log"
@@ -25,17 +27,20 @@
   [[tests.outputs]]
     extract_from = "foo.first"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test swimlane 1"
 
   [[tests.outputs]]
     extract_from = "bar"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test swimlane 1"
       "new_field.equals" = "new field added"
 
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test swimlane 1"
 
 [[tests]]
@@ -49,9 +54,11 @@
   [[tests.outputs]]
     extract_from = "foo.second"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test swimlane 2"
 
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
+      type = "check_fields"
       "message.equals" = "test swimlane 2"


### PR DESCRIPTION
Closes #5724 

The type field for conditions is no longer optional.

So, for example using this transform:

```toml
[transforms.filter]
  type = "filter"
  inputs = ["stdin"]
  condition."message.contains" = "funky"
```

Now results in this error:

```
Jan 11 11:53:31.861 ERROR vector::cli: Configuration error. error=missing field `type` for key `transforms.filter` at line 9 column 1
```

Which is not ideal, the error should really say `missing field 'condition.type'`. I'm not sure of a way to make this work though, any ideas?

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>