### PR TITLE
feat(observability): emit basic component utilization statistics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod types;
 #[cfg(any(feature = "sources-utils-udp", feature = "sinks-utils-udp"))]
 pub mod udp;
 pub mod unit_test;
+pub(crate) mod utilization;
 pub mod validate;
 #[cfg(windows)]
 pub mod vector_windows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod signal;
 pub mod sink;
 pub mod sinks;
 pub mod sources;
+pub(crate) mod stats;
 pub mod stream;
 pub mod tcp;
 pub mod template;

--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -10,6 +10,7 @@ use crate::{
         AdaptiveConcurrencyObservedRtt,
     },
     sinks::util::retries::{RetryAction, RetryLogic},
+    stats::{Mean, EWMA},
 };
 use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -261,94 +262,5 @@ where
         // Only adjust to the RTT when the request was successfully processed.
         let use_rtt = matches!(response_action, Ok(RetryAction::Successful));
         self.adjust_to_response_inner(start, is_back_pressure, use_rtt)
-    }
-}
-
-/// Exponentially Weighted Moving Average
-#[derive(Clone, Copy, Debug)]
-struct EWMA {
-    average: Option<f64>,
-    alpha: f64,
-}
-
-impl EWMA {
-    fn new(alpha: f64) -> Self {
-        let average = None;
-        Self { average, alpha }
-    }
-
-    fn average(&self) -> Option<f64> {
-        self.average
-    }
-
-    /// Update the current average and return it for convenience
-    fn update(&mut self, point: f64) -> f64 {
-        let average = match self.average {
-            None => point,
-            Some(avg) => point * self.alpha + avg * (1.0 - self.alpha),
-        };
-        self.average = Some(average);
-        average
-    }
-}
-
-/// Simple unweighted arithmetic mean
-#[derive(Clone, Copy, Debug, Default)]
-struct Mean {
-    sum: f64,
-    count: usize,
-}
-
-impl Mean {
-    /// Update the and return the current average
-    fn update(&mut self, point: f64) {
-        self.sum += point;
-        self.count += 1;
-    }
-
-    fn average(&self) -> Option<f64> {
-        match self.count {
-            0 => None,
-            _ => Some(self.sum / self.count as f64),
-        }
-    }
-
-    fn reset(&mut self) {
-        self.sum = 0.0;
-        self.count = 0;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mean_update_works() {
-        let mut mean = Mean::default();
-        assert_eq!(mean.average(), None);
-        mean.update(0.0);
-        assert_eq!(mean.average(), Some(0.0));
-        mean.update(2.0);
-        assert_eq!(mean.average(), Some(1.0));
-        mean.update(4.0);
-        assert_eq!(mean.average(), Some(2.0));
-        assert_eq!(mean.count, 3);
-        assert_eq!(mean.sum, 6.0);
-    }
-
-    #[test]
-    fn ewma_update_works() {
-        let mut mean = EWMA::new(0.5);
-        assert_eq!(mean.average(), None);
-        mean.update(2.0);
-        assert_eq!(mean.average(), Some(2.0));
-        mean.update(2.0);
-        assert_eq!(mean.average(), Some(2.0));
-        mean.update(1.0);
-        assert_eq!(mean.average(), Some(1.5));
-        mean.update(2.0);
-        assert_eq!(mean.average(), Some(1.75));
-        assert_eq!(mean.average, Some(1.75));
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,88 @@
+/// Exponentially Weighted Moving Average
+#[derive(Clone, Copy, Debug)]
+pub struct EWMA {
+    average: Option<f64>,
+    alpha: f64,
+}
+
+impl EWMA {
+    pub fn new(alpha: f64) -> Self {
+        let average = None;
+        Self { average, alpha }
+    }
+
+    pub fn average(&self) -> Option<f64> {
+        self.average
+    }
+
+    /// Update the current average and return it for convenience
+    pub fn update(&mut self, point: f64) -> f64 {
+        let average = match self.average {
+            None => point,
+            Some(avg) => point * self.alpha + avg * (1.0 - self.alpha),
+        };
+        self.average = Some(average);
+        average
+    }
+}
+
+/// Simple unweighted arithmetic mean
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Mean {
+    sum: f64,
+    count: usize,
+}
+
+impl Mean {
+    /// Update the and return the current average
+    pub fn update(&mut self, point: f64) {
+        self.sum += point;
+        self.count += 1;
+    }
+
+    pub fn average(&self) -> Option<f64> {
+        match self.count {
+            0 => None,
+            _ => Some(self.sum / self.count as f64),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.sum = 0.0;
+        self.count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mean_update_works() {
+        let mut mean = Mean::default();
+        assert_eq!(mean.average(), None);
+        mean.update(0.0);
+        assert_eq!(mean.average(), Some(0.0));
+        mean.update(2.0);
+        assert_eq!(mean.average(), Some(1.0));
+        mean.update(4.0);
+        assert_eq!(mean.average(), Some(2.0));
+        assert_eq!(mean.count, 3);
+        assert_eq!(mean.sum, 6.0);
+    }
+
+    #[test]
+    fn ewma_update_works() {
+        let mut mean = EWMA::new(0.5);
+        assert_eq!(mean.average(), None);
+        mean.update(2.0);
+        assert_eq!(mean.average(), Some(2.0));
+        mean.update(2.0);
+        assert_eq!(mean.average(), Some(2.0));
+        mean.update(1.0);
+        assert_eq!(mean.average(), Some(1.5));
+        mean.update(2.0);
+        assert_eq!(mean.average(), Some(1.75));
+        assert_eq!(mean.average, Some(1.75));
+    }
+}

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -1,0 +1,103 @@
+use crate::{stats, Event};
+use async_stream::stream;
+use futures::{Stream, StreamExt};
+use std::time::{Duration, Instant};
+
+/// Wrap a stream to emit stats about utilization. This is designed for use with the input channels
+/// of transform and sinks components, and measures the amount of time that the stream is waiting
+/// for input from upstream. We make the simplifying assumption that this wait time is when the
+/// component is idle and the rest of the time it is doing useful work. This is more true for sinks
+/// than transforms, which can be blocked by downstream components, but with knowledge of the
+/// config the data is still useful.
+pub fn wrap(inner: impl Stream<Item = Event>) -> impl Stream<Item = Event> {
+    let mut timer = Timer::new();
+    let mut interval = tokio::time::interval(Duration::from_secs(5));
+    stream! {
+        tokio::pin!(inner);
+        loop {
+            timer.start_wait();
+            let value = tokio::select! {
+                value = inner.next() => {
+                    timer.stop_wait();
+                    value
+                },
+                _ = interval.tick() => {
+                    timer.report();
+                    continue
+                }
+            };
+            if let Some(value) = value {
+                yield value
+            } else {
+                break
+            }
+        }
+    }
+}
+
+struct Timer {
+    overall_start: Instant,
+    span_start: Instant,
+    waiting: bool,
+    total_wait: Duration,
+    ewma: stats::EWMA,
+}
+
+/// A simple, specialized timer for tracking spans of waiting vs not-waiting time and reporting
+/// a smoothed estimate of utilization.
+///
+/// This implementation uses the idea of spans and reporting periods. Spans are a period of time
+/// spent entirely in one state, aligning with state transitions but potentially more granular.
+/// Reporting periods are expected to be of uniform length and used to aggregate span data into
+/// time-weighted averages.
+impl Timer {
+    fn new() -> Self {
+        Self {
+            overall_start: Instant::now(),
+            span_start: Instant::now(),
+            waiting: false,
+            total_wait: Duration::new(0, 0),
+            ewma: stats::EWMA::new(0.9),
+        }
+    }
+
+    /// Begin a new span representing time spent waiting
+    fn start_wait(&mut self) {
+        self.end_span();
+        self.waiting = true;
+    }
+
+    /// Complete the current waiting span and begin a non-waiting span
+    fn stop_wait(&mut self) {
+        assert!(self.waiting);
+
+        self.end_span();
+        self.waiting = false;
+    }
+
+    /// Meant to be called on a regular interval, this method calculates wait ratio  since the last
+    /// time it was called and reports the resulting utilization average.
+    fn report(&mut self) {
+        // End the current span so it can be accounted for, but do not change whether or not we're
+        // in the waiting state. This way the next span inherits the correct status.
+        self.end_span();
+
+        let total_duration = self.overall_start.elapsed();
+        let wait_ratio = self.total_wait.as_secs_f64() / total_duration.as_secs_f64();
+        let utilization = 1.0 - wait_ratio;
+
+        self.ewma.update(utilization);
+        debug!(utilization = %self.ewma.average().unwrap_or(f64::NAN));
+
+        // Reset overall statistics for the next reporting period.
+        self.overall_start = self.span_start;
+        self.total_wait = Duration::new(0, 0);
+    }
+
+    fn end_span(&mut self) {
+        if self.waiting {
+            self.total_wait += self.span_start.elapsed();
+        }
+        self.span_start = Instant::now();
+    }
+}


### PR DESCRIPTION
See code comments for most of the explanation, but this introduces some simplified (but hopefully still useful) statistics about which components are bottlenecked.

Right now the data is just output as debug logs, but it would be relatively straightforward to emit gauges or something similar if we consider that a better user experience. Right now the focus was to keep things as simple as possible.