### PR TITLE
fix(dev): Update Cargo.lock with new Vector version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,7 +8182,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "approx",


### PR DESCRIPTION
I'm not sure how much of a problem this kind of discrepancy is but should be addressed ASAP