### PR TITLE
enhancement(releasing): Correct the glibc requirements for packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,24 @@ assets = [
 ]
 license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"
-depends = "libc6 (>= 2.17)"
+
+# libc requirements are defined by `cross`
+# https://github.com/rust-embedded/cross#supported-targets
+# Though, it seems like aarch64 libc is actually 2.18 and not 2.19
+[package.metadata.deb.variants.armv7-unknown-linux-gnueabihf]
+depends = "libc6 (>= 2.15)"
+
+[package.metadata.deb.variants.x86_64-unknown-linux-gnu]
+depends = "libc6 (>= 2.15)"
+
+[package.metadata.deb.variants.x86_64-unknown-linux-musl]
+depends = ""
+
+[package.metadata.deb.variants.aarch64-unknown-linux-gnu]
+depends = "libc6 (>= 2.18)"
+
+[package.metadata.deb.variants.aarch64-unknown-linux-musl]
+depends = ""
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -714,8 +714,8 @@ package-deb-x86_64-unknown-linux-musl: package-x86_64-unknown-linux-musl ## Buil
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=x86_64-unknown-linux-musl timberio/ci_image ./scripts/package-deb.sh
 
 .PHONY: package-deb-aarch64
-package-deb-aarch64: package-aarch64-unknown-linux-musl  ## Build the aarch64 deb package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=aarch64-unknown-linux-musl timberio/ci_image ./scripts/package-deb.sh
+package-deb-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 deb package
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=aarch64-unknown-linux-gnu timberio/ci_image ./scripts/package-deb.sh
 
 .PHONY: package-deb-armv7-gnu
 package-deb-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-unknown-linux-gnueabihf deb package

--- a/Makefile
+++ b/Makefile
@@ -671,10 +671,10 @@ package-x86_64-unknown-linux-gnu-all: package-x86_64-unknown-linux-gnu package-d
 package-x86_64-unknown-linux-musl-all: package-x86_64-unknown-linux-musl # Build all x86_64 MUSL packages
 
 .PHONY: package-aarch64-unknown-linux-musl-all
-package-aarch64-unknown-linux-musl-all: package-aarch64-unknown-linux-musl package-deb-aarch64 package-rpm-aarch64  # Build all aarch64 MUSL packages
+package-aarch64-unknown-linux-musl-all: package-aarch64-unknown-linux-musl # Build all aarch64 MUSL packages
 
 .PHONY: package-aarch64-unknown-linux-gnu-all
-package-aarch64-unknown-linux-gnu-all: package-aarch64-unknown-linux-gnu # Build all aarch64 GNU packages
+package-aarch64-unknown-linux-gnu-all: package-aarch64-unknown-linux-gnu package-deb-aarch64 package-rpm-aarch64 # Build all aarch64 GNU packages
 
 .PHONY: package-armv7-unknown-linux-gnueabihf-all
 package-armv7-unknown-linux-gnueabihf-all: package-armv7-unknown-linux-gnueabihf package-deb-armv7-gnu package-rpm-armv7-gnu  # Build all armv7-unknown-linux-gnueabihf MUSL packages
@@ -732,7 +732,7 @@ package-rpm-x86_64-unknown-linux-musl: package-x86_64-unknown-linux-musl ## Buil
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=x86_64-unknown-linux-musl timberio/ci_image ./scripts/package-rpm.sh
 
 .PHONY: package-rpm-aarch64
-package-rpm-aarch64: package-aarch64-unknown-linux-musl ## Build the aarch64 rpm package
+package-rpm-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 rpm package
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=aarch64-unknown-linux-musl timberio/ci_image ./scripts/package-rpm.sh
 
 .PHONY: package-rpm-armv7-gnu

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -35,7 +35,6 @@ License: ASL 2.0
 Group: Applications/System
 Source: %{_source}
 URL: %{_url}
-AutoReqProv: no
 
 %description
 %{summary}

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -71,7 +71,7 @@ cat LICENSE NOTICE > "$PROJECT_ROOT/target/debian-license.txt"
 #   --no-build
 #     because this stop should follow a build
 
-cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --no-build --no-strip
+cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET" --no-build --no-strip
 
 # Rename the resulting .deb file to use - instead of _ since this
 # is consistent with our package naming scheme.


### PR DESCRIPTION
Closes: #6648 
Closes: #6547

This updates the glibc requirements for the packages we build to:

* Not require glibc for musl packages
* Requiring glibc 2.15 for armv7 and amd64 builds, 2.18 for aarch64
  following what `cross` links with
* Builds with glibc for the aarch64 packages

It accomplishes this by:

* leveraging `cargo-deb` to have different targets
based on the target tuple which have different glibc requirements.
* removing `AutoReqProv: no` from the rpm spec file. This allows RPM to
just generate the requirements.

For the gnu/x86_64 RPM this looks like:

```
/bin/sh
config(vector) = 0.13.0-1
ld-linux-x86-64.so.2()(64bit)
ld-linux-x86-64.so.2(GLIBC_2.3)(64bit)
libc.so.6()(64bit)
libc.so.6(GLIBC_2.10)(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.15)(64bit)
libc.so.6(GLIBC_2.16)(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.2)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.6)(64bit)
libc.so.6(GLIBC_2.7)(64bit)
libc.so.6(GLIBC_2.9)(64bit)
libdl.so.2()(64bit)
libdl.so.2(GLIBC_2.2.5)(64bit)
libgcc_s.so.1()(64bit)
libgcc_s.so.1(GCC_3.0)(64bit)
libgcc_s.so.1(GCC_3.3)(64bit)
libgcc_s.so.1(GCC_4.2.0)(64bit)
libm.so.6()(64bit)
libm.so.6(GLIBC_2.2.5)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.12)(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.3.2)(64bit)
libpthread.so.0(GLIBC_2.3.3)(64bit)
libresolv.so.2()(64bit)
libresolv.so.2(GLIBC_2.2.5)(64bit)
libresolv.so.2(GLIBC_2.9)(64bit)
librt.so.1()(64bit)
librt.so.1(GLIBC_2.2.5)(64bit)
libstdc++.so.6()(64bit)
libstdc++.so.6(CXXABI_1.3)(64bit)
libstdc++.so.6(GLIBCXX_3.4)(64bit)
libstdc++.so.6(GLIBCXX_3.4.11)(64bit)
libstdc++.so.6(GLIBCXX_3.4.9)(64bit)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)
```

For musl/v86_64 RPM this looks like:

```
/bin/sh
config(vector) = 0.12.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
