### PR TITLE
enhancement(remap): add parse_apache_log function

### DIFF
--- a/docs/reference/remap/functions/parse_apache_log.cue
+++ b/docs/reference/remap/functions/parse_apache_log.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: functions: parse_apache_log: {
-	category: "Parse"
+	category:    "Parse"
 	description: """
 		Parses apache access and error log lines. Lines can be either in [`common`](\(urls.apache_common)) format,
 		[`combined`](\(urls.apache_combined)) format, or default

--- a/docs/reference/remap/functions/parse_apache_log.cue
+++ b/docs/reference/remap/functions/parse_apache_log.cue
@@ -1,0 +1,113 @@
+package metadata
+
+remap: functions: parse_apache_log: {
+	category: "Parse"
+	description: """
+		Parses apache access and error log lines. Lines can be either in [`common`](https://httpd.apache.org/docs/1.3/logs.html#common) format,
+		[`combined`](https://httpd.apache.org/docs/1.3/logs.html#combined) format, or default
+		[`error`](https://httpd.apache.org/docs/1.3/logs.html#errorlog) format.
+		"""
+	notices: [
+		"""
+			Missing information in the log message may be indicated by `-`. These fields will not be present in the result.
+			""",
+	]
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to parse."
+			required:    true
+			type: ["string"]
+		},
+		{
+			name:        "timestamp_format"
+			description: "The [date/time format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) the log message timestamp is encoded in. If the timestamp does not specify a timezone, the time will be parsed in local time."
+			required:    false
+			default:     "%d/%b/%Y:%T %z"
+			type: ["string"]
+		},
+		{
+			name:        "format"
+			description: "The format the log line is to be parsed as."
+			required:    true
+			enum: {
+				"common":   "Common format"
+				"combined": "Apache combined format"
+				"error":    "Default Apache error format"
+			}
+			type: ["string"]
+		},
+	]
+
+	internal_failure_reasons: [
+		"`value` does not match the specified format",
+		"`timestamp_format` is not a valid format string",
+		"timestamp in `value` fails to parse via the provided `timestamp_format`",
+	]
+	return: types: ["object"]
+
+	examples: [
+		{
+			title: "Parse via Common Log Format (with default timestamp format)"
+			source: #"""
+				parse_apache_log("127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326", format: "common")
+				"""#
+			return: {
+				host:      "127.0.0.1"
+				identity:  "bob"
+				user:      "frank"
+				timestamp: "2000-10-10T20:55:36Z"
+				message:   "GET /apache_pb.gif HTTP/1.0"
+				method:    "GET"
+				path:      "/apache_pb.gif"
+				protocol:  "HTTP/1.0"
+				status:    200
+				size:      2326
+			}
+		},
+		{
+			title: "Parse via Combined Log Format (with custom timestamp format)"
+			source: #"""
+				parse_apache_log(
+					s'127.0.0.1 bob frank [2000-10-10T20:55:36Z] \"GET /apache_pb.gif HTTP/1.0\" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"',
+					"combined",
+					"%+"
+				)
+				"""#
+			return: {
+				host:      "127.0.0.1"
+				identity:  "bob"
+				user:      "frank"
+				timestamp: "2000-10-10T20:55:36Z"
+				message:   "GET /apache_pb.gif HTTP/1.0"
+				method:    "GET"
+				path:      "/apache_pb.gif"
+				protocol:  "HTTP/1.0"
+				status:    200
+				size:      2326
+				referrer:  "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth"
+				agent:     "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"
+			}
+		},
+		{
+			title: "Parse Error Format"
+			source: #"""
+				parse_apache_log(
+					s'[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!',
+					"error"
+				)
+				"""#
+			return: {
+				client:    "147.159.108.175"
+				message:   "I will bypass the haptic COM bandwidth, that should matrix the CSS driver!"
+				module:    "ab"
+				pid:       4803
+				port:      24259
+				severity:  "alert"
+				thread:    "3814"
+				timestamp: "2021-03-01T12:00:19+00:00"
+			}
+		},
+	]
+}

--- a/docs/reference/remap/functions/parse_apache_log.cue
+++ b/docs/reference/remap/functions/parse_apache_log.cue
@@ -3,9 +3,9 @@ package metadata
 remap: functions: parse_apache_log: {
 	category: "Parse"
 	description: """
-		Parses apache access and error log lines. Lines can be either in [`common`](https://httpd.apache.org/docs/1.3/logs.html#common) format,
-		[`combined`](https://httpd.apache.org/docs/1.3/logs.html#combined) format, or default
-		[`error`](https://httpd.apache.org/docs/1.3/logs.html#errorlog) format.
+		Parses apache access and error log lines. Lines can be either in [`common`](\(urls.apache_common)) format,
+		[`combined`](\(urls.apache_combined)) format, or default
+		[`error`](\(urls.apache_error)) format.
 		"""
 	notices: [
 		"""
@@ -49,7 +49,7 @@ remap: functions: parse_apache_log: {
 
 	examples: [
 		{
-			title: "Parse via Common Log Format (with default timestamp format)"
+			title: "Parse via Apache log format (common)"
 			source: #"""
 				parse_apache_log("127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] \"GET /apache_pb.gif HTTP/1.0\" 200 2326", format: "common")
 				"""#
@@ -67,12 +67,11 @@ remap: functions: parse_apache_log: {
 			}
 		},
 		{
-			title: "Parse via Combined Log Format (with custom timestamp format)"
+			title: "Parse via Apache log format (combined)"
 			source: #"""
 				parse_apache_log(
-					s'127.0.0.1 bob frank [2000-10-10T20:55:36Z] \"GET /apache_pb.gif HTTP/1.0\" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"',
+					s'127.0.0.1 bob frank [10/Oct/2000:20:55:36 +0000] \"GET /apache_pb.gif HTTP/1.0\" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"',
 					"combined",
-					"%+"
 				)
 				"""#
 			return: {
@@ -91,7 +90,7 @@ remap: functions: parse_apache_log: {
 			}
 		},
 		{
-			title: "Parse Error Format"
+			title: "Parse via Apache log format (error)"
 			source: #"""
 				parse_apache_log(
 					s'[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!',

--- a/docs/reference/remap/functions/parse_apache_log.cue
+++ b/docs/reference/remap/functions/parse_apache_log.cue
@@ -9,7 +9,7 @@ remap: functions: parse_apache_log: {
 		"""
 	notices: [
 		"""
-			Missing information in the log message may be indicated by `-`. These fields will not be present in the result.
+				Missing information in the log message may be indicated by `-`. These fields will not be present in the result.
 			""",
 	]
 

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -7,6 +7,7 @@ urls: {
 	ansi_escape_codes:                                        "\(wikipedia)/wiki/ANSI_escape_code"
 	apache:                                                   "https://httpd.apache.org"
 	apache_common:                                            "\(apache)/docs/1.3/logs.html#common"
+	apache_combined:                                          "\(apache)/docs/1.3/logs.html#combined"
 	apache_error:                                             "\(apache)/docs/1.3/logs.html#errorlog"
 	apache_extended_status:                                   "\(apache)/docs/current/mod/core.html#extendedstatus"
 	apache_install:                                           "\(apache)/docs/current/install.html"

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 vrl = { path = "../core" }
 
 base64 = { version = "0.13", optional = true }
-bytes = { version = "0.5.6", optional = true }
+bytes =  { version = "0.5.6", optional = true }
 chrono = { version = "0.4", optional = true }
 cidr-utils = { version = "0.5", optional = true }
 grok = { version = "1", optional = true }
@@ -76,6 +76,7 @@ default = [
     "parse_aws_alb_log",
     "parse_aws_cloudwatch_log_subscription_message",
     "parse_aws_vpc_flow_log",
+    "parse_apache_log",
     "parse_common_log",
     "parse_duration",
     "parse_glog",
@@ -152,6 +153,7 @@ md5 = ["md-5", "hex"]
 merge = []
 now = ["chrono"]
 object = []
+parse_apache_log = ["chrono"]
 parse_aws_alb_log = ["nom"]
 parse_aws_cloudwatch_log_subscription_message = ["serde_json", "shared/aws_cloudwatch_logs_subscription", "shared/btreemap"]
 parse_aws_vpc_flow_log = []

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 vrl = { path = "../core" }
 
 base64 = { version = "0.13", optional = true }
-bytes =  { version = "0.5.6", optional = true }
+bytes = { version = "0.5.6", optional = true }
 chrono = { version = "0.4", optional = true }
 cidr-utils = { version = "0.5", optional = true }
 grok = { version = "1", optional = true }

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -659,7 +659,7 @@ bench_function! {
             "port": 24259,
             "severity": "alert",
             "thread": "3814",
-            "timestamp": "2021-03-01T12:00:19+00:00"
+            "timestamp": (DateTime::parse_from_rfc3339("2021-03-01T12:00:19Z").unwrap().with_timezone(&Utc)),
         })),
     }
 }

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -41,6 +41,9 @@ criterion_group!(
               merge,
               // TODO: value is dynamic so we cannot assert equality
               //now,
+              parse_apache_log_common,
+              parse_apache_log_combined,
+              parse_apache_log_error,
               parse_aws_alb_log,
               parse_aws_cloudwatch_log_subscription_message,
               parse_aws_vpc_flow_log,
@@ -601,6 +604,73 @@ bench_function! {
             "type": "IPv4",
             "version": 3,
             "vpc_id": "vpc-abcdefab012345678",
+        })),
+    }
+}
+
+bench_function! {
+    parse_apache_log_common => vrl_stdlib::ParseApacheLog;
+
+    literal {
+        args: func_args![value: r#"127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326"#,
+                         format: "common"
+        ],
+        want: Ok(value!({
+            "host": "127.0.0.1",
+            "identity": "bob",
+            "user": "frank",
+            "timestamp": (DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().with_timezone(&Utc)),
+            "message": "GET /apache_pb.gif HTTP/1.0",
+            "method": "GET",
+            "path": "/apache_pb.gif",
+            "protocol": "HTTP/1.0",
+            "status": 200,
+            "size": 2326,
+        })),
+    }
+}
+
+bench_function! {
+    parse_apache_log_combined => vrl_stdlib::ParseApacheLog;
+
+    literal {
+        args: func_args![value: r#"127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0""#,
+                         format: "combined"
+        ],
+        want: Ok(value!({
+            "agent": "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0",
+            "host": "127.0.0.1",
+            "identity": "bob",
+            "user": "frank",
+            "referrer": "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth",
+            "timestamp": (DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().with_timezone(&Utc)),
+            "message": "GET /apache_pb.gif HTTP/1.0",
+            "method": "GET",
+            "path": "/apache_pb.gif",
+            "protocol": "HTTP/1.0",
+            "status": 200,
+            "size": 2326,
+        })),
+    }
+}
+
+bench_function! {
+    parse_apache_log_error => vrl_stdlib::ParseApacheLog;
+
+
+    literal {
+        args: func_args![value: r#"[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
+                         format: "error"
+        ],
+        want: Ok(value!({
+            "client": "147.159.108.175",
+            "message": "I will bypass the haptic COM bandwidth, that should matrix the CSS driver!",
+            "module": "ab",
+            "pid": 4803,
+            "port": 24259,
+            "severity": "alert",
+            "thread": "3814",
+            "timestamp": "2021-03-01T12:00:19+00:00"
         })),
     }
 }

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -41,9 +41,7 @@ criterion_group!(
               merge,
               // TODO: value is dynamic so we cannot assert equality
               //now,
-              parse_apache_log_common,
-              parse_apache_log_combined,
-              parse_apache_log_error,
+              parse_apache_log,
               parse_aws_alb_log,
               parse_aws_cloudwatch_log_subscription_message,
               parse_aws_vpc_flow_log,
@@ -609,9 +607,9 @@ bench_function! {
 }
 
 bench_function! {
-    parse_apache_log_common => vrl_stdlib::ParseApacheLog;
+    parse_apache_log => vrl_stdlib::ParseApacheLog;
 
-    literal {
+    common {
         args: func_args![value: r#"127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326"#,
                          format: "common"
         ],
@@ -628,12 +626,8 @@ bench_function! {
             "size": 2326,
         })),
     }
-}
 
-bench_function! {
-    parse_apache_log_combined => vrl_stdlib::ParseApacheLog;
-
-    literal {
+    combined {
         args: func_args![value: r#"127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0""#,
                          format: "combined"
         ],
@@ -652,13 +646,8 @@ bench_function! {
             "size": 2326,
         })),
     }
-}
 
-bench_function! {
-    parse_apache_log_error => vrl_stdlib::ParseApacheLog;
-
-
-    literal {
+    error {
         args: func_args![value: r#"[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
                          format: "error"
         ],

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -74,6 +74,8 @@ mod now;
 mod object;
 #[cfg(feature = "only_fields")]
 mod only_fields;
+#[cfg(feature = "parse_apache_log")]
+mod parse_apache_log;
 #[cfg(feature = "parse_aws_alb_log")]
 mod parse_aws_alb_log;
 #[cfg(feature = "parse_aws_cloudwatch_log_subscription_message")]
@@ -233,6 +235,8 @@ pub use now::Now;
 pub use object::Object;
 #[cfg(feature = "only_fields")]
 pub use only_fields::OnlyFields;
+#[cfg(feature = "parse_apache_log")]
+pub use parse_apache_log::ParseApacheLog;
 #[cfg(feature = "parse_aws_alb_log")]
 pub use parse_aws_alb_log::ParseAwsAlbLog;
 #[cfg(feature = "parse_aws_cloudwatch_log_subscription_message")]
@@ -408,6 +412,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ParseGrok),
         #[cfg(feature = "parse_json")]
         Box::new(ParseJson),
+        #[cfg(feature = "parse_apache_log")]
+        Box::new(ParseApacheLog),
         #[cfg(feature = "parse_common_log")]
         Box::new(ParseCommonLog),
         #[cfg(feature = "parse_key_value")]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -62,6 +62,8 @@ mod join;
 mod length;
 #[cfg(feature = "log")]
 mod log;
+#[cfg(any(feature = "parse_common_log", feature = "parse_apache_log"))]
+mod log_util;
 #[cfg(feature = "match")]
 mod r#match;
 #[cfg(feature = "md5")]

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -5,10 +5,9 @@ use std::collections::BTreeMap;
 use vrl::prelude::*;
 
 lazy_static! {
-    // Information about the common log format taken from the
-    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
-    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
-    //
+   // Information about the common log format taken from the
+   // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
+   // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
    pub static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
         r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
         ^\s*                                    # Start with any number of whitespaces.
@@ -31,7 +30,6 @@ lazy_static! {
 
     // For the combined log format
     // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#combined
-    //
     pub static ref REGEX_APACHE_COMBINED_LOG: Regex = Regex::new(
         r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
         ^\s*                                    # Start with any number of whitespaces.
@@ -62,7 +60,6 @@ lazy_static! {
     // Error log format defined here
     // It is possible to customise the format output by apache. This function just handles the default defined here.
     // https://github.com/mingrammer/flog/blob/9bc83b14408ca446e934c32e4a88a81a46e78d83/log.go#L16
-    //
     pub static ref REGEX_APACHE_ERROR_LOG: Regex = Regex::new(
         r#"(?x)                                     # Ignore whitespace and comments in the regex expression.
         ^\s*                                        # Start with any number of whitespaces.
@@ -103,6 +100,9 @@ fn parse_time(time: &str, format: &str) -> std::result::Result<DateTime<Utc>, St
         })
 }
 
+/// Takes the field as a string and returns a `Value`.
+/// Most fields are `Value::Bytes`, but some are other types, we convert to those
+/// types based on the fieldname.
 fn capture_value(
     name: &str,
     value: &str,
@@ -119,6 +119,7 @@ fn capture_value(
     })
 }
 
+/// Extracts the log fields from the regex and adds them to a `Value::Object`.
 pub fn log_fields(
     regex: &Regex,
     captures: &Captures,

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -48,7 +48,7 @@ lazy_static! {
         (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
         (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
         (?P<referrer>[[\\"][^"]]*?)             # Match any character except `"`, but `\"`
-        ")))                                    # Match the closing quote 
+        ")))                                    # Match the closing quote
         \s+                                     # Match whitespace
         (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
         (?P<agent>[[\\"][^"]]*?)                # Match any character except `"`, but `\"`

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -1,0 +1,141 @@
+use chrono::prelude::*;
+use lazy_static::lazy_static;
+use regex::{Captures, Regex};
+use std::collections::BTreeMap;
+use vrl::prelude::*;
+
+lazy_static! {
+    // Information about the common log format taken from the
+    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
+    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
+    //
+   pub static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<message>(                           # Match a request with...
+        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
+        )\s+                                    # Match at least one whitespace.
+        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+        (-|(?P<size>\d+))                       # Match `-` or at least one digit.
+        \s*$                                    # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+    // For the combined log format
+    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#combined
+    //
+    pub static ref REGEX_APACHE_COMBINED_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<message>(                           # Match a request with...
+        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
+        )\s+                                    # Match at least one whitespace.
+        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+        (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<referrer>[[\\"][^"]]*?)             # Match any character except `"`, but `\"`
+        ")))                                    # Match the closing quote 
+        \s+                                     # Match whitespace
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<agent>[[\\"][^"]]*?)                # Match any character except `"`, but `\"`
+        ")))                                    # Match the closing quote
+        #\s*$                                   # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+    // Error log format defined here
+    // It is possible to customise the format output by apache. This function just handles the default defined here.
+    // https://github.com/mingrammer/flog/blob/9bc83b14408ca446e934c32e4a88a81a46e78d83/log.go#L16
+    //
+    pub static ref REGEX_APACHE_ERROR_LOG: Regex = Regex::new(
+        r#"(?x)                                     # Ignore whitespace and comments in the regex expression.
+        ^\s*                                        # Start with any number of whitespaces.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+        # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|\[(-|(?P<module>[^:]*):                  # Match `-` or `[` followed by `-` or any character except `:`.
+        (?P<severity>[^\[]*))\])\s+                 # Match ary character except `]`, `]` and at least one whitespace.
+        (-|\[\s*pid\s*(-|(?P<pid>[^:]*):            # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
+        \s*tid\s*(?P<thread>[^\[]*))\])\s           # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
+        (-|\[\s*client\s*(-|(?P<client>[^:]*):      # Match `-` or `[` followed by `client`, `-` or any character except `:`.
+        (?P<port>[^\[]*))\])\s                      # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|(?P<message>.*))                         # Match `-` or any character.
+        \s*$                                        # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+}
+
+// Parse the time as Utc if we can extract the timezone.
+// If we can't `chrono` will error, and we will have to parse the time as a local time.
+fn parse_time(time: &str, format: &str) -> std::result::Result<DateTime<Utc>, String> {
+    DateTime::parse_from_str(time, &format)
+        .map(Into::into)
+        .or_else(|_| {
+            let parsed =
+                &chrono::NaiveDateTime::parse_from_str(time, &format).map_err(|error| {
+                    format!(
+                        r#"failed parsing timestamp {} using format {}: {}"#,
+                        time, format, error
+                    )
+                })?;
+
+            let result = Local.from_local_datetime(&parsed).earliest();
+
+            match result {
+                Some(result) => Ok(result.into()),
+                None => Ok(Local.from_utc_datetime(parsed).into()),
+            }
+        })
+}
+
+fn capture_value(
+    name: &str,
+    value: &str,
+    timestamp_format: &str,
+) -> std::result::Result<Value, String> {
+    Ok(match name.as_ref() {
+        "timestamp" => Value::Timestamp(parse_time(&value, &timestamp_format)?),
+        "status" | "size" | "pid" | "port" => Value::Integer(
+            value
+                .parse()
+                .map_err(|_| format!("failed parsing {}", name))?,
+        ),
+        _ => Value::Bytes(value.to_owned().into()),
+    })
+}
+
+pub fn log_fields(
+    regex: &Regex,
+    captures: &Captures,
+    timestamp_format: &str,
+) -> std::result::Result<Value, String> {
+    Ok(regex
+        .capture_names()
+        .filter_map(|name| {
+            name.and_then(|name| {
+                captures.name(name).map(|value| {
+                    Ok((
+                        name.to_string(),
+                        capture_value(&name, &value.as_str(), &timestamp_format)?,
+                    ))
+                })
+            })
+        })
+        .collect::<std::result::Result<BTreeMap<String, Value>, String>>()?
+        .into())
+}

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -108,7 +108,7 @@ fn capture_value(
     value: &str,
     timestamp_format: &str,
 ) -> std::result::Result<Value, String> {
-    Ok(match name.as_ref() {
+    Ok(match name {
         "timestamp" => Value::Timestamp(parse_time(&value, &timestamp_format)?),
         "status" | "size" | "pid" | "port" => Value::Integer(
             value

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -5,10 +5,10 @@ use std::collections::BTreeMap;
 use vrl::prelude::*;
 
 lazy_static! {
-   // Information about the common log format taken from the
-   // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
-   // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
-   pub static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
+    // Information about the common log format taken from the
+    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
+    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
+    pub static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
         r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
         ^\s*                                    # Start with any number of whitespaces.
         (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
@@ -28,7 +28,6 @@ lazy_static! {
     "#)
     .expect("failed compiling regex for common log");
 
-    // For the combined log format
     // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#combined
     pub static ref REGEX_APACHE_COMBINED_LOG: Regex = Regex::new(
         r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
@@ -57,7 +56,6 @@ lazy_static! {
     "#)
     .expect("failed compiling regex for common log");
 
-    // Error log format defined here
     // It is possible to customise the format output by apache. This function just handles the default defined here.
     // https://github.com/mingrammer/flog/blob/9bc83b14408ca446e934c32e4a88a81a46e78d83/log.go#L16
     pub static ref REGEX_APACHE_ERROR_LOG: Regex = Regex::new(

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -61,6 +61,13 @@ impl Function for ParseApacheLog {
                     indoc! {r#"s'{"agent":"Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0","host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","referrer":"http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
                 ),
             },
+            Example {
+                title: "parse apache error log",
+                source: r#"encode_json(parse_apache_log!(s'[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!', "error"))"#,
+                result: Ok(
+                    indoc! {r#"s'{"client":"147.159.108.175","message":"I will bypass the haptic COM bandwidth, that should matrix the CSS driver!","module":"ab","pid":4803,"port":24259,"severity":"alert","thread":"3814","timestamp":"2021-03-01T12:00:19+00:00"}'"#},
+                ),
+            },
         ]
     }
 }

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -1,91 +1,6 @@
-use chrono::prelude::*;
-use chrono::DateTime;
-use lazy_static::lazy_static;
-use regex::Regex;
+use crate::log_util;
 use std::collections::BTreeMap;
 use vrl::prelude::*;
-
-lazy_static! {
-    // Information about the common log format taken from the
-    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
-    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
-
-    // ApacheCommonLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes}
-    // ApacheCommonLog = "%s - %s [%s] \"%s %s %s\" %d %d"
-    // ApacheCombinedLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes} "{referrer}" "{agent}"
-    // ApacheCombinedLog = "%s - %s [%s] \"%s %s %s\" %d %d \"%s\" \"%s\""
-    // ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client %{client}:{port}] %{message}
-    // ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client %s:%d] %s"
-
-    static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<message>(                           # Match a request with...
-        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
-        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
-        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
-        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
-        )\s+                                    # Match at least one whitespace.
-        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
-        (-|(?P<size>\d+))                       # Match `-` or at least one digit.
-        \s*$                                    # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for common log");
-
-    static ref REGEX_APACHE_COMBINED_LOG: Regex = Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<message>(                           # Match a request with...
-        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
-        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
-        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
-        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
-        )\s+                                    # Match at least one whitespace.
-        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
-        (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
-
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<referrer>[[\\"][^"]]*?)
-        ")))        
-        \s+
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<agent>[[\\"][^"]]*?)
-        ")))
-        #\s*$                                    # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for common log");
-
-    static ref REGEX_APACHE_ERROR_LOG: Regex = Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-
-        (-|\[(-|(?P<module>[^:]*):
-        (?P<severity>[^\[]*))\])\s+            # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-
-        (-|\[\s*pid\s*(-|(?P<pid>[^:]*):\s*tid\s*
-        (?P<thread>[^\[]*))\])\s               # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-
-        (-|\[\s*client\s*(-|(?P<client>[^:]*):
-        (?P<port>[^\[]*))\])\s               # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-
-        (?P<message>.*)
-
-        \s*$                                    # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for common log");
-
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseApacheLog;
@@ -103,14 +18,14 @@ impl Function for ParseApacheLog {
                 required: true,
             },
             Parameter {
-                keyword: "timestamp_format",
-                kind: kind::BYTES,
-                required: false,
-            },
-            Parameter {
                 keyword: "format",
                 kind: kind::BYTES,
                 required: true,
+            },
+            Parameter {
+                keyword: "timestamp_format",
+                kind: kind::BYTES,
+                required: false,
             },
         ]
     }
@@ -131,13 +46,22 @@ impl Function for ParseApacheLog {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "parse apache log",
-            source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326'))"#,
-            result: Ok(
-                indoc! {r#"s'{"host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
-            ),
-        }]
+        &[
+            Example {
+                title: "parse apache common log",
+                source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326', "common"))"#,
+                result: Ok(
+                    indoc! {r#"s'{"host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
+                ),
+            },
+            Example {
+                title: "parse apache combined log",
+                source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"', "combined"))"#,
+                result: Ok(
+                    indoc! {r#"s'{"agent":"Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0","host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","referrer":"http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
+                ),
+            },
+        ]
     }
 }
 
@@ -160,135 +84,33 @@ impl Expression for ParseApacheLogFn {
                 .to_string(),
         };
 
-        let mut log: BTreeMap<String, Value> = BTreeMap::new();
-
-        let captures = match self.format.as_ref() {
-            b"common" => REGEX_APACHE_COMMON_LOG
-                .captures(&message)
-                .ok_or("failed parsing common log line")?,
-            b"combined" => REGEX_APACHE_COMBINED_LOG
-                .captures(&message)
-                .ok_or("failed parsing combined log line")?,
-            b"error" => REGEX_APACHE_ERROR_LOG
-                .captures(&message)
-                .ok_or("failed parsing error log line")?,
+        let regex = match self.format.as_ref() {
+            b"common" => &*log_util::REGEX_APACHE_COMMON_LOG,
+            b"combined" => &*log_util::REGEX_APACHE_COMBINED_LOG,
+            b"error" => &*log_util::REGEX_APACHE_ERROR_LOG,
             _ => panic!(),
         };
 
-        if let Some(host) = captures.name("host").map(|capture| capture.as_str()) {
-            log.insert("host".into(), Value::Bytes(host.to_owned().into()));
-        }
+        let captures = regex
+            .captures(&message)
+            .ok_or("failed parsing common log line")?;
 
-        if let Some(identity) = captures.name("identity").map(|capture| capture.as_str()) {
-            log.insert("identity".into(), Value::Bytes(identity.to_owned().into()));
-        }
-
-        if let Some(user) = captures.name("user").map(|capture| capture.as_str()) {
-            log.insert("user".into(), Value::Bytes(user.to_owned().into()));
-        }
-
-        if let Some(timestamp) = captures.name("timestamp").map(|capture| capture.as_str()) {
-            log.insert(
-                "timestamp".into(),
-                Value::Timestamp(parse_time(&timestamp, &timestamp_format)?),
-            );
-        }
-
-        if let Some(message) = captures.name("message").map(|capture| capture.as_str()) {
-            log.insert("message".into(), Value::Bytes(message.to_owned().into()));
-        }
-
-        if let Some(method) = captures.name("method").map(|capture| capture.as_str()) {
-            log.insert("method".into(), Value::Bytes(method.to_owned().into()));
-        }
-
-        if let Some(path) = captures.name("path").map(|capture| capture.as_str()) {
-            log.insert("path".into(), Value::Bytes(path.to_owned().into()));
-        }
-
-        if let Some(protocol) = captures.name("protocol").map(|capture| capture.as_str()) {
-            log.insert("protocol".into(), Value::Bytes(protocol.to_owned().into()));
-        }
-
-        if let Some(status) = captures.name("status").map(|capture| capture.as_str()) {
-            log.insert(
-                "status".into(),
-                Value::Integer(status.parse().map_err(|_| "failed parsing status code")?),
-            );
-        }
-
-        if let Some(size) = captures.name("size").map(|capture| capture.as_str()) {
-            log.insert(
-                "size".into(),
-                Value::Integer(size.parse().map_err(|_| "failed parsing content length")?),
-            );
-        }
-
-        if let Some(referrer) = captures.name("referrer").map(|capture| capture.as_str()) {
-            log.insert("referrer".into(), Value::Bytes(referrer.to_owned().into()));
-        }
-
-        if let Some(agent) = captures.name("agent").map(|capture| capture.as_str()) {
-            log.insert("agent".into(), Value::Bytes(agent.to_owned().into()));
-        }
-
-        if let Some(module) = captures.name("module").map(|capture| capture.as_str()) {
-            log.insert("module".into(), Value::Bytes(module.to_owned().into()));
-        }
-
-        if let Some(severity) = captures.name("severity").map(|capture| capture.as_str()) {
-            log.insert("severity".into(), Value::Bytes(severity.to_owned().into()));
-        }
-
-        if let Some(pid) = captures.name("pid").map(|capture| capture.as_str()) {
-            log.insert(
-                "pid".into(),
-                Value::Integer(pid.parse().map_err(|_| "failed parsing pid")?),
-            );
-        }
-
-        if let Some(thread) = captures.name("thread").map(|capture| capture.as_str()) {
-            log.insert("thread".into(), Value::Bytes(thread.to_owned().into()));
-        }
-
-        if let Some(client) = captures.name("client").map(|capture| capture.as_str()) {
-            log.insert("client".into(), Value::Bytes(client.to_owned().into()));
-        }
-
-        if let Some(port) = captures.name("port").map(|capture| capture.as_str()) {
-            log.insert("port".into(), Value::Integer(port.parse().map_err(|_| "failed parsing port")?));
-        }
-
-        Ok(log.into())
+        log_util::log_fields(&regex, &captures, &timestamp_format).map_err(Into::into)
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
-        TypeDef::new().fallible().object(type_def())
+        TypeDef::new()
+            .fallible()
+            .object(match self.format.as_ref() {
+                b"common" => type_def_common(),
+                b"combined" => type_def_combined(),
+                b"error" => type_def_error(),
+                _ => unreachable!(),
+            })
     }
 }
 
-fn parse_time(time: &str, format: &str) -> std::result::Result<DateTime<Utc>, String> {
-    DateTime::parse_from_str(time, &format)
-        .map(Into::into)
-        .or_else(|_| {
-            let parsed =
-                &chrono::NaiveDateTime::parse_from_str(time, &format).map_err(|error| {
-                    format!(
-                        r#"failed parsing timestamp {} using format {}: {}"#,
-                        time, format, error
-                    )
-                })?;
-
-            let result = Local.from_local_datetime(&parsed).earliest();
-
-            match result {
-                Some(result) => Ok(result.into()),
-                None => Ok(Local.from_utc_datetime(parsed).into()),
-            }
-        })
-}
-
-fn type_def() -> BTreeMap<&'static str, TypeDef> {
+fn type_def_common() -> BTreeMap<&'static str, TypeDef> {
     map! {
          "host": Kind::Bytes | Kind::Null,
          "identity": Kind::Bytes | Kind::Null,
@@ -303,11 +125,38 @@ fn type_def() -> BTreeMap<&'static str, TypeDef> {
     }
 }
 
-// combined
+fn type_def_combined() -> BTreeMap<&'static str, TypeDef> {
+    map! {
+        "host": Kind::Bytes | Kind::Null,
+        "identity": Kind::Bytes | Kind::Null,
+        "user": Kind::Bytes | Kind::Null,
+        "timestamp": Kind::Timestamp | Kind::Null,
+        "message": Kind::Bytes | Kind::Null,
+        "method": Kind::Bytes | Kind::Null,
+        "path": Kind::Bytes | Kind::Null,
+        "protocol": Kind::Bytes | Kind::Null,
+        "status": Kind::Integer | Kind::Null,
+        "size": Kind::Integer | Kind::Null,
+        "referrer": Kind::Bytes | Kind::Null,
+        "agent": Kind::Bytes | Kind::Null,
+    }
+}
+
+fn type_def_error() -> BTreeMap<&'static str, TypeDef> {
+    map! {
+         "timestamp": Kind::Timestamp | Kind::Null,
+         "module": Kind::Bytes | Kind::Null,
+         "severity": Kind::Bytes | Kind::Null,
+         "thread": Kind::Bytes | Kind::Null,
+         "port": Kind::Bytes | Kind::Null,
+         "message": Kind::Bytes | Kind::Null,
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::prelude::*;
     use shared::btreemap;
 
     test_function![
@@ -329,7 +178,7 @@ mod tests {
                 "status" => 200,
                 "size" => 2326,
             }),
-            tdef: TypeDef::new().fallible().object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_common()),
         }
 
         combined_line_valid {
@@ -350,7 +199,7 @@ mod tests {
                 "referrer" => "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth",
                 "agent" => "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0",
             }),
-            tdef: TypeDef::new().fallible().object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_combined()),
         }
 
         combined_line_missing_fields_valid {
@@ -369,12 +218,11 @@ mod tests {
                 "status" => 401,
                 "size" => 84170,
             }),
-            tdef: TypeDef::new().fallible().object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_combined()),
         }
 
         error_line_valid {
-            args: func_args![value: r#"[Mon Mar 01 12:00:19 2021] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
-                             timestamp_format: "%a %b %d %H:%M:%S %Y",
+            args: func_args![value: r#"[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
                              format: "error"
                              ],
             want: Ok(btreemap! {
@@ -387,60 +235,54 @@ mod tests {
                 "client" => "147.159.108.175",
                 "port" => 24259
             }),
-            tdef: TypeDef::new().fallible().object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_error()),
         }
 
-
-
-        /*
         log_line_valid_empty {
-            args: func_args![value: "- - - - - - -"],
+            args: func_args![value: "- - - - - - -",
+                             format: "common",
+            ],
             want: Ok(btreemap! {}),
-            tdef: TypeDef::new().fallible.object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_common()),
         }
 
         log_line_valid_empty_variant {
-            args: func_args![value: r#"- - - [-] "-" - -"#],
+            args: func_args![value: r#"- - - [-] "-" - -"#,
+                             format: "common",
+            ],
             want: Ok(btreemap! {}),
-            tdef: TypeDef::new().fallible.object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_common()),
         }
-        */
 
-        /*
-        log_line_valid_with_timestamp_format {
-            args: {
-                let mut args = func_args![value: r#"- - - [2000-10-10T20:55:36Z] "-" - -"#];
-                args.insert(
-                    "timestamp_format",
-                    expression::Argument::new(
-                        Box::new(Literal::from("%+").into()),
-                        |_| true,
-                        "timestamp_format",
-                        "parse_common_log",
-                    )
-                    .into(),
-                );
-                args
-            },
+        log_line_valid_with_local_timestamp_format {
+            args: func_args![value: format!("[{}] - - - -",
+                                            Utc.ymd(2000, 10, 10).and_hms(20,55,36)
+                                              .with_timezone(&Local)
+                                              .format("%a %b %d %H:%M:%S %Y").to_string()
+                                            ),
+                             timestamp_format: "%a %b %d %H:%M:%S %Y",
+                             format: "error",
+            ],
             want: Ok(btreemap! {
                 "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().into()),
             }),
-            tdef: TypeDef::new().fallible.object(type_def()),
+            tdef: TypeDef::new().fallible().object(type_def_error()),
         }
-        */
 
-        /*
         log_line_invalid {
-            args: func_args![value: r#"not a common log line"#],
-            want: Err("function call error: failed parsing common log line"),
-            tdef: TypeDef::new().fallible.object(type_def()),
+            args: func_args![value: r#"not a common log line"#,
+                             format: "common",
+            ],
+            want: Err("failed parsing common log line"),
+            tdef: TypeDef::new().fallible().object(type_def_common()),
         }
 
         log_line_invalid_timestamp {
-            args: func_args![value: r#"- - - [1234] - - -"#],
-            want: Err("function call error: failed parsing timestamp 1234 using format %d/%b/%Y:%T %z: input contains invalid characters"),
-            tdef: TypeDef::new().fallible.object(type_def()),
+            args: func_args![value: r#"- - - [1234] - - - - - "#,
+                             format: "combined",
+            ],
+            want: Err("failed parsing timestamp 1234 using format %d/%b/%Y:%T %z: input contains invalid characters"),
+            tdef: TypeDef::new().fallible().object(type_def_combined()),
         }
-        */
     ];
 }

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -1,0 +1,446 @@
+use chrono::prelude::*;
+use chrono::DateTime;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::BTreeMap;
+use vrl::prelude::*;
+
+lazy_static! {
+    // Information about the common log format taken from the
+    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
+    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
+
+    // ApacheCommonLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes}
+    // ApacheCommonLog = "%s - %s [%s] \"%s %s %s\" %d %d"
+    // ApacheCombinedLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes} "{referrer}" "{agent}"
+    // ApacheCombinedLog = "%s - %s [%s] \"%s %s %s\" %d %d \"%s\" \"%s\""
+    // ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client %{client}:{port}] %{message}
+    // ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client %s:%d] %s"
+
+    static ref REGEX_APACHE_COMMON_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<message>(                           # Match a request with...
+        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
+        )\s+                                    # Match at least one whitespace.
+        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+        (-|(?P<size>\d+))                       # Match `-` or at least one digit.
+        \s*$                                    # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+    static ref REGEX_APACHE_COMBINED_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<message>(                           # Match a request with...
+        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
+        )\s+                                    # Match at least one whitespace.
+        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+        (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
+
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<referrer>[[\\"][^"]]*?)
+        ")))        
+        \s+
+        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+        (?P<agent>[[\\"][^"]]*?)
+        ")))
+        #\s*$                                    # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+    static ref REGEX_APACHE_ERROR_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+
+        (-|\[(-|(?P<module>[^:]*):
+        (?P<severity>[^\[]*))\])\s+            # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+
+        (-|\[\s*pid\s*(-|(?P<pid>[^:]*):\s*tid\s*
+        (?P<thread>[^\[]*))\])\s               # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+
+        (-|\[\s*client\s*(-|(?P<client>[^:]*):
+        (?P<port>[^\[]*))\])\s               # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+
+        (?P<message>.*)
+
+        \s*$                                    # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for common log");
+
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ParseApacheLog;
+
+impl Function for ParseApacheLog {
+    fn identifier(&self) -> &'static str {
+        "parse_apache_log"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "timestamp_format",
+                kind: kind::BYTES,
+                required: false,
+            },
+            Parameter {
+                keyword: "format",
+                kind: kind::BYTES,
+                required: true,
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let variants = vec![value!("common"), value!("combined"), value!("error")];
+
+        let value = arguments.required("value");
+        let format = arguments.required_enum("format", &variants)?.unwrap_bytes();
+
+        let timestamp_format = arguments.optional("timestamp_format");
+
+        Ok(Box::new(ParseApacheLogFn {
+            value,
+            format,
+            timestamp_format,
+        }))
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "parse apache log",
+            source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326'))"#,
+            result: Ok(
+                indoc! {r#"s'{"host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
+            ),
+        }]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseApacheLogFn {
+    value: Box<dyn Expression>,
+    format: Bytes,
+    timestamp_format: Option<Box<dyn Expression>>,
+}
+
+impl Expression for ParseApacheLogFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let bytes = self.value.resolve(ctx)?;
+        let message = bytes.try_bytes_utf8_lossy()?;
+        let timestamp_format = match &self.timestamp_format {
+            None => "%d/%b/%Y:%T %z".to_owned(),
+            Some(timestamp_format) => timestamp_format
+                .resolve(ctx)?
+                .try_bytes_utf8_lossy()?
+                .to_string(),
+        };
+
+        let mut log: BTreeMap<String, Value> = BTreeMap::new();
+
+        let captures = match self.format.as_ref() {
+            b"common" => REGEX_APACHE_COMMON_LOG
+                .captures(&message)
+                .ok_or("failed parsing common log line")?,
+            b"combined" => REGEX_APACHE_COMBINED_LOG
+                .captures(&message)
+                .ok_or("failed parsing combined log line")?,
+            b"error" => REGEX_APACHE_ERROR_LOG
+                .captures(&message)
+                .ok_or("failed parsing error log line")?,
+            _ => panic!(),
+        };
+
+        if let Some(host) = captures.name("host").map(|capture| capture.as_str()) {
+            log.insert("host".into(), Value::Bytes(host.to_owned().into()));
+        }
+
+        if let Some(identity) = captures.name("identity").map(|capture| capture.as_str()) {
+            log.insert("identity".into(), Value::Bytes(identity.to_owned().into()));
+        }
+
+        if let Some(user) = captures.name("user").map(|capture| capture.as_str()) {
+            log.insert("user".into(), Value::Bytes(user.to_owned().into()));
+        }
+
+        if let Some(timestamp) = captures.name("timestamp").map(|capture| capture.as_str()) {
+            log.insert(
+                "timestamp".into(),
+                Value::Timestamp(parse_time(&timestamp, &timestamp_format)?),
+            );
+        }
+
+        if let Some(message) = captures.name("message").map(|capture| capture.as_str()) {
+            log.insert("message".into(), Value::Bytes(message.to_owned().into()));
+        }
+
+        if let Some(method) = captures.name("method").map(|capture| capture.as_str()) {
+            log.insert("method".into(), Value::Bytes(method.to_owned().into()));
+        }
+
+        if let Some(path) = captures.name("path").map(|capture| capture.as_str()) {
+            log.insert("path".into(), Value::Bytes(path.to_owned().into()));
+        }
+
+        if let Some(protocol) = captures.name("protocol").map(|capture| capture.as_str()) {
+            log.insert("protocol".into(), Value::Bytes(protocol.to_owned().into()));
+        }
+
+        if let Some(status) = captures.name("status").map(|capture| capture.as_str()) {
+            log.insert(
+                "status".into(),
+                Value::Integer(status.parse().map_err(|_| "failed parsing status code")?),
+            );
+        }
+
+        if let Some(size) = captures.name("size").map(|capture| capture.as_str()) {
+            log.insert(
+                "size".into(),
+                Value::Integer(size.parse().map_err(|_| "failed parsing content length")?),
+            );
+        }
+
+        if let Some(referrer) = captures.name("referrer").map(|capture| capture.as_str()) {
+            log.insert("referrer".into(), Value::Bytes(referrer.to_owned().into()));
+        }
+
+        if let Some(agent) = captures.name("agent").map(|capture| capture.as_str()) {
+            log.insert("agent".into(), Value::Bytes(agent.to_owned().into()));
+        }
+
+        if let Some(module) = captures.name("module").map(|capture| capture.as_str()) {
+            log.insert("module".into(), Value::Bytes(module.to_owned().into()));
+        }
+
+        if let Some(severity) = captures.name("severity").map(|capture| capture.as_str()) {
+            log.insert("severity".into(), Value::Bytes(severity.to_owned().into()));
+        }
+
+        if let Some(pid) = captures.name("pid").map(|capture| capture.as_str()) {
+            log.insert(
+                "pid".into(),
+                Value::Integer(pid.parse().map_err(|_| "failed parsing pid")?),
+            );
+        }
+
+        if let Some(thread) = captures.name("thread").map(|capture| capture.as_str()) {
+            log.insert("thread".into(), Value::Bytes(thread.to_owned().into()));
+        }
+
+        if let Some(client) = captures.name("client").map(|capture| capture.as_str()) {
+            log.insert("client".into(), Value::Bytes(client.to_owned().into()));
+        }
+
+        if let Some(port) = captures.name("port").map(|capture| capture.as_str()) {
+            log.insert("port".into(), Value::Integer(port.parse().map_err(|_| "failed parsing port")?));
+        }
+
+        Ok(log.into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().fallible().object(type_def())
+    }
+}
+
+fn parse_time(time: &str, format: &str) -> std::result::Result<DateTime<Utc>, String> {
+    DateTime::parse_from_str(time, &format)
+        .map(Into::into)
+        .or_else(|_| {
+            let parsed =
+                &chrono::NaiveDateTime::parse_from_str(time, &format).map_err(|error| {
+                    format!(
+                        r#"failed parsing timestamp {} using format {}: {}"#,
+                        time, format, error
+                    )
+                })?;
+
+            let result = Local.from_local_datetime(&parsed).earliest();
+
+            match result {
+                Some(result) => Ok(result.into()),
+                None => Ok(Local.from_utc_datetime(parsed).into()),
+            }
+        })
+}
+
+fn type_def() -> BTreeMap<&'static str, TypeDef> {
+    map! {
+         "host": Kind::Bytes | Kind::Null,
+         "identity": Kind::Bytes | Kind::Null,
+         "user": Kind::Bytes | Kind::Null,
+         "timestamp": Kind::Timestamp | Kind::Null,
+         "message": Kind::Bytes | Kind::Null,
+         "method": Kind::Bytes | Kind::Null,
+         "path": Kind::Bytes | Kind::Null,
+         "protocol": Kind::Bytes | Kind::Null,
+         "status": Kind::Integer | Kind::Null,
+         "size": Kind::Integer | Kind::Null,
+    }
+}
+
+// combined
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::btreemap;
+
+    test_function![
+        parse_common_log => ParseApacheLog;
+
+        common_line_valid {
+            args: func_args![value: r#"127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326"#,
+                             format: "common"
+            ],
+            want: Ok(btreemap! {
+                "host" => "127.0.0.1",
+                "identity" => "bob",
+                "user" => "frank",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().into()),
+                "message" => "GET /apache_pb.gif HTTP/1.0",
+                "method" => "GET",
+                "path" => "/apache_pb.gif",
+                "protocol" => "HTTP/1.0",
+                "status" => 200,
+                "size" => 2326,
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        combined_line_valid {
+            args: func_args![value: r#"224.92.49.50 bob frank [25/Feb/2021:12:44:08 +0000] "PATCH /one-to-one HTTP/1.1" 401 84170 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0""#,
+                             format: "combined"
+                             ],
+            want: Ok(btreemap! {
+                "host" => "224.92.49.50",
+                "identity" => "bob",
+                "user" => "frank",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-02-25T12:44:08Z").unwrap().into()),
+                "message" => "PATCH /one-to-one HTTP/1.1",
+                "method" => "PATCH",
+                "path" => "/one-to-one",
+                "protocol" => "HTTP/1.1",
+                "status" => 401,
+                "size" => 84170,
+                "referrer" => "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth",
+                "agent" => "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0",
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        combined_line_missing_fields_valid {
+            args: func_args![value: r#"224.92.49.50 bob frank [25/Feb/2021:12:44:08 +0000] "PATCH /one-to-one HTTP/1.1" 401 84170 - -"#,
+                             format: "combined"
+                             ],
+            want: Ok(btreemap! {
+                "host" => "224.92.49.50",
+                "identity" => "bob",
+                "user" => "frank",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-02-25T12:44:08Z").unwrap().into()),
+                "message" => "PATCH /one-to-one HTTP/1.1",
+                "method" => "PATCH",
+                "path" => "/one-to-one",
+                "protocol" => "HTTP/1.1",
+                "status" => 401,
+                "size" => 84170,
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        error_line_valid {
+            args: func_args![value: r#"[Mon Mar 01 12:00:19 2021] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
+                             timestamp_format: "%a %b %d %H:%M:%S %Y",
+                             format: "error"
+                             ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-03-01T12:00:19Z").unwrap().into()),
+                "message" => "I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!",
+                "module" => "ab",
+                "severity" => "alert",
+                "pid" => 4803,
+                "thread" => "3814",
+                "client" => "147.159.108.175",
+                "port" => 24259
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+
+
+        /*
+        log_line_valid_empty {
+            args: func_args![value: "- - - - - - -"],
+            want: Ok(btreemap! {}),
+            tdef: TypeDef::new().fallible.object(type_def()),
+        }
+
+        log_line_valid_empty_variant {
+            args: func_args![value: r#"- - - [-] "-" - -"#],
+            want: Ok(btreemap! {}),
+            tdef: TypeDef::new().fallible.object(type_def()),
+        }
+        */
+
+        /*
+        log_line_valid_with_timestamp_format {
+            args: {
+                let mut args = func_args![value: r#"- - - [2000-10-10T20:55:36Z] "-" - -"#];
+                args.insert(
+                    "timestamp_format",
+                    expression::Argument::new(
+                        Box::new(Literal::from("%+").into()),
+                        |_| true,
+                        "timestamp_format",
+                        "parse_common_log",
+                    )
+                    .into(),
+                );
+                args
+            },
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().into()),
+            }),
+            tdef: TypeDef::new().fallible.object(type_def()),
+        }
+        */
+
+        /*
+        log_line_invalid {
+            args: func_args![value: r#"not a common log line"#],
+            want: Err("function call error: failed parsing common log line"),
+            tdef: TypeDef::new().fallible.object(type_def()),
+        }
+
+        log_line_invalid_timestamp {
+            args: func_args![value: r#"- - - [1234] - - -"#],
+            want: Err("function call error: failed parsing timestamp 1234 using format %d/%b/%Y:%T %z: input contains invalid characters"),
+            tdef: TypeDef::new().fallible.object(type_def()),
+        }
+        */
+    ];
+}

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -95,7 +95,7 @@ impl Expression for ParseApacheLogFn {
             b"common" => &*log_util::REGEX_APACHE_COMMON_LOG,
             b"combined" => &*log_util::REGEX_APACHE_COMBINED_LOG,
             b"error" => &*log_util::REGEX_APACHE_ERROR_LOG,
-            _ => panic!(),
+            _ => unreachable!(),
         };
 
         let captures = regex

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -34,7 +34,10 @@ impl Function for ParseApacheLog {
         let variants = vec![value!("common"), value!("combined"), value!("error")];
 
         let value = arguments.required("value");
-        let format = arguments.required_enum("format", &variants)?.unwrap_bytes();
+        let format = arguments
+            .required_enum("format", &variants)?
+            .try_bytes()
+            .expect("format not bytes");
 
         let timestamp_format = arguments.optional("timestamp_format");
 

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -85,7 +85,7 @@ struct ParseApacheLogFn {
 impl Expression for ParseApacheLogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let bytes = self.value.resolve(ctx)?;
-        let message = bytes.try_bytes_utf8_lossy().unwrap();
+        let message = bytes.try_bytes_utf8_lossy()?;
         let timestamp_format = match &self.timestamp_format {
             None => "%d/%b/%Y:%T %z".to_owned(),
             Some(timestamp_format) => timestamp_format

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -54,21 +54,21 @@ impl Function for ParseApacheLog {
                 title: "parse apache common log",
                 source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326', "common"))"#,
                 result: Ok(
-                    indoc! {r#"s'{"host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
+                    r#"s'{"host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#,
                 ),
             },
             Example {
                 title: "parse apache combined log",
                 source: r#"encode_json(parse_apache_log!(s'127.0.0.1 bob frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth" "Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0"', "combined"))"#,
                 result: Ok(
-                    indoc! {r#"s'{"agent":"Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0","host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","referrer":"http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#},
+                    r#"s'{"agent":"Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/1945-10-12 Firefox/37.0","host":"127.0.0.1","identity":"bob","message":"GET /apache_pb.gif HTTP/1.0","method":"GET","path":"/apache_pb.gif","protocol":"HTTP/1.0","referrer":"http://www.seniorinfomediaries.com/vertical/channels/front-end/bandwidth","size":2326,"status":200,"timestamp":"2000-10-10T20:55:36+00:00","user":"frank"}'"#,
                 ),
             },
             Example {
                 title: "parse apache error log",
                 source: r#"encode_json(parse_apache_log!(s'[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client 147.159.108.175:24259] I will bypass the haptic COM bandwidth, that should matrix the CSS driver!', "error"))"#,
                 result: Ok(
-                    indoc! {r#"s'{"client":"147.159.108.175","message":"I will bypass the haptic COM bandwidth, that should matrix the CSS driver!","module":"ab","pid":4803,"port":24259,"severity":"alert","thread":"3814","timestamp":"2021-03-01T12:00:19+00:00"}'"#},
+                    r#"s'{"client":"147.159.108.175","message":"I will bypass the haptic COM bandwidth, that should matrix the CSS driver!","module":"ab","pid":4803,"port":24259,"severity":"alert","thread":"3814","timestamp":"2021-03-01T12:00:19+00:00"}'"#,
                 ),
             },
         ]

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -85,7 +85,7 @@ struct ParseApacheLogFn {
 impl Expression for ParseApacheLogFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let bytes = self.value.resolve(ctx)?;
-        let message = bytes.try_bytes_utf8_lossy()?;
+        let message = bytes.try_bytes_utf8_lossy().unwrap();
         let timestamp_format = match &self.timestamp_format {
             None => "%d/%b/%Y:%T %z".to_owned(),
             Some(timestamp_format) => timestamp_format

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -1,33 +1,6 @@
-use chrono::DateTime;
-use lazy_static::lazy_static;
-use regex::Regex;
+use crate::log_util;
 use std::collections::BTreeMap;
 use vrl::prelude::*;
-
-lazy_static! {
-    // Information about the common log format taken from the
-    // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
-    // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
-    static ref REGEX_COMMON_LOG: Regex = Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<message>(                           # Match a request with...
-        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
-        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
-        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
-        |[[\\"][^"]]*?))\s*))"                  # ...Or match any charater except `"`, but `\"`, and any amount of whitespaces.
-        )\s+                                    # Match at least one whitespace.
-        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
-        (-|(?P<size>\d+))                       # Match `-` or at least one digit.
-        \s*$                                    # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for common log");
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseCommonLog;
@@ -91,71 +64,16 @@ impl Expression for ParseCommonLogFn {
                 .to_string(),
         };
 
-        let mut log: BTreeMap<String, Value> = BTreeMap::new();
-
-        let captures = REGEX_COMMON_LOG
+        let captures = log_util::REGEX_APACHE_COMMON_LOG
             .captures(&message)
             .ok_or("failed parsing common log line")?;
 
-        if let Some(host) = captures.name("host").map(|capture| capture.as_str()) {
-            log.insert("host".into(), Value::Bytes(host.to_owned().into()));
-        }
-
-        if let Some(identity) = captures.name("identity").map(|capture| capture.as_str()) {
-            log.insert("identity".into(), Value::Bytes(identity.to_owned().into()));
-        }
-
-        if let Some(user) = captures.name("user").map(|capture| capture.as_str()) {
-            log.insert("user".into(), Value::Bytes(user.to_owned().into()));
-        }
-
-        if let Some(timestamp) = captures.name("timestamp").map(|capture| capture.as_str()) {
-            log.insert(
-                "timestamp".into(),
-                Value::Timestamp(
-                    DateTime::parse_from_str(timestamp, &timestamp_format)
-                        .map_err(|error| {
-                            format!(
-                                r#"failed parsing timestamp {} using format {}: {}"#,
-                                timestamp, timestamp_format, error
-                            )
-                        })?
-                        .into(),
-                ),
-            );
-        }
-
-        if let Some(message) = captures.name("message").map(|capture| capture.as_str()) {
-            log.insert("message".into(), Value::Bytes(message.to_owned().into()));
-        }
-
-        if let Some(method) = captures.name("method").map(|capture| capture.as_str()) {
-            log.insert("method".into(), Value::Bytes(method.to_owned().into()));
-        }
-
-        if let Some(path) = captures.name("path").map(|capture| capture.as_str()) {
-            log.insert("path".into(), Value::Bytes(path.to_owned().into()));
-        }
-
-        if let Some(protocol) = captures.name("protocol").map(|capture| capture.as_str()) {
-            log.insert("protocol".into(), Value::Bytes(protocol.to_owned().into()));
-        }
-
-        if let Some(status) = captures.name("status").map(|capture| capture.as_str()) {
-            log.insert(
-                "status".into(),
-                Value::Integer(status.parse().map_err(|_| "failed parsing status code")?),
-            );
-        }
-
-        if let Some(size) = captures.name("size").map(|capture| capture.as_str()) {
-            log.insert(
-                "size".into(),
-                Value::Integer(size.parse().map_err(|_| "failed parsing content length")?),
-            );
-        }
-
-        Ok(log.into())
+        log_util::log_fields(
+            &log_util::REGEX_APACHE_COMMON_LOG,
+            &captures,
+            &timestamp_format,
+        )
+        .map_err(Into::into)
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -178,10 +96,10 @@ fn type_def() -> BTreeMap<&'static str, TypeDef> {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::prelude::*;
     use shared::btreemap;
 
     test_function![
@@ -201,69 +119,41 @@ mod tests {
                 "status" => 200,
                 "size" => 2326,
             }),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
 
         log_line_valid_empty {
             args: func_args![value: "- - - - - - -"],
             want: Ok(btreemap! {}),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
 
         log_line_valid_empty_variant {
             args: func_args![value: r#"- - - [-] "-" - -"#],
             want: Ok(btreemap! {}),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
 
         log_line_valid_with_timestamp_format {
-            args: {
-                let mut args = func_args![value: r#"- - - [2000-10-10T20:55:36Z] "-" - -"#];
-                args.insert(
-                    "timestamp_format",
-                    expression::Argument::new(
-                        Box::new(Literal::from("%+").into()),
-                        |_| true,
-                        "timestamp_format",
-                        "parse_common_log",
-                    )
-                    .into(),
-                );
-                args
-            },
+            args: func_args![value: r#"- - - [2000-10-10T20:55:36Z] "-" - -"#,
+                             timestamp_format: "%+",
+            ],
             want: Ok(btreemap! {
                 "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2000-10-10T20:55:36Z").unwrap().into()),
             }),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
 
         log_line_invalid {
             args: func_args![value: r#"not a common log line"#],
-            want: Err("function call error: failed parsing common log line"),
+            want: Err("failed parsing common log line"),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
 
         log_line_invalid_timestamp {
             args: func_args![value: r#"- - - [1234] - - -"#],
-            want: Err("function call error: failed parsing timestamp 1234 using format %d/%b/%Y:%T %z: input contains invalid characters"),
-        }
-    ];
-
-    test_type_def![
-        value_string {
-            expr: |_| ParseCommonLogFn { value: Literal::from("foo").boxed(), timestamp_format: None },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, inner_type_def: Some(inner_type_def()) },
-        }
-
-        value_non_string {
-            expr: |_| ParseCommonLogFn { value: Literal::from(1).boxed(), timestamp_format: None },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, inner_type_def: Some(inner_type_def()) },
-        }
-
-        timestamp_format_string {
-            expr: |_| ParseCommonLogFn { value: Literal::from("foo").boxed(), timestamp_format: Some(Literal::from("foo").boxed()) },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, inner_type_def: Some(inner_type_def()) },
-        }
-
-        timestamp_format_non_string {
-            expr: |_| ParseCommonLogFn { value: Literal::from("foo").boxed(), timestamp_format: Some(Literal::from(1).boxed()) },
-            def: TypeDef { fallible: true, kind: value::Kind::Map, inner_type_def: Some(inner_type_def()) },
+            want: Err("failed parsing timestamp 1234 using format %d/%b/%Y:%T %z: input contains invalid characters"),
+            tdef: TypeDef::new().fallible().object(type_def()),
         }
     ];
 }
-*/


### PR DESCRIPTION
Closes #5369 

This adds the `parse_apache_log` remap function. We can parse common, combined or default error formats.

It is possible to customise the error log format in apache. This function doesn't cater for that.

The common format is exactly the same as the already existing `parse_common_log` function that we have.  This pr factors that code out into a shared module, so both functions call the same code.