### PR TITLE
chore(sinks): Defer allocation of batch buffers until first use

### DIFF
--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -188,15 +188,6 @@ pub trait Batch: Sized {
     fn fresh(&self) -> Self;
     fn finish(self) -> Self::Output;
     fn num_items(&self) -> usize;
-
-    /// Replace the current batch with a fresh one, returning the old one.
-    fn fresh_replace(&mut self) -> Self
-    where
-        Self: Sized,
-    {
-        let fresh = self.fresh();
-        std::mem::replace(self, fresh)
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -381,7 +381,8 @@ mod test {
                 match buffer.push(event) {
                     PushResult::Overflow(_) => panic!("overflowed too early"),
                     PushResult::Ok(true) => {
-                        result.push(buffer.fresh_replace().finish());
+                        let batch = std::mem::replace(&mut buffer, MetricsBuffer::new(batch_size));
+                        result.push(batch.finish());
                     }
                     PushResult::Ok(false) => (),
                 }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -109,7 +109,7 @@ impl DerefMut for MetricEntry {
 /// metrics have their their samples compressed with
 /// `compress_distribution` below.
 pub struct MetricsBuffer {
-    metrics: MetricSet,
+    metrics: Option<MetricSet>,
     max_events: usize,
 }
 
@@ -120,7 +120,7 @@ impl MetricsBuffer {
 
     fn with_capacity(max_events: usize) -> Self {
         Self {
-            metrics: MetricSet::with_capacity(max_events),
+            metrics: None,
             max_events,
         }
     }
@@ -145,12 +145,16 @@ impl Batch for MetricsBuffer {
             PushResult::Overflow(item)
         } else {
             let item = item.into_metric();
+            let max_events = self.max_events;
+            let metrics = self
+                .metrics
+                .get_or_insert_with(|| MetricSet::with_capacity(max_events));
             let new_entry = match item.data.kind {
                 MetricKind::Absolute => MetricEntry(item),
                 MetricKind::Incremental => {
                     // Incremental metrics update existing entries, if present
                     let entry = MetricEntry(item);
-                    self.metrics
+                    metrics
                         .take(&entry)
                         .map(|mut existing| {
                             existing.data.update(&entry.data);
@@ -159,7 +163,7 @@ impl Batch for MetricsBuffer {
                         .unwrap_or(entry)
                 }
             };
-            self.metrics.replace(new_entry);
+            metrics.replace(new_entry);
             PushResult::Ok(self.num_items() >= self.max_events)
         }
     }
@@ -173,11 +177,19 @@ impl Batch for MetricsBuffer {
     }
 
     fn finish(self) -> Self::Output {
-        self.metrics.0.into_iter().map(finish_metric).collect()
+        self.metrics
+            .unwrap_or_else(|| MetricSet::with_capacity(0))
+            .0
+            .into_iter()
+            .map(finish_metric)
+            .collect()
     }
 
     fn num_items(&self) -> usize {
-        self.metrics.len()
+        self.metrics
+            .as_ref()
+            .map(|metrics| metrics.0.len())
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
Second attempt at something that will fix the inefficiency identified in #6341 without the trait complications of the previous pull request #6570. This defers allocation of batch buffers until their first push.

Signed-off-by: Bruce Guenter <bruce@timber.io>