### PR TITLE
chore(external docs):  Port over the about section

### DIFF
--- a/docs/manual/about.md
+++ b/docs/manual/about.md
@@ -8,7 +8,6 @@ hide_pagination: true
 This section will cover Vector's basic concepts and provide a foundation
 for the rest of the documentation.
 
-<Jump to="/docs/about/concepts/">Concepts</Jump>
-<Jump to="/docs/about/data-model/">Data model</Jump>
-<Jump to="/docs/about/guarantees/">Guarantees</Jump>
-<Jump to="/docs/about/what-is-vector/">What is vector</Jump>
+<Jump to="/docs/about/concepts/" leftIcon="book">Concepts</Jump>
+<Jump to="/docs/about/under-the-hood/" leftIcon="book">Under the hood</Jump>
+<Jump to="/docs/about/what-is-vector/" leftIcon="book">What is vector</Jump>

--- a/docs/manual/about/concepts.md
+++ b/docs/manual/about/concepts.md
@@ -5,29 +5,50 @@ description: The fundamental Vector concepts. A great place to start learning ab
 
 <SVG src="/optimized_svg/concepts_687_357.svg" />
 
-It's worth getting familiar with the basic concepts that comprise Vector as they
-are used throughout the documentation. This knowledge will be helpful as you
-proceed and is also cool to brag about amongst your friends.
+In order to understand Vector, you must first understand the fundamental
+concepts. The following concepts are ordered progressively, starting with the
+individual unit of data ([events](#events)) and broadening all the way to
+Vector's deployment models ([pipelines](#pipelines)).
+
+## Events
+
+"Events" represent the individual units of data in Vector. They must fit into
+one of the following types.
+
+<Jump to="/docs/about/under-the-hood/architecture/data-model/">Data model</Jump>
+
+### Logs
+
+A "log" event is a generic key/value representation of an event.
+
+<Jump to="/docs/about/under-the-hood/architecture/data-model/log/">Log events</Jump>
+
+### Metrics
+
+A "metric" event is a first-class representation of numerical operation
+performed on a time series. Vector's metric events are fully interoperable.
+
+<Jump to="/docs/about/under-the-hood/architecture/data-model/log/">Metric events</Jump>
 
 ## Components
 
 "Component" is the generic term we use for [sources](#sources),
-[transforms](#transforms), and [sinks](#sinks). You compose components to create
-pipelines, allowing you to ingest, transform, and send data.
+[transforms](#transforms), and [sinks](#sinks). Components ingest, transform,
+and route events. You compose components to create [topologies](#topology).
 
-<Jump to="/components/">View all components</Jump>
+<Jump to="/components/">Components</Jump>
 
 ### Sources
 
-Vector wouldn't be very useful if it couldn't ingest data. A "source" defines where Vector
-should pull data from, or how it should receive data pushed to it. A pipeline
-can have any number of sources, and as they ingest data they proceed to
-normalize it into [events](#events) \(see next section\). This sets the stage
+Vector wouldn't be very useful if it couldn't ingest data. A "source" defines
+where Vector should pull data from, or how it should receive data pushed to it.
+A [topology](#topology) can have any number of sources, and as they ingest data
+they proceed to normalize it into [events](#events) \(see next section\). This sets the stage
 for easy and consistent processing of your data. Examples of sources include
 [`file`][docs.sources.file], [`syslog`][docs.sources.syslog],
 [`StatsD`][docs.sources.statsd], and [`stdin`][docs.sources.stdin].
 
-<Jump to="/docs/reference/sources/">View all sources</Jump>
+<Jump to="/docs/reference/configuration/sources/">Sources</Jump>
 
 ### Transforms
 
@@ -36,7 +57,7 @@ Vector. This might involve parsing, filtering, sampling, or aggregating. You can
 have any number of transforms in your pipeline and how they are composed is up
 to you.
 
-<Jump to="/docs/reference/transforms/">View all transforms</Jump>
+<Jump to="/docs/reference/configuration/transforms/">Transforms</Jump>
 
 ### Sinks
 
@@ -46,29 +67,51 @@ interacting with. For example, the [`socket` sink][docs.sinks.socket] will
 stream individual events, while the [`aws_s3` sink][docs.sinks.aws_s3] will
 buffer and flush data.
 
-<Jump to="/docs/reference/sinks/">View all sinks</Jump>
+<Jump to="/docs/reference/configuration/sinks/">Sinks</Jump>
 
-## Events
+## Pipeline
 
-Data, such as logs and metrics, that passes through Vector is known as an
-"event". Events are explained in detail in the [data model][docs.data-model]
-section.
+A "Pipeline" is a directed acyclic graph of [components](#components). Each
+component is a node on the graph with directed edges. Data must flow in one
+direction, from sources to sinks. Components can produce zero or more events.
 
-<Jump to="/docs/about/data-model/">View data model</Jump>
+<Jump to="/docs/about/under-the-hood/architecture/pipeline-model/">Pipeline model</Jump>
 
-## Pipelines
+## Roles
 
-A "pipeline" is the end result of connecting [sources](#sources),
-[transforms](#transforms), and [sinks](#sinks). You can see a full example of a
-pipeline in the [configuration section][docs.setup.configuration].
+A "role" refers to a deployment role that Vector fills in order to create
+end-to-end pipelines.
 
-<Jump to="/docs/setup/configuration/">View configuration</Jump>
+<Jump to="/docs/setup/deployment/roles/">Deployment roles</Jump>
 
-[docs.setup.configuration]: /docs/setup/configuration/
-[docs.data-model]: /docs/about/data-model/
-[docs.sinks.aws_s3]: /docs/reference/sinks/aws_s3/
-[docs.sinks.socket]: /docs/reference/sinks/socket/
-[docs.sources.file]: /docs/reference/sources/file/
-[docs.sources.statsd]: /docs/reference/sources/statsd/
-[docs.sources.stdin]: /docs/reference/sources/stdin/
-[docs.sources.syslog]: /docs/reference/sources/syslog/
+### Agent
+
+The "agent" role is designed for deploying Vector to the edge, typically for
+data collection.
+
+<Jump to="/docs/setup/deployment/roles/#agent">Agent role</Jump>
+
+### Aggregator
+
+The "aggregator" role is designed to collect and process data from multiple
+upstream sources. These upstream sources could be other Vector agents or
+non-Vector agents such as Syslog-ng.
+
+<Jump to="/docs/setup/deployment/roles/#aggregator">Aggregator role</Jump>
+
+## Topology
+
+A "topology" refers to the end result of deploying Vector into your
+infrastructure. A topology may be as simple as deploying
+Vector as an agent, or it may be as complex as deploying Vector as an agent
+and routing data through multiple Vector aggregators.
+
+<Jump to="/docs/setup/deployment/topologies/">Deployment topologies</Jump>
+
+[docs.data-model]: /docs/about/under-the-hood/architecture/data-model/
+[docs.sinks.aws_s3]: /docs/reference/configuration/sinks/aws_s3/
+[docs.sinks.socket]: /docs/reference/configuration/sinks/socket/
+[docs.sources.file]: /docs/reference/configuration/sources/file/
+[docs.sources.statsd]: /docs/reference/configuration/sources/statsd/
+[docs.sources.stdin]: /docs/reference/configuration/sources/stdin/
+[docs.sources.syslog]: /docs/reference/configuration/sources/syslog/

--- a/docs/manual/about/under-the-hood.md
+++ b/docs/manual/about/under-the-hood.md
@@ -1,0 +1,10 @@
+---
+title: Under the hood
+description: "The Vector architecture and internals"
+sidebar_label: hidden
+hide_pagination: true
+---
+
+<Jump to="/docs/about/under-the-hood/architecture/" leftIcon="book">Architecture</Jump>
+<Jump to="/docs/about/under-the-hood/guarantees/" leftIcon="book">Guarantees</Jump>
+<Jump to="/docs/about/under-the-hood/networking/" leftIcon="book">Networking</Jump>

--- a/docs/manual/about/under-the-hood/architecture.md
+++ b/docs/manual/about/under-the-hood/architecture.md
@@ -1,0 +1,21 @@
+---
+title: Architecture
+description: "Vector's architecture"
+sidebar_label: hidden
+hide_pagination: true
+---
+
+<SVG src="/optimized_svg/architecture_840_293.svg" />
+
+In this section we'll cover the various models that combine to form Vector's
+architecture. The following models are ordered progressively, starting with the
+[data model][docs.architecture.data-model] and broadening all the way to
+Vector's [runtime model][docs.architecture.runtime-model].
+
+<Jump to="/docs/about/under-the-hood/architecture/data-model/">Data model</Jump>
+<Jump to="/docs/about/under-the-hood/architecture/pipeline-model/">Topology model</Jump>
+<Jump to="/docs/about/under-the-hood/architecture/concurrency-model/">Concurrency model</Jump>
+<Jump to="/docs/about/under-the-hood/architecture/runtime-model/">Runtime model</Jump>
+
+[docs.architecture.data-model]: /docs/about/under-the-hood/architecture/data-model/
+[docs.architecture.runtime-model]: /docs/about/under-the-hood/architecture/runtime-model/

--- a/docs/manual/about/under-the-hood/architecture/concurrency-model.md
+++ b/docs/manual/about/under-the-hood/architecture/concurrency-model.md
@@ -1,0 +1,35 @@
+---
+title: Concurrency Model
+description: Vector's concurrency model enables automatic CPU concurrency.
+---
+
+<SVG src="/optimized_svg/concurrency-model_842_494.svg" />
+
+<Alert severity="warning">
+
+Vector's concurrency model is currently a work in progress. We are expecting
+to complete the work in Q2 of 2021.
+
+</Alert>
+
+Vector implements a concurrency model that scales naturally with incoming data
+volume as shown above. Each Vector [source][docs.sources] is responsible for
+defining the unit of concurrency and implementing it accordingly. This allows
+for a natural concurrency model that adapts to however Vector is being used,
+avoiding the need for tedious concurrency tuning and configuration.
+
+For example, the [`file` source][docs.sources.file] implements concurrency
+across the number of files it's tailing, and the
+[`socket` source][docs.sources.socket] implements concurrency across the number
+active open connection it's maintaining.
+
+## Stateless function transforms
+
+As covered in the [topology model document](topology-model), Vector's
+concurrency relies on stateless function transforms that can be inlined at the
+source level. Therefore, task transforms should be defined at the end of
+your topology to allow for maximum transform inlining.
+
+[docs.sources.file]: /docs/reference/configuration/sources/file/
+[docs.sources.socket]: /docs/reference/configuration/sources/socket/
+[docs.sources]: /docs/reference/configuration/sources/

--- a/docs/manual/about/under-the-hood/architecture/data-model.md
+++ b/docs/manual/about/under-the-hood/architecture/data-model.md
@@ -1,0 +1,36 @@
+---
+title: Data Model
+sidebar_label: hidden
+description: Vector's internal data model -- event and it's subtypes.
+---
+
+<SVG src="/optimized_svg/data-model-event_808_359.svg" />
+
+The individual units of data flowing through Vector are known as **events**.
+Events must fall into one of Vector's defined observability types.
+
+## Event Types
+
+Vector defines subtypes for events. This is necessary to establish domain
+specific requirements enabling interoperability with existing monitoring and
+observability systems.
+
+<Jump to="/docs/about/under-the-hood/architecture/data-model/log/" leftIcon="book">Log</Jump>
+<Jump to="/docs/about/under-the-hood/architecture/data-model/metric/" leftIcon="book">Metric</Jump>
+
+## FAQ
+
+### Why Not _Just_ Events?
+
+We, _very much_, like the idea of an event-only world, one where every service
+is perfectly instrumented with events that contain rich data and context.
+Unfortunately, that is not the case; existing services often emit metrics,
+traces, and logs of varying quality. By designing Vector to meet services where
+they are in their current state, we serve as a bridge to newer standards. This is why
+we place "events" at the top of our data model, where logs and metrics are
+derived.
+
+Finally, a sophisticated data model that accounts for the various data types
+allows for _correct_ interoperability between observability systems. For
+example, a pipeline with a `statsd` source and a `prometheus` sink would not
+be possible without the correct internal metrics data types.

--- a/docs/manual/about/under-the-hood/architecture/data-model/log.md
+++ b/docs/manual/about/under-the-hood/architecture/data-model/log.md
@@ -1,0 +1,18 @@
+---
+title: Log Event
+description: Vector's internal log data model.
+---
+
+<SVG src="/optimized_svg/data-model-log_1526_907.svg" />
+
+## Description
+
+A Vector log event is a structured representation of a
+point-in-time event. It contains an arbitrary set of
+fields that describe the event.
+
+A key tenet of Vector is to remain schema neutral. This
+ensures that Vector can work with any schema, supporting
+legacy and future schemas as your needs evolve. Vector
+does not require any specific fields, and each component
+will document the fields it provides.

--- a/docs/manual/about/under-the-hood/architecture/data-model/metric.md
+++ b/docs/manual/about/under-the-hood/architecture/data-model/metric.md
@@ -1,0 +1,21 @@
+---
+title: Metric Event
+description: Vector's internal metric data model.
+---
+
+<SVG src="/optimized_svg/data-model-metric_1513_942.svg" />
+
+## Description
+
+A Vector metric event represents a numerical operation
+performed on a time series. Unlike other tools, metrics
+in Vector are first class citizens, they are not represented
+as structured logs. This makes them interoperable with
+various metrics services without the need for any
+transformation.
+
+Vector's metric data model favors accuracy and correctness over
+ideological purity. Therefore, Vector's metric types are a
+conglomeration of various metric types found in the wild, such as
+Prometheus and Statsd. This ensures metric data is _correctly_
+interoperable between systems.

--- a/docs/manual/about/under-the-hood/architecture/pipeline-model.md
+++ b/docs/manual/about/under-the-hood/architecture/pipeline-model.md
@@ -1,0 +1,46 @@
+---
+title: Pipeline Model
+description: Vector's pipeline model explains how data is collected and routed within Vector.
+---
+
+<SVG src="/optimized_svg/pipeline-model_1350_760.svg" />
+
+Vector's pipeline model is based on a [directed acyclic graph][urls.dag] of
+[components][urls.vector_components] that contains independent subgraphs.
+[Events][docs.architecture.data-model] must flow in a single direction from sources
+to sinks, and cannot create cycles. Each component in the graph can produce zero
+or more events.
+
+## Defining pipelines
+
+A Vector pipeline is defined through a TOML, YAML, or JSON
+[configuration][urls.vector_configuration] file. For maintainability,
+many Vector users use data templating languages like [Jsonnet][urls.jsonnet]
+or [Cue][urls.cue].
+
+Configuration is checked during compile-time (Vector boot) to present simple
+mistakes and enforce the DAG properties.
+
+## In-flight manipulation
+
+Vector's configured pipeline can be adjusted in real-time without restarting Vector.
+
+### Reload
+
+Vector supports hot [reloading][docs.process-management#reloading] to apply
+any configuration changes. This is achieved by sending a `SIGHUP` process
+signal to Vector's process.
+
+### API
+
+Vector also includes an [API][docs.reference.api] that allows for real-time
+observation and manipulation of a running Vector instance.
+
+[docs.architecture.data-model]: /docs/about/under-the-hood/architecture/data-model/
+[docs.process-management#reloading]: /docs/administration/process-management/#reloading
+[docs.reference.api]: /docs/reference/api/
+[urls.cue]: https://cuelang.org/
+[urls.dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
+[urls.jsonnet]: https://jsonnet.org/
+[urls.vector_components]: /components/
+[urls.vector_configuration]: /docs/configuration/

--- a/docs/manual/about/under-the-hood/architecture/runtime-model.md
+++ b/docs/manual/about/under-the-hood/architecture/runtime-model.md
@@ -1,0 +1,74 @@
+---
+title: Runtime Model
+description: Vector's runtime model and how it manages concurrency.
+---
+
+<SVG src="/optimized_svg/runtime-model_770_325.svg" />
+
+Vector's runtime is a futures-based asynchronous runtime where nodes in Vector's
+[DAG topology model][docs.architecture.pipeline-model] roughly map to asynchonous
+[tasks](#tasks) that [communicate](#data-model) via channels, all
+[scheduled](#scheduled) by the [Tokio][urls.rust_tokio] runtime.
+
+## Tasks
+
+Nodes in Vector's [topology][docs.architecture.pipeline-model] roughly map to
+asynchronous tasks, with the exception being stateless transforms that are
+inlined into the source for [concurrency][docs.architecture.concurrency-model]
+reasons.
+
+### Source tasks
+
+[Sources][docs.sources] are tasks with an output channel. This
+interface is intentionally simple and favors internal composability to allow for
+maximum flexibility across Vector's wide array of sources.
+
+### Transform tasks
+
+[Transforms][docs.transforms] can both be tasks or stateless functions
+depending on their purpose.
+
+#### Stateless function transforms
+
+Stateless function transforms are single operation transforms that do not
+maintain state across multiple events. For example, the
+[`remap` transform][docs.transforms.remap] performs individual
+operations on events as they are received and immediately returns. This
+function-like simplificity allows them to be inlined at the source level to
+achieve our [conccurency model](concurrency-model).
+
+#### Task transforms
+
+Task transforms can optionally maintain state across multiple events. Therefore,
+they run as separate tasks and cannot be inlined at the source level for
+concurrency. An example of task transform is the
+[`dedupe` transform][docs.transforms.dedupe], which maintains state to
+drop duplicate events.
+
+### Sink tasks
+
+[Sinks][docs.sinks] are tasks with an input channel. This interface is
+intentionally simple and favors internal composability to allow for maximum
+flexibility. Sinks share a lot of infrastructure that make them easy and
+flexible to build. Such as streaming, batching, partitioning, networking,
+retries, and buffers.
+
+## Scheduler
+
+Vectur leverages the [Tokio][urls.rust_tokio] runtime for task scheduling.
+
+## Data plane
+
+Nodes in Vector's [DAG topology][docs.architecture.pipeline-model] communicate
+via channels. Edge nodes are customized channels with dynamic output control
+where back pressure is the default, but can be customized on a per-sink basis to
+shed load or persist to disk.
+
+[docs.architecture.concurrency-model]: /docs/about/under-the-hood/architecture/concurrency-model/
+[docs.architecture.pipeline-model]: /docs/about/under-the-hood/architecture/pipeline-model/
+[docs.sinks]: /docs/reference/configuration/sinks/
+[docs.sources]: /docs/reference/configuration/sources/
+[docs.transforms.dedupe]: /docs/reference/configuration/transforms/dedupe/
+[docs.transforms.remap]: /docs/reference/configuration/transforms/remap/
+[docs.transforms]: /docs/reference/configuration/transforms/
+[urls.rust_tokio]: https://github.com/tokio-rs/tokio

--- a/docs/manual/about/under-the-hood/guarantees.md
+++ b/docs/manual/about/under-the-hood/guarantees.md
@@ -1,12 +1,7 @@
 ---
 title: Guarantees
-description: Vector's gaurantees. Covering delivery and reliability guarantees for each Vector component.
+description: Vector's gaurantees. Covering delivery and stability guarantees for each Vector component.
 ---
-
-Faults in distributed systems are like green Skittles, we all wish they'd never
-happen but in reality the best we can do is understand and control the damage
-they cause. In event streaming pipelines that means understanding delivery
-and stability guarantees and their implications on your overall system.
 
 Vector attempts to make it clear which guarantees you can expect from it. We
 categorize all components by their targeted delivery guarantee and also by
@@ -25,13 +20,13 @@ support specific guarantees.
 
 ### At-Least-Once
 
-The `at-least-once` delivery guarantee ensures that an
-[event][docs.data-model] received by Vector will be delivered at least
-once to the configured destination(s). While rare, it is possible for an event
-to be delivered more than once. See the [Does Vector support exactly once
-delivery](#does-vector-support-exactly-once-delivery) FAQ below).
+The `at-least-once` delivery guarantee ensures that an [event][docs.data-model]
+received by a Vector component will be delivered at least once. While rare, it
+is possible for an event to be delivered more than once. See the
+[Does Vector support exactly once delivery](#does-vector-support-exactly-once-delivery)
+FAQ below).
 
-<Alert type="warning">
+<Alert variant="outlined" severity="warning">
 
 In order to achieve at least once delivery between restarts your source must
 be configured to use `disk` based buffers:
@@ -50,19 +45,18 @@ Refer to each [sink's][docs.sinks] documentation for further guidance on its
 buffer options.
 
 </Alert>
+
 <Jump to="/components/?at-least-once=true">View all at-least-once components</Jump>
+
 </li>
 <li>
 
 ### Best-Effort
 
-A `best-effort` delivery guarantee means that Vector will make a best effort to
-deliver each event, but cannot _guarantee_ delivery. This is usually due to
-limitations of the underlying protocol; which are outside the scope of Vector. It's
-important to note that while data loss is possible, it is usually rare and
-Vector does everything within its control to ensure data is not lost. For more
-info, see the
-["Do I need at least once delivery?"](#do-i-need-at-least-once-delivery) FAQ.
+A `best-effort` delivery guarantee means that a Vector component will make a
+best effort to deliver each event, but cannot _guarantee_ delivery. This is
+usually due to limitations of the underlying protocol; which are outside the
+control of Vector.
 
 Note that this is _not_ the same as `at-most-once` delivery, as it is still
 possible for Vector to introduce duplicates under extreme circumstances.
@@ -70,16 +64,16 @@ possible for Vector to introduce duplicates under extreme circumstances.
 </li>
 </ul>
 
-## Reliability Guarantee
+## Stability Guarantees
 
 <ul class="connected-list">
 <li>
 
-### Prod-Ready
+### Stable
 
-The `prod-ready` status is a _subjective_ status defined by the Vector team. It is
-intended to give you a general idea of a feature's reliability for production
-environments. A feature is `prod-ready` if it meets the following criteria:
+The `stable` status is a _subjective_ status defined by the Vector team. It is
+intended to give you a general idea of a feature's stability for production
+environments. A feature is `stable` if it meets the following criteria:
 
 1. A meaningful amount of users (generally >50) have been using the feature in
    a production environment for sustained periods without issue.
@@ -88,7 +82,7 @@ environments. A feature is `prod-ready` if it meets the following criteria:
 3. The feature API is stable and unlikely to change.
 4. There are no major [open bugs][urls.vector_bug_issues] for the feature.
 
-<Jump to="/components/?prod-ready=true">View all prod-ready components</Jump>
+<Jump to="/components/?stable=true">View all stable components</Jump>
 
 </li>
 <li>
@@ -96,8 +90,17 @@ environments. A feature is `prod-ready` if it meets the following criteria:
 ### Beta
 
 The `beta` status means that a feature has not met the criteria outlined in
-the [Prod-Ready](#prod-ready) section and therefore should be used with caution
+the [stable](#stable) section and therefore should be used with caution
 in production environments.
+
+</li>
+<li>
+
+### Deprecated
+
+The `deprecated` status means that a feature will be removed in the next major
+version of Vector. We will provide ample time to transition and, when possible,
+we will strive to retain backward compatibility.
 
 </li>
 </ul>
@@ -125,7 +128,7 @@ limitations of the underlying protocol.
 No, Vector does not support exactly once delivery. There are future plans to
 partially support this for sources and sinks that support it, for example Kafka,
 but it remains unclear if Vector will ever be able to achieve this.
-We recommend [subscribing to our mailing list](https://vector.dev/community),
+We recommend [subscribing to our mailing list](/community),
 which will keep you in the loop if this ever changes.
 
 ### How can I find components that meet these guarantees?
@@ -133,7 +136,7 @@ which will keep you in the loop if this ever changes.
 Head over to the [components section][pages.components] and use the guarantee
 filters.
 
-[docs.data-model]: /docs/about/data-model/
-[docs.sinks]: /docs/reference/sinks/
+[docs.data-model]: /docs/about/under-the-hood/architecture/data-model/
+[docs.sinks]: /docs/reference/configuration/sinks/
 [pages.components]: /components/
 [urls.vector_bug_issues]: https://github.com/timberio/vector/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+bug%22

--- a/docs/manual/about/under-the-hood/networking.md
+++ b/docs/manual/about/under-the-hood/networking.md
@@ -1,0 +1,14 @@
+---
+title: Networking
+description: "Vector's networking internals"
+sidebar_label: hidden
+hide_pagination: true
+---
+
+<Alert variant="outlined" severity="warning">
+
+This section is currently a work in progress.
+
+</Alert>
+
+<Jump to="/docs/about/under-the-hood/networking/adaptive-request-concurrency/" leftIcon="book">ARC</Jump>

--- a/docs/manual/about/under-the-hood/networking/adaptive-request-concurrency.md
+++ b/docs/manual/about/under-the-hood/networking/adaptive-request-concurrency.md
@@ -1,0 +1,17 @@
+---
+title: Adaptive Request Concurrency (ARC)
+sidebar_label: ARC
+description: The fundamental Vector concepts. A great place to start learning about Vector.
+---
+
+![The Adaptive Request Concurrency decision chart](/img/adaptive-concurrency.png)
+
+ARC (Adaptive Request Concurrency) is a Vector networking feature that does away
+with static rate limits and automatically optimizes HTTP concurrency limits
+based on downstream service responses. The underlying [mechanism](#how-it-works)
+is a feedback loop inspired by TCP congestion control algorithms.
+
+The end result is improved performance and reliability across your entire
+observability infrastructure.
+
+<Jump to="/blog/adaptive-request-concurrency/">Read the feature announcement</Jump>

--- a/docs/manual/about/what-is-vector.md
+++ b/docs/manual/about/what-is-vector.md
@@ -1,44 +1,23 @@
 ---
 title: "What is Vector?"
-description: "High-level description of the Vector observability data collector and router."
+description: "High-level overview of the Vector observability data pipeline"
 ---
 
 <SVG src="/optimized_svg/components_683_294.svg" />
 
-Vector is a lightweight, ultra-fast, [open-source][urls.vector_repo] tool for
-building observability pipelines. Compared to Logstash and friends, Vector
-[improves throughput by ~10X while significantly reducing CPU and memory
-usage][urls.vector_performance].
+Vector is a high-performance observability data pipeline that puts organizations
+in control of their observability data. [Collect][docs.sources],
+[transform][docs.transforms], and [route][docs.sinks] all your logs, metrics,
+and traces to any vendors you want today and any other vendors you may want
+tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and
+data security where you need it, not where is most convenient for your vendors.
+Open source and up to 10x faster than every alternative.
 
-### Principles
-
-- **Reliability First.** - Built in [Rust][urls.rust], Vector's primary design goal is reliability.
-- **One Tool. All Data.** - One simple tool gets your [logs][docs.data-model.log], [metrics][docs.data-model.metric], and traces (coming soon) from A to B.
-- **Single Responsibility.** - Vector is a _data router_, it does not plan to become a distributed processing framework.
-
-### Who should use Vector?
-
-- You _SHOULD_ use Vector to replace Logstash, Fluent\*, Telegraf, Beats, or similar tools.
-- You _SHOULD_ use Vector as a [daemon][docs.strategies#daemon] or [sidecar][docs.strategies#sidecar].
-- You _SHOULD_ use Vector as a Kafka consumer/producer for observability data.
-- You _SHOULD_ use Vector in resource constrained environments (such as devices).
-- You _SHOULD NOT_ use Vector if you need an advanced distributed stream processing framework.
-- You _SHOULD NOT_ use Vector to replace Kafka. Vector is designed to work with Kafka!
-- You _SHOULD NOT_ use Vector for non-observability data such as analytics data.
-
-### Community
-
-- Vector is **downloaded over 100,000 times per day**.
-- Vector's largest user **processes over 10TB daily**.
-- Vector is **used by multiple fortune 500 companies** with stringent production requirements.
-- Vector has **over 15 active contributors** and growing.
+Vector is downloaded millions of times per month and relied on by companies
+like T-Mobile, Comcast, Zendesk, and Discord to own their observability data.
 
 <Jump to="/guides/getting-started/">Get started</Jump>
 
-[docs.data-model.log]: /docs/about/data-model/log/
-[docs.data-model.metric]: /docs/about/data-model/metric/
-[docs.strategies#daemon]: /docs/setup/deployment/strategies/#daemon
-[docs.strategies#sidecar]: /docs/setup/deployment/strategies/#sidecar
-[urls.rust]: https://www.rust-lang.org/
-[urls.vector_performance]: https://vector.dev/#performance
-[urls.vector_repo]: https://github.com/timberio/vector
+[docs.sinks]: /docs/reference/configuration/sinks/
+[docs.sources]: /docs/reference/configuration/sources/
+[docs.transforms]: /docs/reference/configuration/transforms/


### PR DESCRIPTION
Porting over the "About" section from the `vector-website` repo.  I've updated the links for images in these files as needed.