### PR TITLE
chore(external docs): Note that the log stream must be unique for aws_cloudwatch_logs

### DIFF
--- a/docs/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -105,7 +105,7 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			}
 		}
 		stream_name: {
-			description: "The [stream name](\(urls.aws_cloudwatch_logs_stream_name)) of the target CloudWatch Logs stream."
+			description: "The [stream name](\(urls.aws_cloudwatch_logs_stream_name)) of the target CloudWatch Logs stream. Note that there can only be one writer to a log stream at a time so if you are running multiple vectors all writing to the same log group, include a identifier in the stream name that is guaranteed to be unique by vector instance (for example, you might choose `host`)"
 			required:    true
 			type: string: {
 				examples: ["{{ host }}", "%Y-%m-%d", "stream-name"]


### PR DESCRIPTION
As having multiple vectors writing to the same stream will result in AWS
API errors regarding the sequence token.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
