### PR TITLE
fix(remap): `ipv6_to_ipv4` function allows ipv4 addresses to pass through

### DIFF
--- a/docs/reference/remap/functions/ipv6_to_ipv4.cue
+++ b/docs/reference/remap/functions/ipv6_to_ipv4.cue
@@ -17,6 +17,9 @@ remap: functions: ipv6_to_ipv4: {
 	category: "IP"
 	description: #"""
 		Converts the provided `ip` to an IPv4 address.
+
+		If the parameter is already an IPv4 address it is passed through untouched. If it is an IPv6 address it has
+		to be an IPv4 compatible address.
 		"""#
 	examples: [
 		{


### PR DESCRIPTION
Closes #6046 

The `ipv6_to_ipv4` function was taking ipv4 addresses and converting them to ipv6 - the opposite of the intended purpose of this function. This fixes the function to just pass the ipv4 address through.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
