### PR TITLE
fix(remap): allow underscores after reserved keywords for variable names

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -89,7 +89,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 
 // Other ----------------------------------------------------------------------
 
-ident = @{ !(reserved_keyword ~ !ASCII_ALPHANUMERIC) ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+ident = @{ !(reserved_keyword ~ !(ASCII_ALPHANUMERIC | "_")) ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 field = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 bang  =  { "!" }
 block =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }


### PR DESCRIPTION
Recent changes to prevent reserved keywords being used as variables names was also preventing variable names with an underscore after a reserved keyword.

eg.

- `if_foo`
- `for_zorp`
- `for_`

were also being denied. I can't think of a reason why we shouldn't allow these.

Feel free to just close if you disagree.



Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
