### PR TITLE
fix(remap): fix field sublocation_type in parse_aws_vpc_flow_log

### DIFF
--- a/lib/remap-functions/src/parse_aws_vpc_flow_log.rs
+++ b/lib/remap-functions/src/parse_aws_vpc_flow_log.rs
@@ -132,7 +132,7 @@ fn parse_log(input: &str, format: Option<&str>) -> ParseResult<Value> {
                     "pkt_dstaddr" => identity,
                     "region" => identity,
                     "az_id" => identity,
-                    "sublocation_type  " => identity,
+                    "sublocation_type" => identity,
                     "sublocation_id" => identity
                 );
 


### PR DESCRIPTION
Introduced in initial PR: https://github.com/timberio/vector/pull/5504