### PR TITLE
chore(ci): Only upload benchmark artifacts on master

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -87,6 +87,7 @@ jobs:
           path: "./target/criterion.zip"
       - name: Upload criterion data to S3
         run: scripts/upload-benchmarks-s3.sh
+        if: github.ref == 'refs/heads/master'
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
I don't think these are useful for branches, but this specifically
addresses the issue that this check always fails for PRs from forked
repos as they don't have access to the AWS secrets.

Closes https://github.com/timberio/vector/issues/6131

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
