### PR TITLE
fix(performance): Address failing bench in master

### DIFF
--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -84,7 +84,7 @@ fn benchmark_parse_json(c: &mut Criterion) {
   type = "remap"
   inputs = ["in"]
   source = """
-    . = parse_json!(.message)
+    . = parse_json!(string!(.message))
   """
             "#,
         ),


### PR DESCRIPTION
This PR fixes a recent oversight that's causing the benchmarking suite to fail on `master`