### PR TITLE
chore(ci): Fix rustup not found for benchmark runners

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,7 +51,13 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: |
+          whoami
+          echo "HOME: $HOME"
+          echo "GITHUB_PATH: $GITHUB_PATH"
+          env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          which rustup
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Download baseline benchmarks


### PR DESCRIPTION
Opening as draft to debug why it cannot find `rustup` which is installed.