### PR TITLE
chore(file source): Suffix config values with units

### DIFF
--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -103,7 +103,7 @@ components: sources: file: {
 				}
 			}
 		}
-		glob_minimum_cooldown: {
+		glob_minimum_cooldown_ms: {
 			common:      false
 			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files."
 			required:    false
@@ -128,9 +128,9 @@ components: sources: file: {
 			required:    false
 			type: bool: default: false
 		}
-		ignore_older: {
+		ignore_older_secs: {
 			common:      true
-			description: "Ignore files with a data modification date that does not exceed this age."
+			description: "Ignore files with a data modification date older than the specified number of seconds."
 			required:    false
 			type: uint: {
 				default: null
@@ -183,7 +183,7 @@ components: sources: file: {
 			required:    false
 			type: bool: default: false
 		}
-		remove_after: {
+		remove_after_secs: {
 			common:      false
 			description: "Timeout from reaching `eof` after which file will be removed from filesystem, unless new data is written in the meantime. If not specified, files will not be removed."
 			required:    false


### PR DESCRIPTION
Also clarify ignore_older_secs in the docs.

Looking at our existing config options, we commonly suffix duration based config keys with their unit. This brings a few more in-line and resolves some user confusion: #6558

Aliases are added to maintain existing names.

Closes: #6558

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
