### PR TITLE
chore(metrics): Simplify Metric::new name/namespace parameter

### DIFF
--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -64,7 +64,7 @@ mod test {
         assert_eq!(cond.check(&Event::from("just a log")), true);
         assert_eq!(
             cond.check(&Event::from(Metric::new(
-                "test metric".to_string(),
+                "test metric",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             ))),

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -64,7 +64,7 @@ mod test {
         assert_eq!(cond.check(&Event::from("just a log")), false);
         assert_eq!(
             cond.check(&Event::from(Metric::new(
-                "test metric".to_string(),
+                "test metric",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             ))),

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -160,7 +160,7 @@ mod test {
             (
                 Event::Metric(
                     Metric::new(
-                        "zork".into(),
+                        "zork",
                         MetricKind::Incremental,
                         MetricValue::Counter { value: 1.0 },
                     )

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -164,7 +164,7 @@ mod test {
                         MetricKind::Incremental,
                         MetricValue::Counter { value: 1.0 },
                     )
-                    .with_namespace(Some("zerk".into()))
+                    .with_namespace(Some("zerk"))
                     .with_tags(Some({
                         let mut tags = BTreeMap::new();
                         tags.insert("host".into(), "zoobub".into());

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -225,11 +225,11 @@ pub enum StatisticKind {
 }
 
 impl Metric {
-    pub fn new(name: String, kind: MetricKind, value: MetricValue) -> Self {
+    pub fn new<T: Into<String>>(name: T, kind: MetricKind, value: MetricValue) -> Self {
         Self {
             series: MetricSeries {
                 name: MetricName {
-                    name,
+                    name: name.into(),
                     namespace: None,
                 },
                 tags: None,
@@ -898,13 +898,13 @@ mod test {
     #[test]
     fn merge_counters() {
         let mut counter = Metric::new(
-            "counter".into(),
+            "counter",
             MetricKind::Incremental,
             MetricValue::Counter { value: 1.0 },
         );
 
         let delta = Metric::new(
-            "counter".into(),
+            "counter",
             MetricKind::Incremental,
             MetricValue::Counter { value: 2.0 },
         )
@@ -916,7 +916,7 @@ mod test {
         assert_eq!(
             counter,
             Metric::new(
-                "counter".into(),
+                "counter",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 3.0 },
             )
@@ -926,13 +926,13 @@ mod test {
     #[test]
     fn merge_gauges() {
         let mut gauge = Metric::new(
-            "gauge".into(),
+            "gauge",
             MetricKind::Incremental,
             MetricValue::Gauge { value: 1.0 },
         );
 
         let delta = Metric::new(
-            "gauge".into(),
+            "gauge",
             MetricKind::Incremental,
             MetricValue::Gauge { value: -2.0 },
         )
@@ -944,7 +944,7 @@ mod test {
         assert_eq!(
             gauge,
             Metric::new(
-                "gauge".into(),
+                "gauge",
                 MetricKind::Incremental,
                 MetricValue::Gauge { value: -1.0 },
             )
@@ -954,7 +954,7 @@ mod test {
     #[test]
     fn merge_sets() {
         let mut set = Metric::new(
-            "set".into(),
+            "set",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["old".into()].into_iter().collect(),
@@ -962,7 +962,7 @@ mod test {
         );
 
         let delta = Metric::new(
-            "set".into(),
+            "set",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["new".into()].into_iter().collect(),
@@ -976,7 +976,7 @@ mod test {
         assert_eq!(
             set,
             Metric::new(
-                "set".into(),
+                "set",
                 MetricKind::Incremental,
                 MetricValue::Set {
                     values: vec!["old".into(), "new".into()].into_iter().collect()
@@ -988,7 +988,7 @@ mod test {
     #[test]
     fn merge_histograms() {
         let mut dist = Metric::new(
-            "hist".into(),
+            "hist",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: samples![1.0 => 10],
@@ -997,7 +997,7 @@ mod test {
         );
 
         let delta = Metric::new(
-            "hist".into(),
+            "hist",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: samples![1.0 => 20],
@@ -1012,7 +1012,7 @@ mod test {
         assert_eq!(
             dist,
             Metric::new(
-                "hist".into(),
+                "hist",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: samples![1.0 => 10, 1.0 => 20],
@@ -1028,7 +1028,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "one".into(),
+                    "one",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1.23 },
                 )
@@ -1041,7 +1041,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "two word".into(),
+                    "two word",
                     MetricKind::Incremental,
                     MetricValue::Gauge { value: 2.0 }
                 )
@@ -1054,7 +1054,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "namespace".into(),
+                    "namespace",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1.23 },
                 )
@@ -1067,7 +1067,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "namespace".into(),
+                    "namespace",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1.23 },
                 )
@@ -1084,11 +1084,7 @@ mod test {
         assert_eq!(
             format!(
                 "{}",
-                Metric::new(
-                    "three".into(),
-                    MetricKind::Absolute,
-                    MetricValue::Set { values }
-                )
+                Metric::new("three", MetricKind::Absolute, MetricValue::Set { values })
             ),
             r#"three{} = "four=4" "thrəë" v1 v2_two"#
         );
@@ -1097,7 +1093,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "four".into(),
+                    "four",
                     MetricKind::Absolute,
                     MetricValue::Distribution {
                         samples: samples![1.0 => 3, 2.0 => 4],
@@ -1112,7 +1108,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "five".into(),
+                    "five",
                     MetricKind::Absolute,
                     MetricValue::AggregatedHistogram {
                         buckets: buckets![51.0 => 53, 52.0 => 54],
@@ -1128,7 +1124,7 @@ mod test {
             format!(
                 "{}",
                 Metric::new(
-                    "six".into(),
+                    "six",
                     MetricKind::Absolute,
                     MetricValue::AggregatedSummary {
                         quantiles: quantiles![1.0 => 63.0, 2.0 => 64.0],
@@ -1144,7 +1140,7 @@ mod test {
     #[test]
     fn object_metric_all_fields() {
         let metric = Metric::new(
-            "zub".into(),
+            "zub",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.23 },
         )
@@ -1175,7 +1171,7 @@ mod test {
     #[test]
     fn object_metric_fields() {
         let mut metric = Metric::new(
-            "name".into(),
+            "name",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.23 },
         )
@@ -1225,7 +1221,7 @@ mod test {
     #[test]
     fn object_metric_invalid_paths() {
         let mut metric = Metric::new(
-            "name".into(),
+            "name",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.23 },
         );

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -242,8 +242,8 @@ impl Metric {
         }
     }
 
-    pub fn with_namespace(mut self, namespace: Option<String>) -> Self {
-        self.series.name.namespace = namespace;
+    pub fn with_namespace<T: Into<String>>(mut self, namespace: Option<T>) -> Self {
+        self.series.name.namespace = namespace.map(Into::into);
         self
     }
 
@@ -307,7 +307,7 @@ impl Metric {
             .collect::<MetricTags>();
 
         Self::new(key.name().to_string(), MetricKind::Absolute, value)
-            .with_namespace(Some("vector".to_string()))
+            .with_namespace(Some("vector"))
             .with_timestamp(Some(Utc::now()))
             .with_tags(if labels.is_empty() {
                 None
@@ -908,7 +908,7 @@ mod test {
             MetricKind::Incremental,
             MetricValue::Counter { value: 2.0 },
         )
-        .with_namespace(Some("vector".to_string()))
+        .with_namespace(Some("vector"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()));
 
@@ -936,7 +936,7 @@ mod test {
             MetricKind::Incremental,
             MetricValue::Gauge { value: -2.0 },
         )
-        .with_namespace(Some("vector".to_string()))
+        .with_namespace(Some("vector"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()));
 
@@ -968,7 +968,7 @@ mod test {
                 values: vec!["new".into()].into_iter().collect(),
             },
         )
-        .with_namespace(Some("vector".to_string()))
+        .with_namespace(Some("vector"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()));
 
@@ -1004,7 +1004,7 @@ mod test {
                 statistic: StatisticKind::Histogram,
             },
         )
-        .with_namespace(Some("vector".to_string()))
+        .with_namespace(Some("vector"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()));
 
@@ -1058,7 +1058,7 @@ mod test {
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1.23 },
                 )
-                .with_namespace(Some("vector".to_string()))
+                .with_namespace(Some("vector"))
             ),
             r#"vector_namespace{} = 1.23"#
         );
@@ -1071,7 +1071,7 @@ mod test {
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1.23 },
                 )
-                .with_namespace(Some("vector host".to_string()))
+                .with_namespace(Some("vector host"))
             ),
             r#""vector host"_namespace{} = 1.23"#
         );
@@ -1144,7 +1144,7 @@ mod test {
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.23 },
         )
-        .with_namespace(Some("zoob".into()))
+        .with_namespace(Some("zoob"))
         .with_tags(Some({
             let mut map = MetricTags::new();
             map.insert("tig".to_string(), "tog".to_string());

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -309,12 +309,12 @@ mod tests {
     fn encode_events_basic_counter() {
         let events = vec![
             Metric::new(
-                "exception_total".into(),
+                "exception_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             ),
             Metric::new(
-                "bytes_out".into(),
+                "bytes_out",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 2.5 },
             )
@@ -322,7 +322,7 @@ mod tests {
                 Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789),
             )),
             Metric::new(
-                "healthcheck".into(),
+                "healthcheck",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn encode_events_absolute_gauge() {
         let events = vec![Metric::new(
-            "temperature".into(),
+            "temperature",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 10.0 },
         )];
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     fn encode_events_distribution() {
         let events = vec![Metric::new(
-            "latency".into(),
+            "latency",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![11.0 => 100, 12.0 => 50],
@@ -407,7 +407,7 @@ mod tests {
     #[test]
     fn encode_events_set() {
         let events = vec![Metric::new(
-            "users".into(),
+            "users",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
@@ -522,7 +522,7 @@ mod integration_tests {
             for _ in 0..100 {
                 let event = Event::Metric(
                     Metric::new(
-                        "counter".to_string(),
+                        "counter",
                         MetricKind::Incremental,
                         MetricValue::Counter { value: 1.0 },
                     )

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -526,7 +526,7 @@ mod integration_tests {
                         MetricKind::Incremental,
                         MetricValue::Counter { value: 1.0 },
                     )
-                    .with_namespace(Some(namespace)),
+                    .with_namespace(Some(*namespace)),
                 );
                 events.push(event);
             }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -526,7 +526,7 @@ mod integration_tests {
                         MetricKind::Incremental,
                         MetricValue::Counter { value: 1.0 },
                     )
-                    .with_namespace(Some(namespace.to_string())),
+                    .with_namespace(Some(namespace)),
                 );
                 events.push(event);
             }

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -196,7 +196,7 @@ mod test {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 100.0 },
             )
-            .with_namespace(Some("vector".into()))
+            .with_namespace(Some("vector"))
             .with_tags(Some(
                 vec![
                     ("key2".to_owned(), "value2".to_owned()),

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -192,7 +192,7 @@ mod test {
     fn encodes_counter() {
         let event = Event::Metric(
             Metric::new(
-                "foos".into(),
+                "foos",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 100.0 },
             )
@@ -217,7 +217,7 @@ mod test {
     #[test]
     fn encodes_set() {
         let event = Event::Metric(Metric::new(
-            "users".into(),
+            "users",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["bob".into()].into_iter().collect(),
@@ -232,7 +232,7 @@ mod test {
     #[test]
     fn encodes_histogram_without_timestamp() {
         let event = Event::Metric(Metric::new(
-            "glork".into(),
+            "glork",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![10.0 => 1],
@@ -248,7 +248,7 @@ mod test {
     #[test]
     fn encodes_metric_text() {
         let event = Event::Metric(Metric::new(
-            "users".into(),
+            "users",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["bob".into()].into_iter().collect(),

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -550,13 +550,13 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
-            .with_namespace(Some("test".into())),
+            .with_namespace(Some("test")),
             Metric::new(
                 "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("test".into()))
+            .with_namespace(Some("test"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
             Metric::new(
@@ -564,7 +564,7 @@ mod tests {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("test".into()))
+            .with_namespace(Some("test"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
         ];
@@ -602,14 +602,14 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_timestamp(Some(ts())),
             Metric::new(
                 "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
         ];

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -546,13 +546,13 @@ mod tests {
 
         let events = vec![
             Metric::new(
-                "total".into(),
+                "total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
             .with_namespace(Some("test".into())),
             Metric::new(
-                "check".into(),
+                "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -560,7 +560,7 @@ mod tests {
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "unsupported".into(),
+                "unsupported",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -598,14 +598,14 @@ mod tests {
         let interval = 60;
         let events = vec![
             Metric::new(
-                "total".into(),
+                "total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
             .with_namespace(Some("ns".into()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "check".into(),
+                "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -625,7 +625,7 @@ mod tests {
     #[test]
     fn encode_gauge() {
         let events = vec![Metric::new(
-            "volume".into(),
+            "volume",
             MetricKind::Absolute,
             MetricValue::Gauge { value: -1.1 },
         )
@@ -642,7 +642,7 @@ mod tests {
     #[test]
     fn encode_set() {
         let events = vec![Metric::new(
-            "users".into(),
+            "users",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
@@ -744,7 +744,7 @@ mod tests {
     fn encode_distribution() {
         // https://docs.datadoghq.com/developers/metrics/metrics_type/?tab=histogram#metric-type-definition
         let events = vec![Metric::new(
-            "requests".into(),
+            "requests",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 3, 2.0 => 3, 3.0 => 2],
@@ -765,7 +765,7 @@ mod tests {
     fn encode_datadog_distribution() {
         // https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
         let events = vec![Metric::new(
-            "requests".into(),
+            "requests",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 3, 2.0 => 3, 3.0 => 2],

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -171,7 +171,7 @@ mod tests {
         let metrics = vec![
             Event::from(
                 Metric::new(
-                    "metric1".to_string(),
+                    "metric1",
                     MetricKind::Incremental,
                     MetricValue::Counter { value: 42.0 },
                 )
@@ -184,7 +184,7 @@ mod tests {
             ),
             Event::from(
                 Metric::new(
-                    "metric2".to_string(),
+                    "metric2",
                     MetricKind::Absolute,
                     MetricValue::Distribution {
                         samples: crate::samples![1.0 => 100, 2.0 => 200, 3.0 => 300],

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -366,14 +366,14 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_timestamp(Some(ts())),
             Metric::new(
                 "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
         ];
@@ -393,7 +393,7 @@ mod tests {
             MetricKind::Incremental,
             MetricValue::Gauge { value: -1.5 },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -413,7 +413,7 @@ mod tests {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -435,7 +435,7 @@ mod tests {
                 sum: 12.5,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -474,7 +474,7 @@ mod tests {
                 sum: 12.5,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -513,7 +513,7 @@ mod tests {
                 sum: 12.0,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -552,7 +552,7 @@ mod tests {
                 sum: 12.0,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -591,7 +591,7 @@ mod tests {
                     statistic: StatisticKind::Histogram,
                 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
             Metric::new(
@@ -607,7 +607,7 @@ mod tests {
                     statistic: StatisticKind::Histogram,
                 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_timestamp(Some(ts())),
             Metric::new(
                 "sparse_stats",
@@ -622,7 +622,7 @@ mod tests {
                     statistic: StatisticKind::Histogram,
                 },
             )
-            .with_namespace(Some("ns".into()))
+            .with_namespace(Some("ns"))
             .with_timestamp(Some(ts())),
         ];
 
@@ -698,7 +698,7 @@ mod tests {
                 statistic: StatisticKind::Histogram,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -716,7 +716,7 @@ mod tests {
                 statistic: StatisticKind::Histogram,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -734,7 +734,7 @@ mod tests {
                 statistic: StatisticKind::Summary,
             },
         )
-        .with_namespace(Some("ns".into()))
+        .with_namespace(Some("ns"))
         .with_tags(Some(tags()))
         .with_timestamp(Some(ts()))];
 
@@ -784,14 +784,14 @@ mod tests {
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 2.5 },
             )
-            .with_namespace(Some("vector".into()))
+            .with_namespace(Some("vector"))
             .with_timestamp(Some(ts())),
             Metric::new(
                 "mem",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 1000.0 },
             )
-            .with_namespace(Some("vector".into()))
+            .with_namespace(Some("vector"))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
         ];
@@ -938,7 +938,7 @@ mod integration_tests {
                     MetricKind::Incremental,
                     MetricValue::Counter { value: i as f64 },
                 )
-                .with_namespace(Some("ns".to_string()))
+                .with_namespace(Some("ns"))
                 .with_tags(Some(
                     vec![
                         ("region".to_owned(), "us-west-1".to_owned()),
@@ -1023,7 +1023,7 @@ mod integration_tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: i as f64 },
             )
-            .with_namespace(Some("ns".to_string()))
+            .with_namespace(Some("ns"))
             .with_tags(Some(
                 vec![
                     ("region".to_owned(), "us-west-1".to_owned()),

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -934,7 +934,7 @@ mod integration_tests {
         for i in 0..10 {
             let event = Event::Metric(
                 Metric::new(
-                    metric,
+                    metric.clone(),
                     MetricKind::Incremental,
                     MetricValue::Counter { value: i as f64 },
                 )

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -362,14 +362,14 @@ mod tests {
     fn test_encode_counter() {
         let events = vec![
             Metric::new(
-                "total".into(),
+                "total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.5 },
             )
             .with_namespace(Some("ns".into()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "check".into(),
+                "check",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn test_encode_gauge() {
         let events = vec![Metric::new(
-            "meter".to_owned(),
+            "meter",
             MetricKind::Incremental,
             MetricValue::Gauge { value: -1.5 },
         )
@@ -407,7 +407,7 @@ mod tests {
     #[test]
     fn test_encode_set() {
         let events = vec![Metric::new(
-            "users".into(),
+            "users",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
@@ -427,7 +427,7 @@ mod tests {
     #[test]
     fn test_encode_histogram_v1() {
         let events = vec![Metric::new(
-            "requests".to_owned(),
+            "requests",
             MetricKind::Absolute,
             MetricValue::AggregatedHistogram {
                 buckets: crate::buckets![1.0 => 1, 2.1 => 2, 3.0 => 3],
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn test_encode_histogram() {
         let events = vec![Metric::new(
-            "requests".to_owned(),
+            "requests",
             MetricKind::Absolute,
             MetricValue::AggregatedHistogram {
                 buckets: crate::buckets![1.0 => 1, 2.1 => 2, 3.0 => 3],
@@ -505,7 +505,7 @@ mod tests {
     #[test]
     fn test_encode_summary_v1() {
         let events = vec![Metric::new(
-            "requests_sum".to_owned(),
+            "requests_sum",
             MetricKind::Absolute,
             MetricValue::AggregatedSummary {
                 quantiles: crate::quantiles![0.01 => 1.5, 0.5 => 2.0, 0.99 => 3.0],
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn test_encode_summary() {
         let events = vec![Metric::new(
-            "requests_sum".to_owned(),
+            "requests_sum",
             MetricKind::Absolute,
             MetricValue::AggregatedSummary {
                 quantiles: crate::quantiles![0.01 => 1.5, 0.5 => 2.0, 0.99 => 3.0],
@@ -584,7 +584,7 @@ mod tests {
     fn test_encode_distribution() {
         let events = vec![
             Metric::new(
-                "requests".into(),
+                "requests",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![1.0 => 3, 2.0 => 3, 3.0 => 2],
@@ -595,7 +595,7 @@ mod tests {
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "dense_stats".into(),
+                "dense_stats",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: (0..20)
@@ -610,7 +610,7 @@ mod tests {
             .with_namespace(Some("ns".into()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "sparse_stats".into(),
+                "sparse_stats",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: (1..5)
@@ -691,7 +691,7 @@ mod tests {
     #[test]
     fn test_encode_distribution_empty_stats() {
         let events = vec![Metric::new(
-            "requests".into(),
+            "requests",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: vec![],
@@ -709,7 +709,7 @@ mod tests {
     #[test]
     fn test_encode_distribution_zero_counts_stats() {
         let events = vec![Metric::new(
-            "requests".into(),
+            "requests",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 0, 2.0 => 0],
@@ -727,7 +727,7 @@ mod tests {
     #[test]
     fn test_encode_distribution_summary() {
         let events = vec![Metric::new(
-            "requests".into(),
+            "requests",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 3, 2.0 => 3, 3.0 => 2],
@@ -780,14 +780,14 @@ mod tests {
 
         let events = vec![
             Metric::new(
-                "cpu".into(),
+                "cpu",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 2.5 },
             )
             .with_namespace(Some("vector".into()))
             .with_timestamp(Some(ts())),
             Metric::new(
-                "mem".into(),
+                "mem",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 1000.0 },
             )
@@ -934,7 +934,7 @@ mod integration_tests {
         for i in 0..10 {
             let event = Event::Metric(
                 Metric::new(
-                    metric.to_string(),
+                    metric,
                     MetricKind::Incremental,
                     MetricValue::Counter { value: i as f64 },
                 )

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -479,7 +479,7 @@ mod tests {
     #[test]
     fn kafka_encode_event_metric_text() {
         let metric = Metric::new(
-            "kafka-metric".to_owned(),
+            "kafka-metric",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.0 },
         );
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn kafka_encode_event_metric_json() {
         let metric = Metric::new(
-            "kafka-metric".to_owned(),
+            "kafka-metric",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.0 },
         );

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -424,7 +424,7 @@ mod tests {
         let mut sink = PrometheusExporter::new(config, cx.acker());
 
         let m1 = Metric::new(
-            "absolute".to_string(),
+            "absolute",
             MetricKind::Absolute,
             MetricValue::Counter { value: 32. },
         )

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn test_encode_counter_event() {
         let events = vec![Metric::new(
-            "pool.used".into(),
+            "pool.used",
             MetricKind::Incremental,
             MetricValue::Counter { value: 42.0 },
         )
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn test_encode_counter_event_no_namespace() {
         let events = vec![Metric::new(
-            "used".into(),
+            "used",
             MetricKind::Incremental,
             MetricValue::Counter { value: 42.0 },
         )
@@ -300,14 +300,14 @@ mod tests {
     fn test_encode_counter_multiple_events() {
         let events = vec![
             Metric::new(
-                "pool.used".into(),
+                "pool.used",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 42.0 },
             )
             .with_namespace(Some("jvm".into()))
             .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0))),
             Metric::new(
-                "pool.committed".into(),
+                "pool.committed",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 18874368.0 },
             )
@@ -365,7 +365,7 @@ mod tests {
         for (i, (namespace, metric, val)) in metrics.iter().enumerate() {
             let event = Event::from(
                 Metric::new(
-                    metric.to_string(),
+                    metric,
                     MetricKind::Incremental,
                     MetricValue::Counter { value: *val as f64 },
                 )

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -365,11 +365,11 @@ mod tests {
         for (i, (namespace, metric, val)) in metrics.iter().enumerate() {
             let event = Event::from(
                 Metric::new(
-                    metric,
+                    *metric,
                     MetricKind::Incremental,
                     MetricValue::Counter { value: *val as f64 },
                 )
-                .with_namespace(Some(namespace))
+                .with_namespace(Some(*namespace))
                 .with_tags(Some(
                     vec![("os.host".to_owned(), "somehost".to_owned())]
                         .into_iter()

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -272,7 +272,7 @@ mod tests {
             MetricKind::Incremental,
             MetricValue::Counter { value: 42.0 },
         )
-        .with_namespace(Some("jvm".into()))
+        .with_namespace(Some("jvm"))
         .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)))];
 
         assert_eq!(
@@ -304,14 +304,14 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 42.0 },
             )
-            .with_namespace(Some("jvm".into()))
+            .with_namespace(Some("jvm"))
             .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0))),
             Metric::new(
                 "pool.committed",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 18874368.0 },
             )
-            .with_namespace(Some("jvm".into()))
+            .with_namespace(Some("jvm"))
             .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 1))),
         ];
 
@@ -369,7 +369,7 @@ mod tests {
                     MetricKind::Incremental,
                     MetricValue::Counter { value: *val as f64 },
                 )
-                .with_namespace(Some(namespace.to_string()))
+                .with_namespace(Some(namespace))
                 .with_tags(Some(
                     vec![("os.host".to_owned(), "somehost".to_owned())]
                         .into_iter()

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -294,7 +294,7 @@ mod test {
     #[test]
     fn test_encode_counter() {
         let metric1 = Metric::new(
-            "counter".to_owned(),
+            "counter",
             MetricKind::Incremental,
             MetricValue::Counter { value: 1.5 },
         )
@@ -309,7 +309,7 @@ mod test {
     #[test]
     fn test_encode_absolute_counter() {
         let metric1 = Metric::new(
-            "counter".to_owned(),
+            "counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.5 },
         );
@@ -324,7 +324,7 @@ mod test {
     #[test]
     fn test_encode_gauge() {
         let metric1 = Metric::new(
-            "gauge".to_owned(),
+            "gauge",
             MetricKind::Incremental,
             MetricValue::Gauge { value: -1.5 },
         )
@@ -339,7 +339,7 @@ mod test {
     #[test]
     fn test_encode_absolute_gauge() {
         let metric1 = Metric::new(
-            "gauge".to_owned(),
+            "gauge",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 1.5 },
         )
@@ -354,7 +354,7 @@ mod test {
     #[test]
     fn test_encode_distribution() {
         let metric1 = Metric::new(
-            "distribution".to_owned(),
+            "distribution",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.5 => 1],
@@ -372,7 +372,7 @@ mod test {
     #[test]
     fn test_encode_set() {
         let metric1 = Metric::new(
-            "set".to_owned(),
+            "set",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["abc".to_owned()].into_iter().collect(),
@@ -409,7 +409,7 @@ mod test {
         let events = vec![
             Event::Metric(
                 Metric::new(
-                    "counter".to_owned(),
+                    "counter",
                     MetricKind::Incremental,
                     MetricValue::Counter { value: 1.5 },
                 )
@@ -418,7 +418,7 @@ mod test {
             ),
             Event::Metric(
                 Metric::new(
-                    "histogram".to_owned(),
+                    "histogram",
                     MetricKind::Incremental,
                     MetricValue::Distribution {
                         samples: crate::samples![2.0 => 100],

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -413,7 +413,7 @@ mod test {
                     MetricKind::Incremental,
                     MetricValue::Counter { value: 1.5 },
                 )
-                .with_namespace(Some("vector".into()))
+                .with_namespace(Some("vector"))
                 .with_tags(Some(tags())),
             ),
             Event::Metric(
@@ -425,7 +425,7 @@ mod test {
                         statistic: StatisticKind::Histogram,
                     },
                 )
-                .with_namespace(Some("vector".into())),
+                .with_namespace(Some("vector")),
             ),
         ];
         let (mut tx, rx) = mpsc::channel(1);

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -190,7 +190,7 @@ fn apache_metrics(
                                     Some(&tags),
                                 )
                                 .chain(vec![Ok(Metric::new(
-                                    "up".into(),
+                                    "up",
                                     MetricKind::Absolute,
                                     MetricValue::Gauge { value: 1.0 },
                                 )
@@ -224,7 +224,7 @@ fn apache_metrics(
                                 });
                                 Some(
                                     stream::iter(vec![Metric::new(
-                                        "up".into(),
+                                        "up",
                                         MetricKind::Absolute,
                                         MetricValue::Gauge { value: 1.0 },
                                     )
@@ -242,7 +242,7 @@ fn apache_metrics(
                                 });
                                 Some(
                                     stream::iter(vec![Metric::new(
-                                        "up".into(),
+                                        "up",
                                         MetricKind::Absolute,
                                         MetricValue::Gauge { value: 0.0 },
                                     )

--- a/src/sources/apache_metrics/parser.rs
+++ b/src/sources/apache_metrics/parser.rs
@@ -536,7 +536,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -544,7 +544,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -552,7 +552,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "total" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -560,7 +560,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "writing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -568,7 +568,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -576,7 +576,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "dnslookup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -584,7 +584,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "finishing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -592,7 +592,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "idle_cleanup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -600,7 +600,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -608,7 +608,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "logging" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -616,7 +616,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 325.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "open" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -624,7 +624,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "reading" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -632,7 +632,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "sending" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -640,7 +640,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "starting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -648,7 +648,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 64.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "waiting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -656,14 +656,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 12.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "busy" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -671,7 +671,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 74.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "idle" }))
                 .with_timestamp(Some(now)),
             ]
@@ -745,14 +745,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 30.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -760,7 +760,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -768,7 +768,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "total" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -776,7 +776,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "writing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -784,14 +784,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.846154 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "type" => "children_system" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -799,7 +799,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "type" => "children_user" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -807,7 +807,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.02 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "type" => "system" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -815,7 +815,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.2 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "type" => "user" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -823,14 +823,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 11.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -838,7 +838,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "dnslookup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -846,7 +846,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "finishing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -854,7 +854,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "idle_cleanup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -862,7 +862,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -870,7 +870,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "logging" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -878,7 +878,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 325.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "open" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -886,7 +886,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "reading" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -894,7 +894,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "sending" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -902,7 +902,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "starting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -910,7 +910,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 64.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "waiting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -918,21 +918,21 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 222208.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "uptime_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 26.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_timestamp(Some(now)),
                 Metric::new(
                     "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "busy" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
@@ -940,7 +940,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 74.0 },
                 )
-                .with_namespace(Some("apache".into()))
+                .with_namespace(Some("apache"))
                 .with_tags(Some(btreemap! { "state" => "idle" }))
                 .with_timestamp(Some(now)),
             ]
@@ -976,7 +976,7 @@ ConnsTotal: 1
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 1.0 },
             )
-            .with_namespace(Some("apache".into()))
+            .with_namespace(Some("apache"))
             .with_tags(Some(btreemap! { "state" => "total" }))
             .with_timestamp(Some(now)),]
         );

--- a/src/sources/apache_metrics/parser.rs
+++ b/src/sources/apache_metrics/parser.rs
@@ -154,7 +154,7 @@ fn line_to_metrics<'a>(
         result.map(move |statistic| match statistic {
             StatusFieldStatistic::ServerUptimeSeconds(value) => Box::new(iter::once(
                 Metric::new(
-                    "uptime_seconds_total".into(),
+                    "uptime_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: value as f64,
@@ -166,7 +166,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::TotalAccesses(value) => Box::new(iter::once(
                 Metric::new(
-                    "access_total".into(),
+                    "access_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: value as f64,
@@ -178,7 +178,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::TotalKBytes(value) => Box::new(iter::once(
                 Metric::new(
-                    "sent_bytes_total".into(),
+                    "sent_bytes_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: (value * 1024) as f64,
@@ -190,7 +190,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::TotalDuration(value) => Box::new(iter::once(
                 Metric::new(
-                    "duration_seconds_total".into(),
+                    "duration_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: value as f64,
@@ -202,7 +202,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::CPUUser(value) => Box::new(iter::once(
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value },
                 )
@@ -217,7 +217,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUSystem(value) => Box::new(iter::once(
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value },
                 )
@@ -232,7 +232,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUChildrenUser(value) => Box::new(iter::once(
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value },
                 )
@@ -247,7 +247,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPUChildrenSystem(value) => Box::new(iter::once(
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value },
                 )
@@ -262,7 +262,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::CPULoad(value) => Box::new(iter::once(
                 Metric::new(
-                    "cpu_load".into(),
+                    "cpu_load",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value },
                 )
@@ -273,7 +273,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::IdleWorkers(value) => Box::new(iter::once(
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -290,7 +290,7 @@ fn line_to_metrics<'a>(
                 as Box<dyn Iterator<Item = Metric>>,
             StatusFieldStatistic::BusyWorkers(value) => Box::new(iter::once(
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -306,7 +306,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::ConnsTotal(value) => Box::new(iter::once(
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -322,7 +322,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::ConnsAsyncWriting(value) => Box::new(iter::once(
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -338,7 +338,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::ConnsAsyncClosing(value) => Box::new(iter::once(
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -354,7 +354,7 @@ fn line_to_metrics<'a>(
             )),
             StatusFieldStatistic::ConnsAsyncKeepAlive(value) => Box::new(iter::once(
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge {
                         value: value as f64,
@@ -406,7 +406,7 @@ fn score_to_metric(
     count: u32,
 ) -> Metric {
     Metric::new(
-        "scoreboard".into(),
+        "scoreboard",
         MetricKind::Absolute,
         MetricValue::Gauge {
             value: count.into(),
@@ -532,7 +532,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             metrics,
             vec![
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -540,7 +540,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -548,7 +548,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -556,7 +556,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "total" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -564,7 +564,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "writing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -572,7 +572,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -580,7 +580,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "dnslookup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -588,7 +588,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "finishing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -596,7 +596,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "idle_cleanup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -604,7 +604,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -612,7 +612,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "logging" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 325.0 },
                 )
@@ -620,7 +620,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "open" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -628,7 +628,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "reading" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -636,7 +636,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "sending" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -644,7 +644,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "starting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 64.0 },
                 )
@@ -652,14 +652,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "waiting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "uptime_seconds_total".into(),
+                    "uptime_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 12.0 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -667,7 +667,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "busy" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 74.0 },
                 )
@@ -741,14 +741,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
             metrics,
             vec![
                 Metric::new(
-                    "access_total".into(),
+                    "access_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 30.0 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -756,7 +756,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -764,7 +764,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -772,7 +772,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "total" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "connections".into(),
+                    "connections",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -780,14 +780,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "writing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "cpu_load".into(),
+                    "cpu_load",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.846154 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -795,7 +795,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "type" => "children_system" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.0 },
                 )
@@ -803,7 +803,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "type" => "children_user" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.02 },
                 )
@@ -811,7 +811,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "type" => "system" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "cpu_seconds_total".into(),
+                    "cpu_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.2 },
                 )
@@ -819,14 +819,14 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "type" => "user" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "duration_seconds_total".into(),
+                    "duration_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 11.0 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -834,7 +834,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "closing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -842,7 +842,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "dnslookup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -850,7 +850,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "finishing" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -858,7 +858,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "idle_cleanup" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -866,7 +866,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "keepalive" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -874,7 +874,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "logging" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 325.0 },
                 )
@@ -882,7 +882,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "open" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -890,7 +890,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "reading" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -898,7 +898,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "sending" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -906,7 +906,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "starting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "scoreboard".into(),
+                    "scoreboard",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 64.0 },
                 )
@@ -914,21 +914,21 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "waiting" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "sent_bytes_total".into(),
+                    "sent_bytes_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 222208.0 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "uptime_seconds_total".into(),
+                    "uptime_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 26.0 },
                 )
                 .with_namespace(Some("apache".into()))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -936,7 +936,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                 .with_tags(Some(btreemap! { "state" => "busy" }))
                 .with_timestamp(Some(now)),
                 Metric::new(
-                    "workers".into(),
+                    "workers",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 74.0 },
                 )
@@ -972,7 +972,7 @@ ConnsTotal: 1
         assert_eq!(
             metrics,
             vec![Metric::new(
-                "connections".into(),
+                "connections",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 1.0 },
             )

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -538,7 +538,7 @@ mod test {
             parse(json.as_bytes(), namespace()).unwrap(),
             vec![
                 Metric::new(
-                    "blkio_recursive_io_service_bytes_total".into(),
+                    "blkio_recursive_io_service_bytes_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
@@ -558,7 +558,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "blkio_recursive_io_service_bytes_total".into(),
+                    "blkio_recursive_io_service_bytes_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 520192.0 },
                 )
@@ -616,7 +616,7 @@ mod test {
             parse(json.as_bytes(), namespace()).unwrap(),
             vec![
                 Metric::new(
-                    "cpu_online_cpus".into(),
+                    "cpu_online_cpus",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -634,7 +634,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_system_jiffies_total".into(),
+                    "cpu_usage_system_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: 2007130000000.0
@@ -654,7 +654,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_usermode_jiffies_total".into(),
+                    "cpu_usage_usermode_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 510000000.0 },
                 )
@@ -672,7 +672,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_kernelmode_jiffies_total".into(),
+                    "cpu_usage_kernelmode_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 190000000.0 },
                 )
@@ -690,7 +690,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_total_jiffies_total".into(),
+                    "cpu_usage_total_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: 2324920942.0
@@ -710,7 +710,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_throttling_periods_total".into(),
+                    "cpu_throttling_periods_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
@@ -728,7 +728,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_throttled_periods_total".into(),
+                    "cpu_throttled_periods_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
@@ -746,7 +746,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_throttled_time_seconds_total".into(),
+                    "cpu_throttled_time_seconds_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
@@ -764,7 +764,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_percpu_jiffies_total".into(),
+                    "cpu_usage_percpu_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: 1095931487.0
@@ -785,7 +785,7 @@ mod test {
                 ))
                 .with_timestamp(Some(ts())),
                 Metric::new(
-                    "cpu_usage_percpu_jiffies_total".into(),
+                    "cpu_usage_percpu_jiffies_total",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: 1228989455.0
@@ -867,7 +867,7 @@ mod test {
                 .find(|m| m.name() == "memory_used_bytes")
                 .unwrap(),
             &Metric::new(
-                "memory_used_bytes".into(),
+                "memory_used_bytes",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 40120320.0 },
             )
@@ -892,7 +892,7 @@ mod test {
                 .find(|m| m.name() == "memory_max_used_bytes")
                 .unwrap(),
             &Metric::new(
-                "memory_max_used_bytes".into(),
+                "memory_max_used_bytes",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 47177728.0 },
             )
@@ -917,7 +917,7 @@ mod test {
                 .find(|m| m.name() == "memory_active_anonymous_bytes")
                 .unwrap(),
             &Metric::new(
-                "memory_active_anonymous_bytes".into(),
+                "memory_active_anonymous_bytes",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 34885632.0 },
             )
@@ -942,7 +942,7 @@ mod test {
                 .find(|m| m.name() == "memory_total_page_faults_total")
                 .unwrap(),
             &Metric::new(
-                "memory_total_page_faults_total".into(),
+                "memory_total_page_faults_total",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 31131.0 },
             )
@@ -993,7 +993,7 @@ mod test {
                 .find(|m| m.name() == "network_receive_bytes_total")
                 .unwrap(),
             &Metric::new(
-                "network_receive_bytes_total".into(),
+                "network_receive_bytes_total",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 329932716.0 },
             )
@@ -1019,7 +1019,7 @@ mod test {
                 .find(|m| m.name() == "network_transmit_bytes_total")
                 .unwrap(),
             &Metric::new(
-                "network_transmit_bytes_total".into(),
+                "network_transmit_bytes_total",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 2001229.0 },
             )

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -690,14 +690,10 @@ impl HostMetricsConfig {
         value: f64,
         tags: BTreeMap<String, String>,
     ) -> Metric {
-        Metric::new(
-            name.into(),
-            MetricKind::Absolute,
-            MetricValue::Counter { value },
-        )
-        .with_namespace(self.namespace.0.clone())
-        .with_tags(Some(tags))
-        .with_timestamp(Some(timestamp))
+        Metric::new(name, MetricKind::Absolute, MetricValue::Counter { value })
+            .with_namespace(self.namespace.0.clone())
+            .with_tags(Some(tags))
+            .with_timestamp(Some(timestamp))
     }
 
     fn gauge(
@@ -707,14 +703,10 @@ impl HostMetricsConfig {
         value: f64,
         tags: BTreeMap<String, String>,
     ) -> Metric {
-        Metric::new(
-            name.into(),
-            MetricKind::Absolute,
-            MetricValue::Gauge { value },
-        )
-        .with_namespace(self.namespace.0.clone())
-        .with_tags(Some(tags))
-        .with_timestamp(Some(timestamp))
+        Metric::new(name, MetricKind::Absolute, MetricValue::Gauge { value })
+            .with_namespace(self.namespace.0.clone())
+            .with_tags(Some(tags))
+            .with_timestamp(Some(timestamp))
     }
 }
 

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -288,7 +288,7 @@ impl MongoDBMetrics {
         value: MetricValue,
         tags: BTreeMap<String, String>,
     ) -> Metric {
-        Metric::new(name.into(), MetricKind::Absolute, value)
+        Metric::new(name, MetricKind::Absolute, value)
             .with_namespace(self.namespace.clone())
             .with_tags(Some(tags))
             .with_timestamp(Some(Utc::now()))

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -221,7 +221,7 @@ impl NginxMetrics {
     }
 
     fn create_metric(&self, name: &str, value: MetricValue) -> Metric {
-        Metric::new(name.into(), MetricKind::Absolute, value)
+        Metric::new(name, MetricKind::Absolute, value)
             .with_namespace(self.namespace.clone())
             .with_tags(Some(self.tags.clone()))
             .with_timestamp(Some(Utc::now()))

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -734,7 +734,7 @@ impl PostgresqlMetrics {
         value: MetricValue,
         tags: BTreeMap<String, String>,
     ) -> Metric {
-        Metric::new(name.into(), MetricKind::Absolute, value)
+        Metric::new(name, MetricKind::Absolute, value)
             .with_namespace(self.namespace.clone())
             .with_tags(Some(tags))
             .with_timestamp(Some(Utc::now()))

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -165,7 +165,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "uptime".into(),
+                "uptime",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 123.0 },
             )]),
@@ -215,7 +215,7 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "name".into(),
+                    "name",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.23 },
                 )
@@ -228,7 +228,7 @@ mod test {
                     .collect()
                 )),
                 Metric::new(
-                    "name2".into(),
+                    "name2",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: std::f64::INFINITY
@@ -243,7 +243,7 @@ mod test {
                     .collect()
                 )),
                 Metric::new(
-                    "name2".into(),
+                    "name2",
                     MetricKind::Absolute,
                     MetricValue::Counter {
                         value: std::f64::NEG_INFINITY
@@ -271,7 +271,7 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "http_requests_total".into(),
+                    "http_requests_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 1027.0 },
                 )
@@ -284,7 +284,7 @@ mod test {
                     .collect()
                 )),
                 Metric::new(
-                    "http_requests_total".into(),
+                    "http_requests_total",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 3.0 },
                 )
@@ -311,7 +311,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "latency".into(),
+                "latency",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 123.0 },
             )]),
@@ -327,7 +327,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "metric_without_timestamp_and_labels".into(),
+                "metric_without_timestamp_and_labels",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 12.47 },
             )]),
@@ -343,7 +343,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "no_labels".into(),
+                "no_labels",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 3.0 },
             )]),
@@ -386,7 +386,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "name".into(),
+                "name",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
@@ -404,7 +404,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "name".into(),
+                "name",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
@@ -422,7 +422,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "name".into(),
+                "name",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
@@ -440,7 +440,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "name".into(),
+                "name",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
@@ -457,7 +457,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "telemetry_scrape_size_bytes_count".into(),
+                "telemetry_scrape_size_bytes_count",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 1890.0 },
             )
@@ -499,7 +499,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "something_weird".into(),
+                "something_weird",
                 MetricKind::Absolute,
                 MetricValue::Gauge {
                     value: std::f64::INFINITY
@@ -525,7 +525,7 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "latency".into(),
+                    "latency",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 1.0 },
                 )
@@ -535,7 +535,7 @@ mod test {
                         .collect()
                 )),
                 Metric::new(
-                    "latency".into(),
+                    "latency",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 2.0 },
                 )
@@ -561,17 +561,17 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "uptime".into(),
+                    "uptime",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 123.0 },
                 ),
                 Metric::new(
-                    "temperature".into(),
+                    "temperature",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: -1.5 },
                 ),
                 Metric::new(
-                    "launch_count".into(),
+                    "launch_count",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 10.0 },
                 )
@@ -614,22 +614,22 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "uptime".into(),
+                    "uptime",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 123.0 },
                 ),
                 Metric::new(
-                    "last_downtime".into(),
+                    "last_downtime",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 4.0 },
                 ),
                 Metric::new(
-                    "temperature".into(),
+                    "temperature",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: -1.5 },
                 ),
                 Metric::new(
-                    "temperature_7_days_average".into(),
+                    "temperature_7_days_average",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.1 },
                 )
@@ -655,7 +655,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "http_request_duration_seconds".into(),
+                "http_request_duration_seconds",
                 MetricKind::Absolute,
                 MetricValue::AggregatedHistogram {
                     buckets: crate::buckets![
@@ -718,7 +718,7 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "gitlab_runner_job_duration_seconds".into(), MetricKind::Absolute, MetricValue::AggregatedHistogram {
+                    "gitlab_runner_job_duration_seconds", MetricKind::Absolute, MetricValue::AggregatedHistogram {
                         buckets: crate::buckets![
                             30.0 => 327,
                             60.0 => 147,
@@ -736,7 +736,7 @@ mod test {
                     },
                 ).with_tags(Some(vec![("runner".into(), "z".into())].into_iter().collect())),
                 Metric::new(
-                    "gitlab_runner_job_duration_seconds".into(), MetricKind::Absolute, MetricValue::AggregatedHistogram {
+                    "gitlab_runner_job_duration_seconds", MetricKind::Absolute, MetricValue::AggregatedHistogram {
                         buckets: crate::buckets![
                             30.0 => 1,
                             60.0 => 0,
@@ -754,7 +754,7 @@ mod test {
                     },
                 ).with_tags(Some(vec![("runner".into(), "x".into())].into_iter().collect())),
                 Metric::new(
-                    "gitlab_runner_job_duration_seconds".into(), MetricKind::Absolute, MetricValue::AggregatedHistogram {
+                    "gitlab_runner_job_duration_seconds", MetricKind::Absolute, MetricValue::AggregatedHistogram {
                         buckets: crate::buckets![
                             30.0 => 285, 60.0 => 880, 300.0 => 1906, 600.0 => 80, 1800.0 => 101, 3600.0 => 3,
                             7200.0 => 0, 10800.0 => 0, 18000.0 => 0, 36000.0 => 0
@@ -794,7 +794,7 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "rpc_duration_seconds".into(),
+                    "rpc_duration_seconds",
                     MetricKind::Absolute,
                     MetricValue::AggregatedSummary {
                         quantiles: crate::quantiles![
@@ -812,7 +812,7 @@ mod test {
                     vec![("service".into(), "a".into())].into_iter().collect()
                 )),
                 Metric::new(
-                    "go_gc_duration_seconds".into(),
+                    "go_gc_duration_seconds",
                     MetricKind::Absolute,
                     MetricValue::AggregatedSummary {
                         quantiles: crate::quantiles![
@@ -856,19 +856,19 @@ mod test {
             parse(exp),
             Ok(vec![
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 263719.0 },
                 )
                 .with_tags(Some(btreemap! { "direction" => "in", "host" => "*" })),
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 255061.0 },
                 )
                 .with_tags(Some(btreemap! { "direction" => "in", "host" => "_" })),
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 8658.0 },
                 )
@@ -876,19 +876,19 @@ mod test {
                     btreemap! { "direction" => "in", "host" => "nginx-vts-status" }
                 )),
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 944199.0 },
                 )
                 .with_tags(Some(btreemap! { "direction" => "out", "host" => "*" })),
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 360775.0 },
                 )
                 .with_tags(Some(btreemap! { "direction" => "out", "host" => "_" })),
                 Metric::new(
-                    "nginx_server_bytes".into(),
+                    "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 583424.0 },
                 )
@@ -896,37 +896,37 @@ mod test {
                     btreemap! { "direction" => "out", "host" => "nginx-vts-status" }
                 )),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "bypass" })),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "expired" })),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "hit" })),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "miss" })),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "revalidated" })),
                 Metric::new(
-                    "nginx_server_cache".into(),
+                    "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -359,7 +359,7 @@ mod test {
         assert_eq!(
             parse(exp),
             Ok(vec![Metric::new(
-                "msdos_file_access_time_seconds".into(),
+                "msdos_file_access_time_seconds",
                 MetricKind::Absolute,
                 MetricValue::Gauge {
                     value: 1458255915.0

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -230,7 +230,7 @@ mod test {
         assert_eq!(
             parse("foo:1|c"),
             Ok(Metric::new(
-                "foo".into(),
+                "foo",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )),
@@ -242,7 +242,7 @@ mod test {
         assert_eq!(
             parse("foo:1|c|#tag1,tag2:value"),
             Ok(Metric::new(
-                "foo".into(),
+                "foo",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -262,7 +262,7 @@ mod test {
         assert_eq!(
             parse("bar:2|c|@0.1"),
             Ok(Metric::new(
-                "bar".into(),
+                "bar",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 20.0 },
             )),
@@ -274,7 +274,7 @@ mod test {
         assert_eq!(
             parse("bar:2|c|@0"),
             Ok(Metric::new(
-                "bar".into(),
+                "bar",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 2.0 },
             )),
@@ -286,7 +286,7 @@ mod test {
         assert_eq!(
             parse("glork:320|ms|@0.1"),
             Ok(Metric::new(
-                "glork".into(),
+                "glork",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![0.320 => 10],
@@ -301,7 +301,7 @@ mod test {
         assert_eq!(
             parse("glork:320|h|@0.1|#region:us-west1,production,e:"),
             Ok(Metric::new(
-                "glork".into(),
+                "glork",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![320.0 => 10],
@@ -325,7 +325,7 @@ mod test {
         assert_eq!(
             parse("glork:320|d|@0.1|#region:us-west1,production,e:"),
             Ok(Metric::new(
-                "glork".into(),
+                "glork",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![320.0 => 10],
@@ -349,7 +349,7 @@ mod test {
         assert_eq!(
             parse("gaugor:333|g"),
             Ok(Metric::new(
-                "gaugor".into(),
+                "gaugor",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 333.0 },
             )),
@@ -361,7 +361,7 @@ mod test {
         assert_eq!(
             parse("gaugor:-4|g"),
             Ok(Metric::new(
-                "gaugor".into(),
+                "gaugor",
                 MetricKind::Incremental,
                 MetricValue::Gauge { value: -4.0 },
             )),
@@ -369,7 +369,7 @@ mod test {
         assert_eq!(
             parse("gaugor:+10|g"),
             Ok(Metric::new(
-                "gaugor".into(),
+                "gaugor",
                 MetricKind::Incremental,
                 MetricValue::Gauge { value: 10.0 },
             )),
@@ -381,7 +381,7 @@ mod test {
         assert_eq!(
             parse("uniques:765|s"),
             Ok(Metric::new(
-                "uniques".into(),
+                "uniques",
                 MetricKind::Incremental,
                 MetricValue::Set {
                     values: vec!["765".into()].into_iter().collect()

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn add_tags() {
         let event = Event::Metric(Metric::new(
-            "bar".into(),
+            "bar",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 10.0 },
         ));
@@ -142,7 +142,7 @@ mod tests {
         tags.insert("region".to_string(), "us-east-1".to_string());
         let event = Event::Metric(
             Metric::new(
-                "bar".into(),
+                "bar",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 10.0 },
             )

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -414,7 +414,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "status".into(),
+                "status",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -445,7 +445,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "http_requests_total".into(),
+                "http_requests_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -481,7 +481,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "exception_total".into(),
+                "exception_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -525,7 +525,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "amount_total".into(),
+                "amount_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 33.99 },
             )
@@ -551,7 +551,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "memory_rss_bytes".into(),
+                "memory_rss_bytes",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 123.0 },
             )
@@ -624,7 +624,7 @@ mod tests {
         assert_eq!(
             output.pop().unwrap().into_metric(),
             Metric::new(
-                "exception_total".into(),
+                "exception_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -633,7 +633,7 @@ mod tests {
         assert_eq!(
             output.pop().unwrap().into_metric(),
             Metric::new(
-                "status".into(),
+                "status",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -676,7 +676,7 @@ mod tests {
         assert_eq!(
             output.pop().unwrap().into_metric(),
             Metric::new(
-                "xyz_exception_total".into(),
+                "xyz_exception_total",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
@@ -686,7 +686,7 @@ mod tests {
         assert_eq!(
             output.pop().unwrap().into_metric(),
             Metric::new(
-                "local_abc_status_set".into(),
+                "local_abc_status_set",
                 MetricKind::Incremental,
                 MetricValue::Set {
                     values: vec!["42".into()].into_iter().collect()
@@ -714,7 +714,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "unique_user_ip".into(),
+                "unique_user_ip",
                 MetricKind::Incremental,
                 MetricValue::Set {
                     values: vec!["1.2.3.4".into()].into_iter().collect()
@@ -741,7 +741,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "response_time".into(),
+                "response_time",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![2.5 => 1],
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(
             metric.into_metric(),
             Metric::new(
-                "response_time".into(),
+                "response_time",
                 MetricKind::Incremental,
                 MetricValue::Distribution {
                     samples: crate::samples![2.5 => 1],

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -449,7 +449,7 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("app".into()))
+            .with_namespace(Some("app"))
             .with_tags(Some(
                 vec![
                     ("method".to_owned(), "post".to_owned()),
@@ -680,7 +680,7 @@ mod tests {
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 1.0 },
             )
-            .with_namespace(Some("local".into()))
+            .with_namespace(Some("local"))
             .with_timestamp(Some(ts()))
         );
         assert_eq!(

--- a/src/transforms/lua/v2/interop/event.rs
+++ b/src/transforms/lua/v2/interop/event.rs
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn to_lua_metric() {
         let event = Event::Metric(Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.57721566 },
         ));
@@ -130,7 +130,7 @@ mod test {
             }
         }"#;
         let expected = Event::Metric(Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.57721566 },
         ));

--- a/src/transforms/lua/v2/interop/metric.rs
+++ b/src/transforms/lua/v2/interop/metric.rs
@@ -224,7 +224,7 @@ mod test {
     #[test]
     fn to_lua_counter_full() {
         let metric = Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Incremental,
             MetricValue::Counter { value: 1.0 },
         )
@@ -256,7 +256,7 @@ mod test {
     #[test]
     fn to_lua_counter_minimal() {
         let metric = Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.57721566 },
         );
@@ -272,7 +272,7 @@ mod test {
     #[test]
     fn to_lua_gauge() {
         let metric = Metric::new(
-            "example gauge".into(),
+            "example gauge",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 1.6180339 },
         );
@@ -283,7 +283,7 @@ mod test {
     #[test]
     fn to_lua_set() {
         let metric = Metric::new(
-            "example set".into(),
+            "example set",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["value".into(), "another value".into()]
@@ -304,7 +304,7 @@ mod test {
     #[test]
     fn to_lua_distribution() {
         let metric = Metric::new(
-            "example distribution".into(),
+            "example distribution",
             MetricKind::Incremental,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 10, 1.0 => 20],
@@ -326,7 +326,7 @@ mod test {
     #[test]
     fn to_lua_aggregated_histogram() {
         let metric = Metric::new(
-            "example histogram".into(),
+            "example histogram",
             MetricKind::Incremental,
             MetricValue::AggregatedHistogram {
                 buckets: crate::buckets![1.0 => 20, 2.0 => 10, 4.0 => 45, 8.0 => 12],
@@ -351,7 +351,7 @@ mod test {
     #[test]
     fn to_lua_aggregated_summary() {
         let metric = Metric::new(
-            "example summary".into(),
+            "example summary",
             MetricKind::Incremental,
             MetricValue::AggregatedSummary {
                 quantiles: crate::quantiles![
@@ -382,7 +382,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 0.57721566 },
         );
@@ -412,7 +412,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Incremental,
             MetricValue::Counter { value: 1.0 },
         )
@@ -436,7 +436,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example gauge".into(),
+            "example gauge",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 1.6180339 },
         );
@@ -454,7 +454,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example set".into(),
+            "example set",
             MetricKind::Absolute,
             MetricValue::Set {
                 values: vec!["value".into(), "another value".into()]
@@ -478,7 +478,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example distribution".into(),
+            "example distribution",
             MetricKind::Absolute,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 10, 1.0 => 20],
@@ -501,7 +501,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example histogram".into(),
+            "example histogram",
             MetricKind::Absolute,
             MetricValue::AggregatedHistogram {
                 buckets: crate::buckets![1.0 => 20, 2.0 => 10, 4.0 => 45, 8.0 => 12],
@@ -526,7 +526,7 @@ mod test {
             }
         }"#;
         let expected = Metric::new(
-            "example summary".into(),
+            "example summary",
             MetricKind::Absolute,
             MetricValue::AggregatedSummary {
                 quantiles: crate::quantiles![

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -785,7 +785,7 @@ mod tests {
         .unwrap();
 
         let event = Event::Metric(Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.0 },
         ));
@@ -795,7 +795,7 @@ mod tests {
         let output = out_stream.next().await.unwrap();
 
         let expected = Event::Metric(Metric::new(
-            "example counter".into(),
+            "example counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 2.0 },
         ));

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn transform_counter() {
         let counter = Metric::new(
-            "counter".into(),
+            "counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.0 },
         )
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn transform_gauge() {
         let gauge = Metric::new(
-            "gauge".into(),
+            "gauge",
             MetricKind::Absolute,
             MetricValue::Gauge { value: 1.0 },
         )
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn transform_set() {
         let set = Metric::new(
-            "set".into(),
+            "set",
             MetricKind::Absolute,
             MetricValue::Set {
                 values: vec!["one".into(), "two".into()].into_iter().collect(),
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn transform_distribution() {
         let distro = Metric::new(
-            "distro".into(),
+            "distro",
             MetricKind::Absolute,
             MetricValue::Distribution {
                 samples: crate::samples![1.0 => 10, 2.0 => 20],
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn transform_histogram() {
         let histo = Metric::new(
-            "histo".into(),
+            "histo",
             MetricKind::Absolute,
             MetricValue::AggregatedHistogram {
                 buckets: crate::buckets![1.0 => 10, 2.0 => 20],
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn transform_summary() {
         let summary = Metric::new(
-            "summary".into(),
+            "summary",
             MetricKind::Absolute,
             MetricValue::AggregatedSummary {
                 quantiles: crate::quantiles![50.0 => 10.0, 90.0 => 20.0],

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -172,7 +172,7 @@ mod tests {
                     MetricKind::Incremental,
                     MetricValue::Counter { value: 1.0 },
                 )
-                .with_namespace(Some("zerk".into()))
+                .with_namespace(Some("zerk"))
                 .with_tags(Some({
                     let mut tags = BTreeMap::new();
                     tags.insert("host".into(), "zoobub".into());

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn check_remap_metric() {
         let metric = Event::Metric(Metric::new(
-            "counter".into(),
+            "counter",
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.0 },
         ));
@@ -168,7 +168,7 @@ mod tests {
             result,
             Event::Metric(
                 Metric::new(
-                    "zork".into(),
+                    "zork",
                     MetricKind::Incremental,
                     MetricValue::Counter { value: 1.0 },
                 )

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -88,7 +88,7 @@ mod tests {
     fn remove_tags() {
         let event = Event::Metric(
             Metric::new(
-                "foo".into(),
+                "foo",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 10.0 },
             )
@@ -117,7 +117,7 @@ mod tests {
     fn remove_all_tags() {
         let event = Event::Metric(
             Metric::new(
-                "foo".into(),
+                "foo",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 10.0 },
             )
@@ -137,7 +137,7 @@ mod tests {
     #[test]
     fn remove_tags_from_none() {
         let event = Event::Metric(Metric::new(
-            "foo".into(),
+            "foo",
             MetricKind::Incremental,
             MetricValue::Set {
                 values: vec!["bar".into()].into_iter().collect(),

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -282,7 +282,7 @@ mod tests {
     fn make_metric(tags: BTreeMap<String, String>) -> Event {
         Event::Metric(
             Metric::new(
-                "event".into(),
+                "event",
                 metric::MetricKind::Incremental,
                 metric::MetricValue::Counter { value: 1.0 },
             )


### PR DESCRIPTION
This is just a very mechanical cleanup I saw while working on something else. I thought it would result in more lines joined together after `rustfmt` ran, but not much changed.

Signed-off-by: Bruce Guenter <bruce@timber.io>