### PR TITLE
chore(external docs): Remove unreported metrics from kafka sink

### DIFF
--- a/docs/reference/components/kafka.cue
+++ b/docs/reference/components/kafka.cue
@@ -99,11 +99,4 @@ components: _kafka: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		consumer_offset_updates_failed_total: components.sources.internal_metrics.output.metrics.consumer_offset_updates_failed_total
-		events_failed_total:                  components.sources.internal_metrics.output.metrics.events_failed_total
-		processed_bytes_total:                components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:               components.sources.internal_metrics.output.metrics.processed_events_total
-	}
 }

--- a/docs/reference/components/sources/kafka.cue
+++ b/docs/reference/components/sources/kafka.cue
@@ -215,5 +215,12 @@ components: sources: kafka: {
 		}
 	}
 
+	telemetry: metrics: {
+		consumer_offset_updates_failed_total: components.sources.internal_metrics.output.metrics.consumer_offset_updates_failed_total
+		events_failed_total:                  components.sources.internal_metrics.output.metrics.events_failed_total
+		processed_bytes_total:                components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:               components.sources.internal_metrics.output.metrics.processed_events_total
+	}
+
 	how_it_works: components._kafka.how_it_works
 }


### PR DESCRIPTION
These were documented as being reported for both the `kafka` source and
sink, but are only reported for the source currently.
`consumer_offset_updates_failed_total` is likely to only apply to the
source anyway.

I opened https://github.com/timberio/vector/issues/6133 to cover adding
them to the sink.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
