### PR TITLE
enhancement(remap): added 'rate_limit_secs' to log function

### DIFF
--- a/docs/reference/remap/functions/log.cue
+++ b/docs/reference/remap/functions/log.cue
@@ -27,15 +27,21 @@ remap: functions: log: {
 			}
 			default: "info"
 		},
+		{
+			name:        "rate_limit_secs"
+			description: "Specifies that the log message is output no more than once per the given number of seconds."
+			required:    false
+			default:     1
+			type: ["integer"]
+		},
 	]
 	internal_failure_reasons: []
 	return: types: ["null"]
-
 	examples: [
 		{
 			title: "Log a message"
 			source: #"""
-				log("Hello, World!", level: "info")
+				log("Hello, World!", level: "info": rate_limit_secs: 60)
 				"""#
 			return: null
 		},

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,6 +55,7 @@ impl Application {
             "off" => "off".to_owned(),
             level => [
                 format!("vector={}", level),
+                format!("remap={}", level),
                 format!("codec={}", level),
                 format!("file_source={}", level),
                 "tower_limit=trace".to_owned(),


### PR DESCRIPTION
Closes #6307 

This adds a `rate_limit_secs` parameter to the remap log function, defaulting to 1 second.

I did find some strangeness in the rate that the log messages were being output in a script that logged multiple messages with different rates. I will raise an issue shortly..

**EDIT** Of course, the reason the rate limiting is strange is because although the log messages are two separate lines in a Remap script, they are all going through a single (eg.) `warn!` line here, so the limiter is applying itself to both remap log messages. I'm looking for a way around this now, but if anyone has any ideas feel free to shout!

This PR is blocked on #6342.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
