### PR TITLE
chore(external docs): Build complete vector docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,8 +276,6 @@ default-msvc = ["api", "api-client", "leveldb", "rdkafka-cmake", "sinks", "sourc
 default-musl = ["api", "api-client", "leveldb", "rdkafka-cmake", "sinks", "sources", "transforms", "unix", "vendor-all", "vrl-cli"]
 default-no-api-client = ["api", "leveldb", "rdkafka-plain", "sinks", "sources", "transforms", "unix", "vendor-all", "vrl-cli"]
 default-no-vrl-cli = ["api", "leveldb", "rdkafka-plain", "sinks", "sources", "transforms", "unix", "vendor-all"]
-# The docs feature specifies which packages are included in the Rustdoc available at https://rustdoc.vector.dev
-docs = ["api", "sinks", "sources", "transforms"]
 
 all-logs = ["sinks-logs", "sources-logs", "transforms-logs"]
 all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]

--- a/Makefile
+++ b/Makefile
@@ -644,9 +644,9 @@ check-events: ## Check that events satisfy patterns set in https://github.com/ti
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-events.sh
 
 ##@ Rustdoc
-build-rustdoc: ## Build a subset of Vector's Rustdocs (as specified by the "docs" feature)
+build-rustdoc: ## Build Vector's Rustdocs
 	# This command is mostly intended for use by the build process in timberio/vector-rustdoc
-	${MAYBE_ENVIRONMENT_EXEC} cargo doc --no-deps --no-default-features --features docs
+	${MAYBE_ENVIRONMENT_EXEC} cargo doc --no-deps
 
 ##@ Packaging
 


### PR DESCRIPTION
I think it useful to build vector's docs with all features. We are using `--no-deps` so it should not build docs for vector's dependencies.

Broken off from
https://github.com/timberio/vector/pull/6553#discussion_r583105047

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
