### PR TITLE
chore(host_metrics source): Adds cue docs for customizing sysfs and procfs in host_metrics component

### DIFF
--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -45,7 +45,7 @@ components: sources: host_metrics: {
 		platform_name: null
 	}
 
-    env_vars: {
+	env_vars: {
 		PROCFS_ROOT: {
 			description: "Sets an arbitrary path to the system's Procfs root. Can be used to expose host metrics from within a container. Unset and uses system `/proc` by default."
 			type: string: {
@@ -57,11 +57,11 @@ components: sources: host_metrics: {
 		SYSFS_ROOT: {
 			description: "Sets an arbitrary path to the system's Sysfs root. Can be used to expose host metrics from within a container. Unset and uses system `/sys` by default."
 			type: string: {
-                default: null
+				default: null
 				examples: ["/mnt/host/sys"]
 			}
 		}
-    }
+	}
 
 	configuration: {
 		collectors: {

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -50,7 +50,7 @@ components: sources: host_metrics: {
 			description: "Sets an arbitrary path to the system's Procfs root. Can be used to expose host metrics from within a container."
 			type: string: {
 				default: null
-				examples: "/mnt/host/proc"
+				examples: ["/mnt/host/proc"]
 			}
 		}
 
@@ -58,7 +58,7 @@ components: sources: host_metrics: {
 			description: "Sets an arbitrary path to the system's Sysfs root. Can be used to expose host metrics from within a container."
 			type: string: {
                 default: null
-				examples: "/mnt/host/sys"
+				examples: ["/mnt/host/sys"]
 			}
 		}
     }

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -47,7 +47,7 @@ components: sources: host_metrics: {
 
     env_vars: {
 		PROCFS_ROOT: {
-			description: "Sets an arbitrary path to the system's Procfs root. Can be used to expose host metrics from within a container."
+			description: "Sets an arbitrary path to the system's Procfs root. Can be used to expose host metrics from within a container. Unset and uses system `/proc` by default."
 			type: string: {
 				default: null
 				examples: ["/mnt/host/proc"]
@@ -55,7 +55,7 @@ components: sources: host_metrics: {
 		}
 
 		SYSFS_ROOT: {
-			description: "Sets an arbitrary path to the system's Sysfs root. Can be used to expose host metrics from within a container."
+			description: "Sets an arbitrary path to the system's Sysfs root. Can be used to expose host metrics from within a container. Unset and uses system `/sys` by default."
 			type: string: {
                 default: null
 				examples: ["/mnt/host/sys"]

--- a/docs/reference/components/sources/host_metrics.cue
+++ b/docs/reference/components/sources/host_metrics.cue
@@ -45,6 +45,24 @@ components: sources: host_metrics: {
 		platform_name: null
 	}
 
+    env_vars: {
+		PROCFS_ROOT: {
+			description: "Sets an arbitrary path to the system's Procfs root. Can be used to expose host metrics from within a container."
+			type: string: {
+				default: null
+				examples: "/mnt/host/proc"
+			}
+		}
+
+		SYSFS_ROOT: {
+			description: "Sets an arbitrary path to the system's Sysfs root. Can be used to expose host metrics from within a container."
+			type: string: {
+                default: null
+				examples: "/mnt/host/sys"
+			}
+		}
+    }
+
 	configuration: {
 		collectors: {
 			description: "The list of host metric collector services to use. Defaults to all collectors."


### PR DESCRIPTION
Signed-off-by: Ian Henry <ianjhenry00@gmail.com>
