### PR TITLE
enhancement(ci): Add VRL test suite to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,16 @@ jobs:
           RUSTFLAGS: "-D warnings"
         run: cargo test --no-fail-fast --no-default-features --features default-msvc
 
+  test-vrl:
+    name: VRL - Linux
+    continue-on-error: true
+    runs-on: ubuntu-20.04
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: make test-vrl
+
   check-component-features:
     name: Component Features - Linux
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,11 @@ release-helm: ## Package and release Helm Chart
 sync-install: ## Sync the install.sh script for access via sh.vector.dev
 	@aws s3 cp distribution/install.sh s3://sh.vector.dev --sse --acl public-read
 
+##@ Vector Remap Language
+.PHONY: test-vrl
+test-vrl: ## Run the VRL test suite
+	(cd lib/vrl/tests && ${MAYBE_ENVIRONMENT_EXEC} cargo run)
+
 ##@ Utility
 
 .PHONY: build-ci-docker-images

--- a/Makefile
+++ b/Makefile
@@ -780,9 +780,10 @@ sync-install: ## Sync the install.sh script for access via sh.vector.dev
 	@aws s3 cp distribution/install.sh s3://sh.vector.dev --sse --acl public-read
 
 ##@ Vector Remap Language
+
 .PHONY: test-vrl
 test-vrl: ## Run the VRL test suite
-	(cd lib/vrl/tests && ${MAYBE_ENVIRONMENT_EXEC} cargo run)
+	@scripts/test-vrl.sh
 
 ##@ Utility
 

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -24,7 +24,7 @@ impl Function for ParseSyslog {
             title: "parse syslog",
             source: r#"encode_json(parse_syslog!(s'<13>1 2020-03-13T20:45:38.119Z dynamicwireless.name non 2426 ID931 [exampleSDID@32473 iut="3" eventSource= "Application" eventID="1011"] Try to override the THX port, maybe it will reboot the neural interface!'))"#,
             result: Ok(
-                r#"s'{"appname":"non","exampleSDID@32473.eventID":"1011","exampleSDID@32473.eventSource":"Application","exampleSDID@32473.iut":"3","facility":"user","hostname":"dynamicwireless.name","message":"Try to override the THX port, maybe it will reboot the neural interface!","msgid":"ID931","procid":2426,"severity":"notice","timestamp":"2020-03-13T20:45:38.119+00:00", "version": 1}'"#,
+                r#"s'{"appname":"non","exampleSDID@32473.eventID":"1011","exampleSDID@32473.eventSource":"Application","exampleSDID@32473.iut":"3","facility":"user","hostname":"dynamicwireless.name","message":"Try to override the THX port, maybe it will reboot the neural interface!","msgid":"ID931","procid":2426,"severity":"notice","timestamp":"2020-03-13T20:45:38.119+00:00","version":1}'"#,
             ),
         }]
     }

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -356,18 +356,21 @@ fn compare_partial_diagnostic(got: &str, want: &str) -> bool {
 }
 
 fn print_result(failed_count: usize) {
-    let code = if failed_count > 0 {
-        1
-    } else {
-        0
-    };
+    let code = if failed_count > 0 { 1 } else { 0 };
 
     println!("\n");
 
     if failed_count > 0 {
-        println!("  Overall result: {}\n\n    Number failed: {}\n", Colour::Red.bold().paint("FAILED"), failed_count);
+        println!(
+            "  Overall result: {}\n\n    Number failed: {}\n",
+            Colour::Red.bold().paint("FAILED"),
+            failed_count
+        );
     } else {
-        println!("  Overall result: {}\n", Colour::Green.bold().paint("SUCCESS"));
+        println!(
+            "  Overall result: {}\n",
+            Colour::Green.bold().paint("SUCCESS")
+        );
     }
 
     std::process::exit(code)

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -208,9 +208,7 @@ fn main() {
         }
     }
 
-    if failed_count > 0 {
-        std::process::exit(1)
-    }
+    print_result(failed_count)
 }
 
 #[derive(Debug)]
@@ -355,4 +353,22 @@ fn compare_partial_diagnostic(got: &str, want: &str) -> bool {
         .filter(|line| line.trim().starts_with("error[E"))
         .zip(want.trim().lines())
         .all(|(got, want)| got.contains(want))
+}
+
+fn print_result(failed_count: usize) {
+    let code = if failed_count > 0 {
+        1
+    } else {
+        0
+    };
+
+    println!("\n");
+
+    if failed_count > 0 {
+        println!("  Overall result: {}\n\n    Number failed: {}\n", Colour::Red.bold().paint("FAILED"), failed_count);
+    } else {
+        println!("  Overall result: {}\n", Colour::Green.bold().paint("SUCCESS"));
+    }
+
+    std::process::exit(code)
 }

--- a/scripts/test-vrl.sh
+++ b/scripts/test-vrl.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# test-vrl.sh
+#
+# SUMMARY
+#
+#   Run the Vector Remap Language test suite
+
+(
+  cd "$(dirname "${BASH_SOURCE[0]}")/../lib/vrl/tests"
+
+  cargo run
+)
+


### PR DESCRIPTION
This PR adds the VRL test suite in `lib/vrl/tests` to our current CI testing pipeline. I've somewhat arbitrarily chosen to run this on Ubuntu, as I'm not sure that the platform should matter, but I'm open to suggestion on that.