### PR TITLE
fix(config): Update example config

### DIFF
--- a/config/vector.toml
+++ b/config/vector.toml
@@ -8,11 +8,11 @@
 #
 # ------------------------------------------------------------------------------
 # Website: https://vector.dev
-# Docs: https://vector.dev/docs/
+# Docs: https://vector.dev/docs
 # Chat: https://chat.vector.dev
 # ------------------------------------------------------------------------------
 
-# Change this if you need to use a non-default directory for data storage:
+# Change this to use a non-default directory for Vector data storage:
 # data_dir = "/var/lib/vector"
 
 # Random Syslog-formatted logs
@@ -42,13 +42,3 @@ encoding.codec = "json"
 #[api]
 #enabled = true
 #address = "127.0.0.1:8686"
-
-# Host-level metrics (CPU, memory, disk, etc.)
-# Uncomment this if you enable the API:
-#[sources.host_metrics]
-#type = "host_metrics"
-
-# Vector's own internal metrics
-# Uncomment this if you enable the API:
-#[sources.internal_metrics]
-#type = "internal_metrics"

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -17,7 +17,7 @@
 # Vector's API (disabled by default)
 # Enable and try it out with the `vector top` command
 [api]
-enabled = false
+# enabled = true
 # address = "127.0.0.1:8686"
 
 # Dummy Apache formatted logs
@@ -26,23 +26,25 @@ type = "generator"
 format = "syslog"
 interval = 1
 
-# Parse Apache formatted logs
+# Parse Syslog logs
 # See the Remap reference: https://vector.dev/docs/reference/vrl/
 [transforms.parse_logs]
 type = "remap"
+inputs = ["dummy_logs"]
 source = '''
-. = parse_syslog(.message)
+. = parse_syslog!(string!(.message))
 '''
 
-# Host-level metrics (cpu, memory, disk, etc)
-[sources.host_metrics]
-type = "host_metrics"
+# Host-level metrics (CPU, memory, disk, etc)
+#[sources.host_metrics]
+#type = "host_metrics"
 
 # Vector's own internal metrics
-[sources.internal_metrics]
-type = "internal_metrics"
+#[sources.internal_metrics]
+#type = "internal_metrics"
 
-# Print it all out for inspection
+# Print out parsed logs
 [sinks.print]
 type = "console"
-inputs = ["parse_logs", "host_metrics", "internal_metrics"]
+inputs = ["parse_logs"]
+encoding.codec = "json"

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -12,22 +12,17 @@
 # Chat: https://chat.vector.dev
 # ------------------------------------------------------------------------------
 
+# Change this if you need to use a non-default directory for data storage:
 # data_dir = "/var/lib/vector"
 
-# Vector's API (disabled by default)
-# Enable and try it out with the `vector top` command
-[api]
-# enabled = true
-# address = "127.0.0.1:8686"
-
-# Dummy Apache formatted logs
+# Random Syslog-formatted logs
 [sources.dummy_logs]
 type = "generator"
 format = "syslog"
 interval = 1
 
 # Parse Syslog logs
-# See the Remap reference: https://vector.dev/docs/reference/vrl/
+# See the Vector Remap Language reference for more info: https://vrl.dev
 [transforms.parse_logs]
 type = "remap"
 inputs = ["dummy_logs"]
@@ -35,16 +30,25 @@ source = '''
 . = parse_syslog!(string!(.message))
 '''
 
-# Host-level metrics (CPU, memory, disk, etc)
-#[sources.host_metrics]
-#type = "host_metrics"
-
-# Vector's own internal metrics
-#[sources.internal_metrics]
-#type = "internal_metrics"
-
-# Print out parsed logs
+# Print parsed logs to stdout
 [sinks.print]
 type = "console"
 inputs = ["parse_logs"]
 encoding.codec = "json"
+
+# Vector's GraphQL API (disabled by default)
+# Uncomment to try it out with the `vector top` command or
+# in your browser at http://localhost:8686
+#[api]
+#enabled = true
+#address = "127.0.0.1:8686"
+
+# Host-level metrics (CPU, memory, disk, etc.)
+# Uncomment this if you enable the API:
+#[sources.host_metrics]
+#type = "host_metrics"
+
+# Vector's own internal metrics
+# Uncomment this if you enable the API:
+#[sources.internal_metrics]
+#type = "internal_metrics"

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -7,6 +7,6 @@ set -euo pipefail
 #
 #   Ensures that all examples are valid
 
-for config in ./config/examples/*.toml ; do
+for config in ./config/**/*.toml ; do
   cargo run -- validate --deny-warnings --no-environment "$config"
 done


### PR DESCRIPTION
This PR fixes the example config in `config/vector.toml` by fixing the VRL program. It also removes the internal and host metrics from the console output, as that pushes a *lot* of information through the console and seems bound, I think, to be more confusing than illuminating.

Closes #6694