### PR TITLE
chore(external docs): Remove the rawConfig from Helm tutorial

### DIFF
--- a/docs/reference/installation/_interfaces/helm3.cue
+++ b/docs/reference/installation/_interfaces/helm3.cue
@@ -41,9 +41,8 @@ installation: _interfaces: "helm3": {
 				  stdout:
 				    type: console
 				    inputs: ["kubernetes_logs"]
-				    rawConfig: |
-				      target = "stdout"
-				      encoding = "json"
+				    target: "stdout"
+				    encoding: "json"
 				VALUES
 				"""#
 			install:   #"helm install --namespace \#(_namespace) --create-namespace \#(_release_name) \#(_repo_name)/\#(_chart_name) --values values.yaml"#


### PR DESCRIPTION
Closes #6047.

I think we need a way to add some kind of notes/warning to the tutorial steps. I.e. I'd mention that `rawConfig` used to be a thing and is now deprecated there. Is there any better place for it?