### PR TITLE
feat(remap): added support for Remap comments

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -134,6 +134,8 @@ reserved_keyword = @{
     | boolean
 }
 
+COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }
+
 WHITESPACE  = _{ " " | "\t" | ("\\" ~ NEWLINE) }
 
 // end of expression

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -137,6 +137,7 @@ impl fmt::Display for Rule {
             target_regular,
             value,
             variable,
+            COMMENT,
             WHITESPACE,
         ]
     }

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1660,3 +1660,21 @@
     extract_from = "remap_function_decode_base64"
     [[tests.outputs.conditions]]
     "result.equals" = "Bron-Y-Aur Stomp"
+
+[transforms.remap_comments]
+  inputs = []
+  type = "remap"
+  source = """
+    .a = 1 # .a = 2
+    # .a = 3
+  """
+[[tests]]
+  name = "remap_comments"
+  [tests.input]
+    insert_at = "remap_comments"
+    type = "log"
+    [tests.input.log_fields]
+  [[tests.outputs]]
+    extract_from = "remap_comments"
+    [[tests.outputs.conditions]]
+      "a.equals" = 1


### PR DESCRIPTION
Closes #5443 

Add support for inserting comments into Remap using the `#` character.

```coffeescript
# This is a comment.
x = 1 # And so is this
```

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
