### PR TITLE
feat(transforms): sample - field option

### DIFF
--- a/benches/topology.rs
+++ b/benches/topology.rs
@@ -297,6 +297,7 @@ fn benchmark_complex(c: &mut Criterion) {
                         rate: sample_rate,
                         key_field: None,
                         exclude: None,
+                        field: None,
                     },
                 );
                 config.add_sink(

--- a/docs/reference/components/transforms/sample.cue
+++ b/docs/reference/components/transforms/sample.cue
@@ -67,6 +67,16 @@ components: transforms: sample: {
 				syntax: "remap_boolean_expression"
 			}
 		}
+		field: {
+			common:      true
+			description: "The log field to decode. The field must hold a string value."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "message"
+				syntax:  "literal"
+			}
+		}
 		rate: {
 			description: """
 				The rate at which events will be forwarded, expressed as 1/N. For example,

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -71,6 +71,7 @@ async fn sample() {
             rate: 10,
             key_field: Some(config::log_schema().message_key().into()),
             exclude: None,
+            field: None,
         },
     );
     config.add_sink(


### PR DESCRIPTION
Closes #497

This PR adds the `field` option to the `sampler` transform.

Signed-off-by: Rémi Doreau <remi.d45@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
