### PR TITLE
chore(administration): make vector repository a CUE module

### DIFF
--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,0 +1,1 @@
+module: "vector.dev"


### PR DESCRIPTION
As discussed with @binarylogic, the vector project has been an excellent
source of regression tests for the CUE project.

Making vector a CUE module will mean we can add the project to the unity
(https://github.com/cue-sh/unity) regression test setup. The goal of
unity is to provide a corpus of CUE code against which we can run
regression tests and CUE (performance) experiments.

In those same discussions with @binarylogic we discussed how to
potentially refactor the vector project more towards CUE's package
model, and/or support additional input modes for cmd/cue itself that fit
better with vector's single-package approach (which works incredibly
well for the use-case). We leave any such changes for a later PR/CL here
or in the CUE project.
