### PR TITLE
chore(metrics)!: Rework histogram/summary data model

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -169,9 +169,13 @@ _values: {
 }
 
 #MetricEventDistribution: {
-	values: [float, ...float]
-	sample_rates: [uint, ...uint]
+	samples: [#DistributionSample, ...#DistributionSample]
 	statistic: "histogram" | "summary"
+}
+
+#DistributionSample: {
+	value: float
+	rate:  uint
 }
 
 #MetricEventGauge: {
@@ -179,10 +183,14 @@ _values: {
 }
 
 #MetricEventHistogram: {
-	buckets: [float, ...float]
-	counts: [int, ...int]
-	count: int
+	buckets: [#HistogramBucket, ...#HistogramBucket]
+	count: uint
 	sum:   float
+}
+
+#HistogramBucket: {
+	upper_limit: float
+	count:       uint
 }
 
 #MetricEventSet: {
@@ -190,10 +198,14 @@ _values: {
 }
 
 #MetricEventSummary: {
-	quantiles: [float, ...float]
-	values: [float, ...float]
+	quantiles: [#SummaryQuantile, ...#SummaryQuantile]
 	count: int
 	sum:   float
+}
+
+#SummaryQuantile: {
+	upper_limit: float
+	value:       float
 }
 
 #MetricTags: [Name=string]: close({

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -118,8 +118,11 @@ components: sinks: influxdb_metrics: {
 				name:      _name
 				namespace: "app"
 				distribution: {
-					values: [1.0, 5.0, 3.0]
-					sample_rates: [1, 2, 3]
+					samples: [
+						{value: 1.0, rate: 1},
+						{value: 5.0, rate: 2},
+						{value: 3.0, rate: 3},
+					]
 					statistic: "histogram"
 				}
 				tags: {
@@ -158,8 +161,11 @@ components: sinks: influxdb_metrics: {
 				kind: "absolute"
 				name: _name
 				histogram: {
-					buckets: [1.0, 2.1, 3.0]
-					counts: [2, 5, 10]
+					buckets: [
+						{upper_limit: 1.0, count: 2},
+						{upper_limit: 2.1, count: 5},
+						{upper_limit: 3.0, count: 10},
+					]
 					count: 17
 					sum:   46.2
 				}
@@ -196,8 +202,11 @@ components: sinks: influxdb_metrics: {
 				kind: "absolute"
 				name: _name
 				summary: {
-					quantiles: [0.01, 0.5, 0.99]
-					values: [1.5, 2.0, 3.0]
+					quantiles: [
+						{upper_limit: 0.01, value: 1.5},
+						{upper_limit: 0.5, value:  2.0},
+						{upper_limit: 0.99, value: 3.0},
+					]
 					count: 6
 					sum:   12.1
 				}

--- a/docs/reference/components/sinks/prometheus_exporter.cue
+++ b/docs/reference/components/sinks/prometheus_exporter.cue
@@ -196,8 +196,19 @@ components: sinks: prometheus_exporter: {
 				kind: "absolute"
 				name: _name
 				histogram: {
-					buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
-					counts: [0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+					buckets: [
+						{upper_limit: 0.005, count: 0},
+						{upper_limit: 0.01, count:  1},
+						{upper_limit: 0.025, count: 0},
+						{upper_limit: 0.05, count:  1},
+						{upper_limit: 0.1, count:   0},
+						{upper_limit: 0.25, count:  0},
+						{upper_limit: 0.5, count:   0},
+						{upper_limit: 1.0, count:   0},
+						{upper_limit: 2.5, count:   0},
+						{upper_limit: 5.0, count:   0},
+						{upper_limit: 10.0, count:  0},
+					]
 					count: 2
 					sum:   0.789
 				}
@@ -233,8 +244,11 @@ components: sinks: prometheus_exporter: {
 				name: _name
 				kind: "incremental"
 				distribution: {
-					values: [0.0, 1.0, 4.0]
-					sample_rates: [4, 2, 1]
+					samples: [
+						{value: 0.0, rate: 4},
+						{value: 1.0, rate: 2},
+						{value: 4.0, rate: 1},
+					]
 					statistic: "histogram"
 				}
 				tags: {
@@ -264,8 +278,11 @@ components: sinks: prometheus_exporter: {
 				name: _name
 				kind: "incremental"
 				distribution: {
-					values: [0.0, 1.0, 4.0]
-					sample_rates: [3, 2, 1]
+					samples: [
+						{value: 0.0, rate: 3},
+						{value: 1.0, rate: 2},
+						{value: 4.0, rate: 1},
+					]
 					statistic: "summary"
 				}
 			}
@@ -291,8 +308,11 @@ components: sinks: prometheus_exporter: {
 				name: _name
 				kind: "absolute"
 				summary: {
-					quantiles: [0.01, 0.5, 0.99]
-					values: [1.5, 2.0, 3.0]
+					quantiles: [
+						{upper_limit: 0.01, value: 1.5},
+						{upper_limit: 0.5, value:  2.0},
+						{upper_limit: 0.99, value: 3.0},
+					]
 					count: 6
 					sum:   12.0
 				}

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -301,8 +301,7 @@ components: transforms: log_to_metric: {
 					host:   "10.22.11.222"
 				}
 				distribution: {
-					values: [54.2]
-					sample_rates: [1]
+					samples: [{value: 54.2, rate: 1}]
 					statistic: "histogram"
 				}
 			}}]
@@ -337,8 +336,7 @@ components: transforms: log_to_metric: {
 					host:   "10.22.11.222"
 				}
 				distribution: {
-					values: [54.2]
-					sample_rates: [1]
+					samples: [{value: 54.2, rate: 1}]
 					statistic: "summary"
 				}
 			}}]

--- a/docs/reference/components/transforms/metric_to_log.cue
+++ b/docs/reference/components/transforms/metric_to_log.cue
@@ -74,8 +74,10 @@ components: transforms: metric_to_log: {
 					code: "200"
 				}
 				histogram: {
-					buckets: [1.0, 2.0]
-					counts: [10, 20]
+					buckets: [
+						{upper_limit: 1.0, count: 10},
+						{upper_limit: 2.0, count: 20},
+					]
 					count: 30
 					sum:   50.0
 				}

--- a/docs/reference/components/transforms/metric_to_log.cue
+++ b/docs/reference/components/transforms/metric_to_log.cue
@@ -89,8 +89,16 @@ components: transforms: metric_to_log: {
 				}
 				kind: "absolute"
 				histogram: {
-					buckets: [1.0, 2.0]
-					counts: [10, 20]
+					buckets: [
+						{
+							"count":       10
+							"upper_limit": 1.0
+						},
+						{
+							"count":       20
+							"upper_limit": 2.0
+						},
+					]
 					count: 30
 					sum:   50.0
 				}

--- a/docs/reference/data_model/schema.cue
+++ b/docs/reference/data_model/schema.cue
@@ -93,20 +93,35 @@ data_model: schema: {
 					type: object: {
 						examples: []
 						options: {
-							sample_rates: {
-								description: "The rate at which each individual value was sampled."
+							samples: {
+								description: "The set of sampled values."
 								required:    true
 								warnings: []
-								type: array: items: type: uint: {
-									examples: [12, 43, 25]
-									unit: null
+								type: array: items: type: object: {
+									examples: []
+									options: {
+										rate: {
+											description: "The rate at which this value was sampled."
+											required:    true
+											warnings: []
+											type: uint: {
+												examples: [12, 43, 25]
+												unit: null
+											}
+										}
+										value: {
+											description: "The value being sampled."
+											required:    true
+											warnings: []
+											// FIXME: making this float, as it should be, makes cue blow up
+											type: uint: {
+												// FIXME: Adding even empty examples makes cue blow up
+												// examples: [12.0, 43.3, 25.2]
+												unit: null
+											}
+										}
+									}
 								}
-							}
-							values: {
-								description: "The list of values contained within the distribution."
-								required:    true
-								warnings: []
-								type: array: items: type: float: examples: [12.0, 43.3, 25.2]
 							}
 							statistic: {
 								description: "The statistic to be calculated from the values."
@@ -163,25 +178,40 @@ data_model: schema: {
 						examples: []
 						options: {
 							buckets: {
-								description: "The buckets contained within this histogram."
+								description: "The set of buckets containing the histogram values."
 								required:    true
 								warnings: []
-								type: array: items: type: float: examples: [1.0, 2.0, 5.0, 10.0, 25.0]
+								type: array: items: type: object: {
+									examples: []
+									options: {
+										count: {
+											description: "The number of values contained within this bucket."
+											required:    true
+											warnings: []
+											type: uint: {
+												examples: [1, 10, 25, 100]
+												unit: null
+											}
+										}
+										upper_limit: {
+											description: "The upper limit of the samples within the bucket."
+											required:    true
+											warnings: []
+											// FIXME: making this float, as it should be, makes cue blow up
+											type: uint: {
+												// FIXME: Adding even empty examples makes cue blow up
+												// examples: [12.0, 43.3, 25.2]
+												unit: null
+											}
+										}
+									}
+								}
 							}
 							count: {
 								description: "The total number of values contained within the histogram."
 								required:    true
 								warnings: []
 								type: uint: {
-									examples: [1, 10, 25, 100]
-									unit: null
-								}
-							}
-							counts: {
-								description: "The number of values contained within each bucket."
-								required:    true
-								warnings: []
-								type: array: items: type: uint: {
 									examples: [1, 10, 25, 100]
 									unit: null
 								}
@@ -274,11 +304,35 @@ data_model: schema: {
 								}
 							}
 							quantiles: {
-								description: "The quantiles contained within the summary, where 0 ≤ quantile ≤ 1."
+								description: "The set of observations."
 								required:    true
 								warnings: []
-								type: array: {
-									items: type: float: examples: [0.1, 0.5, 0.75, 1.0]
+								type: array: items: type: object: {
+									examples: []
+									options: {
+										value: {
+											description: "The value of this quantile range."
+											required:    true
+											warnings: []
+											// FIXME: making this float, as it should be, makes cue blow up
+											type: uint: {
+												// FIXME: Adding even empty examples makes cue blow up
+												// examples: [2.1, 4.68, 23.02, 120.1]
+												unit: null
+											}
+										}
+										upper_limit: {
+											description: "The upper limit for this quantile range, where 0 ≤ upper_limit ≤ 1."
+											required:    true
+											warnings: []
+											// FIXME: making this float, as it should be, makes cue blow up
+											type: uint: {
+												// FIXME: Adding even empty examples makes cue blow up
+												// examples: [0.1, 0.5, 0.75, 1.0]
+												unit: null
+											}
+										}
+									}
 								}
 							}
 							sum: {
@@ -287,14 +341,6 @@ data_model: schema: {
 								warnings: []
 								type: float: {
 									examples: [1.0, 10.0, 25.0, 100.0]
-								}
-							}
-							values: {
-								description: "The values contained within the summary that align with the `quantiles`."
-								required:    true
-								warnings: []
-								type: array: {
-									items: type: float: examples: [2.1, 4.68, 23.02, 120.1]
 								}
 							}
 						}

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -171,13 +171,12 @@ impl CloudWatchMetricsSvc {
                             ..Default::default()
                         }),
                         MetricValue::Distribution {
-                            values,
-                            sample_rates,
+                            samples,
                             statistic: _,
                         } => Some(MetricDatum {
                             metric_name,
-                            values: Some(values.to_vec()),
-                            counts: Some(sample_rates.iter().cloned().map(f64::from).collect()),
+                            values: Some(samples.iter().map(|s| s.value).collect()),
+                            counts: Some(samples.iter().map(|s| f64::from(s.rate)).collect()),
                             timestamp,
                             dimensions,
                             ..Default::default()
@@ -381,8 +380,7 @@ mod tests {
             tags: None,
             kind: MetricKind::Incremental,
             value: MetricValue::Distribution {
-                values: vec![11.0, 12.0],
-                sample_rates: vec![100, 50],
+                samples: crate::samples![11.0 => 100, 12.0 => 50],
                 statistic: StatisticKind::Histogram,
             },
         }];
@@ -496,8 +494,7 @@ mod integration_tests {
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![i as f64],
-                    sample_rates: vec![100],
+                    samples: crate::samples![i as f64 => 100],
                     statistic: StatisticKind::Histogram,
                 },
             });

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -244,7 +244,7 @@ mod test {
             },
         });
         assert_eq!(
-            r#"{"name":"glork","kind":"incremental","distribution":{"values":[10.0],"sample_rates":[1],"statistic":"histogram"}}"#,
+            r#"{"name":"glork","kind":"incremental","distribution":{"samples":[{"value":10.0,"rate":1}],"statistic":"histogram"}}"#,
             encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -159,6 +159,7 @@ mod test {
     use crate::event::metric::{Metric, MetricKind, MetricValue, StatisticKind};
     use crate::event::{Event, Value};
     use chrono::{offset::TimeZone, Utc};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn generate_config() {
@@ -238,8 +239,7 @@ mod test {
             tags: None,
             kind: MetricKind::Incremental,
             value: MetricValue::Distribution {
-                values: vec![10.0],
-                sample_rates: vec![1],
+                samples: crate::samples![10.0 => 1],
                 statistic: StatisticKind::Histogram,
             },
         });

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -112,6 +112,7 @@ mod tests {
         test_util, Event,
     };
     use chrono::{offset::TimeZone, Utc};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn generate_config() {
@@ -191,8 +192,7 @@ mod tests {
                 ),
                 kind: MetricKind::Absolute,
                 value: MetricValue::Distribution {
-                    values: vec![1.0, 2.0, 3.0],
-                    sample_rates: vec![100, 200, 300],
+                    samples: crate::samples![1.0 => 100, 2.0 => 200, 3.0 => 300],
                     statistic: StatisticKind::Histogram,
                 },
             }),

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -202,8 +202,13 @@ mod tests {
         let _ = sink.run(stream::iter(metrics)).await.unwrap();
 
         let output = rx.take(len).collect::<Vec<_>>().await;
-        assert_eq!("{\"event\":{\"counter\":{\"value\":42.0},\"kind\":\"incremental\",\"name\":\"metric1\",\"tags\":{\"os.host\":\"somehost\"}},\"fields\":{},\"time\":1597784401.0}", output[0].1);
         assert_eq!(
-            "{\"event\":{\"distribution\":{\"sample_rates\":[100,200,300],\"statistic\":\"histogram\",\"values\":[1.0,2.0,3.0]},\"kind\":\"absolute\",\"name\":\"metric2\",\"tags\":{\"os.host\":\"somehost\"}},\"fields\":{},\"time\":1597784402.0}", output[1].1);
+            r#"{"event":{"counter":{"value":42.0},"kind":"incremental","name":"metric1","tags":{"os.host":"somehost"}},"fields":{},"time":1597784401.0}"#,
+            output[0].1
+        );
+        assert_eq!(
+            r#"{"event":{"distribution":{"samples":[{"rate":100,"value":1.0},{"rate":200,"value":2.0},{"rate":300,"value":3.0}],"statistic":"histogram"},"kind":"absolute","name":"metric2","tags":{"os.host":"somehost"}},"fields":{},"time":1597784402.0}"#,
+            output[1].1
+        );
     }
 }

--- a/src/sinks/util/statistic.rs
+++ b/src/sinks/util/statistic.rs
@@ -28,25 +28,6 @@ impl DistributionStatistic {
             }
         }
 
-        Self::from_base(samples, quantiles)
-    }
-
-    pub fn from_values_counts(values: &[f64], counts: &[u32], quantiles: &[f64]) -> Option<Self> {
-        if values.len() != counts.len() {
-            return None;
-        }
-
-        let mut samples = Vec::new();
-        for (v, c) in values.iter().zip(counts.iter()) {
-            for _ in 0..*c {
-                samples.push(*v);
-            }
-        }
-
-        Self::from_base(samples, quantiles)
-    }
-
-    fn from_base(mut samples: Vec<f64>, quantiles: &[f64]) -> Option<Self> {
         if samples.is_empty() {
             return None;
         }

--- a/src/sinks/util/statistic.rs
+++ b/src/sinks/util/statistic.rs
@@ -1,3 +1,4 @@
+use crate::event::metric::Sample;
 use snafu::Snafu;
 use std::cmp::Ordering;
 
@@ -19,7 +20,18 @@ pub struct DistributionStatistic {
 }
 
 impl DistributionStatistic {
-    pub fn new(values: &[f64], counts: &[u32], quantiles: &[f64]) -> Option<Self> {
+    pub fn from_samples(source: &[Sample], quantiles: &[f64]) -> Option<Self> {
+        let mut samples = Vec::new();
+        for sample in source {
+            for _ in 0..sample.rate {
+                samples.push(sample.value);
+            }
+        }
+
+        Self::from_base(samples, quantiles)
+    }
+
+    pub fn from_values_counts(values: &[f64], counts: &[u32], quantiles: &[f64]) -> Option<Self> {
         if values.len() != counts.len() {
             return None;
         }
@@ -31,6 +43,10 @@ impl DistributionStatistic {
             }
         }
 
+        Self::from_base(samples, quantiles)
+    }
+
+    fn from_base(mut samples: Vec<f64>, quantiles: &[f64]) -> Option<Self> {
         if samples.is_empty() {
             return None;
         }

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -113,16 +113,14 @@ mod tests {
         assert_eq!(MetricValue::Counter { value: 7.0 }, output["bar"].value);
         assert_eq!(
             MetricValue::Distribution {
-                values: vec![5.0, 6.0],
-                sample_rates: vec![1, 1],
+                samples: crate::samples![5.0 => 1, 6.0 => 1],
                 statistic: StatisticKind::Histogram
             },
             output["baz"].value
         );
         assert_eq!(
             MetricValue::Distribution {
-                values: vec![7.0, 8.0],
-                sample_rates: vec![1, 1],
+                samples: crate::samples![7.0 => 1, 8.0 => 1],
                 statistic: StatisticKind::Histogram
             },
             output["quux"].value

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -76,8 +76,7 @@ pub fn parse(packet: &str) -> Result<Metric, ParseError> {
                 tags,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![convert_to_base_units(unit, val)],
-                    sample_rates: vec![sample_rate as u32],
+                    samples: crate::samples![convert_to_base_units(unit, val) => sample_rate as u32],
                     statistic: convert_to_statistic(unit),
                 },
             }
@@ -321,8 +320,7 @@ mod test {
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![0.320],
-                    sample_rates: vec![10],
+                    samples: crate::samples![0.320 => 10],
                     statistic: StatisticKind::Histogram
                 },
             }),
@@ -348,8 +346,7 @@ mod test {
                 ),
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![320.0],
-                    sample_rates: vec![10],
+                    samples: crate::samples![320.0 => 10],
                     statistic: StatisticKind::Histogram
                 },
             }),
@@ -375,8 +372,7 @@ mod test {
                 ),
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![320.0],
-                    sample_rates: vec![10],
+                    samples: crate::samples![320.0 => 10],
                     statistic: StatisticKind::Summary
                 },
             }),

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -258,8 +258,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 tags,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![value],
-                    sample_rates: vec![1],
+                    samples: crate::samples![value => 1],
                     statistic: StatisticKind::Histogram,
                 },
             })
@@ -284,8 +283,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
                 tags,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![value],
-                    sample_rates: vec![1],
+                    samples: crate::samples![value => 1],
                     statistic: StatisticKind::Summary,
                 },
             })
@@ -768,8 +766,7 @@ mod tests {
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![2.5],
-                    sample_rates: vec![1],
+                    samples: crate::samples![2.5 => 1],
                     statistic: StatisticKind::Histogram
                 },
             }
@@ -799,8 +796,7 @@ mod tests {
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Distribution {
-                    values: vec![2.5],
-                    sample_rates: vec![1],
+                    samples: crate::samples![2.5 => 1],
                     statistic: StatisticKind::Summary
                 },
             }

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -238,19 +238,25 @@ mod tests {
             collected,
             vec![
                 (
-                    String::from("distribution.sample_rates[0]"),
+                    String::from("distribution.samples[0].rate"),
                     &Value::from(10)
                 ),
                 (
-                    String::from("distribution.sample_rates[1]"),
+                    String::from("distribution.samples[0].value"),
+                    &Value::from(1.0)
+                ),
+                (
+                    String::from("distribution.samples[1].rate"),
                     &Value::from(20)
+                ),
+                (
+                    String::from("distribution.samples[1].value"),
+                    &Value::from(2.0)
                 ),
                 (
                     String::from("distribution.statistic"),
                     &Value::from("histogram")
                 ),
-                (String::from("distribution.values[0]"), &Value::from(1.0)),
-                (String::from("distribution.values[1]"), &Value::from(2.0)),
                 (String::from("kind"), &Value::from("absolute")),
                 (String::from("name"), &Value::from("distro")),
                 (String::from("timestamp"), &Value::from(ts())),
@@ -280,22 +286,22 @@ mod tests {
             collected,
             vec![
                 (
-                    String::from("aggregated_histogram.buckets[0]"),
-                    &Value::from(1.0)
-                ),
-                (
-                    String::from("aggregated_histogram.buckets[1]"),
-                    &Value::from(2.0)
-                ),
-                (String::from("aggregated_histogram.count"), &Value::from(30)),
-                (
-                    String::from("aggregated_histogram.counts[0]"),
+                    String::from("aggregated_histogram.buckets[0].count"),
                     &Value::from(10)
                 ),
                 (
-                    String::from("aggregated_histogram.counts[1]"),
+                    String::from("aggregated_histogram.buckets[0].upper_limit"),
+                    &Value::from(1.0)
+                ),
+                (
+                    String::from("aggregated_histogram.buckets[1].count"),
                     &Value::from(20)
                 ),
+                (
+                    String::from("aggregated_histogram.buckets[1].upper_limit"),
+                    &Value::from(2.0)
+                ),
+                (String::from("aggregated_histogram.count"), &Value::from(30)),
                 (String::from("aggregated_histogram.sum"), &Value::from(50.0)),
                 (String::from("kind"), &Value::from("absolute")),
                 (String::from("name"), &Value::from("histo")),
@@ -320,7 +326,6 @@ mod tests {
         };
 
         let log = do_transform(summary).unwrap();
-        dbg!(&log);
         let collected: Vec<_> = log.all_fields().collect();
 
         assert_eq!(
@@ -328,22 +333,22 @@ mod tests {
             vec![
                 (String::from("aggregated_summary.count"), &Value::from(30)),
                 (
-                    String::from("aggregated_summary.quantiles[0]"),
+                    String::from("aggregated_summary.quantiles[0].upper_limit"),
                     &Value::from(50.0)
                 ),
                 (
-                    String::from("aggregated_summary.quantiles[1]"),
-                    &Value::from(90.0)
-                ),
-                (String::from("aggregated_summary.sum"), &Value::from(50.0)),
-                (
-                    String::from("aggregated_summary.values[0]"),
+                    String::from("aggregated_summary.quantiles[0].value"),
                     &Value::from(10.0)
                 ),
                 (
-                    String::from("aggregated_summary.values[1]"),
+                    String::from("aggregated_summary.quantiles[1].upper_limit"),
+                    &Value::from(90.0)
+                ),
+                (
+                    String::from("aggregated_summary.quantiles[1].value"),
                     &Value::from(20.0)
                 ),
+                (String::from("aggregated_summary.sum"), &Value::from(50.0)),
                 (String::from("kind"), &Value::from("absolute")),
                 (String::from("name"), &Value::from("summary")),
                 (String::from("timestamp"), &Value::from(ts())),

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -107,6 +107,7 @@ mod tests {
         Metric, Value,
     };
     use chrono::{offset::TimeZone, DateTime, Utc};
+    use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
 
     #[test]
@@ -225,8 +226,7 @@ mod tests {
             tags: None,
             kind: MetricKind::Absolute,
             value: MetricValue::Distribution {
-                values: vec![1.0, 2.0],
-                sample_rates: vec![10, 20],
+                samples: crate::samples![1.0 => 10, 2.0 => 20],
                 statistic: StatisticKind::Histogram,
             },
         };
@@ -267,8 +267,7 @@ mod tests {
             tags: None,
             kind: MetricKind::Absolute,
             value: MetricValue::AggregatedHistogram {
-                buckets: vec![1.0, 2.0],
-                counts: vec![10, 20],
+                buckets: crate::buckets![1.0 => 10, 2.0 => 20],
                 count: 30,
                 sum: 50.0,
             },
@@ -314,14 +313,14 @@ mod tests {
             tags: None,
             kind: MetricKind::Absolute,
             value: MetricValue::AggregatedSummary {
-                quantiles: vec![50.0, 90.0],
-                values: vec![10.0, 20.0],
+                quantiles: crate::quantiles![50.0 => 10.0, 90.0 => 20.0],
                 count: 30,
                 sum: 50.0,
             },
         };
 
         let log = do_transform(summary).unwrap();
+        dbg!(&log);
         let collected: Vec<_> = log.all_fields().collect();
 
         assert_eq!(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,7 +29,10 @@ use tracing::{error, info};
 use vector::{
     buffers::Acker,
     config::{DataType, GlobalOptions, SinkConfig, SinkContext, SourceConfig, TransformConfig},
-    event::{metric::MetricValue, Value},
+    event::{
+        metric::{self, MetricValue},
+        Value,
+    },
     shutdown::ShutdownSignal,
     sinks::{util::StreamSink, Healthcheck, VectorSink},
     sources::Source,
@@ -212,12 +215,13 @@ impl FunctionTransform for MockTransform {
                     *value += self.increase;
                 }
                 MetricValue::Distribution {
-                    ref mut values,
-                    ref mut sample_rates,
+                    ref mut samples,
                     statistic: _,
                 } => {
-                    values.push(self.increase);
-                    sample_rates.push(1);
+                    samples.push(metric::Sample {
+                        value: self.increase,
+                        rate: 1,
+                    });
                 }
                 MetricValue::AggregatedHistogram {
                     ref mut count,


### PR DESCRIPTION
The `MetricValue` type stored samples, buckets, and quantiles in pairs
of arrays. This reworks the appropriate variants to use an array of a
composite type that better represents the underlying data.

Several tests that rely on the JSON format are failing. I am unsure how
best to resolve this format change.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #5581