### PR TITLE
chore(remap): update vrl url in error message

### DIFF
--- a/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
+++ b/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
@@ -9,5 +9,5 @@
 #   │ unexpected syntax token: "PathField"
 #   │ expected one of: "\n", "!", "(", "[", "_", "false", "float literal", "function call", "identifier", "if", "integer literal", "null", "regex literal", "string literal", "timestamp literal", "true", "{", "path literal"
 #   │
-#   = see language documentation at: https://vector.dev/docs/reference/vrl/
+#   = see language documentation at https://vrl.dev
 @timestamp = now()


### PR DESCRIPTION
The VRL url that was printed in error messages was changed prior to a pr getting merged, which resulted in this test failing.



Signed-off-by: Stephen Wakely <stephen.wakely@datadoghq.com>
