### PR TITLE
chore(ci): Add missing dependency to release-docker step

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -292,6 +292,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-18.04
     needs:
+      - build-aarch64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-20.04
     needs:
+      - build-aarch64-unknown-linux-gnu-packages
       - build-aarch64-unknown-linux-musl-packages
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages


### PR DESCRIPTION
`release-docker` additionally needs the artifacts from `build-aarch64-unknown-linux-gnu-packages`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
