### PR TITLE
fix(elasticsearch source): fix aws elasticsearch bug with `aws.region`

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -441,6 +441,7 @@ impl ElasticSearchCommon {
 
     fn signed_request(&self, method: &str, uri: &Uri, use_params: bool) -> SignedRequest {
         let mut request = SignedRequest::new(method, "es", &self.region, uri.path());
+        request.hostname = uri.host().map(|s| s.to_owned());
         if use_params {
             for (key, value) in &self.query_params {
                 request.add_param(key, value);


### PR DESCRIPTION
when both `aws.region` and `aws.assume_role` is set, vector sends request with wrong `host` header. Here's example config and log message

```toml
[sources.stdin]
        type = "stdin"

# Output data
[sinks.out]
        type = "elasticsearch"
        inputs = [ "stdin" ]
        index = "foo-%F"
        endpoint = "https://foobarbaz.ap-northeast-1.es.amazonaws.com"
        auth.assume_role = "arn:aws:iam::798290317353:role/lg-es-role"
        auth.strategy = "aws" # required
        aws.region = "ap-northeast-1"
```

```
ttp: vector::internal_events::http_client: Sending HTTP request. uri=https://foobarbaz.ap-northeast-1.es.amazonaws.com/_cluster/health method=GET version=HTTP/1.1 headers={"authorization": Sensitive, "content-length": "0", "content-type": "application/octet-stream", "host": "es.ap-northeast-1.amazonaws.com", "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "x-amz-date": "20210219T141355Z", "x-amz-security-token": "======", "user-agent": "Vector/0.12.0 (g750e383 x86_64-unknown-linux-musl 2021-02-19)", "accept-encoding": "identity"} body=[empty]
```

not that host in uri `foobarbaz.ap-northeast-1.es.amazonaws.com` and host in header `es.ap-northeast-1.amazonaws.com` differs. it happens only when `aws.region` is set.

The PR fixes the bug by setting `host` of request signer to provided endpoint.