### PR TITLE
chore(remap): condition without subfields is set to Remap source

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -68,7 +68,7 @@ mod tests {
     fn deserialize_anycondition_default() {
         let conf: Test = toml::from_str(r#"condition = ".nork == false""#).unwrap();
         assert_eq!(
-            r#"String(".nork == false""#,
+            r#"String(".nork == false")"#,
             format!("{:?}", conf.condition)
         )
     }
@@ -82,7 +82,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            r#"Map(CheckFieldsConfig { predicates: {"norg.equals": "nork"} }"#,
+            r#"Map(CheckFieldsConfig { predicates: {"norg.equals": "nork"} })"#,
             format!("{:?}", conf.condition)
         )
     }
@@ -96,7 +96,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            r#"Map(RemapConfig { source: ".nork == true" }"#,
+            r#"Map(RemapConfig { source: ".nork == true" })"#,
             format!("{:?}", conf.condition)
         )
     }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -57,6 +57,7 @@ impl AnyCondition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[derive(Deserialize, Debug)]
     struct Test {
@@ -67,36 +68,36 @@ mod tests {
     fn deserialize_anycondition_default() {
         let conf: Test = toml::from_str(r#"condition = ".nork == false""#).unwrap();
         assert_eq!(
-            "Test { condition: String(\".nork == false\") }",
-            format!("{:?}", conf)
+            r#"String(".nork == false""#,
+            format!("{:?}", conf.condition)
         )
     }
 
     #[test]
     fn deserialize_anycondition_check_fields() {
-        let conf: Test = toml::from_str(
-            r#"condition.type = "check_fields"
-               condition."norg.equals" = "nork""#,
-        )
+        let conf: Test = toml::from_str(indoc! {r#"
+            condition.type = "check_fields"
+            condition."norg.equals" = "nork"
+        "#})
         .unwrap();
 
         assert_eq!(
-            "Test { condition: Map(CheckFieldsConfig { predicates: {\"norg.equals\": \"nork\"} }) }",
-            format!("{:?}", conf)
+            r#"Map(CheckFieldsConfig { predicates: {"norg.equals": "nork"} }"#,
+            format!("{:?}", conf.condition)
         )
     }
 
     #[test]
     fn deserialize_anycondition_remap() {
-        let conf: Test = toml::from_str(
-            r#"condition.type = "remap"
-               condition.source = '.nork == true'"#,
-        )
+        let conf: Test = toml::from_str(indoc! {r#"
+            condition.type = "remap"
+            condition.source = '.nork == true'
+        "#})
         .unwrap();
 
         assert_eq!(
-            "Test { condition: Map(RemapConfig { source: \".nork == true\" }) }",
-            format!("{:?}", conf)
+            r#"Map(RemapConfig { source: ".nork == true" }"#,
+            format!("{:?}", conf.condition)
         )
     }
 }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,5 +1,6 @@
 use crate::config::component::ComponentDescription;
 use crate::Event;
+use serde::{Deserialize, Serialize};
 
 pub mod check_fields;
 pub mod is_log;
@@ -7,6 +8,8 @@ pub mod is_metric;
 pub mod remap;
 
 pub use check_fields::CheckFieldsConfig;
+
+use self::remap::RemapConfig;
 
 pub trait Condition: Send + Sync + dyn_clone::DynClone {
     fn check(&self, e: &Event) -> bool;
@@ -34,3 +37,66 @@ dyn_clone::clone_trait_object!(ConditionConfig);
 pub type ConditionDescription = ComponentDescription<Box<dyn ConditionConfig>>;
 
 inventory::collect!(ConditionDescription);
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum AnyCondition {
+    String(String),
+    Map(Box<dyn ConditionConfig>),
+}
+
+impl AnyCondition {
+    pub fn build(&self) -> crate::Result<Box<dyn Condition>> {
+        match self {
+            AnyCondition::String(s) => RemapConfig { source: s.clone() }.build(),
+            AnyCondition::Map(m) => m.build(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize, Debug)]
+    struct Test {
+        condition: AnyCondition,
+    }
+
+    #[test]
+    fn deserialize_anycondition_default() {
+        let conf: Test = toml::from_str(r#"condition = ".nork == false""#).unwrap();
+        assert_eq!(
+            "Test { condition: String(\".nork == false\") }",
+            format!("{:?}", conf)
+        )
+    }
+
+    #[test]
+    fn deserialize_anycondition_check_fields() {
+        let conf: Test = toml::from_str(
+            r#"condition.type = "check_fields"
+               condition."norg.equals" = "nork""#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            "Test { condition: Map(CheckFieldsConfig { predicates: {\"norg.equals\": \"nork\"} }) }",
+            format!("{:?}", conf)
+        )
+    }
+
+    #[test]
+    fn deserialize_anycondition_remap() {
+        let conf: Test = toml::from_str(
+            r#"condition.type = "remap"
+               condition.source = '.nork == true'"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            "Test { condition: Map(RemapConfig { source: \".nork == true\" }) }",
+            format!("{:?}", conf)
+        )
+    }
+}

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -7,9 +7,9 @@ use crate::{
 use remap::{value, Program, Runtime, TypeConstraint, TypeDef, Value};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 pub struct RemapConfig {
-    source: String,
+    pub source: String,
 }
 
 inventory::submit! {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -495,15 +495,7 @@ fn default_test_input_type() -> String {
 #[serde(deny_unknown_fields)]
 pub struct TestOutput {
     pub extract_from: String,
-    pub conditions: Option<Vec<TestCondition>>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-pub enum TestCondition {
-    Embedded(Box<dyn conditions::ConditionConfig>),
-    NoTypeEmbedded(conditions::CheckFieldsConfig),
-    String(String),
+    pub conditions: Option<Vec<conditions::AnyCondition>>,
 }
 
 impl Config {

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -1,7 +1,7 @@
-use super::{Config, ConfigBuilder, TestCondition, TestDefinition, TestInput, TestInputValue};
+use super::{Config, ConfigBuilder, TestDefinition, TestInput, TestInputValue};
 use crate::config::{self, TransformConfig};
 use crate::{
-    conditions::{Condition, ConditionConfig},
+    conditions::Condition,
     event::{Event, Value},
     transforms::Transform,
 };
@@ -503,37 +503,15 @@ async fn build_unit_test(
                 .iter()
                 .enumerate()
             {
-                match cond_conf {
-                    TestCondition::Embedded(b) => match b.build() {
-                        Ok(c) => {
-                            conditions.push(c);
-                        }
-                        Err(e) => {
-                            errors.push(format!(
-                                "failed to create test condition '{}': {}",
-                                index, e,
-                            ));
-                        }
-                    },
-                    TestCondition::NoTypeEmbedded(n) => match n.build() {
-                        Ok(c) => {
-                            conditions.push(c);
-                        }
-                        Err(e) => {
-                            errors.push(format!(
-                                "failed to create test condition '{}': {}",
-                                index, e,
-                            ));
-                        }
-                    },
-                    TestCondition::String(_s) => {
-                        errors.push(format!(
-                            "failed to create test condition '{}': condition references are not yet supported",
-                            index
-                        ));
-                    }
+                match cond_conf.build() {
+                    Ok(c) => conditions.push(c),
+                    Err(e) => errors.push(format!(
+                        "failed to create test condition '{}': {}",
+                        index, e,
+                    )),
                 }
             }
+
             UnitTestCheck {
                 extract_from: o.extract_from.clone(),
                 conditions,

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{Condition, ConditionConfig},
+    conditions::{AnyCondition, Condition},
     config::{DataType, GenerateConfig, TransformConfig, TransformDescription},
     event::Event,
     internal_events::{FilterEventDiscarded, FilterEventProcessed},
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 struct FilterConfig {
-    condition: Box<dyn ConditionConfig>,
+    condition: AnyCondition,
 }
 
 inventory::submit! {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{Condition, ConditionConfig},
+    conditions::{AnyCondition, Condition},
     config::{DataType, TransformConfig, TransformDescription},
     event::discriminant::Discriminant,
     event::{Event, LogEvent},
@@ -39,8 +39,8 @@ pub struct ReduceConfig {
 
     /// An optional condition that determines when an event is the end of a
     /// reduce.
-    pub ends_when: Option<Box<dyn ConditionConfig>>,
-    pub starts_when: Option<Box<dyn ConditionConfig>>,
+    pub ends_when: Option<AnyCondition>,
+    pub starts_when: Option<AnyCondition>,
 }
 
 inventory::submit! {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{Condition, ConditionConfig},
+    conditions::{AnyCondition, Condition},
     config::{DataType, GenerateConfig, TransformConfig, TransformDescription},
     event::Event,
     internal_events::RouteEventDiscarded,
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct LaneConfig {
     #[serde(flatten)]
-    condition: Box<dyn ConditionConfig>,
+    condition: AnyCondition,
 }
 
 #[async_trait::async_trait]
@@ -67,7 +67,7 @@ impl FunctionTransform for Lane {
 pub struct RouteConfig {
     // Deprecated name
     #[serde(alias = "lanes")]
-    route: IndexMap<String, Box<dyn ConditionConfig>>,
+    route: IndexMap<String, AnyCondition>,
 }
 
 inventory::submit! {


### PR DESCRIPTION
Ref #4791 

This updates the conditions such that if you don't specify a subfield it will take the value as the remap source.

So both these examples work and are equivalent:

```toml
[transforms.filter]
  type = "filter"
  inputs = ["stdin"]
  condition.type = "remap"
  condition.source = 'contains!(.message, "funky")'
```

```toml
  type = "filter"
  inputs = ["stdin"]
  condition = 'contains!(.message, "funky")'
```

`check_fields` conditions work and can be set as before. A deprecation warning is still emitted.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

