### PR TITLE
fix(kubernetes_logs source): Support for collecting logs from static pods

### DIFF
--- a/src/kubernetes/hash_value.rs
+++ b/src/kubernetes/hash_value.rs
@@ -4,6 +4,8 @@ use k8s_openapi::{apimachinery::pkg::apis::meta::v1::ObjectMeta, Metadata};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
+use super::pod_manager_logic::extract_static_pod_config_hashsum;
+
 /// A wrapper that provides a [`Hash`] implementation for any k8s resource
 /// object.
 /// Delegates to object uid for hashing and equality.
@@ -20,10 +22,17 @@ where
     }
 
     /// Get the `uid` from the `T`'s [`Metadata`] (if any).
+    ///
+    /// If the static pod config hashsum annotation exists in the metadata, it
+    /// will be used instead of the mirror pod uid.
     pub fn uid(&self) -> Option<&str> {
-        let ObjectMeta { ref uid, .. } = self.0.metadata();
-        let uid = uid.as_ref()?;
-        Some(uid.as_str())
+        let metadata = self.0.metadata();
+        // If static pod config hashsum annotation exists in the metadata -
+        // use it instead of the uid.
+        if let Some(config_hashsum) = extract_static_pod_config_hashsum(metadata) {
+            return Some(config_hashsum);
+        }
+        Some(metadata.uid.as_ref()?.as_str())
     }
 }
 
@@ -68,5 +77,73 @@ where
 {
     fn as_ref(&self) -> &T {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use k8s_openapi::api::core::v1::Pod;
+
+    use super::*;
+
+    #[test]
+    fn test_uid() {
+        let cases = vec![
+            // No uid or config hashsum.
+            (Pod::default(), None),
+            // Has uid, doesn't have a config hashsum.
+            (
+                Pod {
+                    metadata: ObjectMeta {
+                        uid: Some("uid".to_owned()),
+                        ..ObjectMeta::default()
+                    },
+                    ..Pod::default()
+                },
+                Some("uid"),
+            ),
+            // Has both the uid and the config hashsum.
+            (
+                Pod {
+                    metadata: ObjectMeta {
+                        uid: Some("uid".to_owned()),
+                        annotations: Some(
+                            vec![(
+                                "kubernetes.io/config.mirror".to_owned(),
+                                "config-hashsum".to_owned(),
+                            )]
+                            .into_iter()
+                            .collect(),
+                        ),
+                        ..ObjectMeta::default()
+                    },
+                    ..Pod::default()
+                },
+                Some("config-hashsum"),
+            ),
+            // Has only the config hashsum.
+            (
+                Pod {
+                    metadata: ObjectMeta {
+                        annotations: Some(
+                            vec![(
+                                "kubernetes.io/config.mirror".to_owned(),
+                                "config-hashsum".to_owned(),
+                            )]
+                            .into_iter()
+                            .collect(),
+                        ),
+                        ..ObjectMeta::default()
+                    },
+                    ..Pod::default()
+                },
+                Some("config-hashsum"),
+            ),
+        ];
+
+        for (pod, expected) in cases {
+            let hash_value = HashValue::new(pod);
+            assert_eq!(hash_value.uid(), expected);
+        }
     }
 }

--- a/src/kubernetes/mod.rs
+++ b/src/kubernetes/mod.rs
@@ -27,6 +27,7 @@ pub mod hash_value;
 pub mod instrumenting_watcher;
 pub mod mock_watcher;
 pub mod multi_response_decoder;
+pub mod pod_manager_logic;
 pub mod reflector;
 pub mod resource_version;
 pub mod state;

--- a/src/kubernetes/pod_manager_logic.rs
+++ b/src/kubernetes/pod_manager_logic.rs
@@ -1,0 +1,71 @@
+//! This mod contains bits of logic related to the `kubelet` part called
+//! Pod Manager internal implementation.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+/// Extract the static pod config hashsum from the mirror pod annotations.
+///
+/// This part of Kubernetes changed a bit over time, so we're implemeting
+/// support up to 1.14, which is an MSKV at this time.
+///
+/// See: https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81
+pub fn extract_static_pod_config_hashsum(metadata: &ObjectMeta) -> Option<&str> {
+    let annotations = metadata.annotations.as_ref()?;
+    annotations
+        .get("kubernetes.io/config.mirror")
+        .map(String::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_static_pod_config_hashsum() {
+        let cases = vec![
+            (ObjectMeta::default(), None),
+            (
+                ObjectMeta {
+                    annotations: Some(vec![].into_iter().collect()),
+                    ..ObjectMeta::default()
+                },
+                None,
+            ),
+            (
+                ObjectMeta {
+                    annotations: Some(
+                        vec![(
+                            "kubernetes.io/config.mirror".to_owned(),
+                            "config-hashsum".to_owned(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..ObjectMeta::default()
+                },
+                Some("config-hashsum"),
+            ),
+            (
+                ObjectMeta {
+                    annotations: Some(
+                        vec![
+                            (
+                                "kubernetes.io/config.mirror".to_owned(),
+                                "config-hashsum".to_owned(),
+                            ),
+                            ("other".to_owned(), "value".to_owned()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..ObjectMeta::default()
+                },
+                Some("config-hashsum"),
+            ),
+        ];
+
+        for (metadata, expected) in cases {
+            assert_eq!(extract_static_pod_config_hashsum(&metadata), expected);
+        }
+    }
+}

--- a/src/kubernetes/state/evmap.rs
+++ b/src/kubernetes/state/evmap.rs
@@ -149,6 +149,28 @@ mod tests {
         assert_eq!(val, Box::new(HashValue::new(pod)));
     }
 
+    #[test]
+    fn test_kv_static_pod() {
+        let pod = Pod {
+            metadata: ObjectMeta {
+                uid: Some("uid".to_owned()),
+                annotations: Some(
+                    vec![(
+                        "kubernetes.io/config.mirror".to_owned(),
+                        "config-hashsum".to_owned(),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+                ..ObjectMeta::default()
+            },
+            ..Pod::default()
+        };
+        let (key, val) = kv(pod.clone()).unwrap();
+        assert_eq!(key, "config-hashsum");
+        assert_eq!(val, Box::new(HashValue::new(pod)));
+    }
+
     #[tokio::test]
     async fn test_without_debounce() {
         let (state_reader, state_writer) = evmap::new();

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -3,10 +3,10 @@
 #![deny(missing_docs)]
 
 use super::path_helpers::build_pod_logs_directory;
-use crate::kubernetes as k8s;
+use crate::kubernetes::{self as k8s, pod_manager_logic::extract_static_pod_config_hashsum};
 use evmap::ReadHandle;
 use file_source::paths_provider::PathsProvider;
-use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
+use k8s_openapi::api::core::v1::Pod;
 use std::path::PathBuf;
 
 /// A paths provider implementation that uses the state obtained from the
@@ -93,19 +93,6 @@ fn extract_pod_logs_directory(pod: &Pod) -> Option<PathBuf> {
     };
 
     Some(build_pod_logs_directory(&namespace, &name, &uid))
-}
-
-/// Extract the static pod config hashsum from the mirror pod annotations.
-///
-/// This part of Kubernetes changed a bit over time, so we're implemeting
-/// support up to 1.14, which is an MSKV at this time.
-///
-/// See: https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81
-fn extract_static_pod_config_hashsum(metadata: &ObjectMeta) -> Option<&str> {
-    let annotations = metadata.annotations.as_ref()?;
-    annotations
-        .get("kubernetes.io/config.mirror")
-        .map(String::as_str)
 }
 
 const CONTAINER_EXCLUSION_ANNOTATION_KEY: &str = "vector.dev/exclude-containers";

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -6,7 +6,7 @@ use super::path_helpers::build_pod_logs_directory;
 use crate::kubernetes as k8s;
 use evmap::ReadHandle;
 use file_source::paths_provider::PathsProvider;
-use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use std::path::PathBuf;
 
 /// A paths provider implementation that uses the state obtained from the
@@ -60,12 +60,52 @@ impl PathsProvider for K8sPathsProvider {
     }
 }
 
+/// This function takes a `Pod` resource and returns the path to where the logs
+/// for the said `Pod` are expected to be found.
+///
+/// In the common case, the effective path is built using the `namespace`,
+/// `name` and `uid` of the Pod. However, there's a special case for
+/// `Static Pod`s: they keep their logs at the path that consists of config
+/// hashsum instead of the `Pod` `uid`. The reason for this is `kubelet` is
+/// locally authoritative over those `Pod`s, and the API only has
+/// `Monitor Pod`s - the "dummy" entires useful for discovery and association.
+/// Their UIDs are generated at the Kubernetes API side, and do not represent
+/// the actual config hashsum as one would expect.
+///
+/// To work around this, we use the mirror pod annotations (if any) to obtain
+/// the effective config hashsum, see the `extract_static_pod_config_hashsum`
+/// function that does this.
+///
+/// See https://github.com/timberio/vector/issues/6001
+/// See https://github.com/kubernetes/kubernetes/blob/ef3337a443b402756c9f0bfb1f844b1b45ce289d/pkg/kubelet/pod/pod_manager.go#L30-L44
+/// See https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81
 fn extract_pod_logs_directory(pod: &Pod) -> Option<PathBuf> {
     let metadata = &pod.metadata;
     let namespace = metadata.namespace.as_ref()?;
     let name = metadata.name.as_ref()?;
-    let uid = metadata.uid.as_ref()?;
+
+    let uid = if let Some(static_pod_config_hashsum) = extract_static_pod_config_hashsum(metadata) {
+        // If there's a static pod config hashsum - use it instead of uid.
+        static_pod_config_hashsum
+    } else {
+        // In the common case - just fallback to the real pod uid.
+        metadata.uid.as_ref()?
+    };
+
     Some(build_pod_logs_directory(&namespace, &name, &uid))
+}
+
+/// Extract the static pod config hashsum from the mirror pod annotations.
+///
+/// This part of Kubernetes changed a bit over time, so we're implemeting
+/// support up to 1.14, which is an MSKV at this time.
+///
+/// See: https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81
+fn extract_static_pod_config_hashsum(metadata: &ObjectMeta) -> Option<&str> {
+    let annotations = metadata.annotations.as_ref()?;
+    annotations
+        .get("kubernetes.io/config.mirror")
+        .map(String::as_str)
 }
 
 const CONTAINER_EXCLUSION_ANNOTATION_KEY: &str = "vector.dev/exclude-containers";
@@ -174,7 +214,9 @@ mod tests {
     #[test]
     fn test_extract_pod_logs_directory() {
         let cases = vec![
+            // Empty pod.
             (Pod::default(), None),
+            // Happy path.
             (
                 Pod {
                     metadata: ObjectMeta {
@@ -187,6 +229,7 @@ mod tests {
                 },
                 Some("/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid"),
             ),
+            // No uid.
             (
                 Pod {
                     metadata: ObjectMeta {
@@ -198,6 +241,7 @@ mod tests {
                 },
                 None,
             ),
+            // No name.
             (
                 Pod {
                     metadata: ObjectMeta {
@@ -209,6 +253,7 @@ mod tests {
                 },
                 None,
             ),
+            // No namespace.
             (
                 Pod {
                     metadata: ObjectMeta {
@@ -219,6 +264,27 @@ mod tests {
                     ..Pod::default()
                 },
                 None,
+            ),
+            // Static pod config hashsum as uid.
+            (
+                Pod {
+                    metadata: ObjectMeta {
+                        namespace: Some("sandbox0-ns".to_owned()),
+                        name: Some("sandbox0-name".to_owned()),
+                        uid: Some("sandbox0-uid".to_owned()),
+                        annotations: Some(
+                            vec![(
+                                "kubernetes.io/config.mirror".to_owned(),
+                                "sandbox0-config-hashsum".to_owned(),
+                            )]
+                            .into_iter()
+                            .collect(),
+                        ),
+                        ..ObjectMeta::default()
+                    },
+                    ..Pod::default()
+                },
+                Some("/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-config-hashsum"),
             ),
         ];
 


### PR DESCRIPTION
Closes #6001.

After #6061 is complete, we should add E2E tests for this.

- [x] collect logs
- [x] annotate logs with pod metadata