### PR TITLE
feat(remap): add abort-statement

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -214,13 +214,13 @@ remap: #Remap & {
 				"""
 		},
 		{
-			title: "Unhandled error"
+			title: "Unhandled fallible assignment"
 			input: log: message: "key1=value1 key2=value2"
 			source: """
 				structured = parse_key_value(.message)
 				"""
 			raises: compiletime: """
-				error[E103]: unhandled error
+				error[E103]: unhandled fallible assignment
 				  ┌─ :1:14
 				  │
 				1 │ structured = parse_key_value(.message)

--- a/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
+++ b/docs/reference/remap/errors/103_unhandled_assignment_runtime_error.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: errors: "103": {
-	title:       "Unhandled error"
+	title:       "Unhandled fallible assignment"
 	description: """
 		The right-hand side of this [assignment](\(urls.vrl_expressions)#\(remap.literals.regular_expression.anchor))
 		is fallible (that is, it can produce a [runtime error](\(urls.vrl_runtime_errors))), but the error isn't
@@ -17,7 +17,7 @@ remap: errors: "103": {
 	examples: [...{
 		input: log: message: "key=value"
 		source: #"""
-			. |= parse_key_value(.message)
+			. = parse_key_value(.message)
 			"""#
 	}]
 
@@ -25,22 +25,22 @@ remap: errors: "103": {
 		{
 			"title": "\(title) (coalescing)"
 			diff: #"""
-				-. |= parse_key_value(.message)
-				+. |= parse_key_value(.message) ?? {}
+				-. = parse_key_value(.message)
+				+. = parse_key_value(.message) ?? {}
 				"""#
 		},
 		{
 			"title": "\(title) (raising)"
 			diff: #"""
-				-. |= parse_key_value(.message)
-				+. |= parse_key_value!(.message)
+				-. = parse_key_value(.message)
+				+. = parse_key_value!(.message)
 				"""#
 		},
 		{
 			"title": "\(title) (assigning)"
 			diff: #"""
-				-. |= parse_key_value(.message)
-				+., err |= parse_key_value(.message)
+				-. = parse_key_value(.message)
+				+., err = parse_key_value(.message)
 				"""#
 		},
 	]

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -93,6 +93,7 @@ impl<'a> Compiler<'a> {
             FunctionCall(node) => self.compile_function_call(node).into(),
             Variable(node) => self.compile_variable(node).into(),
             Unary(node) => self.compile_unary(node).into(),
+            Abort(node) => self.compile_abort(node).into(),
         }
     }
 
@@ -379,6 +380,10 @@ impl<'a> Compiler<'a> {
             self.errors.push(Box::new(err));
             Not::noop()
         })
+    }
+
+    fn compile_abort(&mut self, _: Node<()>) -> Abort {
+        Abort
     }
 
     fn handle_parser_error(&mut self, error: parser::Error) {

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -3,6 +3,7 @@ use diagnostic::{DiagnosticError, Label, Note};
 use dyn_clone::{clone_trait_object, DynClone};
 use std::fmt;
 
+mod abort;
 mod array;
 mod block;
 mod function_argument;
@@ -23,6 +24,7 @@ pub(crate) mod literal;
 pub(crate) mod predicate;
 pub(crate) mod query;
 
+pub use abort::Abort;
 pub use array::Array;
 pub use assignment::Assignment;
 pub use block::Block;
@@ -81,6 +83,7 @@ pub enum Expr {
     Variable(Variable),
     Noop(Noop),
     Unary(Unary),
+    Abort(Abort),
 }
 
 impl Expr {
@@ -104,6 +107,7 @@ impl Expr {
             Variable(..) => "variable call",
             Noop(..) => "noop",
             Unary(..) => "unary operation",
+            Abort(..) => "abort operation",
         }
     }
 }
@@ -123,6 +127,7 @@ impl Expression for Expr {
             Variable(v) => v.resolve(ctx),
             Noop(v) => v.resolve(ctx),
             Unary(v) => v.resolve(ctx),
+            Abort(v) => v.resolve(ctx),
         }
     }
 
@@ -140,6 +145,7 @@ impl Expression for Expr {
             Variable(v) => v.type_def(state),
             Noop(v) => v.type_def(state),
             Unary(v) => v.type_def(state),
+            Abort(v) => v.type_def(state),
         }
     }
 }
@@ -159,6 +165,7 @@ impl fmt::Display for Expr {
             Variable(v) => v.fmt(f),
             Noop(v) => v.fmt(f),
             Unary(v) => v.fmt(f),
+            Abort(v) => v.fmt(f),
         }
     }
 }
@@ -225,6 +232,12 @@ impl From<Unary> for Expr {
     }
 }
 
+impl From<Abort> for Expr {
+    fn from(abort: Abort) -> Self {
+        Expr::Abort(abort)
+    }
+}
+
 // -----------------------------------------------------------------------------
 
 #[derive(thiserror::Error, Debug)]
@@ -264,16 +277,19 @@ impl DiagnosticError for Error {
 
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Default, PartialEq)]
-pub struct ExpressionError {
-    pub message: String,
-    pub labels: Vec<Label>,
-    pub notes: Vec<Note>,
+#[derive(Debug, PartialEq)]
+pub enum ExpressionError {
+    Abort,
+    Error {
+        message: String,
+        labels: Vec<Label>,
+        notes: Vec<Note>,
+    },
 }
 
 impl std::fmt::Display for ExpressionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.message.fmt(f)
+        self.message().fmt(f)
     }
 }
 
@@ -289,23 +305,39 @@ impl DiagnosticError for ExpressionError {
     }
 
     fn message(&self) -> String {
-        self.message.clone()
+        use ExpressionError::*;
+
+        match self {
+            Abort => "aborted".to_owned(),
+            Error { message, .. } => message.clone(),
+        }
     }
 
     fn labels(&self) -> Vec<Label> {
-        self.labels.clone()
+        use ExpressionError::*;
+
+        match self {
+            Abort => vec![],
+            Error { labels, .. } => labels.clone(),
+        }
     }
 
     fn notes(&self) -> Vec<Note> {
-        self.notes.clone()
+        use ExpressionError::*;
+
+        match self {
+            Abort => vec![],
+            Error { notes, .. } => notes.clone(),
+        }
     }
 }
 
 impl From<String> for ExpressionError {
     fn from(message: String) -> Self {
-        ExpressionError {
+        ExpressionError::Error {
             message,
-            ..Default::default()
+            labels: vec![],
+            notes: vec![],
         }
     }
 }

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -1,0 +1,22 @@
+use crate::expression::{ExpressionError, Resolved};
+use crate::{Context, Expression, State, TypeDef};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Abort;
+
+impl Expression for Abort {
+    fn resolve(&self, _: &mut Context) -> Resolved {
+        Err(ExpressionError::Abort)
+    }
+
+    fn type_def(&self, _: &State) -> TypeDef {
+        TypeDef::new().infallible().null()
+    }
+}
+
+impl fmt::Display for Abort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "abort")
+    }
+}

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -30,7 +30,10 @@ impl Assignment {
                 // Fallible expressions require infallible assignment.
                 if type_def.is_fallible() {
                     return Err(Error {
-                        variant: ErrorVariant::UnhandledError(target.to_string(), expr.to_string()),
+                        variant: ErrorVariant::FallibleAssignment(
+                            target.to_string(),
+                            expr.to_string(),
+                        ),
                         span,
                         expr_span,
                         assignment_span,
@@ -444,8 +447,8 @@ pub enum ErrorVariant {
     #[error("unnecessary no-op assignment")]
     UnnecessaryNoop(Span),
 
-    #[error("unhandled error")]
-    UnhandledError(String, String),
+    #[error("unhandled fallible assignment")]
+    FallibleAssignment(String, String),
 
     #[error("unnecessary error assignment")]
     InfallibleAssignment(String, String, Span, Span),
@@ -472,7 +475,7 @@ impl DiagnosticError for Error {
 
         match &self.variant {
             UnnecessaryNoop(..) => 640,
-            UnhandledError(..) => 103,
+            FallibleAssignment(..) => 103,
             InfallibleAssignment(..) => 104,
             InvalidTarget(..) => 641,
         }
@@ -487,7 +490,7 @@ impl DiagnosticError for Error {
                 Label::context("either assign to a path or variable here", *target_span),
                 Label::context("or remove the assignment", self.assignment_span),
             ],
-            UnhandledError(target, expr) => vec![
+            FallibleAssignment(target, expr) => vec![
                 Label::primary("this expression is fallible", self.expr_span),
                 Label::context("update the expression to be infallible", self.expr_span),
                 Label::context(
@@ -512,7 +515,7 @@ impl DiagnosticError for Error {
         use ErrorVariant::*;
 
         match &self.variant {
-            UnhandledError(..) | InfallibleAssignment(..) => vec![Note::SeeErrorDocs],
+            FallibleAssignment(..) | InfallibleAssignment(..) => vec![Note::SeeErrorDocs],
             _ => vec![],
         }
     }

--- a/lib/vrl/compiler/src/value/error.rs
+++ b/lib/vrl/compiler/src/value/error.rs
@@ -83,9 +83,10 @@ impl DiagnosticError for Error {
 
 impl From<Error> for ExpressionError {
     fn from(err: Error) -> Self {
-        ExpressionError {
+        Self::Error {
             message: err.message(),
-            ..Default::default()
+            labels: vec![],
+            notes: vec![],
         }
     }
 }

--- a/lib/vrl/core/src/lib.rs
+++ b/lib/vrl/core/src/lib.rs
@@ -7,7 +7,7 @@ pub use compiler::{
     state, value, Context, Expression, Function, Program, Target, Value,
 };
 pub use diagnostic;
-pub use runtime::{Runtime, RuntimeResult};
+pub use runtime::{Runtime, RuntimeResult, Terminate};
 
 /// Compile a given source into the final [`Program`].
 pub fn compile(source: &str, fns: &[Box<dyn Function>]) -> compiler::Result {

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -209,6 +209,7 @@ pub enum Expr {
     FunctionCall(Node<FunctionCall>),
     Variable(Node<Ident>),
     Unary(Node<Unary>),
+    Abort(Node<()>),
 }
 
 impl fmt::Debug for Expr {
@@ -225,6 +226,7 @@ impl fmt::Debug for Expr {
             FunctionCall(v) => format!("{:?}", v),
             Variable(v) => format!("{:?}", v),
             Unary(v) => format!("{:?}", v),
+            Abort(_) => "abort".to_owned(),
         };
 
         write!(f, "Expr({})", value)
@@ -245,6 +247,7 @@ impl fmt::Display for Expr {
             FunctionCall(v) => v.fmt(f),
             Variable(v) => v.fmt(f),
             Unary(v) => v.fmt(f),
+            Abort(_) => f.write_str("abort"),
         }
     }
 }

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -245,6 +245,7 @@ pub enum Token<S> {
     Null,
     False,
     True,
+    Abort,
 
     // tokens
     Colon,
@@ -325,6 +326,7 @@ impl<S> Token<S> {
             If => If,
             Null => Null,
             True => True,
+            Abort => Abort,
 
             // tokens
             Colon => Colon,
@@ -378,6 +380,7 @@ where
             If => "If",
             Null => "Null",
             True => "True",
+            Abort => "Abort",
 
             // tokens
             Colon => "Colon",
@@ -418,13 +421,15 @@ impl<'input> Token<&'input str> {
             "true" => True,
             "false" => False,
             "null" => Null,
+            "abort" => Abort,
 
             // reserved identifiers
-            "abort" | "array" | "bool" | "boolean" | "break" | "continue" | "do" | "emit"
-            | "float" | "for" | "forall" | "foreach" | "all" | "each" | "any" | "try"
-            | "undefined" | "int" | "integer" | "iter" | "object" | "regex" | "return"
-            | "string" | "traverse" | "timestamp" | "duration" | "unless" | "walk" | "while"
-            | "loop" => ReservedIdentifier(s),
+            "array" | "bool" | "boolean" | "break" | "continue" | "do" | "emit" | "float"
+            | "for" | "forall" | "foreach" | "all" | "each" | "any" | "try" | "undefined"
+            | "int" | "integer" | "iter" | "object" | "regex" | "return" | "string"
+            | "traverse" | "timestamp" | "duration" | "unless" | "walk" | "while" | "loop" => {
+                ReservedIdentifier(s)
+            }
 
             _ if s.contains('@') => PathField(s),
 

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -35,6 +35,7 @@ extern {
         "null" => Token::Null,
         "true" => Token::True,
         "false" => Token::False,
+        "abort" => Token::Abort,
 
         ";" => Token::SemiColon,
         "\n" => Token::Newline,
@@ -208,6 +209,7 @@ Exprs: Vec<Node<Expr>> = {
 
 Expr: Node<Expr> = {
     Sp<IfStatement> => Node::new(<>.span(), Expr::IfStatement(<>)),
+    Sp<AbortExpr>,
     AssignmentExpr,
 };
 
@@ -222,6 +224,8 @@ Ident: Ident = "identifier" => Ident(<>.to_owned());
 
 PathField: Ident = "path field" => Ident(<>.to_owned());
 
+AbortExpr: Expr = Sp<"abort"> => Expr::Abort(<>.map(|_| ()));
+
 // An identifier that is allowed to include reserved keywords.
 AnyIdent: Ident = {
     "identifier" => Ident(<>.to_owned()),
@@ -231,6 +235,7 @@ AnyIdent: Ident = {
     "null" => Ident("null".to_owned()),
     "true" => Ident("true".to_owned()),
     "false" => Ident("false".to_owned()),
+    "abort" => Ident("abort".to_owned()),
 };
 
 // -----------------------------------------------------------------------------

--- a/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
+++ b/lib/vrl/tests/tests/diagnostics/syntax_error_ampersat_variable.vrl
@@ -7,7 +7,7 @@
 #   │ ^^^^^^^^^^
 #   │ │
 #   │ unexpected syntax token: "PathField"
-#   │ expected one of: "\n", "!", "(", "[", "_", "false", "float literal", "function call", "identifier", "if", "integer literal", "null", "regex literal", "string literal", "timestamp literal", "true", "{", "path literal"
+#   │ expected one of: "\n", "!", "(", "[", "_", "abort", "false", "float literal", "function call", "identifier", "if", "integer literal", "null", "regex literal", "string literal", "timestamp literal", "true", "{", "path literal"
 #   │
 #   = see language documentation at https://vrl.dev
 @timestamp = now()

--- a/lib/vrl/tests/tests/diagnostics/syntax_error_path_segment.vrl
+++ b/lib/vrl/tests/tests/diagnostics/syntax_error_path_segment.vrl
@@ -7,7 +7,7 @@
 #   │     ^
 #   │     │
 #   │     unexpected end of query path
-#   │     expected one of: "(", "identifier", "path field", "string literal"
+#   │     expected one of: "(", "abort", "identifier", "path field", "string literal"
 #   │
 #   = see language documentation at https://vrl.dev
 

--- a/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unhandled_parse_regex_all_type.vrl
@@ -1,7 +1,7 @@
 # object: { "message": "bananas and another ant" }
 # result:
 #
-# error[E103]: unhandled error
+# error[E103]: unhandled fallible assignment
 #   ┌─ :3:6
 #   │
 # 3 │ .a = sha3(.result[0].an)

--- a/lib/vrl/tests/tests/examples/blog_vector_remap_language_error_diagnostic.vrl
+++ b/lib/vrl/tests/tests/examples/blog_vector_remap_language_error_diagnostic.vrl
@@ -7,7 +7,7 @@
 #
 # result:
 #
-# error[E103]: unhandled error
+# error[E103]: unhandled fallible assignment
 #   ┌─ :2:5
 #   │
 # 2 │ . = parse_common_log(.log)

--- a/lib/vrl/tests/tests/expressions/abort/abort.vrl
+++ b/lib/vrl/tests/tests/expressions/abort/abort.vrl
@@ -1,0 +1,5 @@
+# result: { "foo": true }
+
+.foo = true
+abort
+.bar = false


### PR DESCRIPTION
This PR adds a new `abort` statement.

This will be used (in a follow-up PR) together with a Vector Remap transform `drop_on_abort` option, to allow people to ignore an event without generating an error during processing in a VRL program.

For example, one could write:

```coffee
status, err = int(.status)
if err != null {
	abort
}
```

In this case, if `.status` isn't an integer, we don't want to raise an error, but we know we want to drop the relevant event.

To support this, there are two changes made:

- At runtime, we now distinguish between two type of non-ok results: `Terminate::Abort` and `Terminate::Error`. The caller (in this case, Vector), can distinguish between the two and decide what to do in each specific case.
- A new `abort` statement is added to the language to facilitate this behaviour.