### PR TITLE
fix(setup): Pod security policy in helm chart

### DIFF
--- a/distribution/helm/vector-agent/templates/podsecuritypolicy.yaml
+++ b/distribution/helm/vector-agent/templates/podsecuritypolicy.yaml
@@ -12,6 +12,7 @@ spec:
   volumes:
     - 'hostPath'
     - 'configMap'
+    - 'emptyDir'
     - 'secret'
     - 'projected'
   allowedHostPaths:
@@ -21,6 +22,10 @@ spec:
       readOnly: true
     - pathPrefix: "/var/lib/vector"
       readOnly: false
+    - pathPrefix: "/sys"
+      readOnly: true
+    - pathPrefix: "/proc"
+      readOnly: true
     {{- range .Values.extraVolumes }}
     {{- if .hostPath }}
     - pathPrefix: {{ .hostPath.path }}


### PR DESCRIPTION
The following changes were necessary to start the vector-agent pods on a cluster with an unprivileged default PSP.  