### PR TITLE
chore(external docs): Fixes cue quoting

### DIFF
--- a/docs/reference/remap/functions/string.cue
+++ b/docs/reference/remap/functions/string.cue
@@ -28,7 +28,7 @@ remap: functions: string: {
 	examples: [
 		{
 			title: "Declare a string type"
-			input: log: message: '{"field": "value"}'
+			input: log: message: #"{"field": "value"}"#
 			source: #"""
 				string!(.message)
 				"""#


### PR DESCRIPTION
One more misquoted cue field that was ending up as base64.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
