### PR TITLE
chore(external docs): Add missing log_schema global options to docs

### DIFF
--- a/docs/reference/configuration.cue
+++ b/docs/reference/configuration.cue
@@ -41,7 +41,7 @@ configuration: {
 							Sets the event key to use for the event message field.
 							"""
 						required: false
-						warnings: []
+						warnings: ["This option is deprecated in-lieu of using [`remap` transform][docs.transforms.remap] to rename fields"]
 						type: string: {
 							default: "message"
 							examples: ["message", "@message"]
@@ -55,7 +55,7 @@ configuration: {
 							Sets the event key to use for the event timestamp field.
 							"""
 						required: false
-						warnings: []
+						warnings: ["This option is deprecated in-lieu of using [`remap` transform][docs.transforms.remap] to rename fields"]
 						type: string: {
 							default: "timestamp"
 							examples: ["timestamp", "@timestamp"]
@@ -69,7 +69,7 @@ configuration: {
 							Sets the event key to use for the event host field.
 							"""
 						required: false
-						warnings: []
+						warnings: ["This option is deprecated in-lieu of using [`remap` transform][docs.transforms.remap] to rename fields"]
 						type: string: {
 							default: "host"
 							examples: ["host", "@host"]
@@ -84,7 +84,7 @@ configuration: {
 							field that is set by some sources.
 							"""
 						required: false
-						warnings: []
+						warnings: ["This option is deprecated in-lieu of using [`remap` transform][docs.transforms.remap] to rename fields"]
 						type: string: {
 							default: "source_type"
 							examples: ["source_type", "@source_type"]

--- a/docs/reference/configuration.cue
+++ b/docs/reference/configuration.cue
@@ -23,6 +23,78 @@ configuration: {
 			}
 		}
 
+		log_schema: {
+			common: false
+			description: """
+				Configures default log schema for all events. This is used by
+				Vector source components to assign the fields on incoming
+				events.
+				"""
+			required: false
+			warnings: []
+			type: object: {
+				examples: []
+				options: {
+					message_key: {
+						common: true
+						description: """
+							Sets the event key to use for the event message field.
+							"""
+						required: false
+						warnings: []
+						type: string: {
+							default: "message"
+							examples: ["message", "@message"]
+							syntax: "literal"
+						}
+					}
+
+					timestamp_key: {
+						common: true
+						description: """
+							Sets the event key to use for the event timestamp field.
+							"""
+						required: false
+						warnings: []
+						type: string: {
+							default: "timestamp"
+							examples: ["timestamp", "@timestamp"]
+							syntax: "literal"
+						}
+					}
+
+					host_key: {
+						common: true
+						description: """
+							Sets the event key to use for the event host field.
+							"""
+						required: false
+						warnings: []
+						type: string: {
+							default: "host"
+							examples: ["host", "@host"]
+							syntax: "literal"
+						}
+					}
+
+					source_type_key: {
+						common: true
+						description: """
+							Sets the event key to use for the event source type
+							field that is set by some sources.
+							"""
+						required: false
+						warnings: []
+						type: string: {
+							default: "source_type"
+							examples: ["source_type", "@source_type"]
+							syntax: "literal"
+						}
+					}
+				}
+			}
+		}
+
 		healthchecks: {
 			common: false
 			description: """


### PR DESCRIPTION
It seems like maybe they've been missing since we switched to cue?

Noticed by user in discord: https://discord.com/channels/742820443487993987/746070591097798688/821522831007285269 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
