### PR TITLE
chore(ci): remove redundant build profile

### DIFF
--- a/scripts/slim-builds.sh
+++ b/scripts/slim-builds.sh
@@ -21,19 +21,6 @@ incremental = false
 EOF
 
 cat <<-EOF >> ./Cargo.toml
-[profile.dev]
-# See defaults https://doc.rust-lang.org/cargo/reference/profiles.html#dev
-opt-level = 0
-debug = true
-debug-assertions = true
-overflow-checks = true
-lto = false
-panic = 'unwind'
-# Disabled, see build.incremental
-# incremental = true
-codegen-units = 256
-rpath = false
-
 [profile.release]
 # See defaults https://doc.rust-lang.org/cargo/reference/profiles.html#release
 opt-level = 3


### PR DESCRIPTION
It's not clear to me why profile.dev was being written to Cargo.toml by
slim-builds.sh given that all of the values are defaulted.

The one value, `incremental`, that is changed, is changed in
`~/.cargo/config` which will override any profiles.

> The incremental value can be overridden globally with the
CARGO_INCREMENTAL environment variable or the build.incremental config
variable.

https://doc.rust-lang.org/cargo/reference/profiles.html#incremental

I think the release profile is similar, but will be removed by
https://github.com/timberio/vector/pull/6202 so I left it for now.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
