### PR TITLE
enhancement(http source): URL path configuration flexibility, path also exposed as a new field

### DIFF
--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -123,6 +123,11 @@ components: sources: http: {
 					}
 				}
 				timestamp: fields._current_timestamp
+				vector_http_path: {
+					description: "The HTTP path the event was received from."
+					required:     false
+					type: string: examples: ["/event/foo"]
+				}
 			}
 		}
 		structured: {
@@ -136,6 +141,11 @@ components: sources: http: {
 					type: "*": {}
 				}
 				timestamp: fields._current_timestamp
+				vector_http_path: {
+					description: "The HTTP path the event was received from."
+					required:     false
+					type: string: examples: ["/event/foo"]
+				}
 			}
 		}
 	}

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -123,7 +123,7 @@ components: sources: http: {
 				If set to true only request using the exact URL path specified in path will be accepted,
 				else event log sent to a URL path that starts with the value of path will be accepted.
 				With strict_path set to false and path set to \"/\" the configured HTTP source will
-				accept log events from any URL path. 
+				accept log events from any URL path.
 				"""
 			required: false
 			type: bool: default: true
@@ -188,7 +188,7 @@ components: sources: http: {
 
 	examples: [
 		{
-			_path:   "/"
+			_path:       "/"
 			_line:       "Hello world"
 			_user_agent: "my-service/v2.1"
 			title:       "text/plain"
@@ -219,7 +219,7 @@ components: sources: http: {
 			}]
 		},
 		{
-			_path:   "/events"
+			_path:       "/events"
 			_path_key:   "vector_http_path"
 			_line:       "{\"key\": \"val\"}"
 			_user_agent: "my-service/v2.1"
@@ -229,7 +229,7 @@ components: sources: http: {
 				address:  "0.0.0.0:\(_port)"
 				encoding: "json"
 				headers: ["User-Agent"]
-				_path: _path
+				_path:    _path
 				path_key: _path_key
 			}
 			input: """

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -107,7 +107,7 @@ components: sources: http: {
 				}
 			}
 		}
-		url_path: {
+		path: {
 			common:      false
 			description: "The URL path on which log event POST request shall be sent."
 			required:    false
@@ -118,14 +118,14 @@ components: sources: http: {
 			}
 		}
 		strict_path: {
-			common:      false
+			common: false
 			description: """
-				If set to true only request using the exact URL path specified in url_path will be accepted,
-				else event log sent to a URL path that starts with the value of url_path will be accepted.
-				With strict_path sets to false and url_path sets to \"/\" the configured HTTP source will
+				If set to true only request using the exact URL path specified in path will be accepted,
+				else event log sent to a URL path that starts with the value of path will be accepted.
+				With strict_path set to false and path set to \"/\" the configured HTTP source will
 				accept log events from any URL path. 
 				"""
-			required:    false
+			required: false
 			type: bool: default: true
 		}
 		path_key: {
@@ -154,7 +154,7 @@ components: sources: http: {
 				}
 				path: {
 					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
-					required:     true
+					required:    true
 					type: string: {
 						examples: ["/", "/logs/event712"]
 						syntax: "literal"
@@ -175,7 +175,7 @@ components: sources: http: {
 				}
 				path: {
 					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
-					required:     true
+					required:    true
 					type: string: {
 						examples: ["/", "/logs/event712"]
 						syntax: "literal"
@@ -188,7 +188,7 @@ components: sources: http: {
 
 	examples: [
 		{
-			_url_path:   "/"
+			_path:   "/"
 			_line:       "Hello world"
 			_user_agent: "my-service/v2.1"
 			title:       "text/plain"
@@ -200,7 +200,7 @@ components: sources: http: {
 			}
 			input: """
 				```http
-				POST \( _url_path ) HTTP/1.1
+				POST \( _path ) HTTP/1.1
 				Content-Type: text/plain
 				User-Agent: \( _user_agent )
 				X-Forwarded-For: \( _values.local_host )
@@ -213,13 +213,13 @@ components: sources: http: {
 					host:         _values.local_host
 					message:      _line
 					timestamp:    _values.current_timestamp
-					path:         _url_path
+					path:         _path
 					"User-Agent": _user_agent
 				}
 			}]
 		},
 		{
-			_url_path:   "/events"
+			_path:   "/events"
 			_path_key:   "vector_http_path"
 			_line:       "{\"key\": \"val\"}"
 			_user_agent: "my-service/v2.1"
@@ -229,12 +229,12 @@ components: sources: http: {
 				address:  "0.0.0.0:\(_port)"
 				encoding: "json"
 				headers: ["User-Agent"]
-				url_path: _url_path
+				_path: _path
 				path_key: _path_key
 			}
 			input: """
 				```http
-				POST \( _url_path ) HTTP/1.1
+				POST \( _path ) HTTP/1.1
 				Content-Type: application/json
 				User-Agent: \( _user_agent )
 				X-Forwarded-For: \( _values.local_host )
@@ -246,7 +246,7 @@ components: sources: http: {
 					host:         _values.local_host
 					key:          "val"
 					timestamp:    _values.current_timestamp
-					_path_key:    _url_path
+					_path_key:    _path
 					"User-Agent": _user_agent
 				}
 			}]

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -109,7 +109,7 @@ components: sources: http: {
 		}
 		path: {
 			common:      false
-			description: "The URL path on which log event POST request shall be sent."
+			description: "The URL path on which log event POST requests shall be sent."
 			required:    false
 			type: string: {
 				default: "/"
@@ -120,17 +120,17 @@ components: sources: http: {
 		strict_path: {
 			common: false
 			description: """
-				If set to true only request using the exact URL path specified in path will be accepted,
-				else event log sent to a URL path that starts with the value of path will be accepted.
-				With strict_path set to false and path set to \"/\" the configured HTTP source will
-				accept log events from any URL path.
+				If set to `true`, only requests using the exact URL path specified in `path` will be accepted;
+				otherwise requests sent to a URL path that starts with the value of `path` will be accepted.
+				With `strict_path` set to `false` and `path` set to `""`, the configured HTTP source will
+				accept requests from any URL path.
 				"""
 			required: false
 			type: bool: default: true
 		}
 		path_key: {
 			common:      false
-			description: "The event key in which the requested URL path used to send the log event will be stored."
+			description: "The event key in which the requested URL path used to send the request will be stored."
 			required:    false
 			type: string: {
 				default: "path"
@@ -153,7 +153,7 @@ components: sources: http: {
 					}
 				}
 				path: {
-					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
+					description: "The HTTP path the event was received from. The key can be changed using the `path_key` configuration setting"
 					required:    true
 					type: string: {
 						examples: ["/", "/logs/event712"]
@@ -174,7 +174,7 @@ components: sources: http: {
 					type: "*": {}
 				}
 				path: {
-					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
+					description: "The HTTP path the event was received from. The key can be changed using the `path_key` configuration setting"
 					required:    true
 					type: string: {
 						examples: ["/", "/logs/event712"]

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -107,8 +107,38 @@ components: sources: http: {
 				}
 			}
 		}
+		url_path: {
+			common:      false
+			description: "The URL path on which log event POST request shall be sent."
+			required:    false
+			type: string: {
+				default: "/"
+				examples: ["/event/path", "/logs"]
+				syntax: "literal"
+			}
+		}
+		strict_path: {
+			common:      false
+			description: """
+				If set to true only request using the exact URL path specified in url_path will be accepted,
+				else event log sent to a URL path that starts with the value of url_path will be accepted.
+				With strict_path sets to false and url_path sets to \"/\" the configured HTTP source will
+				accept log events from any URL path. 
+				"""
+			required:    false
+			type: bool: default: true
+		}
+		path_key: {
+			common:      false
+			description: "The event key in which the requested URL path used to send the log event will be stored."
+			required:    false
+			type: string: {
+				default: "path"
+				examples: ["vector_http_path"]
+				syntax: "literal"
+			}
+		}
 	}
-
 	output: logs: {
 		text: {
 			description: "An individual line from a `text/plain` request"
@@ -122,12 +152,15 @@ components: sources: http: {
 						syntax: "literal"
 					}
 				}
-				timestamp: fields._current_timestamp
-				vector_http_path: {
-					description: "The HTTP path the event was received from."
-					required:     false
-					type: string: examples: ["/event/foo"]
+				path: {
+					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
+					required:     true
+					type: string: {
+						examples: ["/", "/logs/event712"]
+						syntax: "literal"
+					}
 				}
+				timestamp: fields._current_timestamp
 			}
 		}
 		structured: {
@@ -140,18 +173,22 @@ components: sources: http: {
 					required:      false
 					type: "*": {}
 				}
-				timestamp: fields._current_timestamp
-				vector_http_path: {
-					description: "The HTTP path the event was received from."
-					required:     false
-					type: string: examples: ["/event/foo"]
+				path: {
+					description: "The HTTP path the event was received from. The key can be changed using the path_key configuration setting"
+					required:     true
+					type: string: {
+						examples: ["/", "/logs/event712"]
+						syntax: "literal"
+					}
 				}
+				timestamp: fields._current_timestamp
 			}
 		}
 	}
 
 	examples: [
 		{
+			_url_path:   "/"
 			_line:       "Hello world"
 			_user_agent: "my-service/v2.1"
 			title:       "text/plain"
@@ -162,24 +199,28 @@ components: sources: http: {
 				headers: ["User-Agent"]
 			}
 			input: """
-             ```http
-             Content-Type: text/plain
-             User-Agent: \( _user_agent )
-             X-Forwarded-For: \( _values.local_host )
+				```http
+				POST \( _url_path ) HTTP/1.1
+				Content-Type: text/plain
+				User-Agent: \( _user_agent )
+				X-Forwarded-For: \( _values.local_host )
 
-             \( _line )
-             ```
-             """
+				\( _line )
+				```
+				"""
 			output: [{
 				log: {
 					host:         _values.local_host
 					message:      _line
 					timestamp:    _values.current_timestamp
+					path:         _url_path
 					"User-Agent": _user_agent
 				}
 			}]
 		},
 		{
+			_url_path:   "/events"
+			_path_key:   "vector_http_path"
 			_line:       "{\"key\": \"val\"}"
 			_user_agent: "my-service/v2.1"
 			title:       "application/json"
@@ -188,21 +229,24 @@ components: sources: http: {
 				address:  "0.0.0.0:\(_port)"
 				encoding: "json"
 				headers: ["User-Agent"]
+				url_path: _url_path
+				path_key: _path_key
 			}
 			input: """
-             ```http
-             Content-Type: application/json
-             User-Agent: \( _user_agent )
-             X-Forwarded-For: \( _values.local_host )
-
-             \( _line )
-             ```
-             """
+				```http
+				POST \( _url_path ) HTTP/1.1
+				Content-Type: application/json
+				User-Agent: \( _user_agent )
+				X-Forwarded-For: \( _values.local_host )
+				\( _line )
+				```
+				"""
 			output: [{
 				log: {
 					host:         _values.local_host
 					key:          "val"
 					timestamp:    _values.current_timestamp
+					_path_key:    _url_path
 					"User-Agent": _user_agent
 				}
 			}]

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -62,6 +62,7 @@ impl HttpSource for LogplexSource {
         body: Bytes,
         header_map: HeaderMap,
         query_parameters: HashMap<String, String>,
+        _full_path: &str,
     ) -> Result<Vec<Event>, ErrorMessage> {
         decode_message(body, header_map)
             .map(|events| add_query_parameters(events, &self.query_parameters, query_parameters))

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -82,7 +82,15 @@ impl SourceConfig for LogplexConfig {
         let source = LogplexSource {
             query_parameters: self.query_parameters.clone(),
         };
-        source.run(self.address, "events", &self.tls, &self.auth, out, shutdown)
+        source.run(
+            self.address,
+            "events",
+            true,
+            &self.tls,
+            &self.auth,
+            out,
+            shutdown,
+        )
     }
 
     fn output_type(&self) -> DataType {

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -1,6 +1,8 @@
 use crate::{
-    config::{log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
-        SourceDescription},
+    config::{
+        log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
+        SourceDescription,
+    },
     event::{Event, Value},
     shutdown::ShutdownSignal,
     sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -756,7 +756,7 @@ mod tests {
         .await;
 
         assert_eq!(
-            405,
+            404,
             send_with_path(addr, "{\"key1\":\"value1\"}", "/event/path").await
         );
     }

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -54,7 +54,7 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
         out: Pipeline,
     ) -> crate::Result<sources::Source> {
         let source = RemoteWriteSource;
-        source.run(self.address, "", &self.tls, &self.auth, out, shutdown)
+        source.run(self.address, "", true, &self.tls, &self.auth, out, shutdown)
     }
 
     fn output_type(&self) -> crate::config::DataType {
@@ -95,6 +95,7 @@ impl HttpSource for RemoteWriteSource {
         mut body: Bytes,
         header_map: HeaderMap,
         _query_parameters: HashMap<String, String>,
+        _full_path: &str,
     ) -> Result<Vec<Event>, ErrorMessage> {
         // If `Content-Encoding` header isn't `snappy` HttpSource won't decode it for us
         // se we need to.

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -211,7 +211,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                         debug!(message = "Path rejected.");
                         Err(warp::reject::custom(
                             ErrorMessage::new(StatusCode::NOT_FOUND,
-                            StatusCode::NOT_FOUND.canonical_reason().unwrap().to_string())
+                            "Not found".to_string())
                         ))
                     }
                 }).untuple_one()

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -180,13 +180,14 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         body: Bytes,
         header_map: HeaderMap,
         query_parameters: HashMap<String, String>,
-        full_path: &str,
+        path: &str,
     ) -> Result<Vec<Event>, ErrorMessage>;
 
     fn run(
         self,
         address: SocketAddr,
-        path: &'static str,
+        path: &str,
+        strict_path: bool,
         tls: &Option<TlsConfig>,
         auth: &Option<HttpSourceAuthConfig>,
         out: Pipeline,
@@ -194,14 +195,16 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
     ) -> crate::Result<crate::sources::Source> {
         let tls = MaybeTlsSettings::from_config(tls, true)?;
         let auth = HttpSourceAuth::try_from(auth.as_ref())?;
+        let path = path.to_owned();
         Ok(Box::pin(async move {
             let span = crate::trace::current_span();
-
             let mut filter: BoxedFilter<()> = warp::post().boxed();
-            if !path.is_empty() && path != "/" {
-                for s in path.split('/') {
-                    filter = filter.and(warp::path(s)).boxed();
-                }
+            for s in path.split('/').filter(|&x| !x.is_empty()) {
+                filter = filter.and(warp::path(s.to_string())).boxed()
+            }
+            if strict_path {
+                debug!(message = "Strict path enabled.");
+                filter = filter.and(warp::path::end()).boxed();
             }
             let svc = filter
                 .and(warp::path::full())


### PR DESCRIPTION
Closes #5112 

Add three options to the http source:
* `url_path`: the path where log event should be posted (default: /)
* `path_key`: the name of the key used to export the path for each log even (default: path)
* `strict_path`: whether strict path should be enforce, if true only event send to the exact url_path will be accepted, if false log sent to a path that start with the value of url_path will be accepted

For example:
```
url_path: "/events"
strict_path: false
```

Will accept events posted to "/events/1234" and "/events/5678".

Outside the http source there is no behaviour change.

Open question: should we accept all URLs for the `heroku_logs` source as it would allow a user to send logs from multiple app to the same source.