### PR TITLE
chore(administration): Fix types in PR template according to semantic.yml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
   <type>!?(<scope>): <description>
 
-  * `type` = chore, docs, enhancement, newfeat, perf
+  * `type` = chore, enhancement, feat, fix
   * `!` = signals a breaking change
   * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
   * `description` = short description of the change


### PR DESCRIPTION
Noticed in https://github.com/timberio/vector/pull/6692 that the PR template doesn't specify the same types as in [semantic.yml](https://github.com/timberio/vector/blob/v0.12.0/.github/semantic.yml#L13-L17).