### PR TITLE
fix(tests): Explicitly mount docker socket for AWS ECS metadata mock container

### DIFF
--- a/scripts/setup_integration/aws_integration_env.sh
+++ b/scripts/setup_integration/aws_integration_env.sh
@@ -29,7 +29,7 @@ start_podman () {
   localstack/localstack-full:0.11.6
   podman run -d --pod=vector-test-integration-aws --name vector_mockwatchlogs \
   -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
-  podman run -d --pod=vector-test-integration-aws -v /var/run:/var/run --name vector_local_ecs \
+  podman run -d --pod=vector-test-integration-aws -v /var/run/docker.sock:/var/run/docker.sock --name vector_local_ecs \
   -e RUST_LOG=trace amazon/amazon-ecs-local-container-endpoints:latest
 }
 
@@ -43,7 +43,7 @@ start_docker () {
   localstack/localstack-full:0.11.6
   docker run -d --network=vector-test-integration-aws -p 6000:6000 --name vector_mockwatchlogs \
   -e RUST_LOG=trace luciofranco/mockwatchlogs:latest
-  docker run -d --network=vector-test-integration-aws -v /var/run:/var/run -p 9088:80 --name vector_local_ecs \
+  docker run -d --network=vector-test-integration-aws -v /var/run/docker.sock:/var/run/docker.sock -p 9088:80 --name vector_local_ecs \
   -e RUST_LOG=trace amazon/amazon-ecs-local-container-endpoints:latest
 }
 


### PR DESCRIPTION
On OSX, the docker socket is a symlink so just mounting `/var/run`
results in the container not being able to follow the symlink to the
socket itself.

```
➜  vector git:(tokio-1.0) ls -l /var/run/docker.sock
lrwxr-xr-x  1 root  daemon  74 Feb 24 15:39 /var/run/docker.sock ->
/Users/jesse.szwedko/Library/Containers/com.docker.docker/Data/docker.sock
```

Mounting the symlink directly appears to work. I'm guessing `docker` has
special handling for this.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
