### PR TITLE
chore: Adjust metrics dashmap to use twox hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7941,6 +7941,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
+dependencies = [
+ "cfg-if 0.1.10",
+ "rand 0.7.3",
+ "static_assertions",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8343,6 +8354,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tower",
  "tui",
+ "twox-hash",
  "typetag",
  "url",
  "uuid 0.8.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,7 @@ thread_local = "=1.0.1"
 tokio-postgres = { version = "0.5.5", features = ["runtime", "with-chrono-0_4"], optional = true }
 toml = "0.5.8"
 typetag = "0.1.6"
+twox-hash = "1.6"
 url = "2.2.1"
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
 warp = { version = "0.2.5", default-features = false, optional = true }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,11 +5,13 @@ use metrics_tracing_context::{LabelFilter, TracingContextLayer};
 use metrics_util::layers::Layer;
 use metrics_util::{CompositeKey, Handle, MetricKind};
 use once_cell::sync::OnceCell;
+use std::hash::BuildHasherDefault;
 use std::hash::Hash;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
+use twox_hash::XxHash64;
 
 static CONTROLLER: OnceCell<Controller> = OnceCell::new();
 
@@ -45,7 +47,7 @@ pub fn init() -> crate::Result<()> {
 
     // Prepare the registry.
     let registry = VectorRegistry {
-        map: DashMap::new(),
+        map: DashMap::default(),
     };
     let registry = Arc::new(registry);
 
@@ -106,7 +108,7 @@ where
     K: Eq + Hash + Clone + 'static,
     H: 'static,
 {
-    pub map: DashMap<K, H>,
+    pub map: DashMap<K, H, BuildHasherDefault<XxHash64>>,
 }
 
 impl<K, H> VectorRegistry<K, H>


### PR DESCRIPTION
The default hasher in Rust hashmaps is secure against untrusted input but is
quite slow. This commit adjusts our metrics dashmap to use a faster hash because
we can trust its input, on account of it's under our control. This reduces the hash time
in our metrics from 3% of execution in `file -> remap -> blackhole` to 2%. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
