### PR TITLE
chore(ci): More consistent docker push logic

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -14,7 +14,7 @@ CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 VERSION="${VECTOR_VERSION:-"$(scripts/version.sh)"}"
 DATE="${DATE:-"$(date -u +%Y-%m-%d)"}"
 PLATFORM="${PLATFORM:-}"
-PUSH="${PUSH:-}"
+PUSH="${PUSH:-"true"}"
 REPO="${REPO:-"timberio/vector"}"
 
 #
@@ -29,18 +29,24 @@ build() {
   local DOCKERFILE="distribution/docker/$BASE/Dockerfile"
 
   if [ -n "$PLATFORM" ]; then
+    ARGS=()
+    if [[ "$PUSH" == "true" ]]; then
+      ARGS+=(--push)
+    fi
+
     docker buildx build \
       --platform="$PLATFORM" \
       --tag "$TAG" \
       target/artifacts \
-      -f "$DOCKERFILE" --push
+      -f "$DOCKERFILE" \
+      "${ARGS[@]}"
   else
     docker build \
       --tag "$TAG" \
       target/artifacts \
       -f "$DOCKERFILE"
 
-      if [ -n "$PUSH" ]; then
+      if [[ "$PUSH" == "true" ]]; then
         docker push "$TAG"
       fi
   fi

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -104,7 +104,7 @@ if [[ -z "${CONTAINER_IMAGE:-}" ]]; then
       CHANNEL="test" \
       BASE="$BASE_TAG" \
       TAG="$VERSION_TAG" \
-      PUSH="" \
+      PUSH="false" \
       scripts/build-docker.sh
 
     # Prepare the container image for the deployment command.


### PR DESCRIPTION
This is a follow-up after the #5848. That PR missed a case of non-native docker image builds, so we fix the soundness of this logic.
At the same time, we switch to an easier to use env var value-based condition from the env var presence condition.