### PR TITLE
enhancement(external docs): Pare down VRL error docs

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -14,22 +14,12 @@ package metadata
 	}
 
 	#Example: {
-		title:  string
-		input?: #Event
-		source: string
-		raises?: {
-			compiletime?: string
-			runtime?:     string
-		}
-
-		if raises == _|_ {
-			return?: _
-			output?: #Event
-		}
-
-		if raises != _|_ {
-			diff?: string
-		}
+		title:   string
+		input?:  #Event
+		source:  string
+		diff?:   string
+		return?: _
+		output?: #Event
 
 		notes?: [string, ...string]
 		warnings?: [string, ...string]

--- a/docs/reference/remap/errors/100_unhandled_root_runtime_error.cue
+++ b/docs/reference/remap/errors/100_unhandled_root_runtime_error.cue
@@ -19,16 +19,6 @@ remap: errors: "100": {
 			source: #"""
 				get_env_var("HOST")
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ 	(5 / 2)
-				  │     ^^^^^
-				  │     │
-				  │     this expression is unhandled
-				  │
-				"""#
 			diff: #"""
 				- 	get_env_var("HOST")
 				+# 	.host = get_env_var("HOST")

--- a/docs/reference/remap/errors/101_malformed_regex_literal.cue
+++ b/docs/reference/remap/errors/101_malformed_regex_literal.cue
@@ -22,16 +22,6 @@ remap: errors: "101": {
 			source: #"""
 				. |= parse_regex!(.message, r'^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$')
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ 	. |= parse_regex(.message, r'^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$')
-				  │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-				  │                                │
-				  │                                this regular expression is invalid
-				  │
-				"""#
 			diff: #"""
 				-. |= parse_regex!(.message, r'^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$')
 				+. |= parse_common_log!(.message)

--- a/docs/reference/remap/errors/102_non_boolean_if_expression_predicate.cue
+++ b/docs/reference/remap/errors/102_non_boolean_if_expression_predicate.cue
@@ -26,16 +26,6 @@ remap: errors: "102": {
 					. |= parse_key_value!(.message)
 				}
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ 	if .message {
-				  │        ^^^^^^^^
-				  │        │
-				  │        if expression predicates must resolve to a strict boolean
-				  │
-				"""#
 			diff: #"""
 				-if .message {
 				+if exists(.message) {

--- a/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
+++ b/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
@@ -19,16 +19,6 @@ remap: errors: "103": {
 		source: #"""
 			. |= parse_key_value(.message)
 			"""#
-		raises: compiletime: #"""
-			error: \#(title)
-			  ┌─ :1:1
-			  │
-			1 │ . |= parse_key_value(.message)
-			  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-			  │ │
-			  │ This assingment does not handle errors
-			  │
-			"""#
 	}]
 
 	examples: [

--- a/docs/reference/remap/errors/104_unnecessary_error_assignment.cue
+++ b/docs/reference/remap/errors/104_unnecessary_error_assignment.cue
@@ -20,16 +20,6 @@ remap: errors: "104": {
 			source: #"""
 				.message, err = downcase(.message)
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ .message, err = downcase(.message)
-				  │           ^^^
-				  │           │
-				  │           unneeded error assignment
-				  │
-				"""#
 			diff: #"""
 				-.message, err = downcase(.message)
 				+.message = downcase(.message)

--- a/docs/reference/remap/errors/105_undefined_function.cue
+++ b/docs/reference/remap/errors/105_undefined_function.cue
@@ -17,16 +17,6 @@ remap: errors: "105": {
 			source: #"""
 				parse_keyvalue(.message)
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ parse_keyvalue(.message)
-				  │ ^^^^^^^^^^^^^^
-				  │ │
-				  │ Undefined function
-				  │
-				"""#
 			diff: #"""
 				-parse_keyvalue(.message)
 				+parse_key_value(.message)

--- a/docs/reference/remap/errors/106_function_argument_arity_mismatch.cue
+++ b/docs/reference/remap/errors/106_function_argument_arity_mismatch.cue
@@ -17,16 +17,6 @@ remap: errors: "106": {
 			source: #"""
 				parse_json(.message, pretty: true)
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ parse_json(.message, pretty: true)
-				  │                      ^^^^^^^^^^^^
-				  │                      │
-				  │                      This argument exceeds the function arity
-				  │
-				"""#
 			diff: #"""
 				-parse_json(.message, pretty: true)
 				+parse_json(.message)

--- a/docs/reference/remap/errors/107_required_function_argument_missing.cue
+++ b/docs/reference/remap/errors/107_required_function_argument_missing.cue
@@ -17,16 +17,6 @@ remap: errors: "107": {
 			source: #"""
 				parse_timestamp(.timestamp)
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ parse_timestamp(.timestamp)
-				  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-				  │ │
-				  │ The required `format` argument is missing
-				  │
-				"""#
 			diff: #"""
 				-parse_timestamp(.timestamp)
 				+parse_timestamp(.timestamp, format: "%D")

--- a/docs/reference/remap/errors/108_unknown_function_argument_keyword.cue
+++ b/docs/reference/remap/errors/108_unknown_function_argument_keyword.cue
@@ -17,16 +17,6 @@ remap: errors: "108": {
 			source: #"""
 				parse_timestamp(.timestamp, fmt: "%D")
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ parse_timestamp(.timestamp, fmt: "%D")
-				  │                             ^^^
-				  │                             │
-				  │                             The `fmt` argument is unknown
-				  │
-				"""#
 			diff: #"""
 				-parse_timestamp(.timestamp)
 				+parse_timestamp(.timestamp, format: "%D")

--- a/docs/reference/remap/errors/109_cannot_abort_function.cue
+++ b/docs/reference/remap/errors/109_cannot_abort_function.cue
@@ -18,16 +18,6 @@ remap: errors: "109": {
 			source: #"""
 				downcase!(.message)
 				"""#
-			raises: compiletime: #"""
-				error: \#(title)
-				  ┌─ :1:1
-				  │
-				1 │ downcase!(.message)
-				  │         ^
-				  │         │
-				  │         This function is not fallible
-				  │
-				"""#
 			diff: #"""
 				-downcase!(.message)
 				+downcase(.message)

--- a/docs/reference/remap/errors/110_invalid_argument_type.cue
+++ b/docs/reference/remap/errors/110_invalid_argument_type.cue
@@ -20,17 +20,6 @@ remap: errors: "110": {
 		source: #"""
 			downcase(.message)
 			"""#
-		raises: compiletime: #"""
-			error: \#(title)
-			  ┌─ :1:1
-			  │
-			1 │ downcase(.message)
-			  │          ^^^^^^^^
-			  │          │
-			  │          this expression resolves to unknown type
-			  |          but the parameter "value" expects the exact type "string"
-			  │
-			"""#
 	}]
 
 	examples: [

--- a/docs/reference/remap/functions/assert.cue
+++ b/docs/reference/remap/functions/assert.cue
@@ -46,7 +46,6 @@ remap: functions: assert: {
 			source: #"""
 				assert("foo" == "bar", message: "Foo must be foo!")
 				"""#
-			raises: runtime: "Foo must be foo!"
 		},
 	]
 }


### PR DESCRIPTION
In going through and trying to exhaustively document VRL errors, I was struck by the thought that our current approach might be overkill. First, I'm not sure I see the value in providing an example compiler error output (in addition, those examples will be hard to maintain as the compiler will likely undergo swift changes post-0.12).

This is marked as a draft, as it includes only a proposed new `#Error` template and two reworked error codes.