### PR TITLE
enhancement(ci): Restrict benchmark runs to specific directories

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,10 +1,7 @@
 name: Benchmark Suite
 
 on:
-  pull_request: {}
-  push:
-    branches:
-      - master
+  pull_request:
     paths:
       - ".github/workflows/benches.yml"
       - ".cargo/**"
@@ -17,6 +14,9 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "rust-toolchain"
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 env:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -17,6 +17,18 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/benches.yml"
+      - ".cargo/**"
+      - "benches/**"
+      - "lib/**"
+      - "proto/**"
+      - "src/**"
+      - "tests/**"
+      - "build.rs"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
A while back, in PR #5610, I *thought* I was restricting benchmark runs for PRs with changes only to certain paths. But it turns out those changes were only for pushes to `master`. Mea culpa. This PR fixes that.

One effect of these changes is to *always* run the benches on pushes to `master`. I'm not sure if this is desired, so please let me know if not.