### PR TITLE
chore(ci): Pin Github Actions runners to Ubuntu 18.04 for certain jobs

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   cancel-previous:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 3
     if: github.ref != 'refs/heads/master'
     steps:
@@ -103,7 +103,7 @@ jobs:
     needs:
       - cancel-previous
       - bench
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   cancel-previous:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 3
     if: github.ref != 'refs/heads/master'
     steps:
@@ -103,7 +103,7 @@ jobs:
     needs:
       - cancel-previous
       - bench
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   publish-new-environment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   publish-new-environment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sync-install:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: sudo apt-get install --yes python3-setuptools python3.6-dev
@@ -25,7 +25,7 @@ jobs:
   test-install:
     needs:
       - sync-install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - run: sudo apt-get install --yes curl bc
       - run:  curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y
@@ -37,7 +37,7 @@ jobs:
     needs:
       - sync-install
       - test-install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -25,7 +25,7 @@ jobs:
   test-install:
     needs:
       - sync-install
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - run: sudo apt-get install --yes curl bc
       - run:  curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y
@@ -37,7 +37,7 @@ jobs:
     needs:
       - sync-install
       - test-install
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -329,7 +329,7 @@ jobs:
       - test-integration-loki
       - test-integration-pulsar
       - test-integration-splunk
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -329,7 +329,7 @@ jobs:
       - test-integration-loki
       - test-integration-pulsar
       - test-integration-splunk
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -80,7 +80,7 @@ jobs:
   # See https://github.community/t/feature-request-and-use-case-example-to-allow-matrix-in-if-s/126067
   compute-k8s-test-plan:
     name: Compute K8s test plan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     if: |
@@ -135,7 +135,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
@@ -169,7 +169,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
       - test-e2e-kubernetes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -80,7 +80,7 @@ jobs:
   # See https://github.community/t/feature-request-and-use-case-example-to-allow-matrix-in-if-s/126067
   compute-k8s-test-plan:
     name: Compute K8s test plan
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     if: |
@@ -135,7 +135,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
@@ -169,7 +169,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
       - test-e2e-kubernetes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -28,7 +28,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -50,7 +50,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -73,7 +73,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -88,7 +88,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -110,7 +110,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -212,7 +212,7 @@ jobs:
   deb-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         container: ["ubuntu:14.04","ubuntu:16.04","ubuntu:18.04","ubuntu:20.04","debian:8","debian:9","debian:10"]
@@ -244,7 +244,7 @@ jobs:
   rpm-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
@@ -290,7 +290,7 @@ jobs:
           tar -xvf target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz && vector-x86_64-apple-darwin/bin/vector --version
 
   release-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
@@ -346,7 +346,7 @@ jobs:
           make release-docker
 
   release-s3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
@@ -428,7 +428,7 @@ jobs:
         run: make release-s3
 
   release-cloudsmith:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
@@ -542,7 +542,7 @@ jobs:
           file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   release-helm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       # This is not strictly required, but ensures that Helm Chart doesn't
       # appear before the image it refers to.
@@ -576,7 +576,7 @@ jobs:
       - deb-verify
       - rpm-verify
       - osx-verify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -28,7 +28,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -50,7 +50,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -73,7 +73,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -88,7 +88,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -110,7 +110,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -212,7 +212,7 @@ jobs:
   deb-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         container: ["ubuntu:14.04","ubuntu:16.04","ubuntu:18.04","ubuntu:20.04","debian:8","debian:9","debian:10"]
@@ -244,7 +244,7 @@ jobs:
   rpm-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
@@ -428,7 +428,7 @@ jobs:
         run: make release-s3
 
   release-cloudsmith:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
@@ -576,7 +576,7 @@ jobs:
       - deb-verify
       - rpm-verify
       - osx-verify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -29,7 +29,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -51,7 +51,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -74,7 +74,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -89,7 +89,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -111,7 +111,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -213,7 +213,7 @@ jobs:
   deb-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         container: ["ubuntu:14.04","ubuntu:16.04","ubuntu:18.04","ubuntu:20.04","debian:8","debian:9","debian:10"]
@@ -245,7 +245,7 @@ jobs:
   rpm-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
@@ -291,7 +291,7 @@ jobs:
           tar -xvf target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz && vector-x86_64-apple-darwin/bin/vector --version
 
   release-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
@@ -347,7 +347,7 @@ jobs:
           make release-docker
 
   release-s3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
@@ -530,7 +530,7 @@ jobs:
           make release-homebrew
 
   release-cloudsmith:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
@@ -644,7 +644,7 @@ jobs:
           file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   release-helm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       # This is not strictly required, but ensures that Helm Chart doesn't
       # appear before the image it refers to.
@@ -679,7 +679,7 @@ jobs:
       - release-cloudsmith
       - release-github
       - release-helm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -29,7 +29,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -51,7 +51,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -74,7 +74,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -89,7 +89,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: make ci-sweep
@@ -111,7 +111,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -213,7 +213,7 @@ jobs:
   deb-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         container: ["ubuntu:14.04","ubuntu:16.04","ubuntu:18.04","ubuntu:20.04","debian:8","debian:9","debian:10"]
@@ -245,7 +245,7 @@ jobs:
   rpm-verify:
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
@@ -291,7 +291,7 @@ jobs:
           tar -xvf target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz && vector-x86_64-apple-darwin/bin/vector --version
 
   release-docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
@@ -530,7 +530,7 @@ jobs:
           make release-homebrew
 
   release-cloudsmith:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
@@ -679,7 +679,7 @@ jobs:
       - release-cloudsmith
       - release-github
       - release-helm
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-harness:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     needs: version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   changes:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-18.04
       # Set job outputs to values from filter step
       outputs:
         source: ${{ steps.filter.outputs.source }}
@@ -287,7 +287,7 @@ jobs:
       - test-windows
       - check-component-features
       - checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Discord notification
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   changes:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       # Set job outputs to values from filter step
       outputs:
         source: ${{ steps.filter.outputs.source }}
@@ -287,7 +287,7 @@ jobs:
       - test-windows
       - check-component-features
       - checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Discord notification
       env:

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -25,7 +25,9 @@ apt-get install --yes grub-efi
 update-grub
 set -e
 
-apt upgrade --yes
+# using force-overwrite due to
+# https://github.com/actions/virtual-environments/issues/2703
+apt upgrade  -o Dpkg::Options::="--force-overwrite" --yes
 
 # Deps
 apt install --yes \


### PR DESCRIPTION
ubuntu-latest is in the process of being migrated which means the jobs
can run on either 18.04 or 20.04:

actions/virtual-environments#1816

We've seen some failures on 20.04 that we'll need to address before
upgrading.

https://github.com/timberio/vector/actions/runs/559968325

Also replace `ubuntu-latest` with `ubuntu-20.04` for jobs that seem to be fine on 20.04.

I ended up including a fix for https://github.com/actions/virtual-environments/issues/2703 as well.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
