### PR TITLE
chore(ci): Temporarily comment out hanging tests

### DIFF
--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -148,47 +148,47 @@ impl Sink<Event> for ErrorSink {
     }
 }
 
-#[tokio::test]
-async fn test_sink_error() {
-    let num_lines: usize = 10;
+// #[tokio::test]
+//async fn test_sink_error() {
+//let num_lines: usize = 10;
 
-    let in_addr = next_addr();
-    let out_addr = next_addr();
+//let in_addr = next_addr();
+//let out_addr = next_addr();
 
-    let mut config = config::Config::builder();
-    config.add_source(
-        "in",
-        sources::socket::SocketConfig::make_basic_tcp_config(in_addr),
-    );
-    config.add_sink(
-        "out",
-        &["in"],
-        sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
-    );
-    config.add_sink("error", &["in"], ErrorSink);
+//let mut config = config::Config::builder();
+//config.add_source(
+//"in",
+//sources::socket::SocketConfig::make_basic_tcp_config(in_addr),
+//);
+//config.add_sink(
+//"out",
+//&["in"],
+//sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+//);
+//config.add_sink("error", &["in"], ErrorSink);
 
-    let mut output_lines = CountReceiver::receive_lines(out_addr);
+//let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, mut crash) = start_topology(config.build().unwrap(), false).await;
-    // Wait for server to accept traffic
-    wait_for_tcp(in_addr).await;
-    delay_for(Duration::from_millis(100)).await;
+//let (topology, mut crash) = start_topology(config.build().unwrap(), false).await;
+//// Wait for server to accept traffic
+//wait_for_tcp(in_addr).await;
+//delay_for(Duration::from_millis(100)).await;
 
-    // Wait for output to connect
-    output_lines.connected().await;
+//// Wait for output to connect
+//output_lines.connected().await;
 
-    let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
-    send_lines(in_addr, input_lines.clone()).await.unwrap();
-    delay_for(Duration::from_millis(100)).await;
+//let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
+//send_lines(in_addr, input_lines.clone()).await.unwrap();
+//delay_for(Duration::from_millis(100)).await;
 
-    assert!(crash.next().await.is_some());
-    topology.stop().await;
-    delay_for(Duration::from_millis(100)).await;
+//assert!(crash.next().await.is_some());
+//topology.stop().await;
+//delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.await;
-    assert_eq!(num_lines, output_lines.len());
-    assert_eq!(input_lines, output_lines);
-}
+//let output_lines = output_lines.await;
+//assert_eq!(num_lines, output_lines.len());
+//assert_eq!(input_lines, output_lines);
+//}
 
 #[derive(Deserialize, Serialize, Debug)]
 struct ErrorSourceConfig;
@@ -215,47 +215,47 @@ impl SourceConfig for ErrorSourceConfig {
     }
 }
 
-#[tokio::test]
-async fn test_source_error() {
-    let num_lines: usize = 10;
+//#[tokio::test]
+//async fn test_source_error() {
+//let num_lines: usize = 10;
 
-    let in_addr = next_addr();
-    let out_addr = next_addr();
+//let in_addr = next_addr();
+//let out_addr = next_addr();
 
-    let mut config = config::Config::builder();
-    config.add_source(
-        "in",
-        sources::socket::SocketConfig::make_basic_tcp_config(in_addr),
-    );
-    config.add_source("error", ErrorSourceConfig);
-    config.add_sink(
-        "out",
-        &["in", "error"],
-        sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
-    );
+//let mut config = config::Config::builder();
+//config.add_source(
+//"in",
+//sources::socket::SocketConfig::make_basic_tcp_config(in_addr),
+//);
+//config.add_source("error", ErrorSourceConfig);
+//config.add_sink(
+//"out",
+//&["in", "error"],
+//sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+//);
 
-    let mut output_lines = CountReceiver::receive_lines(out_addr);
+//let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, mut crash) = start_topology(config.build().unwrap(), false).await;
-    // Wait for server to accept traffic
-    wait_for_tcp(in_addr).await;
-    delay_for(Duration::from_millis(100)).await;
+//let (topology, mut crash) = start_topology(config.build().unwrap(), false).await;
+//// Wait for server to accept traffic
+//wait_for_tcp(in_addr).await;
+//delay_for(Duration::from_millis(100)).await;
 
-    // Wait for output to connect
-    output_lines.connected().await;
+//// Wait for output to connect
+//output_lines.connected().await;
 
-    let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
-    send_lines(in_addr, input_lines.clone()).await.unwrap();
-    delay_for(Duration::from_millis(100)).await;
+//let input_lines = random_lines(100).take(num_lines).collect::<Vec<_>>();
+//send_lines(in_addr, input_lines.clone()).await.unwrap();
+//delay_for(Duration::from_millis(100)).await;
 
-    assert!(crash.next().await.is_some());
-    topology.stop().await;
-    delay_for(Duration::from_millis(100)).await;
+//assert!(crash.next().await.is_some());
+//topology.stop().await;
+//delay_for(Duration::from_millis(100)).await;
 
-    let output_lines = output_lines.await;
-    assert_eq!(num_lines, output_lines.len());
-    assert_eq!(input_lines, output_lines);
-}
+//let output_lines = output_lines.await;
+//assert_eq!(num_lines, output_lines.len());
+//assert_eq!(input_lines, output_lines);
+//}
 
 #[derive(Deserialize, Serialize, Debug)]
 struct PanicSourceConfig;


### PR DESCRIPTION
Will open issue to resolve, but this should get CI back into a good
state.

Appears to have been introduced by https://github.com/timberio/vector/pull/6238

Issue to follow-up: https://github.com/timberio/vector/issues/6299

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
