### PR TITLE
chore: Drop internal `trait BoolAndSome`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,20 +121,3 @@ mod built_info {
 pub fn get_hostname() -> std::io::Result<String> {
     Ok(hostname::get()?.to_string_lossy().into())
 }
-
-// This is a private implementation of the unstable `bool_to_option`
-// feature. This can be removed once this stabilizes:
-// https://github.com/rust-lang/rust/issues/64260
-trait BoolAndSome {
-    fn and_some<T>(self, value: T) -> Option<T>;
-}
-
-impl BoolAndSome for bool {
-    fn and_some<T>(self, value: T) -> Option<T> {
-        if self {
-            Some(value)
-        } else {
-            None
-        }
-    }
-}

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -17,7 +17,6 @@ use crate::{
         start_topology,
         stats::{HistogramStats, LevelTimeHistogram, TimeHistogram, WeightedSumStats},
     },
-    BoolAndSome,
 };
 use core::task::Context;
 use futures::{
@@ -78,7 +77,7 @@ struct LimitParams {
 impl LimitParams {
     fn action_at_level(&self, level: usize) -> Option<Action> {
         self.limit
-            .and_then(|limit| (level > limit).and_some(self.action))
+            .and_then(|limit| (level > limit).then(|| self.action))
     }
 
     fn scale(&self, level: usize) -> f64 {

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     internal_events::HostMetricsEventReceived,
     shutdown::ShutdownSignal,
-    BoolAndSome, Pipeline,
+    Pipeline,
 };
 use chrono::{DateTime, Utc};
 use futures::{stream, SinkExt, StreamExt};
@@ -461,7 +461,7 @@ impl HostMetricsConfig {
                         self.network
                             .devices
                             .contains_str(counter.interface())
-                            .and_some(counter)
+                            .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
                     .map(|counter| {
@@ -540,7 +540,7 @@ impl HostMetricsConfig {
                         self.filesystem
                             .mountpoints
                             .contains_path(partition.mount_point())
-                            .and_some(partition)
+                            .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
                     // Filter on configured devices
@@ -552,7 +552,7 @@ impl HostMetricsConfig {
                                     self.filesystem.devices.contains_path(device.as_ref())
                                 })
                                 .unwrap_or(true))
-                        .and_some(partition)
+                        .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
                     // Filter on configured filesystems
@@ -560,7 +560,7 @@ impl HostMetricsConfig {
                         self.filesystem
                             .filesystems
                             .contains_str(partition.file_system().as_str())
-                            .and_some(partition)
+                            .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
                     // Load usage from the partition mount point
@@ -634,7 +634,7 @@ impl HostMetricsConfig {
                         self.disk
                             .devices
                             .contains_path(counter.device_name().as_ref())
-                            .and_some(counter)
+                            .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
                     .map(|counter| {

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -452,7 +452,6 @@ fn open_read(filename: &Path, note: &'static str) -> Result<(Vec<u8>, PathBuf)> 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::BoolAndSome;
 
     const TEST_PKCS12_PATH: &str = "tests/data/localhost.p12";
     const TEST_PEM_CRT_BYTES: &[u8] = include_bytes!("../../tests/data/localhost.crt");
@@ -620,8 +619,8 @@ mod test {
         TlsConfig {
             enabled,
             options: TlsOptions {
-                crt_file: set_crt.and_some(TEST_PEM_CRT_PATH.into()),
-                key_file: set_key.and_some(TEST_PEM_KEY_PATH.into()),
+                crt_file: set_crt.then(|| TEST_PEM_CRT_PATH.into()),
+                key_file: set_key.then(|| TEST_PEM_KEY_PATH.into()),
                 ..Default::default()
             },
         }


### PR DESCRIPTION
This is no longer needed as `fn bool::then` is now stable.

Signed-off-by: Bruce Guenter <bruce@timber.io>