### PR TITLE
fix(tests): revert poll watcher change

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 #[cfg(unix)]
-use notify::{Op, PollWatcher, RawEvent, RecursiveMode, Watcher};
+use notify::{raw_watcher, Op, RawEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{path::PathBuf, time::Duration};
 #[cfg(unix)]
 use std::{
@@ -99,16 +99,18 @@ fn raise_sighup() {
 }
 
 #[cfg(unix)]
-fn create_watcher(config_paths: &[PathBuf]) -> Result<(PollWatcher, Receiver<RawEvent>), Error> {
+fn create_watcher(
+    config_paths: &[PathBuf],
+) -> Result<(RecommendedWatcher, Receiver<RawEvent>), Error> {
     info!("Creating configuration file watcher.");
     let (sender, receiver) = channel();
-    let mut watcher = PollWatcher::with_delay_ms(sender, 1000)?;
+    let mut watcher = raw_watcher(sender)?;
     add_paths(&mut watcher, config_paths)?;
     Ok((watcher, receiver))
 }
 
 #[cfg(unix)]
-fn add_paths(watcher: &mut PollWatcher, config_paths: &[PathBuf]) -> Result<(), Error> {
+fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &[PathBuf]) -> Result<(), Error> {
     for path in config_paths {
         watcher.watch(path, RecursiveMode::NonRecursive)?;
     }


### PR DESCRIPTION
This reverts https://github.com/timberio/vector/pull/6286

I haven't been able to track down why the tests don't pass yet so
reverting this for now to get master back to green since it was
only made to improve CI flakiness.

Fixes: https://github.com/timberio/vector/issues/6301

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
