### PR TITLE
chore(kubernetes_logs source): Don't publish vector-aggregator until agent->agg comms are corrected

### DIFF
--- a/scripts/release-helm.sh
+++ b/scripts/release-helm.sh
@@ -50,6 +50,19 @@ scripts/helm-dependencies.sh validate
 # Read the shared scripting config.
 source "distribution/helm/scripting-config.sh"
 
+# Filter out vector and aggregator if not publishing to nightly
+NIGHTLY_CHARTS=( "vector" "vector-aggregator" )
+
+if [ "${CHANNEL}" != "nightly" ]; then
+    for IDX in "${!CHARTS_TO_PUBLISH[@]}"; do
+        if [[ "${NIGHTLY_CHARTS[*]}" =~ ${CHARTS_TO_PUBLISH[$IDX]} ]]; then
+            unset "CHARTS_TO_PUBLISH[$IDX]"
+        fi
+    done
+fi
+
+CHARTS_TO_PUBLISH=("${CHARTS_TO_PUBLISH[@]}")
+
 # Package our charts.
 for CHART in "${CHARTS_TO_PUBLISH[@]}"; do
   helm package \


### PR DESCRIPTION
Adds a filtration to our release script to not publish the aggregator and unified helm charts to stable. This should remain filtered out until we complete the work on the vector:vector comms alterations or remove the consumption of the `vector` source and sink from the `kubernetes_logs` source.

Signed-off-by: Ian Henry <ianjhenry00@gmail.com>