### PR TITLE
chore(ci): Disable file watcher tests on OSX

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -136,6 +136,7 @@ mod tests {
         tokio::time::timeout(timeout, signal.recv()).await.is_ok()
     }
 
+    #[cfg(not(target_os = "macos"))] // https://github.com/timberio/vector/issues/5000
     #[tokio::test]
     async fn file_update() {
         trace_init();
@@ -151,6 +152,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "macos"))] // https://github.com/timberio/vector/issues/5000
     #[tokio::test]
     async fn sym_file_update() {
         trace_init();


### PR DESCRIPTION
These seem to fail fairly frequently and make CI noisy.

Issue to address: https://github.com/timberio/vector/issues/5000

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
