### PR TITLE
fix(remap): re-enable @ in identifiers.

### DIFF
--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -220,6 +220,7 @@ pub struct Lexer<'input> {
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Token<S> {
     Identifier(S),
+    PathField(S),
     FunctionCall(S),
     Operator(S),
 
@@ -300,6 +301,7 @@ impl<S> Token<S> {
         use self::Token::*;
         match self {
             Identifier(s) => Identifier(f(s)),
+            PathField(s) => PathField(f(s)),
             FunctionCall(s) => FunctionCall(f(s)),
             Operator(s) => Operator(f(s)),
 
@@ -359,6 +361,7 @@ where
 
         let s = match *self {
             Identifier(_) => "Identifier",
+            PathField(_) => "PathField",
             FunctionCall(_) => "FunctionCall",
             Operator(_) => "Operator",
             StringLiteral(_) => "StringLiteral",
@@ -422,6 +425,8 @@ impl<'input> Token<&'input str> {
             | "undefined" | "int" | "integer" | "iter" | "object" | "regex" | "return"
             | "string" | "traverse" | "timestamp" | "duration" | "unless" | "walk" | "while"
             | "loop" => ReservedIdentifier(s),
+
+            _ if s.contains("@") => PathField(s),
 
             _ => Identifier(s),
         }
@@ -1358,13 +1363,13 @@ mod test {
             vec![
                 (r#"~              "#, LQuery),
                 (r#"~              "#, Dot),
-                (r#" ~~~~          "#, Identifier("@foo")),
+                (r#" ~~~~          "#, PathField("@foo")),
                 (r#"    ~          "#, RQuery),
                 (r#"      ~        "#, LQuery),
                 (r#"      ~        "#, Dot),
                 (r#"       ~~~     "#, Identifier("bar")),
                 (r#"          ~    "#, Dot),
-                (r#"           ~~~~"#, Identifier("@ook")),
+                (r#"           ~~~~"#, PathField("@ook")),
                 (r#"              ~"#, RQuery),
             ],
         );

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -1069,7 +1069,7 @@ impl<'input> Lexer<'input> {
 // -----------------------------------------------------------------------------
 
 fn is_ident_start(ch: char) -> bool {
-    matches!(ch, 'a'..='z')
+    matches!(ch, '@' | 'a'..='z')
 }
 
 fn is_ident_continue(ch: char) -> bool {
@@ -1346,6 +1346,25 @@ mod test {
                 (r#"            ~  "#, RQuery),
                 (r#"              ~"#, LQuery),
                 (r#"              ~"#, Dot),
+                (r#"              ~"#, RQuery),
+            ],
+        );
+    }
+
+    #[test]
+    fn ampersat_in_query() {
+        test(
+            data(r#".@foo .bar.@ook"#),
+            vec![
+                (r#"~              "#, LQuery),
+                (r#"~              "#, Dot),
+                (r#" ~~~~          "#, Identifier("@foo")),
+                (r#"    ~          "#, RQuery),
+                (r#"      ~        "#, LQuery),
+                (r#"      ~        "#, Dot),
+                (r#"       ~~~     "#, Identifier("bar")),
+                (r#"          ~    "#, Dot),
+                (r#"           ~~~~"#, Identifier("@ook")),
                 (r#"              ~"#, RQuery),
             ],
         );

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -426,7 +426,7 @@ impl<'input> Token<&'input str> {
             | "string" | "traverse" | "timestamp" | "duration" | "unless" | "walk" | "while"
             | "loop" => ReservedIdentifier(s),
 
-            _ if s.contains("@") => PathField(s),
+            _ if s.contains('@') => PathField(s),
 
             _ => Identifier(s),
         }

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -14,6 +14,7 @@ extern {
 
     enum Tok<'input> {
         "identifier" => Token::Identifier(<&'input str>),
+        "path field" => Token::PathField(<&'input str>),
         "string literal" => Token::StringLiteral(<StringLiteral<&'input str>>),
         "integer literal" => Token::IntegerLiteral(<i64>),
         "float literal" => Token::FloatLiteral(<NotNan<f64>>),
@@ -219,6 +220,8 @@ NonterminalNewline: () = "\n";
 
 Ident: Ident = "identifier" => Ident(<>.to_owned());
 
+PathField: Ident = "path field" => Ident(<>.to_owned());
+
 // An identifier that is allowed to include reserved keywords.
 AnyIdent: Ident = {
     "identifier" => Ident(<>.to_owned()),
@@ -377,6 +380,7 @@ PathSegment: PathSegment = {
 
 pub Field: Field = {
     AnyIdent => Field::Regular(<>),
+    PathField => Field::Regular(<>),
     String => Field::Quoted(<>),
 };
 

--- a/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
+++ b/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
@@ -1,0 +1,13 @@
+# result:
+#
+# error[E203]: syntax error
+#   ┌─ :1:1
+#   │
+# 1 │ @timestamp = now()
+#   │ ^^^^^^^^^^
+#   │ │
+#   │ unexpected syntax token: "PathField"
+#   │ expected one of: "\n", "!", "(", "[", "_", "false", "float literal", "function call", "identifier", "if", "integer literal", "null", "regex literal", "string literal", "timestamp literal", "true", "{", "path literal"
+#   │
+#   = see language documentation at: https://vector.dev/docs/reference/vrl/
+@timestamp = now()

--- a/lib/vrl/tests/tests/diagnostics/syntax_error_path_segment.vrl
+++ b/lib/vrl/tests/tests/diagnostics/syntax_error_path_segment.vrl
@@ -7,7 +7,7 @@
 #   │     ^
 #   │     │
 #   │     unexpected end of query path
-#   │     expected one of: "(", "identifier", "string literal"
+#   │     expected one of: "(", "identifier", "path field", "string literal"
 #   │
 #   = see language documentation at: https://vector.dev/docs/reference/vrl/
 

--- a/lib/vrl/tests/tests/expressions/query/ampersat.vrl
+++ b/lib/vrl/tests/tests/expressions/query/ampersat.vrl
@@ -1,0 +1,4 @@
+# object: { "foo@bar": { "@buz" : [ { "wibble@" : 42 } ] } }
+# result: 42
+
+.foo@bar.(@noog | @buz)[0].wibble@


### PR DESCRIPTION
Closes #6489 

This allows `@` in identifiers such as:

```
.@timestamp = now()
```

Signed-off-by: Stephen Wakely <stephen.wakely@datadoghq.com>
