### PR TITLE
chore(ci): Temporarily ignore RUSTSEC-2020-0146

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,14 +48,6 @@ ignore = [
     # https://github.com/timberio/vector/issues/5585
     "RUSTSEC-2020-0056",
 
-    # Some lock_api lock guard objects can cause data races
-    # https://github.com/timberio/vector/issues/5587
-    "RUSTSEC-2020-0070",
-
-    # GenericMutexGuard allows data races of non-Sync types across threads
-    # https://github.com/timberio/vector/issues/5586
-    "RUSTSEC-2020-0072",
-
     # difference is unmaintained
     # https://github.com/timberio/vector/issues/6224
     "RUSTSEC-2020-0095",
@@ -63,4 +55,8 @@ ignore = [
     # Soundness issues in `raw-cpuid`
     # https://github.com/timberio/vector/issues/6223
     "RUSTSEC-2021-0013",
+
+    # arr! macro erases lifetimes
+    # https://github.com/timberio/vector/issues/6584
+    "RUSTSEC-2020-0146",
 ]


### PR DESCRIPTION
Tracking issue to resolve:
https://github.com/timberio/vector/issues/6584

Also removed a couple of no longer relevant ignored CVEs.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
