### PR TITLE
fix(cli): Fix function doc URL in VRL REPL

### DIFF
--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -248,7 +248,7 @@ fn show_func_docs(line: &str, pattern: &Regex) {
     let func_name = matches.get(1).unwrap().as_str();
 
     if stdlib::all().iter().any(|f| f.identifier() == func_name) {
-        let func_url = format!("{}/#{}", DOCS_URL, func_name);
+        let func_url = format!("{}/functions/#{}", DOCS_URL, func_name);
         open_url(&func_url);
     } else {
         println!("function name {} not recognized", func_name);


### PR DESCRIPTION
I'm not sure how this got overwritten but this will set things aright