### PR TITLE
chore(sinks): Split batch buffer creation out of `trait Batch`

### DIFF
--- a/benches/batch.rs
+++ b/benches/batch.rs
@@ -78,7 +78,7 @@ fn benchmark_batching(c: &mut Criterion) {
                         .size;
                     let batch_sink = BatchSink::new(
                         tower::service_fn(|_| future::ok::<_, Infallible>(())),
-                        Buffer::new(batch, *compression),
+                        Buffer::maker(batch, *compression),
                         Duration::from_secs(1),
                         acker,
                     )
@@ -121,7 +121,7 @@ impl Partition<Bytes> for InnerBuffer {
 impl PartitionedBuffer {
     pub fn new(batch: BatchSize<Buffer>, compression: Compression) -> Self {
         Self {
-            inner: Buffer::new(batch, compression),
+            inner: Buffer::maker(batch, compression),
             key: None,
         }
     }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -195,8 +195,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             ));
 
         let encoding = self.encoding.clone();
-        let buffer = PartitionBuffer::new(VecBuffer::new(batch.size));
-        let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
+        let maker = PartitionBuffer::maker(VecBuffer::maker(batch.size));
+        let sink = PartitionBatchSink::new(svc, maker, batch.timeout, cx.acker())
             .sink_map_err(|error| error!(message = "Fatal cloudwatchlogs sink error.", %error))
             .with_flat_map(move |event| {
                 stream::iter(partition_encode(event, &encoding, &log_group, &log_stream)).map(Ok)

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -143,7 +143,7 @@ impl CloudWatchMetricsSvc {
 
         let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
 
-        let buffer = PartitionBuffer::new(MetricsBuffer::new(batch.size));
+        let buffer = PartitionBuffer::maker(MetricsBuffer::maker(batch.size));
         let mut normalizer = MetricNormalizer::<AwsCloudwatchMetricNormalize>::default();
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -157,7 +157,7 @@ impl KinesisFirehoseService {
             .batch_sink(
                 KinesisFirehoseRetryLogic,
                 kinesis,
-                VecBuffer::new(batch.size),
+                VecBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -161,7 +161,7 @@ impl KinesisService {
             .batch_sink(
                 KinesisRetryLogic,
                 kinesis,
-                VecBuffer::new(batch.size),
+                VecBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -228,7 +228,7 @@ impl S3SinkConfig {
             .settings(request, S3RetryLogic)
             .service(s3);
 
-        let buffer = PartitionBuffer::new(Buffer::new(batch.size, self.compression));
+        let buffer = PartitionBuffer::maker(Buffer::maker(batch.size, self.compression));
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .with_flat_map(move |e| stream::iter(encode_event(e, &key_prefix, &encoding)).map(Ok))

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -171,7 +171,7 @@ impl SqsSink {
             .batch_sink(
                 SqsRetryLogic,
                 sqs,
-                VecBuffer::new(batch.size),
+                VecBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -119,7 +119,7 @@ impl SinkConfig for AzureMonitorLogsConfig {
 
         let sink = BatchedHttpSink::new(
             sink,
-            JsonArrayBuffer::new(batch_settings.size),
+            JsonArrayBuffer::maker(batch_settings.size),
             request_settings,
             batch_settings.timeout,
             client,

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -83,7 +83,7 @@ impl SinkConfig for ClickhouseConfig {
 
         let sink = BatchedHttpSink::with_retry_logic(
             config.clone(),
-            Buffer::new(batch.size, self.compression),
+            Buffer::maker(batch.size, self.compression),
             ClickhouseRetryLogic::default(),
             request,
             batch.timeout,

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -141,7 +141,7 @@ impl SinkConfig for ElasticSearchConfig {
 
         let sink = BatchedHttpSink::with_retry_logic(
             common,
-            Buffer::new(batch.size, compression),
+            Buffer::maker(batch.size, compression),
             ElasticSearchRetryLogic,
             request,
             batch.timeout,

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -225,7 +225,7 @@ impl GcsSink {
             .settings(request, GcsRetryLogic)
             .service(self);
 
-        let buffer = PartitionBuffer::new(Buffer::new(batch.size, config.compression));
+        let buffer = PartitionBuffer::maker(Buffer::maker(batch.size, config.compression));
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .sink_map_err(|error| error!(message = "Fatal gcp_cloud_storage error.", %error))

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -93,7 +93,7 @@ impl SinkConfig for PubsubConfig {
 
         let sink = BatchedHttpSink::new(
             sink,
-            JsonArrayBuffer::new(batch_settings.size),
+            JsonArrayBuffer::maker(batch_settings.size),
             request_settings,
             batch_settings.timeout,
             client,

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -132,7 +132,7 @@ impl SinkConfig for StackdriverConfig {
 
         let sink = BatchedHttpSink::new(
             sink,
-            JsonArrayBuffer::new(batch.size),
+            JsonArrayBuffer::maker(batch.size),
             request,
             batch.timeout,
             client,

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -62,7 +62,7 @@ impl SinkConfig for HoneycombConfig {
 
         let sink = BatchedHttpSink::new(
             self.clone(),
-            JsonArrayBuffer::new(batch_settings.size),
+            JsonArrayBuffer::maker(batch_settings.size),
             request_settings,
             batch_settings.timeout,
             client.clone(),

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -145,7 +145,7 @@ impl SinkConfig for HttpSinkConfig {
 
         let sink = BatchedHttpSink::new(
             config,
-            Buffer::new(batch.size, Compression::None),
+            Buffer::maker(batch.size, Compression::None),
             request,
             batch.timeout,
             client,

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -132,7 +132,7 @@ impl SinkConfig for InfluxDBLogsConfig {
 
         let sink = BatchedHttpSink::new(
             sink,
-            Buffer::new(batch.size, Compression::None),
+            Buffer::maker(batch.size, Compression::None),
             request,
             batch.timeout,
             client,

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -144,7 +144,7 @@ impl InfluxDBSvc {
             .batch_sink(
                 HttpRetryLogic,
                 influxdb_http_service,
-                MetricsBuffer::new(batch.size),
+                MetricsBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -88,7 +88,7 @@ impl SinkConfig for LogdnaConfig {
 
         let sink = PartitionHttpSink::new(
             self.clone(),
-            PartitionBuffer::new(JsonArrayBuffer::new(batch_settings.size)),
+            PartitionBuffer::maker(JsonArrayBuffer::maker(batch_settings.size)),
             request_settings,
             batch_settings.timeout,
             client.clone(),

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -123,7 +123,7 @@ impl SinkConfig for LokiConfig {
 
         let sink = PartitionHttpSink::new(
             sink,
-            PartitionBuffer::new(LokiBuffer::new(
+            PartitionBuffer::maker(LokiBuffer::maker(
                 batch_settings.size,
                 GlobalTimestamps::default(),
                 config.out_of_order_action.clone(),

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -100,7 +100,7 @@ impl SinkConfig for RemoteWriteConfig {
         let sink = {
             let service = request.service(HttpRetryLogic, service);
             let service = ServiceBuilder::new().service(service);
-            let buffer = PartitionBuffer::new(MetricsBuffer::new(batch.size));
+            let buffer = PartitionBuffer::maker(MetricsBuffer::maker(batch.size));
             let mut normalizer = MetricNormalizer::<PrometheusMetricNormalize>::default();
 
             PartitionBatchSink::new(service, buffer, batch.timeout, cx.acker())

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -152,7 +152,7 @@ impl SematextMetricsService {
             .batch_sink(
                 HttpRetryLogic,
                 sematext_service,
-                MetricsBuffer::new(batch.size),
+                MetricsBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -112,7 +112,7 @@ impl SinkConfig for HecSinkConfig {
 
         let sink = BatchedHttpSink::new(
             self.clone(),
-            Buffer::new(batch.size, self.compression),
+            Buffer::maker(batch.size, self.compression),
             request,
             batch.timeout,
             client.clone(),

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -103,7 +103,7 @@ impl SinkConfig for StatsdSinkConfig {
                 let service = StatsdSvc { inner: service };
                 let sink = BatchSink::new(
                     ServiceBuilder::new().service(service),
-                    Buffer::new(batch.size, Compression::None),
+                    Buffer::maker(batch.size, Compression::None),
                     batch.timeout,
                     cx.acker(),
                 )

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -152,7 +152,7 @@ impl SinkConfig for TestConfig {
             .batch_sink(
                 TestRetryLogic,
                 TestSink::new(self),
-                VecBuffer::new(batch.size),
+                VecBuffer::maker(batch.size),
                 batch.timeout,
                 cx.acker(),
             )

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -188,15 +188,6 @@ pub trait Batch: Sized {
     fn fresh(&self) -> Self;
     fn finish(self) -> Self::Output;
     fn num_items(&self) -> usize;
-
-    /// Replace the current batch with a fresh one, returning the old one.
-    fn fresh_replace(&mut self) -> Self
-    where
-        Self: Sized,
-    {
-        let fresh = self.fresh();
-        std::mem::replace(self, fresh)
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -190,7 +190,6 @@ pub trait Batch: Sized {
 
     fn push(&mut self, item: Self::Input) -> PushResult<Self::Input>;
     fn is_empty(&self) -> bool;
-    fn fresh(&self) -> Self;
     fn finish(self) -> Self::Output;
     fn num_items(&self) -> usize;
 }
@@ -247,13 +246,6 @@ where
 
     fn is_empty(&self) -> bool {
         !self.was_full && self.inner.is_empty()
-    }
-
-    fn fresh(&self) -> Self {
-        Self {
-            inner: self.inner.fresh(),
-            was_full: false,
-        }
     }
 
     fn finish(self) -> Self::Output {

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -170,6 +170,11 @@ pub enum PushResult<T> {
     Overflow(T),
 }
 
+pub trait BatchMaker {
+    type Batch: Batch;
+    fn new_batch(&self) -> Self::Batch;
+}
+
 pub trait Batch: Sized {
     type Input;
     type Output;

--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -22,12 +22,12 @@ pub struct JsonArrayBufferMaker {
 impl BatchMaker for JsonArrayBufferMaker {
     type Batch = JsonArrayBuffer;
     fn new_batch(&self) -> Self::Batch {
-        JsonArrayBuffer::new(self.settings)
+        JsonArrayBuffer::with_settings(self.settings)
     }
 }
 
 impl JsonArrayBuffer {
-    pub fn new(settings: BatchSize<Self>) -> Self {
+    fn with_settings(settings: BatchSize<Self>) -> Self {
         Self {
             buffer: Vec::new(),
             total_bytes: 0,
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn multi_object_array() {
         let batch = BatchSettings::default().bytes(9999).events(2).size;
-        let mut buffer = JsonArrayBuffer::new(batch);
+        let mut buffer = JsonArrayBuffer::maker(batch).new_batch();
 
         assert_eq!(
             buffer.push(json!({

--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -73,10 +73,6 @@ impl Batch for JsonArrayBuffer {
         self.buffer.is_empty()
     }
 
-    fn fresh(&self) -> Self {
-        Self::new(self.settings)
-    }
-
     fn finish(self) -> Self::Output {
         self.buffer
     }

--- a/src/sinks/util/buffer/json.rs
+++ b/src/sinks/util/buffer/json.rs
@@ -1,5 +1,6 @@
 use super::super::batch::{
-    err_event_too_large, Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+    err_event_too_large, Batch, BatchConfig, BatchError, BatchMaker, BatchSettings, BatchSize,
+    PushResult,
 };
 use serde_json::value::{to_raw_value, RawValue, Value};
 
@@ -14,6 +15,17 @@ pub struct JsonArrayBuffer {
     settings: BatchSize<Self>,
 }
 
+pub struct JsonArrayBufferMaker {
+    settings: BatchSize<JsonArrayBuffer>,
+}
+
+impl BatchMaker for JsonArrayBufferMaker {
+    type Batch = JsonArrayBuffer;
+    fn new_batch(&self) -> Self::Batch {
+        JsonArrayBuffer::new(self.settings)
+    }
+}
+
 impl JsonArrayBuffer {
     pub fn new(settings: BatchSize<Self>) -> Self {
         Self {
@@ -21,6 +33,10 @@ impl JsonArrayBuffer {
             total_bytes: 0,
             settings,
         }
+    }
+
+    pub fn maker(settings: BatchSize<Self>) -> JsonArrayBufferMaker {
+        JsonArrayBufferMaker { settings }
     }
 }
 

--- a/src/sinks/util/buffer/loki.rs
+++ b/src/sinks/util/buffer/loki.rs
@@ -96,7 +96,7 @@ pub struct LokiBufferMaker {
 impl BatchMaker for LokiBufferMaker {
     type Batch = LokiBuffer;
     fn new_batch(&self) -> Self::Batch {
-        Self::Batch::new(
+        Self::Batch::with_settings(
             self.settings,
             self.global_timestamps.clone(),
             self.out_of_order_action.clone(),
@@ -105,7 +105,7 @@ impl BatchMaker for LokiBufferMaker {
 }
 
 impl LokiBuffer {
-    pub fn new(
+    fn with_settings(
         settings: BatchSize<Self>,
         global_timestamps: GlobalTimestamps,
         out_of_order_action: OutOfOrderAction,
@@ -306,11 +306,12 @@ mod tests {
 
     #[test]
     fn insert_single() {
-        let mut buffer = LokiBuffer::new(
+        let mut buffer = LokiBuffer::maker(
             BatchSettings::default().size,
             Default::default(),
             Default::default(),
-        );
+        )
+        .new_batch();
         assert!(matches!(
             buffer.push(LokiRecord {
                 partition: PartitionKey { tenant_id: None },
@@ -333,11 +334,12 @@ mod tests {
 
     #[test]
     fn insert_multiple_streams() {
-        let mut buffer = LokiBuffer::new(
+        let mut buffer = LokiBuffer::maker(
             BatchSettings::default().size,
             Default::default(),
             Default::default(),
-        );
+        )
+        .new_batch();
         for n in 1..4 {
             assert!(matches!(
                 buffer.push(LokiRecord {
@@ -362,11 +364,12 @@ mod tests {
 
     #[test]
     fn insert_multiple_one_stream() {
-        let mut buffer = LokiBuffer::new(
+        let mut buffer = LokiBuffer::maker(
             BatchSettings::default().size,
             Default::default(),
             Default::default(),
-        );
+        )
+        .new_batch();
         for n in 1..4 {
             assert!(matches!(
                 buffer.push(LokiRecord {

--- a/src/sinks/util/buffer/loki.rs
+++ b/src/sinks/util/buffer/loki.rs
@@ -232,14 +232,6 @@ impl Batch for LokiBuffer {
         self.streams.is_empty()
     }
 
-    fn fresh(&self) -> Self {
-        Self::new(
-            self.settings,
-            self.global_timestamps.clone(),
-            self.out_of_order_action.clone(),
-        )
-    }
-
     fn finish(self) -> Self::Output {
         let mut latest_timestamps = self.latest_timestamps.expect("Batch is empty");
         let streams_json = self

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -185,10 +185,6 @@ impl Batch for MetricsBuffer {
         self.num_items() == 0
     }
 
-    fn fresh(&self) -> Self {
-        Self::with_capacity(self.max_events)
-    }
-
     fn finish(self) -> Self::Output {
         self.metrics.0.into_iter().map(finish_metric).collect()
     }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -381,7 +381,8 @@ mod test {
                 match buffer.push(event) {
                     PushResult::Overflow(_) => panic!("overflowed too early"),
                     PushResult::Ok(true) => {
-                        result.push(buffer.fresh_replace().finish());
+                        let batch = std::mem::replace(&mut buffer, MetricsBuffer::new(batch_size));
+                        result.push(batch.finish());
                     }
                     PushResult::Ok(false) => (),
                 }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -1,6 +1,8 @@
 use crate::{
     event::metric::{Metric, MetricKind, MetricValue, Sample},
-    sinks::util::batch::{Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult},
+    sinks::util::batch::{
+        Batch, BatchConfig, BatchError, BatchMaker, BatchSettings, BatchSize, PushResult,
+    },
     Event,
 };
 use std::{
@@ -113,9 +115,24 @@ pub struct MetricsBuffer {
     max_events: usize,
 }
 
+pub struct MetricsBufferMaker {
+    settings: BatchSize<MetricsBuffer>,
+}
+
+impl BatchMaker for MetricsBufferMaker {
+    type Batch = MetricsBuffer;
+    fn new_batch(&self) -> Self::Batch {
+        Self::Batch::new(self.settings)
+    }
+}
+
 impl MetricsBuffer {
     pub fn new(settings: BatchSize<Self>) -> Self {
         Self::with_capacity(settings.events)
+    }
+
+    pub fn maker(settings: BatchSize<Self>) -> MetricsBufferMaker {
+        MetricsBufferMaker { settings }
     }
 
     fn with_capacity(max_events: usize) -> Self {

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -22,7 +22,6 @@ pub struct Buffer {
     num_items: usize,
     num_bytes: usize,
     settings: BatchSize<Self>,
-    compression: Compression,
 }
 
 pub struct BufferMaker {
@@ -33,7 +32,7 @@ pub struct BufferMaker {
 impl BatchMaker for BufferMaker {
     type Batch = Buffer;
     fn new_batch(&self) -> Self::Batch {
-        Self::Batch::new(self.settings, self.compression)
+        Self::Batch::with_settings(self.settings, self.compression)
     }
 }
 
@@ -44,7 +43,7 @@ pub enum InnerBuffer {
 }
 
 impl Buffer {
-    pub fn new(settings: BatchSize<Self>, compression: Compression) -> Self {
+    fn with_settings(settings: BatchSize<Self>, compression: Compression) -> Self {
         let buffer = Vec::with_capacity(settings.bytes);
         let inner = match compression {
             Compression::None => InnerBuffer::Plain(buffer),
@@ -61,7 +60,6 @@ impl Buffer {
             num_items: 0,
             num_bytes: 0,
             settings,
-            compression,
         }
     }
 

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -43,7 +43,7 @@ pub enum InnerBuffer {
 }
 
 impl Buffer {
-    fn with_settings(settings: BatchSize<Self>, compression: Compression) -> Self {
+    pub fn with_settings(settings: BatchSize<Self>, compression: Compression) -> Self {
         let buffer = Vec::with_capacity(settings.bytes);
         let inner = match compression {
             Compression::None => InnerBuffer::Plain(buffer),

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -127,10 +127,6 @@ impl Batch for Buffer {
         self.is_empty()
     }
 
-    fn fresh(&self) -> Self {
-        Self::new(self.settings, self.compression)
-    }
-
     fn finish(self) -> Self::Output {
         match self.inner {
             InnerBuffer::Plain(inner) => inner,

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -79,10 +79,6 @@ where
         self.inner.is_empty()
     }
 
-    fn fresh(&self) -> Self {
-        Self::new(self.inner.fresh())
-    }
-
     fn finish(mut self) -> Self::Output {
         let key = self.key.take().unwrap();
         let inner = self.inner.finish();

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -23,7 +23,7 @@ where
 {
     type Batch = PartitionBuffer<M::Batch, K>;
     fn new_batch(&self) -> Self::Batch {
-        Self::Batch::new(self.batch_maker.new_batch())
+        Self::Batch::with_batch(self.batch_maker.new_batch())
     }
 }
 
@@ -34,7 +34,7 @@ pub struct PartitionInnerBuffer<T, K> {
 }
 
 impl<T, K> PartitionBuffer<T, K> {
-    pub fn new(inner: T) -> Self {
+    fn with_batch(inner: T) -> Self {
         Self { inner, key: None }
     }
 

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -1,5 +1,6 @@
 use super::{
-    err_event_too_large, Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
+    err_event_too_large, Batch, BatchConfig, BatchError, BatchMaker, BatchSettings, BatchSize,
+    PushResult,
 };
 use bytes::Bytes;
 
@@ -14,6 +15,17 @@ pub struct VecBuffer<T> {
     settings: BatchSize<Self>,
 }
 
+pub struct VecBufferMaker<T> {
+    settings: BatchSize<VecBuffer<T>>,
+}
+
+impl<T: EncodedLength> BatchMaker for VecBufferMaker<T> {
+    type Batch = VecBuffer<T>;
+    fn new_batch(&self) -> Self::Batch {
+        Self::Batch::new(self.settings)
+    }
+}
+
 impl<T> VecBuffer<T> {
     pub fn new(settings: BatchSize<Self>) -> Self {
         Self::new_with_settings(settings)
@@ -25,6 +37,10 @@ impl<T> VecBuffer<T> {
             bytes: 0,
             settings,
         }
+    }
+
+    pub fn maker(settings: BatchSize<Self>) -> VecBufferMaker<T> {
+        VecBufferMaker { settings }
     }
 }
 

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -22,16 +22,12 @@ pub struct VecBufferMaker<T> {
 impl<T: EncodedLength> BatchMaker for VecBufferMaker<T> {
     type Batch = VecBuffer<T>;
     fn new_batch(&self) -> Self::Batch {
-        Self::Batch::new(self.settings)
+        Self::Batch::with_settings(self.settings)
     }
 }
 
 impl<T> VecBuffer<T> {
-    pub fn new(settings: BatchSize<Self>) -> Self {
-        Self::new_with_settings(settings)
-    }
-
-    fn new_with_settings(settings: BatchSize<Self>) -> Self {
+    fn with_settings(settings: BatchSize<Self>) -> Self {
         Self {
             batch: Vec::with_capacity(settings.events),
             bytes: 0,
@@ -105,7 +101,7 @@ mod tests {
     #[test]
     fn obeys_max_events() {
         let settings = BatchSettings::default().events(2).size;
-        let mut buffer = VecBuffer::new(settings);
+        let mut buffer = VecBuffer::maker(settings).new_batch();
         let data = "dummy".to_string();
 
         assert_eq!(buffer.is_empty(), true);
@@ -129,7 +125,7 @@ mod tests {
     #[test]
     fn obeys_max_bytes() {
         let settings = BatchSettings::default().events(99).bytes(22).size;
-        let mut buffer = VecBuffer::new(settings);
+        let mut buffer = VecBuffer::maker(settings).new_batch();
         let data = "some bytes".to_string();
 
         assert_eq!(buffer.is_empty(), true);

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -76,10 +76,6 @@ impl<T: EncodedLength> Batch for VecBuffer<T> {
         self.batch.is_empty()
     }
 
-    fn fresh(&self) -> Self {
-        Self::new_with_settings(self.settings)
-    }
-
     fn finish(self) -> Self::Output {
         self.batch
     }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::borrow::Cow;
 
-pub use batch::{Batch, BatchConfig, BatchSettings, BatchSize, PushResult};
+pub use batch::{Batch, BatchConfig, BatchMaker, BatchSettings, BatchSize, PushResult};
 pub use buffer::json::{BoxedRawValue, JsonArrayBuffer};
 pub use buffer::metrics::MetricEntry;
 pub use buffer::partition::Partition;


### PR DESCRIPTION
This is much less appealing that I had envisioned, but it gets the job done. I also tried to just use a closure instead of a new trait, but the complex trait bounds on the sinks made that too difficult for me to reason about. It would however likely be less code, so if anybody has a better idea I am open to all ideas.

The core motivation for this is that, in its current state, `PartitionBatchSink` carries around a batch buffer, only to all `fresh` on it to create a new one. That is a pointless use of allocated memory, so this splits the concerns of creating a batch buffer into a new trait and uses that instead.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #6341 