### PR TITLE
chore(ci): Pin Ruby at 2.7 in CI for OSX

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -e -o verbose
 
-brew install ruby coreutils cuelang/tap/cue
+brew install ruby@2.7 coreutils cuelang/tap/cue
 
 echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"
 


### PR DESCRIPTION
It was installing the now-released 3.0

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
