### PR TITLE
fix(remap): Change description of error code 103

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -219,7 +219,7 @@ remap: #Remap & {
 				structured = parse_key_value(.message)
 				"""
 			raises: compiletime: """
-				error[E103]: unhandled fallible assignment
+				error[E103]: unhandled error
 				  ┌─ :1:14
 				  │
 				1 │ structured = parse_key_value(.message)

--- a/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
+++ b/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
@@ -3,15 +3,15 @@ package metadata
 remap: errors: "103": {
 	title:       "Unhandled error"
 	description: """
-		The right-hand side of the [assignment expression](\(urls.vrl_expressions)#\(remap.literals.regular_expression.anchor))
-		is fallible and can produce a [runtime error](\(urls.vrl_runtime_errors)), but the error isn't being
+		The right-hand side of this [assignment](\(urls.vrl_expressions)#\(remap.literals.regular_expression.anchor))
+		is fallible (that is, it can produce a [runtime error](\(urls.vrl_runtime_errors))), but the error isn't
 		[handled](\(urls.vrl_error_handling)).
 		"""
 	rationale:   remap._fail_safe_blurb
 	resolution:  """
-		[Handle](\(urls.vrl_error_handling)) the runtime error by [assigning](\(urls.vrl_error_handling_assigning)),
-		[coalescing](\(urls.vrl_error_handling_coalescing)), or [raising](\(urls.vrl_error_handling_raising)) the
-		error.
+		[Handle](\(urls.vrl_error_handling)) the runtime error by either
+		[assigning](\(urls.vrl_error_handling_assigning)) it, [coalescing](\(urls.vrl_error_handling_coalescing)) it, or
+		[raising](\(urls.vrl_error_handling_raising)) it.
 		"""
 
 	examples: [...{

--- a/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
+++ b/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
@@ -1,9 +1,9 @@
 package metadata
 
 remap: errors: "103": {
-	title:       "Unhandled assignment runtime error"
+	title:       "Unhandled error"
 	description: """
-		The right-hand side of an [assignment expression](\(urls.vrl_expressions)#\(remap.literals.regular_expression.anchor))
+		The right-hand side of the [assignment expression](\(urls.vrl_expressions)#\(remap.literals.regular_expression.anchor))
 		is fallible and can produce a [runtime error](\(urls.vrl_runtime_errors)), but the error isn't being
 		[handled](\(urls.vrl_error_handling)).
 		"""

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -30,10 +30,7 @@ impl Assignment {
                 // Fallible expressions require infallible assignment.
                 if type_def.is_fallible() {
                     return Err(Error {
-                        variant: ErrorVariant::UnhandledError(
-                            target.to_string(),
-                            expr.to_string(),
-                        ),
+                        variant: ErrorVariant::UnhandledError(target.to_string(), expr.to_string()),
                         span,
                         expr_span,
                         assignment_span,

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -30,7 +30,7 @@ impl Assignment {
                 // Fallible expressions require infallible assignment.
                 if type_def.is_fallible() {
                     return Err(Error {
-                        variant: ErrorVariant::FallibleAssignment(
+                        variant: ErrorVariant::UnhandledError(
                             target.to_string(),
                             expr.to_string(),
                         ),
@@ -428,8 +428,8 @@ pub enum ErrorVariant {
     #[error("unnecessary no-op assignment")]
     UnnecessaryNoop(Span),
 
-    #[error("unhandled fallible assignment")]
-    FallibleAssignment(String, String),
+    #[error("unhandled error")]
+    UnhandledError(String, String),
 
     #[error("unnecessary error assignment")]
     InfallibleAssignment(String, String, Span, Span),
@@ -456,7 +456,7 @@ impl DiagnosticError for Error {
 
         match &self.variant {
             UnnecessaryNoop(..) => 640,
-            FallibleAssignment(..) => 103,
+            UnhandledError(..) => 103,
             InfallibleAssignment(..) => 104,
             InvalidTarget(..) => 641,
         }
@@ -471,7 +471,7 @@ impl DiagnosticError for Error {
                 Label::context("either assign to a path or variable here", *target_span),
                 Label::context("or remove the assignment", self.assignment_span),
             ],
-            FallibleAssignment(target, expr) => vec![
+            UnhandledError(target, expr) => vec![
                 Label::primary("this expression is fallible", self.expr_span),
                 Label::context("update the expression to be infallible", self.expr_span),
                 Label::context(
@@ -496,7 +496,7 @@ impl DiagnosticError for Error {
         use ErrorVariant::*;
 
         match &self.variant {
-            FallibleAssignment(..) | InfallibleAssignment(..) => vec![Note::SeeErrorDocs],
+            UnhandledError(..) | InfallibleAssignment(..) => vec![Note::SeeErrorDocs],
             _ => vec![],
         }
     }

--- a/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
@@ -1,7 +1,7 @@
 # object: { "message": "bananas and another ant" }
 # result:
 #
-# error[E103]: unhandled fallible assignment
+# error[E103]: unhandled error
 #   ┌─ :3:6
 #   │
 # 3 │ .a = sha3(.result[0].an)

--- a/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
+++ b/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
@@ -1,7 +1,7 @@
 # object: { "foo": "bar" }
 # result:
 #
-# error[E103]: unhandled fallible assignment
+# error[E103]: unhandled error
 #   ┌─ :4:8
 #   │
 # 4 │ .foo = upcase(.foo) # string


### PR DESCRIPTION
I'm aware that `unhandled error` doesn't *quite* capture what's happening here. But I like (a) the concision and (b) the proximity to error messages in other languages.

Closes #6702