### PR TITLE
chore(config): Move `assume_role` option to `auth.assume_role`

### DIFF
--- a/docs/reference/components/aws.cue
+++ b/docs/reference/components/aws.cue
@@ -2,14 +2,25 @@ package metadata
 
 components: _aws: {
 	configuration: {
-		assume_role: {
-			category:    "Auth"
+		auth: {
 			common:      false
-			description: "The ARN of an [IAM role](\(urls.aws_iam_role)) to assume at startup."
+			description: "Options for the authentication strategy."
 			required:    false
-			type: string: {
-				default: null
-				examples: ["arn:aws:iam::123456789098:role/my_role"]
+			warnings: []
+			type: object: {
+				examples: []
+				options: {
+					assume_role: {
+						category:    "Auth"
+						common:      false
+						description: "The ARN of an [IAM role](\(urls.aws_iam_role)) to assume at startup."
+						required:    false
+						type: string: {
+							default: null
+							examples: ["arn:aws:iam::123456789098:role/my_role"]
+						}
+					}
+				}
 			}
 		}
 

--- a/src/rusoto/auth.rs
+++ b/src/rusoto/auth.rs
@@ -1,0 +1,37 @@
+use super::AwsCredentialsProvider;
+use rusoto_core::Region;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum AWSAuthentication {
+    Role { assume_role: String },
+    Default,
+}
+
+impl AWSAuthentication {
+    pub fn build(
+        &self,
+        region: &Region,
+        old_assume_role: Option<String>,
+    ) -> crate::Result<AwsCredentialsProvider> {
+        if old_assume_role.is_some() {
+            warn!("Option `assume_role` has been renamed to `auth.assume_role`. Please use that one instead.");
+        }
+        match self {
+            Self::Role { assume_role } => {
+                if old_assume_role.is_some() {
+                    warn!("Ignoring option `assume_role` and using option `auth.assume_role` instead.");
+                }
+                AwsCredentialsProvider::new(region, Some(assume_role.clone()))
+            }
+            Self::Default => AwsCredentialsProvider::new(region, old_assume_role),
+        }
+    }
+}
+
+impl Default for AWSAuthentication {
+    fn default() -> Self {
+        Self::Default
+    }
+}

--- a/src/rusoto/auth.rs
+++ b/src/rusoto/auth.rs
@@ -52,41 +52,52 @@ mod tests {
 
     #[test]
     fn parsing_default() {
-        toml::from_str::<ComponentConfig>(
+        let config = toml::from_str::<ComponentConfig>(
             r#"
         "#,
         )
         .unwrap();
+
+        assert!(matches!(config.auth, AWSAuthentication::Default {}));
     }
 
     #[test]
     fn parsing_old_assume_role() {
-        toml::from_str::<ComponentConfig>(
+        let config = toml::from_str::<ComponentConfig>(
             r#"
             assume_role = "root"
         "#,
         )
         .unwrap();
+
+        assert!(matches!(config.auth, AWSAuthentication::Default {}));
     }
 
     #[test]
     fn parsing_assume_role() {
-        toml::from_str::<ComponentConfig>(
+        let config = toml::from_str::<ComponentConfig>(
             r#"
             auth.assume_role = "root"
         "#,
         )
         .unwrap();
+
+        assert!(matches!(config.auth, AWSAuthentication::Role{..}));
     }
 
     #[test]
     fn parsing_both_assume_role() {
-        toml::from_str::<ComponentConfig>(
+        let config = toml::from_str::<ComponentConfig>(
             r#"
             assume_role = "root"
-            auth.assume_role = "root"
+            auth.assume_role = "auth.root"
         "#,
         )
         .unwrap();
+
+        match config.auth {
+            AWSAuthentication::Role { assume_role } => assert_eq!(&assume_role, "auth.root"),
+            _ => panic!(),
+        }
     }
 }

--- a/src/rusoto/mod.rs
+++ b/src/rusoto/mod.rs
@@ -28,7 +28,9 @@ use std::{
 };
 use tower::{Service, ServiceExt};
 
+pub mod auth;
 pub mod region;
+pub use auth::AWSAuthentication;
 pub use region::{region_from_endpoint, RegionOrEndpoint};
 
 pub type Client = HttpClient<super::http::HttpClient<RusotoBody>>;

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -74,6 +74,7 @@ pub struct CloudwatchLogsSinkConfig {
     pub request: TowerRequestConfig<Option<usize>>,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -3,7 +3,7 @@ mod request;
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::{Event, LogEvent, Value},
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::{FixedRetryPolicy, RetryLogic},
@@ -72,7 +72,9 @@ pub struct CloudwatchLogsSinkConfig {
     pub batch: BatchConfig,
     #[serde(default)]
     pub request: TowerRequestConfig<Option<usize>>,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 inventory::submit! {
@@ -97,6 +99,7 @@ fn default_config(e: Encoding) -> CloudwatchLogsSinkConfig {
         batch: Default::default(),
         request: Default::default(),
         assume_role: Default::default(),
+        auth: Default::default(),
     }
 }
 
@@ -158,7 +161,7 @@ impl CloudwatchLogsSinkConfig {
         let region = (&self.region).try_into()?;
 
         let client = rusoto::client()?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(CloudWatchLogsClient::new_with_client(client, region))
@@ -884,6 +887,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -930,6 +934,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -995,6 +1000,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -1066,6 +1072,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -1117,6 +1124,7 @@ mod integration_tests {
             },
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -1164,6 +1172,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -1249,6 +1258,7 @@ mod integration_tests {
             batch: Default::default(),
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let client = config.create_client().unwrap();

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -46,6 +46,7 @@ pub struct CloudWatchMetricsSinkConfig {
     pub request: TowerRequestConfig,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -4,7 +4,7 @@ use crate::{
         metric::{Metric, MetricKind, MetricValue},
         Event,
     },
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         retries::RetryLogic, BatchConfig, BatchSettings, Compression, MetricBuffer,
         PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig,
@@ -44,7 +44,9 @@ pub struct CloudWatchMetricsSinkConfig {
     pub batch: BatchConfig,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 lazy_static! {
@@ -114,7 +116,7 @@ impl CloudWatchMetricsSinkConfig {
         };
 
         let client = rusoto::client()?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(CloudWatchClient::new_with_client(client, region))

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -352,7 +352,7 @@ mod integration_tests {
         delay_for(Duration::from_secs(1)).await;
 
         let config = ElasticSearchConfig {
-            auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
+            auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default {})),
             endpoint: "http://localhost:4571".into(),
             index: Some(stream.clone()),
             ..Default::default()

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::Event,
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::RetryLogic,
@@ -46,7 +46,9 @@ pub struct KinesisFirehoseSinkConfig {
     pub batch: BatchConfig,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 lazy_static! {
@@ -127,7 +129,7 @@ impl KinesisFirehoseSinkConfig {
         let region = (&self.region).try_into()?;
 
         let client = rusoto::client()?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(KinesisFirehoseClient::new_with_client(client, region))
@@ -333,6 +335,7 @@ mod integration_tests {
                 ..Default::default()
             },
             assume_role: None,
+            auth: Default::default(),
         };
 
         let cx = SinkContext::new_test();
@@ -348,7 +351,7 @@ mod integration_tests {
         delay_for(Duration::from_secs(1)).await;
 
         let config = ElasticSearchConfig {
-            auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
+            auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
             endpoint: "http://localhost:4571".into(),
             index: Some(stream.clone()),
             ..Default::default()

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -352,7 +352,7 @@ mod integration_tests {
         delay_for(Duration::from_secs(1)).await;
 
         let config = ElasticSearchConfig {
-            auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
+            auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
             endpoint: "http://localhost:4571".into(),
             index: Some(stream.clone()),
             ..Default::default()

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -48,6 +48,7 @@ pub struct KinesisFirehoseSinkConfig {
     pub request: TowerRequestConfig,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::Event,
     internal_events::AwsKinesisStreamsEventSent,
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::RetryLogic,
@@ -49,7 +49,9 @@ pub struct KinesisSinkConfig {
     pub batch: BatchConfig,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 lazy_static! {
@@ -130,7 +132,7 @@ impl KinesisSinkConfig {
         let region = (&self.region).try_into()?;
 
         let client = rusoto::client()?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
         Ok(KinesisClient::new_with_client(client, region))
@@ -420,6 +422,7 @@ mod integration_tests {
             },
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         let cx = SinkContext::new_test();

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -51,6 +51,7 @@ pub struct KinesisSinkConfig {
     pub request: TowerRequestConfig,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     serde::to_string,
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
@@ -56,7 +56,9 @@ pub struct S3SinkConfig {
     pub batch: BatchConfig,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -147,6 +149,7 @@ impl GenerateConfig for S3SinkConfig {
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
             assume_role: None,
+            auth: AWSAuthentication::default(),
         })
         .unwrap()
     }
@@ -258,7 +261,7 @@ impl S3SinkConfig {
         let region = (&self.region).try_into()?;
         let client = rusoto::client()?;
 
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         Ok(S3Client::new_with(client, creds, region))
     }
@@ -736,6 +739,7 @@ mod integration_tests {
             },
             request: TowerRequestConfig::default(),
             assume_role: None,
+            auth: Default::default(),
         }
     }
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -58,6 +58,7 @@ pub struct S3SinkConfig {
     pub request: TowerRequestConfig,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     internal_events::{AwsSqsEventSent, AwsSqsMessageGroupIdMissingKeys},
-    rusoto,
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         retries::RetryLogic,
@@ -56,12 +56,14 @@ pub struct SqsSink {
 pub struct SqsSinkConfig {
     pub queue_url: String,
     #[serde(flatten)]
-    pub region: rusoto::RegionOrEndpoint,
+    pub region: RegionOrEndpoint,
     pub encoding: EncodingConfig<Encoding>,
     pub message_group_id: Option<String>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub assume_role: Option<String>,
+    // Deprecated name. Moved to auth.
+    assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 }
 
 lazy_static! {
@@ -132,7 +134,7 @@ impl SqsSinkConfig {
         let region = (&self.region).try_into()?;
         let client = rusoto::client()?;
 
-        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+        let creds = self.auth.build(&region, self.assume_role.clone())?;
 
         Ok(SqsClient::new_with(client, creds, region))
     }
@@ -334,11 +336,12 @@ mod integration_tests {
 
         let config = SqsSinkConfig {
             queue_url: queue_url.clone(),
-            region: rusoto::RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
             encoding: Encoding::Text.into(),
             message_group_id: None,
             request: Default::default(),
             assume_role: None,
+            auth: Default::default(),
         };
 
         config.clone().healthcheck(client.clone()).await.unwrap();

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -63,6 +63,7 @@ pub struct SqsSinkConfig {
     pub request: TowerRequestConfig,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    #[serde(default)]
     pub auth: AWSAuthentication,
 }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -783,7 +783,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
                 endpoint: "http://localhost:4571".into(),
                 ..config()
             },
@@ -798,7 +798,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
                 endpoint: "http://localhost:4571".into(),
                 compression: Compression::gzip_default(),
                 ..config()

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -392,7 +392,7 @@ impl ElasticSearchCommon {
 
         let credentials = match &config.auth {
             Some(ElasticSearchAuth::Basic { .. }) | None => None,
-            Some(ElasticSearchAuth::Aws(auth)) => Some(auth.build(&region, None)?),
+            Some(ElasticSearchAuth::Aws(aws)) => Some(aws.build(&region, None)?),
         };
 
         let compression = config.compression;
@@ -520,6 +520,26 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<ElasticSearchConfig>();
+    }
+
+    #[test]
+    fn parse_aws_auth() {
+        toml::from_str::<ElasticSearchConfig>(
+            r#"
+            endpoint = ""
+            auth.strategy = "aws"
+            auth.assume_role = "role"
+        "#,
+        )
+        .unwrap();
+
+        toml::from_str::<ElasticSearchConfig>(
+            r#"
+            endpoint = ""
+            auth.strategy = "aws"
+        "#,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -4,7 +4,7 @@ use crate::{
     event::Event,
     http::{Auth, HttpClient, MaybeAuth},
     internal_events::{ElasticSearchEventEncoded, ElasticSearchMissingKeys},
-    rusoto::{self, region_from_endpoint, RegionOrEndpoint},
+    rusoto::{self, region_from_endpoint, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpSink, RequestConfig},
@@ -85,7 +85,7 @@ pub enum Encoding {
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
 pub enum ElasticSearchAuth {
     Basic { user: String, password: String },
-    Aws { assume_role: Option<String> },
+    Aws(AWSAuthentication),
 }
 
 #[derive(Derivative, Deserialize, Serialize, Clone, Debug)]
@@ -392,9 +392,7 @@ impl ElasticSearchCommon {
 
         let credentials = match &config.auth {
             Some(ElasticSearchAuth::Basic { .. }) | None => None,
-            Some(ElasticSearchAuth::Aws { assume_role }) => Some(
-                rusoto::AwsCredentialsProvider::new(&region, assume_role.clone())?,
-            ),
+            Some(ElasticSearchAuth::Aws(auth)) => Some(auth.build(&region, None)?),
         };
 
         let compression = config.compression;
@@ -765,7 +763,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
                 endpoint: "http://localhost:4571".into(),
                 ..config()
             },
@@ -780,7 +778,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default)),
                 endpoint: "http://localhost:4571".into(),
                 compression: Compression::gzip_default(),
                 ..config()

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -783,7 +783,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default {})),
                 endpoint: "http://localhost:4571".into(),
                 ..config()
             },
@@ -798,7 +798,7 @@ mod integration_tests {
 
         run_insert_tests(
             ElasticSearchConfig {
-                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default{})),
+                auth: Some(ElasticSearchAuth::Aws(AWSAuthentication::Default {})),
                 endpoint: "http://localhost:4571".into(),
                 compression: Compression::gzip_default(),
                 ..config()

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -48,7 +48,8 @@ struct AwsS3Config {
 
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
-    pub auth: AWSAuthentication,
+    #[serde(default)]
+    auth: AWSAuthentication,
 
     multiline: Option<MultilineConfig>,
 }

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -2,7 +2,7 @@ use super::util::MultilineConfig;
 use crate::{
     config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
     line_agg,
-    rusoto::{self, RegionOrEndpoint},
+    rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     shutdown::ShutdownSignal,
     Pipeline,
 };
@@ -46,7 +46,9 @@ struct AwsS3Config {
 
     sqs: Option<sqs::Config>,
 
+    // Deprecated name. Moved to auth.
     assume_role: Option<String>,
+    pub auth: AWSAuthentication,
 
     multiline: Option<MultilineConfig>,
 }
@@ -101,10 +103,11 @@ impl AwsS3Config {
         let region: Region = (&self.region).try_into().context(RegionParse {})?;
 
         let client = rusoto::client().with_context(|| Client {})?;
-        let creds: Arc<rusoto::AwsCredentialsProvider> =
-            rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())
-                .context(Credentials {})?
-                .into();
+        let creds: Arc<rusoto::AwsCredentialsProvider> = self
+            .auth
+            .build(&region, self.assume_role.clone())
+            .context(Credentials {})?
+            .into();
         let s3_client = S3Client::new_with(
             client.clone(),
             Arc::<rusoto::AwsCredentialsProvider>::clone(&creds),


### PR DESCRIPTION
Closes #4200

### Open questions

- [x] This also moves `assume_role` in source `aws_s3` and sink `aws_sqs`. @binarylogic this is fine?

### Notes
`AWSAuthentication` is an `enum` since #4199 will add an additional variant.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
