### PR TITLE
chore: Switch Remap to #Event definition

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -17,7 +17,7 @@ _values: {
 }
 
 // `#Any` allows for any value.
-#Any: _ | {[_=string]: #Any}
+#Any: _ | {[_=string]: #Any} | [...#Any]
 
 #Arch: "ARM64" | "ARMv7" | "x86_64"
 
@@ -83,8 +83,8 @@ _values: {
 #Enum: [Name=_]: string
 
 #Event: {
-	{log: #LogEvent} |
-	{metric: #MetricEvent}
+	log?:    #LogEvent
+	metric?: #MetricEvent
 }
 
 // `#EventType` represents one of Vector's supported event types.
@@ -494,10 +494,10 @@ _values: {
 
 #Unit: "bytes" | "events" | "milliseconds" | "requests" | "seconds"
 
-components:    _ | *{}
-configuration: _ | *{}
-data_model:    _ | *{}
-installation:  _ | *{}
-process:       _ | *{}
-releases:      _ | *{}
-remap:         _ | *{}
+components:    _
+configuration: _
+data_model:    _
+installation:  _
+process:       _
+releases:      _
+remap:         _

--- a/docs/reference/remap/parse_json.cue
+++ b/docs/reference/remap/parse_json.cue
@@ -21,13 +21,11 @@ remap: functions: parse_json: {
 	examples: [
 		{
 			title: "Parse JSON (success)"
-			input: log: "message": #"{"key": "val"}"#
+			input: log: message: #"{"key": "val"}"#
 			source: #"""
 				. = parse_json(del(.message))
 				"""#
-			output: log: {
-				"message": "action:\"Accept\"; flags:\"802832\"; ifdir:\"inbound\"; ifname:\"eth2-05\"; logid:\"6\"; loguid:\"{0x5f0fa4d6,0x1,0x696ac072,0xc28d839a}\";"
-			}
+			output: log: key: "val"
 		},
 	]
 }

--- a/docs/reference/remap/parse_json.cue
+++ b/docs/reference/remap/parse_json.cue
@@ -21,11 +21,13 @@ remap: functions: parse_json: {
 	examples: [
 		{
 			title: "Parse JSON (success)"
-			input: log: message: #"{"key": "val"}"#
+			input: log: "message": #"{"key": "val"}"#
 			source: #"""
 				. = parse_json(del(.message))
 				"""#
-			output: log: key: "val"
+			output: log: {
+				"message": "action:\"Accept\"; flags:\"802832\"; ifdir:\"inbound\"; ifname:\"eth2-05\"; logid:\"6\"; loguid:\"{0x5f0fa4d6,0x1,0x696ac072,0xc28d839a}\";"
+			}
 		},
 	]
 }

--- a/docs/reference/remap/parse_regex_all.cue
+++ b/docs/reference/remap/parse_regex_all.cue
@@ -26,8 +26,8 @@ remap: functions: parse_regex_all: {
 		{
 			title: "Parse via Regex (all matches)"
 			input: log: message: "first group and second group."
-			source: ". = parse_regex_all(del(.message), /(?P<number>.*?) group/)"
-			output: log: [
+			source: ".matches = parse_regex_all(del(.message), /(?P<number>.*?) group/)"
+			output: input & {log: matches: [
 				{
 					number: "first"
 					"0":    "first group"
@@ -38,7 +38,7 @@ remap: functions: parse_regex_all: {
 					"0":    "second group"
 					"1":    "second"
 				},
-			]
+			]}
 		},
 	]
 }


### PR DESCRIPTION
Uses the `#Event` definition so that we can signal if the event is a log or metric in Remap examples.