### PR TITLE
chore(remap): update functions that should be fallible

### DIFF
--- a/docs/reference/remap/assert.cue
+++ b/docs/reference/remap/assert.cue
@@ -15,7 +15,9 @@ remap: functions: assert: {
 			type: ["string"]
 		},
 	]
-	internal_failure_reason: null
+	internal_failure_reason: [
+		"`condition` evaluates to `false`"
+	]
 	return: ["null"]
 	category: "Test"
 	description: #"""

--- a/docs/reference/remap/assert.cue
+++ b/docs/reference/remap/assert.cue
@@ -16,7 +16,7 @@ remap: functions: assert: {
 		},
 	]
 	internal_failure_reason: [
-		"`condition` evaluates to `false`"
+		"`condition` evaluates to `false`",
 	]
 	return: ["null"]
 	category: "Test"

--- a/docs/reference/remap/ipv6_to_ipv4.cue
+++ b/docs/reference/remap/ipv6_to_ipv4.cue
@@ -11,6 +11,7 @@ remap: functions: ipv6_to_ipv4: {
 	]
 	internal_failure_reasons: [
 		"`ip` is not a valid IP address",
+		"`ipv6` address is not compatible with IPV4",
 	]
 	return: ["string"]
 	category: "IP"

--- a/docs/reference/remap/ipv6_to_ipv4.cue
+++ b/docs/reference/remap/ipv6_to_ipv4.cue
@@ -11,7 +11,7 @@ remap: functions: ipv6_to_ipv4: {
 	]
 	internal_failure_reasons: [
 		"`ip` is not a valid IP address",
-		"`ipv6` address is not compatible with IPV4",
+		"`ip` is an IPv6 address that is not compatible with IPv4",
 	]
 	return: ["string"]
 	category: "IP"

--- a/lib/remap-functions/src/assert.rs
+++ b/lib/remap-functions/src/assert.rs
@@ -67,12 +67,7 @@ impl Expression for AssertFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.condition
             .type_def(state)
-            .fallible_unless(value::Kind::Boolean)
-            .merge_with_default_optional(
-                self.message
-                    .as_ref()
-                    .map(|message| message.type_def(state).fallible_unless(value::Kind::Bytes)),
-            )
+            .into_fallible(true)
             .with_constraint(value::Kind::Null)
     }
 }

--- a/lib/remap-functions/src/ip_cidr_contains.rs
+++ b/lib/remap-functions/src/ip_cidr_contains.rs
@@ -66,12 +66,8 @@ impl Expression for IpCidrContainsFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
-            .merge(
-                self.cidr
-                    .type_def(state)
-                    .fallible_unless(value::Kind::Bytes),
-            )
+            .merge(self.cidr.type_def(state).into_fallible(true))
+            .into_fallible(true)
             .with_constraint(value::Kind::Boolean)
     }
 }
@@ -88,6 +84,7 @@ mod tests {
         },
         def: TypeDef {
             kind: value::Kind::Boolean,
+            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/ip_subnet.rs
+++ b/lib/remap-functions/src/ip_subnet.rs
@@ -94,12 +94,8 @@ impl Expression for IpSubnetFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
-            .merge(
-                self.subnet
-                    .type_def(state)
-                    .fallible_unless(value::Kind::Bytes),
-            )
+            .merge(self.subnet.type_def(state).into_fallible(true))
+            .into_fallible(true)
             .with_constraint(value::Kind::Bytes)
     }
 }
@@ -168,6 +164,7 @@ mod tests {
         },
         def: TypeDef {
             kind: value::Kind::Bytes,
+            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/ip_to_ipv6.rs
+++ b/lib/remap-functions/src/ip_to_ipv6.rs
@@ -55,7 +55,7 @@ impl Expression for IpToIpv6Fn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
+            .into_fallible(true)
             .with_constraint(value::Kind::Bytes)
     }
 }
@@ -71,6 +71,7 @@ mod tests {
         },
         def: TypeDef {
             kind: value::Kind::Bytes,
+            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/ipv6_to_ipv4.rs
+++ b/lib/remap-functions/src/ipv6_to_ipv4.rs
@@ -58,7 +58,7 @@ impl Expression for Ipv6ToIpV4Fn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
+            .into_fallible(true)
             .with_constraint(value::Kind::Bytes)
     }
 }
@@ -74,6 +74,7 @@ mod tests {
         },
         def: TypeDef {
             kind: value::Kind::Bytes,
+            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/parse_aws_alb_log.rs
+++ b/lib/remap-functions/src/parse_aws_alb_log.rs
@@ -53,7 +53,6 @@ impl Expression for ParseAwsAlbLogFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
             .into_fallible(true) // Log parsing error
             .with_constraint(value::Kind::Map)
     }

--- a/lib/remap-functions/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/remap-functions/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -57,7 +57,6 @@ impl Expression for ParseAwsCloudWatchLogSubscriptionMessageFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
             .into_fallible(true) // Message parsing error
             .with_constraint(value::Kind::Map)
     }

--- a/lib/remap-functions/src/parse_aws_vpc_flow_log.rs
+++ b/lib/remap-functions/src/parse_aws_vpc_flow_log.rs
@@ -62,7 +62,6 @@ impl Expression for ParseAwsVpcFlowLogFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
             .into_fallible(true) // Log parsing error
             .with_constraint(value::Kind::Map)
     }

--- a/lib/remap-functions/src/parse_duration.rs
+++ b/lib/remap-functions/src/parse_duration.rs
@@ -119,7 +119,6 @@ impl Expression for ParseDurationFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
             .merge(output_def)
             .into_fallible(true) // parsing errors
             .with_constraint(value::Kind::Float)

--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -110,7 +110,7 @@ impl Expression for ParseGrokFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
+            .into_fallible(true)
             .with_constraint(value::Kind::Array)
     }
 }
@@ -132,6 +132,7 @@ mod test {
         },
         def: TypeDef {
             kind: value::Kind::Array,
+            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -110,7 +110,7 @@ impl Expression for ParseGrokFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .into_fallible(true)
+            .fallible_unless(value::Kind::Bytes)
             .with_constraint(value::Kind::Array)
     }
 }
@@ -132,7 +132,6 @@ mod test {
         },
         def: TypeDef {
             kind: value::Kind::Array,
-            fallible: true,
             ..Default::default()
         },
     }];

--- a/lib/remap-functions/src/parse_json.rs
+++ b/lib/remap-functions/src/parse_json.rs
@@ -43,7 +43,6 @@ impl Expression for ParseJsonFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::Bytes)
             .into_fallible(true) // JSON parsing errors
             .with_constraint(
                 Kind::Bytes

--- a/lib/remap-functions/src/parse_url.rs
+++ b/lib/remap-functions/src/parse_url.rs
@@ -51,7 +51,6 @@ impl Expression for ParseUrlFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
             .into_fallible(true) // URL parsing error
             .with_constraint(value::Kind::Map)
     }

--- a/lib/remap-functions/src/to_syslog_facility.rs
+++ b/lib/remap-functions/src/to_syslog_facility.rs
@@ -79,18 +79,16 @@ mod tests {
     use super::*;
     use value::Kind;
 
-    test_type_def![
-        value_non_integer_fallible {
-            expr: |_| ToSyslogFacilityFn {
-                value: Literal::from("foo").boxed(),
-            },
-            def: TypeDef {
-                fallible: true,
-                kind: Kind::Bytes,
-                ..Default::default()
-            },
-        }
-    ];
+    test_type_def![value_non_integer_fallible {
+        expr: |_| ToSyslogFacilityFn {
+            value: Literal::from("foo").boxed(),
+        },
+        def: TypeDef {
+            fallible: true,
+            kind: Kind::Bytes,
+            ..Default::default()
+        },
+    }];
 
     test_function![
         to_syslog_facility => ToSyslogFacility;

--- a/lib/remap-functions/src/to_syslog_facility.rs
+++ b/lib/remap-functions/src/to_syslog_facility.rs
@@ -80,17 +80,6 @@ mod tests {
     use value::Kind;
 
     test_type_def![
-        value_integer_non_fallible {
-            expr: |_| ToSyslogFacilityFn {
-                value: Literal::from(3).boxed(),
-            },
-            def: TypeDef {
-                fallible: true,
-                kind: Kind::Bytes,
-                ..Default::default()
-            },
-        }
-
         value_non_integer_fallible {
             expr: |_| ToSyslogFacilityFn {
                 value: Literal::from("foo").boxed(),

--- a/lib/remap-functions/src/to_syslog_level.rs
+++ b/lib/remap-functions/src/to_syslog_level.rs
@@ -66,18 +66,16 @@ mod tests {
     use super::*;
     use value::Kind;
 
-    test_type_def![
-        value_non_integer_fallible {
-            expr: |_| ToSyslogLevelFn {
-                value: Literal::from("foo").boxed(),
-            },
-            def: TypeDef {
-                fallible: true,
-                kind: Kind::Bytes,
-                ..Default::default()
-            },
-        }
-    ];
+    test_type_def![value_non_integer_fallible {
+        expr: |_| ToSyslogLevelFn {
+            value: Literal::from("foo").boxed(),
+        },
+        def: TypeDef {
+            fallible: true,
+            kind: Kind::Bytes,
+            ..Default::default()
+        },
+    }];
 
     test_function![
         to_syslog_level => ToSyslogLevel;

--- a/lib/remap-functions/src/to_syslog_level.rs
+++ b/lib/remap-functions/src/to_syslog_level.rs
@@ -56,7 +56,7 @@ impl Expression for ToSyslogLevelFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::Integer)
+            .into_fallible(true)
             .with_constraint(Kind::Bytes)
     }
 }
@@ -67,17 +67,6 @@ mod tests {
     use value::Kind;
 
     test_type_def![
-        value_integer_non_fallible {
-            expr: |_| ToSyslogLevelFn {
-                value: Literal::from(3).boxed(),
-            },
-            def: TypeDef {
-                fallible: false,
-                kind: Kind::Bytes,
-                ..Default::default()
-            },
-        }
-
         value_non_integer_fallible {
             expr: |_| ToSyslogLevelFn {
                 value: Literal::from("foo").boxed(),

--- a/lib/remap-functions/src/to_syslog_severity.rs
+++ b/lib/remap-functions/src/to_syslog_severity.rs
@@ -58,7 +58,7 @@ impl Expression for ToSyslogSeverityFn {
 
         self.value
             .type_def(state)
-            .fallible_unless(Kind::Bytes)
+            .into_fallible(true)
             .with_constraint(Kind::Integer)
     }
 }
@@ -69,13 +69,6 @@ mod tests {
     use value::Kind;
 
     test_type_def![
-        value_string_infallible {
-            expr: |_| ToSyslogSeverityFn {
-                value: Literal::from("warning").boxed(),
-            },
-            def: TypeDef { fallible: false, kind: Kind::Integer, ..Default::default() },
-        }
-
         value_not_string_fallible {
             expr: |_| ToSyslogSeverityFn {
                 value: Literal::from(27).boxed(),

--- a/lib/remap-functions/src/to_syslog_severity.rs
+++ b/lib/remap-functions/src/to_syslog_severity.rs
@@ -68,14 +68,16 @@ mod tests {
     use super::*;
     use value::Kind;
 
-    test_type_def![
-        value_not_string_fallible {
-            expr: |_| ToSyslogSeverityFn {
-                value: Literal::from(27).boxed(),
-            },
-            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
-        }
-    ];
+    test_type_def![value_not_string_fallible {
+        expr: |_| ToSyslogSeverityFn {
+            value: Literal::from(27).boxed(),
+        },
+        def: TypeDef {
+            fallible: true,
+            kind: Kind::Integer,
+            ..Default::default()
+        },
+    }];
 
     test_function![
         to_level => ToSyslogSeverity;


### PR DESCRIPTION
There were a number of functions that should always be fallible that were not being marked as such. For example the ip functions are always fallible even when the parameter is a string because that may not represent a valid IP address.

There were also a number of places that did:

```rust
          .fallible_unless(value::Kind::Bytes)
          .into_fallible(true)
```

I have removed the `fallible_unless` line since that is unnecessary.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>