### PR TITLE
enhancement(remap): improved type definitions for `or` with nullable fields

### DIFF
--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -137,6 +137,21 @@ mod tests {
             },
         }
 
+        or_not_nullable {
+            expr: |_| Arithmetic::new(
+                Box::new(
+                IfStatement::new(IfCondition(Box::new(lit!(true).into())),
+                                 Box::new(lit!("string").into()),
+                                 Box::new(lit!(42).into())).into()),
+                Box::new(lit!("another string").into()),
+                Operator::Or,
+            ),
+            def: TypeDef {
+                kind: Kind::Bytes | Kind::Integer,
+                ..Default::default()
+            },
+        }
+
         multiply {
             expr: |_| Arithmetic::new(
                 Box::new(Noop.into()),

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -62,7 +62,7 @@ impl Expression for Arithmetic {
             Or if !lhs_def.kind.is_boolean() => {
                 // We can remove Null from the lhs since we know that if the lhs is Null
                 // we will be taking the rhs and only the rhs type_def will then be relevant.
-                lhs_def - Kind::Null | rhs_def
+                (lhs_def - Kind::Null) | rhs_def
             }
             Or => type_def,
             ErrorOr if !lhs_def.is_fallible() => lhs_def,

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -28,7 +28,7 @@ impl From<(Span, Error)> for Diagnostic {
 ///
 /// The initializer of this type errors if the condition doesn't resolve to a
 /// boolean.
-pub struct IfCondition(Box<Expr>);
+pub struct IfCondition(pub(crate) Box<Expr>);
 
 impl IfCondition {
     pub fn new(expression: Box<Expr>, state: &state::Compiler) -> Result<Self, Error> {

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -137,7 +137,6 @@ impl Sub<value::Kind> for TypeDef {
         self.kind -= other;
         self
     }
-
 }
 
 impl From<value::Kind> for TypeDef {

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -1,6 +1,6 @@
 use crate::value;
 use std::collections::{btree_map::Entry, BTreeMap};
-use std::ops::{BitAnd, BitOr};
+use std::ops::{BitAnd, BitOr, Sub};
 
 /// Properties for a given expression that express the expected outcome of the
 /// expression.
@@ -127,6 +127,17 @@ impl BitAnd for TypeDef {
             inner_type_def,
         }
     }
+}
+
+impl Sub<value::Kind> for TypeDef {
+    type Output = Self;
+
+    /// Removes the given kinds from this type definition.
+    fn sub(mut self, other: value::Kind) -> Self::Output {
+        self.kind -= other;
+        self
+    }
+
 }
 
 impl From<value::Kind> for TypeDef {

--- a/lib/remap-tests/tests/examples/successful_parse_syslog_type.vrl
+++ b/lib/remap-tests/tests/examples/successful_parse_syslog_type.vrl
@@ -3,4 +3,4 @@
 
 result = parse_syslog!(.message)
 sha = sha3(value: result.message)
-sha + (result.appname || "<no app name>") ?? ""
+sha + (result.appname || "<no app name>")


### PR DESCRIPTION
Following from #6182, a number of functions return fields that can be `Null`, for example `appname` from `parse_syslog` can be `Kind::Bytes | Kind::Null`.

This PR makes it possible to specify a default value using Or. Since we know that if the lhs is either Null or Bytes, we can deduce that the whole expression `lhs | rhs` will either be the `lhs - Kind::Null` or the `rhs`. 

Eg. This now typechecks:

```
.parsed = parse_syslog(.message)
.sha = sha3(.parsed.appname || "default")
```

However this will still not typecheck, the `procid` field can be either a string, an integer or null. So even after an Or it could still be an Integer or a String.:

```
.parsed = parse_syslog(.message)
.sha = sha3(.parsed.procid || "default")
```




Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
