### PR TITLE
fix(remap): `parse_syslog` function should error on an invalid syslog message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6609,9 +6609,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7981176aaf014836371693ebc7e254e865bb2dafa9f7d71943fbde7c87640e35"
+checksum = "b87c43adeba9354cdb8527ad333bae41caf5cad5ce5cbeb8b11eafcf9de5e07a"
 dependencies = [
  "chrono",
  "nom 6.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ http = "0.2"
 typetag = "0.1.6"
 toml = "0.5.8"
 syslog = "5"
-syslog_loose = "0.8.0"
+syslog_loose = "0.10.0"
 leveldb = { version = "0.8", optional = true, default-features = false }
 db-key = "0.0.5"
 headers = "0.3"

--- a/lib/remap-functions/Cargo.toml
+++ b/lib/remap-functions/Cargo.toml
@@ -27,7 +27,7 @@ sha-2 = { package = "sha2", version = "0.9", optional = true }
 sha-3 = { package = "sha3", version = "0.9", optional = true }
 shared = { path = "../shared", default-features = false, optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.8", optional = true }
+syslog_loose = { version = "0.10", optional = true }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }


### PR DESCRIPTION
Closes #6015 
Ref #6249 

If `parse_syslog` is not passed a valid syslog message, it should error rather than return the unparsed message.

----

It's worth noting that the error message returned is just a generic `could not parse` message. Since the parser tries a fair number of different combinations to parse the message successfully, it is hard to actually pinpoint a specific part of the message that is responsible for the failure.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
