### PR TITLE
chore(external docs): Comprehensive component examples

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -70,24 +70,36 @@ components: {
 			context?: string
 			"configuration": {
 				for k, v in configuration {
-					"\( k )"?: _ | *null
+					if v.required {
+						"\( k )": _
+					}
+
+					if !v.required {
+						"\( k )"?: _ | *null
+					}
+				}
+
+				"type": type
+
+				if configuration.inputs != _|_ {
+					inputs: ["component_id"]
 				}
 			}
 
 			if Kind == "source" {
-				input: string
+				input?: string
 			}
 
 			if Kind != "source" {
-				input: #Event | [#Event, ...#Event]
+				input?: #Event | [#Event, ...#Event]
 			}
 
 			if Kind == "sink" {
-				output: string
+				output?: string
 			}
 
 			if Kind != "sink" {
-				output: #Event | [#Event, ...#Event] | null
+				output?: #Event | [#Event, ...#Event] | null
 			}
 
 			notes?: string

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -147,7 +147,7 @@ components: sinks: [Name=string]: {
 							}
 						}
 
-						if sinks[Name].features.healthcheck.enabled {except_fields: {
+						except_fields: {
 							common:      false
 							description: "Prevent the sink from encoding the specified labels."
 							required:    false
@@ -157,26 +157,25 @@ components: sinks: [Name=string]: {
 							}
 						}
 
-							only_fields: {
-								common:      false
-								description: "Prevent the sink from encoding the specified labels."
-								required:    false
-								type: array: {
-									default: null
-									items: type: string: examples: ["message", "parent.child"]
-								}
+						only_fields: {
+							common:      false
+							description: "Prevent the sink from encoding the specified labels."
+							required:    false
+							type: array: {
+								default: null
+								items: type: string: examples: ["message", "parent.child"]
 							}
+						}
 
-							timestamp_format: {
-								common:      false
-								description: "How to format event timestamps."
-								required:    false
-								type: string: {
-									default: "rfc3339"
-									enum: {
-										rfc3339: "Formats as a RFC3339 string"
-										unix:    "Formats as a unix timestamp"
-									}
+						timestamp_format: {
+							common:      false
+							description: "How to format event timestamps."
+							required:    false
+							type: string: {
+								default: "rfc3339"
+								enum: {
+									rfc3339: "Formats as a RFC3339 string"
+									unix:    "Formats as a unix timestamp"
 								}
 							}
 						}

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -23,10 +23,7 @@ components: sinks: influxdb_metrics: {
 				timeout_secs: 1
 			}
 			compression: enabled: false
-			encoding: {
-				enabled: true
-				codec: enabled: false
-			}
+			encoding: enabled:    false
 			request: {
 				enabled:                    true
 				concurrency:                5
@@ -92,8 +89,13 @@ components: sinks: influxdb_metrics: {
 			_name:  "logins"
 			_value: 1.5
 			title:  "Counter"
-			configuration: {
+			"configuration": {
+				bucket:            configuration.bucket.type.string.examples[0]
+				database:          configuration.database.type.string.examples[0]
 				default_namespace: "service"
+				endpoint:          configuration.endpoint.type.string.examples[0]
+				org:               configuration.org.type.string.examples[0]
+				token:             configuration.token.type.string.examples[0]
 			}
 			input: metric: {
 				kind: "incremental"
@@ -112,7 +114,13 @@ components: sinks: influxdb_metrics: {
 			_name: "sparse_stats"
 			title: "Distribution"
 			notes: "For distributions with histogram, summary is computed."
-			configuration: {}
+			"configuration": {
+				bucket:   configuration.bucket.type.string.examples[0]
+				database: configuration.database.type.string.examples[0]
+				endpoint: configuration.endpoint.type.string.examples[0]
+				org:      configuration.org.type.string.examples[0]
+				token:    configuration.token.type.string.examples[0]
+			}
 			input: metric: {
 				kind:      "incremental"
 				name:      _name
@@ -136,8 +144,13 @@ components: sinks: influxdb_metrics: {
 			_name:  "memory_rss"
 			_value: 1.5
 			title:  "Gauge"
-			configuration: {
+			"configuration": {
+				bucket:            configuration.bucket.type.string.examples[0]
+				database:          configuration.database.type.string.examples[0]
 				default_namespace: "service"
+				endpoint:          configuration.endpoint.type.string.examples[0]
+				org:               configuration.org.type.string.examples[0]
+				token:             configuration.token.type.string.examples[0]
 			}
 			input: metric: {
 				kind:      "absolute"
@@ -156,7 +169,14 @@ components: sinks: influxdb_metrics: {
 			_host: _values.local_host
 			_name: "requests"
 			title: "Histogram"
-			configuration: {}
+			"configuration": {
+				bucket:            configuration.bucket.type.string.examples[0]
+				database:          configuration.database.type.string.examples[0]
+				default_namespace: "service"
+				endpoint:          configuration.endpoint.type.string.examples[0]
+				org:               configuration.org.type.string.examples[0]
+				token:             configuration.token.type.string.examples[0]
+			}
 			input: metric: {
 				kind: "absolute"
 				name: _name
@@ -180,7 +200,14 @@ components: sinks: influxdb_metrics: {
 			_name:  "users"
 			_value: 1.5
 			title:  "Set"
-			configuration: {}
+			"configuration": {
+				bucket:            configuration.bucket.type.string.examples[0]
+				database:          configuration.database.type.string.examples[0]
+				default_namespace: "service"
+				endpoint:          configuration.endpoint.type.string.examples[0]
+				org:               configuration.org.type.string.examples[0]
+				token:             configuration.token.type.string.examples[0]
+			}
 			input: metric: {
 				kind: "incremental"
 				name: _name
@@ -197,7 +224,14 @@ components: sinks: influxdb_metrics: {
 			_host: _values.local_host
 			_name: "requests"
 			title: "Summary"
-			configuration: {}
+			"configuration": {
+				bucket:            configuration.bucket.type.string.examples[0]
+				database:          configuration.database.type.string.examples[0]
+				default_namespace: "service"
+				endpoint:          configuration.endpoint.type.string.examples[0]
+				org:               configuration.org.type.string.examples[0]
+				token:             configuration.token.type.string.examples[0]
+			}
 			input: metric: {
 				kind: "absolute"
 				name: _name

--- a/docs/reference/components/sinks/prometheus_exporter.cue
+++ b/docs/reference/components/sinks/prometheus_exporter.cue
@@ -143,7 +143,8 @@ components: sinks: prometheus_exporter: {
 			_namespace: "service"
 			_value:     1.5
 			title:      "Counter"
-			configuration: {
+			"configuration": {
+				address:           configuration.address.type.string.examples[0]
 				default_namespace: _namespace
 			}
 			input: metric: {
@@ -168,7 +169,9 @@ components: sinks: prometheus_exporter: {
 			_namespace: "app"
 			_value:     1.5
 			title:      "Gauge"
-			configuration: {}
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
+			}
 			input: metric: {
 				kind:      "absolute"
 				name:      _name
@@ -190,7 +193,8 @@ components: sinks: prometheus_exporter: {
 			_host: _values.local_host
 			_name: "response_time_s"
 			title: "Histogram"
-			configuration: {
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
 			}
 			input: metric: {
 				kind: "absolute"
@@ -237,7 +241,8 @@ components: sinks: prometheus_exporter: {
 			_name: "request_retries"
 			title: "Distribution to histogram"
 			notes: "Histogram will be computed out of values and then passed to prometheus."
-			configuration: {
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
 				buckets: [0.0, 1.0, 3.0]
 			}
 			input: metric: {
@@ -271,7 +276,8 @@ components: sinks: prometheus_exporter: {
 			_name: "request_retries"
 			title: "Distribution to summary"
 			notes: "Summary will be computed out of values and then passed to prometheus."
-			configuration: {
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
 				quantiles: [0.5, 0.75, 0.95]
 			}
 			input: metric: {
@@ -303,7 +309,9 @@ components: sinks: prometheus_exporter: {
 			_host: _values.local_host
 			_name: "requests"
 			title: "Summary"
-			configuration: {}
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
+			}
 			input: metric: {
 				name: _name
 				kind: "absolute"

--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -85,6 +85,23 @@ components: sources: apache_metrics: {
 		}
 	}
 
+	examples: [
+		{
+			title: "Collect Apache server metrics (default)"
+			"configuration": {
+				endpoints: [configuration.endpoints.type.array.items.type.string.examples[0]]
+			}
+		},
+		{
+			title: "Collect Apache server metrics (explicit)"
+			"configuration": {
+				endpoints: [configuration.endpoints.type.array.items.type.string.examples[0]]
+				scrape_interval_secs: configuration.scrape_interval_secs.type.uint.default
+				namespace:            configuration.namespace.type.string.default
+			}
+		},
+	]
+
 	output: metrics: {
 		// Default Apache metrics tags
 		_apache_metrics_tags: {

--- a/docs/reference/components/sources/socket.cue
+++ b/docs/reference/components/sources/socket.cue
@@ -60,11 +60,13 @@ components: sources: socket: {
 
 	configuration: {
 		address: {
+			common:        true
 			description:   "The address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd socket activation. If an address is used it _must_ include a port."
 			relevant_when: "mode = `tcp` or `udp`"
-			required:      true
+			required:      false
 			warnings: []
 			type: string: {
+				default: null
 				examples: ["0.0.0.0:\(_port)", "systemd", "systemd#3"]
 			}
 		}
@@ -102,11 +104,13 @@ components: sources: socket: {
 			}
 		}
 		path: {
+			common:        true
 			description:   "The unix socket path. *This should be an absolute path*."
 			relevant_when: "mode = `unix`"
-			required:      true
+			required:      false
 			warnings: []
 			type: string: {
+				default: null
 				examples: ["/path/to/socket"]
 			}
 		}
@@ -138,7 +142,10 @@ components: sources: socket: {
 				2019-02-13T19:48:34+00:00 [info] Started GET "/" for 127.0.0.1
 				"""
 			title: "Socket line"
-			configuration: {}
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
+				mode:    "tcp"
+			}
 			input: """
 				```text
 				\( _line )

--- a/docs/reference/components/sources/syslog.cue
+++ b/docs/reference/components/sources/syslog.cue
@@ -137,7 +137,10 @@ components: sources: syslog: {
 			_procid:       "2426"
 			_timestamp:    "2020-03-13T20:45:38.119Z"
 			title:         "Syslog Eve"
-			configuration: {}
+			"configuration": {
+				address: configuration.address.type.string.examples[0]
+				mode:    'tcp'
+			}
 			input: """
 				```text
 				<13>1 \(_timestamp) \(_hostname) \(_app_name) \(_procid) \(_msgid) [exampleSDID@32473 iut="\(_iut)" eventSource="\(_event_source)" eventID="\(_event_id)"] \(_message)

--- a/docs/reference/components/transforms/lua.cue
+++ b/docs/reference/components/transforms/lua.cue
@@ -222,6 +222,7 @@ components: transforms: lua: {
 		{
 			title: "Add, rename, & remove log fields"
 			configuration: {
+				version: 2
 				hooks: process: """
 					function (event, emit)
 					  -- Add root level field
@@ -254,6 +255,7 @@ components: transforms: lua: {
 		{
 			title: "Add, rename, remove metric tags"
 			configuration: {
+				version: 2
 				hooks: process: """
 					function (event, emit)
 					  -- Add tag
@@ -296,6 +298,7 @@ components: transforms: lua: {
 		{
 			title: "Drop an event"
 			configuration: {
+				version: 2
 				hooks: process: """
 					function (event, emit)
 					  -- Drop event entirely by not calling the `emit` function
@@ -311,6 +314,7 @@ components: transforms: lua: {
 		{
 			title: "Iterate over log fields"
 			configuration: {
+				version: 2
 				hooks: process: """
 					function (event, emit)
 					  -- Remove all fields where the value is "-"
@@ -335,6 +339,7 @@ components: transforms: lua: {
 		{
 			title: "Parse timestamps"
 			configuration: {
+				version: 2
 				hooks: {
 					init: """
 						-- Parse timestamps like `2020-04-07 06:26:02.643`
@@ -376,6 +381,7 @@ components: transforms: lua: {
 		{
 			title: "Count the number of logs"
 			configuration: {
+				version: 2
 				hooks: {
 					init:     "init"
 					process:  "process"

--- a/docs/reference/components/transforms/tag_cardinality_limit.cue
+++ b/docs/reference/components/transforms/tag_cardinality_limit.cue
@@ -109,6 +109,7 @@ components: transforms: tag_cardinality_limit: {
 					value_limit:           1
 					limit_exceeded_action: "drop_tag"
 				}
+				mode: "probablistic"
 			}
 			input: [
 				{metric: {


### PR DESCRIPTION
This PR introduces explicit component examples directly in the cue data. The intent is to replace our contrived examples with ones written by humans.

The website code used to derive user-friendly component examples is some of the most complicated code in the website, and it will make transitioning to a new site difficult. Adding explicit examples in the data itself makes all of this much simpler, avoiding the need for complicated code to derive configuration examples from the configuration option metadata.