### PR TITLE
fix(tests): Fix `make check-clippy` on macOS

### DIFF
--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -117,14 +117,12 @@ fn add_paths(watcher: &mut RecommendedWatcher, config_paths: &[PathBuf]) -> Resu
     Ok(())
 }
 
-#[cfg(unix)]
-#[cfg(test)]
+#[cfg(all(test, unix, not(target_os = "macos")))] // https://github.com/timberio/vector/issues/5000
 mod tests {
     use super::*;
     use crate::test_util::{temp_file, trace_init};
     use std::time::Duration;
     use std::{fs::File, io::Write};
-    #[cfg(unix)]
     use tokio::signal::unix::{signal, SignalKind};
 
     async fn test(file: &mut File, timeout: Duration) -> bool {
@@ -136,7 +134,6 @@ mod tests {
         tokio::time::timeout(timeout, signal.recv()).await.is_ok()
     }
 
-    #[cfg(not(target_os = "macos"))] // https://github.com/timberio/vector/issues/5000
     #[tokio::test]
     async fn file_update() {
         trace_init();
@@ -152,7 +149,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_os = "macos"))] // https://github.com/timberio/vector/issues/5000
     #[tokio::test]
     async fn sym_file_update() {
         trace_init();


### PR DESCRIPTION
Clippy was complaining of unused imports on macOS due to tests themselves being marked with `not(target_os = "macos")`.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
