### PR TITLE
feat(remap): support dropping events when remap fails or is aborted

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -47,6 +47,7 @@ fn benchmark_remap(c: &mut Criterion) {
                 "#}
                 .to_string(),
                 drop_on_error: true,
+                drop_on_abort: true,
             })
             .unwrap(),
         );
@@ -106,7 +107,8 @@ fn benchmark_remap(c: &mut Criterion) {
         let mut tform: Box<dyn FunctionTransform> = Box::new(
             Remap::new(RemapConfig {
                 source: ".bar = parse_json!(string!(.foo))".to_owned(),
-                drop_on_error: false,
+                drop_on_error: true,
+                drop_on_abort: true,
             })
             .unwrap(),
         );
@@ -176,6 +178,7 @@ fn benchmark_remap(c: &mut Criterion) {
                 "#}
                 .to_owned(),
                 drop_on_error: true,
+                drop_on_abort: true,
             })
             .unwrap(),
         );

--- a/benches/wasm/mod.rs
+++ b/benches/wasm/mod.rs
@@ -83,7 +83,8 @@ pub fn add_fields(criterion: &mut Criterion) {
                         .test_key2 = "test_value2"
                     "#}
                     .to_string(),
-                    drop_on_error: false,
+                    drop_on_error: true,
+                    drop_on_abort: true,
                 })
                 .unwrap(),
             ),

--- a/docs/reference/components/transforms/remap.cue
+++ b/docs/reference/components/transforms/remap.cue
@@ -69,9 +69,15 @@ components: transforms: "remap": {
 			description: """
 				Drop the event if the VRL program returns an error at runtime.
 				"""
-			type: bool: {
-				default: false
-			}
+			type: bool: default: false
+		}
+		drop_on_abort: {
+			common:   false
+			required: false
+			description: """
+				Drop the event if the VRL program is manually aborted through the `abort` statement.
+				"""
+			type: bool: default: true
 		}
 	}
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -383,6 +383,7 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_abort(&mut self, _: Node<()>) -> Abort {
+        self.fallible = true;
         Abort
     }
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -13,6 +13,7 @@ pub struct Compiler<'a> {
     state: &'a mut State,
     errors: Errors,
     fallible: bool,
+    abortable: bool,
 }
 
 impl<'a> Compiler<'a> {
@@ -22,6 +23,7 @@ impl<'a> Compiler<'a> {
             state,
             errors: vec![],
             fallible: false,
+            abortable: false,
         }
     }
 
@@ -39,6 +41,7 @@ impl<'a> Compiler<'a> {
         Ok(Program {
             expressions,
             fallible: self.fallible,
+            abortable: self.abortable,
         })
     }
 
@@ -383,7 +386,7 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_abort(&mut self, _: Node<()>) -> Abort {
-        self.fallible = true;
+        self.abortable = true;
         Abort
     }
 

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 pub struct Program {
     pub(crate) expressions: Vec<Box<dyn Expression>>,
     pub(crate) fallible: bool,
+    pub(crate) abortable: bool,
 }
 
 impl Program {
@@ -15,6 +16,12 @@ impl Program {
     /// (`foo!()`) is used within the source.
     pub fn is_fallible(&self) -> bool {
         self.fallible
+    }
+
+    /// Returns whether the compiled program can be aborted
+    /// (if there is an `abort` statement within the program).
+    pub fn is_abortable(&self) -> bool {
+        self.abortable
     }
 }
 

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -14,13 +14,15 @@ impl Program {
     ///
     /// A program can only fail at runtime if the fallible-function-call
     /// (`foo!()`) is used within the source.
-    pub fn is_fallible(&self) -> bool {
+    pub fn can_fail(&self) -> bool {
         self.fallible
     }
 
-    /// Returns whether the compiled program can be aborted
-    /// (if there is an `abort` statement within the program).
-    pub fn is_abortable(&self) -> bool {
+    /// Returns whether the compiled program can be aborted at runtime.
+    ///
+    /// A program can only abort at runtime if there's an explicit `abort`
+    /// statement in the source.
+    pub fn can_abort(&self) -> bool {
         self.abortable
     }
 }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -45,3 +45,22 @@ impl InternalEvent for RemapConditionExecutionError {
         counter!("processing_errors_total", 1);
     }
 }
+
+#[derive(Debug)]
+pub struct RemapMappingAbort {
+    /// If set to true, the remap transform has dropped the event after an abort
+    /// during mapping. This internal event will reflect that in its messaging.
+    pub event_dropped: bool,
+}
+
+impl InternalEvent for RemapMappingAbort {
+    fn emit_logs(&self) {
+        let message = if self.event_dropped {
+            "Event mapping aborted; discarding event."
+        } else {
+            "Event mapping aborted."
+        };
+
+        debug!(message, internal_log_rate_secs = 30)
+    }
+}

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -148,6 +148,7 @@ mod tests {
 "#
             .to_string(),
             drop_on_error: true,
+            drop_on_abort: false,
         };
         let mut tform = Remap::new(conf).unwrap();
 
@@ -174,6 +175,7 @@ mod tests {
                 .baz = 12
             "#},
             drop_on_error: false,
+            drop_on_abort: false,
         };
         let mut tform = Remap::new(conf).unwrap();
 
@@ -199,6 +201,7 @@ mod tests {
                 .baz = 12
             "#},
             drop_on_error: false,
+            drop_on_abort: false,
         };
         let mut tform = Remap::new(conf).unwrap();
 
@@ -224,6 +227,7 @@ mod tests {
                        .kind = "incremental""#
                 .to_string(),
             drop_on_error: true,
+            drop_on_abort: false,
         };
         let mut tform = Remap::new(conf).unwrap();
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -70,15 +70,16 @@ impl Remap {
 
 impl FunctionTransform for Remap {
     fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
-        let original_event =
-            if !(self.drop_on_error || self.drop_on_abort) && self.program.is_fallible() {
-                // We need to clone the original event, since it might be mutated by
-                // the program before it aborts, while we want to return the
-                // unmodified event when an error occurs.
-                Some(event.clone())
-            } else {
-                None
-            };
+        let original_event = if (!self.drop_on_error && self.program.is_fallible())
+            || (!self.drop_on_abort && self.program.is_abortable())
+        {
+            // We need to clone the original event, since it might be mutated by
+            // the program before it aborts, while we want to return the
+            // unmodified event when an error occurs.
+            Some(event.clone())
+        } else {
+            None
+        };
 
         let mut runtime = Runtime::default();
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -15,6 +15,7 @@ use vrl::{Program, Runtime, Terminate};
 pub struct RemapConfig {
     pub source: String,
     pub drop_on_error: bool,
+    #[serde(default = "crate::serde::default_true")]
     pub drop_on_abort: bool,
 }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -78,6 +78,7 @@ impl FunctionTransform for Remap {
         // The `drop_on_{error, abort}` transform config allows operators to
         // ignore events if their failed/aborted, in which case we can skip the
         // cloning, since any mutations made by VRL will be ignored regardless.
+        #[allow(clippy::if_same_then_else)]
         let original_event = if !self.drop_on_error && self.program.can_fail() {
             Some(event.clone())
         } else if !self.drop_on_abort && self.program.can_abort() {

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -19,7 +19,7 @@
     extract_from = "remap_abort"
     [[tests.outputs.conditions]]
       type = "remap"
-      source = ".foo == false && .bar == true"
+      source = ".foo == true && .bar == true"
 
 [transforms.remap_abort_drop_on_abort]
   inputs = []

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1,3 +1,45 @@
+[transforms.remap_abort]
+  inputs = []
+  type = "remap"
+  drop_on_abort = false
+  source = """
+    .foo = false
+    abort
+    .bar = false
+  """
+[[tests]]
+  name = "remap_abort"
+  [tests.input]
+    insert_at = "remap_abort"
+    type = "log"
+    [tests.input.log_fields]
+      foo = true
+      bar = true
+  [[tests.outputs]]
+    extract_from = "remap_abort"
+    [[tests.outputs.conditions]]
+      type = "remap"
+      source = ".foo == false && .bar == true"
+
+[transforms.remap_abort_drop_on_abort]
+  inputs = []
+  type = "remap"
+  drop_on_abort = true
+  source = """
+    .foo = false
+    abort
+    .bar = false
+  """
+[[tests]]
+  name = "remap_abort_drop_on_abort"
+  no_outputs_from = ["remap_abort_drop_on_abort"]
+  [tests.input]
+    insert_at = "remap_abort_drop_on_abort"
+    type = "log"
+    [tests.input.log_fields]
+      foo = true
+      bar = true
+
 [transforms.remap_nested]
   inputs = []
   type = "remap"


### PR DESCRIPTION
Dropping on error was previously possible, but undocumented.

This PR also adds an option to `drop_on_abort`, which defaults to `true`, and will instruct Vector to drop events when the program is manually aborted through the `abort` statement.

closes #6720