### PR TITLE
fix(ci): Fix workflow for packaging debian

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,14 +63,6 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-arm64.deb"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
     runs-on: ubuntu-20.04
@@ -86,6 +78,14 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-arm64.deb"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-armv7-unknown-linux-gnueabihf-packages:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -431,7 +431,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-      - build-aarch64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-gnu-packages
       - build-armv7-unknown-linux-gnueabihf-packages
       - deb-verify
       - rpm-verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,6 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-arm64.deb"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-aarch64-unknown-linux-gnu-packages:
     runs-on: ubuntu-20.04
@@ -87,6 +79,14 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu.tar.gz"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-arm64.deb
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-arm64.deb"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-armv7-unknown-linux-gnueabihf-packages:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,7 +533,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build-x86_64-unknown-linux-gnu-packages
-      - build-aarch64-unknown-linux-musl-packages
+      - build-aarch64-unknown-linux-gnu-packages
       - build-armv7-unknown-linux-gnueabihf-packages
       - deb-verify
       - rpm-verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ debug = false     # Do not include debug symbols in the executable.
 debug = true
 
 [package.metadata.deb]
+name = "vector"
 maintainer-scripts = "distribution/debian/scripts/"
 conf-files = ["/etc/vector/vector.toml"]
 assets = [

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ package-rpm-x86_64-unknown-linux-musl: package-x86_64-unknown-linux-musl ## Buil
 
 .PHONY: package-rpm-aarch64
 package-rpm-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 rpm package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=aarch64-unknown-linux-musl timberio/ci_image ./scripts/package-rpm.sh
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/timberio/vector/ -e TARGET=aarch64-unknown-linux-gnu timberio/ci_image ./scripts/package-rpm.sh
 
 .PHONY: package-rpm-armv7-gnu
 package-rpm-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-unknown-linux-gnueabihf rpm package

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -14,11 +14,6 @@ set -x
 
 TARGET="${TARGET:?"You must specify a target triple, ex: x86_64-apple-darwin"}"
 
-# The arch is the first part of the target
-# For some architectures, like armv7hl it doesn't match the arch
-# from Rust target triple and needs to be specified manually.
-ARCH="${ARCH:-"$(echo "$TARGET" | cut -d'-' -f1)"}"
-
 #
 # Local vars
 #
@@ -78,6 +73,17 @@ cat LICENSE NOTICE > "$PROJECT_ROOT/target/debian-license.txt"
 
 cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET" --no-build --no-strip
 
-# Rename the resulting .deb file to use - instead of _ and remove the debian
-# target triple to be consistent with our package naming scheme.
-mv -v "target/${TARGET}/debian/vector-${TARGET}_${PACKAGE_VERSION}_${ARCH}.deb"  "target/artifacts/vector-${PACKAGE_VERSION}-${ARCH}.deb"
+# Rename the resulting .deb file to remove TARGET from name and use - instead of
+# _ since this is consistent with our package naming scheme.
+for file in target/"${TARGET}"/debian/*.deb; do
+  base=$(basename "${file}")
+  nbase=${base//_/-}
+  nbase=${nbase//${TARGET}/}
+  mv "${file}" target/"${TARGET}"/debian/"${nbase}";
+done
+
+#
+# Move the deb into the artifacts dir
+#
+
+mv -v "target/$TARGET/debian"/*.deb target/artifacts

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -77,8 +77,8 @@ cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET
 # _ since this is consistent with our package naming scheme.
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
-  nbase=${base//_/-}
   nbase=${nbase//-${TARGET}/}
+  nbase=${nbase//_/-}
   mv "${file}" target/"${TARGET}"/debian/"${nbase}";
 done
 

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -77,7 +77,7 @@ cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET
 # _ since this is consistent with our package naming scheme.
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
-  nbase=${nbase//-${TARGET}/}
+  nbase=${base//-${TARGET}/}
   nbase=${nbase//_/-}
   mv "${file}" target/"${TARGET}"/debian/"${nbase}";
 done

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -14,6 +14,11 @@ set -x
 
 TARGET="${TARGET:?"You must specify a target triple, ex: x86_64-apple-darwin"}"
 
+# The arch is the first part of the target
+# For some architectures, like armv7hl it doesn't match the arch
+# from Rust target triple and needs to be specified manually.
+ARCH="${ARCH:-"$(echo "$TARGET" | cut -d'-' -f1)"}"
+
 #
 # Local vars
 #
@@ -73,16 +78,6 @@ cat LICENSE NOTICE > "$PROJECT_ROOT/target/debian-license.txt"
 
 cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET" --no-build --no-strip
 
-# Rename the resulting .deb file to use - instead of _ since this
-# is consistent with our package naming scheme.
-for file in target/"${TARGET}"/debian/*.deb; do
-  base=$(basename "${file}")
-  nbase=${base//_/-}
-  mv "${file}" target/"${TARGET}"/debian/"${nbase}";
-done
-
-#
-# Move the deb into the artifacts dir
-#
-
-mv -v "target/$TARGET/debian"/*.deb target/artifacts
+# Rename the resulting .deb file to use - instead of _ and remove the debian
+# target triple to be consistent with our package naming scheme.
+mv -v "target/${TARGET}/debian/vector-${TARGET}_${PACKAGE_VERSION}_${ARCH}.deb"  "target/artifacts/vector-${PACKAGE_VERSION}-${ARCH}.deb"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -78,7 +78,7 @@ cargo deb --target "$TARGET" --deb-version "$PACKAGE_VERSION" --variant "$TARGET
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
   nbase=${base//_/-}
-  nbase=${nbase//${TARGET}/}
+  nbase=${nbase//-${TARGET}/}
   mv "${file}" target/"${TARGET}"/debian/"${nbase}";
 done
 


### PR DESCRIPTION
This:

* Renames the built debian packages to match expectations of
  vector-VERSION-ARCH.deb
* Updates the nightly/release workflows to move the package uploading
  for aarch64 to the gnu steps since we've updated the default packaging
  to package glibc artifacts on aarch64

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
