### PR TITLE
fix(remap): Fix is_nullish input type issue

### DIFF
--- a/lib/remap-functions/src/is_nullish.rs
+++ b/lib/remap-functions/src/is_nullish.rs
@@ -13,7 +13,7 @@ impl Function for IsNullish {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            accepts: |v| matches!(v, Value::Bytes(_) | Value::Null),
+            accepts: |_| true,
             required: true,
         }]
     }


### PR DESCRIPTION
`is_nullish` is supposed to accept all types and thus to be infallible, but the `accepts` function on `master` is a holdover from an early incarnation of the function that was only intended to work with strings and `null`. This PR brings `accepts` in line with the actual behavior of the function.