### PR TITLE
chore(ci): Add S3 redirects for old artifact names

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -65,6 +65,15 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   aws s3 cp "$td_nightly" "s3://packages.timber.io/vector/nightly/latest" --recursive --sse --acl public-read
   echo "Uploaded archives"
 
+  echo "Redirecting old artifact names"
+  find "$td_nightly" -maxdepth 1 -type f -print 0 | while read -r -d $'\0' file  ; do
+    file=$(basename "$file")
+    # vector-nightly-amd64.deb -> vector-amd64.deb
+    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/nightly/$DATE/${file/-nightly//}" --website-redirect "/vector/nightly/$DATE/$file" --acl public-read
+    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/nightly/latest/${file/-nightly//}" --website-redirect "/vector/nightly/latest/$file" --acl public-read
+  done
+  echo "Redirected old artifact names"
+
   # Verify that the files exist and can be downloaded
   echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
   sleep "$VERIFY_TIMEOUT"
@@ -100,6 +109,15 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   echo "Uploading artifacts to s3://packages.timber.io/vector/latest/"
   aws s3 cp "$td_latest" "s3://packages.timber.io/vector/latest/" --recursive --sse --acl public-read
   echo "Uploaded latest archives"
+
+  echo "Redirecting old artifact names"
+  find "$td" -maxdepth 1 -type f -print 0 | while read -r -d $'\0' file  ; do
+    file=$(basename "$file")
+    # vector-$version-amd64.deb -> vector-amd64.deb
+    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/$i/${file/-$i//}" --website-redirect "/vector/$i/$file" --acl public-read
+    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/latest/${file/-$i//}" --website-redirect "/vector/latest/$file" --acl public-read
+  done
+  echo "Redirected old artifact names"
 
   # Verify that the files exist and can be downloaded
   sleep "$VERIFY_TIMEOUT"


### PR DESCRIPTION
This uploads artifact redirects as part of the release to keep backwards
compatibility with the links.

For example,
https://packages.timber.io/vector/nightly/2021-01-10/vector-amd64.deb
is pointed to
https://packages.timber.io/vector/nightly/2021-01-10/vector-nightly-amd64.deb.

I initially looked at [S3's conditional redirects](https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects) but this doesn't seem powerful enough to model the patterns we need.

Assuming we like this, I'll try to backpopulate the old releases.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
