### PR TITLE
fix(file source): Deprecate fingerprint.bytes option

### DIFF
--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -85,20 +85,10 @@ components: sources: file: {
 					type: string: {
 						default: "checksum"
 						enum: {
-							checksum:         "Read `bytes` bytes from the head of the file to uniquely identify files via a checksum."
+							checksum:         "Read the first line of the file,  skipping the first `ignored_header_bytes` bytes to uniquely identify files via a checksum."
 							device_and_inode: "Uses the [device and inode](\(urls.inode)) to unique identify files."
 						}
 						syntax: "literal"
-					}
-				}
-				bytes: {
-					common:        false
-					description:   "The number of bytes read off the head of the file to generate a unique fingerprint."
-					relevant_when: "strategy = \"checksum\""
-					required:      false
-					type: uint: {
-						default: 256
-						unit:    "bytes"
 					}
 				}
 				ignored_header_bytes: {

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -85,7 +85,7 @@ components: sources: file: {
 					type: string: {
 						default: "checksum"
 						enum: {
-							checksum:         "Read the first line of the file,  skipping the first `ignored_header_bytes` bytes to uniquely identify files via a checksum."
+							checksum:         "Read the first line of the file, skipping the first `ignored_header_bytes` bytes, to uniquely identify files via a checksum."
 							device_and_inode: "Uses the [device and inode](\(urls.inode)) to unique identify files."
 						}
 						syntax: "literal"

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -124,7 +124,7 @@ impl From<FingerprintConfig> for FingerprintStrategy {
             } => {
                 let bytes = match bytes {
                     Some(bytes) => {
-                        warn!(message = "`fingerprint.bytes` will be used to convert old file fingerprints created by vector < v0.11.0, but are not supported for new file fingerprints. The first line will be used instead.");
+                        warn!(message = "The `fingerprint.bytes` option will be used to convert old file fingerprints created by vector < v0.11.0, but are not supported for new file fingerprints. The first line will be used instead.");
                         bytes
                     }
                     None => 256,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -92,7 +92,7 @@ pub enum FingerprintConfig {
     Checksum {
         // Deprecated name
         #[serde(alias = "fingerprint_bytes")]
-        bytes: usize,
+        bytes: Option<usize>,
         ignored_header_bytes: usize,
     },
     #[serde(rename = "device_and_inode")]
@@ -121,10 +121,19 @@ impl From<FingerprintConfig> for FingerprintStrategy {
             FingerprintConfig::Checksum {
                 bytes,
                 ignored_header_bytes,
-            } => FingerprintStrategy::Checksum {
-                bytes,
-                ignored_header_bytes,
-            },
+            } => {
+                let bytes = match bytes {
+                    Some(bytes) => {
+                        warn!(message = "`fingerprint.bytes` will be used to convert old file fingerprints created by vector < v0.11.0, but are not supported for new file fingerprints. The first line will be used instead.");
+                        bytes
+                    }
+                    None => 256,
+                };
+                FingerprintStrategy::Checksum {
+                    bytes,
+                    ignored_header_bytes,
+                }
+            }
             FingerprintConfig::DevInode => FingerprintStrategy::DevInode,
         }
     }
@@ -146,7 +155,7 @@ impl Default for FileConfig {
             ignore_older: None,
             max_line_bytes: default_max_line_bytes(),
             fingerprint: FingerprintConfig::Checksum {
-                bytes: 256,
+                bytes: None,
                 ignored_header_bytes: 0,
             },
             ignore_not_found: false,
@@ -425,7 +434,7 @@ mod tests {
     fn test_default_file_config(dir: &tempfile::TempDir) -> file::FileConfig {
         file::FileConfig {
             fingerprint: FingerprintConfig::Checksum {
-                bytes: 8,
+                bytes: Some(8),
                 ignored_header_bytes: 0,
             },
             data_dir: Some(dir.path().to_path_buf()),
@@ -461,7 +470,7 @@ mod tests {
         assert_eq!(
             config.fingerprint,
             FingerprintConfig::Checksum {
-                bytes: 256,
+                bytes: None,
                 ignored_header_bytes: 0,
             }
         );
@@ -487,7 +496,7 @@ mod tests {
         assert_eq!(
             config.fingerprint,
             FingerprintConfig::Checksum {
-                bytes: 128,
+                bytes: Some(128),
                 ignored_header_bytes: 512,
             }
         );


### PR DESCRIPTION
This option was deprecated in 0.11.0 via https://github.com/timberio/vector/pull/5215, but the docs hadn't been updated.
The option is kept around and parsed from config files in order to
migrate checkpoints written by vector pre 0.11.0 to the new
checksum strategy which is to only checksum the first line (after
ignored_header_bytes).

This change removes `fingerprint.bytes` from the docs and outputs
a warning if the user has set it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
