### PR TITLE
fix(remap): use levenstein distance to find alternative suggestions for undefined functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8502,6 +8502,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "chrono",
  "glob 0.3.0",
+ "jemallocator",
  "prettydiff",
  "regex",
  "serde",

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -8,6 +8,7 @@ mod block;
 mod function_argument;
 mod group;
 mod if_statement;
+mod levenstein;
 mod noop;
 mod not;
 mod object;

--- a/lib/vrl/compiler/src/expression/levenstein.rs
+++ b/lib/vrl/compiler/src/expression/levenstein.rs
@@ -1,0 +1,129 @@
+use std::cmp::min;
+
+fn min3<T>(a: T, b: T, c: T) -> T
+where
+    T: Ord,
+{
+    min(a, min(b, c))
+}
+
+// Calculates the damerau-levenstein distance - the number of edits needed to
+// change one word into another, taking into account transposed letters.
+pub(crate) fn distance(word1: &[char], word2: &[char]) -> usize {
+    let m = word1.len() + 1;
+    let n = word2.len() + 1;
+
+    // Setup a matrix between the two strings
+    let mut matrix = (0..m * n).map(|_| 0_usize).collect::<Vec<_>>();
+
+    // Make it easier to get the correct index in the matrix
+    let pos = |a, b| b * m + a;
+
+    for col in 1..m {
+        matrix[pos(col, 0)] = col;
+    }
+
+    for row in 1..n {
+        matrix[pos(0, row)] = row;
+    }
+
+    for row in 1..n {
+        for col in 1..m {
+            let cost = if word1[col - 1] == word2[row - 1] {
+                0
+            } else {
+                1
+            };
+
+            matrix[pos(col, row)] = min3(
+                matrix[pos(col - 1, row)] + 1,
+                matrix[pos(col, row - 1)] + 1,
+                matrix[pos(col - 1, row - 1)] + cost,
+            );
+
+            // Check for transposed letters.
+            if row > 1
+                && col > 1
+                && word1[col - 1] == word2[row - 2]
+                && word1[col - 2] == word2[row - 1]
+            {
+                matrix[pos(col, row)] =
+                    min(matrix[pos(col, row)], matrix[pos(col - 2, row - 2)] + 1)
+            }
+        }
+    }
+
+    matrix[matrix.len() - 1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_levenstein() {
+        assert_eq!(
+            1,
+            distance(
+                &"cat".chars().collect::<Vec<_>>(),
+                &"cot".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            1,
+            distance(
+                &"ct".chars().collect::<Vec<_>>(),
+                &"cot".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            1,
+            distance(
+                &"cat".chars().collect::<Vec<_>>(),
+                &"ct".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            1,
+            distance(
+                &"cat".chars().collect::<Vec<_>>(),
+                &"cta".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            2,
+            distance(
+                &"cat".chars().collect::<Vec<_>>(),
+                &"tac".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            3,
+            distance(
+                &"cat".chars().collect::<Vec<_>>(),
+                &"".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            3,
+            distance(
+                &"".chars().collect::<Vec<_>>(),
+                &"cat".chars().collect::<Vec<_>>()
+            )
+        );
+
+        assert_eq!(
+            0,
+            distance(
+                &"".chars().collect::<Vec<_>>(),
+                &"".chars().collect::<Vec<_>>()
+            )
+        );
+    }
+}

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -13,6 +13,7 @@ vrl = { path = "../core" }
 ansi_term = "0.12"
 chrono = "0.4"
 glob = "0.3"
+jemallocator = { version = "0.3.0" }
 prettydiff = "0.4"
 regex = "1"
 serde = "1"

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -7,6 +7,9 @@ use vrl::{diagnostic::Formatter, state, Runtime, Value};
 
 use vrl_tests::{docs, Test};
 
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[derive(Debug, StructOpt)]
 #[structopt(name = "VRL Tests", about = "Vector Remap Language Tests")]
 pub struct Cmd {

--- a/lib/vrl/tests/tests/diagnostics/call_to_undefined_function.vrl
+++ b/lib/vrl/tests/tests/diagnostics/call_to_undefined_function.vrl
@@ -4,10 +4,7 @@
 #   ┌─ :2:1
 #   │
 # 2 │ unknown_function(.foo, .bar)
-#   │ ^^^^^^^^^^^^^^^^
-#   │ │
-#   │ undefined function
-#   │ did you mean "parse_duration"?
+#   │ ^^^^^^^^^^^^^^^^ undefined function
 #   │
 #   = learn more about error code 105 at https://errors.vrl.dev/105
 #   = see language documentation at https://vrl.dev

--- a/lib/vrl/tests/tests/diagnostics/call_to_undefined_function.vrl
+++ b/lib/vrl/tests/tests/diagnostics/call_to_undefined_function.vrl
@@ -4,7 +4,10 @@
 #   ┌─ :2:1
 #   │
 # 2 │ unknown_function(.foo, .bar)
-#   │ ^^^^^^^^^^^^^^^^ undefined function
+#   │ ^^^^^^^^^^^^^^^^
+#   │ │
+#   │ undefined function
+#   │ did you mean "parse_duration"?
 #   │
 #   = learn more about error code 105 at https://errors.vrl.dev/105
 #   = see language documentation at https://vrl.dev


### PR DESCRIPTION
Closes #6726 

This changes the algorithm used to find the suggestions for alternative functions when a user uses an unknown function in remap.

For some unknown reason the ngrammatic algorithm was causing a segfault when running a release version with jemallocator used. See #6819 for a minimal case where this would blow up.

This segfault doesn't occur on nightly, so we may want to look into reinstating this functionality on future versions of the Rust compiler.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
