### PR TITLE
chore(setup): Bump version to fix 404 in installer

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -12,7 +12,7 @@ set -u
 
 # If PACKAGE_ROOT is unset or empty, default it.
 PACKAGE_ROOT="${PACKAGE_ROOT:-"https://packages.timber.io/vector"}"
-VECTOR_VERSION="0.11.1"
+VECTOR_VERSION="0.12.0"
 _divider="--------------------------------------------------------------------------------"
 _prompt=">>>"
 _indent="   "


### PR DESCRIPTION
The installer is currently failing because 0.11 is gone from the distribution location.