### PR TITLE
enhancement(remap): improved infallible assignment types

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -1,5 +1,5 @@
 use crate::expression::*;
-use crate::{Function, Program, State};
+use crate::{Function, Program, State, Value};
 use chrono::{TimeZone, Utc};
 use diagnostic::DiagnosticError;
 use ordered_float::NotNan;
@@ -255,12 +255,22 @@ impl<'a> Compiler<'a> {
                     AssignmentOp::Assign => {
                         let expr =
                             Box::new(expr.map(|node| self.compile_expr(Node::new(span, node))));
-                        let node = Variant::Infallible { ok, err, expr };
+                        let node = Variant::Infallible {
+                            ok,
+                            err,
+                            expr,
+                            default: Value::Null,
+                        };
                         Node::new(span, node)
                     }
                     AssignmentOp::Merge => {
                         let expr = self.rewrite_to_merge(span, &ok, expr);
-                        let node = Variant::Infallible { ok, err, expr };
+                        let node = Variant::Infallible {
+                            ok,
+                            err,
+                            expr,
+                            default: Value::Null,
+                        };
 
                         Node::new(span, node)
                     }

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -64,7 +64,7 @@ impl Assignment {
                 Ok(Self { variant })
             }
 
-            Variant::Infallible { ok, err, expr } => {
+            Variant::Infallible { ok, err, expr, .. } => {
                 let ok_span = ok.span();
                 let err_span = err.span();
                 let expr_span = expr.span();
@@ -105,7 +105,8 @@ impl Assignment {
                 // set to being infallible, as the error will be captured by the
                 // "err" target.
                 let ok = Target::try_from(ok.into_inner())?;
-                let type_def = type_def.add_null().infallible();
+                let type_def = type_def.infallible();
+                let default = type_def.kind().default_value();
                 let value = match &expr {
                     Expr::Literal(v) => Some(v.to_value()),
                     _ => None,
@@ -124,6 +125,7 @@ impl Assignment {
                     ok,
                     err,
                     expr: Box::new(expr),
+                    default,
                 };
 
                 Ok(Self { variant })
@@ -156,7 +158,7 @@ impl fmt::Display for Assignment {
 
         match &self.variant {
             Single { target, expr } => write!(f, "{} = {}", target, expr),
-            Infallible { ok, err, expr } => write!(f, "{}, {} = {}", ok, err, expr),
+            Infallible { ok, err, expr, .. } => write!(f, "{}, {} = {}", ok, err, expr),
         }
     }
 }
@@ -167,7 +169,9 @@ impl fmt::Debug for Assignment {
 
         match &self.variant {
             Single { target, expr } => write!(f, "{:?} = {:?}", target, expr),
-            Infallible { ok, err, expr } => write!(f, "Ok({:?}), Err({:?}) = {:?}", ok, err, expr),
+            Infallible { ok, err, expr, .. } => {
+                write!(f, "Ok({:?}), Err({:?}) = {:?}", ok, err, expr)
+            }
         }
     }
 }
@@ -342,8 +346,18 @@ impl TryFrom<ast::AssignmentTarget> for Target {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Variant<T, U> {
-    Single { target: T, expr: Box<U> },
-    Infallible { ok: T, err: T, expr: Box<U> },
+    Single {
+        target: T,
+        expr: Box<U>,
+    },
+    Infallible {
+        ok: T,
+        err: T,
+        expr: Box<U>,
+
+        /// The default `ok` value used when the expression results in an error.
+        default: Value,
+    },
 }
 
 impl<U> Expression for Variant<Target, U>
@@ -359,14 +373,19 @@ where
                 target.insert(value.clone(), ctx);
                 value
             }
-            Infallible { ok, err, expr } => match expr.resolve(ctx) {
+            Infallible {
+                ok,
+                err,
+                expr,
+                default,
+            } => match expr.resolve(ctx) {
                 Ok(value) => {
                     ok.insert(value.clone(), ctx);
                     err.insert(Value::Null, ctx);
                     value
                 }
                 Err(error) => {
-                    ok.insert(Value::Null, ctx);
+                    ok.insert(default.clone(), ctx);
                     let value = Value::from(error.to_string());
                     err.insert(value.clone(), ctx);
                     value
@@ -397,7 +416,7 @@ where
 
         match self {
             Single { target, expr } => write!(f, "{} = {}", target, expr),
-            Infallible { ok, err, expr } => write!(f, "{}, {} = {}", ok, err, expr),
+            Infallible { ok, err, expr, .. } => write!(f, "{}, {} = {}", ok, err, expr),
         }
     }
 }

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -1,6 +1,9 @@
 #![allow(non_upper_case_globals)]
 
 use super::Value;
+use crate::value;
+use chrono::{TimeZone, Utc};
+use regex::Regex;
 use std::fmt;
 use std::ops::Deref;
 
@@ -99,6 +102,29 @@ impl Kind {
                 | Kind::Regex
                 | Kind::Null
         )
+    }
+
+    /// Returns the default [`Value`] for a given [`Kind`].
+    ///
+    /// If the kind is unknown (or inexact), `null` is returned as the default
+    /// value.
+    ///
+    /// These are (somewhat) arbitrary values that mostly shouldn't be used, but
+    /// are particularly useful for the "infallible assignment" expression,
+    /// where the `ok` value is set to the default value kind if the expression
+    /// results in an error.
+    pub fn default_value(self) -> Value {
+        match self {
+            Kind::Bytes => value!(""),
+            Kind::Integer => value!(0),
+            Kind::Float => value!(0.0),
+            Kind::Boolean => value!(false),
+            Kind::Object => value!({}),
+            Kind::Array => value!([]),
+            Kind::Timestamp => Utc.timestamp(0, 0).into(),
+            Kind::Regex => Regex::new("").unwrap().into(),
+            _ => Value::Null,
+        }
     }
 }
 

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -122,6 +122,7 @@ impl Kind {
             Kind::Object => value!({}),
             Kind::Array => value!([]),
             Kind::Timestamp => Utc.timestamp(0, 0).into(),
+            #[allow(clippy::trivial_regex)]
             Kind::Regex => Regex::new("").unwrap().into(),
             _ => Value::Null,
         }

--- a/lib/vrl/tests/tests/expressions/assignment/infallible_external.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/infallible_external.vrl
@@ -1,4 +1,4 @@
-# result: { "err": "can't divide by zero", "ok": null }
+# result: { "err": "can't divide by zero", "ok": 0.0 }
 
 .ok, .err = 1 / 0
 .

--- a/lib/vrl/tests/tests/expressions/assignment/infallible_variable.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/infallible_variable.vrl
@@ -1,4 +1,4 @@
-# result: [null, "can't divide by zero"]
+# result: [0.0, "can't divide by zero"]
 
 ok, err = 1 / 0
 [ok, err]

--- a/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
+++ b/lib/vrl/tests/tests/internal/infallible_ok_maybe_null.vrl
@@ -1,21 +1,6 @@
 # object: { "foo": "bar" }
-# result:
-#
-# error[E103]: unhandled error
-#   ┌─ :4:8
-#   │
-# 4 │ .foo = upcase(.foo) # string
-#   │ ------ ^^^^^^^^^^^^
-#   │ │      │
-#   │ │      this expression is fallible
-#   │ │      update the expression to be infallible
-#   │ or change this to an infallible assignment:
-#   │ .foo, err = upcase(.foo)
-#   │
-#   = see documentation about error handling at https://errors.vrl.dev/#handling
-#   = learn more about error code 103 at https://errors.vrl.dev/103
-#   = see language documentation at https://vrl.dev
+# result: "BAR"
 
 .foo # any
-.foo, err = to_string(.foo) # string or null
+.foo, err = to_string(.foo) # string (empty or "bar")
 .foo = upcase(.foo) # string

--- a/lib/vrl/tests/tests/internal/ok_assignment_default_value.vrl
+++ b/lib/vrl/tests/tests/internal/ok_assignment_default_value.vrl
@@ -1,0 +1,6 @@
+# object: { "status": 201 }
+# result: true
+
+if (status, err = int(.status); err == null) {
+	status >= 200 && status < 300
+}

--- a/lib/vrl/tests/tests/internal/progressive_type_checking.vrl
+++ b/lib/vrl/tests/tests/internal/progressive_type_checking.vrl
@@ -16,7 +16,7 @@
 # }
 
 ok, .err = to_string(.foo)
-.foo1 = upcase(ok) ?? "should be a string"
+.foo1 = upcase(ok)
 
 ok = slice!(.foo, 1)
 .foo2 = push(ok, "baz") ?? "not an array"

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -99,7 +99,7 @@
     extract_from = "remap_arithmetic_error"
     [[tests.outputs.conditions]]
       type = "remap"
-      source = ".a == null"
+      source = ".a == 0.0"
 
 [transforms.remap_boolean_arithmetic]
   inputs = []


### PR DESCRIPTION
This is based on a discussion between @jszwedko and myself in https://github.com/timberio/vector/issues/6507#issuecomment-784250762.

Before, the following program would fail:

```ruby
if (status, err = int(.status); err == null) {
	status >= 200 && status < 300
}
```

This is because the type definition of `status` would either be an `int` if the rhs expression of the assignment succeeded, or `null` if it failed (in which case `err` would be a string with the actual error message).

This is annoying to deal with, as you'll have to then do another type coercion call similar to `int!(status)`.

With the changes in this PR, the infallible assignment implementation now tries to get the "default" (or, as Golang calls them ["zero"](https://tour.golang.org/basics/12)) value for a given type, and returns _that_ value instead. If there is no sensible non-null value to return (when the rhs expression can result in multiple different types), `null` is returned instead.

There's also a path towards a solution where the expressions themselves have to report their default value, which would allow us to provide more sensible values for more cases (including when an expression can result in multiple value types), but that requires a lot more work, and I'm not entirely convinced it would the right approach regardless.

All in all, I think this change improves ergonomics for users, so I'm happy to get this in, but I also think we'll want to make further improvements/refinements in this area in the future.

closes #6591