### PR TITLE
chore: Use experimental metrics with smallvec-based tracing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,9 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.13.0-alpha.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efcf562c6940683fdd0dad97c99a0cef222d3738283d3396a735e8d21190e685"
+version = "0.13.1"
+source = "git+https://github.com/MOZGIII/metrics?rev=9b4835bd7ac2f74eff97f86869812750e2846cb9#9b4835bd7ac2f74eff97f86869812750e2846cb9"
 dependencies = [
  "metrics-macros",
  "proc-macro-hack",
@@ -3657,9 +3656,8 @@ dependencies = [
 
 [[package]]
 name = "metrics-macros"
-version = "0.1.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0197e48db63aa8c28f9fbae021585b8f1b299a0b21640cf98853211ac39eb294"
+version = "0.1.0"
+source = "git+https://github.com/MOZGIII/metrics?rev=9b4835bd7ac2f74eff97f86869812750e2846cb9#9b4835bd7ac2f74eff97f86869812750e2846cb9"
 dependencies = [
  "lazy_static",
  "proc-macro-hack",
@@ -3671,13 +3669,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-tracing-context"
-version = "0.1.0-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b8dc2ecc84c1a248ee1d7f08e8bc537b406aab1c74c1a85d78634517ecddac"
+version = "0.2.0"
+source = "git+https://github.com/MOZGIII/metrics?rev=9b4835bd7ac2f74eff97f86869812750e2846cb9#9b4835bd7ac2f74eff97f86869812750e2846cb9"
 dependencies = [
  "itoa",
  "metrics",
  "metrics-util",
+ "smallvec",
  "tracing 0.1.22",
  "tracing-core 0.1.17",
  "tracing-subscriber",
@@ -3685,17 +3683,17 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.4.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee65f4f3f55b356086562ebfe47e76b61de5ed305ae86f1b65fb7f068f8b1546"
+version = "0.5.0"
+source = "git+https://github.com/MOZGIII/metrics?rev=9b4835bd7ac2f74eff97f86869812750e2846cb9#9b4835bd7ac2f74eff97f86869812750e2846cb9"
 dependencies = [
  "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch 0.9.1",
  "crossbeam-utils 0.8.1",
- "dashmap 3.11.10",
+ "dashmap 4.0.2",
  "indexmap",
  "metrics",
+ "ordered-float",
  "parking_lot 0.11.1",
  "quanta",
  "sketches-ddsketch",
@@ -4885,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9a7776952c6405aab84c51621523a5e053aa6fd63c8f8e8eeaaed79ad6d2dc"
+checksum = "7d2a052c2c109818fafdee6247e74faaf18135e0236709e6a5eb58c775758f15"
 dependencies = [
  "atomic-shim",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,9 @@ tracing-log = "0.1.0"
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", rev = "f470db1b0354b368f62f9ee4d763595d16373231" }
 
 # Metrics
-metrics = "0.13.0-alpha.13"
-metrics-util = "0.4.0-alpha.10"
-metrics-tracing-context = "0.1.0-alpha.7"
+metrics = { version = "0.13.1", git = "https://github.com/MOZGIII/metrics", rev = "9b4835bd7ac2f74eff97f86869812750e2846cb9" }
+metrics-util = { version = "0.5.0", git = "https://github.com/MOZGIII/metrics", rev = "9b4835bd7ac2f74eff97f86869812750e2846cb9" }
+metrics-tracing-context = { version = "0.2.0", git = "https://github.com/MOZGIII/metrics", rev = "9b4835bd7ac2f74eff97f86869812750e2846cb9" }
 
 # Aws
 rusoto_core = { version = "0.45.0", features = ["encoding"], optional = true }

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -5,10 +5,9 @@
 //!
 //! # Usage
 //!
-//! To run these benches, use the following commands:
+//! To run these benches, use the following command:
 //!
-//!     cargo bench --no-default-features --features "metrics-benches" --bench metrics_on
-//!     cargo bench --no-default-features --features "metrics-benches" --bench metrics_off
+//!     cargo bench --no-default-features --features "metrics-benches"
 //!
 //! These will run benches with metrics core system on and off respectively.
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,7 +22,7 @@ static CARDINALITY_KEY_DATA_NAME: [SharedString; 1] =
     [SharedString::const_str(&CARDINALITY_KEY_NAME)];
 static CARDINALITY_KEY_DATA: KeyData = KeyData::from_static_name(&CARDINALITY_KEY_DATA_NAME);
 static CARDINALITY_KEY: CompositeKey =
-    CompositeKey::new(MetricKind::COUNTER, Key::Borrowed(&CARDINALITY_KEY_DATA));
+    CompositeKey::new(MetricKind::Counter, Key::Borrowed(&CARDINALITY_KEY_DATA));
 
 fn metrics_enabled() -> bool {
     !matches!(std::env::var("DISABLE_INTERNAL_METRICS_CORE"), Ok(x) if x == "true")
@@ -149,7 +149,7 @@ impl VectorRecorder {
 
 impl Recorder for VectorRecorder {
     fn register_counter(&self, key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {
-        let ckey = CompositeKey::new(MetricKind::COUNTER, key);
+        let ckey = CompositeKey::new(MetricKind::Counter, key);
         self.registry.op(
             ckey,
             |_| {},
@@ -157,7 +157,7 @@ impl Recorder for VectorRecorder {
         )
     }
     fn register_gauge(&self, key: Key, _unit: Option<Unit>, _description: Option<&'static str>) {
-        let ckey = CompositeKey::new(MetricKind::GAUGE, key);
+        let ckey = CompositeKey::new(MetricKind::Gauge, key);
         self.registry.op(
             ckey,
             |_| {},
@@ -170,7 +170,7 @@ impl Recorder for VectorRecorder {
         _unit: Option<Unit>,
         _description: Option<&'static str>,
     ) {
-        let ckey = CompositeKey::new(MetricKind::HISTOGRAM, key);
+        let ckey = CompositeKey::new(MetricKind::Histogram, key);
         self.registry.op(
             ckey,
             |_| {},
@@ -179,7 +179,7 @@ impl Recorder for VectorRecorder {
     }
 
     fn increment_counter(&self, key: Key, value: u64) {
-        let ckey = CompositeKey::new(MetricKind::COUNTER, key);
+        let ckey = CompositeKey::new(MetricKind::Counter, key);
         self.registry.op(
             ckey,
             |handle| handle.increment_counter(value),
@@ -187,7 +187,7 @@ impl Recorder for VectorRecorder {
         )
     }
     fn update_gauge(&self, key: Key, value: GaugeValue) {
-        let ckey = CompositeKey::new(MetricKind::GAUGE, key);
+        let ckey = CompositeKey::new(MetricKind::Gauge, key);
         self.registry.op(
             ckey,
             |handle| handle.update_gauge(value),
@@ -195,7 +195,7 @@ impl Recorder for VectorRecorder {
         )
     }
     fn record_histogram(&self, key: Key, value: f64) {
-        let ckey = CompositeKey::new(MetricKind::HISTOGRAM, key);
+        let ckey = CompositeKey::new(MetricKind::Histogram, key);
         self.registry.op(
             ckey,
             |handle| handle.record_histogram(value),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -52,7 +52,7 @@ pub fn init(color: bool, json: bool, levels: &str) {
             .finish()
             .with(Limit::default());
         if metrics_layer_enabled {
-            let formatter = formatter.with(MetricsLayer::new());
+            let formatter = formatter.with(MetricsLayer::all());
             Dispatch::new(BroadcastSubscriber { formatter })
         } else {
             Dispatch::new(BroadcastSubscriber { formatter })
@@ -64,7 +64,7 @@ pub fn init(color: bool, json: bool, levels: &str) {
             .finish()
             .with(Limit::default());
         if metrics_layer_enabled {
-            let formatter = formatter.with(MetricsLayer::new());
+            let formatter = formatter.with(MetricsLayer::all());
             Dispatch::new(BroadcastSubscriber { formatter })
         } else {
             Dispatch::new(BroadcastSubscriber { formatter })


### PR DESCRIPTION
This PR is currently for the purposes of collecting benches only.

---

Just throwing these in from my local system to look at later:

```
group                                                                    branch                                 master
-----                                                                    ------                                 ------
metrics_no_tracing_integration/micro/bare_counter                        1.00     72.3±0.31ns        ? B/sec    1.00     72.5±0.73ns        ? B/sec
metrics_no_tracing_integration/micro/bare_counter_with_dynamic_labels    1.01    141.5±2.35ns        ? B/sec    1.00    140.6±1.95ns        ? B/sec
metrics_no_tracing_integration/micro/bare_counter_with_static_labels     1.00     91.2±0.46ns        ? B/sec    1.03     93.7±0.64ns        ? B/sec
metrics_no_tracing_integration/micro/span_enter_without_counter          1.00    190.0±2.56ns        ? B/sec    1.01    192.6±2.06ns        ? B/sec
metrics_no_tracing_integration/micro/span_no_labels                      1.00    266.2±3.19ns        ? B/sec    1.03   274.8±13.04ns        ? B/sec
metrics_no_tracing_integration/micro/span_with_1_dynamic_label           1.00    266.2±3.00ns        ? B/sec    1.00    266.4±7.53ns        ? B/sec
metrics_no_tracing_integration/micro/span_with_1_static_label            1.00    264.4±5.06ns        ? B/sec    1.03    271.7±6.00ns        ? B/sec
metrics_no_tracing_integration/micro/span_with_2_dynamic_labels          1.00    264.1±4.20ns        ? B/sec    1.01    266.9±4.16ns        ? B/sec
metrics_no_tracing_integration/micro/span_with_2_static_labels           1.00    271.1±5.53ns        ? B/sec    1.00   270.6±14.83ns        ? B/sec
metrics_no_tracing_integration/micro/ununsed_span                        1.00     74.8±1.43ns        ? B/sec    0.99     74.1±0.77ns        ? B/sec
metrics_no_tracing_integration/topology/tcp_socket/01_writer             1.02     22.4±4.64ms    42.7 MB/sec    1.00     21.8±3.38ms    43.7 MB/sec
metrics_no_tracing_integration/topology/tcp_socket/02_writers            1.27    57.4±25.90ms    33.2 MB/sec    1.00    45.3±17.05ms    42.1 MB/sec
metrics_no_tracing_integration/topology/tcp_socket/04_writers            1.05    68.7±18.76ms    55.5 MB/sec    1.00    65.2±26.93ms    58.5 MB/sec
metrics_no_tracing_integration/topology/tcp_socket/08_writers            1.04   119.4±21.53ms    63.9 MB/sec    1.00   115.2±13.89ms    66.2 MB/sec
metrics_no_tracing_integration/topology/tcp_socket/16_writers            1.00    242.0±7.02ms    63.1 MB/sec    1.00    241.0±5.59ms    63.3 MB/sec
metrics_off/micro/bare_counter                                           1.00      3.3±0.03ns        ? B/sec    0.93      3.0±0.05ns        ? B/sec
metrics_off/micro/bare_counter_with_dynamic_labels                       1.00     49.1±1.21ns        ? B/sec    1.02     50.1±1.71ns        ? B/sec
metrics_off/micro/bare_counter_with_static_labels                        1.20      3.4±0.04ns        ? B/sec    1.00      2.8±0.05ns        ? B/sec
metrics_off/micro/span_enter_without_counter                             1.00    189.4±2.17ns        ? B/sec    1.04    196.3±6.01ns        ? B/sec
metrics_off/micro/span_no_labels                                         1.04    199.1±3.82ns        ? B/sec    1.00    191.9±3.33ns        ? B/sec
metrics_off/micro/span_with_1_dynamic_label                              1.01    194.8±4.81ns        ? B/sec    1.00    192.8±4.67ns        ? B/sec
metrics_off/micro/span_with_1_static_label                               1.01    194.8±4.20ns        ? B/sec    1.00    193.3±5.67ns        ? B/sec
metrics_off/micro/span_with_2_dynamic_labels                             1.02   199.6±13.11ns        ? B/sec    1.00    194.8±7.08ns        ? B/sec
metrics_off/micro/span_with_2_static_labels                              1.00    193.1±5.96ns        ? B/sec    1.01    194.7±4.61ns        ? B/sec
metrics_off/micro/ununsed_span                                           1.25      3.6±0.17ns        ? B/sec    1.00      2.9±0.48ns        ? B/sec
metrics_off/topology/tcp_socket/01_writer                                1.00     20.3±4.02ms    47.0 MB/sec    1.00     20.4±3.97ms    46.8 MB/sec
metrics_off/topology/tcp_socket/02_writers                               1.00    47.2±20.39ms    40.4 MB/sec    1.08    51.2±23.92ms    37.2 MB/sec
metrics_off/topology/tcp_socket/04_writers                               1.08    80.2±26.85ms    47.6 MB/sec    1.00    74.4±36.51ms    51.2 MB/sec
metrics_off/topology/tcp_socket/08_writers                               1.05   124.4±40.03ms    61.3 MB/sec    1.00   118.2±30.58ms    64.5 MB/sec
metrics_off/topology/tcp_socket/16_writers                               1.00    236.2±3.92ms    64.6 MB/sec    1.00    237.3±4.25ms    64.3 MB/sec
metrics_on/micro/bare_counter                                            1.04    149.8±3.28ns        ? B/sec    1.00    143.9±4.56ns        ? B/sec
metrics_on/micro/bare_counter_with_dynamic_labels                        1.05   212.9±15.97ns        ? B/sec    1.00    202.9±4.21ns        ? B/sec
metrics_on/micro/bare_counter_with_static_labels                         1.02   182.8±16.65ns        ? B/sec    1.00    179.8±2.74ns        ? B/sec
metrics_on/micro/span_enter_without_counter                              1.01    194.1±3.16ns        ? B/sec    1.00    193.1±3.93ns        ? B/sec
metrics_on/micro/span_no_labels                                          1.07   583.1±24.07ns        ? B/sec    1.00   543.4±14.84ns        ? B/sec
metrics_on/micro/span_with_1_dynamic_label                               1.10   591.3±36.93ns        ? B/sec    1.00    537.0±7.06ns        ? B/sec
metrics_on/micro/span_with_1_static_label                                1.10   595.5±41.73ns        ? B/sec    1.00   539.2±10.27ns        ? B/sec
metrics_on/micro/span_with_2_dynamic_labels                              1.10   601.0±34.70ns        ? B/sec    1.00   545.1±10.13ns        ? B/sec
metrics_on/micro/span_with_2_static_labels                               1.09   601.8±41.26ns        ? B/sec    1.00   553.6±12.17ns        ? B/sec
metrics_on/micro/ununsed_span                                            1.05    153.2±6.15ns        ? B/sec    1.00    145.7±3.78ns        ? B/sec
metrics_on/topology/tcp_socket/01_writer                                 1.00     23.9±4.41ms    39.9 MB/sec    1.01     24.2±3.99ms    39.4 MB/sec
metrics_on/topology/tcp_socket/02_writers                                1.06    50.1±21.72ms    38.1 MB/sec    1.00    47.2±18.70ms    40.4 MB/sec
metrics_on/topology/tcp_socket/04_writers                                1.00    61.7±18.43ms    61.8 MB/sec    1.09    67.4±21.04ms    56.6 MB/sec
metrics_on/topology/tcp_socket/08_writers                                1.07   125.3±31.22ms    60.9 MB/sec    1.00   116.8±10.44ms    65.3 MB/sec
metrics_on/topology/tcp_socket/16_writers                                1.00    243.1±7.31ms    62.8 MB/sec    1.01   245.6±10.20ms    62.1 MB/sec

```