### PR TITLE
fix(kubernetes platform): Adhere to ct linting rules

### DIFF
--- a/distribution/helm/vector-agent/Chart.yaml
+++ b/distribution/helm/vector-agent/Chart.yaml
@@ -3,8 +3,8 @@ name: vector-agent
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to collect Kubernetes logs with Vector
-version: "0.0.0" # overwritten via --version on publishing
-appVersion: "0.0.0" # overwritten via --app-version on publishing
+version: "0.0.0"  # overwritten via --version on publishing
+appVersion: "0.0.0"  # overwritten via --app-version on publishing
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -138,11 +138,11 @@ vectorSink:
   # The name to use for the "built-in" vector sink.
   sinkId: vector_sink
   # Inputs of the built-in vector sink.
-  inputs: null # ["my_input_1", "my_input_2"]
+  inputs: null  # ["my_input_1", "my_input_2"]
   # The host of the Vector to send the data to.
-  host: null # "vector.internal"
+  host: null  # "vector.internal"
   # The port of the Vector to send the data to.
-  port: null # 9000
+  port: null  # 9000
   # Raw TOML config to embed at the vector sink.
   rawConfig: null
 

--- a/distribution/helm/vector-aggregator/Chart.yaml
+++ b/distribution/helm/vector-aggregator/Chart.yaml
@@ -3,8 +3,8 @@ name: vector-aggregator
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to aggregate data with Vector
-version: "0.0.0" # overwritten via --version on publishing
-appVersion: "0.0.0" # overwritten via --app-version on publishing
+version: "0.0.0"  # overwritten via --version on publishing
+appVersion: "0.0.0"  # overwritten via --app-version on publishing
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/

--- a/distribution/helm/vector/Chart.yaml
+++ b/distribution/helm/vector/Chart.yaml
@@ -3,8 +3,8 @@ name: vector
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart for Vector observability stack
-version: "0.0.0" # overwritten via --version on publishing
-appVersion: "0.0.0" # overwritten via --app-version on publishing
+version: "0.0.0"  # overwritten via --version on publishing
+appVersion: "0.0.0"  # overwritten via --app-version on publishing
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/


### PR DESCRIPTION
Running [chart testing](https://github.com/helm/chart-testing) against the Helm charts had a few minor issues - below is the output. This PR fixes this allowing the charts to successfully pass linting.

```
➜  vector git:(master) ✗ docker run -it --rm -v $(pwd):/src quay.io/helmpack/chart-testing:v3.3.1 sh -c "cd /src; ct lint --chart-dirs distribution/helm --all --validate-maintainers=false"
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 vector => (version: "0.0.0", path: "distribution/helm/vector")
 vector-agent => (version: "0.0.0", path: "distribution/helm/vector-agent")
 vector-aggregator => (version: "0.0.0", path: "distribution/helm/vector-aggregator")
 vector-shared => (version: "0.1.0", path: "distribution/helm/vector-shared")
------------------------------------------------------------------------------------------------------------------------

Saving 2 charts
Deleting outdated charts
walk.go:74: found symbolic link in path: /src/distribution/helm/vector/charts/vector-agent resolves to /src/distribution/helm/vector-agent
walk.go:74: found symbolic link in path: /src/distribution/helm/vector/charts/vector-agent/charts/vector-shared resolves to /src/distribution/helm/vector-shared
walk.go:74: found symbolic link in path: /src/distribution/helm/vector/charts/vector-aggregator resolves to /src/distribution/helm/vector-aggregator
walk.go:74: found symbolic link in path: /src/distribution/helm/vector/charts/vector-aggregator/charts/vector-shared resolves to /src/distribution/helm/vector-shared
walk.go:74: found symbolic link in path: /src/distribution/helm/vector-agent/charts/vector-shared resolves to /src/distribution/helm/vector-shared
walk.go:74: found symbolic link in path: /src/distribution/helm/vector-aggregator/charts/vector-shared resolves to /src/distribution/helm/vector-shared
Linting chart 'vector => (version: "0.0.0", path: "distribution/helm/vector")'
Validating /src/distribution/helm/vector/Chart.yaml...
Validation success! 👍
distribution/helm/vector/Chart.yaml
  6:18      error    too few spaces before comment  (comments)
  7:21      error    too few spaces before comment  (comments)

Saving 1 charts
Deleting outdated charts
walk.go:74: found symbolic link in path: /src/distribution/helm/vector-agent/charts/vector-shared resolves to /src/distribution/helm/vector-shared
Linting chart 'vector-agent => (version: "0.0.0", path: "distribution/helm/vector-agent")'
Validating /src/distribution/helm/vector-agent/Chart.yaml...
Validation success! 👍
distribution/helm/vector-agent/Chart.yaml
  6:18      error    too few spaces before comment  (comments)
  7:21      error    too few spaces before comment  (comments)

Saving 1 charts
Deleting outdated charts
walk.go:74: found symbolic link in path: /src/distribution/helm/vector-aggregator/charts/vector-shared resolves to /src/distribution/helm/vector-shared
Linting chart 'vector-aggregator => (version: "0.0.0", path: "distribution/helm/vector-aggregator")'
Validating /src/distribution/helm/vector-aggregator/Chart.yaml...
Validation success! 👍
distribution/helm/vector-aggregator/Chart.yaml
  6:18      error    too few spaces before comment  (comments)
  7:21      error    too few spaces before comment  (comments)

Linting chart 'vector-shared => (version: "0.1.0", path: "distribution/helm/vector-shared")'
Validating /src/distribution/helm/vector-shared/Chart.yaml...
Validation success! 👍
[Errno 2] No such file or directory: 'distribution/helm/vector-shared/values.yaml'
------------------------------------------------------------------------------------------------------------------------
 ✖︎ vector => (version: "0.0.0", path: "distribution/helm/vector") > Error waiting for process: exit status 1
 ✖︎ vector-agent => (version: "0.0.0", path: "distribution/helm/vector-agent") > Error waiting for process: exit status 1
 ✖︎ vector-aggregator => (version: "0.0.0", path: "distribution/helm/vector-aggregator") > Error waiting for process: exit status 1
 ✖︎ vector-shared => (version: "0.1.0", path: "distribution/helm/vector-shared") > Error waiting for process: exit status 255
------------------------------------------------------------------------------------------------------------------------
Error: Error linting charts: Error processing charts
Error linting charts: Error processing charts
```