### PR TITLE
fix(remap): test for full error message in `parse_regex` test

### DIFF
--- a/lib/remap-functions/src/parse_regex.rs
+++ b/lib/remap-functions/src/parse_regex.rs
@@ -158,7 +158,7 @@ mod tests {
                 pattern: Regex::new(r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#)
                             .unwrap()
             ],
-            want: Err("unable to parse regular expression".to_string()),
+            want: Err("function call error: unable to parse regular expression".to_string()),
         }
     ];
 }


### PR DESCRIPTION
The `no_match` test was testing for the error message `unable to parse regular expression` whereas it should have been testing for the full error message `function call error: unable to parse regular expression`.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
