### PR TITLE
chore(tests): Pin thread_local to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6686,9 +6686,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
@@ -7656,6 +7656,7 @@ dependencies = [
  "syslog",
  "syslog_loose",
  "tempfile",
+ "thread_local",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,9 @@ dirs-next = { version = "2.0.0", optional = true }
 fakedata_generator = "0.2.4"
 postgres-openssl = { version = "0.3.0", optional = true }
 tokio-postgres = { version = "0.5.5", optional = true, features = ["runtime", "with-chrono-0_4"] }
+# Indirect dependency; pinning until
+# https://github.com/timberio/vector/issues/6005 is resolved
+thread_local = "= 1.0.1"
 
 # For WASM
 vector-wasm = { path = "lib/vector-wasm", optional = true }


### PR DESCRIPTION
Until https://github.com/timberio/vector/issues/6005 is resolved.

Inadvertently upgraded in #6028 

Fixes https://github.com/timberio/vector/actions/runs/493151187

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
