### PR TITLE
enhancement(remap): added is_log and is_metric functions

### DIFF
--- a/docs/reference/remap/functions/is_log.cue
+++ b/docs/reference/remap/functions/is_log.cue
@@ -10,13 +10,14 @@ remap: functions: is_log: {
 			"If the current event is a [`log` event](\(urls.vector_log)), then `true` is returned.",
 		]
 	}
-	category: "Event"
+	category:    "Event"
 	description: """
 		Determines whether the current event is a [`log` event](\(urls.vector_log)).
 		"""
 	examples: [
 		{
 			title: "A log event"
+			input: log: message: "Hello, world!"
 			source: """
 				is_log()
 				"""

--- a/docs/reference/remap/functions/is_log.cue
+++ b/docs/reference/remap/functions/is_log.cue
@@ -11,9 +11,9 @@ remap: functions: is_log: {
 		]
 	}
 	category: "Event"
-	description: #"""
-		Determines whether the current event is a log event.
-		"""#
+	description: """
+		Determines whether the current event is a [`log` event](\(urls.vector_log)).
+		"""
 	examples: [
 		{
 			title: "A log event"

--- a/docs/reference/remap/functions/is_log.cue
+++ b/docs/reference/remap/functions/is_log.cue
@@ -1,0 +1,26 @@
+package metadata
+
+remap: functions: is_log: {
+	arguments: [
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["boolean"]
+		rules: [
+			#"If the current event is a log event, then `true` is returned."#,
+		]
+	}
+	category: "Type"
+	description: #"""
+		Determines whether the current event is a log event.
+		"""#
+	examples: [
+		{
+			title: "A log event"
+			source: """
+				is_log()
+				"""
+			return: true
+		},
+	]
+}

--- a/docs/reference/remap/functions/is_log.cue
+++ b/docs/reference/remap/functions/is_log.cue
@@ -10,7 +10,7 @@ remap: functions: is_log: {
 			#"If the current event is a log event, then `true` is returned."#,
 		]
 	}
-	category: "Type"
+	category: "Event"
 	description: #"""
 		Determines whether the current event is a log event.
 		"""#

--- a/docs/reference/remap/functions/is_log.cue
+++ b/docs/reference/remap/functions/is_log.cue
@@ -7,7 +7,7 @@ remap: functions: is_log: {
 	return: {
 		types: ["boolean"]
 		rules: [
-			#"If the current event is a log event, then `true` is returned."#,
+			"If the current event is a [`log` event](\(urls.vector_log)), then `true` is returned.",
 		]
 	}
 	category: "Event"

--- a/docs/reference/remap/functions/is_metric.cue
+++ b/docs/reference/remap/functions/is_metric.cue
@@ -7,7 +7,7 @@ remap: functions: is_metric: {
 	return: {
 		types: ["boolean"]
 		rules: [
-			#"If the current event is a metric event, then `true` is returned."#,
+			"If the current event is a [`metric` event](\(urls.vector_metric)), then `true` is returned."#,
 		]
 	}
 	category: "Event"

--- a/docs/reference/remap/functions/is_metric.cue
+++ b/docs/reference/remap/functions/is_metric.cue
@@ -7,16 +7,22 @@ remap: functions: is_metric: {
 	return: {
 		types: ["boolean"]
 		rules: [
-			"If the current event is a [`metric` event](\(urls.vector_metric)), then `true` is returned."#,
+			"If the current event is a [`metric` event](\(urls.vector_metric)), then `true` is returned.",
 		]
 	}
-	category: "Event"
+	category:    "Event"
 	description: """
 		Determines whether the current event is a [`metric` event](\(urls.vector_metric)).
 		"""
 	examples: [
 		{
 			title: "A metric event"
+			input: metric: {
+				kind: "incremental"
+				name: "user_login_total"
+				counter: value: 102.0
+				tags: host:     "my.host.com"
+			}
 			source: """
 				is_metric()
 				"""

--- a/docs/reference/remap/functions/is_metric.cue
+++ b/docs/reference/remap/functions/is_metric.cue
@@ -11,9 +11,9 @@ remap: functions: is_metric: {
 		]
 	}
 	category: "Event"
-	description: #"""
-		Determines whether the current event is a metric event.
-		"""#
+	description: """
+		Determines whether the current event is a [`metric` event](\(urls.vector_metric)).
+		"""
 	examples: [
 		{
 			title: "A metric event"

--- a/docs/reference/remap/functions/is_metric.cue
+++ b/docs/reference/remap/functions/is_metric.cue
@@ -10,7 +10,7 @@ remap: functions: is_metric: {
 			#"If the current event is a metric event, then `true` is returned."#,
 		]
 	}
-	category: "Type"
+	category: "Event"
 	description: #"""
 		Determines whether the current event is a metric event.
 		"""#

--- a/docs/reference/remap/functions/is_metric.cue
+++ b/docs/reference/remap/functions/is_metric.cue
@@ -1,0 +1,26 @@
+package metadata
+
+remap: functions: is_metric: {
+	arguments: [
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["boolean"]
+		rules: [
+			#"If the current event is a metric event, then `true` is returned."#,
+		]
+	}
+	category: "Type"
+	description: #"""
+		Determines whether the current event is a metric event.
+		"""#
+	examples: [
+		{
+			title: "A metric event"
+			source: """
+				is_metric()
+				"""
+			return: true
+		},
+	]
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -435,6 +435,7 @@ urls: {
 	vector_log:                                               "\(vector_website)/docs/about/data-model/log/"
 	vector_log_data_types:                                    "\(vector_website)/docs/about/data-model/log/#types"
 	vector_lua_rfc:                                           "\(vector_repo)/blob/master/rfcs/2020-03-06-1999-api-extensions-for-lua-transform.md"
+	vector_metric:                                            "\(vector_website)/docs/about/data-model/metric/"
 	vector_msi_source_files:                                  "\(vector_repo)/tree/master/distribution/msi"
 	vector_nightly_builds:                                    "https://packages.timber.io/vector/nightly/latest/"
 	vector_nix_package:                                       "\(github)/NixOS/nixpkgs/blob/master/pkgs/tools/misc/vector/default.nix"

--- a/lib/remap-functions/Cargo.toml
+++ b/lib/remap-functions/Cargo.toml
@@ -61,6 +61,8 @@ default = [
     "ip_subnet",
     "ip_to_ipv6",
     "ipv6_to_ipv4",
+    "is_log",
+    "is_metric",
     "is_nullish",
     "length",
     "log",
@@ -130,6 +132,8 @@ ip_cidr_contains = ["cidr-utils"]
 ip_subnet = ["lazy_static", "regex"]
 ip_to_ipv6 = []
 ipv6_to_ipv4 = []
+is_log = []
+is_metric = []
 is_nullish = []
 length = []
 log = ["tracing"]

--- a/lib/remap-functions/src/is_log.rs
+++ b/lib/remap-functions/src/is_log.rs
@@ -1,0 +1,48 @@
+use remap::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct IsLog;
+
+impl Function for IsLog {
+    fn identifier(&self) -> &'static str {
+        "is_log"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[]
+    }
+
+    fn compile(&self, _arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+        Ok(Box::new(IsLogFn))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IsLogFn;
+
+impl Expression for IsLogFn {
+    fn execute(&self, _state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        Ok((object.identifier() == "log").into())
+    }
+
+    fn type_def(&self, _state: &state::Compiler) -> TypeDef {
+        TypeDef {
+            fallible: false,
+            kind: value::Kind::Boolean,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_type_def![infallible {
+        expr: |_| IsLogFn,
+        def: TypeDef {
+            kind: value::Kind::Boolean,
+            ..Default::default()
+        },
+    }];
+}

--- a/lib/remap-functions/src/is_metric.rs
+++ b/lib/remap-functions/src/is_metric.rs
@@ -1,0 +1,48 @@
+use remap::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct IsMetric;
+
+impl Function for IsMetric {
+    fn identifier(&self) -> &'static str {
+        "is_metric"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[]
+    }
+
+    fn compile(&self, _arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+        Ok(Box::new(IsMetricFn))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IsMetricFn;
+
+impl Expression for IsMetricFn {
+    fn execute(&self, _state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        Ok((object.identifier() == "metric").into())
+    }
+
+    fn type_def(&self, _state: &state::Compiler) -> TypeDef {
+        TypeDef {
+            fallible: false,
+            kind: value::Kind::Boolean,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_type_def![infallible {
+        expr: |_| IsMetricFn,
+        def: TypeDef {
+            kind: value::Kind::Boolean,
+            ..Default::default()
+        },
+    }];
+}

--- a/lib/remap-functions/src/lib.rs
+++ b/lib/remap-functions/src/lib.rs
@@ -46,6 +46,10 @@ mod ip_subnet;
 mod ip_to_ipv6;
 #[cfg(feature = "ipv6_to_ipv4")]
 mod ipv6_to_ipv4;
+#[cfg(feature = "is_log")]
+mod is_log;
+#[cfg(feature = "is_metric")]
+mod is_metric;
 #[cfg(feature = "is_nullish")]
 mod is_nullish;
 #[cfg(feature = "length")]
@@ -187,6 +191,10 @@ pub use ip_subnet::IpSubnet;
 pub use ip_to_ipv6::IpToIpv6;
 #[cfg(feature = "ipv6_to_ipv4")]
 pub use ipv6_to_ipv4::Ipv6ToIpV4;
+#[cfg(feature = "is_log")]
+pub use is_log::IsLog;
+#[cfg(feature = "is_metric")]
+pub use is_metric::IsMetric;
 #[cfg(feature = "is_nullish")]
 pub use is_nullish::IsNullish;
 #[cfg(feature = "length")]
@@ -324,6 +332,10 @@ pub fn all() -> Vec<Box<dyn remap::Function>> {
         Box::new(IpToIpv6),
         #[cfg(feature = "ipv6_to_ipv4")]
         Box::new(Ipv6ToIpV4),
+        #[cfg(feature = "is_log")]
+        Box::new(IsLog),
+        #[cfg(feature = "is_metric")]
+        Box::new(IsMetric),
         #[cfg(feature = "is_nullish")]
         Box::new(IsNullish),
         #[cfg(feature = "length")]

--- a/lib/remap-lang/src/object.rs
+++ b/lib/remap-lang/src/object.rs
@@ -51,4 +51,10 @@ pub trait Object: std::fmt::Debug {
     /// If `compact` is true, after deletion, if an empty object or array is
     /// left behind, it should be removed as well.
     fn remove(&mut self, path: &Path, compact: bool) -> Result<Option<Value>, String>;
+
+    /// An identifier for this object so Remap can identify what type of data it
+    /// is working with.
+    ///
+    /// In vector this will be either `log` or `metric`.
+    fn identifier(&self) -> &'static str;
 }

--- a/lib/remap-lang/src/value/object.rs
+++ b/lib/remap-lang/src/value/object.rs
@@ -1,6 +1,10 @@
 use crate::{Object, Path, Value};
 
 impl Object for Value {
+    fn identifier(&self) -> &'static str {
+        "value"
+    }
+
     fn insert(&mut self, path: &Path, value: Value) -> Result<(), String> {
         self.insert_by_path(path, value);
         Ok(())

--- a/src/event/log_event.rs
+++ b/src/event/log_event.rs
@@ -245,6 +245,10 @@ impl Serialize for LogEvent {
 }
 
 impl Object for LogEvent {
+    fn identifier(&self) -> &'static str {
+        "log"
+    }
+
     fn get(&self, path: &remap::Path) -> Result<Option<remap::Value>, String> {
         if path.is_root() {
             let iter = self

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -569,6 +569,10 @@ enum MetricPathError<'a> {
 }
 
 impl Object for Metric {
+    fn identifier(&self) -> &'static str {
+        "metric"
+    }
+
     fn insert(&mut self, path: &remap::Path, value: remap::Value) -> Result<(), String> {
         if path.is_root() {
             return Err(MetricPathError::SetPathError.to_string());

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1938,3 +1938,49 @@
       source = '''
         .a != ""
       '''
+
+[transforms.remap_function_is_log]
+  inputs = []
+  type = "remap"
+  source = """
+    .log = is_log()
+    .metric = is_metric()
+  """
+[[tests]]
+  name = "remap_function_is_log"
+  [tests.input]
+    insert_at = "remap_function_is_log"
+    type = "log"
+    [tests.input.log_fields]
+  [[tests.outputs]]
+    extract_from = "remap_function_is_log"
+    [[tests.outputs.conditions]]
+      type = "remap"
+      source = '''
+        .log == true && .metric == false
+      '''
+
+[transforms.remap_is_metric]
+  inputs = []
+  type = "remap"
+  source = """
+    .tags.log = to_string(is_log())
+    .tags.metric = to_string(is_metric())
+  """
+[[tests]]
+  name = "remap_is_metric"
+  [tests.input]
+    insert_at = "remap_is_metric"
+    type = "metric"
+    [tests.input.metric]
+      name = "example counter"
+      namespace = "zork"
+      kind = "absolute"
+      counter.value = 1.0
+  [[tests.outputs]]
+    extract_from = "remap_is_metric"
+    [[tests.outputs.conditions]]
+      type = "remap"
+      source = '''
+        .tags.log == "false" && .tags.metric == "true" ?? false
+      '''


### PR DESCRIPTION
Ref #4791 

This adds `is_log` and `is_metric` Remap functions so we can deprecate the `is_log` and `is_metric` conditions in favour of Remap.

To work out what type of event we are dealing with I have added an `identifier` function to the `Object` trait that returns a string identifier. The `is_log` function just checks that this string is == "log" and `is_metric` checks == "metric".

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
