### PR TITLE
enhancement(external docs): Add docs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,7 @@ default-cmake = ["api", "api-client", "vrl-cli", "sources", "transforms", "sinks
 default-msvc = ["api", "api-client", "vrl-cli", "sources", "transforms", "sinks", "vendor-openssl", "vendor-libz", "leveldb", "rdkafka-cmake"]
 default-no-api-client = ["api", "sources", "vrl-cli", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
 default-no-vrl-cli = ["api", "sources", "transforms", "sinks", "vendor-all", "unix", "leveldb", "rdkafka-plain"]
+docs = ["api", "sources", "transforms", "sinks"]
 
 all-logs = ["sources-logs", "transforms-logs", "sinks-logs"]
 all-metrics = ["sources-metrics", "transforms-metrics", "sinks-metrics"]


### PR DESCRIPTION
Now that we have [published RustDoc](https://vector-rustdoc.netlify.app/vector/) for Vector, this PR creates a `docs` feature that enables us to determine what gets published there. At the moment, the feature list is hard-coded in another repo but I think it'd be better to have that dictated here.