### PR TITLE
chore(observability): Prefer using Display for logging errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -448,7 +448,7 @@ warn!("Failed to merge value: {}.", err);
 Yep!
 
 ```rust
-warn!(message = "Failed to merge value.", error = ?error);
+warn!(message = "Failed to merge value.", %error);
 ```
 
 #### Feature flags

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -342,7 +342,7 @@ where
             match result {
                 Ok(()) => {}
                 Err(error) => {
-                    error!(message = "Output channel closed.", error = ?error);
+                    error!(message = "Output channel closed.", %error);
                     return Err(error);
                 }
             }

--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -251,7 +251,7 @@ where
                 } else {
                     warn!(
                         message = "Unhandled error response.",
-                        ?error,
+                        %error,
                         internal_log_rate_secs = 5
                     );
                     false

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -174,11 +174,7 @@ impl SourceConfig for MockSourceConfig {
                 }
             })
             .map(Ok)
-            .forward(
-                out.sink_map_err(
-                    |error| error!(message = "Error sending in sink..", error = ?error),
-                ),
-            )
+            .forward(out.sink_map_err(|error| error!(message = "Error sending in sink..", %error)))
             .inspect(|_| info!("Finished sending."))
             .await
         }))
@@ -366,7 +362,7 @@ where
     async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {
             if let Err(error) = self.sink.send(event).await {
-                error!(message = "Ingesting an event failed at mock sink.", ?error);
+                error!(message = "Ingesting an event failed at mock sink.", %error);
             }
 
             self.acker.ack(1);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -286,7 +286,7 @@ impl TransformConfig for MockTransformConfig {
 pub struct MockSinkConfig<T>
 where
     T: Sink<Event> + Unpin + std::fmt::Debug + Clone + Send + Sync + 'static,
-    <T as Sink<Event>>::Error: std::fmt::Debug,
+    <T as Sink<Event>>::Error: std::fmt::Display,
 {
     #[serde(skip)]
     sink: Option<T>,
@@ -297,7 +297,7 @@ where
 impl<T> MockSinkConfig<T>
 where
     T: Sink<Event> + Unpin + std::fmt::Debug + Clone + Send + Sync + 'static,
-    <T as Sink<Event>>::Error: std::fmt::Debug,
+    <T as Sink<Event>>::Error: std::fmt::Display,
 {
     pub fn new(sink: T, healthy: bool) -> Self {
         Self {
@@ -318,7 +318,7 @@ enum HealthcheckError {
 impl<T> SinkConfig for MockSinkConfig<T>
 where
     T: Sink<Event> + Unpin + std::fmt::Debug + Clone + Send + Sync + 'static,
-    <T as Sink<Event>>::Error: std::fmt::Debug,
+    <T as Sink<Event>>::Error: std::fmt::Display,
 {
     async fn build(&self, cx: SinkContext) -> Result<(VectorSink, Healthcheck), vector::Error> {
         let sink = MockSink {
@@ -357,7 +357,7 @@ struct MockSink<S> {
 impl<S> StreamSink for MockSink<S>
 where
     S: Sink<Event> + Send + std::marker::Unpin,
-    <S as Sink<Event>>::Error: std::fmt::Debug,
+    <S as Sink<Event>>::Error: std::fmt::Display,
 {
     async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {


### PR DESCRIPTION
The CONTRIBUTING guide accidentally had an example of using Debug, but
we'd decided to prefer Display for errors.

Fixes https://github.com/timberio/vector/issues/6380

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
