### PR TITLE
chore(external docs): Remove the mention of multiline support from kubernetes_logs

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -407,10 +407,12 @@ components: sources: kubernetes_logs: {
 		partial_message_merging: {
 			title: "Partial message merging"
 			body:  """
-					Vector, by default, will merge partial messages that are split due to the Docker
-					size limit. For everything else, the
-					[`kubernetes_logs` source](\(urls.vector_kubernetes_logs_source)) offers `multiline`
-					options to configure custom merging to handle merging things like stacktraces.
+					Vector, by default, will merge partial messages that are
+					split due to the Docker size limit. For everything else, it
+					is recommended to use the [`reduce`
+					transform](\(urls.vector_reduce_transform)) which offers
+					the ability to handle custom merging of things like
+					stacktraces.
 					"""
 		}
 

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -442,6 +442,7 @@ urls: {
 	vector_receiving_sources:                                 "\(vector_website)/components/?functions%5B%5D=receive"
 	vector_regex_parser:                                      "\(vector_website)/docs/reference/transforms/regex_parser/"
 	vector_releases:                                          "\(vector_website)/releases/latest/"
+	vector_reduce_transform:                                  "\(vector_website)/docs/reference/transforms/reduce/"
 	vector_remap_transform:                                   "\(vector_website)/docs/reference/transforms/remap/"
 	vector_repo:                                              "\(github)/timberio/vector"
 	vector_roadmap:                                           "https://roadmap.vector.dev"


### PR DESCRIPTION
This support was never added as
https://github.com/timberio/vector/issues/4211 was closed in-lieu of
https://github.com/timberio/vector/pull/4743

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
