### PR TITLE
chore(ci): Make tests for tracing-limit more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,6 +4212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock_instant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "717e29a243b81f8130e31e24e04fb151b04a44b5a7d05370935f7d937e9de06d"
+
+[[package]]
 name = "mongodb"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7762,6 +7768,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "criterion",
  "dashmap 4.0.2",
+ "mock_instant",
  "tracing 0.1.23",
  "tracing-core 0.1.17",
  "tracing-subscriber",

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -15,6 +15,7 @@ dashmap = "4"
 [dev-dependencies]
 criterion = "0.3"
 tracing = "0.1.15"
+mock_instant = { version = "0.2" }
 
 [[bench]]
 name = "limit"


### PR DESCRIPTION
Use a fake clock since the OSX Github Actions runner seems particularly
noisy: https://github.com/timberio/vector/pull/6614#issuecomment-790885300

I should have done this originally anyway for robustness and to not
artificially bloat the test time.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
