### PR TITLE
enhancement(ci): rustdoc build changes

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,28 +1,25 @@
-# This Action triggers a build of Vector's Rustdoc each time a PR is merged
+# This Action triggers a build of Vector's rustdoc each time a PR is merged
 # to `master`.
 #
-# Netlify account for Rustdoc site: https://app.netlify.com/sites/vector-rustdoc
+# Netlify account for the Vector rustdoc site: https://app.netlify.com/sites/vector-rustdoc
 # Repo that builds the site: https://github.com/timberio/vector-rustdoc
-# Root URL for Rustdoc site: https://vector-rustdoc.netlify.app
+# Root URL for rustdoc site: https://vector-rustdoc.netlify.app
 # Pretty URL for the published docs: https://rustdoc.vector.dev
 name: Publish Vector Rustdoc
 
-# Action is triggered only if changes are merged, not just pushed
-# See also the "if" statement in the job definition
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+  branches:
+    - master
 
 jobs:
   trigger-site-build:
     name: Trigger a build of Vector's Rustdoc site (hosted by Netlify)
     runs-on: ubuntu-20.04
-    if: github.event.pull_request.merged == true # Trigger only on successful merge
     steps:
       - name: Trigger via CURL request
         # https://github.com/wei/curl
-        uses: wei/curl@v1
+        uses: wei/curl@012398a392d02480afa2720780031f8621d5f94c
         with:
           # Trigger a new build via webhook
           args: -X POST -d {} ${{ secrets.NETLIFY_RUSTDOC_HOOK }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,8 +9,8 @@ name: Publish Vector Rustdoc
 
 on:
   push:
-  branches:
-    - master
+    branches:
+      - master
 
 jobs:
   trigger-site-build:


### PR DESCRIPTION
This PR follows up on #6551 with some small changes suggested by @jszwedko. The third-party Action is now tied to a specific commit and the job is run on push rather than merge, which is effectively the same thing but easier to understand.