### PR TITLE
chore: Only build repl if it's a flagged-on feature

### DIFF
--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -75,14 +75,13 @@ fn run(opts: &Opts) -> Result<(), Error> {
     }
 }
 
-#[cfg(feature = "repl")]
 fn repl(objects: Vec<Value>) -> Result<(), Error> {
-    repl::run(objects);
-    Ok(())
-}
-#[cfg(not(feature = "repl"))]
-fn repl(_objects: Vec<Value>) -> Result<(), Error> {
-    Err(Error::ReplFeature)
+    if cfg!(feature = "repl") {
+        repl::run(objects);
+        Ok(())
+    } else {
+        Err(Error::ReplFeature)
+    }
 }
 
 fn execute(object: &mut impl Target, source: String) -> Result<Value, Error> {

--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -1,4 +1,6 @@
-use super::{repl, Error};
+#[cfg(feature = "repl")]
+use super::repl;
+use super::Error;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{self, Read};
@@ -73,13 +75,14 @@ fn run(opts: &Opts) -> Result<(), Error> {
     }
 }
 
+#[cfg(feature = "repl")]
 fn repl(objects: Vec<Value>) -> Result<(), Error> {
-    if cfg!(feature = "repl") {
-        repl::run(objects);
-        Ok(())
-    } else {
-        Err(Error::ReplFeature)
-    }
+    repl::run(objects);
+    Ok(())
+}
+#[cfg(not(feature = "repl"))]
+fn repl(_objects: Vec<Value>) -> Result<(), Error> {
+    Err(Error::ReplFeature)
 }
 
 fn execute(object: &mut impl Target, source: String) -> Result<Value, Error> {


### PR DESCRIPTION
This commit corrects the build if `--no-default-features` is passed.
Previously we'd try to import repl even if that wasn't available.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
