### PR TITLE
enhancement(remap): added the parse_logfmt remap function

### DIFF
--- a/docs/reference/remap/functions/parse_logfmt.cue
+++ b/docs/reference/remap/functions/parse_logfmt.cue
@@ -1,0 +1,48 @@
+package metadata
+
+remap: functions: parse_logfmt: {
+	category:    "Parse"
+	description: #"""
+		Parses the `value` in key/value format as [logfmt](\#(urls.logfmt)).
+
+		* Keys and values can be wrapped with `"`.
+		* `"` characters can be escaped by `\`.
+		"""#
+	notices: [
+		"""
+			All values are returned as strings, it is recommended to manually coerce values as you see fit.
+			""",
+	]
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to parse."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` is not a properly formatted key/value string",
+	]
+	return: types: ["object"]
+
+	examples: [
+		{
+			title: "Parse logfmt log"
+			source: #"""
+				parse_logfmt(
+					"@timestamp=\"Sun Jan 10 16:47:39 EST 2021\" level=info msg=\"Stopping all fetchers\" tag#production=stopping_fetchers id=ConsumerFetcherManager-1382721708341 module=kafka.consumer.ConsumerFetcherManager"
+				)
+				"""#
+			return: {
+				"@timestamp":     "Sun Jan 10 16:47:39 EST 2021"
+				level:            "info"
+				msg:              "Stopping all fetchers"
+				"tag#production": "stopping_fetchers"
+				id:               "ConsumerFetcherManager-1382721708341"
+				module:           "kafka.consumer.ConsumerFetcherManager"
+			}
+		},
+	]
+}

--- a/docs/reference/remap/functions/parse_logfmt.cue
+++ b/docs/reference/remap/functions/parse_logfmt.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: parse_logfmt: {
 	category:    "Parse"
 	description: #"""
-		Parses the `value` in key/value format as [logfmt](\#(urls.logfmt)).
+		Parses the `value` in [logfmt](\#(urls.logfmt)).
 
 		* Keys and values can be wrapped with `"`.
 		* `"` characters can be escaped by `\`.

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -83,6 +83,7 @@ default = [
     "parse_grok",
     "parse_json",
     "parse_key_value",
+    "parse_logfmt",
     "parse_regex_all",
     "parse_regex",
     "parse_syslog",
@@ -163,6 +164,7 @@ parse_glog = ["chrono"]
 parse_grok = ["grok"]
 parse_json = ["serde_json"]
 parse_key_value = ["nom"]
+parse_logfmt = ["parse_key_value"]
 parse_regex = ["regex"]
 parse_regex_all = ["regex"]
 parse_syslog = ["syslog_loose"]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -96,6 +96,8 @@ mod parse_grok;
 mod parse_json;
 #[cfg(feature = "parse_key_value")]
 mod parse_key_value;
+#[cfg(feature = "parse_logfmt")]
+mod parse_logfmt;
 #[cfg(feature = "parse_regex")]
 mod parse_regex;
 #[cfg(feature = "parse_regex_all")]
@@ -257,6 +259,8 @@ pub use parse_grok::ParseGrok;
 pub use parse_json::ParseJson;
 #[cfg(feature = "parse_key_value")]
 pub use parse_key_value::ParseKeyValue;
+#[cfg(feature = "parse_logfmt")]
+pub use parse_logfmt::ParseLogFmt;
 #[cfg(feature = "parse_regex")]
 pub use parse_regex::ParseRegex;
 #[cfg(feature = "parse_regex_all")]
@@ -420,6 +424,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ParseCommonLog),
         #[cfg(feature = "parse_key_value")]
         Box::new(ParseKeyValue),
+        #[cfg(feature = "parse_logfmt")]
+        Box::new(ParseLogFmt),
         #[cfg(feature = "parse_regex")]
         Box::new(ParseRegex),
         #[cfg(feature = "parse_regex_all")]

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -76,9 +76,9 @@ impl Function for ParseKeyValue {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ParseKeyValueFn {
-    value: Box<dyn Expression>,
-    key_value_delimiter: Box<dyn Expression>,
-    field_delimiter: Box<dyn Expression>,
+    pub(crate) value: Box<dyn Expression>,
+    pub(crate) key_value_delimiter: Box<dyn Expression>,
+    pub(crate) field_delimiter: Box<dyn Expression>,
 }
 
 impl Expression for ParseKeyValueFn {

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -1,0 +1,42 @@
+use crate::parse_key_value::ParseKeyValueFn;
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ParseLogFmt;
+
+impl Function for ParseLogFmt {
+    fn identifier(&self) -> &'static str {
+        "parse_logfmt"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "simple log",
+            source: r#"parse_logfmt!("zork=zook zonk=nork")"#,
+            result: Ok(r#"{"zork": "zook", "zonk": "nork"}"#),
+        }]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+
+        // The parse_logfmt function is just an alias for `parse_key_value` with the following
+        // parameters for the delimiters.
+        let key_value_delimiter = expr!("=");
+        let field_delimiter = expr!(" ");
+
+        Ok(Box::new(ParseKeyValueFn {
+            value,
+            key_value_delimiter,
+            field_delimiter,
+        }))
+    }
+}


### PR DESCRIPTION
Closes #6418 

This is just an alias for the parse_key_value function with default parameters. The compiler for this function just creates a `ParseKeyValueFn` and passes the default parameters.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
