### PR TITLE
chore(ci): Fix language bench tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ test: ## Run the unit test suite
 test-components: ## Test with all components enabled
 # TODO(jesse) add `wasm-benches` when https://github.com/timberio/vector/issues/5106 is fixed
 # test-components: $(WASM_MODULE_OUTPUTS)
-test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches remap-benches"
+test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches language-benches metrics-benches remap-benches"
 test-components: test
 
 .PHONY: test-all

--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,9 @@ test: ## Run the unit test suite
 
 .PHONY: test-components
 test-components: ## Test with all components enabled
-# TODO(jesse) add `wasm-benches` when https://github.com/timberio/vector/issues/5106 is fixed
+# TODO(jesse) add `language-benches wasm-benches` when https://github.com/timberio/vector/issues/5106 is fixed
 # test-components: $(WASM_MODULE_OUTPUTS)
-test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches language-benches metrics-benches remap-benches"
+test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches metrics-benches remap-benches"
 test-components: test
 
 .PHONY: test-all

--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -25,7 +25,7 @@ fn benchmark_add_fields(c: &mut Criterion) {
                   inputs = ["in"]
                   source = """
                   .four = 4
-                  .five = 4
+                  .five = 5
                   """
             "#},
         ),
@@ -68,12 +68,10 @@ fn benchmark_add_fields(c: &mut Criterion) {
         ),
     ];
 
-    let input = r#"{"one":1,"two":2,"three":3}"#;
-    let output =
-        serde_json::from_str(r#"{ "one": 1, "two": 2, "three": 3, "four": 4, "five": 5 }"#)
-            .unwrap();
+    let input = "";
+    let output = serde_json::from_str(r#"{"four": 4, "five": 5 }"#).unwrap();
 
-    benchmark_configs(c, "add_fields", configs, "in", "last", input, output);
+    benchmark_configs(c, "add_fields", configs, "in", "last", input, &output);
 }
 
 fn benchmark_parse_json(c: &mut Criterion) {
@@ -133,7 +131,7 @@ fn benchmark_parse_json(c: &mut Criterion) {
         r#"{"string":"bar","array":[1,2,3],"boolean":true,"number":47.5,"object":{"key":"value"}}"#;
     let output = serde_json::from_str(r#"{ "array": [1, 2, 3], "boolean": true, "number": 47.5, "object": { "key": "value" }, "string": "bar" }"#).unwrap();
 
-    benchmark_configs(c, "parse_json", configs, "in", "last", input, output);
+    benchmark_configs(c, "parse_json", configs, "in", "last", input, &output);
 }
 
 fn benchmark_parse_syslog(c: &mut Criterion) {
@@ -156,15 +154,14 @@ fn benchmark_parse_syslog(c: &mut Criterion) {
                   type = "regex_parser"
                   inputs = ["in"]
                   field = "message"
-                  patterns = ['^<(?P<priority>\d+)>(?P<version>\d+) (?P<timestamp>%S+) (?P<hostname>%S+) (?P<appname>%S+) (?P<procid>\S+) (?P<msgid>\S+) (?P<sdata>%S+) (?P<message>.+)$']
+                  patterns = ['^<(?P<priority>\d+)>(?P<version>\d+) (?P<timestamp>\S+) (?P<hostname>\S+) (?P<appname>\S+) (?P<procid>\S+) (?P<msgid>\S+) (?P<sdata>\S+) (?P<message>.+)$']
                   types.appname = "string"
-                  types.facility = "string"
                   types.hostname = "string"
                   types.level = "string"
                   types.message = "string"
                   types.msgid = "string"
                   types.procid = "int"
-                  types.timestamp = "timestamp|%F"
+                  types.timestamp = "timestamp|%Y-%m-%dT%H:%M:%S%.fZ"
             "#},
         ),
         (
@@ -177,9 +174,9 @@ fn benchmark_parse_syslog(c: &mut Criterion) {
                   source = """
                   local function parse_syslog(message)
                     local pattern = "^<(%d+)>(%d+) (%S+) (%S+) (%S+) (%S+) (%S+) (%S+) (.+)$"
-                    local priority, version, timestamp, host, appname, procid, msgid, sdata, message = string.match(message, pattern)
+                    local priority, version, timestamp, hostname, appname, procid, msgid, sdata, message = string.match(message, pattern)
 
-                    return {priority = priority, version = version, timestamp = timestamp, host = host, appname = appname, procid = procid, msgid = msgid, sdata = sdata, message = message}
+                    return {priority = priority, version = version, timestamp = timestamp, hostname = hostname, appname = appname, procid = tonumber(procid), msgid = msgid, sdata = sdata, message = message}
                   end
 
                   function process(event, emit)
@@ -203,9 +200,11 @@ fn benchmark_parse_syslog(c: &mut Criterion) {
     ];
 
     let input = r#"<12>3 2020-12-19T21:48:09.004Z initech.io su 4015 ID81 - TPS report missing cover sheet"#;
-    let output = serde_json::from_str(r#"{ "appname": "su", "facility": "user", "hostname": "initech.io", "severity": "warning", "message": "TPS report missing cover sheet", "msgid": "ID81", "procid": 4015, "timestamp": "2020-12-19 21:48:09.004 +00:00", "version": 3 }"#).unwrap();
+    // intentionally leaves out facility and severity as the native implementation, using
+    // `regex_parser`, is not able to capture this
+    let output = serde_json::from_str(r#"{ "appname": "su", "hostname": "initech.io", "message": "TPS report missing cover sheet", "msgid": "ID81", "procid": 4015, "timestamp": "2020-12-19T21:48:09.004Z" }"#).unwrap();
 
-    benchmark_configs(c, "parse_syslog", configs, "in", "last", input, output);
+    benchmark_configs(c, "parse_syslog", configs, "in", "last", input, &output);
 }
 
 /// Benches a set of transform configs for comparison
@@ -226,7 +225,7 @@ fn benchmark_configs(
     input_name: &str,
     output_name: &str,
     input: &str,
-    output: serde_json::Value,
+    output: &serde_json::map::Map<String, serde_json::Value>,
 ) {
     vector::test_util::trace_init();
 
@@ -297,9 +296,14 @@ fn benchmark_configs(
                         #[cfg(debug_assertions)]
                         {
                             assert_eq!(num_lines, output_lines.len());
-                            for output_line in output_lines {
-                                let actual = serde_json::from_str(output_line);
-                                assert_eq!(output, actual);
+                            for output_line in &output_lines {
+                                let actual: serde_json::map::Map<String, serde_json::Value> =
+                                    serde_json::from_str(output_line).unwrap();
+                                // avoids asserting the actual == expected as the socket trasform
+                                // adds dynamic keys like timestamp
+                                for (key, value) in output.iter() {
+                                    assert_eq!(Some(value), actual.get(key), "for key {}", key,);
+                                }
                             }
                         }
 

--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -64,6 +64,8 @@ fn benchmark_add_fields(c: &mut Criterion) {
                   inputs = ["in"]
                   module = "tests/data/wasm/add_fields/target/wasm32-wasi/release/add_fields.wasm"
                   artifact_cache = "target/artifacts/"
+                  options.four = 4
+                  options.five = 5
             "#},
         ),
     ];

--- a/tests/data/wasm/parse_syslog/fixtures/a/expected.json
+++ b/tests/data/wasm/parse_syslog/fixtures/a/expected.json
@@ -6,6 +6,6 @@
   "message": "TPS report missing cover sheet",
   "msgid": "ID81",
   "procid": 4015,
-  "timestamp": "2020-12-19 21:48:09.004 +00:00",
+  "timestamp": "2020-12-19T21:48:09.004+00:00",
   "version": 3
 }


### PR DESCRIPTION
Turns out these weren't running in CI because I neglected to add them to
the features for `make test-components`.

This adds them to run in CI and fixes a few issues. I changed the
assertion to assert that the expected value is a subset of the actual
one to ignore keys automatically added by the `socket` source component
(like `timestamp`). These assertions only run during tests and not
during the actual benchmark.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
