### PR TITLE
fix(kubernetes platform): vector-agent pod security policy

### DIFF
--- a/distribution/helm/vector-agent/templates/podsecuritypolicy.yaml
+++ b/distribution/helm/vector-agent/templates/podsecuritypolicy.yaml
@@ -13,12 +13,14 @@ spec:
     - 'hostPath'
     - 'configMap'
     - 'secret'
+    - 'projected'
   allowedHostPaths:
     - pathPrefix: "/var/log"
       readOnly: true
-    - pathPrefix: "/var/lib/docker/containers"
+    - pathPrefix: "/var/lib"
       readOnly: true
-    - pathPrefix: "/var/lib/vector/"
+    - pathPrefix: "/var/lib/vector"
+      readOnly: false
     {{- range .Values.extraVolumes }}
     {{- if .hostPath }}
     - pathPrefix: {{ .hostPath.path }}
@@ -28,7 +30,7 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    rule: 'MustRunAsNonRoot'
+    rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:


### PR DESCRIPTION
This PR adjust the pod security policy since we experienced problems when trying to run with the current one. Basically it is necessary with a bit more permissions to be able to actually tail the logs on the host node.