### PR TITLE
chore(external docs): Update Splunk HEC endpoint link

### DIFF
--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -60,8 +60,8 @@ components: sinks: splunk_hec: {
 				interface: {
 					socket: {
 						api: {
-							title: "Splunk HEC protocol"
-							url:   urls.splunk_hec_protocol
+							title: "Splunk HEC event endpoint"
+							url:   urls.splunk_hec_event_endpoint
 						}
 						direction: "outgoing"
 						protocols: ["http"]


### PR DESCRIPTION
The question of which endpoint we use has come up a few times, most
lately here:

https://github.com/timberio/vector/issues/6185#issue-792042826

This updates the link to link directly to the endpoint we use.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
