### PR TITLE
fix(config): Preload log scheme

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -147,12 +147,10 @@ impl Application {
                     path = ?config_paths
                 );
 
-                let mut config =
-                    config::load_from_paths(&config_paths, false).map_err(handle_config_errors)?;
+                config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
 
-                config::LOG_SCHEMA
-                    .set(config.global.log_schema.clone())
-                    .expect("Couldn't set schema");
+                let mut config =
+                    config::load_from_paths(&config_paths).map_err(handle_config_errors)?;
 
                 if !config.healthchecks.enabled {
                     info!("Health checks are disabled.");
@@ -233,7 +231,7 @@ impl Application {
                         // Reload paths
                         config_paths = config::process_paths(&opts.config_paths_with_formats()).unwrap_or(config_paths);
                         // Reload config
-                        let new_config = config::load_from_paths(&config_paths, false).map_err(handle_config_errors).ok();
+                        let new_config = config::load_from_paths(&config_paths).map_err(handle_config_errors).ok();
 
                         if let Some(mut new_config) = new_config {
                             new_config.healthchecks.set_require_healthy(opts.require_healthy);

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -55,12 +55,8 @@ impl From<Config> for ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    pub fn build(self) -> Result<Config, Vec<String>> {
-        self.build_with(false)
-    }
-
-    pub fn build_with(self, deny_warnings: bool) -> Result<Config, Vec<String>> {
-        compiler::compile(self, deny_warnings)
+    pub fn build(self) -> Result<(Config, Vec<String>), Vec<String>> {
+        compiler::compile(self)
     }
 
     pub fn add_source<S: SourceConfig + 'static, T: Into<String>>(&mut self, name: T, source: S) {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -55,7 +55,17 @@ impl From<Config> for ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    pub fn build(self) -> Result<(Config, Vec<String>), Vec<String>> {
+    pub fn build(self) -> Result<Config, Vec<String>> {
+        let (config, warnings) = self.build_with_warnings()?;
+
+        for warning in warnings {
+            warn!("{}", warning);
+        }
+
+        Ok(config)
+    }
+
+    pub fn build_with_warnings(self) -> Result<(Config, Vec<String>), Vec<String>> {
         compiler::compile(self)
     }
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -78,7 +78,7 @@ pub fn process_paths(config_paths: &[(PathBuf, FormatHint)]) -> Option<Vec<(Path
 
 pub fn load_from_paths(config_paths: &[(PathBuf, FormatHint)]) -> Result<Config, Vec<String>> {
     let (builder, load_warnings) = load_builder_from_paths(config_paths)?;
-    let (config, build_warnings) = builder.build()?;
+    let (config, build_warnings) = builder.build_with_warnings()?;
 
     for warning in load_warnings.into_iter().chain(build_warnings) {
         warn!("{}", warning);
@@ -110,7 +110,7 @@ pub fn load_builder_from_paths(
 
 pub fn load_from_str(input: &str, format: FormatHint) -> Result<Config, Vec<String>> {
     let (builder, load_warnings) = load_from_inputs(std::iter::once((input.as_bytes(), format)))?;
-    let (config, build_warnings) = builder.build()?;
+    let (config, build_warnings) = builder.build_with_warnings()?;
 
     for warning in load_warnings.into_iter().chain(build_warnings) {
         warn!("{}", warning);

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1,4 +1,4 @@
-use super::{builder::ConfigBuilder, format, handle_warnings, vars, Config, Format, FormatHint};
+use super::{builder::ConfigBuilder, format, vars, Config, Format, FormatHint};
 use glob::glob;
 use lazy_static::lazy_static;
 use std::{
@@ -76,17 +76,20 @@ pub fn process_paths(config_paths: &[(PathBuf, FormatHint)]) -> Option<Vec<(Path
     Some(paths)
 }
 
-pub fn load_from_paths(
-    config_paths: &[(PathBuf, FormatHint)],
-    deny_warnings: bool,
-) -> Result<Config, Vec<String>> {
-    load_builder_from_paths(config_paths, deny_warnings)?.build_with(deny_warnings)
+pub fn load_from_paths(config_paths: &[(PathBuf, FormatHint)]) -> Result<Config, Vec<String>> {
+    let (builder, load_warnings) = load_builder_from_paths(config_paths)?;
+    let (config, build_warnings) = builder.build()?;
+
+    for warning in load_warnings.into_iter().chain(build_warnings) {
+        warn!("{}", warning);
+    }
+
+    Ok(config)
 }
 
 pub fn load_builder_from_paths(
     config_paths: &[(PathBuf, FormatHint)],
-    deny_warnings: bool,
-) -> Result<ConfigBuilder, Vec<String>> {
+) -> Result<(ConfigBuilder, Vec<String>), Vec<String>> {
     let mut inputs = Vec::new();
     let mut errors = Vec::new();
 
@@ -99,32 +102,42 @@ pub fn load_builder_from_paths(
     }
 
     if errors.is_empty() {
-        load_from_inputs(inputs, deny_warnings)
+        load_from_inputs(inputs)
     } else {
         Err(errors)
     }
 }
 
 pub fn load_from_str(input: &str, format: FormatHint) -> Result<Config, Vec<String>> {
-    load_from_inputs(std::iter::once((input.as_bytes(), format)), false)?.build()
+    let (builder, load_warnings) = load_from_inputs(std::iter::once((input.as_bytes(), format)))?;
+    let (config, build_warnings) = builder.build()?;
+
+    for warning in load_warnings.into_iter().chain(build_warnings) {
+        warn!("{}", warning);
+    }
+
+    Ok(config)
 }
 
 fn load_from_inputs(
     inputs: impl IntoIterator<Item = (impl std::io::Read, FormatHint)>,
-    deny_warnings: bool,
-) -> Result<ConfigBuilder, Vec<String>> {
+) -> Result<(ConfigBuilder, Vec<String>), Vec<String>> {
     let mut config = Config::builder();
     let mut errors = Vec::new();
+    let mut warnings = Vec::new();
 
     for (input, format) in inputs {
-        if let Err(errs) = load(input, format, deny_warnings).and_then(|n| config.append(n)) {
+        if let Err(errs) = load(input, format).and_then(|(n, mut warn)| {
+            warnings.append(&mut warn);
+            config.append(n)
+        }) {
             // TODO: add back paths
             errors.extend(errs.iter().map(|e| e.to_string()));
         }
     }
 
     if errors.is_empty() {
-        Ok(config)
+        Ok((config, warnings))
     } else {
         Err(errors)
     }
@@ -148,8 +161,7 @@ fn open_config(path: &Path) -> Option<File> {
 fn load(
     mut input: impl std::io::Read,
     format: FormatHint,
-    deny_warnings: bool,
-) -> Result<ConfigBuilder, Vec<String>> {
+) -> Result<(ConfigBuilder, Vec<String>), Vec<String>> {
     let mut source_string = String::new();
     input
         .read_to_string(&mut source_string)
@@ -162,7 +174,6 @@ fn load(
         }
     }
     let (with_vars, warnings) = vars::interpolate(&source_string, &vars);
-    handle_warnings(warnings, deny_warnings)?;
 
-    format::deserialize(&with_vars, format)
+    format::deserialize(&with_vars, format).map(|builder| (builder, warnings))
 }

--- a/src/config/log_schema.rs
+++ b/src/config/log_schema.rs
@@ -24,9 +24,8 @@ pub fn init_log_schema(
     deny_seted: bool,
 ) -> Result<(), Vec<String>> {
     let (builder, _) = load_builder_from_paths(config_paths)?;
-    let (config, _) = builder.build_with_warnings()?;
 
-    if LOG_SCHEMA.set(config.global.log_schema).is_err() && deny_seted {
+    if LOG_SCHEMA.set(builder.global.log_schema).is_err() && deny_seted {
         panic!("Couldn't set schema");
     }
 

--- a/src/config/log_schema.rs
+++ b/src/config/log_schema.rs
@@ -24,9 +24,9 @@ pub fn init_log_schema(
     deny_seted: bool,
 ) -> Result<(), Vec<String>> {
     let (builder, _) = load_builder_from_paths(config_paths)?;
-    let (config, _) = builder.build()?;
+    let (config, _) = builder.build_with_warnings()?;
 
-    if LOG_SCHEMA.set(config.global.log_schema.clone()).is_err() && deny_seted {
+    if LOG_SCHEMA.set(config.global.log_schema).is_err() && deny_seted {
         panic!("Couldn't set schema");
     }
 

--- a/src/config/log_schema.rs
+++ b/src/config/log_schema.rs
@@ -33,6 +33,9 @@ pub fn init_log_schema(
     Ok(())
 }
 
+/// Components should use global LogShema returned by this function.
+/// The returned value can differ from LogSchema::default()
+/// which is unchanging.
 pub fn log_schema() -> &'static LogSchema {
     LOG_SCHEMA.get().unwrap_or(&LOG_SCHEMA_DEFAULT)
 }
@@ -62,16 +65,16 @@ impl Default for LogSchema {
 }
 
 impl LogSchema {
-    pub fn default_message_key() -> String {
+    fn default_message_key() -> String {
         String::from("message")
     }
-    pub fn default_timestamp_key() -> String {
+    fn default_timestamp_key() -> String {
         String::from("timestamp")
     }
-    pub fn default_host_key() -> String {
+    fn default_host_key() -> String {
         String::from("host")
     }
-    pub fn default_source_type_key() -> String {
+    fn default_source_type_key() -> String {
         String::from("source_type")
     }
 

--- a/src/config/log_schema.rs
+++ b/src/config/log_schema.rs
@@ -17,15 +17,15 @@ lazy_static::lazy_static! {
 
 /// Loads Log Schema from configurations and sets global schema.
 /// Once this is done, configurations can be correctly loaded using
-/// seted log schema.
-/// If deny seted, will panic if schema has already been seted.
+/// configured log schema defaults.
+/// If deny is set, will panic if schema has already been set.
 pub fn init_log_schema(
     config_paths: &[(PathBuf, FormatHint)],
-    deny_seted: bool,
+    deny_if_set: bool,
 ) -> Result<(), Vec<String>> {
     let (builder, _) = load_builder_from_paths(config_paths)?;
 
-    if LOG_SCHEMA.set(builder.global.log_schema).is_err() && deny_seted {
+    if LOG_SCHEMA.set(builder.global.log_schema).is_err() && deny_if_set {
         panic!("Couldn't set schema");
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,8 +35,11 @@ pub mod watcher;
 pub use builder::ConfigBuilder;
 pub use diff::ConfigDiff;
 pub use format::{Format, FormatHint};
-pub use loading::{load_from_paths, load_from_str, merge_path_lists, process_paths, CONFIG_PATHS};
-pub use log_schema::{log_schema, LogSchema, LOG_SCHEMA};
+pub use loading::{
+    load_builder_from_paths, load_from_paths, load_from_str, merge_path_lists, process_paths,
+    CONFIG_PATHS,
+};
+pub use log_schema::{init_log_schema, log_schema, LogSchema};
 pub use unit_test::build_unit_tests_main as build_unit_tests;
 pub use validation::warnings;
 
@@ -519,19 +522,6 @@ impl Config {
             .cloned()
             .unwrap_or_else(|| vec![String::from(identifier)])
     }
-}
-
-fn handle_warnings(warnings: Vec<String>, deny_warnings: bool) -> Result<(), Vec<String>> {
-    if !warnings.is_empty() {
-        if deny_warnings {
-            return Err(warnings);
-        } else {
-            for warning in warnings {
-                warn!("{}", &warning);
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(all(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,7 +56,7 @@ pub struct Config {
     expansions: IndexMap<String, Vec<String>>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub struct GlobalOptions {
     #[serde(default = "default_data_dir")]

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -11,12 +11,9 @@ use std::{collections::HashMap, path::PathBuf};
 pub async fn build_unit_tests_main(
     paths: &[(PathBuf, config::FormatHint)],
 ) -> Result<Vec<UnitTest>, Vec<String>> {
-    let config = super::loading::load_builder_from_paths(paths, false)?;
+    config::init_log_schema(paths, false)?;
 
-    // Ignore failures on calls other than the first
-    crate::config::LOG_SCHEMA
-        .set(config.global.log_schema.clone())
-        .ok();
+    let (config, _) = super::loading::load_builder_from_paths(paths)?;
 
     build_unit_tests(config).await
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -215,7 +215,7 @@ fn create_service_arguments(
     config_paths: &[(PathBuf, config::FormatHint)],
 ) -> Option<Vec<OsString>> {
     let config_paths = config::process_paths(&config_paths)?;
-    match config::load_from_paths(&config_paths, false) {
+    match config::load_from_paths(&config_paths) {
         Ok(_) => Some(
             config_paths
                 .iter()

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -1,4 +1,4 @@
-use super::{default_host_key, Encoding};
+use super::{host_key, Encoding};
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     sinks::splunk_hec::HecSinkConfig,
@@ -22,7 +22,7 @@ pub struct HumioLogsConfig {
 
     pub(in crate::sinks::humio) event_type: Option<Template>,
 
-    #[serde(default = "default_host_key")]
+    #[serde(default = "host_key")]
     pub(in crate::sinks::humio) host_key: String,
 
     #[serde(default)]
@@ -49,7 +49,7 @@ impl GenerateConfig for HumioLogsConfig {
             source: None,
             encoding: Encoding::Json.into(),
             event_type: None,
-            host_key: default_host_key(),
+            host_key: host_key(),
             compression: Compression::default(),
             request: TowerRequestConfig::default(),
             batch: BatchConfig::default(),

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -1,4 +1,4 @@
-use super::{default_host_key, logs::HumioLogsConfig, Encoding};
+use super::{host_key, logs::HumioLogsConfig, Encoding};
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription, TransformConfig},
     sinks::util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
@@ -25,7 +25,7 @@ pub struct HumioMetricsConfig {
 
     event_type: Option<Template>,
 
-    #[serde(default = "default_host_key")]
+    #[serde(default = "host_key")]
     host_key: String,
 
     #[serde(default)]

--- a/src/sinks/humio/mod.rs
+++ b/src/sinks/humio/mod.rs
@@ -20,6 +20,6 @@ impl From<Encoding> for splunk_hec::Encoding {
     }
 }
 
-fn default_host_key() -> String {
-    crate::config::LogSchema::default().host_key().to_string()
+fn host_key() -> String {
+    crate::config::log_schema().host_key().to_string()
 }

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -33,7 +33,7 @@ pub struct HecSinkConfig {
     // Deprecated name
     #[serde(alias = "host")]
     pub endpoint: String,
-    #[serde(default = "default_host_key")]
+    #[serde(default = "host_key")]
     pub host_key: String,
     #[serde(default)]
     pub indexed_fields: Vec<String>,
@@ -65,8 +65,8 @@ pub enum Encoding {
     Json,
 }
 
-fn default_host_key() -> String {
-    crate::config::LogSchema::default().host_key().to_string()
+fn host_key() -> String {
+    crate::config::log_schema().host_key().to_string()
 }
 
 inventory::submit! {
@@ -78,7 +78,7 @@ impl GenerateConfig for HecSinkConfig {
         toml::Value::try_from(Self {
             token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned(),
             endpoint: "endpoint".to_owned(),
-            host_key: default_host_key(),
+            host_key: host_key(),
             indexed_fields: vec![],
             index: None,
             sourcetype: None,

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -63,7 +63,7 @@ enum Error {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields, default)]
 pub struct DockerLogsConfig {
-    #[serde(default = "default_host_key")]
+    #[serde(default = "host_key")]
     host_key: String,
     docker_host: Option<String>,
     tls: Option<DockerTlsConfig>,
@@ -88,7 +88,7 @@ pub struct DockerTlsConfig {
 impl Default for DockerLogsConfig {
     fn default() -> Self {
         Self {
-            host_key: default_host_key(),
+            host_key: host_key(),
             docker_host: None,
             tls: None,
             exclude_containers: None,
@@ -103,7 +103,7 @@ impl Default for DockerLogsConfig {
     }
 }
 
-fn default_host_key() -> String {
+fn host_key() -> String {
     log_schema().host_key().to_string()
 }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -207,8 +207,11 @@ impl RunningTopology {
     /// On Error, topology is in invalid state.
     /// May change componenets even if reload fails.
     pub async fn reload_config_and_respawn(&mut self, new_config: Config) -> Result<bool, ()> {
-        if self.config.global.data_dir != new_config.global.data_dir {
-            error!(message = "The data_dir cannot be changed while reloading config file; reload aborted.", data_dir = ?self.config.global.data_dir);
+        if self.config.global != new_config.global {
+            error!(
+                message =
+                    "Global options can't be changed while reloading config file; reload aborted."
+            );
             return Ok(false);
         }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -210,7 +210,7 @@ impl RunningTopology {
         if self.config.global != new_config.global {
             error!(
                 message =
-                    "Global options can't be changed while reloading config file; reload aborted."
+                    "Global options can't be changed while reloading config file; reload aborted. Please restart vector to reload the configuration file."
             );
             return Ok(false);
         }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -104,7 +104,10 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
         .ok()?;
 
     // Build
-    let (config, build_warnings) = builder.build().map_err(&mut report_error).ok()?;
+    let (config, build_warnings) = builder
+        .build_with_warnings()
+        .map_err(&mut report_error)
+        .ok()?;
 
     // Warnings
     let warnings = load_warnings

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -80,8 +80,6 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
     }
 }
 
-/// Ok if all configs were successfully validated.
-/// Err Some contains only successfully validated configs.
 fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
     // Prepare paths
     let paths = opts.paths_with_formats();
@@ -92,18 +90,40 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
         return None;
     };
 
+    // Load
     let paths_list: Vec<_> = paths.iter().map(|(path, _)| path).collect();
-    match config::load_from_paths(&paths, opts.deny_warnings) {
-        Ok(config) => {
-            fmt.success(format!("Loaded {:?}", &paths_list));
-            Some(config)
+    let mut report_error = |errors| {
+        fmt.title(format!("Failed to load {:?}", &paths_list));
+        fmt.sub_error(errors);
+    };
+    config::init_log_schema(&paths, true)
+        .map_err(&mut report_error)
+        .ok()?;
+    let (builder, load_warnings) = config::load_builder_from_paths(&paths)
+        .map_err(&mut report_error)
+        .ok()?;
+
+    // Build
+    let (config, build_warnings) = builder.build().map_err(&mut report_error).ok()?;
+
+    // Warnings
+    let warnings = load_warnings
+        .into_iter()
+        .chain(build_warnings)
+        .collect::<Vec<_>>();
+    if !warnings.is_empty() {
+        if opts.deny_warnings {
+            report_error(warnings);
+            return None;
         }
-        Err(errors) => {
-            fmt.title(format!("Failed to load {:?}", &paths_list));
-            fmt.sub_error(errors);
-            None
-        }
+
+        fmt.title(format!("Loaded with warnings {:?}", &paths_list));
+        fmt.sub_warning(warnings);
+    } else {
+        fmt.success(format!("Loaded {:?}", &paths_list));
     }
+
+    Some(config)
 }
 
 async fn validate_environment(opts: &Opts, config: &Config, fmt: &mut Formatter) -> bool {
@@ -123,10 +143,6 @@ async fn validate_components(
     diff: &ConfigDiff,
     fmt: &mut Formatter,
 ) -> Option<Pieces> {
-    crate::config::LOG_SCHEMA
-        .set(config.global.log_schema.clone())
-        .expect("Couldn't set schema");
-
     match topology::builder::build_pieces(config, diff, HashMap::new()).await {
         Ok(pieces) => {
             fmt.success("Component configuration");
@@ -292,6 +308,14 @@ impl Formatter {
             "",
             width = title.as_ref().len()
         ))
+    }
+
+    /// A list of warnings that go with a title.
+    fn sub_warning<I: IntoIterator>(&mut self, warnings: I)
+    where
+        I::Item: fmt::Display,
+    {
+        self.sub(self.warning_intro.clone(), warnings)
     }
 
     /// A list of errors that go with a title.

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -163,10 +163,10 @@ fn log_schema() {
             r#"
         data_dir = "${VECTOR_DATA_DIR}"
         log_schema.message_key = "test_msg"
-    
+
         [sources.in_console]
             type = "stdin"
-    
+
         [sinks.out_console]
             inputs = ["in_console"]
             type = "console"

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -20,7 +20,7 @@ mod support;
 use crate::support::{create_directory, create_file, overwrite_file};
 
 const STARTUP_TIME: Duration = Duration::from_secs(2);
-const SHUTDOWN_TIME: Duration = Duration::from_secs(3);
+const SHUTDOWN_TIME: Duration = Duration::from_secs(4);
 const RELOAD_TIME: Duration = Duration::from_secs(5);
 
 const STDIO_CONFIG: &'static str = r#"

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -5,6 +5,7 @@ use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid,
 };
+use serde_json::{json, Value};
 use std::{
     io::Write,
     net::SocketAddr,
@@ -150,6 +151,54 @@ fn auto_shutdown() {
     let assert = cmd.write_stdin("42").assert();
 
     assert.success().stdout("42\n");
+}
+
+#[test]
+fn log_schema() {
+    // Vector command
+    let mut cmd = Command::cargo_bin("vector").unwrap();
+    cmd.arg("--quiet")
+        .arg("-c")
+        .arg(create_file(
+            r#"
+        data_dir = "${VECTOR_DATA_DIR}"
+        log_schema.message_key = "test_msg"
+    
+        [sources.in_console]
+            type = "stdin"
+    
+        [sinks.out_console]
+            inputs = ["in_console"]
+            type = "console"
+            encoding = "json"
+    "#,
+        ))
+        .env("VECTOR_DATA_DIR", create_directory());
+
+    // Run vector
+    let mut vector = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Give vector time to start.
+    sleep(STARTUP_TIME);
+
+    vector
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all("42".as_bytes())
+        .unwrap();
+
+    // Wait for shutdown
+    let output = vector.wait_with_output().unwrap();
+    assert!(output.status.success(), "Vector didn't exit successfully.");
+
+    // Output
+    let event: Value = serde_json::from_slice(output.stdout.as_slice()).unwrap();
+    assert_eq!(event["test_msg"], json!("42"));
 }
 
 #[test]


### PR DESCRIPTION
Closes  #6394

Resolves the race between loading log schema from the config file and using said schema for building the same config by first loading config and setting log schema and then loading config as usual. 

Replaces #6552

### Todo

- [ ] Check impact on start time 
- [ ] Add note to global options documentation how they can't be changed when reloading
- [x] Add whole program test

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
