### PR TITLE
 enhancement(remap): improve nginx log parsing ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,9 +7776,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -7797,9 +7797,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -8506,6 +8506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt 0.3.21",
+ "tracing-subscriber",
  "vrl",
  "vrl-parser",
  "vrl-stdlib",

--- a/docs/reference/remap/expressions/assignment.cue
+++ b/docs/reference/remap/expressions/assignment.cue
@@ -8,7 +8,7 @@ remap: expressions: assignment: {
 		"""
 	return: """
 		Returns the value of the right-hand-side expression only if the expression succeeds. If the expression errors,
-		the error must be [handled](\(urls.vrl_errors_reference)) and null is returned.
+		the error must be [handled](\(urls.vrl_errors_reference)).
 		"""
 
 	grammar: {

--- a/lib/shared/src/conversion.rs
+++ b/lib/shared/src/conversion.rs
@@ -213,6 +213,7 @@ const TIMESTAMP_TZ_FORMATS: &[&str] = &[
     "%a %d %b %T %Z %Y",  // `date` command output
     "%a %d %b %T %z %Y",  // `date` command output, numeric TZ
     "%a %d %b %T %#z %Y", // `date` command output, numeric TZ
+    "%d/%b/%Y:%T %z",     // Common Log
 ];
 
 /// Parse a string into a timestamp using one of a set of formats

--- a/lib/shared/src/conversion.rs
+++ b/lib/shared/src/conversion.rs
@@ -346,6 +346,7 @@ mod tests {
         assert_eq!(parse_timestamp(tz, "3-Feb-2001 14:05:06"), good);
         assert_eq!(parse_timestamp(tz, "2001-02-02T22:05:06-06:00"), good);
         assert_eq!(parse_timestamp(tz, "Sat, 03 Feb 2001 07:05:06 +0300"), good);
+        assert_eq!(parse_timestamp(tz, "03/Feb/2001:02:05:06 -0200"), good);
     }
 
     #[cfg(unix)] // see https://github.com/timberio/vector/issues/1201

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -7,17 +7,15 @@ publish = false
 
 [dependencies]
 parser = { package = "vrl-parser", path = "../parser" }
-# stdlib = { package = "vrl-stdlib", path = "../stdlib" }
+stdlib = { package = "vrl-stdlib", path = "../stdlib" }
 vrl = { path = "../core" }
+
 ansi_term = "0.12"
 chrono = "0.4"
 glob = "0.3"
 prettydiff = "0.4"
 regex = "1"
-serde_json = "1"
 serde = "1"
+serde_json = "1"
 structopt = { version = "0.3", default-features = false }
-
-[dependencies.stdlib]
-package = "vrl-stdlib"
-path = "../stdlib"
+tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt"] }

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use glob::glob;
 use std::str::FromStr;
 use structopt::StructOpt;
-use tracing_subscriber;
 use vrl::{diagnostic::Formatter, state, Runtime, Value};
 
 use vrl_tests::{docs, Test};

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use glob::glob;
 use std::str::FromStr;
 use structopt::StructOpt;
+use tracing_subscriber;
 use vrl::{diagnostic::Formatter, state, Runtime, Value};
 
 use vrl_tests::{docs, Test};
@@ -24,10 +25,19 @@ pub struct Cmd {
 
     #[structopt(long)]
     skip_functions: bool,
+
+    /// When enabled, any log output at the INFO or above level is printed
+    /// during the test run.
+    #[structopt(short, long)]
+    logging: bool,
 }
 
 fn main() {
     let cmd = Cmd::from_args();
+
+    if cmd.logging {
+        tracing_subscriber::fmt::init();
+    }
 
     let mut failed_count = 0;
     let mut category = "".to_owned();

--- a/lib/vrl/tests/tests/examples/parse_nginx_access_log.vrl
+++ b/lib/vrl/tests/tests/examples/parse_nginx_access_log.vrl
@@ -1,0 +1,74 @@
+# object:
+# {
+#   "message": "[06/Nov/2014:19:10:38 +0600] 66.249.65.159 GET /news/53f8d72920ba2744fe873ebc.html 204 1245 5943 2.412 6.433 sessions_show app_name env_here 42 127.0.0.1 foo 123 \"error message here\" 456",
+#   "file": "/var/log/nginx.log",
+#   "source_type": "file"
+# }
+#
+# result:
+# {
+#   "app": "app_name",
+#   "code": 42,
+#   "debug": "foo",
+#   "env": "env_here",
+#   "error": "error message here",
+#   "host": "66.249.65.159",
+#   "ip": "127.0.0.1",
+#   "method": "GET",
+#   "req_id": "456",
+#   "req_len": 1245,
+#   "res_len": 5943,
+#   "status": 204,
+#   "status_class": "2xx",
+#   "t_time": 2412.0,
+#   "timestamp": "2014-11-06T13:10:38Z",
+#   "u_time": 6433.0,
+#   "uri": "/manage/v1/sessions/REDACTED",
+#   "user_id": "123",
+#   "x_route": "sessions_show"
+# }
+
+# parse message
+parsed = parse_tokens!(.message)
+
+# delete unused fields
+del(.file)
+del(.message)
+del(.source_type)
+
+# assign parsed fields
+.timestamp = to_timestamp!(parsed[0])
+.host = parsed[1]
+.method = parsed[2]
+.uri = parsed[3]
+.status = to_int!(parsed[4])
+.req_len = to_int!(parsed[5])
+.res_len = to_int!(parsed[6])
+if (t_time, err = to_float(parsed[7]); err == null) {
+    .t_time = t_time * 1000
+}
+if (u_time, err = to_float(parsed[8]); err == null) {
+    .u_time = u_time * 1000
+}
+.x_route = parsed[9]
+.app = parsed[10]
+.env = parsed[11]
+.code = to_int!(parsed[12])
+.ip = parsed[13]
+.debug = parsed[14]
+.user_id = parsed[15]
+.error = parsed[16]
+.req_id = parsed[17]
+
+# add additional context
+if .x_route == "sessions_show" || .x_route == "sessions_delete" {
+    .uri = "/manage/v1/sessions/REDACTED"
+}
+
+if (status_class, err = .status / 100; err == null) {
+    .status_class = to_string(to_int(floor(status_class))) + "xx"
+} else {
+    .status_class = "???"
+}
+
+.


### PR DESCRIPTION
This adds an example on parsing nginx access logs using the `parse_tokens` function.

The program for this was reported by as user to us as being cumbersome to work with. With the changes in https://github.com/timberio/vector/pull/6716 and the added common-log timestamp format support added in this PR, parsing becomes a bit easier to manage.

Eventually, we'll have a function specifically to parse nginx logs (see #6103), but the changes in this and the linked PR are still relevant, even outside the use-case of parsing Nginx logs.