### PR TITLE
chore(ci): Configure noise thresholds for metrics benchmarks

### DIFF
--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -99,6 +99,9 @@ fn bench_topology(c: &mut Criterion, bench_name: &'static str) {
 
     let mut group = c.benchmark_group(format!("{}/{}", bench_name, "topology"));
     group.sampling_mode(SamplingMode::Flat);
+    // Encapsulate noise seen in
+    // https://github.com/timberio/vector/runs/1746002475
+    group.noise_threshold(0.10);
 
     for &num_writers in [1, 2, 4, 8, 16].iter() {
         group.throughput(Throughput::Bytes(
@@ -180,6 +183,8 @@ fn bench_topology(c: &mut Criterion, bench_name: &'static str) {
 #[inline]
 fn bench_micro(c: &mut Criterion, bench_name: &'static str) {
     let mut group = c.benchmark_group(format!("{}/{}", bench_name, "micro"));
+    // https://github.com/timberio/vector/runs/1746002475
+    group.noise_threshold(0.05);
     group.bench_function("bare_counter", |b| {
         b.iter(|| {
             counter!("test", 1);

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -2,6 +2,8 @@ use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 
 fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("metrics_snapshot");
+    // https://github.com/timberio/vector/runs/1746002475
+    group.noise_threshold(0.02);
     for &cardinality in [0, 1, 10, 100, 1000, 10000].iter() {
         group.bench_with_input(
             BenchmarkId::new("cardinality", cardinality),


### PR DESCRIPTION
Based on
https://github.com/timberio/vector/runs/1746002475

We can refine these, but this should give us a starting point.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
