### PR TITLE
enhancement(remap): improved type definitions for `or` with nullable fields

### DIFF
--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -94,8 +94,13 @@ impl Expression for Op {
             // null || ...
             Or if lhs_kind.is_null() => rhs_def,
 
-            // "foo" || ...
-            Or if !lhs_kind.is_boolean() => lhs_def,
+            Or if !lhs_kind.contains(K::Null) => lhs_def,
+
+            Or if !lhs_kind.is_boolean() => {
+                // We can remove Null from the lhs since we know that if the lhs is Null
+                // we will be taking the rhs and only the rhs type_def will then be relevant.
+                (lhs_def - K::Null).merge(rhs_def.clone())
+            }
 
             // ... || ...
             Or => merged_def,
@@ -224,7 +229,7 @@ impl DiagnosticError for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expression::Literal;
+    use crate::expression::{Block, IfStatement, Literal, Predicate};
     use crate::{test_type_def, value::Kind};
     use ast::Opcode::*;
     use ordered_float::NotNan;
@@ -445,6 +450,34 @@ mod tests {
                 opcode: Err,
             },
             want: TypeDef::new().scalar(Kind::Float | Kind::Bytes),
+        }
+
+        or_nullable {
+            expr: |_| Op {
+                lhs: Box::new(
+                    IfStatement {
+                        predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
+                        consequent: Block::new(vec![Literal::from("string").into()]),
+                        alternative: None,
+                    }.into()),
+                rhs: Box::new(Literal::from("another string").into()),
+                opcode: Or,
+            },
+            want: TypeDef::new().scalar(Kind::Bytes),
+        }
+
+        or_not_nullable {
+            expr: |_| Op {
+                lhs: Box::new(
+                    IfStatement {
+                        predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
+                        consequent: Block::new(vec![Literal::from("string").into()]),
+                        alternative:  Some(Block::new(vec![Literal::from(42).into()])).into()
+                }.into()),
+                rhs: Box::new(Literal::from("another string").into()),
+                opcode: Or,
+            },
+            want: TypeDef::new().scalar(Kind::Bytes | Kind::Integer),
         }
     ];
 }

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -99,7 +99,7 @@ impl Expression for Op {
             Or if !lhs_kind.is_boolean() => {
                 // We can remove Null from the lhs since we know that if the lhs is Null
                 // we will be taking the rhs and only the rhs type_def will then be relevant.
-                (lhs_def - K::Null).merge(rhs_def.clone())
+                (lhs_def - K::Null).merge(rhs_def)
             }
 
             // ... || ...
@@ -472,7 +472,7 @@ mod tests {
                     IfStatement {
                         predicate: Predicate::new_unchecked(vec![Literal::from(true).into()]),
                         consequent: Block::new(vec![Literal::from("string").into()]),
-                        alternative:  Some(Block::new(vec![Literal::from(42).into()])).into()
+                        alternative:  Some(Block::new(vec![Literal::from(42).into()]))
                 }.into()),
                 rhs: Box::new(Literal::from("another string").into()),
                 opcode: Or,

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -94,8 +94,10 @@ impl Expression for Op {
             // null || ...
             Or if lhs_kind.is_null() => rhs_def,
 
+            // not null || ...
             Or if !lhs_kind.contains(K::Null) => lhs_def,
 
+            // ... || ...
             Or if !lhs_kind.is_boolean() => {
                 // We can remove Null from the lhs since we know that if the lhs is Null
                 // we will be taking the rhs and only the rhs type_def will then be relevant.
@@ -334,17 +336,17 @@ mod tests {
 
         add_other {
             expr: |_| op(Add, (), ()),
-            want: TypeDef::new().fallible().scalar(Kind::Bytes | Kind::Integer | Kind::Float),
+            want: TypeDef::new().fallible().bytes().add_integer().add_float(),
         }
 
         remainder {
             expr: |_| op(Rem, (), ()),
-            want: TypeDef::new().fallible().scalar(Kind::Integer | Kind::Float),
+            want: TypeDef::new().fallible().integer().add_float(),
         }
 
         subtract {
             expr: |_| op(Sub, (), ()),
-            want: TypeDef::new().fallible().scalar(Kind::Integer | Kind::Float),
+            want: TypeDef::new().fallible().integer().add_float(),
         }
 
         divide {
@@ -411,7 +413,7 @@ mod tests {
                 rhs: Box::new(Literal::from(true).into()),
                 opcode: Err,
             },
-            want: TypeDef::new().scalar(Kind::Float | Kind::Boolean),
+            want: TypeDef::new().float().add_boolean(),
         }
 
         error_or_fallible {
@@ -449,7 +451,7 @@ mod tests {
                 }.into()),
                 opcode: Err,
             },
-            want: TypeDef::new().scalar(Kind::Float | Kind::Bytes),
+            want: TypeDef::new().float().add_bytes(),
         }
 
         or_nullable {
@@ -463,7 +465,7 @@ mod tests {
                 rhs: Box::new(Literal::from("another string").into()),
                 opcode: Or,
             },
-            want: TypeDef::new().scalar(Kind::Bytes),
+            want: TypeDef::new().bytes(),
         }
 
         or_not_nullable {
@@ -477,7 +479,7 @@ mod tests {
                 rhs: Box::new(Literal::from("another string").into()),
                 opcode: Or,
             },
-            want: TypeDef::new().scalar(Kind::Bytes | Kind::Integer),
+            want: TypeDef::new().bytes().add_integer(),
         }
     ];
 }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -27,15 +27,12 @@ impl Sub<Kind> for TypeDef {
 
     /// Removes the given kinds from this type definition.
     fn sub(mut self, other: Kind) -> Self::Output {
-        let kind = match self.kind {
+        self.kind = match self.kind {
             KindInfo::Unknown => KindInfo::Unknown,
             KindInfo::Known(kinds) => {
-                // Note, it would be much nicer to use retain here, but that is unfortunately still in nightly.
                 KindInfo::Known(kinds.into_iter().filter(|k| k.to_kind() != other).collect())
             }
         };
-
-        self.kind = kind;
 
         self
     }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -1,6 +1,9 @@
 use crate::value::Kind;
 use crate::{map, path, Path};
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Sub,
+};
 
 /// Properties for a given expression that express the expected outcome of the
 /// expression.
@@ -17,6 +20,25 @@ pub struct TypeDef {
     /// This is wrapped in a [`TypeKind`] enum, such that we encode details
     /// about potential inner kinds for collections (arrays or objects).
     kind: KindInfo,
+}
+
+impl Sub<Kind> for TypeDef {
+    type Output = Self;
+
+    /// Removes the given kinds from this type definition.
+    fn sub(mut self, other: Kind) -> Self::Output {
+        let kind = match self.kind {
+            KindInfo::Unknown => KindInfo::Unknown,
+            KindInfo::Known(kinds) => {
+                // Note, it would be much nicer to use retain here, but that is unfortunately still in nightly.
+                KindInfo::Known(kinds.into_iter().filter(|k| k.to_kind() != other).collect())
+            }
+        };
+
+        self.kind = kind;
+
+        self
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]

--- a/lib/vrl/tests/tests/examples/successful_parse_syslog_type.vrl
+++ b/lib/vrl/tests/tests/examples/successful_parse_syslog_type.vrl
@@ -4,4 +4,4 @@
 .message = to_string!(.message)
 result = parse_syslog!(.message)
 sha = sha3(value: result.message)
-sha + (result.appname || "<no app name>") ?? ""
+sha + (result.appname || "<no app name>")


### PR DESCRIPTION
Replacing #6344 - I've updated it to work with the recent parser changes.

Following from #6182, a number of functions return fields that can be `Null`, for example `appname` from `parse_syslog` can be `Kind::Bytes | Kind::Null`.

This PR makes it possible to specify a default value using Or. Since we know that if the lhs is either Null or Bytes, we can deduce that the whole expression `lhs | rhs` will either be the `lhs - Kind::Null` or the `rhs`. 

Eg. This now typechecks:

```
.parsed = parse_syslog(.message)
.sha = sha3(.parsed.appname || "default")
```

However this will still not typecheck, the `procid` field can be either a string, an integer or null. So even after an Or it could still be an Integer or a String.:

```
.parsed = parse_syslog(.message)
.sha = sha3(.parsed.procid || "default")
```

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
