### PR TITLE
chore: Add missing update to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,7 @@ dependencies = [
  "futures 0.3.13",
  "glob 0.3.0",
  "indexmap",
+ "libc",
  "quickcheck",
  "scan_fmt",
  "serde",


### PR DESCRIPTION
This change was missed in a previous update

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>