### PR TITLE
fix(remap): Restore changes to ipv6_to_ipv4

### DIFF
--- a/docs/reference/remap/functions/ipv6_to_ipv4.cue
+++ b/docs/reference/remap/functions/ipv6_to_ipv4.cue
@@ -4,6 +4,9 @@ remap: functions: ipv6_to_ipv4: {
 	category: "IP"
 	description: """
 		Converts the `ip` to an IPv4 address.
+
+		If the parameter is already an IPv4 address it is passed through untouched. If it is an IPv6 address it has
+		to be an IPv4 compatible address.
 		"""
 
 	arguments: [

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -48,7 +48,7 @@ impl Expression for Ipv6ToIpV4Fn {
             .map_err(|err| format!("unable to parse IP address: {}", err))?;
 
         match ip {
-            IpAddr::V4(addr) => Ok(addr.to_ipv6_mapped().to_string().into()),
+            IpAddr::V4(addr) => Ok(addr.to_string().into()),
             IpAddr::V6(addr) => match addr.to_ipv4() {
                 Some(addr) => Ok(addr.to_string().into()),
                 None => Err(format!("IPV6 address {} is not compatible with IPV4", addr).into()),
@@ -60,57 +60,49 @@ impl Expression for Ipv6ToIpV4Fn {
         TypeDef::new().fallible().bytes()
     }
 }
+/*
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::map;
+    remap::test_type_def![value_string {
+        expr: |_| Ipv6ToIpV4Fn {
+            value: Literal::from("192.168.0.1").boxed()
+        },
+        def: TypeDef {
+            kind: value::Kind::Bytes,
+            fallible: true,
+            ..Default::default()
+        },
+    }];
 
-//     vrl::test_type_def![value_string {
-//         expr: |_| Ipv6ToIpV4Fn {
-//             value: Literal::from("192.168.0.1").boxed()
-//         },
-//         def: TypeDef {
-//             kind: value::Kind::Bytes,
-//             fallible: true,
-//             ..Default::default()
-//         },
-//     }];
+    test_function![
+        ipv6_to_ipv4 => Ipv6ToIpV4;
 
-//     #[test]
-//     fn ipv6_to_ipv4() {
-//         let cases = vec![
-//             (
-//                 map!["foo": "i am not an ipaddress"],
-//                 Err("function call error: unable to parse IP address: invalid IP address syntax".to_string()),
-//                 Ipv6ToIpV4Fn::new(Box::new(Path::from("foo"))),
-//             ),
-//             (
-//                 map!["foo": "2001:0db8:85a3::8a2e:0370:7334"],
-//                 Err("function call error: IPV6 address 2001:db8:85a3::8a2e:370:7334 is not compatible with IPV4".to_string()),
-//                 Ipv6ToIpV4Fn::new(Box::new(Path::from("foo"))),
-//             ),
-//             (
-//                 map!["foo": "::ffff:192.168.0.1"],
-//                 Ok(Value::from("192.168.0.1")),
-//                 Ipv6ToIpV4Fn::new(Box::new(Path::from("foo"))),
-//             ),
-//             (
-//                 map!["foo": "0:0:0:0:0:ffff:c633:6410"],
-//                 Ok(Value::from("198.51.100.16")),
-//                 Ipv6ToIpV4Fn::new(Box::new(Path::from("foo"))),
-//             ),
-//         ];
+        error {
+            args: func_args![value: "i am not an ipaddress"],
+            want: Err("function call error: unable to parse IP address: invalid IP address syntax".to_string()),
+        }
 
-//         let mut state = state::Program::default();
+        incompatible {
+            args: func_args![value: "2001:0db8:85a3::8a2e:0370:7334"],
+            want: Err("function call error: IPV6 address 2001:db8:85a3::8a2e:370:7334 is not compatible with IPV4".to_string()),
+        }
 
-//         for (object, exp, func) in cases {
-//             let mut object = Value::Map(object);
-//             let got = func
-//                 .resolve(&mut ctx)
-//                 .map_err(|e| format!("{:#}", anyhow::anyhow!(e)));
+        ipv4_compatible {
+            args: func_args![value: "::ffff:192.168.0.1"],
+            want: Ok(Value::from("192.168.0.1")),
+        }
 
-//             assert_eq!(got, exp);
-//         }
-//     }
-// }
+        ipv6 {
+            args: func_args![value: "0:0:0:0:0:ffff:c633:6410"],
+            want: Ok(Value::from("198.51.100.16")),
+        }
+
+        ipv4 {
+            args: func_args![value: "198.51.100.16"],
+            want: Ok(Value::from("198.51.100.16")),
+        }
+    ];
+}
+*/


### PR DESCRIPTION
Part of https://github.com/timberio/vector/issues/6476.