### PR TITLE
chore(releasing): Slightly fiddle with release build options, container paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["default-no-api-client"]
 [profile.release]
 lto = true        # Optimize our binary at link stage.
 codegen-units = 1 # Increases compile time but improves optmization alternatives.
-debug = true      # Include debug symbols in the executable, benefits tooling.
+debug = false     # Do not include debug symbols in the executable.
 opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ path = "src/api/schema/gen.rs"
 required-features = ["default-no-api-client"]
 
 [profile.release]
-lto = true
-codegen-units = 1
+lto = true        # Optimize our binary at link stage.
+codegen-units = 1 # Increases compile time but improves optmization alternatives.
+debug = true      # Include debug symbols in the executable, benefits tooling.
+opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ required-features = ["default-no-api-client"]
 lto = true        # Optimize our binary at link stage.
 codegen-units = 1 # Increases compile time but improves optmization alternatives.
 debug = false     # Do not include debug symbols in the executable.
-opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
 
 [profile.bench]
 debug = true

--- a/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
@@ -1,1 +1,1 @@
-FROM rustembedded/cross:aarch64-unknown-linux-gnu
+FROM docker.io/rustembedded/cross:aarch64-unknown-linux-gnu

--- a/scripts/cross/aarch64-unknown-linux-musl.dockerfile
+++ b/scripts/cross/aarch64-unknown-linux-musl.dockerfile
@@ -1,1 +1,1 @@
-FROM rustembedded/cross:aarch64-unknown-linux-musl
+FROM docker.io/rustembedded/cross:aarch64-unknown-linux-musl

--- a/scripts/cross/armv7-unknown-linux-musleabihf.dockerfile
+++ b/scripts/cross/armv7-unknown-linux-musleabihf.dockerfile
@@ -1,1 +1,1 @@
-FROM rustembedded/cross:armv7-unknown-linux-musleabihf
+FROM docker.io/rustembedded/cross:armv7-unknown-linux-musleabihf

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,1 +1,1 @@
-FROM rustembedded/cross:x86_64-unknown-linux-gnu
+FROM docker.io/rustembedded/cross:x86_64-unknown-linux-gnu

--- a/scripts/cross/x86_64-unknown-linux-musl.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-musl.dockerfile
@@ -1,1 +1,1 @@
-FROM rustembedded/cross:x86_64-unknown-linux-musl
+FROM docker.io/rustembedded/cross:x86_64-unknown-linux-musl


### PR DESCRIPTION
This commit documents the release build options in `Cargo.toml` without 
changing them. It also sets the container paths for builds to absolute paths, 
resolving a build issue on my strict podman install. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
