### PR TITLE
fix: #5642 - build deb packages that install on Deb 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ assets = [
 ]
 license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"
-depends = ""
+depends = "libc6 (>= 2.17)"
 
 [workspace]
 members = [

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -8,7 +8,7 @@ rustup default "$(cat rust-toolchain)"
 rustup component add rustfmt
 rustup component add clippy
 rustup target add wasm32-wasi
-rustup run stable cargo install cargo-deb --git https://github.com/mmstick/cargo-deb.git
+rustup run stable cargo install cargo-deb --git https://github.com/mmstick/cargo-deb.git --rev b06dc4e635e07c0566446a0e91faf42ab868e634
 
 cd scripts
 bundle update --bundler

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -8,7 +8,7 @@ rustup default "$(cat rust-toolchain)"
 rustup component add rustfmt
 rustup component add clippy
 rustup target add wasm32-wasi
-rustup run stable cargo install cargo-deb --version '^1.28.0'
+rustup run stable cargo install cargo-deb --git https://github.com/mmstick/cargo-deb.git
 
 cd scripts
 bundle update --bundler


### PR DESCRIPTION
This took a lot of fiddly testing. We now hard-code the earliest glibc we support (2.17) as the dependency of the Debian package. This ensures Debian/Ubuntu releases that choke on an empty `Depends:` field. Later Debian/Ubuntu releases should work forwards too.

We've also updated to the latest `cargo-deb` release, which support dropping the `Depends` field if not dependencies are present.

Signed-off-by: James Turnbull <james@lovedthanlost.net>
