### PR TITLE
enhancement(remap): don't mutate event when program fails

### DIFF
--- a/docs/reference/components/transforms/remap.cue
+++ b/docs/reference/components/transforms/remap.cue
@@ -105,6 +105,24 @@ components: transforms: "remap": {
 				[Vector Remap Language reference](\#(urls.vrl_reference)).
 				"""#
 		}
+		lazy_event_mutation: {
+			title: "Lazy Event Mutation"
+			body:  #"""
+				When you make changes to an event through VRL's path assignment syntax, the change
+				is not immediately applied to the actual event. If the program fails to run to
+				completion, any changes made until that point are dropped, and the event is kept in
+				its original state.
+
+				If you want to make sure your event is changed as expected, you have to rewrite
+				your program to never fail at runtime (the compiler will help you with this).
+
+				Alternatively, if you want to ignore/drop events that caused the program to fail,
+				you can set the `drop_on_error` configuration value to `true`.
+
+				Learn more about Runtime Errors in the [Vector Remap Language
+				reference](\#(urls.vrl_runtime_errors)).
+				"""#
+		}
 	}
 
 	telemetry: metrics: {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -12,6 +12,7 @@ pub struct Compiler<'a> {
     fns: &'a [Box<dyn Function>],
     state: &'a mut State,
     errors: Errors,
+    fallible: bool,
 }
 
 impl<'a> Compiler<'a> {
@@ -20,6 +21,7 @@ impl<'a> Compiler<'a> {
             fns,
             state,
             errors: vec![],
+            fallible: false,
         }
     }
 
@@ -34,7 +36,10 @@ impl<'a> Compiler<'a> {
             return Err(self.errors);
         }
 
-        Ok(Program(expressions))
+        Ok(Program {
+            expressions,
+            fallible: self.fallible,
+        })
     }
 
     fn compile_root_exprs(
@@ -326,6 +331,10 @@ impl<'a> Compiler<'a> {
             .into_iter()
             .map(|node| Node::new(node.span(), self.compile_function_argument(node)))
             .collect();
+
+        if abort_on_error {
+            self.fallible = true;
+        }
 
         FunctionCall::new(
             call_span,

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -3,14 +3,27 @@ use std::iter::IntoIterator;
 use std::ops::Deref;
 
 #[derive(Debug, Clone)]
-pub struct Program(pub(crate) Vec<Box<dyn Expression>>);
+pub struct Program {
+    pub(crate) expressions: Vec<Box<dyn Expression>>,
+    pub(crate) fallible: bool,
+}
+
+impl Program {
+    /// Returns whether the compiled program can fail at runtime.
+    ///
+    /// A program can only fail at runtime if the fallible-function-call
+    /// (`foo!()`) is used within the source.
+    pub fn is_fallible(&self) -> bool {
+        self.fallible
+    }
+}
 
 impl IntoIterator for Program {
     type Item = Box<dyn Expression>;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.expressions.into_iter()
     }
 }
 
@@ -18,6 +31,6 @@ impl Deref for Program {
     type Target = [Box<dyn Expression>];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.expressions
     }
 }


### PR DESCRIPTION
This change makes sure the original event is kept as-is, if the VRL program fails at runtime.

This currently "just" clones the event before processing, which of course has a performance impact. Longer term, we can improve this by tracking which fields have been mutated, and only keeping their original values around, but I deemed that too big a change right now to work on.

Meanwhile, I think this is a worthwhile change to make. If people _really_ need the highest possible performance, they can still set `drop_on_err`, as the implementation in this PR takes that flag into account when deciding of the original event needs to be tracked or not.

**update**: pushed another commit based on an [observation made by @jszwedko](https://github.com/timberio/vector/issues/6025#issuecomment-770924310) that we wouldn't need to clone if we knew at compile-time if the program is infallible. This should further reduce the number of clones needed.

closes #6025