### PR TITLE
enhancement(config): deprecate `check_fields` conditions

### DIFF
--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -532,6 +532,7 @@ impl CheckFieldsConfig {
 #[typetag::serde(name = "check_fields")]
 impl ConditionConfig for CheckFieldsConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
+        warn!(message = "The `check_fields` condition is deprecated, use `remap` instead.",);
         build_predicates(&self.predicates)
             .map(|preds| -> Box<dyn Condition> { Box::new(CheckFields { predicates: preds }) })
             .map_err(|errs| {

--- a/tests/behavior/formats/simple.json
+++ b/tests/behavior/formats/simple.json
@@ -25,9 +25,8 @@
           "extract_from": "add_fields_nested",
           "conditions": [
             {
-              "a.b.equals": 123,
-              "x.y.equals": 456,
-              "x.z.equals": 789
+                "type": "remap",
+                "source": ".a.b == 123 && .x.y == 456 && .x.z == 789"
             }
           ]
         }

--- a/tests/behavior/formats/simple.toml
+++ b/tests/behavior/formats/simple.toml
@@ -15,5 +15,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = ".a.b == 123 && .x.y == 456 && .x.z == 789"
+      type = "remap"
+      source = ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/formats/simple.toml
+++ b/tests/behavior/formats/simple.toml
@@ -15,6 +15,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested"
     [[tests.outputs.conditions]]
-      "a.b.equals" = 123
-      "x.y.equals" = 456
-      "x.z.equals" = 789
+        type = "remap"
+        source = ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/formats/simple.yaml
+++ b/tests/behavior/formats/simple.yaml
@@ -17,6 +17,5 @@ tests:
     outputs:
       - extract_from: add_fields_nested
         conditions:
-          - a.b.equals: 123
-            x.y.equals: 456
-            x.z.equals: 789
+           - type: remap
+             source: ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/formats/simple.yml
+++ b/tests/behavior/formats/simple.yml
@@ -17,6 +17,5 @@ tests:
     outputs:
       - extract_from: add_fields_nested
         conditions:
-          - a.b.equals: 123
-            x.y.equals: 456
-            x.z.equals: 789
+           - type: remap
+             source: ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -40,11 +40,11 @@
   [[tests.outputs]]
     extract_from = "add_fields_array"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == [0, "1", 2.0] && \
-            .b == [0, null, "two"]
-        '''
+      type = "remap"
+      source = '''
+        .a == [0, "1", 2.0] && \
+        .b == [0, null, "two"]
+      '''
 
 [transforms.add_fields_scalar_then_nested_1]
   inputs = []
@@ -65,8 +65,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_nested_2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.a.b == "new value"'
+      type = "remap"
+      source = '.a.b == "new value"'
 
 [transforms.add_fields_nested_then_scalar_1]
   inputs = []
@@ -87,8 +87,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested_then_scalar_2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.a == "new value"'
+      type = "remap"
+      source = '.a == "new value"'
 
 [transforms.add_fields_scalar_then_scalar_1]
   inputs = []
@@ -109,8 +109,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_scalar_2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.a == "new value"'
+      type = "remap"
+      source = '.a == "new value"'
 
 [transforms.add_fields_templated_1]
   inputs = []
@@ -131,8 +131,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.b == "a was: initial value"'
+      type = "remap"
+      source = '.b == "a was: initial value"'
 
 [transforms.add_fields_templated_nested_1]
   inputs = []
@@ -153,5 +153,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_nested_2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.b.c == "a.b was: initial value"'
+      type = "remap"
+      source = '.b.c == "a.b was: initial value"'

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -14,9 +14,12 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested"
     [[tests.outputs.conditions]]
-      "a.b.equals" = 123
-      "x.y.equals" = 456
-      "x.z.equals" = 789
+        type = "remap"
+        source = '''
+            .a.b == 123
+            .x.y == 456
+            .x.z == 789
+        '''
 
 [transforms.add_fields_array]
   inputs = []
@@ -37,13 +40,11 @@
   [[tests.outputs]]
     extract_from = "add_fields_array"
     [[tests.outputs.conditions]]
-      "a[0].equals" = 0
-      "a[1].equals" = "1"
-      "a[2].equals" = 2.0
-
-      "b[0].equals" = 0
-      "b[1].equals" = "<null>"
-      "b[2].equals" = "two"
+        type = "remap"
+        source = '''
+            .a == [0, "1", 2.0] && \
+            .b == [0, null, "two"]
+        '''
 
 [transforms.add_fields_scalar_then_nested_1]
   inputs = []
@@ -64,7 +65,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_nested_2"
     [[tests.outputs.conditions]]
-      "a.b.equals" = "new value"
+        type = "remap"
+        source = '.a.b == "new value"'
 
 [transforms.add_fields_nested_then_scalar_1]
   inputs = []
@@ -85,7 +87,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested_then_scalar_2"
     [[tests.outputs.conditions]]
-      "a.equals" = "new value"
+        type = "remap"
+        source = '.a == "new value"'
 
 [transforms.add_fields_scalar_then_scalar_1]
   inputs = []
@@ -106,7 +109,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_scalar_2"
     [[tests.outputs.conditions]]
-      "a.equals" = "new value"
+        type = "remap"
+        source = '.a == "new value"'
 
 [transforms.add_fields_templated_1]
   inputs = []
@@ -127,7 +131,8 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_2"
     [[tests.outputs.conditions]]
-      "b.equals" = "a was: initial value"
+        type = "remap"
+        source = '.b == "a was: initial value"'
 
 [transforms.add_fields_templated_nested_1]
   inputs = []
@@ -148,4 +153,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_nested_2"
     [[tests.outputs.conditions]]
-      "b.c.equals" = "a.b was: initial value"
+        type = "remap"
+        source = '.b.c == "a.b was: initial value"'

--- a/tests/behavior/transforms/ansi_stripper.toml
+++ b/tests/behavior/transforms/ansi_stripper.toml
@@ -11,7 +11,8 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_simple"
     [[tests.outputs.conditions]]
-      "message.equals" = "hello123"
+        type = "remap"
+        source = '.message == "hello123"'
 
 [transforms.ansi_stripper_nested]
   inputs = []
@@ -27,4 +28,5 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_nested"
     [[tests.outputs.conditions]]
-      "a.b.equals" = "hello123"
+        type = "remap"
+        source = '.a.b == "hello123"'

--- a/tests/behavior/transforms/ansi_stripper.toml
+++ b/tests/behavior/transforms/ansi_stripper.toml
@@ -11,8 +11,8 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.message == "hello123"'
+      type = "remap"
+      source = '.message == "hello123"'
 
 [transforms.ansi_stripper_nested]
   inputs = []
@@ -28,5 +28,5 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.a.b == "hello123"'
+      type = "remap"
+      source = '.a.b == "hello123"'

--- a/tests/behavior/transforms/coercer.toml
+++ b/tests/behavior/transforms/coercer.toml
@@ -23,12 +23,15 @@
   [[tests.outputs]]
     extract_from = "coercer_simple"
     [[tests.outputs.conditions]]
-      "integer_field.equals" = 123
-      "boolean_field.equals" = true
-      "float_field.equals" = 3.1415926535
-      "string_field.equals" = "-1"
-      "timestamp_field.equals" = "2020-02-20T12:34:56.123456789Z"
-      "timestamp_field_formatted.equals" = "2020-02-20T12:34:56Z"
+      type = "remap"
+      source = '''
+        .integer_field == 123 && \
+        .boolean_field == true && \
+        .float_field == 3.1415926535 && \
+        .string_field == "-1" && \
+        .timestamp_field == to_timestamp("2020-02-20T12:34:56.123456789Z") && \
+        .timestamp_field_formatted == to_timestamp("2020-02-20T12:34:56Z")
+      '''
 
 [transforms.coercer_nested]
   inputs = []
@@ -45,4 +48,5 @@
   [[tests.outputs]]
     extract_from = "coercer_nested"
     [[tests.outputs.conditions]]
-      "nested.field.equals" = 1234
+      type = "remap"
+      source = ".nested.field == 1234"

--- a/tests/behavior/transforms/concat.toml
+++ b/tests/behavior/transforms/concat.toml
@@ -15,8 +15,8 @@
   [[tests.outputs]]
     extract_from = "concat_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.concatenated == "on wo re"'
+      type = "remap"
+      source = '.concatenated == "on wo re"'
 
 [transforms.concat_nested]
   inputs = []
@@ -35,5 +35,5 @@
   [[tests.outputs]]
     extract_from = "concat_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '.nested.concatenated.field == "ababab cdcdcd efe"'
+      type = "remap"
+      source = '.nested.concatenated.field == "ababab cdcdcd efe"'

--- a/tests/behavior/transforms/concat.toml
+++ b/tests/behavior/transforms/concat.toml
@@ -15,7 +15,8 @@
   [[tests.outputs]]
     extract_from = "concat_simple"
     [[tests.outputs.conditions]]
-      "concatenated.equals" = "on wo re"
+        type = "remap"
+        source = '.concatenated == "on wo re"'
 
 [transforms.concat_nested]
   inputs = []
@@ -34,4 +35,5 @@
   [[tests.outputs]]
     extract_from = "concat_nested"
     [[tests.outputs.conditions]]
-      "nested.concatenated.field.equals" = "ababab cdcdcd efe"
+        type = "remap"
+        source = '.nested.concatenated.field == "ababab cdcdcd efe"'

--- a/tests/behavior/transforms/dedupe.toml
+++ b/tests/behavior/transforms/dedupe.toml
@@ -67,14 +67,14 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .a == 1 && .b == 2 && .c == 3
+        .a == 1 && .b == 2 && .c == 3
       '''
   [[tests.outputs]]
     extract_from = "dedupe_field_order"
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .a == 1 && .b == 3 && .c == 3
+        .a == 1 && .b == 3 && .c == 3
       '''
 
 [transforms.dedupe_nested_fields]

--- a/tests/behavior/transforms/dedupe.toml
+++ b/tests/behavior/transforms/dedupe.toml
@@ -26,15 +26,13 @@
   [[tests.outputs]]
     extract_from = "dedupe_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.equals" = 1
-      "b.equals" = 2
+      type = "remap"
+      source = ".a == 1 && .b == 2"
   [[tests.outputs]]
     extract_from = "dedupe_simple"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.equals" = 2
-      "b.equals" = 4
+      type = "remap"
+      source = ".a == 2 && .b == 4"
 
 [transforms.dedupe_field_order]
   inputs = []
@@ -67,17 +65,17 @@
   [[tests.outputs]]
     extract_from = "dedupe_field_order"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.equals" = 1
-      "b.equals" = 2
-      "c.equals" = 3
+      type = "remap"
+      source = '''
+            .a == 1 && .b == 2 && .c == 3
+      '''
   [[tests.outputs]]
     extract_from = "dedupe_field_order"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.equals" = 1
-      "b.equals" = 3
-      "c.equals" = 3
+      type = "remap"
+      source = '''
+            .a == 1 && .b == 3 && .c == 3
+      '''
 
 [transforms.dedupe_nested_fields]
   inputs = []
@@ -107,12 +105,10 @@
   [[tests.outputs]]
     extract_from = "dedupe_nested_fields"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.b.c.equals" = "d"
-      "b.equals" = 2
+      type = "remap"
+      source = '.a.b.c == "d" && .b == 2'
   [[tests.outputs]]
     extract_from = "dedupe_nested_fields"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "a.b.equals" = "c.d"
-      "b.equals" = 4
+      type = "remap"
+      source = '.a.b == "c.d" && .b == 4'

--- a/tests/behavior/transforms/filter.toml
+++ b/tests/behavior/transforms/filter.toml
@@ -4,8 +4,8 @@
   [transforms.filter_a.condition]
     type = "remap"
     source = '''
-           message = if exists(.tags) { .tags.message } else { .message }
-           message == "test filter 1"
+      message = if exists(.tags) { .tags.message } else { .message }
+      message == "test filter 1"
     '''
 [transforms.filter_b]
   inputs = ["ignored"]
@@ -13,9 +13,9 @@
   [transforms.filter_b.condition]
     type = "remap"
     source = '''
-        message = if exists(.tags) { .tags.message } else { .message }
-        contains(message, "test filter") && \
-        contains(message, "2")
+      message = if exists(.tags) { .tags.message } else { .message }
+      contains(message, "test filter") && \
+      contains(message, "2")
     '''
 [transforms.filter_c]
   inputs = ["ignored"]

--- a/tests/behavior/transforms/filter.toml
+++ b/tests/behavior/transforms/filter.toml
@@ -2,15 +2,21 @@
   inputs = ["ignored"]
   type = "filter"
   [transforms.filter_a.condition]
-    type = "check_fields"
-    "message.eq" = "test filter 1"
+    type = "remap"
+    source = '''
+           message = if exists(.tags) { .tags.message } else { .message }
+           message == "test filter 1"
+    '''
 [transforms.filter_b]
   inputs = ["ignored"]
   type = "filter"
   [transforms.filter_b.condition]
-    type = "check_fields"
-    "message.contains" = "test filter"
-    "message.contains" = "2"
+    type = "remap"
+    source = '''
+        message = if exists(.tags) { .tags.message } else { .message }
+        contains(message, "test filter") && \
+        contains(message, "2")
+    '''
 [transforms.filter_c]
   inputs = ["ignored"]
   type = "filter"
@@ -26,8 +32,8 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test filter 1"
+      type = "remap"
+      source = '.message == "test filter 1"'
 
 [[tests]]
   name = "filter test 1b"
@@ -59,8 +65,8 @@
   [[tests.outputs]]
     extract_from = "filter_b"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test filter 2"
+      type = "remap"
+      source = '.message == "test filter 2"'
 
 [[tests]]
   name = "filter test 2c"
@@ -81,5 +87,5 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test filter 1"
+      type = "remap"
+      source = '.tags.message == "test filter 1"'

--- a/tests/behavior/transforms/grok_parser.toml
+++ b/tests/behavior/transforms/grok_parser.toml
@@ -11,8 +11,11 @@
   [[tests.outputs]]
     extract_from = "grok_parser_simple"
     [[tests.outputs.conditions]]
-      "timestamp.equals" = "12/Dec/2015:18:32:56 +0100"
-      "message.equals" = "hello"
+      type = "remap"
+      source = '''
+        .timestamp == "12/Dec/2015:18:32:56 +0100" && \
+        .message == "hello"
+      '''
 
 [transforms.grok_parser_nested]
   inputs = []
@@ -27,5 +30,8 @@
   [[tests.outputs]]
     extract_from = "grok_parser_nested"
     [[tests.outputs.conditions]]
-      "nested.timestamp.equals" = "12/Dec/2015:18:32:56 +0100"
-      "doubly.nested.message.equals" = "hello"
+      type = "remap"
+      source = '''
+        .nested.timestamp == "12/Dec/2015:18:32:56 +0100" && \
+        .doubly.nested.message == "hello"
+      '''

--- a/tests/behavior/transforms/json_parser.toml
+++ b/tests/behavior/transforms/json_parser.toml
@@ -10,8 +10,11 @@
   [[tests.outputs]]
     extract_from = "json_parser_nested"
     [[tests.outputs.conditions]]
-      "a.equals" = 3
-      "b.c.equals" = 4
+        type = "remap"
+        source = '''
+            .a == 3 && \
+            .b.c == 4
+        '''
 
 [transforms.json_parser_target_field]
   inputs = []
@@ -26,8 +29,11 @@
   [[tests.outputs]]
     extract_from = "json_parser_target_field"
     [[tests.outputs.conditions]]
-      "target_field.a.equals" = 3
-      "target_field.b.c.equals" = 4
+        type = "remap"
+        source = '''
+            .target_field.a == 3
+            .target_field.b.c == 4
+        '''
 
 [transforms.json_parser_null_value]
   inputs = []
@@ -41,5 +47,8 @@
   [[tests.outputs]]
     extract_from = "json_parser_null_value"
     [[tests.outputs.conditions]]
-      "a.equals" = 3
-      "b.equals" = "<null>"
+        type = "remap"
+        source = '''
+            .a == 3 && \
+            .b == null
+        '''

--- a/tests/behavior/transforms/json_parser.toml
+++ b/tests/behavior/transforms/json_parser.toml
@@ -10,11 +10,11 @@
   [[tests.outputs]]
     extract_from = "json_parser_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 3 && \
-            .b.c == 4
-        '''
+      type = "remap"
+      source = '''
+        .a == 3 && \
+        .b.c == 4
+      '''
 
 [transforms.json_parser_target_field]
   inputs = []
@@ -29,11 +29,11 @@
   [[tests.outputs]]
     extract_from = "json_parser_target_field"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .target_field.a == 3
-            .target_field.b.c == 4
-        '''
+      type = "remap"
+      source = '''
+        .target_field.a == 3
+        .target_field.b.c == 4
+      '''
 
 [transforms.json_parser_null_value]
   inputs = []
@@ -47,8 +47,8 @@
   [[tests.outputs]]
     extract_from = "json_parser_null_value"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 3 && \
-            .b == null
-        '''
+      type = "remap"
+      source = '''
+        .a == 3 && \
+        .b == null
+      '''

--- a/tests/behavior/transforms/key_value_parser.toml
+++ b/tests/behavior/transforms/key_value_parser.toml
@@ -21,8 +21,8 @@
       [[tests.outputs.conditions]]
         type = "remap"
         source = '''
-            .data.action == "Accept"
-            .data.ifdir == "inbound"
+          .data.action == "Accept"
+          .data.ifdir == "inbound"
         '''
 
 [transforms.key_value_parser_defaults]
@@ -41,6 +41,6 @@
       [[tests.outputs.conditions]]
         type = "remap"
         source = '''
-                .action == "\"Accept\""
-                .ifdir == "\"inbound\""
+          .action == "\"Accept\""
+          .ifdir == "\"inbound\""
         '''

--- a/tests/behavior/transforms/key_value_parser.toml
+++ b/tests/behavior/transforms/key_value_parser.toml
@@ -19,9 +19,11 @@
     [[tests.outputs]]
       extract_from = "key_value_parser"
       [[tests.outputs.conditions]]
-        type = "check_fields"
-        "data.action.equals" = "Accept"
-        "data.ifdir.equals" = "inbound"
+        type = "remap"
+        source = '''
+            .data.action == "Accept"
+            .data.ifdir == "inbound"
+        '''
 
 [transforms.key_value_parser_defaults]
   inputs = []
@@ -37,7 +39,8 @@
     [[tests.outputs]]
       extract_from = "key_value_parser_defaults"
       [[tests.outputs.conditions]]
-        type = "check_fields"
-        "action.equals" = "\"Accept\""
-        "ifdir.equals" = "\"inbound\""
-
+        type = "remap"
+        source = '''
+                .action == "\"Accept\""
+                .ifdir == "\"inbound\""
+        '''

--- a/tests/behavior/transforms/logfmt_parser.toml
+++ b/tests/behavior/transforms/logfmt_parser.toml
@@ -15,13 +15,13 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .code == 1234 && \
-            .flag == true && \
-            .number == 42.3 && \
-            .rest == "word"
-        '''
+      type = "remap"
+      source = '''
+        .code == 1234 && \
+        .flag == true && \
+        .number == 42.3 && \
+        .rest == "word"
+      '''
 
 [transforms.logfmt_parser_nested]
   inputs = []
@@ -40,10 +40,10 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .nested.code == 1234 && \
-            .nested.flag == true && \
-            .nested.number == 42.3 && \
-            .nested.rest == "word"
-        '''
+      type = "remap"
+      source = '''
+        .nested.code == 1234 && \
+        .nested.flag == true && \
+        .nested.number == 42.3 && \
+        .nested.rest == "word"
+      '''

--- a/tests/behavior/transforms/logfmt_parser.toml
+++ b/tests/behavior/transforms/logfmt_parser.toml
@@ -15,10 +15,13 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_simple"
     [[tests.outputs.conditions]]
-      "code.equals" = 1234
-      "flag.equals" = true
-      "number.equals" = 42.3
-      "rest.equals" = "word"
+        type = "remap"
+        source = '''
+            .code == 1234 && \
+            .flag == true && \
+            .number == 42.3 && \
+            .rest == "word"
+        '''
 
 [transforms.logfmt_parser_nested]
   inputs = []
@@ -37,7 +40,10 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_nested"
     [[tests.outputs.conditions]]
-      "nested.code.equals" = 1234
-      "nested.flag.equals" = true
-      "nested.number.equals" = 42.3
-      "nested.rest.equals" = "word"
+        type = "remap"
+        source = '''
+            .nested.code == 1234 && \
+            .nested.flag == true && \
+            .nested.number == 42.3 && \
+            .nested.rest == "word"
+        '''

--- a/tests/behavior/transforms/lua_v1.toml
+++ b/tests/behavior/transforms/lua_v1.toml
@@ -14,8 +14,11 @@
   [[tests.outputs]]
     extract_from = "lua_unversioned"
     [[tests.outputs.conditions]]
-      "a.exists" = false
-      "b.equals" = "example value"
+        type = "remap"
+        source = '''
+            !exists(.a) && \
+            .b == "example value"
+        ''' 
 
 [transforms.lua_v1]
   inputs = []
@@ -34,5 +37,8 @@
   [[tests.outputs]]
     extract_from = "lua_v1"
     [[tests.outputs.conditions]]
-      "a.exists" = false
-      "b.equals" = "example value"
+        type = "remap"
+        source = '''
+            !exists(.a) && \
+            .b == "example value"
+        '''

--- a/tests/behavior/transforms/lua_v1.toml
+++ b/tests/behavior/transforms/lua_v1.toml
@@ -14,11 +14,11 @@
   [[tests.outputs]]
     extract_from = "lua_unversioned"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            !exists(.a) && \
-            .b == "example value"
-        ''' 
+      type = "remap"
+      source = '''
+        !exists(.a) && \
+        .b == "example value"
+      '''
 
 [transforms.lua_v1]
   inputs = []
@@ -37,8 +37,8 @@
   [[tests.outputs]]
     extract_from = "lua_v1"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            !exists(.a) && \
-            .b == "example value"
-        '''
+      type = "remap"
+      source = '''
+        !exists(.a) && \
+        .b == "example value"
+      '''

--- a/tests/behavior/transforms/lua_v2.toml
+++ b/tests/behavior/transforms/lua_v2.toml
@@ -18,11 +18,11 @@
   [[tests.outputs]]
     extract_from = "lua_v2_log"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            !exists(.a) && \
-            .b == "example value"
-        '''
+      type = "remap"
+      source = '''
+        !exists(.a) && \
+        .b == "example value"
+      '''
 
 [transforms.lua_v2_source]
   inputs = []
@@ -45,11 +45,11 @@
   [[tests.outputs]]
     extract_from = "lua_v2_source"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .some_field == "some value" && \
-            .inserted_field == "inserted value"
-        '''
+      type = "remap"
+      source = '''
+        .some_field == "some value" && \
+        .inserted_field == "inserted value"
+      '''
 
 [transforms.lua_v2_metric]
   inputs = []
@@ -128,7 +128,7 @@
   [[tests.outputs]]
     extract_from = "lua_v2_metric_to_log"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .field == "example value"
-        '''
+      type = "remap"
+      source = '''
+        .field == "example value"
+      '''

--- a/tests/behavior/transforms/lua_v2.toml
+++ b/tests/behavior/transforms/lua_v2.toml
@@ -18,8 +18,11 @@
   [[tests.outputs]]
     extract_from = "lua_v2_log"
     [[tests.outputs.conditions]]
-      "a.exists" = false
-      "b.equals" = "example value"
+        type = "remap"
+        source = '''
+            !exists(.a) && \
+            .b == "example value"
+        '''
 
 [transforms.lua_v2_source]
   inputs = []
@@ -42,8 +45,11 @@
   [[tests.outputs]]
     extract_from = "lua_v2_source"
     [[tests.outputs.conditions]]
-      "some_field.equals" = "some value"
-      "inserted_field.equals" = "inserted value"
+        type = "remap"
+        source = '''
+            .some_field == "some value" && \
+            .inserted_field == "inserted value"
+        '''
 
 [transforms.lua_v2_metric]
   inputs = []
@@ -122,4 +128,7 @@
   [[tests.outputs]]
     extract_from = "lua_v2_metric_to_log"
     [[tests.outputs.conditions]]
-      "field.equals" = "example value"
+        type = "remap"
+        source = '''
+            .field == "example value"
+        '''

--- a/tests/behavior/transforms/merge.toml
+++ b/tests/behavior/transforms/merge.toml
@@ -17,11 +17,11 @@
   [[tests.outputs]]
     extract_from = "merge"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .message == "hello world" && \
-            !exists(."_partial")
-        '''
+      type = "remap"
+      source = '''
+        .message == "hello world" && \
+        !exists(."_partial")
+      '''
 
 [transforms.merge_nested]
   inputs = []
@@ -43,11 +43,11 @@
   [[tests.outputs]]
     extract_from = "merge_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .nested.message == "hello world" && \
-            !exists(."_partial")
-        ''' 
+      type = "remap"
+      source = '''
+        .nested.message == "hello world" && \
+        !exists(."_partial")
+      '''
 
 [transforms.merge_nested_marker]
   inputs = []
@@ -70,8 +70,8 @@
   [[tests.outputs]]
     extract_from = "merge_nested_marker"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .nested.message == "hello world" && \
-            !exists(.nested.is_partial)
-        '''
+      type = "remap"
+      source = '''
+        .nested.message == "hello world" && \
+        !exists(.nested.is_partial)
+      '''

--- a/tests/behavior/transforms/merge.toml
+++ b/tests/behavior/transforms/merge.toml
@@ -17,8 +17,11 @@
   [[tests.outputs]]
     extract_from = "merge"
     [[tests.outputs.conditions]]
-      "message.equals" = "hello world"
-      "_partial.exists" = false
+        type = "remap"
+        source = '''
+            .message == "hello world" && \
+            !exists(."_partial")
+        '''
 
 [transforms.merge_nested]
   inputs = []
@@ -40,8 +43,11 @@
   [[tests.outputs]]
     extract_from = "merge_nested"
     [[tests.outputs.conditions]]
-      "nested.message.equals" = "hello world"
-      "_partial.exists" = false
+        type = "remap"
+        source = '''
+            .nested.message == "hello world" && \
+            !exists(."_partial")
+        ''' 
 
 [transforms.merge_nested_marker]
   inputs = []
@@ -64,5 +70,8 @@
   [[tests.outputs]]
     extract_from = "merge_nested_marker"
     [[tests.outputs.conditions]]
-      "nested.message.equals" = "hello world"
-      "nested.is_partial.exists" = false
+        type = "remap"
+        source = '''
+            .nested.message == "hello world" && \
+            !exists(.nested.is_partial)
+        '''

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -70,20 +70,20 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .message == "first message value" && \
-            .host == "host1" && \
-            .request_id == "1" && \
-            .counter == 21 && \
-            exists(.timestamp_end)
+        .message == "first message value" && \
+        .host == "host1" && \
+        .request_id == "1" && \
+        .counter == 21 && \
+        exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .message == "other reduce one" && \
-            .host == "host3" && \
-            .request_id == "2" && \
-            .counter == 20 && \
-            exists(.timestamp_end)
+        .message == "other reduce one" && \
+        .host == "host3" && \
+        .request_id == "2" && \
+        .counter == 20 && \
+        exists(.timestamp_end)
       '''
 
 ##------------------------------------------------------------------------------
@@ -177,22 +177,22 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .message == "first message value second message value third message value" && \
-            .another == "foo\nbar baz\nqux\nquux" && \
-            .host == "host1" && \
-            .request_id == "1" && \
-            .counter == 21 && \
-            exists(.timestamp_end)
+        .message == "first message value second message value third message value" && \
+        .another == "foo\nbar baz\nqux\nquux" && \
+        .host == "host1" && \
+        .request_id == "1" && \
+        .counter == 21 && \
+        exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .message == "other reduce one other reduce two other reduce three" && \
-            .concat_array == ["foo", "bar", "baz"] && \
-            .host == "host3" && \
-            .request_id == "2" && \
-            .counter == 20 && \
-            exists(.timestamp_end)
+        .message == "other reduce one other reduce two other reduce three" && \
+        .concat_array == ["foo", "bar", "baz"] && \
+        .host == "host3" && \
+        .request_id == "2" && \
+        .counter == 20 && \
+        exists(.timestamp_end)
       '''
 
 ##------------------------------------------------------------------------------
@@ -239,9 +239,9 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .mins == 5.1 && \
-            .maxs == 7.2 && \
-            exists(.timestamp_end)
+        .mins == 5.1 && \
+        .maxs == 7.2 && \
+        exists(.timestamp_end)
       '''
 
 [[tests]]
@@ -274,9 +274,9 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .mins == 5 && \
-            .maxs == 7 && \
-            exists(.timestamp_end)
+        .mins == 5 && \
+        .maxs == 7 && \
+        exists(.timestamp_end)
       '''
 
 ##------------------------------------------------------------------------------
@@ -352,16 +352,16 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .request_id == "1" && \
-            .counter == 6 && \
-            exists(.timestamp_end)
+        .request_id == "1" && \
+        .counter == 6 && \
+        exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .request_id == "2" && \
-            .counter == 7 && \
-            exists(.test_end_message)
+        .request_id == "2" && \
+        .counter == 7 && \
+        exists(.test_end_message)
       '''
     [[tests.outputs.conditions]]
       type = "remap"
@@ -369,7 +369,7 @@
         .request_id == "3" && \
         .counter == 5 && \
         exists(.test_end_message)
-      ''' 
+      '''
 
 ##------------------------------------------------------------------------------
 
@@ -427,7 +427,7 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-             .message == "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
+        .message == "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
       '''
 
 ##------------------------------------------------------------------------------
@@ -487,11 +487,11 @@
 ##------------------------------------------------------------------------------
 
 [transforms.line_termination]
-    inputs = []
-    type = "reduce"
-    merge_strategies.message = "concat"
-    ends_when.type = "remap"
-    ends_when.source = """ends_with(strip_whitespace(.message), ";")"""
+  inputs = []
+  type = "reduce"
+  merge_strategies.message = "concat"
+  ends_when.type = "remap"
+  ends_when.source = """ends_with(strip_whitespace(.message), ";")"""
 
 [[tests]]
   name = "reduce_line_termination"
@@ -669,6 +669,6 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            starts_with(.message, "2020-10-19 04:34:15,389") && \
-            ends_with(.message, "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]")
+        starts_with(.message, "2020-10-19 04:34:15,389") && \
+        ends_with(.message, "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]")
       '''

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -3,8 +3,8 @@
   type = "reduce"
   group_by = [ "request_id" ]
   [transforms.reduce.ends_when]
-    type = "check_fields"
-    "test_end_message.exists" = true
+    type = "remap"
+    source = "exists(.test_end_message)"
 
 [[tests]]
   name = "reduce_basic"
@@ -68,19 +68,23 @@
   [[tests.outputs]]
     extract_from = "reduce"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "first message value"
-      "host.equals" = "host1"
-      "request_id.equals" = "1"
-      "counter.equals" = 21
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .message == "first message value" && \
+            .host == "host1" && \
+            .request_id == "1" && \
+            .counter == 21 && \
+            exists(.timestamp_end)
+      '''
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "other reduce one"
-      "host.equals" = "host3"
-      "request_id.equals" = "2"
-      "counter.equals" = 20
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .message == "other reduce one" && \
+            .host == "host3" && \
+            .request_id == "2" && \
+            .counter == 20 && \
+            exists(.timestamp_end)
+      '''
 
 ##------------------------------------------------------------------------------
 
@@ -96,8 +100,8 @@
     "concat_array" = "concat"
 
   [transforms.reduce_strats.ends_when]
-    type = "check_fields"
-    "test_end_message.exists" = true
+    type = "remap"
+    source = 'exists(.test_end_message)'
 
 [[tests]]
   name = "reduce_merge_strategies"
@@ -171,23 +175,25 @@
   [[tests.outputs]]
     extract_from = "reduce_strats"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "first message value second message value third message value"
-      "another.equals" = "foo\nbar baz\nqux\nquux"
-      "host.equals" = "host1"
-      "request_id.equals" = "1"
-      "counter.equals" = 21
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .message == "first message value second message value third message value" && \
+            .another == "foo\nbar baz\nqux\nquux" && \
+            .host == "host1" && \
+            .request_id == "1" && \
+            .counter == 21 && \
+            exists(.timestamp_end)
+      '''
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "other reduce one other reduce two other reduce three"
-      "concat_array[0].equals" = "foo"
-      "concat_array[1].equals" = "bar"
-      "concat_array[2].equals" = "baz"
-      "host.equals" = "host3"
-      "request_id.equals" = "2"
-      "counter.equals" = 20
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .message == "other reduce one other reduce two other reduce three" && \
+            .concat_array == ["foo", "bar", "baz"] && \
+            .host == "host3" && \
+            .request_id == "2" && \
+            .counter == 20 && \
+            exists(.timestamp_end)
+      '''
 
 ##------------------------------------------------------------------------------
 
@@ -200,8 +206,8 @@
     "maxs" = "max"
 
   [transforms.reduce_numbers.ends_when]
-    type = "check_fields"
-    "test_end_message.exists" = true
+    type = "remap"
+    source = "exists(.test_end_message)"
 
 [[tests]]
   name = "reduce_number_strategies_1"
@@ -231,10 +237,12 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "mins.equals" = 5.1
-      "maxs.equals" = 7.2
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .mins == 5.1 && \
+            .maxs == 7.2 && \
+            exists(.timestamp_end)
+      '''
 
 [[tests]]
   name = "reduce_number_strategies_2"
@@ -264,10 +272,12 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "mins.equals" = 5
-      "maxs.equals" = 7
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .mins == 5 && \
+            .maxs == 7 && \
+            exists(.timestamp_end)
+      '''
 
 ##------------------------------------------------------------------------------
 
@@ -340,20 +350,26 @@
   [[tests.outputs]]
     extract_from = "ends_when_remap"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "request_id.equals" = "1"
-      "counter.equals" = 6
-      "timestamp_end.exists" = true
+      type = "remap"
+      source = '''
+            .request_id == "1" && \
+            .counter == 6 && \
+            exists(.timestamp_end)
+      '''
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "request_id.equals" = "2"
-      "counter.equals" = 7
-      "test_end_message.exists" = true
+      type = "remap"
+      source = '''
+            .request_id == "2" && \
+            .counter == 7 && \
+            exists(.test_end_message)
+      '''
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "request_id.equals" = "3"
-      "counter.equals" = 5
-      "test_end_message.exists" = true
+      type = "remap"
+      source = '''
+        .request_id == "3" && \
+        .counter == 5 && \
+        exists(.test_end_message)
+      ''' 
 
 ##------------------------------------------------------------------------------
 
@@ -406,11 +422,13 @@
   [[tests.outputs]]
     extract_from = "ruby_exception"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"
+      type = "remap"
+      source = '.message == "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
+      type = "remap"
+      source = '''
+             .message == "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
+      '''
 
 ##------------------------------------------------------------------------------
 
@@ -457,14 +475,14 @@
   [[tests.outputs]]
     extract_from = "line_continuation"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "First-line"
+      type = "remap"
+      source = '.message == "First-line"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "Second line\\ more second line\\      end of second line"
+      type = "remap"
+      source = '.message == "Second line\\ more second line\\      end of second line"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "third line"
+      type = "remap"
+      source = '.message == "third line"'
 
 ##------------------------------------------------------------------------------
 
@@ -511,14 +529,14 @@
   [[tests.outputs]]
     extract_from = "line_termination"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "first line;"
+      type = "remap"
+      source = '.message == "first line;"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "second line more of the second line end of second line;         "
+      type = "remap"
+      source = '.message == "second line more of the second line end of second line;         "'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "third line;"
+      type = "remap"
+      source = '.message == "third line;"'
 
 ##------------------------------------------------------------------------------
 
@@ -565,14 +583,14 @@
   [[tests.outputs]]
     extract_from = "log_stream"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "<12> first line   more of the first line"
+      type = "remap"
+      source = '.message == "<12> first line   more of the first line"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "<22> second line"
+      type = "remap"
+      source = '.message == "<22> second line"'
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "<17> third line"
+      type = "remap"
+      source = '.message == "<17> third line"'
 
 ##------------------------------------------------------------------------------
 
@@ -649,6 +667,8 @@
   [[tests.outputs]]
     extract_from = "java_exception"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.starts_with" = "2020-10-19 04:34:15,389"
-      "message.ends_with" = "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]"
+      type = "remap"
+      source = '''
+            starts_with(.message, "2020-10-19 04:34:15,389") && \
+            ends_with(.message, "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]")
+      '''

--- a/tests/behavior/transforms/regex_parser.toml
+++ b/tests/behavior/transforms/regex_parser.toml
@@ -11,12 +11,12 @@
   [[tests.outputs]]
     extract_from = "regex_parser_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .timestamp == "2020-01-01T12:34:56Z" && \
-            .level == "INFO" && \
-            .message == "hello"
-        '''
+      type = "remap"
+      source = '''
+        .timestamp == "2020-01-01T12:34:56Z" && \
+        .level == "INFO" && \
+        .message == "hello"
+      '''
 
 [transforms.regex_parser_target]
   inputs = []
@@ -32,9 +32,9 @@
   [[tests.outputs]]
     extract_from = "regex_parser_target"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .something.timestamp == "2020-01-01T12:34:56Z" && \
-            .something.level == "INFO" && \
-            .something.message == "hello"
-        '''
+      type = "remap"
+      source = '''
+        .something.timestamp == "2020-01-01T12:34:56Z" && \
+        .something.level == "INFO" && \
+        .something.message == "hello"
+      '''

--- a/tests/behavior/transforms/regex_parser.toml
+++ b/tests/behavior/transforms/regex_parser.toml
@@ -11,9 +11,12 @@
   [[tests.outputs]]
     extract_from = "regex_parser_simple"
     [[tests.outputs.conditions]]
-      "timestamp.equals" = "2020-01-01T12:34:56Z"
-      "level.equals" = "INFO"
-      "message.equals" = "hello"
+        type = "remap"
+        source = '''
+            .timestamp == "2020-01-01T12:34:56Z" && \
+            .level == "INFO" && \
+            .message == "hello"
+        '''
 
 [transforms.regex_parser_target]
   inputs = []
@@ -29,6 +32,9 @@
   [[tests.outputs]]
     extract_from = "regex_parser_target"
     [[tests.outputs.conditions]]
-      "something.timestamp.equals" = "2020-01-01T12:34:56Z"
-      "something.level.equals" = "INFO"
-      "something.message.equals" = "hello"
+        type = "remap"
+        source = '''
+            .something.timestamp == "2020-01-01T12:34:56Z" && \
+            .something.level == "INFO" && \
+            .something.message == "hello"
+        '''

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -15,9 +15,12 @@
   [[tests.outputs]]
     extract_from = "remap_nested"
     [[tests.outputs.conditions]]
-      "a.b.equals" = 123
-      "x.y.equals" = 456
-      "x.z.equals" = 789
+      type = "remap"
+      source = '''
+        .a.b == 123 && \
+        .x.y == 456 && \
+        .x.z == 789
+      '''
 
 [transforms.remap_array]
   inputs = []
@@ -38,13 +41,15 @@
   [[tests.outputs]]
     extract_from = "remap_array"
     [[tests.outputs.conditions]]
-      "a[0].equals" = 0
-      "a[1].equals" = "1"
-      "a[2].equals" = 2.0
-
-      "b[0].equals" = 0
-      "b[1].equals" = "<null>"
-      "b[2].equals" = "two"
+      type = "remap"
+      source = '''
+        .a[0] == 0 && \
+        .a[1] == "1" && \
+        .a[2] == 2.0 && \
+        .b[0] == 0 && \
+        .b[1] == null && \
+        .b[2] == "two"
+      '''
 
 [transforms.remap_arithmetic]
   inputs = []
@@ -71,12 +76,15 @@
   [[tests.outputs]]
     extract_from = "remap_arithmetic"
     [[tests.outputs.conditions]]
-      "result_a.equals" = 27
-      "result_b.equals" = 51
-      "result_c.equals" = 17
-      "result_d.equals" = 20
-      "result_e.equals" = 0.75
-      "result_f.equals" = 0
+      type = "remap"
+      source = '''
+        .result_a == 27 && \
+        .result_b == 51 && \
+        .result_c == 17 && \
+        .result_d == 20 && \
+        .result_e == 0.75 && \
+        .result_f == 0
+     '''
 
 [transforms.remap_arithmetic_error]
   inputs = []
@@ -92,8 +100,11 @@
     insert_at = "remap_arithmetic_error"
     type = "log"
     [tests.input.log_fields]
-      a = 10
-      b = 0
+        type = "remap"
+        source = '''
+          .a = 10 && \
+          .b = 0
+        '''
 
 [transforms.remap_boolean_arithmetic]
   inputs = []
@@ -117,10 +128,13 @@
   [[tests.outputs]]
     extract_from = "remap_boolean_arithmetic"
     [[tests.outputs.conditions]]
-      "result_a.equals" = true
-      "result_b.equals" = false
-      "result_c.equals" = true
-      "result_d.equals" = false
+        type = "remap"
+        source = '''
+           .result_a == true && \
+           .result_b == false && \
+           .result_c == true && \
+           .result_d == false
+        '''
 
 [transforms.remap_coercion]
   inputs = []
@@ -147,11 +161,14 @@
   [[tests.outputs]]
     extract_from = "remap_coercion"
     [[tests.outputs.conditions]]
-      "foo.equals" = "10"
-      "bar.equals" = 20
-      "baz.equals" = 30.3
-      "bev.equals" = true
-      "a.equals" = "2020-09-14 09:53:44 UTC"
+        type = "remap"
+        source = '''
+            .foo == "10" && \
+            .bar == 20 && \
+            .baz == 30.3 && \
+            .bev == true && \
+            .a == "2020-09-14 09:53:44 UTC"
+        '''
 
 [transforms.remap_quoted_path]
   inputs = []
@@ -170,7 +187,10 @@
   [[tests.outputs]]
     extract_from = "remap_quoted_path"
     [[tests.outputs.conditions]]
-      "a.b\\.c.equals" = "baz"
+        type = "remap"
+        source = '''
+            .a."b.c" == "baz"
+        '''
 
 [transforms.remap_infallible_assignment]
   inputs = []
@@ -251,12 +271,15 @@
   [[tests.outputs]]
     extract_from = "remap_function_arguments"
     [[tests.outputs.conditions]]
-      "a.equals" = "10"
-      "b.equals" = "10"
-      "c.equals" = ""
-      "d.equals" = ""
-      "e.equals" = "30"
-      "f.equals" = "30"
+        type = "remap"
+        source = '''
+            .a == "10" && \
+            .b == "10" && \
+            .c == "" && \
+            .d == "" && \
+            .e == "30" && \
+            .f == "30"
+        '''
 
 [transforms.remap_function_upcase]
   inputs = []
@@ -283,10 +306,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_upcase"
     [[tests.outputs.conditions]]
-      "a.equals" = "A"
-      "b.equals" = "BBB BB"
-      "c.c.equals" = "C.C"
-      "f.equals" = "ff"
+        type = "remap"
+        source = '''
+          .a == "A" && \
+          .b == "BBB BB" && \
+          .c.c == "C.C" && \
+          .f == "ff"
+        '''
 
 [transforms.remap_function_upcase_error]
   inputs = []
@@ -332,10 +358,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_downcase"
     [[tests.outputs.conditions]]
-      "a.equals" = "a"
-      "b.equals" = "bbb bb"
-      "c.c.equals" = "c.c"
-      "f.equals" = "FF"
+        type = "remap"
+        source = '''
+            .a == "a" && \
+            .b == "bbb bb" && \
+            .c.c == "c.c" && \
+            .f == "FF"
+        '''
 
 [transforms.remap_function_downcase_error]
   inputs = []
@@ -375,8 +404,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_uuid_v4"
     [[tests.outputs.conditions]]
-      "a.regex" = "(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-      "b.equals" = "bar"
+        type = "remap"
+        source = '''
+            match(.a, /(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/) && \
+            .b == "bar"
+        '''
 
 [transforms.remap_function_sha1]
   inputs = []
@@ -399,8 +431,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha1"
     [[tests.outputs.conditions]]
-      "a.equals" = "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
-      "b.equals" = "6f74c252bb7f19f553115af5e49a733b9ff17138"
+        type = "remap"
+        source = '''
+          .a == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" && \
+          .b == "6f74c252bb7f19f553115af5e49a733b9ff17138"
+        '''
 
 [transforms.remap_function_sha1_error]
   inputs = []
@@ -441,8 +476,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_md5"
     [[tests.outputs.conditions]]
-      "a.equals" = "acbd18db4cc2f85cedef654fccc4a4d8"
-      "b.equals" = "223cfa6567e4c0599c9a23628bf7a234"
+        type = "remap"
+        source = '''
+            .a == "acbd18db4cc2f85cedef654fccc4a4d8" && \
+            .b == "223cfa6567e4c0599c9a23628bf7a234"
+        '''
+        
 
 [transforms.remap_function_md5_error]
   inputs = []
@@ -465,9 +504,9 @@
 [transforms.remap_function_now]
   inputs = []
   type = "remap"
-  source = """
+  source = '''
     .a = now()
-  """
+  '''
 [[tests]]
   name = "remap_function_now"
   [tests.input]
@@ -477,7 +516,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_now"
     [[tests.outputs.conditions]]
-      "a.ends_with" = "Z"
+        type = "remap"
+        source = '''
+            ends_with(to_string(.a), "UTC")
+        '''
 
 [transforms.remap_function_format_timestamp]
   inputs = []
@@ -495,7 +537,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_format_timestamp"
     [[tests.outputs.conditions]]
-      "a.equals" = "1970-01-01T00:00:10+00:00"
+        type = "remap"
+        source = '''
+            .a == "1970-01-01T00:00:10+00:00"
+        '''
 
 [transforms.remap_function_contains]
   inputs = []
@@ -521,13 +566,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_contains"
     [[tests.outputs.conditions]]
-      "a.equals" = false
-      "b.equals" = true
-      "c.equals" = false
-      "d.equals" = true
-      "e.equals" = true
-      "f.equals" = false
-      "g.equals" = true
+        type = "remap"
+        source = '''
+            .a == false && \
+            .b == true && \
+            .c == false && \
+            .d == true && \
+            .e == true && \
+            .f == false && \
+            .g == true
+        '''
 
 [transforms.remap_function_starts_with]
   inputs = []
@@ -550,11 +598,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_starts_with"
     [[tests.outputs.conditions]]
-      "a.equals" = true
-      "b.equals" = true
-      "c.equals" = false
-      "d.equals" = false
-      "e.equals" = true
+        type = "remap"
+        source = '''
+            .a == true && \
+            .b == true && \
+            .c == false && \
+            .d == false && \
+            .e == true
+        '''
 
 [transforms.remap_function_ends_with]
   inputs = []
@@ -577,11 +628,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_ends_with"
     [[tests.outputs.conditions]]
-      "a.equals" = true
-      "b.equals" = true
-      "c.equals" = false
-      "d.equals" = false
-      "e.equals" = true
+        type = "remap"
+        source = '''
+            .a == true && \
+            .b == true && \
+            .c == false && \
+            .d == false && \
+            .e == true
+        '''
 
 [transforms.remap_function_slice]
   inputs = []
@@ -603,18 +657,21 @@
   [[tests.outputs]]
     extract_from = "remap_function_slice"
     [[tests.outputs.conditions]]
-      "a.equals" = "oobar"
-      "b.equals" = "f"
-      "c.equals" = "ar"
-      "d.equals" = "ooba"
+        type = "remap"
+        source = '''
+            .a == "oobar" && \
+            .b == "f" && \
+            .c == "ar" && \
+            .d == "ooba"
+        '''
 
 [transforms.remap_function_parse_tokens]
   inputs = []
   type = "remap"
-  source = """
+  source = '''
     .a = parse_tokens(.a)
     .b = parse_tokens(.b)
-  """
+  ''' 
 [[tests]]
   name = "remap_function_parse_tokens"
   [tests.input]
@@ -626,16 +683,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_tokens"
     [[tests.outputs.conditions]]
-      "a.length_eq" = 7
-      "a[0].equals" = "217.250.207.207"
-      "a[1].equals" = "<null>"
-      "a[2].equals" = "<null>"
-      "a[3].equals" = "07/Sep/2020:16:38:00 -0400"
-      "a[4].equals" = "DELETE /deliverables/next-generation/user-centric HTTP/1.1"
-      "a[5].equals" = "205"
-      "a[6].equals" = "11881"
-      "b.length_eq" = 1
-      "b[0].equals" = "bar"
+        type = "remap"
+        source = '''
+            .a == ["217.250.207.207", \
+                   null, \
+                   null, \
+                   "07/Sep/2020:16:38:00 -0400", \
+                   "DELETE /deliverables/next-generation/user-centric HTTP/1.1", \
+                   "205", "11881" ] && \
+            .b == ["bar"]
+        '''
 
 [transforms.remap_function_sha2]
   inputs = []
@@ -658,8 +715,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha2"
     [[tests.outputs.conditions]]
-      "a.equals" = "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d"
-      "b.equals" = "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
+        type = "remap"
+        source = '''
+            .a == "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d" && \
+            .b == "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
+        '''
 
 [transforms.remap_function_sha3]
   inputs = []
@@ -682,8 +742,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha3"
     [[tests.outputs.conditions]]
-      "a.equals" = "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
-      "b.equals" = "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"
+        type = "remap"
+        source = '''
+            .a == "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7" && \
+            .b == "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"
+        '''
 
 [transforms.remap_function_parse_duration]
   inputs = []
@@ -703,8 +766,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_duration"
     [[tests.outputs.conditions]]
-      "a.equals" = 2000
-      "b.equals" = 0.1
+        type = "remap"
+        source = '''
+            .a == 2000 && \
+            .b == 0.1
+        '''
 
 [transforms.remap_function_format_number]
   inputs = []
@@ -722,7 +788,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_format_number"
     [[tests.outputs.conditions]]
-      "a.equals" = "1.234,56"
+        type = "remap"
+        source = '''
+            .a == "1.234,56"
+        '''
 
 [transforms.remap_function_parse_url]
   inputs = []
@@ -740,15 +809,18 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_url"
     [[tests.outputs.conditions]]
-      "parts.scheme.equals" = "https"
-      "parts.username.equals" = ""
-      "parts.password.equals" = ""
-      "parts.host.equals" = "master.vector.dev"
-      "parts.port.equals" = "<null>"
-      "parts.path.equals" = "/docs/reference/transforms/merge/"
-      "parts.query.length_eq" = 1
-      "parts.query.hello.equals" = "world"
-      "parts.fragment.equals" = "configuration"
+        type = "remap"
+        source = '''
+            # "parts.query.length_eq" = 1 && \
+            .parts.scheme == "https" && \
+            .parts.username == "" && \
+            .parts.password == "" && \
+            .parts.host == "master.vector.dev" && \
+            .parts.port == null && \
+            .parts.path == "/docs/reference/transforms/merge/" && \
+            .parts.query.hello == "world" && \
+            .parts.fragment == "configuration"
+        '''
 
 [transforms.remap_function_ceil]
   inputs = []
@@ -768,9 +840,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_ceil"
     [[tests.outputs.conditions]]
-      "a.equals" = 93
-      "b.equals" = 92.5
-      "c.equals" = 92.49
+        type = "remap"
+        source = '''
+            .a == 93 && \
+            .b == 92.5 && \
+            .c == 92.49
+        '''
 
 [transforms.remap_function_floor]
   inputs = []
@@ -790,9 +865,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_floor"
     [[tests.outputs.conditions]]
-      "a.equals" = 92
-      "b.equals" = 92.4
-      "c.equals" = 92.48
+        type = "remap"
+        source = '''
+            .a == 92 && \
+            .b == 92.4 && \
+            .c == 92.48
+        '''
 
 [transforms.remap_function_round]
   inputs = []
@@ -812,9 +890,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_round"
     [[tests.outputs.conditions]]
-      "a.equals" = 92
-      "b.equals" = 92.5
-      "c.equals" = 92.49
+        type = "remap"
+        source = '''
+            .a == 92 && \
+            .b == 92.5 && \
+            .c == 92.49
+        '''
 
 [transforms.remap_function_parse_syslog]
   inputs = []
@@ -832,13 +913,16 @@
   [[tests.outputs]]
   extract_from = "remap_function_parse_syslog"
   [[tests.outputs.conditions]]
-    "a.facility.equals" = "daemon"
-    "a.severity.equals" = "warning"
-    "a.timestamp.equals" = "2020-05-22T17:59:09.250Z"
-    "a.hostname.equals" = "OX-XXX-MX204"
-    "a.appname.equals" = "OX-XXX-CONTEUDO:rpd"
-    "a.procid.equals" = 6589
-    "a.message.equals" = "bgp_listen_accept: %DAEMON-4: Connection attempt from unconfigured neighbor: 2001:XXX::219:166+57284"
+        type = "remap"
+        source = '''
+            .a.facility == "daemon" && \
+            .a.severity == "warning" && \
+            .a.timestamp == to_timestamp("2020-05-22T17:59:09.250Z") && \
+            .a.hostname == "OX-XXX-MX204" && \
+            .a.appname == "OX-XXX-CONTEUDO:rpd" && \
+            .a.procid == 6589 && \
+            .a.message == "bgp_listen_accept: %DAEMON-4: Connection attempt from unconfigured neighbor: 2001:XXX::219:166+57284"
+        '''
 
 [transforms.remap_function_split_regex]
   inputs=[]
@@ -856,9 +940,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_split_regex"
     [[tests.outputs.conditions]]
-    "foo[0].equals" = "bar"
-    "foo[1].equals" = "bat"
-    "foo[2].equals" = "fizzaxbbuzz"
+        type = "remap"
+        source = '''
+            .foo[0] == "bar" && \
+            .foo[1] == "bat" && \
+            .foo[2] == "fizzaxbbuzz"
+        '''
 
 [transforms.remap_function_split_string]
   inputs=[]
@@ -876,9 +963,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_split_string"
     [[tests.outputs.conditions]]
-    "foo[0].equals" = "bar"
-    "foo[1].equals" = "bat"
-    "foo[2].equals" = "fizz buzz"
+        type = "remap"
+        source = '''
+    .foo[0] == "bar" && \
+    .foo[1] == "bat" && \
+    .foo[2] == "fizz buzz"
+        '''
 
 [transforms.remap_function_parse_timestamp]
   inputs = []
@@ -895,7 +985,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_timestamp"
     [[tests.outputs.conditions]]
-    "foo.equals" = "1970-01-01T00:00:10Z"
+        type = "remap"
+        source = '''
+            .foo == to_timestamp("1970-01-01T00:00:10Z")
+        '''
 
 [transforms.remap_function_truncate]
   inputs = []
@@ -913,8 +1006,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_truncate"
     [[tests.outputs.conditions]]
-    "foo.equals" = "foo"
-    "bar.equals" = "foob..."
+        type = "remap"
+        source = '''
+            .foo == "foo" && \
+            .bar == "foob..."
+        '''
 
 [transforms.remap_function_strip_whitespace]
   inputs = []
@@ -931,7 +1027,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_strip_whitespace"
     [[tests.outputs.conditions]]
-    "foo.equals" = "foobar"
+        type = "remap"
+        source = '''
+            .foo == "foobar"
+        '''
 
 [transforms.remap_function_parse_grok]
   inputs = []
@@ -950,14 +1049,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_grok"
     [[tests.outputs.conditions]]
-    "grokked.timestamp.equals" = "2020-10-02T23:22:12.223222Z"
-    "grokked.level.equals" = "info"
-    "grokked.message.equals" = "Hello world"
-    "grokked.email.equals" = ""
-    "grokked2.timestamp.equals" = "2020-10-02T23:22:12.223222Z"
-    "grokked2.level.equals" = "info"
-    "grokked2.email.exists" = false
-    "grokked2.message.equals" = "Hello world"
+        type = "remap"
+        source = '''
+            .grokked.timestamp == "2020-10-02T23:22:12.223222Z" && \
+            .grokked.level == "info" && \
+            .grokked.message == "Hello world" && \
+            .grokked.email == "" && \
+            .grokked2.timestamp == "2020-10-02T23:22:12.223222Z" && \
+            .grokked2.level == "info" && \
+            !exists(.grokked2.email) && \
+            .grokked2.message == "Hello world"
+        '''
 
 [transforms.remap_function_ip_subnet]
   inputs = []
@@ -977,10 +1079,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_subnet"
     [[tests.outputs.conditions]]
-    "a.equals" = "192.168.0.0"
-    "b.equals" = "192.0.0.0"
-    "c.equals" = "2404:6800::"
-    "d.equals" = "2404::"
+        type = "remap"
+        source = '''
+            .a == "192.168.0.0" && \
+            .b == "192.0.0.0" && \
+            .c == "2404:6800::" && \
+            .d == "2404::"
+        '''
 
 [transforms.remap_function_ip_cidr_contains]
   inputs = []
@@ -1000,10 +1105,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_cidr_contains"
     [[tests.outputs.conditions]]
-    "a.equals" = true
-    "b.equals" = false
-    "c.equals" = true
-    "d.equals" = false
+        type = "remap"
+        source = '''
+            .a == true && \
+            .b == false && \
+            .c == true && \
+            .d == false
+        '''
 
 [transforms.remap_function_ip_to_ipv6]
   inputs = []
@@ -1020,7 +1128,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_to_ipv6"
     [[tests.outputs.conditions]]
-    "a.equals" = "::ffff:192.168.10.2"
+        type = "remap"
+        source = '''
+            .a == "::ffff:192.168.10.2"
+        '''
 
 [transforms.remap_function_ipv6_to_ipv4]
   inputs = []
@@ -1037,7 +1148,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_ipv6_to_ipv4"
     [[tests.outputs.conditions]]
-    "a.equals" = "192.168.10.2"
+        type = "remap"
+        source = '''
+            .a == "192.168.10.2"
+        '''
 
 [transforms.remap_function_exists]
   inputs = []
@@ -1064,12 +1178,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_exists"
     [[tests.outputs.conditions]]
-    "a.equals" = true
-    "b.equals" = false
-    "c.equals" = true
-    "d.equals" = false
-    "e.equals" = true
-    "f.equals" = false
+        type = "remap"
+        source = '''
+            .a  && !.b  && .c && !.d  && .e && !.f 
+        '''
 
 [transforms.remap_function_compact]
   inputs = []
@@ -1102,12 +1214,15 @@
   [[tests.outputs]]
     extract_from = "remap_function_compact"
     [[tests.outputs.conditions]]
-    "a.equals" = false
-    "b.equals" = true
-    "c.equals" = false
-    "d.equals" = true
-    "e.equals" = false
-    "compactarr[0].equals" = 1
+        type = "remap"
+        source = '''
+            .a == false && \
+            .b == true && \
+            .c == false && \
+            .d == true && \
+            .e == false && \
+            .compactarr[0] == 1
+        '''
 
 [transforms.remap_function_assert_pass]
   inputs = []
@@ -1127,7 +1242,10 @@
   [[tests.outputs]]
   extract_from = "remap_function_assert_pass"
   [[tests.outputs.conditions]]
-  "check.equals" = "checked"
+        type = "remap"
+        source = '''
+  .check == "checked"
+        '''
 
 [transforms.remap_function_assert_fail]
   inputs = []
@@ -1161,7 +1279,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_log"
     [[tests.outputs.conditions]]
-    "foo.equals" = "this should be unchanged"
+        type = "remap"
+        source = '''
+            .foo == "this should be unchanged"
+        '''
 
 [transforms.remap_function_merge]
   inputs=[]
@@ -1186,8 +1307,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_merge"
     [[tests.outputs.conditions]]
-    "bar.field1.equals" = "ook"
-    "bar.field2.equals" = "ook ook"
+        type = "remap"
+        source = '''
+            .bar.field1 == "ook" && \
+            .bar.field2 == "ook ook"
+        '''
 
 [transforms.remap_function_flatten]
   inputs = []
@@ -1211,14 +1335,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_flatten"
     [[tests.outputs.conditions]]
-    "arr[0].equals" = 1
-    "arr[1].equals" = 2
-    "arr[2].equals" = 3
-    "arr[3].equals" = 4
-    "arr[4].equals" = 5
-    "arr[5].equals" = 6
-    "a.equals" = 1
-    "b.equals" = 2
+        type = "remap"
+        source = '''
+            .arr[0] == 1 && \
+            .arr[1] == 2 && \
+            .arr[2] == 3 && \
+            .arr[3] == 4 && \
+            .arr[4] == 5 && \
+            .arr[5] == 6 && \
+            .a == 1 && \
+            .b == 2
+        '''
 
 [transforms.remap_function_redact]
   inputs = []
@@ -1240,11 +1367,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_redact"
     [[tests.outputs.conditions]]
-    "a.equals" = "**** world, **** universe"
-    "b.equals" = "**** ****ld, **** universe"
-    "c.equals" = "hello ****, hello ****"
-    "d.equals" = "hello world, hello universe"
-    "e.equals" = "**** w****rld, **** ****n****v****rs****"
+        type = "remap"
+        source = '''
+            .a == "**** world, **** universe" && \
+            .b == "**** ****ld, **** universe" && \
+            .c == "hello ****, hello ****" && \
+            .d == "hello world, hello universe" && \
+            .e == "**** w****rld, **** ****n****v****rs****"
+        '''
 
 [transforms.remap_function_replace]
   inputs = []
@@ -1263,8 +1393,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_replace"
     [[tests.outputs.conditions]]
-    "a.equals" = "fbaro"
-    "b.equals" = "fbarbar"
+        type = "remap"
+        source = '''
+            .a == "fbaro" && \
+            .b == "fbarbar"
+        '''
 
 [transforms.remap_function_parse_aws_alb_log]
   inputs = []
@@ -1282,35 +1415,38 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_alb_log"
     [[tests.outputs.conditions]]
-      "parts.type.equals" = "http"
-      "parts.timestamp.equals" = "2018-11-30T22:23:00.186641Z"
-      "parts.elb.equals" = "app/my-loadbalancer/50dc6c495c0c9188"
-      "parts.client_host.equals" = "192.168.131.39:2817"
-      "parts.target_host.equals" = "<null>"
-      "parts.request_processing_time.equals" = 0.0
-      "parts.target_processing_time.equals" = 0.001
-      "parts.response_processing_time.equals" = 0.0
-      "parts.elb_status_code.equals" = "200"
-      "parts.target_status_code.equals" = "200"
-      "parts.received_bytes.equals" = 34
-      "parts.sent_bytes.equals" = 366
-      "parts.request_method.equals" = "GET"
-      "parts.request_url.equals" = "http://www.example.com:80/"
-      "parts.request_protocol.equals" = "HTTP/1.1"
-      "parts.user_agent.equals" = "curl/7.46.0"
-      "parts.ssl_cipher.equals" = "<null>"
-      "parts.ssl_protocol.equals" = "<null>"
-      "parts.target_group_arn.equals" = "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"
-      "parts.trace_id.equals" = "Root=1-58337364-23a8c76965a2ef7629b185e3"
-      "parts.domain_name.equals" = "<null>"
-      "parts.chosen_cert_arn.equals" = "<null>"
-      "parts.matched_rule_priority.equals" = "0"
-      "parts.request_creation_time.equals" = "2018-11-30T22:22:48.364000Z"
-      "parts.actions_executed.equals" = "forward"
-      "parts.redirect_url.equals" = "<null>"
-      "parts.error_reason.equals" = "<null>"
-      "parts.classification.equals" = "<null>"
-      "parts.classification_reason.equals" = "<null>"
+        type = "remap"
+        source = '''
+            .parts.type == "http" && \
+            .parts.timestamp == "2018-11-30T22:23:00.186641Z" && \
+            .parts.elb == "app/my-loadbalancer/50dc6c495c0c9188" && \
+            .parts.client_host == "192.168.131.39:2817" && \
+            .parts.target_host == null && \
+            .parts.request_processing_time == 0.0 && \
+            .parts.target_processing_time == 0.001 && \
+            .parts.response_processing_time == 0.0 && \
+            .parts.elb_status_code == "200" && \
+            .parts.target_status_code == "200" && \
+            .parts.received_bytes == 34 && \
+            .parts.sent_bytes == 366 && \
+            .parts.request_method == "GET" && \
+            .parts.request_url == "http://www.example.com:80/" && \
+            .parts.request_protocol == "HTTP/1.1" && \
+            .parts.user_agent == "curl/7.46.0" && \
+            .parts.ssl_cipher == null && \
+            .parts.ssl_protocol == null && \
+            .parts.target_group_arn == "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067" && \
+            .parts.trace_id == "Root=1-58337364-23a8c76965a2ef7629b185e3" && \
+            .parts.domain_name == null && \
+            .parts.chosen_cert_arn == null && \
+            .parts.matched_rule_priority == "0" && \
+            .parts.request_creation_time == "2018-11-30T22:22:48.364000Z" && \
+            .parts.actions_executed == "forward" && \
+            .parts.redirect_url == null && \
+            .parts.error_reason == null && \
+            .parts.classification == null && \
+            .parts.classification_reason == null
+        '''
 
 [transforms.remap_function_parse_aws_vpc_flow_log]
   inputs = []
@@ -1330,26 +1466,29 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_vpc_flow_log"
     [[tests.outputs.conditions]]
-      "a.version.equals" = 2
-      "a.account_id.equals" = 123456789010
-      "a.interface_id.equals" = "eni-1235b8ca123456789"
-      "a.srcaddr.equals" = "<null>"
-      "a.dstaddr.equals" = "<null>"
-      "a.srcport.equals" = "<null>"
-      "a.dstport.equals" = "<null>"
-      "a.protocol.equals" = "<null>"
-      "a.packets.equals" = "<null>"
-      "a.bytes.equals" = "<null>"
-      "a.start.equals" = 1431280876
-      "a.end.equals" = 1431280934
-      "a.action.equals" = "<null>"
-      "a.log_status.equals" = "NODATA"
-      "b.instance_id.equals" = "<null>"
-      "b.interface_id.equals" = "eni-1235b8ca123456789"
-      "b.srcaddr.equals" = "10.0.1.5"
-      "b.dstaddr.equals" = "10.0.0.220"
-      "b.pkt_srcaddr.equals" = "10.0.1.5"
-      "b.pkt_dstaddr.equals" = "203.0.113.5"
+        type = "remap"
+        source = '''
+            .a.version == 2 && \
+            .a.account_id == 123456789010 && \
+            .a.interface_id == "eni-1235b8ca123456789" && \
+            .a.srcaddr == null && \
+            .a.dstaddr == null && \
+            .a.srcport == null && \
+            .a.dstport == null && \
+            .a.protocol == null && \
+            .a.packets == null && \
+            .a.bytes == null && \
+            .a.start == 1431280876 && \
+            .a.end == 1431280934 && \
+            .a.action == null && \
+            .a.log_status == "NODATA" && \
+            .b.instance_id == null && \
+            .b.interface_id == "eni-1235b8ca123456789" && \
+            .b.srcaddr == "10.0.1.5" && \
+            .b.dstaddr == "10.0.0.220" && \
+            .b.pkt_srcaddr == "10.0.1.5" && \
+            .b.pkt_dstaddr == "203.0.113.5"
+        '''
 
 [transforms.remap_metrics]
   inputs = []
@@ -1373,10 +1512,13 @@
   [[tests.outputs]]
     extract_from = "remap_metrics"
     [[tests.outputs.conditions]]
-      "name.equals" = "example counter"
-      "namespace.equals" = "zork"
-      "host.equals" = "ook"
-      "type.equals" = "counter"
+        type = "remap"
+        source = '''
+            .tags.name == "example counter" && \
+            .tags.namespace == "zork" && \
+            .tags.host == "ook" && \
+            .tags.type == "counter"
+        '''
 
 [transforms.remap_function_encode_json]
   inputs = []
@@ -1396,8 +1538,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_encode_json"
     [[tests.outputs.conditions]]
-      "a.equals" = "[1,2,3]"
-      "b.equals" = """{"field1":{"field2":1,"field3":null}}"""
+        type = "remap"
+        source = '''
+            .a == "[1,2,3]" && \
+            .b == "{\"field1\":{\"field2\":1,\"field3\":null}}"
+        '''
 
 [transforms.remap_function_parse_regex]
   inputs = []
@@ -1418,15 +1563,18 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_regex"
     [[tests.outputs.conditions]]
-    "bytes_in.equals" = 5667
-    "host.equals" = "5.86.210.12"
-    "user.equals" = "zieme4647"
-    "timestamp.equals" = "19/06/2019:17:20:49 -0400"
-    "method.equals" = "GET"
-    "path.equals" = "/embrace/supply-chains/dynamic/vertical"
-    "status.equals" = 201
-    "bytes_out.equals" = 20574
-    "0.equals" = "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574"
+        type = "remap"
+        source = '''
+            .bytes_in == 5667 && \
+            .host == "5.86.210.12" && \
+            .user == "zieme4647" && \
+            .timestamp == "19/06/2019:17:20:49 -0400" && \
+            .method == "GET" && \
+            .path == "/embrace/supply-chains/dynamic/vertical" && \
+            .status == 201 && \
+            .bytes_out == 20574 && \
+            .0 == "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574"
+        '''
 
 [transforms.remap_function_parse_regex_all]
   inputs = []
@@ -1444,12 +1592,15 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_regex_all"
     [[tests.outputs.conditions]]
-    "result[0].fruit.equals" = "apples"
-    "result[0].veg.equals" = "carrots"
-    "result[0].0.equals" = "apples and carrots"
-    "result[1].fruit.equals" = "peaches"
-    "result[1].veg.equals" = "peas"
-    "result[1].0.equals" = "peaches and peas"
+        type = "remap"
+        source = '''
+            .result[0].fruit == "apples" && \
+            .result[0].veg == "carrots" && \
+            .result[0].0 == "apples and carrots" && \
+            .result[1].fruit == "peaches" && \
+            .result[1].veg == "peas" && \
+            .result[1].0 == "peaches and peas"
+        '''
 
 [transforms.remap_function_parse_aws_cloudwatch_log_subscription_message]
   inputs = []
@@ -1467,15 +1618,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_cloudwatch_log_subscription_message"
     [[tests.outputs.conditions]]
-      "result.owner.equals" = "CloudwatchLogs"
-      "result.message_type.equals" = "CONTROL_MESSAGE"
-      "result.log_group.equals" = ""
-      "result.log_stream.equals" = ""
-      "result.subscription_filters.length_eq" = 0
-      "result.log_events.length_eq" = 1
-      "result.log_events[0].id.equals" = ""
-      "result.log_events[0].timestamp.equals" = "2020-09-14T19:00:03.794Z"
-      "result.log_events[0].message.equals" = "CWL CONTROL MESSAGE: Checking health of destination Firehose."
+        type = "remap"
+        source = '''
+            .result.owner == "CloudwatchLogs" && \
+            .result.message_type == "CONTROL_MESSAGE" && \
+            .result.subscription_filters == [] && \
+            .result.log_group == "" && \
+            .result.log_stream == "" && \
+            .result.log_events == [{ "id": "", 
+                                     "timestamp": to_timestamp("2020-09-14T19:00:03.794Z"), 
+                                     "message": "CWL CONTROL MESSAGE: Checking health of destination Firehose." }]
+        '''
 
 [transforms.remap_function_parse_key_value]
   inputs = []
@@ -1490,21 +1643,24 @@
     type = "log"
     [tests.input.log_fields]
       message = '''
-	path="/cart_link" host=lumberjack-store.herokuapp.com request_id=6ad70ccd-40db-477c-afce-f7e3719a886b fwd="108.30.189.26" dyno=web.1 connect=0ms service=73ms status=304 bytes=656 protocol=https
-	'''
+        path="/cart_link" host=lumberjack-store.herokuapp.com request_id=6ad70ccd-40db-477c-afce-f7e3719a886b fwd="108.30.189.26" dyno=web.1 connect=0ms service=73ms status=304 bytes=656 protocol=https
+        '''
   [[tests.outputs]]
     extract_from = "remap_function_parse_key_value"
     [[tests.outputs.conditions]]
-    "path.equals" = "/cart_link"
-    "host.equals" = "lumberjack-store.herokuapp.com"
-    "request_id.equals" = "6ad70ccd-40db-477c-afce-f7e3719a886b"
-    "fwd.equals" = "108.30.189.26"
-    "dyno.equals" = "web.1"
-    "connect.equals" = "0ms"
-    "service.equals" = "73ms"
-    "status.equals" = "304"
-    "bytes.equals" = "656"
-    "protocol.equals" = "https"
+        type = "remap"
+        source = '''
+            .path == "/cart_link" && \
+            .host == "lumberjack-store.herokuapp.com" && \
+            .request_id == "6ad70ccd-40db-477c-afce-f7e3719a886b" && \
+            .fwd == "108.30.189.26" && \
+            .dyno == "web.1" && \
+            .connect == "0ms" && \
+            .service == "73ms" && \
+            .status == "304" && \
+            .bytes == "656" && \
+            .protocol == "https"
+        '''
 
 [transforms.remap_function_is_nullish]
   inputs = []
@@ -1534,13 +1690,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_is_nullish"
     [[tests.outputs.conditions]]
-      "a.equals" = true
-      "b.equals" = true
-      "c.equals" = true
-      "d.equals" = true
-      "e.equals" = true
-      "f.equals" = true
-      "g.equals" = false
+        type = "remap"
+        source = '''
+            .a == true && \
+            .b == true && \
+            .c == true && \
+            .d == true && \
+            .e == true && \
+            .f == true && \
+            .g == false
+        '''
 
 [transforms.remap_function_to_syslog_facility]
   inputs = []
@@ -1562,9 +1721,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_to_syslog_facility"
     [[tests.outputs.conditions]]
-      "a.equals" = "daemon"
-      "b.equals" = "ftp"
-      "c.equals" = "local7"
+        type = "remap"
+        source = '''
+            .a == "daemon" && \
+            .b == "ftp" && \
+            .c == "local7"
+        '''
 
 [transforms.remap_function_to_unix_timestamp]
   inputs = []
@@ -1584,9 +1746,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_to_unix_timestamp"
     [[tests.outputs.conditions]]
-      "secs.equals" = 1600077224
-      "millis.equals" = 1600077224000
-      "nanos.equals" = 1600077224000000000
+        type = "remap"
+        source = '''
+            .secs == 1600077224 && \
+            .millis == 1600077224000 && \
+            .nanos == 1600077224000000000
+        '''
 
 [transforms.remap_function_push_to_array]
   inputs = []
@@ -1605,10 +1770,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_push_to_array"
     [[tests.outputs.conditions]]
-      "result[0].equals" = "apple"
-      "result[1].equals" = "orange"
-      "result[2].equals" = "banana"
-      "result[3].equals" = "mango"
+        type = "remap"
+        source = '''
+            .result[0] == "apple" && \
+            .result[1] == "orange" && \
+            .result[2] == "banana" && \
+            .result[3] == "mango"
+        '''
 
 [transforms.remap_function_append_to_array]
   inputs = []
@@ -1627,10 +1795,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_append_to_array"
     [[tests.outputs.conditions]]
-      "result[0].equals" = "apple"
-      "result[1].equals" = "orange"
-      "result[2].equals" = "banana"
-      "result[3].equals" = "mango"
+        type = "remap"
+        source = '''
+            .result[0] == "apple" && \
+            .result[1] == "orange" && \
+            .result[2] == "banana" && \
+            .result[3] == "mango"
+        '''
 
 [transforms.remap_function_encode_base64]
   inputs = []
@@ -1647,7 +1818,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_encode_base64"
     [[tests.outputs.conditions]]
-    "result.equals" = "QnJvbi1ZLUF1ciBTdG9tcA=="
+        type = "remap"
+        source = '''
+            .result == "QnJvbi1ZLUF1ciBTdG9tcA=="
+        '''
 
 [transforms.remap_function_decode_base64]
   inputs = []
@@ -1664,7 +1838,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_decode_base64"
     [[tests.outputs.conditions]]
-    "result.equals" = "Bron-Y-Aur Stomp"
+        type = "remap"
+        source = '''
+            .result == "Bron-Y-Aur Stomp"
+        '''
 
 [transforms.remap_comments]
   inputs = []
@@ -1689,8 +1866,11 @@
   [[tests.outputs]]
     extract_from = "remap_comments"
     [[tests.outputs.conditions]]
-      "a.equals" = 1
-      "b.equals" = true
+        type = "remap"
+        source = '''
+            .a == 1
+	    .b == true
+        '''
 
 [transforms.remap_multiline]
   inputs = []

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1623,8 +1623,8 @@
         .result.subscription_filters == [] && \
         .result.log_group == "" && \
         .result.log_stream == "" && \
-        .result.log_events == [{ "id": "", 
-                                 "timestamp": to_timestamp("2020-09-14T19:00:03.794Z"), 
+        .result.log_events == [{ "id": "",
+                                 "timestamp": to_timestamp("2020-09-14T19:00:03.794Z"),
                                  "message": "CWL CONTROL MESSAGE: Checking health of destination Firehose." }]
       '''
 

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -100,11 +100,11 @@
     insert_at = "remap_arithmetic_error"
     type = "log"
     [tests.input.log_fields]
-        type = "remap"
-        source = '''
-          .a = 10 && \
-          .b = 0
-        '''
+      type = "remap"
+      source = '''
+        .a = 10 && \
+        .b = 0
+      '''
 
 [transforms.remap_boolean_arithmetic]
   inputs = []
@@ -128,13 +128,13 @@
   [[tests.outputs]]
     extract_from = "remap_boolean_arithmetic"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-           .result_a == true && \
-           .result_b == false && \
-           .result_c == true && \
-           .result_d == false
-        '''
+      type = "remap"
+      source = '''
+        .result_a == true && \
+        .result_b == false && \
+        .result_c == true && \
+        .result_d == false
+      '''
 
 [transforms.remap_coercion]
   inputs = []
@@ -161,14 +161,14 @@
   [[tests.outputs]]
     extract_from = "remap_coercion"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo == "10" && \
-            .bar == 20 && \
-            .baz == 30.3 && \
-            .bev == true && \
-            .a == "2020-09-14 09:53:44 UTC"
-        '''
+      type = "remap"
+      source = '''
+        .foo == "10" && \
+        .bar == 20 && \
+        .baz == 30.3 && \
+        .bev == true && \
+        .a == "2020-09-14 09:53:44 UTC"
+      '''
 
 [transforms.remap_quoted_path]
   inputs = []
@@ -187,10 +187,10 @@
   [[tests.outputs]]
     extract_from = "remap_quoted_path"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a."b.c" == "baz"
-        '''
+      type = "remap"
+      source = '''
+        .a."b.c" == "baz"
+      '''
 
 [transforms.remap_infallible_assignment]
   inputs = []
@@ -271,15 +271,15 @@
   [[tests.outputs]]
     extract_from = "remap_function_arguments"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "10" && \
-            .b == "10" && \
-            .c == "" && \
-            .d == "" && \
-            .e == "30" && \
-            .f == "30"
-        '''
+      type = "remap"
+      source = '''
+        .a == "10" && \
+        .b == "10" && \
+        .c == "" && \
+        .d == "" && \
+        .e == "30" && \
+        .f == "30"
+      '''
 
 [transforms.remap_function_upcase]
   inputs = []
@@ -290,7 +290,7 @@
     .c.c = upcase(.c.c)
 
     if upcase(.f) == "F" {
-        .f = "ff"
+      .f = "ff"
     }
   """
 [[tests]]
@@ -306,13 +306,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_upcase"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-          .a == "A" && \
-          .b == "BBB BB" && \
-          .c.c == "C.C" && \
-          .f == "ff"
-        '''
+      type = "remap"
+      source = '''
+        .a == "A" && \
+        .b == "BBB BB" && \
+        .c.c == "C.C" && \
+        .f == "ff"
+      '''
 
 [transforms.remap_function_upcase_error]
   inputs = []
@@ -342,7 +342,7 @@
     .c.c = downcase(.c.c)
 
     if downcase(.f) == "f" {
-        .f = "FF"
+      .f = "FF"
     }
   """
 [[tests]]
@@ -358,13 +358,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_downcase"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "a" && \
-            .b == "bbb bb" && \
-            .c.c == "c.c" && \
-            .f == "FF"
-        '''
+      type = "remap"
+      source = '''
+        .a == "a" && \
+        .b == "bbb bb" && \
+        .c.c == "c.c" && \
+        .f == "FF"
+      '''
 
 [transforms.remap_function_downcase_error]
   inputs = []
@@ -391,7 +391,7 @@
     .a = uuid_v4()
 
     if uuid_v4() != "" {
-        .b = "bar"
+      .b = "bar"
     }
   """
 [[tests]]
@@ -404,11 +404,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_uuid_v4"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            match(.a, /(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/) && \
-            .b == "bar"
-        '''
+      type = "remap"
+      source = '''
+        match(.a, /(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/) && \
+        .b == "bar"
+      '''
 
 [transforms.remap_function_sha1]
   inputs = []
@@ -417,7 +417,7 @@
     .a = sha1(.a)
 
     if sha1(.b) == "62cdb7020ff920e5aa642c3d4066950dd1f01f4d" {
-        .b = sha1(.a + .b + "baz")
+      .b = sha1(.a + .b + "baz")
     }
   """
 [[tests]]
@@ -431,11 +431,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha1"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-          .a == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" && \
-          .b == "6f74c252bb7f19f553115af5e49a733b9ff17138"
-        '''
+      type = "remap"
+      source = '''
+        .a == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" && \
+        .b == "6f74c252bb7f19f553115af5e49a733b9ff17138"
+      '''
 
 [transforms.remap_function_sha1_error]
   inputs = []
@@ -462,7 +462,7 @@
     .a = md5(.a)
 
     if md5(.b) == "37b51d194a7513e45b56f6524f2d51f2" {
-        .b = md5(.a + .b + "baz")
+      .b = md5(.a + .b + "baz")
     }
   """
 [[tests]]
@@ -476,12 +476,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_md5"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "acbd18db4cc2f85cedef654fccc4a4d8" && \
-            .b == "223cfa6567e4c0599c9a23628bf7a234"
-        '''
-        
+      type = "remap"
+      source = '''
+        .a == "acbd18db4cc2f85cedef654fccc4a4d8" && \
+        .b == "223cfa6567e4c0599c9a23628bf7a234"
+      '''
 
 [transforms.remap_function_md5_error]
   inputs = []
@@ -516,10 +515,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_now"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            ends_with(to_string(.a), "UTC")
-        '''
+      type = "remap"
+      source = '''
+        ends_with(to_string(.a), "UTC")
+      '''
 
 [transforms.remap_function_format_timestamp]
   inputs = []
@@ -537,10 +536,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_format_timestamp"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "1970-01-01T00:00:10+00:00"
-        '''
+      type = "remap"
+      source = '''
+        .a == "1970-01-01T00:00:10+00:00"
+      '''
 
 [transforms.remap_function_contains]
   inputs = []
@@ -566,16 +565,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_contains"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == false && \
-            .b == true && \
-            .c == false && \
-            .d == true && \
-            .e == true && \
-            .f == false && \
-            .g == true
-        '''
+      type = "remap"
+      source = '''
+        .a == false && \
+        .b == true && \
+        .c == false && \
+        .d == true && \
+        .e == true && \
+        .f == false && \
+        .g == true
+      '''
 
 [transforms.remap_function_starts_with]
   inputs = []
@@ -598,14 +597,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_starts_with"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == true && \
-            .b == true && \
-            .c == false && \
-            .d == false && \
-            .e == true
-        '''
+      type = "remap"
+      source = '''
+        .a == true && \
+        .b == true && \
+        .c == false && \
+        .d == false && \
+        .e == true
+      '''
 
 [transforms.remap_function_ends_with]
   inputs = []
@@ -628,14 +627,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_ends_with"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == true && \
-            .b == true && \
-            .c == false && \
-            .d == false && \
-            .e == true
-        '''
+      type = "remap"
+      source = '''
+        .a == true && \
+        .b == true && \
+        .c == false && \
+        .d == false && \
+        .e == true
+      '''
 
 [transforms.remap_function_slice]
   inputs = []
@@ -657,13 +656,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_slice"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "oobar" && \
-            .b == "f" && \
-            .c == "ar" && \
-            .d == "ooba"
-        '''
+      type = "remap"
+      source = '''
+        .a == "oobar" && \
+        .b == "f" && \
+        .c == "ar" && \
+        .d == "ooba"
+      '''
 
 [transforms.remap_function_parse_tokens]
   inputs = []
@@ -671,7 +670,7 @@
   source = '''
     .a = parse_tokens(.a)
     .b = parse_tokens(.b)
-  ''' 
+  '''
 [[tests]]
   name = "remap_function_parse_tokens"
   [tests.input]
@@ -683,16 +682,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_tokens"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == ["217.250.207.207", \
-                   null, \
-                   null, \
-                   "07/Sep/2020:16:38:00 -0400", \
-                   "DELETE /deliverables/next-generation/user-centric HTTP/1.1", \
-                   "205", "11881" ] && \
-            .b == ["bar"]
-        '''
+      type = "remap"
+      source = '''
+        .a == ["217.250.207.207", \
+               null, \
+               null, \
+               "07/Sep/2020:16:38:00 -0400", \
+               "DELETE /deliverables/next-generation/user-centric HTTP/1.1", \
+               "205", "11881" ] && \
+        .b == ["bar"]
+      '''
 
 [transforms.remap_function_sha2]
   inputs = []
@@ -701,7 +700,7 @@
     .a = sha2(.a)
 
     if sha2(.b) == "725eb523fe006a6ee0071380bd3b4c57590abd44b88614cd3eddf594e3afe1ac" {
-        .b = sha2(.a + .b + "baz")
+      .b = sha2(.a + .b + "baz")
     }
   """
 [[tests]]
@@ -715,11 +714,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha2"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d" && \
-            .b == "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
-        '''
+      type = "remap"
+      source = '''
+        .a == "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d" && \
+        .b == "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
+      '''
 
 [transforms.remap_function_sha3]
   inputs = []
@@ -728,7 +727,7 @@
     .a = sha3(.a)
 
     if sha3(.b) == "03457d23880d7847fc3f58780dd58cda7237a7144ac6758e76d45cec0e06ba69440a855e913ef03790c618777f5b0ec25fc34c4b82d7538151745b120b4f8b37" {
-        .b = sha3(.a + .b + "baz")
+      .b = sha3(.a + .b + "baz")
     }
   """
 [[tests]]
@@ -742,11 +741,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha3"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7" && \
-            .b == "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"
-        '''
+      type = "remap"
+      source = '''
+        .a == "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7" && \
+        .b == "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"
+      '''
 
 [transforms.remap_function_parse_duration]
   inputs = []
@@ -766,11 +765,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_duration"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 2000 && \
-            .b == 0.1
-        '''
+      type = "remap"
+      source = '''
+        .a == 2000 && \
+        .b == 0.1
+      '''
 
 [transforms.remap_function_format_number]
   inputs = []
@@ -788,10 +787,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_format_number"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "1.234,56"
-        '''
+      type = "remap"
+      source = '''
+        .a == "1.234,56"
+      '''
 
 [transforms.remap_function_parse_url]
   inputs = []
@@ -809,18 +808,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_url"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            # "parts.query.length_eq" = 1 && \
-            .parts.scheme == "https" && \
-            .parts.username == "" && \
-            .parts.password == "" && \
-            .parts.host == "master.vector.dev" && \
-            .parts.port == null && \
-            .parts.path == "/docs/reference/transforms/merge/" && \
-            .parts.query.hello == "world" && \
-            .parts.fragment == "configuration"
-        '''
+      type = "remap"
+      source = '''
+        .parts.scheme == "https" && \
+        .parts.username == "" && \
+        .parts.password == "" && \
+        .parts.host == "master.vector.dev" && \
+        .parts.port == null && \
+        .parts.path == "/docs/reference/transforms/merge/" && \
+        .parts.query.hello == "world" && \
+        .parts.fragment == "configuration"
+      '''
 
 [transforms.remap_function_ceil]
   inputs = []
@@ -840,12 +838,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_ceil"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 93 && \
-            .b == 92.5 && \
-            .c == 92.49
-        '''
+      type = "remap"
+      source = '''
+        .a == 93 && \
+        .b == 92.5 && \
+        .c == 92.49
+      '''
 
 [transforms.remap_function_floor]
   inputs = []
@@ -865,12 +863,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_floor"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 92 && \
-            .b == 92.4 && \
-            .c == 92.48
-        '''
+      type = "remap"
+      source = '''
+        .a == 92 && \
+        .b == 92.4 && \
+        .c == 92.48
+      '''
 
 [transforms.remap_function_round]
   inputs = []
@@ -890,18 +888,18 @@
   [[tests.outputs]]
     extract_from = "remap_function_round"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 92 && \
-            .b == 92.5 && \
-            .c == 92.49
-        '''
+      type = "remap"
+      source = '''
+        .a == 92 && \
+        .b == 92.5 && \
+        .c == 92.49
+      '''
 
 [transforms.remap_function_parse_syslog]
   inputs = []
   type = "remap"
   source = """
-   .a = parse_syslog(.a)
+     .a = parse_syslog(.a)
    """
 [[tests]]
   name = "remap_function_parse_syslog"
@@ -913,16 +911,16 @@
   [[tests.outputs]]
   extract_from = "remap_function_parse_syslog"
   [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a.facility == "daemon" && \
-            .a.severity == "warning" && \
-            .a.timestamp == to_timestamp("2020-05-22T17:59:09.250Z") && \
-            .a.hostname == "OX-XXX-MX204" && \
-            .a.appname == "OX-XXX-CONTEUDO:rpd" && \
-            .a.procid == 6589 && \
-            .a.message == "bgp_listen_accept: %DAEMON-4: Connection attempt from unconfigured neighbor: 2001:XXX::219:166+57284"
-        '''
+    type = "remap"
+    source = '''
+      .a.facility == "daemon" && \
+      .a.severity == "warning" && \
+      .a.timestamp == to_timestamp("2020-05-22T17:59:09.250Z") && \
+      .a.hostname == "OX-XXX-MX204" && \
+      .a.appname == "OX-XXX-CONTEUDO:rpd" && \
+      .a.procid == 6589 && \
+      .a.message == "bgp_listen_accept: %DAEMON-4: Connection attempt from unconfigured neighbor: 2001:XXX::219:166+57284"
+    '''
 
 [transforms.remap_function_split_regex]
   inputs=[]
@@ -940,12 +938,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_split_regex"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo[0] == "bar" && \
-            .foo[1] == "bat" && \
-            .foo[2] == "fizzaxbbuzz"
-        '''
+      type = "remap"
+      source = '''
+        .foo[0] == "bar" && \
+        .foo[1] == "bat" && \
+        .foo[2] == "fizzaxbbuzz"
+      '''
 
 [transforms.remap_function_split_string]
   inputs=[]
@@ -963,12 +961,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_split_string"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-    .foo[0] == "bar" && \
-    .foo[1] == "bat" && \
-    .foo[2] == "fizz buzz"
-        '''
+      type = "remap"
+      source = '''
+        .foo[0] == "bar" && \
+        .foo[1] == "bat" && \
+        .foo[2] == "fizz buzz"
+      '''
 
 [transforms.remap_function_parse_timestamp]
   inputs = []
@@ -985,10 +983,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_timestamp"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo == to_timestamp("1970-01-01T00:00:10Z")
-        '''
+      type = "remap"
+      source = '''
+        .foo == to_timestamp("1970-01-01T00:00:10Z")
+      '''
 
 [transforms.remap_function_truncate]
   inputs = []
@@ -1006,11 +1004,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_truncate"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo == "foo" && \
-            .bar == "foob..."
-        '''
+      type = "remap"
+      source = '''
+        .foo == "foo" && \
+        .bar == "foob..."
+      '''
 
 [transforms.remap_function_strip_whitespace]
   inputs = []
@@ -1027,10 +1025,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_strip_whitespace"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo == "foobar"
-        '''
+      type = "remap"
+      source = '''
+        .foo == "foobar"
+      '''
 
 [transforms.remap_function_parse_grok]
   inputs = []
@@ -1049,17 +1047,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_grok"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .grokked.timestamp == "2020-10-02T23:22:12.223222Z" && \
-            .grokked.level == "info" && \
-            .grokked.message == "Hello world" && \
-            .grokked.email == "" && \
-            .grokked2.timestamp == "2020-10-02T23:22:12.223222Z" && \
-            .grokked2.level == "info" && \
-            !exists(.grokked2.email) && \
-            .grokked2.message == "Hello world"
-        '''
+      type = "remap"
+      source = '''
+        .grokked.timestamp == "2020-10-02T23:22:12.223222Z" && \
+        .grokked.level == "info" && \
+        .grokked.message == "Hello world" && \
+        .grokked.email == "" && \
+        .grokked2.timestamp == "2020-10-02T23:22:12.223222Z" && \
+        .grokked2.level == "info" && \
+        !exists(.grokked2.email) && \
+        .grokked2.message == "Hello world"
+      '''
 
 [transforms.remap_function_ip_subnet]
   inputs = []
@@ -1079,13 +1077,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_subnet"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "192.168.0.0" && \
-            .b == "192.0.0.0" && \
-            .c == "2404:6800::" && \
-            .d == "2404::"
-        '''
+      type = "remap"
+      source = '''
+        .a == "192.168.0.0" && \
+        .b == "192.0.0.0" && \
+        .c == "2404:6800::" && \
+        .d == "2404::"
+      '''
 
 [transforms.remap_function_ip_cidr_contains]
   inputs = []
@@ -1105,13 +1103,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_cidr_contains"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == true && \
-            .b == false && \
-            .c == true && \
-            .d == false
-        '''
+      type = "remap"
+      source = '''
+        .a == true && \
+        .b == false && \
+        .c == true && \
+        .d == false
+      '''
 
 [transforms.remap_function_ip_to_ipv6]
   inputs = []
@@ -1128,10 +1126,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_ip_to_ipv6"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "::ffff:192.168.10.2"
-        '''
+      type = "remap"
+      source = '''
+        .a == "::ffff:192.168.10.2"
+      '''
 
 [transforms.remap_function_ipv6_to_ipv4]
   inputs = []
@@ -1148,10 +1146,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_ipv6_to_ipv4"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "192.168.10.2"
-        '''
+      type = "remap"
+      source = '''
+        .a == "192.168.10.2"
+      '''
 
 [transforms.remap_function_exists]
   inputs = []
@@ -1178,10 +1176,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_exists"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a  && !.b  && .c && !.d  && .e && !.f 
-        '''
+      type = "remap"
+      source = '''
+        .a  && !.b  && .c && !.d  && .e && !.f
+      '''
 
 [transforms.remap_function_compact]
   inputs = []
@@ -1202,27 +1200,27 @@
     type = "log"
     [tests.input.log_fields]
       arr = """
-          [null, "", [], 1]
-          """
+        [null, "", [], 1]
+      """
       map = """
-          {"field1": null,
-           "field2": 32,
-           "field3": "",
-           "field4": { "nested1": 3,
-                       "nested2": null } }
-            """
+        {"field1": null,
+         "field2": 32,
+         "field3": "",
+         "field4": { "nested1": 3,
+                     "nested2": null } }
+      """
   [[tests.outputs]]
     extract_from = "remap_function_compact"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == false && \
-            .b == true && \
-            .c == false && \
-            .d == true && \
-            .e == false && \
-            .compactarr[0] == 1
-        '''
+      type = "remap"
+      source = '''
+        .a == false && \
+        .b == true && \
+        .c == false && \
+        .d == true && \
+        .e == false && \
+        .compactarr[0] == 1
+      '''
 
 [transforms.remap_function_assert_pass]
   inputs = []
@@ -1242,10 +1240,10 @@
   [[tests.outputs]]
   extract_from = "remap_function_assert_pass"
   [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-  .check == "checked"
-        '''
+    type = "remap"
+    source = '''
+      .check == "checked"
+    '''
 
 [transforms.remap_function_assert_fail]
   inputs = []
@@ -1279,10 +1277,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_log"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .foo == "this should be unchanged"
-        '''
+      type = "remap"
+      source = '''
+        .foo == "this should be unchanged"
+      '''
 
 [transforms.remap_function_merge]
   inputs=[]
@@ -1307,21 +1305,21 @@
   [[tests.outputs]]
     extract_from = "remap_function_merge"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .bar.field1 == "ook" && \
-            .bar.field2 == "ook ook"
-        '''
+      type = "remap"
+      source = '''
+        .bar.field1 == "ook" && \
+        .bar.field2 == "ook ook"
+      '''
 
 [transforms.remap_function_flatten]
   inputs = []
   type = "remap"
   source = """
-      .arr = flatten(parse_json(.arr))
-      .map = flatten(parse_json(.map))
-      .a = .map."field1.field2"
-      .b = .map."field1.field3"
-      """
+    .arr = flatten(parse_json(.arr))
+    .map = flatten(parse_json(.map))
+    .a = .map."field1.field2"
+    .b = .map."field1.field3"
+  """
 [[tests]]
   name = "remap_function_flatten"
   [tests.input]
@@ -1335,17 +1333,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_flatten"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .arr[0] == 1 && \
-            .arr[1] == 2 && \
-            .arr[2] == 3 && \
-            .arr[3] == 4 && \
-            .arr[4] == 5 && \
-            .arr[5] == 6 && \
-            .a == 1 && \
-            .b == 2
-        '''
+      type = "remap"
+      source = '''
+        .arr[0] == 1 && \
+        .arr[1] == 2 && \
+        .arr[2] == 3 && \
+        .arr[3] == 4 && \
+        .arr[4] == 5 && \
+        .arr[5] == 6 && \
+        .a == 1 && \
+        .b == 2
+      '''
 
 [transforms.remap_function_redact]
   inputs = []
@@ -1367,14 +1365,14 @@
   [[tests.outputs]]
     extract_from = "remap_function_redact"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "**** world, **** universe" && \
-            .b == "**** ****ld, **** universe" && \
-            .c == "hello ****, hello ****" && \
-            .d == "hello world, hello universe" && \
-            .e == "**** w****rld, **** ****n****v****rs****"
-        '''
+      type = "remap"
+      source = '''
+        .a == "**** world, **** universe" && \
+        .b == "**** ****ld, **** universe" && \
+        .c == "hello ****, hello ****" && \
+        .d == "hello world, hello universe" && \
+        .e == "**** w****rld, **** ****n****v****rs****"
+      '''
 
 [transforms.remap_function_replace]
   inputs = []
@@ -1393,11 +1391,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_replace"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "fbaro" && \
-            .b == "fbarbar"
-        '''
+      type = "remap"
+      source = '''
+        .a == "fbaro" && \
+        .b == "fbarbar"
+      '''
 
 [transforms.remap_function_parse_aws_alb_log]
   inputs = []
@@ -1415,38 +1413,38 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_alb_log"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .parts.type == "http" && \
-            .parts.timestamp == "2018-11-30T22:23:00.186641Z" && \
-            .parts.elb == "app/my-loadbalancer/50dc6c495c0c9188" && \
-            .parts.client_host == "192.168.131.39:2817" && \
-            .parts.target_host == null && \
-            .parts.request_processing_time == 0.0 && \
-            .parts.target_processing_time == 0.001 && \
-            .parts.response_processing_time == 0.0 && \
-            .parts.elb_status_code == "200" && \
-            .parts.target_status_code == "200" && \
-            .parts.received_bytes == 34 && \
-            .parts.sent_bytes == 366 && \
-            .parts.request_method == "GET" && \
-            .parts.request_url == "http://www.example.com:80/" && \
-            .parts.request_protocol == "HTTP/1.1" && \
-            .parts.user_agent == "curl/7.46.0" && \
-            .parts.ssl_cipher == null && \
-            .parts.ssl_protocol == null && \
-            .parts.target_group_arn == "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067" && \
-            .parts.trace_id == "Root=1-58337364-23a8c76965a2ef7629b185e3" && \
-            .parts.domain_name == null && \
-            .parts.chosen_cert_arn == null && \
-            .parts.matched_rule_priority == "0" && \
-            .parts.request_creation_time == "2018-11-30T22:22:48.364000Z" && \
-            .parts.actions_executed == "forward" && \
-            .parts.redirect_url == null && \
-            .parts.error_reason == null && \
-            .parts.classification == null && \
-            .parts.classification_reason == null
-        '''
+      type = "remap"
+      source = '''
+        .parts.type == "http" && \
+        .parts.timestamp == "2018-11-30T22:23:00.186641Z" && \
+        .parts.elb == "app/my-loadbalancer/50dc6c495c0c9188" && \
+        .parts.client_host == "192.168.131.39:2817" && \
+        .parts.target_host == null && \
+        .parts.request_processing_time == 0.0 && \
+        .parts.target_processing_time == 0.001 && \
+        .parts.response_processing_time == 0.0 && \
+        .parts.elb_status_code == "200" && \
+        .parts.target_status_code == "200" && \
+        .parts.received_bytes == 34 && \
+        .parts.sent_bytes == 366 && \
+        .parts.request_method == "GET" && \
+        .parts.request_url == "http://www.example.com:80/" && \
+        .parts.request_protocol == "HTTP/1.1" && \
+        .parts.user_agent == "curl/7.46.0" && \
+        .parts.ssl_cipher == null && \
+        .parts.ssl_protocol == null && \
+        .parts.target_group_arn == "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067" && \
+        .parts.trace_id == "Root=1-58337364-23a8c76965a2ef7629b185e3" && \
+        .parts.domain_name == null && \
+        .parts.chosen_cert_arn == null && \
+        .parts.matched_rule_priority == "0" && \
+        .parts.request_creation_time == "2018-11-30T22:22:48.364000Z" && \
+        .parts.actions_executed == "forward" && \
+        .parts.redirect_url == null && \
+        .parts.error_reason == null && \
+        .parts.classification == null && \
+        .parts.classification_reason == null
+      '''
 
 [transforms.remap_function_parse_aws_vpc_flow_log]
   inputs = []
@@ -1466,39 +1464,39 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_vpc_flow_log"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a.version == 2 && \
-            .a.account_id == 123456789010 && \
-            .a.interface_id == "eni-1235b8ca123456789" && \
-            .a.srcaddr == null && \
-            .a.dstaddr == null && \
-            .a.srcport == null && \
-            .a.dstport == null && \
-            .a.protocol == null && \
-            .a.packets == null && \
-            .a.bytes == null && \
-            .a.start == 1431280876 && \
-            .a.end == 1431280934 && \
-            .a.action == null && \
-            .a.log_status == "NODATA" && \
-            .b.instance_id == null && \
-            .b.interface_id == "eni-1235b8ca123456789" && \
-            .b.srcaddr == "10.0.1.5" && \
-            .b.dstaddr == "10.0.0.220" && \
-            .b.pkt_srcaddr == "10.0.1.5" && \
-            .b.pkt_dstaddr == "203.0.113.5"
-        '''
+      type = "remap"
+      source = '''
+        .a.version == 2 && \
+        .a.account_id == 123456789010 && \
+        .a.interface_id == "eni-1235b8ca123456789" && \
+        .a.srcaddr == null && \
+        .a.dstaddr == null && \
+        .a.srcport == null && \
+        .a.dstport == null && \
+        .a.protocol == null && \
+        .a.packets == null && \
+        .a.bytes == null && \
+        .a.start == 1431280876 && \
+        .a.end == 1431280934 && \
+        .a.action == null && \
+        .a.log_status == "NODATA" && \
+        .b.instance_id == null && \
+        .b.interface_id == "eni-1235b8ca123456789" && \
+        .b.srcaddr == "10.0.1.5" && \
+        .b.dstaddr == "10.0.0.220" && \
+        .b.pkt_srcaddr == "10.0.1.5" && \
+        .b.pkt_dstaddr == "203.0.113.5"
+      '''
 
 [transforms.remap_metrics]
   inputs = []
   type = "remap"
   source = """
-      .tags.host = "ook"
-      .tags.name = .name
-      .tags.namespace = .namespace
-      .tags.type = .type
-   """
+    .tags.host = "ook"
+    .tags.name = .name
+    .tags.namespace = .namespace
+    .tags.type = .type
+  """
 [[tests]]
   name = "remap_metrics"
   [tests.input]
@@ -1512,13 +1510,13 @@
   [[tests.outputs]]
     extract_from = "remap_metrics"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .tags.name == "example counter" && \
-            .tags.namespace == "zork" && \
-            .tags.host == "ook" && \
-            .tags.type == "counter"
-        '''
+      type = "remap"
+      source = '''
+        .tags.name == "example counter" && \
+        .tags.namespace == "zork" && \
+        .tags.host == "ook" && \
+        .tags.type == "counter"
+      '''
 
 [transforms.remap_function_encode_json]
   inputs = []
@@ -1538,11 +1536,11 @@
   [[tests.outputs]]
     extract_from = "remap_function_encode_json"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "[1,2,3]" && \
-            .b == "{\"field1\":{\"field2\":1,\"field3\":null}}"
-        '''
+      type = "remap"
+      source = '''
+        .a == "[1,2,3]" && \
+        .b == "{\"field1\":{\"field2\":1,\"field3\":null}}"
+      '''
 
 [transforms.remap_function_parse_regex]
   inputs = []
@@ -1563,18 +1561,18 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_regex"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .bytes_in == 5667 && \
-            .host == "5.86.210.12" && \
-            .user == "zieme4647" && \
-            .timestamp == "19/06/2019:17:20:49 -0400" && \
-            .method == "GET" && \
-            .path == "/embrace/supply-chains/dynamic/vertical" && \
-            .status == 201 && \
-            .bytes_out == 20574 && \
-            .0 == "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574"
-        '''
+      type = "remap"
+      source = '''
+        .bytes_in == 5667 && \
+        .host == "5.86.210.12" && \
+        .user == "zieme4647" && \
+        .timestamp == "19/06/2019:17:20:49 -0400" && \
+        .method == "GET" && \
+        .path == "/embrace/supply-chains/dynamic/vertical" && \
+        .status == 201 && \
+        .bytes_out == 20574 && \
+        .0 == "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574"
+      '''
 
 [transforms.remap_function_parse_regex_all]
   inputs = []
@@ -1592,15 +1590,15 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_regex_all"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result[0].fruit == "apples" && \
-            .result[0].veg == "carrots" && \
-            .result[0].0 == "apples and carrots" && \
-            .result[1].fruit == "peaches" && \
-            .result[1].veg == "peas" && \
-            .result[1].0 == "peaches and peas"
-        '''
+      type = "remap"
+      source = '''
+        .result[0].fruit == "apples" && \
+        .result[0].veg == "carrots" && \
+        .result[0].0 == "apples and carrots" && \
+        .result[1].fruit == "peaches" && \
+        .result[1].veg == "peas" && \
+        .result[1].0 == "peaches and peas"
+      '''
 
 [transforms.remap_function_parse_aws_cloudwatch_log_subscription_message]
   inputs = []
@@ -1618,17 +1616,17 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_aws_cloudwatch_log_subscription_message"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result.owner == "CloudwatchLogs" && \
-            .result.message_type == "CONTROL_MESSAGE" && \
-            .result.subscription_filters == [] && \
-            .result.log_group == "" && \
-            .result.log_stream == "" && \
-            .result.log_events == [{ "id": "", 
-                                     "timestamp": to_timestamp("2020-09-14T19:00:03.794Z"), 
-                                     "message": "CWL CONTROL MESSAGE: Checking health of destination Firehose." }]
-        '''
+      type = "remap"
+      source = '''
+        .result.owner == "CloudwatchLogs" && \
+        .result.message_type == "CONTROL_MESSAGE" && \
+        .result.subscription_filters == [] && \
+        .result.log_group == "" && \
+        .result.log_stream == "" && \
+        .result.log_events == [{ "id": "", 
+                                 "timestamp": to_timestamp("2020-09-14T19:00:03.794Z"), 
+                                 "message": "CWL CONTROL MESSAGE: Checking health of destination Firehose." }]
+      '''
 
 [transforms.remap_function_parse_key_value]
   inputs = []
@@ -1648,19 +1646,19 @@
   [[tests.outputs]]
     extract_from = "remap_function_parse_key_value"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .path == "/cart_link" && \
-            .host == "lumberjack-store.herokuapp.com" && \
-            .request_id == "6ad70ccd-40db-477c-afce-f7e3719a886b" && \
-            .fwd == "108.30.189.26" && \
-            .dyno == "web.1" && \
-            .connect == "0ms" && \
-            .service == "73ms" && \
-            .status == "304" && \
-            .bytes == "656" && \
-            .protocol == "https"
-        '''
+      type = "remap"
+      source = '''
+        .path == "/cart_link" && \
+        .host == "lumberjack-store.herokuapp.com" && \
+        .request_id == "6ad70ccd-40db-477c-afce-f7e3719a886b" && \
+        .fwd == "108.30.189.26" && \
+        .dyno == "web.1" && \
+        .connect == "0ms" && \
+        .service == "73ms" && \
+        .status == "304" && \
+        .bytes == "656" && \
+        .protocol == "https"
+      '''
 
 [transforms.remap_function_is_nullish]
   inputs = []
@@ -1690,16 +1688,16 @@
   [[tests.outputs]]
     extract_from = "remap_function_is_nullish"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == true && \
-            .b == true && \
-            .c == true && \
-            .d == true && \
-            .e == true && \
-            .f == true && \
-            .g == false
-        '''
+      type = "remap"
+      source = '''
+        .a == true && \
+        .b == true && \
+        .c == true && \
+        .d == true && \
+        .e == true && \
+        .f == true && \
+        .g == false
+      '''
 
 [transforms.remap_function_to_syslog_facility]
   inputs = []
@@ -1721,12 +1719,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_to_syslog_facility"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == "daemon" && \
-            .b == "ftp" && \
-            .c == "local7"
-        '''
+      type = "remap"
+      source = '''
+        .a == "daemon" && \
+        .b == "ftp" && \
+        .c == "local7"
+      '''
 
 [transforms.remap_function_to_unix_timestamp]
   inputs = []
@@ -1746,12 +1744,12 @@
   [[tests.outputs]]
     extract_from = "remap_function_to_unix_timestamp"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .secs == 1600077224 && \
-            .millis == 1600077224000 && \
-            .nanos == 1600077224000000000
-        '''
+      type = "remap"
+      source = '''
+        .secs == 1600077224 && \
+        .millis == 1600077224000 && \
+        .nanos == 1600077224000000000
+      '''
 
 [transforms.remap_function_push_to_array]
   inputs = []
@@ -1770,13 +1768,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_push_to_array"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result[0] == "apple" && \
-            .result[1] == "orange" && \
-            .result[2] == "banana" && \
-            .result[3] == "mango"
-        '''
+      type = "remap"
+      source = '''
+        .result[0] == "apple" && \
+        .result[1] == "orange" && \
+        .result[2] == "banana" && \
+        .result[3] == "mango"
+      '''
 
 [transforms.remap_function_append_to_array]
   inputs = []
@@ -1795,13 +1793,13 @@
   [[tests.outputs]]
     extract_from = "remap_function_append_to_array"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result[0] == "apple" && \
-            .result[1] == "orange" && \
-            .result[2] == "banana" && \
-            .result[3] == "mango"
-        '''
+      type = "remap"
+      source = '''
+        .result[0] == "apple" && \
+        .result[1] == "orange" && \
+        .result[2] == "banana" && \
+        .result[3] == "mango"
+      '''
 
 [transforms.remap_function_encode_base64]
   inputs = []
@@ -1818,10 +1816,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_encode_base64"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result == "QnJvbi1ZLUF1ciBTdG9tcA=="
-        '''
+      type = "remap"
+      source = '''
+        .result == "QnJvbi1ZLUF1ciBTdG9tcA=="
+      '''
 
 [transforms.remap_function_decode_base64]
   inputs = []
@@ -1838,10 +1836,10 @@
   [[tests.outputs]]
     extract_from = "remap_function_decode_base64"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .result == "Bron-Y-Aur Stomp"
-        '''
+      type = "remap"
+      source = '''
+        .result == "Bron-Y-Aur Stomp"
+      '''
 
 [transforms.remap_comments]
   inputs = []
@@ -1866,11 +1864,11 @@
   [[tests.outputs]]
     extract_from = "remap_comments"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a == 1
-	    .b == true
-        '''
+      type = "remap"
+      source = '''
+        .a == 1
+        .b == true
+      '''
 
 [transforms.remap_multiline]
   inputs = []

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -43,12 +43,8 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-        .a[0] == 0 && \
-        .a[1] == "1" && \
-        .a[2] == 2.0 && \
-        .b[0] == 0 && \
-        .b[1] == null && \
-        .b[2] == "two"
+        .a == [0, "1", 2.0] && \
+        .b == [0, null, "two"]
       '''
 
 [transforms.remap_arithmetic]
@@ -208,10 +204,13 @@
   [[tests.outputs]]
     extract_from = "remap_infallible_assignment"
     [[tests.outputs.conditions]]
-      "nope.equals" = "<null>"
-      "err1.equals" = "function call error: unable to parse json: key must be a string at line 1 column 3"
-      "ok.foo.equals" = true
-      "err2.equals" = "<null>"
+      type = "remap"
+      source = '''
+        .nope == null
+        .err1 == "function call error: unable to parse json: key must be a string at line 1 column 3"
+        .ok.foo == true
+        .err2 == null
+      '''
 
 [transforms.remap_error_coalesce_operator]
   inputs = []
@@ -229,8 +228,11 @@
   [[tests.outputs]]
     extract_from = "remap_error_coalesce_operator"
     [[tests.outputs.conditions]]
-      "val1.equals" = "nope"
-      "val2.equals" = true
+      type = "remap"
+      source = '''
+        .val1 == "nope"
+        .val2 == true
+      '''
 
 [transforms.remap_bang_function]
   inputs = []
@@ -247,7 +249,8 @@
   [[tests.outputs]]
     extract_from = "remap_bang_function"
     [[tests.outputs.conditions]]
-      "val.exists" = false
+      type = "remap"
+      source = "!exists(.val)"
 
 [transforms.remap_function_arguments]
   inputs = []
@@ -310,7 +313,7 @@
       source = '''
         .a == "A" && \
         .b == "BBB BB" && \
-        .c.c == "C.C" && \
+        .c == {"c": "C.C"} && \
         .f == "ff"
       '''
 
@@ -362,7 +365,7 @@
       source = '''
         .a == "a" && \
         .b == "bbb bb" && \
-        .c.c == "c.c" && \
+        .c == {"c": "c.c"} && \
         .f == "FF"
       '''
 
@@ -810,14 +813,15 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-        .parts.scheme == "https" && \
-        .parts.username == "" && \
-        .parts.password == "" && \
-        .parts.host == "master.vector.dev" && \
-        .parts.port == null && \
-        .parts.path == "/docs/reference/transforms/merge/" && \
-        .parts.query.hello == "world" && \
-        .parts.fragment == "configuration"
+        .parts == { "scheme": "https",
+                    "username": "",
+                    "password": "",
+                    "host": "master.vector.dev",
+                    "port": null,
+                    "path": "/docs/reference/transforms/merge/",
+                    "query": {"hello": "world"},
+                    "fragment": "configuration"
+	         }
       '''
 
 [transforms.remap_function_ceil]

--- a/tests/behavior/transforms/remove_fields.toml
+++ b/tests/behavior/transforms/remove_fields.toml
@@ -13,8 +13,11 @@
   [[tests.outputs]]
     extract_from = "remove_fields_simple"
     [[tests.outputs.conditions]]
-      "a.exists" = false
-      "b.equals" = 4
+        type = "remap"
+        source = '''
+            !exists(.a) && \
+            .b == 4
+        '''
 
 [transforms.remove_fields_nested]
   inputs = []
@@ -31,8 +34,11 @@
   [[tests.outputs]]
     extract_from = "remove_fields_nested"
     [[tests.outputs.conditions]]
-      "a.b.equals" = 3
-      "a.c.exists" = false
+        type = "remap"
+        source = '''
+            .a.b == 3 && \
+            !exists(.a.c)
+        '''
 
 [transforms.remove_fields_empty_objects]
   inputs = []
@@ -52,9 +58,12 @@
   [[tests.outputs]]
     extract_from = "remove_fields_empty_objects"
     [[tests.outputs.conditions]]
-      "a.b.exists" = false
-      "a.c.exists" = false
-      "a.exists" = false
-      "b.a.exists" = false
-      "b.exists" = true
-      "b.b.equals" = 4
+        type = "remap"
+        source = '''
+            !exists(.a.b) && \
+            !exists(.a.c) && \
+            !exists(.a) && \
+            !exists(.b.a) && \
+            exists(.b) && \
+            .b.b == 4
+        '''

--- a/tests/behavior/transforms/remove_fields.toml
+++ b/tests/behavior/transforms/remove_fields.toml
@@ -13,11 +13,11 @@
   [[tests.outputs]]
     extract_from = "remove_fields_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            !exists(.a) && \
-            .b == 4
-        '''
+      type = "remap"
+      source = '''
+        !exists(.a) && \
+        .b == 4
+      '''
 
 [transforms.remove_fields_nested]
   inputs = []
@@ -34,11 +34,11 @@
   [[tests.outputs]]
     extract_from = "remove_fields_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a.b == 3 && \
-            !exists(.a.c)
-        '''
+      type = "remap"
+      source = '''
+        .a.b == 3 && \
+        !exists(.a.c)
+      '''
 
 [transforms.remove_fields_empty_objects]
   inputs = []
@@ -58,12 +58,12 @@
   [[tests.outputs]]
     extract_from = "remove_fields_empty_objects"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            !exists(.a.b) && \
-            !exists(.a.c) && \
-            !exists(.a) && \
-            !exists(.b.a) && \
-            exists(.b) && \
-            .b.b == 4
-        '''
+      type = "remap"
+      source = '''
+        !exists(.a.b) && \
+        !exists(.a.c) && \
+        !exists(.a) && \
+        !exists(.b.a) && \
+        exists(.b) && \
+        .b.b == 4
+      '''

--- a/tests/behavior/transforms/rename_fields.toml
+++ b/tests/behavior/transforms/rename_fields.toml
@@ -21,18 +21,21 @@
   [[tests.outputs]]
     extract_from = "rename_fields_simple"
     [[tests.outputs.conditions]]
-      # Plain
-      "a.exists" = false
-      "renamed_a.equals" = "a"
-      # Moved via a nested string
-      "b.renamed_c.equals" = "c"
-      "b.c.exists" = false
-      # Didn't change
-      "b.d.equals" = "d"
-      # Moved via a map
-      "b.renamed_e.equals" = "e"
-      # Replaced if conflict
-      "existing.equals" = "replaces"
+        type = "remap"
+        source = '''
+            # Plain
+            !exists(.a) && \
+            .renamed_a == "a" && \
+            # Moved via a nested string
+            .b.renamed_c == "c" && \
+            !exists(.b.c) && \
+            # Didnt change
+            .b.d == "d" && \
+            # Moved via a map
+            .b.renamed_e == "e" && \
+            # Replaced if conflict
+            .existing == "replaces"
+        ''' 
 
 [transforms.rename_fields_empty_objects]
   inputs = []
@@ -55,11 +58,14 @@
   [[tests.outputs]]
     extract_from = "rename_fields_empty_objects"
     [[tests.outputs.conditions]]
-      "a.b.equals" = 1
-      "a.exists" = true
-      "renamed_c.equals" = 2
-      "renamed_d.equals" = "d"
-      "b.d.exists" = false
-      "renamed_e.equals" = "e"
-      "b.e.exists" = false
-      "b.exists" = false
+        type = "remap"
+        source = '''
+            .a.b == 1 && \
+            exists(.a) && \
+            .renamed_c == 2 && \
+            .renamed_d == "d" && \
+            !exists(.b.d) && \
+            .renamed_e == "e" && \
+            !exists(.b.e) && \
+            !exists(.b)
+        '''

--- a/tests/behavior/transforms/rename_fields.toml
+++ b/tests/behavior/transforms/rename_fields.toml
@@ -21,21 +21,21 @@
   [[tests.outputs]]
     extract_from = "rename_fields_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            # Plain
-            !exists(.a) && \
-            .renamed_a == "a" && \
-            # Moved via a nested string
-            .b.renamed_c == "c" && \
-            !exists(.b.c) && \
-            # Didnt change
-            .b.d == "d" && \
-            # Moved via a map
-            .b.renamed_e == "e" && \
-            # Replaced if conflict
-            .existing == "replaces"
-        ''' 
+      type = "remap"
+      source = '''
+        # Plain
+        !exists(.a) && \
+        .renamed_a == "a" && \
+        # Moved via a nested string
+        .b.renamed_c == "c" && \
+        !exists(.b.c) && \
+        # Didnt change
+        .b.d == "d" && \
+        # Moved via a map
+        .b.renamed_e == "e" && \
+        # Replaced if conflict
+        .existing == "replaces"
+      '''
 
 [transforms.rename_fields_empty_objects]
   inputs = []
@@ -58,14 +58,14 @@
   [[tests.outputs]]
     extract_from = "rename_fields_empty_objects"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .a.b == 1 && \
-            exists(.a) && \
-            .renamed_c == 2 && \
-            .renamed_d == "d" && \
-            !exists(.b.d) && \
-            .renamed_e == "e" && \
-            !exists(.b.e) && \
-            !exists(.b)
-        '''
+      type = "remap"
+      source = '''
+        .a.b == 1 && \
+        exists(.a) && \
+        .renamed_c == 2 && \
+        .renamed_d == "d" && \
+        !exists(.b.d) && \
+        .renamed_e == "e" && \
+        !exists(.b.e) && \
+        !exists(.b)
+      '''

--- a/tests/behavior/transforms/split.toml
+++ b/tests/behavior/transforms/split.toml
@@ -11,10 +11,13 @@
   [[tests.outputs]]
     extract_from = "split_simple"
     [[tests.outputs.conditions]]
-      "timestamp.equals" = "2020-01-01T12:34:56Z"
-      "level.equals" = "INFO"
-      "message.equals" = "\"hello,"
-      "trailer.equals" = "world\""
+        type = "remap"
+        source = '''
+            .timestamp == "2020-01-01T12:34:56Z"
+            .level == "INFO"
+            .message == "\"hello,"
+            .trailer == "world\""
+      '''
 
 [transforms.split_nested]
   inputs = []
@@ -29,6 +32,9 @@
   [[tests.outputs]]
     extract_from = "split_nested"
     [[tests.outputs.conditions]]
-      "nested.timestamp.equals" = "2020-01-01T12:34:56Z"
-      "nested.level.equals" = "INFO"
-      "doubly.nested.message.equals" = "hello"
+        type = "remap"
+        source = '''
+            .nested.timestamp == "2020-01-01T12:34:56Z"
+            .nested.level == "INFO"
+            .doubly.nested.message == "hello"
+        '''

--- a/tests/behavior/transforms/split.toml
+++ b/tests/behavior/transforms/split.toml
@@ -11,12 +11,12 @@
   [[tests.outputs]]
     extract_from = "split_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .timestamp == "2020-01-01T12:34:56Z"
-            .level == "INFO"
-            .message == "\"hello,"
-            .trailer == "world\""
+      type = "remap"
+      source = '''
+        .timestamp == "2020-01-01T12:34:56Z"
+        .level == "INFO"
+        .message == "\"hello,"
+        .trailer == "world\""
       '''
 
 [transforms.split_nested]
@@ -32,9 +32,9 @@
   [[tests.outputs]]
     extract_from = "split_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .nested.timestamp == "2020-01-01T12:34:56Z"
-            .nested.level == "INFO"
-            .doubly.nested.message == "hello"
-        '''
+      type = "remap"
+      source = '''
+        .nested.timestamp == "2020-01-01T12:34:56Z"
+        .nested.level == "INFO"
+        .doubly.nested.message == "hello"
+      '''

--- a/tests/behavior/transforms/swimlanes.toml
+++ b/tests/behavior/transforms/swimlanes.toml
@@ -2,11 +2,15 @@
   inputs = ["ignored"]
   type = "swimlanes"
   [transforms.foo.lanes.first]
-    type = "check_fields"
-    "message.eq" = "test swimlane 1"
+    type = "remap"
+    source = '''
+           .message == "test swimlane 1"
+    '''
   [transforms.foo.lanes.second]
-    type = "check_fields"
-    "message.eq" = "test swimlane 2"
+    type = "remap"
+    source = '''
+        .message == "test swimlane 2"
+    '''
   [transforms.foo.lanes.third]
     type = "is_log"
 
@@ -27,21 +31,27 @@
   [[tests.outputs]]
     extract_from = "foo.first"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test swimlane 1"
+      type = "remap"
+      source = '''
+             .message == "test swimlane 1"
+      '''
 
   [[tests.outputs]]
     extract_from = "bar"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test swimlane 1"
-      "new_field.equals" = "new field added"
+      type = "remap"
+      source = '''
+            .message == "test swimlane 1"
+            .new_field == "new field added"
+      '''
 
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test swimlane 1"
+      type = "remap"
+      source = '''
+             .message == "test swimlane 1"
+      '''
 
 [[tests]]
   name = "swimlanes test 2"
@@ -54,11 +64,15 @@
   [[tests.outputs]]
     extract_from = "foo.second"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test swimlane 2"
+      type = "remap"
+      source = '''
+             .message == "test swimlane 2"
+      '''
 
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "test swimlane 2"
+      type = "remap"
+      source = '''
+             .message == "test swimlane 2"
+      '''

--- a/tests/behavior/transforms/swimlanes.toml
+++ b/tests/behavior/transforms/swimlanes.toml
@@ -4,12 +4,12 @@
   [transforms.foo.lanes.first]
     type = "remap"
     source = '''
-           .message == "test swimlane 1"
+      .message == "test swimlane 1"
     '''
   [transforms.foo.lanes.second]
     type = "remap"
     source = '''
-        .message == "test swimlane 2"
+      .message == "test swimlane 2"
     '''
   [transforms.foo.lanes.third]
     type = "is_log"
@@ -33,7 +33,7 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-             .message == "test swimlane 1"
+        .message == "test swimlane 1"
       '''
 
   [[tests.outputs]]
@@ -41,8 +41,8 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-            .message == "test swimlane 1"
-            .new_field == "new field added"
+        .message == "test swimlane 1"
+        .new_field == "new field added"
       '''
 
   [[tests.outputs]]
@@ -50,7 +50,7 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-             .message == "test swimlane 1"
+        .message == "test swimlane 1"
       '''
 
 [[tests]]
@@ -66,7 +66,7 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-             .message == "test swimlane 2"
+        .message == "test swimlane 2"
       '''
 
   [[tests.outputs]]
@@ -74,5 +74,5 @@
     [[tests.outputs.conditions]]
       type = "remap"
       source = '''
-             .message == "test swimlane 2"
+        .message == "test swimlane 2"
       '''

--- a/tests/behavior/transforms/tokenizer.toml
+++ b/tests/behavior/transforms/tokenizer.toml
@@ -11,12 +11,12 @@
   [[tests.outputs]]
     extract_from = "tokenizer_simple"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .timestamp == "2020-01-01T12:34:56Z"
-            .level == "INFO"
-            .message == "hello, world"
-            .trailer == "this is a trailer field"
+      type = "remap"
+      source = '''
+        .timestamp == "2020-01-01T12:34:56Z"
+        .level == "INFO"
+        .message == "hello, world"
+        .trailer == "this is a trailer field"
       '''
 
 [transforms.tokenizer_nested]
@@ -32,9 +32,9 @@
   [[tests.outputs]]
     extract_from = "tokenizer_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
-        source = '''
-            .nested.timestamp == "2020-01-01T12:34:56Z"
-            .nested.level == "INFO"
-            .nested.message == "hello"
+      type = "remap"
+      source = '''
+        .nested.timestamp == "2020-01-01T12:34:56Z"
+        .nested.level == "INFO"
+        .nested.message == "hello"
       '''

--- a/tests/behavior/transforms/tokenizer.toml
+++ b/tests/behavior/transforms/tokenizer.toml
@@ -11,10 +11,13 @@
   [[tests.outputs]]
     extract_from = "tokenizer_simple"
     [[tests.outputs.conditions]]
-      "timestamp.equals" = "2020-01-01T12:34:56Z"
-      "level.equals" = "INFO"
-      "message.equals" = "hello, world"
-      "trailer.equals" = "this is a trailer field"
+        type = "remap"
+        source = '''
+            .timestamp == "2020-01-01T12:34:56Z"
+            .level == "INFO"
+            .message == "hello, world"
+            .trailer == "this is a trailer field"
+      '''
 
 [transforms.tokenizer_nested]
   inputs = []
@@ -29,6 +32,9 @@
   [[tests.outputs]]
     extract_from = "tokenizer_nested"
     [[tests.outputs.conditions]]
-      "nested.timestamp.equals" = "2020-01-01T12:34:56Z"
-      "nested.level.equals" = "INFO"
-      "nested.message.equals" = "hello"
+        type = "remap"
+        source = '''
+            .nested.timestamp == "2020-01-01T12:34:56Z"
+            .nested.level == "INFO"
+            .nested.message == "hello"
+      '''


### PR DESCRIPTION
Closes #5742 

This adds a deprecation warning if the check_fields condition is used. I have **not** added a similar warning to `is_log` or `is_metric` conditions since that is not something Remap can currently do.

I have also updated the behaviour tests to use Remap conditions since many of them were using `check_fields`. 