### PR TITLE
chore(observability): Expand rate limit to additional keys

### DIFF
--- a/lib/tracing-limit/examples/by_span.rs
+++ b/lib/tracing-limit/examples/by_span.rs
@@ -18,18 +18,22 @@ fn main() {
         for i in 0..40 {
             trace!("This field is not rate limited!");
             for key in &["foo", "bar"] {
-                let span = info_span!(
-                    "sink",
-                    component_kind = "sink",
-                    component_name = &key,
-                    component_type = "fake",
-                );
-                let _enter = span.enter();
-                info!(
-                    message = "This message is rate limited by its component",
-                    count = &i,
-                    internal_log_rate_secs = 5,
-                );
+                for line_number in &[1, 2] {
+                    let span = info_span!(
+                        "sink",
+                        component_kind = "sink",
+                        component_name = &key,
+                        component_type = "fake",
+                        vrl_line_number = &line_number,
+                    );
+                    let _enter = span.enter();
+                    info!(
+                        message =
+                            "This message is rate limited by its component and vrl_line_number",
+                        count = &i,
+                        internal_log_rate_secs = 5,
+                    );
+                }
             }
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -1,6 +1,5 @@
 use dashmap::DashMap;
-use std::fmt;
-use std::time::Instant;
+use std::{fmt, time::Instant};
 use tracing_core::{
     callsite::Identifier,
     field::{display, Field, Value, Visit},
@@ -15,13 +14,16 @@ use tracing_subscriber::layer::{Context, Layer};
 extern crate tracing;
 
 const RATE_LIMIT_SECS_FIELD: &str = "internal_log_rate_secs";
-const COMPONENT_NAME_FIELD: &str = "component_name";
 const MESSAGE_FIELD: &str = "message";
+
+/// Keys in RATE_LIMIT_SPAN_GROUPS will cause events to be independently rate limited by the values
+/// for these keys
+const RATE_LIMIT_SPAN_GROUPS: &[&str] = &["component_name", "vrl_line_number", "vrl_position"];
 
 #[derive(Eq, PartialEq, Hash, Clone)]
 struct RateKeyIdentifier {
     callsite: Identifier,
-    component_name: Option<String>,
+    rate_limit_key_values: Vec<(String, TraceValue)>,
 }
 
 pub struct RateLimitedLayer<S, L>
@@ -115,23 +117,27 @@ where
         let mut limit_visitor = LimitVisitor::default();
         event.record(&mut limit_visitor);
 
-        let component_name = {
-            let mut scope = ctx
+        let rate_limit_key_values = {
+            let scope = ctx
                 .lookup_current()
                 .into_iter()
                 .flat_map(|span| span.from_root().chain(std::iter::once(span)));
 
-            scope.find_map(|span| {
-                let extensions = span.extensions();
-                extensions
-                    .get::<RateLimitedSpanKeys>()
-                    .and_then(|fields| fields.component_name.clone())
+            scope.fold(vec![], |mut acc, span| {
+                let mut extensions = span.extensions_mut();
+                acc.append(
+                    &mut extensions
+                        .get_mut::<RateLimitedSpanKeys>()
+                        .map(|fields| std::mem::take(&mut fields.values))
+                        .unwrap_or_default(),
+                );
+                acc
             })
         };
 
         let id = RateKeyIdentifier {
             callsite: metadata.callsite(),
-            component_name,
+            rate_limit_key_values,
         };
 
         let mut state = self.events.entry(id).or_insert(State {
@@ -256,22 +262,74 @@ fn is_limited(metadata: &Metadata<'_>) -> bool {
         .any(|f| f.name() == RATE_LIMIT_SECS_FIELD)
 }
 
+#[derive(PartialEq, Eq, Clone, Hash)]
+enum TraceValue {
+    String(String),
+    Int(i64),
+    Uint(u64),
+    Bool(bool),
+}
+
+impl From<bool> for TraceValue {
+    fn from(b: bool) -> Self {
+        TraceValue::Bool(b)
+    }
+}
+
+impl From<i64> for TraceValue {
+    fn from(i: i64) -> Self {
+        TraceValue::Int(i)
+    }
+}
+
+impl From<u64> for TraceValue {
+    fn from(u: u64) -> Self {
+        TraceValue::Uint(u)
+    }
+}
+
+impl From<String> for TraceValue {
+    fn from(s: String) -> Self {
+        TraceValue::String(s)
+    }
+}
+
 /// RateLimitedSpanKeys records span keys that we use to rate limit callsites separately by. For
 /// example, if a given trace callsite is called from two different components, then they will be
 /// rate limited separately.
 #[derive(Default)]
 struct RateLimitedSpanKeys {
-    pub component_name: Option<String>,
+    pub values: Vec<(String, TraceValue)>,
+}
+
+impl RateLimitedSpanKeys {
+    fn record(&mut self, field: &Field, value: TraceValue) {
+        if RATE_LIMIT_SPAN_GROUPS.contains(&field.name()) {
+            self.values.push((field.name().to_owned(), value));
+        }
+    }
 }
 
 impl Visit for RateLimitedSpanKeys {
-    fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == COMPONENT_NAME_FIELD {
-            self.component_name = Some(value.to_string());
-        }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record(field, value.into());
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record(field, value.into());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record(field, value.into());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, value.to_owned().into());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record(field, format!("{:?}", value).into());
+    }
 }
 
 #[derive(Default)]
@@ -387,7 +445,7 @@ mod test {
     }
 
     #[test]
-    fn rate_limit_by_component_name() {
+    fn rate_limit_by_span_key() {
         let events: Arc<Mutex<Vec<String>>> = Default::default();
 
         let recorder = RecordingLayer::new(Arc::clone(&events));
@@ -396,12 +454,19 @@ mod test {
         tracing::subscriber::with_default(sub, || {
             for _ in 0..21 {
                 for key in &["foo", "bar"] {
-                    let span = info_span!("span", component_name = &key);
-                    let _enter = span.enter();
-                    info!(
-                        message = format!("Hello {}!", key).as_str(),
-                        internal_log_rate_secs = 1
-                    );
+                    for line_number in &[1, 2] {
+                        let span = info_span!(
+                            "span",
+                            component_name = &key,
+                            vrl_line_number = &line_number
+                        );
+                        let _enter = span.enter();
+                        info!(
+                            message =
+                                format!("Hello {} on line_number {}!", key, line_number).as_str(),
+                            internal_log_rate_secs = 1
+                        );
+                    }
                 }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
@@ -414,20 +479,34 @@ mod test {
         assert_eq!(
             *events,
             vec![
-                "Hello foo!",
-                "Hello bar!",
-                "Internal log [Hello foo!] is being rate limited.",
-                "Internal log [Hello bar!] is being rate limited.",
-                "Internal log [Hello foo!] has been rate limited 9 times.",
-                "Hello foo!",
-                "Internal log [Hello bar!] has been rate limited 9 times.",
-                "Hello bar!",
-                "Internal log [Hello foo!] is being rate limited.",
-                "Internal log [Hello bar!] is being rate limited.",
-                "Internal log [Hello foo!] has been rate limited 9 times.",
-                "Hello foo!",
-                "Internal log [Hello bar!] has been rate limited 9 times.",
-                "Hello bar!",
+                "Hello foo on line_number 1!",
+                "Hello foo on line_number 2!",
+                "Hello bar on line_number 1!",
+                "Hello bar on line_number 2!",
+                "Internal log [Hello foo on line_number 1!] is being rate limited.",
+                "Internal log [Hello foo on line_number 2!] is being rate limited.",
+                "Internal log [Hello bar on line_number 1!] is being rate limited.",
+                "Internal log [Hello bar on line_number 2!] is being rate limited.",
+                "Internal log [Hello foo on line_number 1!] has been rate limited 9 times.",
+                "Hello foo on line_number 1!",
+                "Internal log [Hello foo on line_number 2!] has been rate limited 9 times.",
+                "Hello foo on line_number 2!",
+                "Internal log [Hello bar on line_number 1!] has been rate limited 9 times.",
+                "Hello bar on line_number 1!",
+                "Internal log [Hello bar on line_number 2!] has been rate limited 9 times.",
+                "Hello bar on line_number 2!",
+                "Internal log [Hello foo on line_number 1!] is being rate limited.",
+                "Internal log [Hello foo on line_number 2!] is being rate limited.",
+                "Internal log [Hello bar on line_number 1!] is being rate limited.",
+                "Internal log [Hello bar on line_number 2!] is being rate limited.",
+                "Internal log [Hello foo on line_number 1!] has been rate limited 9 times.",
+                "Hello foo on line_number 1!",
+                "Internal log [Hello foo on line_number 2!] has been rate limited 9 times.",
+                "Hello foo on line_number 2!",
+                "Internal log [Hello bar on line_number 1!] has been rate limited 9 times.",
+                "Hello bar on line_number 1!",
+                "Internal log [Hello bar on line_number 2!] has been rate limited 9 times.",
+                "Hello bar on line_number 2!",
             ]
             .into_iter()
             .map(std::borrow::ToOwned::to_owned)


### PR DESCRIPTION
This expands the support for independently rate limiting based on
component_name in span keys to additional keys useful for VRL rate
limiting: `vrl_line_number` and `vrl_position`.

I had originally wanted to have the trace line specify these keys, like:

```
info!("hello", internal_log_rate_secs = 5, internal_log_rate_group_by = ["vrl_line_number"])
```

But tracing doesn't permit lists to be passed through (`tracing::Value`
has no `Vec` or similar implementations:
https://docs.rs/tracing/0.1.25/tracing/trait.Value.html).

So, instead, I just added it as another globally grouped key for now. We
can see how this evolves if we need to additional keys, it might be
worth revisiting how this is structured.

I benchmarked this vs. master using the benchmark mentioned here: again and saw:

master:

```
➜  vector git:(master) perf stat -r 10 bash -c 'yes "invalid json" | head -n 1000000 | ./target/release/vector --config /tmp/perf.toml > /dev/null'

 Performance counter stats for 'bash -c yes "invalid json" | head -n 1000000 | ./target/release/vector --config /tmp/perf.toml > /dev/null' (10 runs):

     176289.620874      task-clock:u (msec)       #    7.160 CPUs utilized            ( +-  0.28% )
                 0      context-switches:u        #    0.000 K/sec
                 0      cpu-migrations:u          #    0.000 K/sec
              6681      page-faults:u             #    0.038 K/sec                    ( +-  0.93% )
   <not supported>      cycles:u
   <not supported>      instructions:u
   <not supported>      branches:u
   <not supported>      branch-misses:u

      24.621407847 seconds time elapsed                                          ( +-  0.28% )
```

PR:

```
 Performance counter stats for 'bash -c yes "invalid json" | head -n 1000000 | ./target/release/vector-2f88d8565 --config /tmp/perf.toml > /dev/null' (10 runs):

     178659.142634      task-clock:u (msec)       #    7.175 CPUs utilized            ( +-  0.41% )
                 0      context-switches:u        #    0.000 K/sec
                 0      cpu-migrations:u          #    0.000 K/sec
              6674      page-faults:u             #    0.037 K/sec                    ( +-  0.65% )
   <not supported>      cycles:u
   <not supported>      instructions:u
   <not supported>      branches:u
   <not supported>      branch-misses:u

      24.898682925 seconds time elapsed                                          ( +-  0.42% )
```

This does show a slight difference but I think an acceptable one. The change was somewhat expected given the additional complexity of finding and building the rate limit key identifiers. I welcome thoughts for improving it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
