### PR TITLE
chore: Avoid re-compiling VRL program for each CLI execute

### DIFF
--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read};
 use std::iter::IntoIterator;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use vrl::{diagnostic::Formatter, state, Runtime, Target, Value};
+use vrl::{diagnostic::Formatter, state, Program, Runtime, Target, Value};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "VRL", about = "Vector Remap Language CLI")]
@@ -52,10 +52,13 @@ fn run(opts: &Opts) -> Result<(), Error> {
         repl(repl_objects)
     } else {
         let objects = read_into_objects(opts.input_file.as_ref())?;
-        let program = read_program(opts.program.as_deref(), opts.program_file.as_ref())?;
+        let source = read_program(opts.program.as_deref(), opts.program_file.as_ref())?;
+        let program = vrl::compile(&source, &stdlib::all()).map_err(|diagnostics| {
+            Error::Parse(Formatter::new(&source, diagnostics).colored().to_string())
+        })?;
 
         for mut object in objects {
-            let result = execute(&mut object, program.clone()).map(|v| {
+            let result = execute(&mut object, &program).map(|v| {
                 if opts.print_object {
                     object.to_string()
                 } else {
@@ -82,15 +85,12 @@ fn repl(objects: Vec<Value>) -> Result<(), Error> {
     }
 }
 
-fn execute(object: &mut impl Target, source: String) -> Result<Value, Error> {
+fn execute(object: &mut impl Target, program: &Program) -> Result<Value, Error> {
     let state = state::Runtime::default();
     let mut runtime = Runtime::new(state);
-    let program = vrl::compile(&source, &stdlib::all()).map_err(|diagnostics| {
-        Error::Parse(Formatter::new(&source, diagnostics).colored().to_string())
-    })?;
 
     runtime
-        .resolve(object, &program)
+        .resolve(object, program)
         .map_err(|err| Error::Runtime(err.to_string()))
 }
 


### PR DESCRIPTION
This commit removes recompilation of the passed VRL program for each
interior execution. The program is compiled only the once now.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
