### PR TITLE
chore(remap): add type def test case

### DIFF
--- a/lib/vrl/tests/tests/issues/6361_query_type_definition.vrl
+++ b/lib/vrl/tests/tests/issues/6361_query_type_definition.vrl
@@ -1,0 +1,6 @@
+# issue: https://github.com/timberio/vector/issues/6361
+# result: "1"
+
+foo = [{ "foo": to_string(1) }]
+bar = foo[0].foo
+upcase(bar)


### PR DESCRIPTION
closes #6361

I previously thought this wasn't working, but I think I accidentally tested against an earlier version of the master branch. This test validates that it works as expected, and keeps working.