### PR TITLE
feat(remap): re-add progressive type-checking to the language

### DIFF
--- a/lib/vrl/compiler/src/expression/if_statement.rs
+++ b/lib/vrl/compiler/src/expression/if_statement.rs
@@ -27,7 +27,7 @@ impl IfStatement {
 
 impl Expression for IfStatement {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let predicate = self.predicate.resolve(ctx)?.unwrap_boolean();
+        let predicate = self.predicate.resolve(ctx)?.try_boolean()?;
 
         match predicate {
             true => self.consequent.resolve(ctx),

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -38,7 +38,7 @@ impl Not {
 
 impl Expression for Not {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        Ok((!self.inner.resolve(ctx)?.unwrap_boolean()).into())
+        Ok((!self.inner.resolve(ctx)?.try_boolean()?).into())
     }
 
     fn type_def(&self, state: &State) -> TypeDef {

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -9,12 +9,12 @@ impl Value {
         let err = || Error::Mul(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_bytes() => rhs.unwrap_bytes().repeat(lhv as usize).into(),
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 * rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_bytes() => rhs.try_bytes()?.repeat(lhv as usize).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 * rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv * i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv * f64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Bytes(lhv) if rhs.is_integer() => {
-                lhv.repeat(rhs.unwrap_integer() as usize).into()
+                lhv.repeat(rhs.try_integer()? as usize).into()
             }
             _ => return Err(err()),
         };
@@ -46,7 +46,7 @@ impl Value {
         let err = || Error::Add(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 + rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 + rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv + i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv + f64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Bytes(_) if rhs.is_null() => self,
@@ -68,7 +68,7 @@ impl Value {
         let err = || Error::Sub(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 - rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 - rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv - i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv - f64::try_from(&rhs).map_err(|_| err())?).into(),
             _ => return Err(err()),
@@ -119,7 +119,7 @@ impl Value {
         let err = || Error::Rem(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 % rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 % rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv % i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv % f64::try_from(&rhs).map_err(|_| err())?).into(),
             _ => return Err(err()),
@@ -133,7 +133,7 @@ impl Value {
         let err = || Error::Rem(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 > rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 > rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv > i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => {
                 (lhv.into_inner() > f64::try_from(&rhs).map_err(|_| err())?).into()
@@ -149,7 +149,7 @@ impl Value {
         let err = || Error::Ge(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 >= rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 >= rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv >= i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => {
                 (lhv.into_inner() >= f64::try_from(&rhs).map_err(|_| err())?).into()
@@ -165,7 +165,7 @@ impl Value {
         let err = || Error::Ge(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => ((lhv as f64) < rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => ((lhv as f64) < rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv < i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => {
                 (lhv.into_inner() < f64::try_from(&rhs).map_err(|_| err())?).into()
@@ -181,7 +181,7 @@ impl Value {
         let err = || Error::Ge(self.kind(), rhs.kind());
 
         let value = match self {
-            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 <= rhs.unwrap_float()).into(),
+            Value::Integer(lhv) if rhs.is_float() => (lhv as f64 <= rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv <= i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => {
                 (lhv.into_inner() <= f64::try_from(&rhs).map_err(|_| err())?).into()

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -13,9 +13,7 @@ impl Value {
             Value::Integer(lhv) if rhs.is_float() => (lhv as f64 * rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv * i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv * f64::try_from(&rhs).map_err(|_| err())?).into(),
-            Value::Bytes(lhv) if rhs.is_integer() => {
-                lhv.repeat(rhs.try_integer()? as usize).into()
-            }
+            Value::Bytes(lhv) if rhs.is_integer() => lhv.repeat(rhs.try_integer()? as usize).into(),
             _ => return Err(err()),
         };
 

--- a/lib/vrl/compiler/src/value/convert.rs
+++ b/lib/vrl/compiler/src/value/convert.rs
@@ -64,13 +64,6 @@ impl Value {
         }
     }
 
-    pub fn unwrap_integer(self) -> i64 {
-        match self {
-            Value::Integer(v) => v,
-            _ => panic!("not an integer"),
-        }
-    }
-
     pub fn try_integer(self) -> Result<i64, Error> {
         match self {
             Value::Integer(v) => Ok(v),
@@ -156,13 +149,6 @@ impl Value {
         }
     }
 
-    pub fn unwrap_float(self) -> f64 {
-        match self {
-            Value::Float(v) => v.into_inner(),
-            _ => panic!("not a float"),
-        }
-    }
-
     pub fn try_float(self) -> Result<f64, Error> {
         match self {
             Value::Float(v) => Ok(v.into_inner()),
@@ -222,20 +208,6 @@ impl Value {
         match self {
             Value::Bytes(v) => Some(v),
             _ => None,
-        }
-    }
-
-    pub fn unwrap_bytes(self) -> Bytes {
-        match self {
-            Value::Bytes(v) => v,
-            _ => panic!("not a bytes"),
-        }
-    }
-
-    pub fn unwrap_bytes_utf8_lossy(&self) -> Cow<'_, str> {
-        match self.as_bytes() {
-            Some(bytes) => String::from_utf8_lossy(&bytes),
-            None => panic!("not a bytes"),
         }
     }
 
@@ -310,13 +282,6 @@ impl Value {
         }
     }
 
-    pub fn unwrap_boolean(self) -> bool {
-        match self {
-            Value::Boolean(v) => v,
-            _ => panic!("not a boolean"),
-        }
-    }
-
     pub fn try_boolean(self) -> Result<bool, Error> {
         match self {
             Value::Boolean(v) => Ok(v),
@@ -345,13 +310,6 @@ impl Value {
         match self {
             Value::Regex(v) => Some(v),
             _ => None,
-        }
-    }
-
-    pub fn unwrap_regex(self) -> Regex {
-        match self {
-            Value::Regex(v) => v,
-            _ => panic!("not a regex"),
         }
     }
 
@@ -389,13 +347,6 @@ impl Value {
         match self {
             Value::Null => Some(()),
             _ => None,
-        }
-    }
-
-    pub fn unwrap_null(self) {
-        match self {
-            Value::Null => (),
-            _ => panic!("not a null"),
         }
     }
 
@@ -446,13 +397,6 @@ impl Value {
         }
     }
 
-    pub fn unwrap_array(self) -> Vec<Value> {
-        match self {
-            Value::Array(v) => v,
-            _ => panic!("not an array"),
-        }
-    }
-
     pub fn try_array(self) -> Result<Vec<Value>, Error> {
         match self {
             Value::Array(v) => Ok(v),
@@ -497,13 +441,6 @@ impl Value {
         }
     }
 
-    pub fn unwrap_object(self) -> BTreeMap<String, Value> {
-        match self {
-            Value::Object(v) => v,
-            _ => panic!("not an object"),
-        }
-    }
-
     pub fn try_object(self) -> Result<BTreeMap<String, Value>, Error> {
         match self {
             Value::Object(v) => Ok(v),
@@ -538,13 +475,6 @@ impl Value {
         match self {
             Value::Timestamp(v) => Some(v),
             _ => None,
-        }
-    }
-
-    pub fn unwrap_timestamp(self) -> DateTime<Utc> {
-        match self {
-            Value::Timestamp(v) => v,
-            _ => panic!("not a timestamp"),
         }
     }
 

--- a/lib/vrl/compiler/src/value/target.rs
+++ b/lib/vrl/compiler/src/value/target.rs
@@ -302,7 +302,7 @@ impl Value {
 
             let map = match self {
                 Value::Object(map) => map,
-                _ => unreachable!(),
+                _ => unreachable!("see invariant above"),
             };
 
             match rest.first() {

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -47,8 +47,8 @@ struct AppendFn {
 
 impl Expression for AppendFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let mut value = self.value.resolve(ctx)?.unwrap_array();
-        let mut items = self.items.resolve(ctx)?.unwrap_array();
+        let mut value = self.value.resolve(ctx)?.try_array()?;
+        let mut items = self.items.resolve(ctx)?.try_array()?;
 
         value.append(&mut items);
 

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -68,14 +68,14 @@ impl AssertFn {
 
 impl Expression for AssertFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        match self.condition.resolve(ctx)?.unwrap_boolean() {
+        match self.condition.resolve(ctx)?.try_boolean()? {
             true => Ok(true.into()),
             false => Err(self
                 .message
                 .as_ref()
                 .map(|m| {
                     m.resolve(ctx)
-                        .map(|v| v.unwrap_bytes_utf8_lossy().into_owned())
+                        .and_then(|v| Ok(v.try_bytes_utf8_lossy()?.into_owned()))
                 })
                 .transpose()?
                 .unwrap_or_else(|| match self.condition.format() {

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -64,8 +64,12 @@ impl Expression for CeilFn {
 
         match self.value.resolve(ctx)? {
             Value::Float(f) => Ok(round_to_precision(*f, precision, f64::ceil).into()),
-            v @ Value::Integer(_) => Ok(v),
-            _ => unreachable!(),
+            value @ Value::Integer(_) => Ok(value),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Float | Kind::Integer,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -141,32 +141,32 @@ impl Expression for CompactFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let options = CompactOptions {
             recursive: match &self.recursive {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => true,
             },
 
             null: match &self.null {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => true,
             },
 
             string: match &self.string {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => true,
             },
 
             map: match &self.map {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => true,
             },
 
             array: match &self.array {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => true,
             },
 
             nullish: match &self.nullish {
-                Some(expr) => expr.resolve(ctx)?.unwrap_boolean(),
+                Some(expr) => expr.resolve(ctx)?.try_boolean()?,
                 None => false,
             },
         };

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -174,7 +174,11 @@ impl Expression for CompactFn {
         match self.value.resolve(ctx)? {
             Value::Object(map) => Ok(Value::from(compact_map(map, &options))),
             Value::Array(arr) => Ok(Value::from(compact_array(arr, &options))),
-            _ => unreachable!(),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Array | Kind::Object,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -49,7 +49,7 @@ struct DecodeBase64Fn {
 
 impl Expression for DecodeBase64Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_bytes();
+        let value = self.value.resolve(ctx)?.try_bytes()?;
 
         let charset = self
             .charset

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -47,7 +47,7 @@ impl DowncaseFn {
 
 impl Expression for DowncaseFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
 
         Ok(String::from_utf8_lossy(&bytes).to_lowercase().into())
     }

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -54,7 +54,11 @@ impl Expression for FlattenFn {
                     .map(|(k, v)| (k, v.clone()))
                     .collect(),
             )),
-            _ => unreachable!(),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Array | Kind::Object,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/floor.rs
+++ b/lib/vrl/stdlib/src/floor.rs
@@ -64,8 +64,12 @@ impl Expression for FloorFn {
 
         match self.value.resolve(ctx)? {
             Value::Float(f) => Ok(round_to_precision(*f, precision, f64::floor).into()),
-            v @ Value::Integer(_) => Ok(v),
-            _ => unreachable!(),
+            value @ Value::Integer(_) => Ok(value),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Float | Kind::Integer,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/format_number.rs
+++ b/lib/vrl/stdlib/src/format_number.rs
@@ -93,7 +93,13 @@ impl Expression for FormatNumberFn {
         let value: Decimal = match self.value.resolve(ctx)? {
             Value::Integer(v) => v.into(),
             Value::Float(v) => Decimal::from_f64(*v).expect("not NaN"),
-            _ => unreachable!(),
+            value => {
+                return Err(value::Error::Expected {
+                    got: value.kind(),
+                    expected: Kind::Integer | Kind::Float,
+                }
+                .into())
+            }
         };
 
         let scale = match &self.scale {

--- a/lib/vrl/stdlib/src/get_env_var.rs
+++ b/lib/vrl/stdlib/src/get_env_var.rs
@@ -39,7 +39,7 @@ struct GetEnvVarFn {
 impl Expression for GetEnvVarFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.name.resolve(ctx)?;
-        let name = value.unwrap_bytes_utf8_lossy();
+        let name = value.try_bytes_utf8_lossy()?;
 
         std::env::var(name.as_ref())
             .map(Into::into)

--- a/lib/vrl/stdlib/src/includes.rs
+++ b/lib/vrl/stdlib/src/includes.rs
@@ -54,7 +54,7 @@ struct IncludesFn {
 
 impl Expression for IncludesFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let list = self.value.resolve(ctx)?.unwrap_array();
+        let list = self.value.resolve(ctx)?.try_array()?;
         let item = self.item.resolve(ctx)?;
 
         let included = list.iter().any(|i| i == &item);

--- a/lib/vrl/stdlib/src/ip_cidr_contains.rs
+++ b/lib/vrl/stdlib/src/ip_cidr_contains.rs
@@ -73,14 +73,14 @@ impl Expression for IpCidrContainsFn {
             let value = self.value.resolve(ctx)?;
 
             value
-                .unwrap_bytes_utf8_lossy()
+                .try_bytes_utf8_lossy()?
                 .parse()
                 .map_err(|err| format!("unable to parse IP address: {}", err))?
         };
 
         let cidr = {
             let value = self.cidr.resolve(ctx)?;
-            let cidr = value.unwrap_bytes_utf8_lossy();
+            let cidr = value.try_bytes_utf8_lossy()?;
 
             IpCidr::from_str(cidr).map_err(|err| format!("unable to parse CIDR: {}", err))?
         };

--- a/lib/vrl/stdlib/src/ip_subnet.rs
+++ b/lib/vrl/stdlib/src/ip_subnet.rs
@@ -57,12 +57,12 @@ impl Expression for IpSubnetFn {
         let value: IpAddr = self
             .value
             .resolve(ctx)?
-            .unwrap_bytes_utf8_lossy()
+            .try_bytes_utf8_lossy()?
             .parse()
             .map_err(|err| format!("unable to parse IP address: {}", err))?;
 
         let mask = self.subnet.resolve(ctx)?;
-        let mask = mask.unwrap_bytes_utf8_lossy();
+        let mask = mask.try_bytes_utf8_lossy()?;
 
         let mask = if mask.starts_with('/') {
             // The parameter is a subnet.

--- a/lib/vrl/stdlib/src/ip_to_ipv6.rs
+++ b/lib/vrl/stdlib/src/ip_to_ipv6.rs
@@ -43,7 +43,7 @@ impl Expression for IpToIpv6Fn {
         let ip: IpAddr = self
             .value
             .resolve(ctx)?
-            .unwrap_bytes_utf8_lossy()
+            .try_bytes_utf8_lossy()?
             .parse()
             .map_err(|err| format!("unable to parse IP address: {}", err))?;
 

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -43,7 +43,7 @@ impl Expression for Ipv6ToIpV4Fn {
         let ip = self
             .value
             .resolve(ctx)?
-            .unwrap_bytes_utf8_lossy()
+            .try_bytes_utf8_lossy()?
             .parse()
             .map_err(|err| format!("unable to parse IP address: {}", err))?;
 

--- a/lib/vrl/stdlib/src/length.rs
+++ b/lib/vrl/stdlib/src/length.rs
@@ -58,7 +58,11 @@ impl Expression for LengthFn {
             Array(v) => Ok(v.len().into()),
             Object(v) => Ok(v.len().into()),
             Bytes(v) => Ok(v.len().into()),
-            _ => unreachable!("argument-type invariant"),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Array | Kind::Object | Kind::Bytes,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -52,7 +52,8 @@ impl Function for Log {
         let level = arguments
             .optional_enum("level", &levels)?
             .unwrap_or_else(|| "info".into())
-            .unwrap_bytes();
+            .try_bytes()
+            .expect("log level not bytes");
 
         Ok(Box::new(LogFn { value, level }))
     }

--- a/lib/vrl/stdlib/src/match.rs
+++ b/lib/vrl/stdlib/src/match.rs
@@ -55,9 +55,9 @@ pub(crate) struct MatchFn {
 impl Expression for MatchFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let string = value.unwrap_bytes_utf8_lossy();
+        let string = value.try_bytes_utf8_lossy()?;
 
-        let pattern = self.pattern.resolve(ctx)?.unwrap_regex();
+        let pattern = self.pattern.resolve(ctx)?.try_regex()?;
 
         Ok(pattern.is_match(&string).into())
     }

--- a/lib/vrl/stdlib/src/md5.rs
+++ b/lib/vrl/stdlib/src/md5.rs
@@ -39,7 +39,7 @@ struct Md5Fn {
 
 impl Expression for Md5Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_bytes();
+        let value = self.value.resolve(ctx)?.try_bytes()?;
 
         Ok(hex::encode(md5::Md5::digest(&value)).into())
     }

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -63,9 +63,9 @@ pub struct MergeFn {
 
 impl Expression for MergeFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let mut to_value = self.to.resolve(ctx)?.unwrap_object();
-        let from_value = self.from.resolve(ctx)?.unwrap_object();
-        let deep = self.deep.resolve(ctx)?.unwrap_boolean();
+        let mut to_value = self.to.resolve(ctx)?.try_object()?;
+        let from_value = self.from.resolve(ctx)?.try_object()?;
+        let deep = self.deep.resolve(ctx)?.try_boolean()?;
 
         merge_maps(&mut to_value, &from_value, deep);
 

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -55,7 +55,7 @@ impl ParseAwsAlbLogFn {
 
 impl Expression for ParseAwsAlbLogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
 
         parse_log(&String::from_utf8_lossy(&bytes))
     }

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -67,7 +67,7 @@ struct ParseAwsCloudWatchLogSubscriptionMessageFn {
 
 impl Expression for ParseAwsCloudWatchLogSubscriptionMessageFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
 
         let message = serde_json::from_slice::<AwsCloudWatchLogsSubscriptionMessage>(&bytes)
             .map_err(|e| format!("unable to parse: {}", e))?;

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -83,11 +83,11 @@ impl ParseAwsVpcFlowLogFn {
 
 impl Expression for ParseAwsVpcFlowLogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let input = String::from_utf8_lossy(&bytes);
 
         if let Some(expr) = &self.format {
-            let bytes = expr.resolve(ctx)?.unwrap_bytes();
+            let bytes = expr.resolve(ctx)?.try_bytes()?;
             parse_log(&input, Some(&String::from_utf8_lossy(&bytes)))
         } else {
             parse_log(&input, None)

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -79,11 +79,11 @@ struct ParseDurationFn {
 
 impl Expression for ParseDurationFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         let conversion_factor = {
-            let bytes = self.unit.resolve(ctx)?.unwrap_bytes();
+            let bytes = self.unit.resolve(ctx)?.try_bytes()?;
             let string = String::from_utf8_lossy(&bytes);
 
             UNITS

--- a/lib/vrl/stdlib/src/parse_glog.rs
+++ b/lib/vrl/stdlib/src/parse_glog.rs
@@ -62,7 +62,7 @@ struct ParseGlogFn {
 
 impl Expression for ParseGlogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let message = String::from_utf8_lossy(&bytes);
 
         let mut log: BTreeMap<String, Value> = BTreeMap::new();

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -85,7 +85,7 @@ struct ParseJsonFn {
 
 impl Expression for ParseJsonFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let value = serde_json::from_slice::<'_, Value>(&bytes)
             .map_err(|e| format!("unable to parse json: {}", e))?;
 

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -84,13 +84,13 @@ pub(crate) struct ParseKeyValueFn {
 impl Expression for ParseKeyValueFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let bytes = value.unwrap_bytes_utf8_lossy();
+        let bytes = value.try_bytes_utf8_lossy()?;
 
         let value = self.key_value_delimiter.resolve(ctx)?;
-        let key_value_delimiter = value.unwrap_bytes_utf8_lossy();
+        let key_value_delimiter = value.try_bytes_utf8_lossy()?;
 
         let value = self.field_delimiter.resolve(ctx)?;
-        let field_delimiter = value.unwrap_bytes_utf8_lossy();
+        let field_delimiter = value.try_bytes_utf8_lossy()?;
 
         let values = parse(&bytes, &key_value_delimiter, &field_delimiter)?;
 

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -56,7 +56,7 @@ pub(crate) struct ParseRegexFn {
 
 impl Expression for ParseRegexFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
 
         let parsed = self

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -44,7 +44,7 @@ struct ParseSyslogFn {
 impl Expression for ParseSyslogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let message = value.unwrap_bytes_utf8_lossy();
+        let message = value.try_bytes_utf8_lossy()?;
 
         let parsed = syslog_loose::parse_message_with_year_exact(&message, resolve_year)?;
 

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -58,17 +58,17 @@ impl ParseTimestampFn {
 impl Expression for ParseTimestampFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let format = self.format.resolve(ctx);
 
         match value {
-            Value::Bytes(v) => Conversion::parse(
-                format
-                    .map(|v| format!("timestamp|{}", String::from_utf8_lossy(&v.unwrap_bytes())))?,
-                TimeZone::Local,
-            )
-            .map_err(|e| format!("{}", e))?
-            .convert(v)
-            .map_err(|e| e.to_string().into()),
+            Value::Bytes(v) => {
+                let bytes = self.format.resolve(ctx)?;
+                let format = bytes.try_bytes_utf8_lossy()?;
+
+                Conversion::parse(format!("timestamp|{}", format), TimeZone::Local)
+                    .map_err(|e| format!("{}", e))?
+                    .convert(v)
+                    .map_err(|e| e.to_string().into())
+            }
             Value::Timestamp(_) => Ok(value),
             _ => Err("unable to convert value to timestamp".into()),
         }

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -63,7 +63,6 @@ impl Expression for ParseTimestampFn {
             Value::Bytes(v) => {
                 let bytes = self.format.resolve(ctx)?;
                 let format = bytes.try_bytes_utf8_lossy()?;
-
                 Conversion::parse(format!("timestamp|{}", format), TimeZone::Local)
                     .map_err(|e| format!("{}", e))?
                     .convert(v)

--- a/lib/vrl/stdlib/src/parse_tokens.rs
+++ b/lib/vrl/stdlib/src/parse_tokens.rs
@@ -52,7 +52,7 @@ impl ParseTokensFn {
 impl Expression for ParseTokensFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let string = value.unwrap_bytes_utf8_lossy();
+        let string = value.try_bytes_utf8_lossy()?;
 
         let tokens: Value = tokenize::parse(&string)
             .into_iter()

--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -53,7 +53,7 @@ struct ParseUrlFn {
 impl Expression for ParseUrlFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let string = value.unwrap_bytes_utf8_lossy();
+        let string = value.try_bytes_utf8_lossy()?;
 
         Url::parse(&string)
             .map_err(|e| format!("unable to parse url: {}", e).into())

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -54,7 +54,7 @@ struct PushFn {
 
 impl Expression for PushFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let mut list = self.value.resolve(ctx)?.unwrap_array();
+        let mut list = self.value.resolve(ctx)?.try_array()?;
         let item = self.item.resolve(ctx)?;
 
         list.push(item);

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -79,12 +79,12 @@ struct ReplaceFn {
 impl Expression for ReplaceFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let value = value.unwrap_bytes_utf8_lossy();
+        let value = value.try_bytes_utf8_lossy()?;
 
         let with_value = self.with.resolve(ctx)?;
-        let with = with_value.unwrap_bytes_utf8_lossy();
+        let with = with_value.try_bytes_utf8_lossy()?;
 
-        let count = self.count.resolve(ctx)?.unwrap_integer();
+        let count = self.count.resolve(ctx)?.try_integer()?;
 
         self.pattern.resolve(ctx).and_then(|pattern| match pattern {
             Value::Bytes(bytes) => {

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -109,7 +109,11 @@ impl Expression for ReplaceFn {
 
                 Ok(replaced)
             }
-            _ => unreachable!("argument-type invariant"),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Regex | Kind::Bytes,
+            }
+            .into()),
         })
     }
 

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -60,7 +60,7 @@ struct RoundFn {
 
 impl Expression for RoundFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let precision = self.precision.resolve(ctx)?.unwrap_integer();
+        let precision = self.precision.resolve(ctx)?.try_integer()?;
 
         match self.value.resolve(ctx)? {
             Value::Float(f) => Ok(round_to_precision(f.into_inner(), precision, f64::round).into()),

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -64,8 +64,12 @@ impl Expression for RoundFn {
 
         match self.value.resolve(ctx)? {
             Value::Float(f) => Ok(round_to_precision(f.into_inner(), precision, f64::round).into()),
-            v @ Value::Integer(_) => Ok(v),
-            _ => unreachable!(),
+            value @ Value::Integer(_) => Ok(value),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Float | Kind::Integer,
+            }
+            .into()),
         }
     }
 

--- a/lib/vrl/stdlib/src/sha1.rs
+++ b/lib/vrl/stdlib/src/sha1.rs
@@ -39,7 +39,7 @@ struct Sha1Fn {
 
 impl Expression for Sha1Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_bytes();
+        let value = self.value.resolve(ctx)?.try_bytes()?;
 
         Ok(hex::encode(sha1::Sha1::digest(&value)).into())
     }

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -53,7 +53,8 @@ impl Function for Sha2 {
         let variant = arguments
             .optional_enum("variant", &variants)?
             .unwrap_or_else(|| value!("SHA-512/256"))
-            .unwrap_bytes();
+            .try_bytes()
+            .expect("variant not bytes");
 
         Ok(Box::new(Sha2Fn { value, variant }))
     }
@@ -67,7 +68,7 @@ struct Sha2Fn {
 
 impl Expression for Sha2Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_bytes();
+        let value = self.value.resolve(ctx)?.try_bytes()?;
 
         let hash = match self.variant.as_ref() {
             b"SHA-224" => encode::<Sha224>(&value),

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -51,7 +51,8 @@ impl Function for Sha3 {
         let variant = arguments
             .optional_enum("variant", &variants)?
             .unwrap_or_else(|| value!("SHA3-512"))
-            .unwrap_bytes();
+            .try_bytes()
+            .expect("variant not bytes");
 
         Ok(Box::new(Sha3Fn { value, variant }))
     }
@@ -65,7 +66,7 @@ struct Sha3Fn {
 
 impl Expression for Sha3Fn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_bytes();
+        let value = self.value.resolve(ctx)?.try_bytes()?;
 
         let hash = match self.variant.as_ref() {
             b"SHA3-224" => encode::<Sha3_224>(&value),

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -67,9 +67,9 @@ struct SliceFn {
 
 impl Expression for SliceFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let start = self.start.resolve(ctx)?.unwrap_integer();
+        let start = self.start.resolve(ctx)?.try_integer()?;
         let end = match &self.end {
-            Some(expr) => Some(expr.resolve(ctx)?.unwrap_integer()),
+            Some(expr) => Some(expr.resolve(ctx)?.try_integer()?),
             None => None,
         };
 

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -102,12 +102,23 @@ impl Expression for SliceFn {
             Value::Array(mut v) => range(v.len() as i64)
                 .map(|range| v.drain(range).collect::<Vec<_>>())
                 .map(Value::from),
-            _ => unreachable!(),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Bytes | Kind::Array,
+            }
+            .into()),
         }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.value.type_def(state).fallible()
+        let td = TypeDef::new().fallible();
+
+        match self.value.type_def(state) {
+            v if v.is_bytes() || v.is_array() => td.merge(v),
+            _ => td.bytes().add_array_mapped::<(), Kind>(map! {
+                (): Kind::all(),
+            }),
+        }
     }
 }
 

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -71,8 +71,8 @@ pub(crate) struct SplitFn {
 impl Expression for SplitFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let string = value.unwrap_bytes_utf8_lossy();
-        let limit = self.limit.resolve(ctx)?.unwrap_integer() as usize;
+        let string = value.try_bytes_utf8_lossy()?;
+        let limit = self.limit.resolve(ctx)?.try_integer()? as usize;
 
         self.pattern.resolve(ctx).and_then(|pattern| match pattern {
             Value::Regex(pattern) => Ok(pattern

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -87,7 +87,11 @@ impl Expression for SplitFn {
                     .collect::<Vec<_>>()
                     .into())
             }
-            _ => unreachable!(),
+            value => Err(value::Error::Expected {
+                got: value.kind(),
+                expected: Kind::Regex | Kind::Bytes,
+            }
+            .into()),
         })
     }
 

--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -70,11 +70,11 @@ struct StartsWithFn {
 
 impl Expression for StartsWithFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let case_sensitive = self.case_sensitive.resolve(ctx)?.unwrap_boolean();
+        let case_sensitive = self.case_sensitive.resolve(ctx)?.try_boolean()?;
 
         let substring = {
             let value = self.substring.resolve(ctx)?;
-            let string = value.unwrap_bytes_utf8_lossy();
+            let string = value.try_bytes_utf8_lossy()?;
 
             match case_sensitive {
                 true => string.into_owned(),
@@ -84,7 +84,7 @@ impl Expression for StartsWithFn {
 
         let value = {
             let value = self.value.resolve(ctx)?;
-            let string = value.unwrap_bytes_utf8_lossy();
+            let string = value.try_bytes_utf8_lossy()?;
 
             match case_sensitive {
                 true => string.into_owned(),

--- a/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
+++ b/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
@@ -35,7 +35,7 @@ struct StripAnsiEscapeCodesFn {
 
 impl Expression for StripAnsiEscapeCodesFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let bytes = self.value.resolve(ctx)?.unwrap_bytes();
+        let bytes = self.value.resolve(ctx)?.try_bytes()?;
 
         strip_ansi_escapes::strip(&bytes)
             .map(Bytes::from)

--- a/lib/vrl/stdlib/src/strip_whitespace.rs
+++ b/lib/vrl/stdlib/src/strip_whitespace.rs
@@ -52,7 +52,7 @@ impl Expression for StripWhitespaceFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
 
-        Ok(value.unwrap_bytes_utf8_lossy().trim().into())
+        Ok(value.try_bytes_utf8_lossy()?.trim().into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/vrl/stdlib/src/to_syslog_facility.rs
+++ b/lib/vrl/stdlib/src/to_syslog_facility.rs
@@ -47,7 +47,7 @@ struct ToSyslogFacilityFn {
 
 impl Expression for ToSyslogFacilityFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?.unwrap_integer();
+        let value = self.value.resolve(ctx)?.try_integer()?;
 
         // Facility codes: https://en.wikipedia.org/wiki/Syslog#Facility
         let code = match value {

--- a/lib/vrl/stdlib/src/to_syslog_severity.rs
+++ b/lib/vrl/stdlib/src/to_syslog_severity.rs
@@ -48,7 +48,7 @@ struct ToSyslogSeverityFn {
 impl Expression for ToSyslogSeverityFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let level = self.value.resolve(ctx)?;
-        let level = level.unwrap_bytes_utf8_lossy();
+        let level = level.try_bytes_utf8_lossy()?;
 
         // Severity levels: https://en.wikipedia.org/wiki/Syslog#Severity_level
         let severity = match &level[..] {

--- a/lib/vrl/stdlib/src/truncate.rs
+++ b/lib/vrl/stdlib/src/truncate.rs
@@ -71,12 +71,12 @@ struct TruncateFn {
 impl Expression for TruncateFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        let mut value = value.unwrap_bytes_utf8_lossy().into_owned();
+        let mut value = value.try_bytes_utf8_lossy()?.into_owned();
 
-        let limit = self.limit.resolve(ctx)?.unwrap_integer();
+        let limit = self.limit.resolve(ctx)?.try_integer()?;
         let limit = if limit < 0 { 0 } else { limit as usize };
 
-        let ellipsis = self.ellipsis.resolve(ctx)?.unwrap_boolean();
+        let ellipsis = self.ellipsis.resolve(ctx)?.try_boolean()?;
 
         let pos = if let Some((pos, chr)) = value.char_indices().take(limit).last() {
             // char_indices gives us the starting position of the character at limit,

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -40,7 +40,7 @@ impl Expression for UpcaseFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
 
-        Ok(value.unwrap_bytes_utf8_lossy().to_uppercase().into())
+        Ok(value.try_bytes_utf8_lossy()?.to_uppercase().into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
@@ -1,27 +1,19 @@
 # object: { "message": "bananas and another ant" }
 # result:
 #
-# error[E110]: invalid argument type
-#   ┌─ :3:11
+# error[E103]: unhandled fallible assignment
+#   ┌─ :3:6
 #   │
 # 3 │ .a = sha3(.result[0].an)
-#   │           ^^^^^^^^^^^^^
-#   │           │
-#   │           this expression resolves to one of "string" or "null"
-#   │           but the parameter "value" expects the exact type "string"
+#   │ ---- ^^^^^^^^^^^^^^^^^^^
+#   │ │    │
+#   │ │    this expression is fallible
+#   │ │    update the expression to be infallible
+#   │ or change this to an infallible assignment:
+#   │ .a, err = sha3(.result[0].an)
 #   │
-#   = try: ensuring an appropriate type at runtime
-#   =
-#   =     .result[0].an = string!(.result[0].an)
-#   =     sha3(.result[0].an)
-#   =
-#   = try: coercing to an appropriate type and specifying a default value as a fallback in case coercion fails
-#   =
-#   =     .result[0].an = to_string(.result[0].an) ?? "default"
-#   =     sha3(.result[0].an)
-#   =
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
-#   = learn more about error code 110 at https://errors.vrl.dev/110
+#   = learn more about error code 103 at https://errors.vrl.dev/103
 #   = see language documentation at https://vrl.dev
 
 .result = parse_regex_all!(.message, r'(?P<an>an.)')

--- a/lib/vrl/tests/tests/diagnostics/unsuccessful_parse_json_type.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unsuccessful_parse_json_type.vrl
@@ -1,27 +1,17 @@
 # object: { "message": "{\"field\": \"value\"}" }
 # result:
 #
-# error[E110]: invalid argument type
-#   ┌─ :4:6
+# error[E100]: unhandled error
+#   ┌─ :4:1
 #   │
 # 4 │ sha3(result.message)
-#   │      ^^^^^^^^^^^^^^
-#   │      │
-#   │      this expression resolves to "unknown type"
-#   │      but the parameter "value" expects the exact type "string"
+#   │ ^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ expression can result in runtime error
+#   │ handle the error case to ensure runtime success
 #   │
-#   = try: ensuring an appropriate type at runtime
-#   =
-#   =     result.message = string!(result.message)
-#   =     sha3(result.message)
-#   =
-#   = try: coercing to an appropriate type and specifying a default value as a fallback in case coercion fails
-#   =
-#   =     result.message = to_string(result.message) ?? "default"
-#   =     sha3(result.message)
-#   =
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
-#   = learn more about error code 110 at https://errors.vrl.dev/110
+#   = learn more about error code 100 at https://errors.vrl.dev/100
 #   = see language documentation at https://vrl.dev
 
 .message = to_string!(.message)

--- a/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
+++ b/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
@@ -1,27 +1,19 @@
 # object: { "foo": "bar" }
 # result:
 #
-# error[E110]: invalid argument type
-#   ┌─ :4:15
+# error[E103]: unhandled fallible assignment
+#   ┌─ :4:8
 #   │
 # 4 │ .foo = upcase(.foo) # string
-#   │               ^^^^
-#   │               │
-#   │               this expression resolves to one of "string" or "null"
-#   │               but the parameter "value" expects the exact type "string"
+#   │ ------ ^^^^^^^^^^^^
+#   │ │      │
+#   │ │      this expression is fallible
+#   │ │      update the expression to be infallible
+#   │ or change this to an infallible assignment:
+#   │ .foo, err = upcase(.foo)
 #   │
-#   = try: ensuring an appropriate type at runtime
-#   =
-#   =     .foo = string!(.foo)
-#   =     upcase(.foo)
-#   =
-#   = try: coercing to an appropriate type and specifying a default value as a fallback in case coercion fails
-#   =
-#   =     .foo = to_string(.foo) ?? "default"
-#   =     upcase(.foo)
-#   =
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
-#   = learn more about error code 110 at https://errors.vrl.dev/110
+#   = learn more about error code 103 at https://errors.vrl.dev/103
 #   = see language documentation at https://vrl.dev
 
 .foo # any

--- a/lib/vrl/tests/tests/internal/progressive_type_checking.vrl
+++ b/lib/vrl/tests/tests/internal/progressive_type_checking.vrl
@@ -1,0 +1,46 @@
+# object: { "foo": "foobar", "bar": ["foo", "bar"], "baz": 10.5 }
+# result:
+#
+# {
+#   "foo1": "FOOBAR",
+#   "err":  null,
+#   "foo2": "not an array",
+#   "foo3": "OOBAR",
+#
+#   "bar1": ["bar", "baz"],
+#   "bar2": ["bar"],
+#
+#   "baz1": ["baz"],
+#   "baz2": "not an array",
+#   "baz3": 10.5
+# }
+
+ok, .err = to_string(.foo)
+.foo1 = upcase(ok) ?? "should be a string"
+
+ok = slice!(.foo, 1)
+.foo2 = push(ok, "baz") ?? "not an array"
+
+ok = slice(.foo, 1) ?? .foo
+.foo3 = upcase(ok) ?? ok
+
+ok = slice!(.bar, 1)
+.bar1 = push(ok, "baz") ?? "should be an array"
+
+ok = slice(.bar, 1) ?? .bar
+.bar2 = upcase(ok) ?? ok
+
+ok = slice(.baz, 1) ?? []
+.baz1 = push(ok, "baz") ?? "should be an array"
+
+ok = slice(.baz, 1) ?? false
+.baz2 = push(ok, "baz") ?? "not an array"
+
+ok = slice(.baz, 1) ?? .baz
+.baz3 = upcase(ok) ?? ok
+
+del(.foo)
+del(.bar)
+del(.baz)
+
+.

--- a/lib/vrl/tests/tests/internal/type_def_merging.vrl
+++ b/lib/vrl/tests/tests/internal/type_def_merging.vrl
@@ -1,0 +1,22 @@
+# result: [1, [0], [0], ["true", 0]]
+
+# NOTE: the function calls in this test are needed to validate the type
+# definition results.
+
+v1 = "foo"
+v1 = 1
+ceil(v1)
+
+v2 = ["true"]
+v2 = [0]
+ceil(v2[0])
+
+v3 = ["true"]
+v3[0] = 0
+ceil(v3[0])
+
+v4 = ["true"]
+v4[1] = 0
+upcase(v4[0])
+
+[v1, v2, v3, v4]


### PR DESCRIPTION
This PR re-adds "progressive type checking" to VRL.

It does this by finding a middle-ground between the **old** progressive type-checking solution (which came with a high degree of overhead for function implementations and thus a higher chance of invalid type definitions returned by functions), and the current situation on the `master` branch in which there is no progressive type-checking any more (resulting in a higher cost for users to make their programs compile).

For a full description on how this works, I encourage you to check out this issue comment: https://github.com/timberio/vector/issues/6507#issuecomment-783231649.

The TL;DR can best be described with two (simple) examples:

## Invalid Type

When the compiler knows a provided argument type will never satisfy the function parameter invariant at runtime, it will fail to compile:

```rust
.foo = 42
sha3(.foo)
```

```text
error[E110]: invalid argument type
  ┌─ :1:6
  │
1 │ sha3(.foo)
  │      ^^^^
  │      │
  │      this expression resolves to the exact type "integer"
  │      but the parameter "value" expects the exact type "string"
  │
  = try: ensuring an appropriate type at runtime
  =
  =     .foo = string!(.foo)
  =     sha3(.foo)
  =
  = try: coercing to an appropriate type and specifying a default value as a fallback in case coercion fails
  =
  =     .foo = to_string(.foo) ?? "default"
  =     sha3(.foo)
  =
  = see documentation about error handling at https://errors.vrl.dev/#handling
  = learn more about error code 110 at https://errors.vrl.dev/110
  = see language documentation at https://vrl.dev
```

This example shows how all type-check errors are reported on the master branch.

## Maybe Invalid Type

The changes in this PR allow functions to accept _potentially valid types_ without them having to _handle those invalid types in their type definitions_. This last part is what differs from the old progressive type-checking implementation, and provides us with less potential function implementation errors.

For this example, we'll provide the program with an external event:

```json
{ "foo": "bar" }
```

And then we run (almost) the same program again:

```rust
sha3(.foo)
```

```text
error[E100]: unhandled error
  ┌─ :1:1
  │
1 │ sha3(.foo)
  │ ^^^^^^^^^^
  │ │
  │ expression can result in runtime error
  │ handle the error case to ensure runtime success
  │
  = see documentation about error handling at https://errors.vrl.dev/#handling
  = learn more about error code 100 at https://errors.vrl.dev/100
  = see language documentation at https://vrl.dev
```

This time we get a different error because the function accepted the `.foo` argument, since the compiler can't know at compile-time which value `.foo` will hold, and thus it _might_ be a valid value type, but it might also not be.

This error can then be handled through whatever means is available given our error-handling story.

All functions have been updated to deal with invalid types at runtime.

closes #6507