### PR TITLE
enhancement(performance): Add HTML reporting feature to Criterion dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ built = { version = "0.4.4", features = ["chrono", "git2"] }
 approx = "0.4.0"
 assert_cmd = "1.0.2"
 base64 = "0.13"
-criterion = "0.3"
+criterion = { version = "0.3", features = ["html_reports"] }
 httpmock = "0.5.2"
 libc = "0.2.80"
 libz-sys = "1.1.2"


### PR DESCRIPTION
I've added this just to silence a warning. If we upgrade Criterion (it looks we probably should soon) we'll need this feature in place to continue getting generated HTML reports.