### PR TITLE
fix(internal docs): Use regular markdown image syntax in reference section

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -410,7 +410,7 @@ components: sinks: [Name=string]: {
 						buffers_batches: {
 							title: "Buffers & batches"
 							body: #"""
-									<SVG src="/optimized_svg/buffers-and-batches-serial_538_160.svg" />
+								    ![Buffers and Batches](/optimized_svg/buffers-and-batches-serial_538_160.svg)
 
 									This component buffers & batches data as shown in the diagram above. You'll notice that Vector treats these concepts
 									differently, instead of treating them as global concepts, Vector treats them

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -410,7 +410,7 @@ components: sinks: [Name=string]: {
 						buffers_batches: {
 							title: "Buffers & batches"
 							body: #"""
-								    ![Buffers and Batches](/optimized_svg/buffers-and-batches-serial_538_160.svg)
+									![Buffers and Batches](/optimized_svg/buffers-and-batches-serial_538_160.svg)
 
 									This component buffers & batches data as shown in the diagram above. You'll notice that Vector treats these concepts
 									differently, instead of treating them as global concepts, Vector treats them


### PR DESCRIPTION
Small fix for SVG image in the reference section.  We should not be using MDX components (React JSX syntax) in the CUE data.  Just use regular markdown syntax.