### PR TITLE
enhancement(kubernetes_logs source): add the ability to specify automountServiceAccountToken for vector-agent

### DIFF
--- a/distribution/helm/vector-agent/templates/serviceaccount.yaml
+++ b/distribution/helm/vector-agent/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -31,6 +31,8 @@ serviceAccount:
   # If not set and `create` is true, a name is generated using the `fullname`
   # template.
   name: ""
+  # Automount API credentials for a service account.
+  automountServiceAccountToken: true
 
 # Add an annotation to the `Pod`s managed by `DaemonSet` with a random value,
 # generated at Helm Chart template evaluation time.

--- a/distribution/helm/vector-aggregator/templates/serviceaccount.yaml
+++ b/distribution/helm/vector-aggregator/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -33,6 +33,8 @@ serviceAccount:
   # If not set and `create` is true, a name is generated using the `fullname`
   # template.
   name: ""
+  # Automount API credentials for a service account.
+  automountServiceAccountToken: true
 
 # Add an annotation to the `Pod`s managed by `StatefulSet` with a random value,
 # generated at Helm Chart template evaluation time.

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-agent/templates/configmap.yaml
 apiVersion: v1

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-aggregator/templates/configmap.yaml
 apiVersion: v1

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector/charts/vector-aggregator/templates/serviceaccount.yaml
 apiVersion: v1
@@ -29,6 +30,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector/charts/vector-agent/templates/configmap.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-agent/templates/configmap.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-aggregator/templates/configmap.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-agent/templates/configmap.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: vector
     app.kubernetes.io/version: "0.0.0"
     app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
 ---
 # Source: vector-aggregator/templates/configmap.yaml
 apiVersion: v1


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

Allow for specifying the automountServiceAccountToken field on the vector-agent service account.
