### PR TITLE
fix(remap): `parse_grok` should error when it fails to parse

### DIFF
--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -103,15 +103,15 @@ impl Expression for ParseGrokFn {
 
                 Ok(Value::from(result))
             }
-            None => Ok(Value::from(BTreeMap::new())),
+            None => Err("unable to parse input with grok pattern".into()),
         }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         self.value
             .type_def(state)
-            .fallible_unless(value::Kind::Bytes)
-            .with_constraint(value::Kind::Array)
+            .into_fallible(true)
+            .with_constraint(value::Kind::Map)
     }
 }
 
@@ -131,10 +131,12 @@ mod test {
             remove_empty: Some(Literal::from(false).boxed()),
         },
         def: TypeDef {
-            kind: value::Kind::Array,
+            kind: value::Kind::Map,
+            fallible: true,
             ..Default::default()
         },
     }];
+
 
     #[test]
     fn check_invalid_grok_error() {
@@ -170,7 +172,7 @@ mod test {
         let cases = vec![
             (
                 map!["message": "an ungrokkable message"],
-                Ok(Value::from(map![])),
+                Err("function call error: unable to parse input with grok pattern".into()),
                 ParseGrokFn::new(
                     Box::new(Path::from("message")),
                     "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
@@ -181,7 +183,7 @@ mod test {
             ),
             (
                 map!["message": "2020-10-02T23:22:12.223222Z an ungrokkable message"],
-                Ok(Value::from(map![])),
+                Err("function call error: unable to parse input with grok pattern".into()),
                 ParseGrokFn::new(
                     Box::new(Path::from("message")),
                     "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"

--- a/lib/remap-functions/src/parse_grok.rs
+++ b/lib/remap-functions/src/parse_grok.rs
@@ -137,7 +137,6 @@ mod test {
         },
     }];
 
-
     #[test]
     fn check_invalid_grok_error() {
         let mut arguments = ArgumentList::default();


### PR DESCRIPTION
Closes #6252 
Ref #6249 

This make `parse_grok` return an error if it doesn't parse the input string correctly.

There was also a bug in the type_def which was declaring it's return type to be an Array. I have fixed it to return Map.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
