### PR TITLE
chore(external docs): Clarify loki remove_timestamp config

### DIFF
--- a/docs/reference/components/sinks/loki.cue
+++ b/docs/reference/components/sinks/loki.cue
@@ -148,7 +148,7 @@ components: sinks: loki: {
 		}
 		remove_timestamp: {
 			common:      false
-			description: "If this is set to `true` then the timestamp will be removed from the event. This is useful because Loki uses the timestamp to index the event."
+			description: "If this is set to `true` then the timestamp will be removed from the event payload. Note the event timestamp will still be sent as metadata to Loki for indexing."
 			required:    false
 			warnings: []
 			type: bool: default: true


### PR DESCRIPTION
A user, and myself, were confused about this option in discord:
https://discord.com/channels/742820443487993987/746070591097798688/819576122881736737

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
