### PR TITLE
chore(remap): `merge` returns the result rather than mutates the parameter

### DIFF
--- a/docs/reference/remap/functions/merge.cue
+++ b/docs/reference/remap/functions/merge.cue
@@ -9,7 +9,7 @@ remap: functions: merge: {
 	arguments: [
 		{
 			name:        "to"
-			description: "The path of the object to merge into."
+			description: "The object to merge into."
 			required:    true
 			type: ["string"]
 		},

--- a/lib/remap-functions/src/merge.rs
+++ b/lib/remap-functions/src/merge.rs
@@ -120,31 +120,31 @@ mod tests {
                               from: map![ "key2": "val2" ]
             ],
             want: Ok(map![ "key1": "val1",
-                            "key2": "val2" ])
+                           "key2": "val2" ])
         }
 
         shallow {
             args: func_args![ to: map![ "key1": "val1",
-                                         "child": map! [ "grandchild1": "val1" ] ],
+                                        "child": map! [ "grandchild1": "val1" ] ],
                               from: map![ "key2": "val2",
-                                           "child": map! [ "grandchild2": "val2" ] ]
+                                          "child": map! [ "grandchild2": "val2" ] ]
             ],
             want: Ok(map![ "key1": "val1",
-                                    "key2": "val2",
-                                    "child": map! [ "grandchild2": "val2" ] ] )
+                           "key2": "val2",
+                           "child": map! [ "grandchild2": "val2" ] ])
         }
 
         deep {
             args: func_args![to: map![ "key1": "val1",
-                                        "child": map! [ "grandchild1": "val1" ] ],
+                                       "child": map![ "grandchild1": "val1" ] ],
                              from: map![ "key2": "val2",
-                                          "child": map! [ "grandchild2": "val2" ] ],
+                                         "child": map![ "grandchild2": "val2" ] ],
                              deep: true
             ],
             want: Ok( map![ "key1": "val1",
-                             "key2": "val2",
-                             "child": map! [ "grandchild1": "val1",
-                                              "grandchild2": "val2" ] ])
+                            "key2": "val2",
+                            "child": map![ "grandchild1": "val1",
+                                           "grandchild2": "val2" ] ])
         }
     ];
 }

--- a/lib/remap-functions/src/merge.rs
+++ b/lib/remap-functions/src/merge.rs
@@ -111,6 +111,45 @@ where
 mod tests {
     use super::*;
     use crate::map;
+    use value::Kind;
+
+    test_type_def![
+
+        value_non_maps {
+            expr: |_| MergeFn {
+                to: array!["ook"].boxed(),
+                from: array!["ook"].boxed(),
+                deep: None
+            },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Map,
+                inner_type_def: Some(Box::new(TypeDef {
+                    fallible: false,
+                    kind: Kind::Bytes,
+                    ..Default::default()
+                }))
+            },
+        }
+
+        value_maps {
+            expr: |_| MergeFn {
+                to: remap::map![ "ook" : 2 ].boxed(),
+                from: remap::map![ "ook" : 4 ].boxed(),
+                deep: None
+            },
+            def: TypeDef {
+                fallible: false,
+                kind: Kind::Map,
+                inner_type_def: Some(Box::new(TypeDef {
+                    fallible: false,
+                    kind: Kind::Integer,
+                    ..Default::default()
+                }))
+            },
+        }
+
+    ];
 
     test_function! [
         merge => Merge;

--- a/lib/remap-functions/src/merge.rs
+++ b/lib/remap-functions/src/merge.rs
@@ -14,7 +14,7 @@ impl Function for Merge {
         &[
             Parameter {
                 keyword: "to",
-                accepts: |_| true,
+                accepts: |v| matches!(v, Value::Map(_)),
                 required: false,
             },
             Parameter {
@@ -31,7 +31,7 @@ impl Function for Merge {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        let to = arguments.required_path("to")?;
+        let to = arguments.required("to")?.boxed();
         let from = arguments.required("from")?.boxed();
         let deep = arguments.optional("deep").map(Expr::boxed);
 
@@ -41,46 +41,37 @@ impl Function for Merge {
 
 #[derive(Debug, Clone)]
 pub struct MergeFn {
-    to: Path,
+    to: Box<dyn Expression>,
     from: Box<dyn Expression>,
     deep: Option<Box<dyn Expression>>,
 }
 
-impl MergeFn {
-    #[cfg(test)]
-    pub fn new(to: Path, from: Box<dyn Expression>, deep: Option<Box<dyn Expression>>) -> Self {
-        Self { to, from, deep }
-    }
-}
-
 impl Expression for MergeFn {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let mut to_value = self.to.execute(state, object)?.try_map()?;
         let from_value = self.from.execute(state, object)?.try_map()?;
         let deep = match &self.deep {
             None => false,
             Some(deep) => deep.execute(state, object)?.try_boolean()?,
         };
 
-        match object.get(&self.to.as_ref())? {
-            Some(Value::Map(mut map1)) => {
-                merge_maps(&mut map1, &from_value, deep);
-                object.insert(&self.to.as_ref(), Value::Map(map1))?;
-                Ok(Value::Null)
-            }
-            _ => Err("parameters passed to merge are non-map values".into()),
-        }
+        merge_maps(&mut to_value, &from_value, deep);
+
+        Ok(to_value.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        // TODO Merge inner types - PR #6182 needs to be merged first.
         self.from
             .type_def(state)
             .fallible_unless(value::Kind::Map)
+            .merge(self.to.type_def(state).fallible_unless(value::Kind::Map))
             .merge_optional(
                 self.deep
                     .as_ref()
                     .map(|deep| deep.type_def(state).fallible_unless(value::Kind::Boolean)),
             )
-            .with_constraint(value::Kind::Null)
+            .with_constraint(value::Kind::Map)
     }
 }
 
@@ -121,88 +112,39 @@ mod tests {
     use super::*;
     use crate::map;
 
-    #[test]
-    fn merge() {
-        let cases = vec![
-            (
-                map!["foo": Value::Boolean(true),
-                     "bar": map!["key2": "val2"]],
-                map!["foo": Value::Boolean(true),
-                     "bar": map!["key2": "val2"]],
-                MergeFn::new(Path::from("foo"), Box::new(Path::from("bar")), None),
-                Err("function call error: parameters passed to merge are non-map values".into()),
-            ),
-            (
-                map!["foo": map![ "key1": "val1" ], "bar": map![ "key2": "val2" ]],
-                map![
-                    "foo":
-                        map![ "key1": "val1",
-                              "key2": "val2" ],
-                    "bar": map![ "key2": "val2" ]
-                ],
-                MergeFn::new(Path::from("foo"), Box::new(Path::from("bar")), None),
-                Ok(Value::Null),
-            ),
-            (
-                map![
-                    "parent1":
-                        map![ "key1": "val1",
-                                       "child": map! [ "grandchild1": "val1" ] ],
-                    "parent2":
-                        map![ "key2": "val2",
-                                       "child": map! [ "grandchild2": "val2" ] ]
-                ],
-                map![
-                    "parent1":
-                        map![ "key1": "val1",
-                                      "key2": "val2",
-                                      "child": map! [ "grandchild2": "val2" ] ],
-                    "parent2":
-                        map! [ "key2": "val2",
-                                       "child": map! [ "grandchild2": "val2" ] ]
-                ],
-                MergeFn::new(Path::from("parent1"), Box::new(Path::from("parent2")), None),
-                Ok(Value::Null),
-            ),
-            (
-                map![
-                    "parent1":
-                        map![ "key1": "val1",
-                              "child": map! [ "grandchild1": "val1" ] ],
-                    "parent2":
-                        map![ "key2": "val2",
-                              "child": map! [ "grandchild2": "val2" ] ]
-                ],
-                map![
-                    "parent1":
-                        map![ "key1": "val1",
-                              "key2": "val2",
-                              "child": map! [ "grandchild1": "val1",
-                                              "grandchild2": "val2" ] ],
-                    "parent2":
-                        map![ "key2": "val2",
-                              "child": map! [ "grandchild2": "val2" ] ]
-                ],
-                MergeFn::new(
-                    Path::from("parent1"),
-                    Box::new(Path::from("parent2")),
-                    Some(Box::new(Literal::from(Value::Boolean(true)))),
-                ),
-                Ok(Value::Null),
-            ),
-        ];
+    test_function! [
+        merge => Merge;
 
-        let mut state = state::Program::default();
-        for (input_event, exp_event, func, exp_result) in cases {
-            let mut input_event = Value::Map(input_event);
-            let exp_event = Value::Map(exp_event);
-
-            let got = func
-                .execute(&mut state, &mut input_event)
-                .map_err(|e| format!("{:#}", anyhow::anyhow!(e)));
-
-            assert_eq!(input_event, exp_event);
-            assert_eq!(got, exp_result);
+        simple {
+            args: func_args![ to: map![ "key1": "val1" ],
+                              from: map![ "key2": "val2" ]
+            ],
+            want: Ok(map![ "key1": "val1",
+                            "key2": "val2" ])
         }
-    }
+
+        shallow {
+            args: func_args![ to: map![ "key1": "val1",
+                                         "child": map! [ "grandchild1": "val1" ] ],
+                              from: map![ "key2": "val2",
+                                           "child": map! [ "grandchild2": "val2" ] ]
+            ],
+            want: Ok(map![ "key1": "val1",
+                                    "key2": "val2",
+                                    "child": map! [ "grandchild2": "val2" ] ] )
+        }
+
+        deep {
+            args: func_args![to: map![ "key1": "val1",
+                                        "child": map! [ "grandchild1": "val1" ] ],
+                             from: map![ "key2": "val2",
+                                          "child": map! [ "grandchild2": "val2" ] ],
+                             deep: true
+            ],
+            want: Ok( map![ "key1": "val1",
+                             "key2": "val2",
+                             "child": map! [ "grandchild1": "val1",
+                                              "grandchild2": "val2" ] ])
+        }
+    ];
 }

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1293,7 +1293,7 @@
   source = """
     .foo = parse_json!(.foo)
     .bar = parse_json!(.bar)
-    merge!(.bar, .foo, deep: true)
+    .bar = merge!(.bar, .foo, deep: true)
   """
 [[tests]]
   name = "remap_function_merge"


### PR DESCRIPTION
Closes #6265 

`merge` used to mutate the first parameter rather than return the merged result, so you would have to do:

```
merge(., parse_json(...))
```

This changes the function so it now returns the result and leaves the first parameter untouched, so you have to do:

```
. = merge(., parse_json(...))
```

This brings it inline with how the rest of the Remap functions work.

Note I haven't needed to change much of the documentation as that was assuming merge worked like this anyway!


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
