### PR TITLE
chore: use PartitionBatchSink in BatchSink

### DIFF
--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -7,7 +7,6 @@ use super::{
     Batch, BatchSink, Partition, PartitionBatchSink,
 };
 use crate::buffers::Acker;
-use futures::TryFutureExt;
 use serde::{
     de::{self, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -24,7 +23,7 @@ use tower::{
 
 pub type Svc<S, L> = RateLimit<Retry<FixedRetryPolicy<L>, AdaptiveConcurrencyLimit<Timeout<S>, L>>>;
 pub type TowerBatchedSink<S, B, L, Request> = BatchSink<Svc<S, L>, B, Request>;
-pub type TowerPartitionSink<S, B, L, K, Request> = PartitionBatchSink<B, Svc<S, L>, K, Request>;
+pub type TowerPartitionSink<S, B, L, K, Request> = PartitionBatchSink<Svc<S, L>, B, K, Request>;
 
 pub trait ServiceBuilderExt<L> {
     fn map<R1, R2, F>(self, f: F) -> ServiceBuilder<Stack<MapLayer<R1, R2>, L>>
@@ -284,10 +283,6 @@ impl TowerRequestSettings {
         batch_timeout: Duration,
         acker: Acker,
     ) -> TowerBatchedSink<S, B, L, Request>
-    // Would like to return `impl Sink + SinkExt<T>` here, but that
-    // doesn't work with later calls to `batched_with_min` etc (via
-    // `trait SinkExt` above), as it is missing a bound on the
-    // associated types that cannot be expressed in stable Rust.
     where
         L: RetryLogic<Response = S::Response>,
         S: Service<Request> + Clone + Send + 'static,
@@ -385,36 +380,45 @@ where
 
 pub struct Map<S, R1, R2> {
     f: Arc<dyn Fn(R1) -> R2 + Send + Sync + 'static>,
-    inner: S,
+    pub(crate) inner: S,
 }
 
 impl<S, R1, R2> Service<R1> for Map<S, R1, R2>
 where
     S: Service<R2>,
-    crate::Error: From<S::Error>,
 {
     type Response = S::Response;
-    type Error = crate::Error;
-    type Future = futures::future::MapErr<S::Future, fn(S::Error) -> crate::Error>;
+    type Error = S::Error;
+    type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map(|result| result.map_err(|e| e.into()))
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: R1) -> Self::Future {
         let req = (self.f)(req);
-        self.inner.call(req).map_err(Into::into)
+        self.inner.call(req)
     }
 }
 
-impl<S: Clone, R1, R2> Clone for Map<S, R1, R2> {
+impl<S, R1, R2> Clone for Map<S, R1, R2>
+where
+    S: Clone,
+{
     fn clone(&self) -> Self {
         Self {
             f: Arc::clone(&self.f),
             inner: self.inner.clone(),
         }
+    }
+}
+
+impl<S, R1, R2> fmt::Debug for Map<S, R1, R2>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Map").field("inner", &self.inner).finish()
     }
 }
 

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -11,7 +11,7 @@
 //! For each of these types this module provides one external type
 //! that can be used within sinks. The simplest type being the `StreamSink`
 //! type should be used when you do not want to batch events but you want
-//! to _stream_ them to the downstream service. `BatchSink` and `PartitonBatchSink`
+//! to _stream_ them to the downstream service. `BatchSink` and `PartitionBatchSink`
 //! are similar in the sense that they both take some `tower::Service`, `Batch` and
 //! `Acker` and will provide full batching, request dispatching and acking based on
 //! the settings passed.
@@ -33,7 +33,8 @@
 
 use super::{
     batch::{Batch, PushResult, StatefulBatch},
-    buffer::partition::Partition,
+    buffer::{Partition, PartitionBuffer, PartitionInnerBuffer},
+    service::{Map, ServiceBuilderExt},
 };
 use crate::{buffers::Acker, Event};
 use async_trait::async_trait;
@@ -56,7 +57,7 @@ use tokio::{
     sync::oneshot,
     time::{delay_for, Delay, Duration},
 };
-use tower::Service;
+use tower::{Service, ServiceBuilder};
 use tracing_futures::Instrument;
 
 // === StreamSink ===
@@ -83,16 +84,18 @@ pub trait StreamSink {
 /// and r3 are dispatched and r2 and r3 complete, all events contained
 /// in all requests will not be acked until r1 has completed.
 #[pin_project]
+#[derive(Debug)]
 pub struct BatchSink<S, B, Request>
 where
     B: Batch<Output = Request>,
 {
-    service: ServiceSink<S, Request>,
-    batch: StatefulBatch<B>,
-    buffer: Option<B::Input>,
-    timeout: Duration,
-    linger: Option<Delay>,
-    closing: bool,
+    #[pin]
+    inner: PartitionBatchSink<
+        Map<S, PartitionInnerBuffer<Request, ()>, Request>,
+        PartitionBuffer<B, ()>,
+        (),
+        PartitionInnerBuffer<Request, ()>,
+    >,
 }
 
 impl<S, B, Request> BatchSink<S, B, Request>
@@ -104,25 +107,22 @@ where
     B: Batch<Output = Request>,
 {
     pub fn new(service: S, batch: B, timeout: Duration, acker: Acker) -> Self {
-        let service = ServiceSink::new(service, acker);
-
-        Self {
-            service,
-            batch: batch.into(),
-            buffer: None,
-            timeout,
-            linger: None,
-            closing: false,
-        }
+        let service = ServiceBuilder::new()
+            .map(|req: PartitionInnerBuffer<Request, ()>| req.into_parts().0)
+            .service(service);
+        let batch = PartitionBuffer::new(batch);
+        let inner = PartitionBatchSink::new(service, batch, timeout, acker);
+        Self { inner }
     }
 }
 
+#[cfg(test)]
 impl<S, B, Request> BatchSink<S, B, Request>
 where
     B: Batch<Output = Request>,
 {
     pub fn get_ref(&self) -> &S {
-        &self.service.service
+        &self.inner.service.service.inner
     }
 }
 
@@ -136,109 +136,21 @@ where
 {
     type Error = crate::Error;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.buffer.is_some() {
-            match self.as_mut().poll_flush(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
-                Poll::Pending => {
-                    if self.buffer.is_some() {
-                        return Poll::Pending;
-                    }
-                }
-            }
-        }
-
-        Poll::Ready(Ok(()))
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(cx)
     }
 
-    fn start_send(mut self: Pin<&mut Self>, item: B::Input) -> Result<(), Self::Error> {
-        if self.linger.is_none() {
-            trace!("Starting new batch timer.");
-            // We just inserted the first item of a new batch, so set our delay to the longest time
-            // we want to allow that item to linger in the batch before being flushed.
-            self.linger = Some(delay_for(self.timeout));
-        }
-
-        if let PushResult::Overflow(item) = self.batch.push(item) {
-            self.buffer = Some(item);
-        }
-
-        Ok(())
+    fn start_send(self: Pin<&mut Self>, item: B::Input) -> Result<(), Self::Error> {
+        let item = PartitionInnerBuffer::new(item, ());
+        self.project().inner.start_send(item)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        loop {
-            // Poll inner service while not ready, if we don't have buffer or any batch.
-            if self.buffer.is_none() && self.batch.is_empty() {
-                ready!(self.service.poll_complete(cx));
-                return Poll::Ready(Ok(()));
-            }
-
-            // Try send batch.
-            if (self.closing && !self.batch.is_empty())
-                || self.batch.was_full()
-                || self
-                    .linger
-                    .as_mut()
-                    .map(|linger| matches!(linger.poll_unpin(cx), Poll::Ready(())))
-                    .unwrap_or(false)
-            {
-                let service_ready = match self.service.poll_ready(cx) {
-                    Poll::Ready(Ok(())) => true,
-                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
-                    Poll::Pending => false,
-                };
-                if service_ready {
-                    trace!("Service ready; Sending batch.");
-
-                    let batch = self.batch.fresh_replace();
-                    self.linger = None;
-
-                    let batch_size = batch.num_items();
-                    let request = batch.finish();
-                    tokio::spawn(self.service.call(request, batch_size));
-
-                    continue;
-                }
-            }
-
-            // Try move buffer to batch.
-            if self.batch.is_empty() {
-                if let Some(item) = self.buffer.take() {
-                    self.as_mut().start_send(item)?;
-                    if self.buffer.is_some() {
-                        unreachable!("Empty buffer overflowed.");
-                    }
-
-                    continue;
-                }
-            }
-
-            // Only poll inner service and return `Poll::Pending` anyway.
-            ready!(self.service.poll_complete(cx));
-            return Poll::Pending;
-        }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(cx)
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        trace!("Closing batch sink.");
-        self.closing = true;
-        self.poll_flush(cx)
-    }
-}
-
-impl<S, B, Request> fmt::Debug for BatchSink<S, B, Request>
-where
-    S: fmt::Debug,
-    B: Batch<Output = Request> + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BatchSink")
-            .field("service", &self.service)
-            .field("batch", &self.batch)
-            .field("timeout", &self.timeout)
-            .finish()
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
     }
 }
 
@@ -263,7 +175,7 @@ where
 /// and r3 are dispatched and r2 and r3 complete, all events contained
 /// in all requests will not be acked until r1 has completed.
 #[pin_project]
-pub struct PartitionBatchSink<B, S, K, Request>
+pub struct PartitionBatchSink<S, B, K, Request>
 where
     B: Batch<Output = Request>,
 {
@@ -276,7 +188,7 @@ where
     closing: bool,
 }
 
-impl<B, S, K, Request> PartitionBatchSink<B, S, K, Request>
+impl<S, B, K, Request> PartitionBatchSink<S, B, K, Request>
 where
     B: Batch<Output = Request>,
     B::Input: Partition<K>,
@@ -301,7 +213,7 @@ where
     }
 }
 
-impl<B, S, K, Request> Sink<B::Input> for PartitionBatchSink<B, S, K, Request>
+impl<S, B, K, Request> Sink<B::Input> for PartitionBatchSink<S, B, K, Request>
 where
     B: Batch<Output = Request>,
     B::Input: Partition<K>,
@@ -430,13 +342,13 @@ where
     }
 }
 
-impl<B, S, K, Request> fmt::Debug for PartitionBatchSink<B, S, K, Request>
+impl<S, B, K, Request> fmt::Debug for PartitionBatchSink<S, B, K, Request>
 where
     S: fmt::Debug,
     B: Batch<Output = Request> + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PartitionedBatchSink")
+        f.debug_struct("PartitionBatchSink")
             .field("service", &self.service)
             .field("batch", &self.batch)
             .field("timeout", &self.timeout)


### PR DESCRIPTION
This just un-reverts #5076. The motivation is to reduce the complexity of our internal sink interfaces.

Signed-off-by: Kirill Fomichev <fanatid@ya.ru>

Closes #6062