### PR TITLE
chore(external docs): Mark `get_hostname` as infallible

### DIFF
--- a/docs/reference/remap/functions/get_hostname.cue
+++ b/docs/reference/remap/functions/get_hostname.cue
@@ -7,7 +7,9 @@ remap: functions: get_hostname: {
 		"""
 
 	arguments: []
-	internal_failure_reasons: []
+	internal_failure_reasons: [
+		"Internal hostname resolution failed."
+	]
 	return: types: ["string"]
 
 	examples: [


### PR DESCRIPTION
Closes #6801