### PR TITLE
feat(config): add wildcard expansion to inputs

### DIFF
--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -39,6 +39,21 @@ impl Clone for ConfigBuilder {
     }
 }
 
+impl From<Config> for ConfigBuilder {
+    fn from(c: Config) -> Self {
+        ConfigBuilder {
+            global: c.global,
+            #[cfg(feature = "api")]
+            api: c.api,
+            healthchecks: c.healthchecks,
+            sources: c.sources,
+            sinks: c.sinks,
+            transforms: c.transforms,
+            tests: c.tests,
+        }
+    }
+}
+
 impl ConfigBuilder {
     pub fn build(self) -> Result<Config, Vec<String>> {
         self.build_with(false)

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -16,6 +16,8 @@ pub fn compile(raw: ConfigBuilder, deny_warnings: bool) -> Result<Config, Vec<St
 
     let mut errors = Vec::new();
 
+    expand_wildcards(&mut config);
+
     expand_macros(&mut config)?;
 
     if let Err(warn) = handle_warnings(validation::warnings(&config), deny_warnings) {
@@ -80,5 +82,141 @@ pub(super) fn expand_macros(config: &mut Config) -> Result<(), Vec<String>> {
     } else {
         config.expansions = expansions;
         Ok(())
+    }
+}
+
+/// Expand trailing `*` wildcards in input lists
+fn expand_wildcards(config: &mut Config) {
+    let candidates = config
+        .sources
+        .keys()
+        .chain(config.transforms.keys())
+        .cloned()
+        .collect::<Vec<String>>();
+
+    for (name, transform) in config.transforms.iter_mut() {
+        expand_inner(&mut transform.inputs, name, &candidates);
+    }
+
+    for (name, sink) in config.sinks.iter_mut() {
+        expand_inner(&mut sink.inputs, name, &candidates);
+    }
+}
+
+fn expand_inner(inputs: &mut Vec<String>, name: &str, candidates: &[String]) {
+    let raw_inputs = inputs.drain(..).collect::<Vec<_>>();
+    for raw_input in raw_inputs {
+        if raw_input.ends_with("*") {
+            let prefix = &raw_input[0..raw_input.len() - 1];
+            for input in candidates {
+                if input.starts_with(prefix) && input != name {
+                    inputs.push(input.clone())
+                }
+            }
+        } else {
+            inputs.push(raw_input);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        config::{DataType, GlobalOptions, SinkConfig, SinkContext, SourceConfig, TransformConfig},
+        shutdown::ShutdownSignal,
+        sinks::{Healthcheck, VectorSink},
+        sources::Source,
+        transforms::Transform,
+        Pipeline,
+    };
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct MockSourceConfig;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct MockTransformConfig;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct MockSinkConfig;
+
+    #[async_trait]
+    #[typetag::serde(name = "mock")]
+    impl SourceConfig for MockSourceConfig {
+        async fn build(
+            &self,
+            _name: &str,
+            _globals: &GlobalOptions,
+            _shutdown: ShutdownSignal,
+            _out: Pipeline,
+        ) -> crate::Result<Source> {
+            unimplemented!()
+        }
+
+        fn source_type(&self) -> &'static str {
+            "mock"
+        }
+
+        fn output_type(&self) -> DataType {
+            DataType::Any
+        }
+    }
+
+    #[async_trait]
+    #[typetag::serde(name = "mock")]
+    impl TransformConfig for MockTransformConfig {
+        async fn build(&self) -> crate::Result<Transform> {
+            unimplemented!()
+        }
+
+        fn transform_type(&self) -> &'static str {
+            "mock"
+        }
+
+        fn input_type(&self) -> DataType {
+            DataType::Any
+        }
+
+        fn output_type(&self) -> DataType {
+            DataType::Any
+        }
+    }
+
+    #[async_trait]
+    #[typetag::serde(name = "mock")]
+    impl SinkConfig for MockSinkConfig {
+        async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+            unimplemented!()
+        }
+
+        fn sink_type(&self) -> &'static str {
+            "mock"
+        }
+
+        fn input_type(&self) -> DataType {
+            DataType::Any
+        }
+    }
+
+    #[test]
+    fn wildcard_expansion() {
+        let mut builder = ConfigBuilder::default();
+        builder.add_source("foo1", MockSourceConfig);
+        builder.add_source("foo2", MockSourceConfig);
+        builder.add_source("bar", MockSourceConfig);
+        builder.add_transform("foos", &["foo*"], MockTransformConfig);
+        builder.add_sink("baz", &["foos*", "b*"], MockSinkConfig);
+        builder.add_sink("quux", &["*"], MockSinkConfig);
+
+        let config = builder.build().expect("build should succeed");
+
+        assert_eq!(config.transforms["foos"].inputs, vec!["foo1", "foo2"]);
+        assert_eq!(config.sinks["baz"].inputs, vec!["foos", "bar"]);
+        assert_eq!(
+            config.sinks["quux"].inputs,
+            vec!["foo1", "foo2", "bar", "foos"]
+        );
     }
 }

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -103,7 +103,7 @@ fn expand_wildcards(config: &mut ConfigBuilder) {
 }
 
 fn expand_wildcards_inner(inputs: &mut Vec<String>, name: &str, candidates: &[String]) {
-    let raw_inputs = inputs.drain(..).collect::<Vec<_>>();
+    let raw_inputs = std::mem::take(inputs);
     for raw_input in raw_inputs {
         if raw_input.ends_with('*') {
             let prefix = &raw_input[0..raw_input.len() - 1];

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -106,7 +106,7 @@ fn expand_wildcards(config: &mut Config) {
 fn expand_inner(inputs: &mut Vec<String>, name: &str, candidates: &[String]) {
     let raw_inputs = inputs.drain(..).collect::<Vec<_>>();
     for raw_input in raw_inputs {
-        if raw_input.ends_with("*") {
+        if raw_input.ends_with('*') {
             let prefix = &raw_input[0..raw_input.len() - 1];
             for input in candidates {
                 if input.starts_with(prefix) && input != name {

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -22,12 +22,14 @@ pub async fn build_unit_tests_main(
     build_unit_tests(config).await
 }
 
-async fn build_unit_tests(builder: ConfigBuilder) -> Result<Vec<UnitTest>, Vec<String>> {
+async fn build_unit_tests(mut builder: ConfigBuilder) -> Result<Vec<UnitTest>, Vec<String>> {
     let mut tests = vec![];
     let mut errors = vec![];
 
+    let expansions = super::compiler::expand_macros(&mut builder)?;
+
     // Don't let this escape since it's not validated
-    let mut config = Config {
+    let config = Config {
         global: builder.global,
         #[cfg(feature = "api")]
         api: builder.api,
@@ -36,10 +38,8 @@ async fn build_unit_tests(builder: ConfigBuilder) -> Result<Vec<UnitTest>, Vec<S
         sinks: builder.sinks,
         transforms: builder.transforms,
         tests: builder.tests,
-        expansions: Default::default(),
+        expansions,
     };
-
-    super::compiler::expand_macros(&mut config)?;
 
     for test in &config.tests {
         match build_unit_test(test, &config).await {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,7 +1,7 @@
-use super::{Config, DataType, Resource};
+use super::{builder::ConfigBuilder, DataType, Resource};
 use std::collections::HashMap;
 
-pub fn check_shape(config: &Config) -> Result<(), Vec<String>> {
+pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     let mut errors = vec![];
 
     if config.sources.is_empty() {
@@ -46,7 +46,7 @@ pub fn check_shape(config: &Config) -> Result<(), Vec<String>> {
     }
 }
 
-pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
+pub fn check_resources(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     let source_resources = config
         .sources
         .iter()
@@ -73,7 +73,7 @@ pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
     }
 }
 
-pub fn warnings(config: &Config) -> Vec<String> {
+pub fn warnings(config: &ConfigBuilder) -> Vec<String> {
     let mut warnings = vec![];
 
     let source_names = config.sources.keys().map(|name| ("source", name.clone()));
@@ -102,7 +102,7 @@ pub fn warnings(config: &Config) -> Vec<String> {
     warnings
 }
 
-pub fn typecheck(config: &Config) -> Result<(), Vec<String>> {
+pub fn typecheck(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     Graph::from(config).typecheck()
 }
 
@@ -223,8 +223,8 @@ impl Graph {
     }
 }
 
-impl From<&Config> for Graph {
-    fn from(config: &Config) -> Self {
+impl From<&ConfigBuilder> for Graph {
+    fn from(config: &ConfigBuilder) -> Self {
         let mut graph = Graph::default();
 
         // TODO: validate that node names are unique across sources/transforms/sinks?

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -8,8 +8,9 @@ async fn load(config: &str, format: config::FormatHint) -> Result<Vec<String>, V
     match config::load_from_str(config, format) {
         Ok(c) => {
             let diff = ConfigDiff::initial(&c);
+            let c2 = config::load_from_str(config, format).unwrap();
             match (
-                config::warnings(&c),
+                config::warnings(&c2.into()),
                 topology::builder::build_pieces(&c, &diff, HashMap::new()).await,
             ) {
                 (warnings, Ok(_pieces)) => Ok(warnings),


### PR DESCRIPTION
Closes #2550

This allows for very simple wildcards in input lists. The `*` must be the last character in the string and we do a simple prefix match against all valid inputs (i.e. self is excluded). We could choose to expand this to a more full-featured glob syntax in the future, but there were enough questions there that this seemed like a better start. It is also my expectation that this should cover >95% of valuable use cases, so it may well be all we ever need.

Signed-off-by: Luke Steensen <luke.steensen@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
