### PR TITLE
fix(metrics, sinks): Move normalization out of MetricsBuffer

### DIFF
--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -194,8 +194,8 @@ impl SinkConfig for DatadogConfig {
             .sink_map_err(|error| error!(message = "Fatal datadog metric sink error.", %error))
             .with_flat_map(move |event: Event| {
                 stream::iter(normalizer.apply(event).map(|event| {
-                    let ep = DatadogEndpoint::from_metric(&event);
-                    Ok(PartitionInnerBuffer::new(event, ep))
+                    let endpoint = DatadogEndpoint::from_metric(&event);
+                    Ok(PartitionInnerBuffer::new(event, endpoint))
                 }))
             });
 

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -4,7 +4,7 @@ use crate::{
     http::HttpClient,
     sinks::{
         util::{
-            buffer::metrics::{MetricNormalize, MetricSet, MetricsBuffer},
+            buffer::metrics::{MetricNormalize, MetricNormalizer, MetricSet, MetricsBuffer},
             encode_namespace,
             http::{HttpBatchService, HttpRetryLogic},
             BatchConfig, BatchSettings, PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer,
@@ -15,7 +15,7 @@ use crate::{
     Event,
 };
 use chrono::{DateTime, Utc};
-use futures::{stream, FutureExt, SinkExt, StreamExt};
+use futures::{stream, FutureExt, SinkExt};
 use http::{uri::InvalidUri, Request, StatusCode, Uri};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -187,13 +187,16 @@ impl SinkConfig for DatadogConfig {
             HttpBatchService::new(client, move |request| ready(sink.build_request(request))),
         );
 
-        let buffer = PartitionBuffer::new(MetricsBuffer::<DatadogMetricNormalize>::new(batch.size));
+        let buffer = PartitionBuffer::new(MetricsBuffer::new(batch.size));
+        let mut normalizer = MetricNormalizer::<DatadogMetricNormalize>::default();
 
         let svc_sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .sink_map_err(|error| error!(message = "Fatal datadog metric sink error.", %error))
             .with_flat_map(move |event: Event| {
-                let ep = DatadogEndpoint::from_metric(&event);
-                stream::iter(Some(PartitionInnerBuffer::new(event, ep))).map(Ok)
+                stream::iter(normalizer.apply(event).map(|event| {
+                    let ep = DatadogEndpoint::from_metric(&event);
+                    Ok(PartitionInnerBuffer::new(event, ep))
+                }))
             });
 
         Ok((VectorSink::Sink(Box::new(svc_sink)), healthcheck))

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::{
         self,
         util::{
-            buffer::metrics::{MetricNormalize, MetricSet, MetricsBuffer},
+            buffer::metrics::{MetricNormalize, MetricNormalizer, MetricSet, MetricsBuffer},
             http::HttpRetryLogic,
             BatchConfig, BatchSettings, PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer,
             TowerRequestConfig,
@@ -96,19 +96,23 @@ impl SinkConfig for RemoteWriteConfig {
         let sink = {
             let service = request.service(HttpRetryLogic, service);
             let service = ServiceBuilder::new().service(service);
-            let buffer =
-                PartitionBuffer::new(MetricsBuffer::<PrometheusMetricNormalize>::new(batch.size));
+            let buffer = PartitionBuffer::new(MetricsBuffer::new(batch.size));
+            let mut normalizer = MetricNormalizer::<PrometheusMetricNormalize>::default();
+
             PartitionBatchSink::new(service, buffer, batch.timeout, cx.acker())
                 .with_flat_map(move |event: Event| {
-                    let tenant_id = tenant_id.as_ref().and_then(|template| {
-                        template
-                            .render_string(&event)
-                            .map_err(|fields| emit!(PrometheusTemplateRenderingError { fields }))
-                            .ok()
-                    });
-                    let key = PartitionKey { tenant_id };
-                    let inner = PartitionInnerBuffer::new(event, key);
-                    stream::iter(Some(Ok(inner)))
+                    stream::iter(normalizer.apply(event).map(|event| {
+                        let tenant_id = tenant_id.as_ref().and_then(|template| {
+                            template
+                                .render_string(&event)
+                                .map_err(|fields| {
+                                    emit!(PrometheusTemplateRenderingError { fields })
+                                })
+                                .ok()
+                        });
+                        let key = PartitionKey { tenant_id };
+                        Ok(PartitionInnerBuffer::new(event, key))
+                    }))
                 })
                 .sink_map_err(
                     |error| error!(message = "Prometheus remote_write sink error.", %error),
@@ -298,6 +302,34 @@ mod tests {
         assert_eq!(orgid.len(), 11);
     }
 
+    #[tokio::test]
+    async fn retains_state_between_requests() {
+        // This sink converts all incremental events to absolute, and
+        // should accumulate their totals between batches.
+        let outputs = send_request(
+            r#"batch.max_events = 1"#,
+            vec![
+                create_inc_event("counter-1".into(), 12.0),
+                create_inc_event("counter-2".into(), 13.0),
+                create_inc_event("counter-1".into(), 14.0),
+            ],
+        )
+        .await;
+
+        assert_eq!(outputs.len(), 3);
+
+        let check_output = |index: usize, name: &str, value: f64| {
+            let (_, req) = &outputs[index];
+            assert_eq!(req.timeseries.len(), 1);
+            assert_eq!(req.timeseries[0].labels, labels!("__name__" => name));
+            assert_eq!(req.timeseries[0].samples.len(), 1);
+            assert_eq!(req.timeseries[0].samples[0].value, value);
+        };
+        check_output(0, "counter-1", 12.0);
+        check_output(1, "counter-2", 13.0);
+        check_output(2, "counter-1", 26.0);
+    }
+
     async fn send_request(
         config: &str,
         events: Vec<Event>,
@@ -335,18 +367,27 @@ mod tests {
     }
 
     pub(super) fn create_event(name: String, value: f64) -> Event {
-        Event::Metric(
-            Metric::new(name, MetricKind::Absolute, MetricValue::Gauge { value })
-                .with_tags(Some(
-                    vec![
-                        ("region".to_owned(), "us-west-1".to_owned()),
-                        ("production".to_owned(), "true".to_owned()),
-                    ]
-                    .into_iter()
-                    .collect(),
-                ))
-                .with_timestamp(Some(chrono::Utc::now())),
+        Metric::new(name, MetricKind::Absolute, MetricValue::Gauge { value })
+            .with_tags(Some(
+                vec![
+                    ("region".to_owned(), "us-west-1".to_owned()),
+                    ("production".to_owned(), "true".to_owned()),
+                ]
+                .into_iter()
+                .collect(),
+            ))
+            .with_timestamp(Some(chrono::Utc::now()))
+            .into()
+    }
+
+    fn create_inc_event(name: String, value: f64) -> Event {
+        Metric::new(
+            name,
+            MetricKind::Incremental,
+            MetricValue::Counter { value },
         )
+        .with_timestamp(Some(chrono::Utc::now()))
+        .into()
     }
 }
 

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -208,6 +208,8 @@ impl<N: MetricNormalize> MetricNormalizer<N> {
         }
     }
 
+    /// This wraps `MetricNormalize::apply_state`, converting to/from
+    /// the `Event` type wrapper. See that function for return values.
     pub fn apply(&mut self, event: Event) -> Option<Event> {
         N::apply_state(&mut self.state, event.into_metric()).map(Into::into)
     }
@@ -228,6 +230,10 @@ impl<N: MetricNormalize> MetricNormalizer<N> {
 /// source, the buffer will compare it's values with the previous known
 /// and calculate the delta.
 pub trait MetricNormalize {
+    /// Apply normalize the given `metric` using `state` to save any
+    /// persistent data between calls. The return value is `None` if the
+    /// incoming metric is only used to set a reference state, and
+    /// `Some(metric)` otherwise.
     fn apply_state(state: &mut MetricSet, metric: Metric) -> Option<Metric>;
 }
 

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -108,29 +108,25 @@ impl DerefMut for MetricEntry {
 /// normalization type `N: MetricNormalize`. Further, distribution
 /// metrics have their their samples compressed with
 /// `compress_distribution` below.
-pub struct MetricsBuffer<N> {
-    state: MetricSet,
+pub struct MetricsBuffer {
     metrics: MetricSet,
     max_events: usize,
-    _normalize: PhantomData<N>,
 }
 
-impl<N> MetricsBuffer<N> {
+impl MetricsBuffer {
     pub fn new(settings: BatchSize<Self>) -> Self {
-        Self::new_with_state(settings.events, MetricSet::default())
+        Self::with_capacity(settings.events)
     }
 
-    fn new_with_state(max_events: usize, state: MetricSet) -> Self {
+    fn with_capacity(max_events: usize) -> Self {
         Self {
-            state,
             metrics: MetricSet::with_capacity(max_events),
             max_events,
-            _normalize: PhantomData::default(),
         }
     }
 }
 
-impl<N: MetricNormalize> Batch for MetricsBuffer<N> {
+impl Batch for MetricsBuffer {
     type Input = Event;
     type Output = Vec<Metric>;
 
@@ -148,23 +144,22 @@ impl<N: MetricNormalize> Batch for MetricsBuffer<N> {
         if self.num_items() >= self.max_events {
             PushResult::Overflow(item)
         } else {
-            if let Some(item) = N::apply_state(&mut self.state, item.into_metric()) {
-                let new_entry = match item.data.kind {
-                    MetricKind::Absolute => MetricEntry(item),
-                    MetricKind::Incremental => {
-                        // Incremental metrics update existing entries, if present
-                        let entry = MetricEntry(item);
-                        self.metrics
-                            .take(&entry)
-                            .map(|mut existing| {
-                                existing.data.update(&entry.data);
-                                existing
-                            })
-                            .unwrap_or(entry)
-                    }
-                };
-                self.metrics.replace(new_entry);
-            }
+            let item = item.into_metric();
+            let new_entry = match item.data.kind {
+                MetricKind::Absolute => MetricEntry(item),
+                MetricKind::Incremental => {
+                    // Incremental metrics update existing entries, if present
+                    let entry = MetricEntry(item);
+                    self.metrics
+                        .take(&entry)
+                        .map(|mut existing| {
+                            existing.data.update(&entry.data);
+                            existing
+                        })
+                        .unwrap_or(entry)
+                }
+            };
+            self.metrics.replace(new_entry);
             PushResult::Ok(self.num_items() >= self.max_events)
         }
     }
@@ -174,7 +169,7 @@ impl<N: MetricNormalize> Batch for MetricsBuffer<N> {
     }
 
     fn fresh(&self) -> Self {
-        Self::new_with_state(self.max_events, self.state.clone())
+        Self::with_capacity(self.max_events)
     }
 
     fn finish(self) -> Self::Output {
@@ -194,6 +189,27 @@ impl<N: MetricNormalize> Batch for MetricsBuffer<N> {
 
     fn num_items(&self) -> usize {
         self.metrics.len()
+    }
+}
+
+/// This is a simple wrapper for using `MetricNormalize` with a
+/// persistent `MetricSet` state, to be used in sinks in `with_flat_map`
+/// before sending the events to the `MetricsBuffer`
+pub struct MetricNormalizer<N> {
+    state: MetricSet,
+    _norm: PhantomData<N>,
+}
+
+impl<N: MetricNormalize> MetricNormalizer<N> {
+    pub fn default() -> Self {
+        Self {
+            state: MetricSet::default(),
+            _norm: PhantomData::default(),
+        }
+    }
+
+    pub fn apply(&mut self, event: Event) -> Option<Event> {
+        N::apply_state(&mut self.state, event.into_metric()).map(Into::into)
     }
 }
 
@@ -350,18 +366,21 @@ mod test {
             .collect()
     }
 
-    fn rebuffer<State: MetricNormalize>(events: Vec<Metric>) -> Buffer {
+    fn rebuffer<State: MetricNormalize>(metrics: Vec<Metric>) -> Buffer {
         let batch_size = BatchSettings::default().bytes(9999).events(6).size;
-        let mut buffer = MetricsBuffer::<State>::new(batch_size);
+        let mut normalizer = MetricNormalizer::<State>::default();
+        let mut buffer = MetricsBuffer::new(batch_size);
         let mut result = vec![];
 
-        for event in events {
-            match buffer.push(Event::Metric(event)) {
-                PushResult::Overflow(_) => panic!("overflowed too early"),
-                PushResult::Ok(true) => {
-                    result.push(buffer.fresh_replace().finish());
+        for metric in metrics {
+            if let Some(event) = normalizer.apply(Event::Metric(metric)) {
+                match buffer.push(event) {
+                    PushResult::Overflow(_) => panic!("overflowed too early"),
+                    PushResult::Ok(true) => {
+                        result.push(buffer.fresh_replace().finish());
+                    }
+                    PushResult::Ok(false) => (),
                 }
-                PushResult::Ok(false) => (),
             }
         }
 

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -230,7 +230,7 @@ impl<N: MetricNormalize> MetricNormalizer<N> {
 /// source, the buffer will compare it's values with the previous known
 /// and calculate the delta.
 pub trait MetricNormalize {
-    /// Apply normalize the given `metric` using `state` to save any
+    /// Apply normalizes the given `metric` using `state` to save any
     /// persistent data between calls. The return value is `None` if the
     /// incoming metric is only used to set a reference state, and
     /// `Some(metric)` otherwise.

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -252,6 +252,10 @@ where
 /// more fine grained partitioning ability. It will hold many different batches
 /// of events and contain linger timeouts for each.
 ///
+/// Note that, unlike `BatchSink`, the `batch` given to this sink is
+/// *only* used to create new batches (via `Batch::fresh`) for each new
+/// partition.
+///
 /// # Acking
 ///
 /// Service based acking will only ack events when all prior request


### PR DESCRIPTION
MetricsBuffer included a `state` component that was used to convert
metrics between absolute and incremental kinds. This relied on the batch
buffer never being dropped but rather just regenerated through
`Batch::fresh`. However, `PartitionBatchSink` never calls `fresh` but
rather generates a new batch for each partition and then just drops it.

This moves the state management out of the buffer and into a flat map
before the metrics enter the buffer.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #6312 