### PR TITLE
fix(external docs): Fix typo in example Vector config

### DIFF
--- a/config/vector.toml
+++ b/config/vector.toml
@@ -45,4 +45,4 @@ type = "internal_metrics"
 # Print it all out for inspection
 [sinks.print]
 type = "console"
-inptus = ["parse_logs", "host_metrics", "internal_metrics"]
+inputs = ["parse_logs", "host_metrics", "internal_metrics"]


### PR DESCRIPTION
Closes #6441