### PR TITLE
chore(performance): small enhancements to vrl function bench output

### DIFF
--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -44,8 +44,10 @@ macro_rules! func_args {
 macro_rules! bench_function {
     ($name:tt => $func:path; $($case:ident { args: $args:expr, want: $(Ok($ok:expr))? $(Err($err:expr))? $(,)* })+) => {
         fn $name(c: &mut criterion::Criterion) {
+            let mut group = c.benchmark_group(&format!("remap-functions/{}", stringify!($name)));
+            group.throughput(criterion::Throughput::Elements(1));
             $(
-                c.bench_function(&format!("{}: {}", stringify!($name), stringify!($case)), |b| {
+                group.bench_function(&format!("{}", stringify!($case)), |b| {
                     let (expression, want) = $crate::__prep_bench_or_test!($func, $args, $(Ok($crate::Value::from($ok)))? $(Err($err.to_owned()))?);
                     let mut compiler_state = $crate::state::Compiler::default();
                     let mut runtime_state = $crate::state::Runtime::default();


### PR DESCRIPTION
I had originally made these in
https://github.com/timberio/vector/pull/6408 but lost them somewhere
along the way in bad merge of master.

This adds throughput measurements to the vrl benches and reformats their
output to use `/`s for namespacing similar to how criterion does it
natively.

`remap-functions` is prepended to namespace all of the remap function benches.

Output now looks like:

```
remap-functions/ceil/literal
                        time:   [110.08 ns 110.26 ns 110.43 ns]
                        thrpt:  [9.0552 Melem/s 9.0696 Melem/s 9.0842 Melem/s]
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
