### PR TITLE
fix(external docs): Fix cargo doc errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ default-msvc = ["api", "api-client", "leveldb", "rdkafka-cmake", "sinks", "sourc
 default-musl = ["api", "api-client", "leveldb", "rdkafka-cmake", "sinks", "sources", "transforms", "unix", "vendor-all", "vrl-cli"]
 default-no-api-client = ["api", "leveldb", "rdkafka-plain", "sinks", "sources", "transforms", "unix", "vendor-all", "vrl-cli"]
 default-no-vrl-cli = ["api", "leveldb", "rdkafka-plain", "sinks", "sources", "transforms", "unix", "vendor-all"]
+# The docs feature specifies which packages are included in the Rustdoc available at https://rustdoc.vector.dev
 docs = ["api", "sinks", "sources", "transforms"]
 
 all-logs = ["sinks-logs", "sources-logs", "transforms-logs"]

--- a/Makefile
+++ b/Makefile
@@ -643,6 +643,11 @@ check-kubernetes-yaml: ## Check that the generated Kubernetes YAML configs are u
 check-events: ## Check that events satisfy patterns set in https://github.com/timberio/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-events.sh
 
+##@ Rustdoc
+build-rustdoc: ## Build a subset of Vector's Rustdocs (as specified by the "docs" feature)
+	# This command is mostly intended for use by the build process in timberio/vector-rustdoc
+	${MAYBE_ENVIRONMENT_EXEC} cargo doc --no-deps --no-default-features --features docs
+
 ##@ Packaging
 
 # archives

--- a/src/event/util/log/all_fields.rs
+++ b/src/event/util/log/all_fields.rs
@@ -5,7 +5,7 @@ use std::{
     iter, slice,
 };
 
-/// Iterates over all paths in form "a.b[0].c[1]" in alphabetical order
+/// Iterates over all paths in form `a.b[0].c[1]` in alphabetical order
 /// and their corresponding values.
 pub fn all_fields(
     fields: &BTreeMap<String, Value>,

--- a/src/event/util/log/keys.rs
+++ b/src/event/util/log/keys.rs
@@ -1,7 +1,7 @@
 use super::{all_fields, Value};
 use std::collections::BTreeMap;
 
-/// Iterates over all paths in form "a.b[0].c[1]" in alphabetical order.
+/// Iterates over all paths in form `a.b[0].c[1]` in alphabetical order.
 /// It is implemented as a wrapper around `all_fields` to reduce code
 /// duplication.
 pub fn keys(fields: &BTreeMap<String, Value>) -> impl Iterator<Item = String> + '_ {

--- a/src/event/util/log/path_iter.rs
+++ b/src/event/util/log/path_iter.rs
@@ -9,15 +9,15 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum PathComponent {
-    /// For example, in "a.b[0].c[2]" the keys are "a", "b", and "c".
+    /// For example, in `a.b[0].c[2]` the keys are "a", "b", and "c".
     Key(String),
-    /// For example, in "a.b[0].c[2]" the indexes are 0 and 2.
+    /// For example, in `a.b[0].c[2]` the indexes are 0 and 2.
     Index(usize),
     /// Indicates that a parsing error occurred.
     Invalid,
 }
 
-/// Iterator over components of paths specified in form "a.b[0].c[2]".
+/// Iterator over components of paths specified in form `a.b[0].c[2]`.
 pub struct PathIter<'a> {
     path: &'a str,
     chars: Chars<'a>,

--- a/src/kubernetes/debounce.rs
+++ b/src/kubernetes/debounce.rs
@@ -45,8 +45,8 @@ impl Debounce {
     }
 
     /// This function exposes the state of the debounce logic.
-    /// If this returns `false`, you shouldn't `poll` on [`debounced`], as it's
-    /// pending indefinitely.
+    /// If this returns `false`, you shouldn't `poll` on [`Self::debounced`], as
+    /// it's pending indefinitely.
     pub fn is_debouncing(&self) -> bool {
         self.sequence_start.is_some()
     }

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -40,7 +40,7 @@ where
     <W as Watcher>::Object: Metadata<Ty = ObjectMeta> + Send,
     S: state::MaintainedWrite<Item = <W as Watcher>::Object>,
 {
-    /// Create a new [`Cache`].
+    /// Create a new [`Reflector`].
     pub fn new(
         watcher: W,
         state_writer: S,

--- a/src/kubernetes/state/delayed_delete.rs
+++ b/src/kubernetes/state/delayed_delete.rs
@@ -23,7 +23,7 @@ where
     T: super::Write + Send,
     <T as super::Write>::Item: Send + Sync,
 {
-    /// Take a [`super::Write`] and return it wrapped with [`Self`].
+    /// Take a [`super::Write`] and return it wrapped with [`Writer`].
     pub fn new(inner: T, delay_for: Duration) -> Self {
         let queue = VecDeque::new();
         Self {

--- a/src/kubernetes/state/evmap.rs
+++ b/src/kubernetes/state/evmap.rs
@@ -23,7 +23,7 @@ where
     T: Metadata<Ty = ObjectMeta> + Send,
 {
     /// Take a [`WriteHandle`], initialize it and return it wrapped with
-    /// [`Self`].
+    /// [`Writer`].
     pub fn new(
         mut inner: WriteHandle<String, Value<T>>,
         flush_debounce_timeout: Option<Duration>,

--- a/src/kubernetes/state/instrumenting.rs
+++ b/src/kubernetes/state/instrumenting.rs
@@ -11,7 +11,7 @@ pub struct Writer<T> {
 }
 
 impl<T> Writer<T> {
-    /// Take a [`super::Write`] and return it wrapped with [`Self`].
+    /// Take a [`super::Write`] and return it wrapped with [`Writer`].
     pub fn new(inner: T) -> Self {
         Self { inner }
     }

--- a/src/kubernetes/state/mod.rs
+++ b/src/kubernetes/state/mod.rs
@@ -38,10 +38,10 @@ pub trait MaintainedWrite: Write {
     /// A future that resolves when maintenance is required.
     ///
     /// Does not perform the maintenance itself, users must call
-    /// [`perform_maintenance`] to actually perform the maintenance.
+    /// [`Self::perform_maintenance`] to actually perform the maintenance.
     ///
     /// `None` if the state doesn't require maintenance, and
-    /// [`perform_maintenance`] shouldn't be called.
+    /// [`Self::perform_maintenance`] shouldn't be called.
     /// [`futures::future::FusedFuture`] should've been used here, but it's
     /// not not trivially implementable with `async/await` syntax, so [`Option`]
     /// wrapper is used instead for the same purpose.


### PR DESCRIPTION
This PR does two things:

1. It adds a `make build-rustdoc` command, largely for use by a build process in another repo
2. It fixes a series of warnings produced by `cargo doc` when building the subset of the Rustdoc targeted for the https://rustdoc.vector.dev site (that link doesn't work yet but it will).