### PR TITLE
fix(remap): allow uppercase and underscores in identifiers.

### DIFF
--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -500,10 +500,13 @@ impl<'input> Iterator for Lexer<'input> {
                     ':' => Some(Ok(self.token(start, Colon))),
                     ',' => Some(Ok(self.token(start, Comma))),
 
-                    '_' if self.test_peek(char::is_alphabetic) => {
+                    '_' if !self.test_peek(is_ident_continue) => {
+                        Some(Ok(self.token(start, Underscore)))
+                    }
+
+                    '?' if self.test_peek(char::is_alphabetic) => {
                         Some(Ok(self.internal_test(start)))
                     }
-                    '_' => Some(Ok(self.token(start, Underscore))),
 
                     '!' if self.test_peek(|ch| ch == '!' || !is_operator(ch)) => {
                         Some(Ok(self.token(start, Bang)))
@@ -1073,12 +1076,12 @@ impl<'input> Lexer<'input> {
 // -----------------------------------------------------------------------------
 
 fn is_ident_start(ch: char) -> bool {
-    matches!(ch, '@' | 'a'..='z')
+    matches!(ch, '@' | '_' | 'a'..='z' | 'A'..='Z')
 }
 
 fn is_ident_continue(ch: char) -> bool {
     match ch {
-        '0'..='9' | '_' => true,
+        '0'..='9' => true,
         ch => is_ident_start(ch),
     }
 }

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -74,14 +74,14 @@ extern {
         "}" => Token::RBrace,
         ")" => Token::RParen,
 
-        "_r" => Token::InternalTest("_r"),
-        "_e" => Token::InternalTest("_e"),
-        "_m" => Token::InternalTest("_m"),
-        "_a" => Token::InternalTest("_a"),
-        "_q" => Token::InternalTest("_q"),
-        "_c" => Token::InternalTest("_c"),
-        "_as" => Token::InternalTest("_as"),
-        "_fn" => Token::InternalTest("_fn"),
+        "?r" => Token::InternalTest("?r"),
+        "?e" => Token::InternalTest("?e"),
+        "?m" => Token::InternalTest("?m"),
+        "?a" => Token::InternalTest("?a"),
+        "?q" => Token::InternalTest("?q"),
+        "?c" => Token::InternalTest("?c"),
+        "?as" => Token::InternalTest("?as"),
+        "?fn" => Token::InternalTest("?fn"),
     }
 }
 
@@ -100,32 +100,32 @@ pub Program: Program = NonterminalNewline* <RootExprs> => Program(<>);
 // and exposes entries into the parser that we don't want or need.
 pub Test: Test = {
     // root
-    "_r" <Expr> => Test::Expr(<>),
+    "?r" <Expr> => Test::Expr(<>),
 
     // expressions
-    "_e" <Literal> => Test::Literal(<>),
-    "_e" <Container> => Test::Container(<>),
+    "?e" <Literal> => Test::Literal(<>),
+    "?e" <Container> => Test::Container(<>),
 
     // arithmetic (math)
-    "_m" <ArithmeticExpr> => Test::Arithmetic(<>),
+    "?m" <ArithmeticExpr> => Test::Arithmetic(<>),
 
     // atoms
-    "_a" <String> => Test::String(<>),
-    "_a" <Integer> => Test::Integer(<>),
-    "_a" <Float> => Test::Float(<>),
-    "_a" <Boolean> => Test::Boolean(<>),
-    "_a" <Null> => Test::Null(()),
-    "_a" <Regex> => Test::Regex(<>),
+    "?a" <String> => Test::String(<>),
+    "?a" <Integer> => Test::Integer(<>),
+    "?a" <Float> => Test::Float(<>),
+    "?a" <Boolean> => Test::Boolean(<>),
+    "?a" <Null> => Test::Null(()),
+    "?a" <Regex> => Test::Regex(<>),
 
     // collections
-    "_c" <Block> => Test::Block(<>),
-    "_c" <Array> => Test::Array(<>),
-    "_c" <Object> => Test::Object(<>),
+    "?c" <Block> => Test::Block(<>),
+    "?c" <Array> => Test::Array(<>),
+    "?c" <Object> => Test::Object(<>),
 
     // other
-    "_as" <Assignment> => Test::Assignment(<>),
-    "_fn" <FunctionCall> => Test::FunctionCall(<>),
-    "_q" <Query> => Test::Query(<>),
+    "?as" <Assignment> => Test::Assignment(<>),
+    "?fn" <FunctionCall> => Test::FunctionCall(<>),
+    "?q" <Query> => Test::Query(<>),
 };
 
 // -----------------------------------------------------------------------------

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -59,8 +59,10 @@ fn main() {
 
 prop_compose! {
     fn identifier()
-        (ident in "[a-z]+".prop_filter("idents can't be reserved names",
-                                       |i| RESERVED.iter().find(|r| *r == i).is_none() ))
+        (ident in "[a-zA-Z_]+[a-zA-Z0-9_]+"
+         .prop_filter("idents can't be reserved names or a single underscore",
+                      |i| RESERVED.iter().find(|r| *r == i).is_none() &&
+                          i != "_"))
     -> String {
             ident
         }

--- a/lib/vrl/tests/tests/expressions/query/mixed_case.vrl
+++ b/lib/vrl/tests/tests/expressions/query/mixed_case.vrl
@@ -1,0 +1,6 @@
+# result: 42
+
+_STRANGE.path = { "PATH": 42 }
+.__ThIs_.Most_Certainly.___Is_Some_Kind_of___ = _STRANGE.path
+
+.__ThIs_.Most_Certainly.___Is_Some_Kind_of___.PATH


### PR DESCRIPTION
Closes #6625 

This updates VRL to allow uppercase characters in identifiers and underscores at the start of identifiers as per the [docs](https://master.vector.dev/docs/reference/vrl/expressions/#path_segments).

Previously underscores at the start of identifiers were being used to access test functions in the parser. I can't see these being used, but I have updated them to be `?`.

Signed-off-by: Stephen Wakely <stephen.wakely@datadoghq.com>

