### PR TITLE
fix(tests): test against released version of loki

### DIFF
--- a/scripts/setup_integration/loki_integration_env.sh
+++ b/scripts/setup_integration/loki_integration_env.sh
@@ -21,13 +21,13 @@ ACTION=$1
 start_podman () {
   podman pod create --replace --name vector-test-integration-loki -p 3100:3100
   podman run -d --pod=vector-test-integration-loki -v "$(pwd)"/tests/data:/etc/loki \
-	 --name vector_loki grafana/loki:master -config.file=/etc/loki/loki-config.yaml
+	 --name vector_loki grafana/loki:2.1.0 -config.file=/etc/loki/loki-config.yaml
 }
 
 start_docker () {
   docker network create vector-test-integration-loki
   docker run -d --network=vector-test-integration-loki -p 3100:3100 -v "$(pwd)"/tests/data:/etc/loki \
-	 --name vector_loki grafana/loki:master -config.file=/etc/loki/loki-config.yaml
+	 --name vector_loki grafana/loki:2.1.0 -config.file=/etc/loki/loki-config.yaml
 }
 
 stop_podman () {


### PR DESCRIPTION
Loki integration tests have been [failing](https://github.com/timberio/vector/actions/runs/518416129) the past couple of days with no apparent change on our side. This changes our integration suite to use the latest release of Loki instead of the latest build from their master branch, which seems to fix the problem.

Without this change, our loki sink's requests to the `/loki/api/v1/push` endpoint were receiving responses with a status code of 400 and a body of `snappy: corrupt input`. As best I can tell, it seems like something broke in Loki and it's no longer respecting the `Content-Type` header that indicates our requests are JSON, not snappy-compressed protobuf messages. I'll open an issue there to follow up in case the relevant change ends up being released.