### PR TITLE
enhancement(remap): Add charset parameter to encode_base64 function

### DIFF
--- a/docs/reference/remap/encode_base64.cue
+++ b/docs/reference/remap/encode_base64.cue
@@ -29,7 +29,7 @@ remap: functions: encode_base64: {
 	]
 	internal_failure_reason: null
 	return: ["string"]
-	category:    "Encode"
+	category: "Encode"
 	description: #"""
 		Encodes the provided `value` to [Base64](\(urls.base64)) either padded or non-padded and
 		using the specified character set.
@@ -67,6 +67,6 @@ remap: functions: encode_base64: {
 				message: "please encode me, but safe for URLs"
 				encoded: "cGxlYXNlIGVuY29kZSBtZSwgYnV0IHNhZmUgZm9yIFVSTHM="
 			}
-		}
+		},
 	]
 }

--- a/docs/reference/remap/encode_base64.cue
+++ b/docs/reference/remap/encode_base64.cue
@@ -15,13 +15,25 @@ remap: functions: encode_base64: {
 			type: ["boolean"]
 			default: true
 		},
+		{
+			name:        "charset"
+			description: ""
+			required:    false
+			type: ["string"]
+			default: "standard"
+			enum: {
+				standard: "[Standard](\(urls.base64_standard)) Base64 format."
+				url_safe: "Modified Base64 for [URL variants](\(urls.base64_url_safe)."
+			}
+		},
 	]
 	internal_failure_reason: null
 	return: ["string"]
 	category:    "Encode"
-	description: """
-		Encodes the provided `value` to [Base64](\(urls.base64)) using the "standard" character set (`+` and `/`).
-		"""
+	description: #"""
+		Encodes the provided `value` to [Base64](\(urls.base64)) either padded or non-padded and
+		using the specified character set.
+		"""#
 	examples: [
 		{
 			title: "Encode string"
@@ -39,11 +51,22 @@ remap: functions: encode_base64: {
 			input: {
 				message: "please encode me, no padding though"
 			}
-			source: ".encoded = encode_base64(.message, padding = false)"
+			source: ".encoded = encode_base64(.message, padding: false)"
 			output: {
 				message: "please encode me, no padding though"
 				encoded: "cGxlYXNlIGVuY29kZSBtZSwgbm8gcGFkZGluZyB0aG91Z2g"
 			}
 		},
+		{
+			title: "Encode URL string"
+			input: {
+				message: "please encode me, but safe for URLs"
+			}
+			source: #".encoded = encode_base64(.message, charset: "url_safe")"#
+			output: {
+				message: "please encode me, but safe for URLs"
+				encoded: "cGxlYXNlIGVuY29kZSBtZSwgYnV0IHNhZmUgZm9yIFVSTHM="
+			}
+		}
 	]
 }

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -77,6 +77,8 @@ urls: {
 	azure_monitor_logs_endpoints:                             "https://docs.microsoft.com/en-us/rest/api/monitor/"
 	base64:                                                   "https://en.wikipedia.org/wiki/Base64"
 	base64_padding:                                           "https://en.wikipedia.org/wiki/Base64#Output_padding"
+	base64_standard:                                          "https://tools.ietf.org/html/rfc4648#section-4"
+	base64_url_safe:                                          "https://en.wikipedia.org/wiki/Base64#URL_applications"
 	basic_auth:                                               "https://en.wikipedia.org/wiki/Basic_access_authentication"
 	big_query_streaming:                                      "https://cloud.google.com/bigquery/streaming-data-into-bigquery"
 	cargo_audit:                                              "https://github.com/RustSec/cargo-audit"

--- a/lib/remap-functions/src/encode_base64.rs
+++ b/lib/remap-functions/src/encode_base64.rs
@@ -128,7 +128,7 @@ impl Expression for EncodeBase64Fn {
         let charset_def = self
             .charset
             .as_ref()
-            .map(|charset| charset.type_def(state).fallible_unless(Kind::Bytes));
+            .map(|charset| charset.type_def(state).into_fallible(true));
 
         self.value
             .type_def(state)
@@ -154,13 +154,13 @@ mod test {
             def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
-        value_string_padding_boolean_charset_specified_infallible {
+        valid_charset_fallible {
             expr: |_| EncodeBase64Fn {
                 value: lit!("foo").boxed(),
                 padding: Some(lit!(false).boxed()),
                 charset: Some(lit!("standard").boxed()),
             },
-            def: TypeDef { kind: Kind::Bytes, ..Default::default() },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         padding_non_boolean_fallible {
@@ -168,15 +168,6 @@ mod test {
                 value: lit!("foo").boxed(),
                 padding: Some(lit!("foo").boxed()),
                 charset: None,
-            },
-            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
-        }
-
-        charset_non_string_fallible {
-            expr: |_| EncodeBase64Fn {
-                value: lit!("foo").boxed(),
-                padding: None,
-                charset: Some(lit!(127).boxed()),
             },
             def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }

--- a/lib/remap-functions/src/encode_base64.rs
+++ b/lib/remap-functions/src/encode_base64.rs
@@ -195,28 +195,28 @@ mod test {
         encode_base64 => EncodeBase64;
 
         with_defaults {
-            args: func_args![value: value!("some string value")],
-            want: Ok(value!("c29tZSBzdHJpbmcgdmFsdWU=")),
+            args: func_args![value: value!("some+=string/value")],
+            want: Ok(value!("c29tZSs9c3RyaW5nL3ZhbHVl")),
         }
 
         with_padding_standard_charset {
-            args: func_args![value: value!("some string value"), padding: value!(true), charset: value!("standard")],
-            want: Ok(value!("c29tZSBzdHJpbmcgdmFsdWU=")),
+            args: func_args![value: value!("some+=string/value"), padding: value!(true), charset: value!("standard")],
+            want: Ok(value!("c29tZSs9c3RyaW5nL3ZhbHVl")),
         }
 
         no_padding_standard_charset {
-            args: func_args![value: value!("some+string+value"), padding: value!(false), charset: value!("standard")],
-            want: Ok(value!("c29tZStzdHJpbmcrdmFsdWU")),
-        }
-
-        no_padding_urlsafe_charset {
-            args: func_args![value: value!("some+string+value"), padding: value!(false), charset: value!("url_safe")],
-            want: Ok(value!("c29tZStzdHJpbmcrdmFsdWU")),
+            args: func_args![value: value!("some+=string/value"), padding: value!(false), charset: value!("standard")],
+            want: Ok(value!("c29tZSs9c3RyaW5nL3ZhbHVl")),
         }
 
         with_padding_urlsafe_charset {
-            args: func_args![value: value!("foo+bar+baz"), padding: value!(false), charset: value!("url_safe")],
-            want: Ok(value!("Zm9vK2JhcitiYXo")),
+            args: func_args![value: value!("some+=string/value"), padding: value!(true), charset: value!("url_safe")],
+            want: Ok(value!("c29tZSs9c3RyaW5nL3ZhbHVl")),
+        }
+
+        no_padding_urlsafe_charset {
+            args: func_args![value: value!("some+=string/value"), padding: value!(false), charset: value!("url_safe")],
+            want: Ok(value!("c29tZSs9c3RyaW5nL3ZhbHVl")),
         }
 
         empty_string_standard_charset {

--- a/lib/remap-functions/src/encode_base64.rs
+++ b/lib/remap-functions/src/encode_base64.rs
@@ -150,6 +150,7 @@ mod test {
             expr: |_| EncodeBase64Fn {
                 value: Literal::from("foo").boxed(),
                 padding: None,
+                charset: Charset::default(),
             },
             def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
@@ -158,6 +159,7 @@ mod test {
             expr: |_| EncodeBase64Fn {
                 value: Literal::from("foo").boxed(),
                 padding: Some(Literal::from(false).boxed()),
+                charset: Charset::default(),
             },
             def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
@@ -166,6 +168,7 @@ mod test {
             expr: |_| EncodeBase64Fn {
                 value: Literal::from("foo").boxed(),
                 padding: Some(Literal::from("foo").boxed()),
+                charset: Charset::default(),
             },
             def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
@@ -174,6 +177,7 @@ mod test {
             expr: |_| EncodeBase64Fn {
                 value: Literal::from(127).boxed(),
                 padding: Some(Literal::from(true).boxed()),
+                charset: Charset::default(),
             },
             def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
@@ -182,6 +186,7 @@ mod test {
             expr: |_| EncodeBase64Fn {
                 value: Literal::from(127).boxed(),
                 padding: Some(Literal::from("foo").boxed()),
+                charset: Charset::default(),
             },
             def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }


### PR DESCRIPTION
Adds a `charset` parameter to the `encode_base64` function with two possible values: `standard` and `url_safe`. It's fairly trivial to add others in the future.

Closes #6011 
