### PR TITLE
enhancement(remap): added `nullish` parameter to `compact`

### DIFF
--- a/docs/reference/remap/compact.cue
+++ b/docs/reference/remap/compact.cue
@@ -43,6 +43,13 @@ remap: functions: compact: {
 			default:     true
 			type: ["boolean"]
 		},
+		{
+			name:        "nullish"
+			description: "Tests if the value is nullish."
+			required:    false
+			default:     false
+			type: ["boolean"]
+		},
 	]
 	return: ["array", "map"]
 	category: "Enumerate"
@@ -52,6 +59,13 @@ remap: functions: compact: {
 		`array`.
 		Specify recursive, if recursive structures should also be compacted, the routine
 		will recurse along and `Array`s or `Map`s and compact those structures.
+		The following are considered nullish in VRL:
+
+		* `null`
+		* A single dash (`"-"`)
+		* Any string that contains only whitespace characters as defined by the the [Unicode
+		  definition of the `White_Space` property](\(urls.unicode_whitespace)). That includes
+		  empty strings (`""`), common characters like `"\n"`, "\r", and others.
 		"""#
 	examples: [
 		{

--- a/lib/remap-functions/src/is_nullish.rs
+++ b/lib/remap-functions/src/is_nullish.rs
@@ -1,5 +1,7 @@
 use remap::prelude::*;
 
+use crate::util;
+
 #[derive(Clone, Copy, Debug)]
 pub struct IsNullish;
 
@@ -30,21 +32,7 @@ struct IsNullishFn {
 
 impl Expression for IsNullishFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        match self.value.execute(state, object)? {
-            Value::Bytes(v) => {
-                let s = &String::from_utf8_lossy(&v)[..];
-
-                match s {
-                    "-" => Ok(true.into()),
-                    _ => {
-                        let has_whitespace = s.chars().all(char::is_whitespace);
-                        Ok(has_whitespace.into())
-                    }
-                }
-            }
-            Value::Null => Ok(true.into()),
-            _ => Ok(false.into()),
-        }
+        Ok(util::is_nullish(&self.value.execute(state, object)?).into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-functions/src/util.rs
+++ b/lib/remap-functions/src/util.rs
@@ -56,6 +56,25 @@ pub(crate) fn capture_regex_to_map(
     indexed.chain(names).collect()
 }
 
+#[cfg(any(feature = "is_nullish", feature = "compact"))]
+pub(crate) fn is_nullish(value: &Value) -> bool {
+    match value {
+        Value::Bytes(v) => {
+            let s = &String::from_utf8_lossy(&v)[..];
+
+            match s {
+                "-" => true,
+                _ => {
+                    let has_whitespace = s.chars().all(char::is_whitespace);
+                    has_whitespace
+                }
+            }
+        }
+        Value::Null => true,
+        _ => false,
+    }
+}
+
 #[macro_export]
 macro_rules! map {
     () => (


### PR DESCRIPTION
Closes #5577 

This adds the `nullish` parameter to the `compact` Remap function.

Note, the issue asks for the parameter to be called `blank`, but I am calling it `nullish`, inline with the `is_nullish` function.

@lucperkins  I'm wondering about the docs, there is a section here I've just copied from the `is_nullish` function. Is there a better way we can do it to share the text?

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

