### PR TITLE
fix(external docs): Fix quoting for filter transform example

### DIFF
--- a/docs/reference/components/transforms/filter.cue
+++ b/docs/reference/components/transforms/filter.cue
@@ -67,7 +67,7 @@ components: transforms: filter: {
 		{
 			title: "Drop debug logs"
 			configuration: {
-				condition: '.level == "debug"'
+				condition: #".level == "debug""#
 			}
 			input: [
 				{


### PR DESCRIPTION
Reported by user in discord:
https://discord.com/channels/742820443487993987/746070591097798688/819318820019109959

Using ' appears to cause cue to base64 encode it when exporting (it was
exported as `LmxldmVsID09ICJkZWJ1ZyI=`).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
