### PR TITLE
fix(remap): allow comments between multiline statements

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -136,7 +136,9 @@ reserved_keyword = @{
 
 COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }
 
-WHITESPACE  = _{ " " | "\t" | ("\\" ~ NEWLINE) }
+empty_line = _{ WHITESPACE* ~ NEWLINE | WHITESPACE* ~ COMMENT }
+
+WHITESPACE  = _{ " " | "\t" | ("\\" ~ empty_line* ) }
 
 // end of expression
 EOE = _{ NEWLINE | ";" }

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -92,6 +92,7 @@ impl fmt::Display for Rule {
             comparison,
             EOE: "",
             EOI: "",
+            empty_line,
             equality,
             expression,
             expressions,

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1686,3 +1686,24 @@
     [[tests.outputs.conditions]]
       "a.equals" = 1
       "b.equals" = true
+
+[transforms.remap_multiline]
+  inputs = []
+  type = "remap"
+  source = '''
+    .a = "A long " + \
+
+         "multiline " + \
+         "string"
+  '''
+[[tests]]
+  name = "remap_multiline"
+  [tests.input]
+    insert_at = "remap_multiline"
+    type = "log"
+    [tests.input.log_fields]
+  [[tests.outputs]]
+    extract_from = "remap_multiline"
+    [[tests.outputs.conditions]]
+      type = "remap"
+      source = '.a == "A long multiline string"'

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1664,7 +1664,7 @@
 [transforms.remap_comments]
   inputs = []
   type = "remap"
-  source = ''' 
+  source = '''
     .a = 1 # .a = 2
     # .a = 3
 
@@ -1674,7 +1674,7 @@
     # .a == 3 && \
 
     .a == 1
-  ''' 
+  '''
 [[tests]]
   name = "remap_comments"
   [tests.input]

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1664,10 +1664,17 @@
 [transforms.remap_comments]
   inputs = []
   type = "remap"
-  source = """
+  source = ''' 
     .a = 1 # .a = 2
     # .a = 3
-  """
+
+    .b = .a == 2 || \
+
+    # We should ignore this too.
+    # .a == 3 && \
+
+    .a == 1
+  ''' 
 [[tests]]
   name = "remap_comments"
   [tests.input]
@@ -1678,3 +1685,4 @@
     extract_from = "remap_comments"
     [[tests.outputs.conditions]]
       "a.equals" = 1
+      "b.equals" = true


### PR DESCRIPTION
Ref: #5443 

This allows you to insert comments between multiline statements within Remap. So this sort of thing is possible:

```coffeescript
.b == 1 && \

# .x == 8 && \ 

# Also make sure c is 8.
.c == 8
```

Particularly handy with long remap conditions.