### PR TITLE
chore(remap): Improve the `Display` performance of `Kind`

### DIFF
--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -28,3 +28,7 @@ criterion = "0.3"
 [[bench]]
 name = "path"
 harness = false
+
+[[bench]]
+name = "kind"
+harness = false

--- a/lib/vrl/compiler/benches/kind.rs
+++ b/lib/vrl/compiler/benches/kind.rs
@@ -1,0 +1,34 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::fmt;
+use vrl_compiler::value::Kind;
+
+struct Parameters {
+    basis: Kind,
+}
+
+static PARAMETERS: [Parameters; 4] = [
+    Parameters { basis: Kind::Bytes },
+    Parameters { basis: Kind::Array },
+    Parameters { basis: Kind::Regex },
+    Parameters { basis: Kind::Null },
+];
+
+impl fmt::Display for Parameters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.basis)
+    }
+}
+
+fn benchmark_kind_display(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vrl_compiler::value::kind::display");
+    for param in &PARAMETERS {
+        group.bench_with_input(BenchmarkId::from_parameter(param), &param, |b, &param| {
+            b.iter(|| format!("{}", param.basis))
+        });
+    }
+}
+
+criterion_group!(name = vrl_compiler_kind;
+                 config = Criterion::default();
+                 targets = benchmark_kind_display);
+criterion_main!(vrl_compiler_kind);

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -251,6 +251,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn quoted() {
+        for i in 0..u16::MAX {
+            let kind = Kind::new(i);
+            assert_eq!(kind.quoted(), format!(r#""{}""#, kind.as_str()));
+        }
+    }
+
+    #[test]
     fn kind_is_scalar() {
         let scalars = vec![
             Kind::Integer,

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -150,7 +150,7 @@ macro_rules! impl_kind {
                     return write!(f, "{}", self.quoted())
                 }
 
-                let mut kinds = vec![];
+                let mut kinds = Vec::with_capacity(16);
                 $(paste::paste! {
                 if self.[<contains_ $name>]() {
                     kinds.push(Kind::$kind.quoted())

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -68,8 +68,21 @@ impl Kind {
         self == self.scalar()
     }
 
-    pub(crate) fn quoted(self) -> String {
-        format!(r#""{}""#, self.as_str())
+    pub(crate) fn quoted(self) -> &'static str {
+        match self {
+            Kind::Bytes => "\"string\"",
+            Kind::Integer => "\"integer\"",
+            Kind::Float => "\"float\"",
+            Kind::Boolean => "\"boolean\"",
+            Kind::Object => "\"object\"",
+            Kind::Array => "\"array\"",
+            Kind::Timestamp => "\"timestamp\"",
+            Kind::Regex => "\"regex\"",
+            Kind::Null => "\"null\"",
+            _ if self.is_all() => "\"unknown type\"",
+            _ if self.is_empty() => "\"none\"",
+            _ => "\"multiple\"",
+        }
     }
 
     pub fn as_str(self) -> &'static str {

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -68,6 +68,14 @@ impl Kind {
         self == self.scalar()
     }
 
+    /// Returns a quoted variant of `as_str`
+    ///
+    /// This function is a close duplicate of `as_str`, returning the same
+    /// underlying str but with quotes. We avoid the obvious `format!("{}",
+    /// self.as_str())` here as that incurs an allocation cost and the `Display`
+    /// of `Kind` is sometimes in the hot path.
+    ///
+    /// See https://github.com/timberio/vector/pull/6878 for details.
     pub(crate) fn quoted(self) -> &'static str {
         match self {
             Kind::Bytes => "\"string\"",


### PR DESCRIPTION
According to the `coz` profiling done in https://github.com/timberio/vector/pull/6868#issuecomment-806040265 the `Display` implementation of `Kind` has an outsized impact on overall throughput, at least in the test setup. Micro-benchmarks have been introduced in this commit. Baseline: 

```
➜  compiler git:(blt-kind_quoted) ✗ cargo criterion kind
    Finished bench [optimized + debuginfo] target(s) in 0.14s
vrl_compiler::value::kind::display/"string"
                        time:   [98.154 ns 98.528 ns 98.918 ns]
                        change: [+1.2007% +1.8956% +2.5809%] (p = 0.00 < 0.05)
                        Performance has regressed.
vrl_compiler::value::kind::display/"array"
                        time:   [94.712 ns 94.971 ns 95.233 ns]
                        change: [-2.9792% -2.2242% -1.4878%] (p = 0.00 < 0.05)
                        Performance has improved.
vrl_compiler::value::kind::display/"regex"
                        time:   [94.924 ns 95.151 ns 95.373 ns]
                        change: [+0.2264% +0.9399% +1.6341%] (p = 0.01 < 0.05)
                        Change within noise threshold.
vrl_compiler::value::kind::display/"null"
                        time:   [97.718 ns 98.008 ns 98.320 ns]
                        change: [+0.9283% +1.6573% +2.3350%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

final commit

```
➜  compiler git:(blt-kind_quoted) ✗ cargo criterion kind
   Compiling vrl-compiler v0.1.0 (/home/blt/projects/com/datadog/vector/lib/vrl/compiler)
    Finished bench [optimized + debuginfo] target(s) in 15.24s
vrl_compiler::value::kind::display/"string"
                        time:   [44.235 ns 44.499 ns 44.782 ns]
                        change: [-12.217% -11.272% -10.344%] (p = 0.00 < 0.05)
                        Performance has improved.
vrl_compiler::value::kind::display/"array"
                        time:   [45.765 ns 46.129 ns 46.505 ns]
                        change: [-5.5479% -4.5953% -3.6834%] (p = 0.00 < 0.05)
                        Performance has improved.
vrl_compiler::value::kind::display/"regex"
                        time:   [45.769 ns 46.100 ns 46.457 ns]
                        change: [-11.310% -10.460% -9.5413%] (p = 0.00 < 0.05)
                        Performance has improved.
vrl_compiler::value::kind::display/"null"
                        time:   [45.919 ns 46.219 ns 46.519 ns]
                        change: [-10.718% -9.8956% -9.0978%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Full-up release from master:

```
Performance counter stats for 'bash -c flog --format json --number 100000 | ./target/release/vector -qq --config vector-nohop.toml' (10 runs):

         11,123.80 msec task-clock                #    3.394 CPUs utilized            ( +-  2.13% )
           285,670      context-switches          #    0.026 M/sec                    ( +-  3.82% )
               373      cpu-migrations            #    0.034 K/sec                    ( +-  6.35% )
             9,036      page-faults               #    0.812 K/sec                    ( +-  0.42% )
    33,976,770,388      cycles                    #    3.054 GHz                      ( +-  1.78% )  (83.18%)
     1,401,074,998      stalled-cycles-frontend   #    4.12% frontend cycles idle     ( +-  4.65% )  (83.47%)
    15,583,691,225      stalled-cycles-backend    #   45.87% backend cycles idle      ( +-  2.23% )  (83.23%)
    40,733,133,240      instructions              #    1.20  insn per cycle
                                                  #    0.38  stalled cycles per insn  ( +-  0.60% )  (83.30%)
     7,682,658,252      branches                  #  690.651 M/sec                    ( +-  0.68% )  (83.30%)
        50,740,890      branch-misses             #    0.66% of all branches          ( +-  1.97% )  (83.52%)

            3.2771 +- 0.0469 seconds time elapsed  ( +-  1.43% )
```

Full-up results from this PR:

```
Performance counter stats for 'bash -c flog --format json --number 100000 | ./target/release/vector -qq --config vector-nohop.toml' (10 runs):

         11,016.83 msec task-clock                #    3.463 CPUs utilized            ( +-  1.03% )
           262,678      context-switches          #    0.024 M/sec                    ( +-  3.95% )
               406      cpu-migrations            #    0.037 K/sec                    ( +-  7.96% )
             8,949      page-faults               #    0.812 K/sec                    ( +-  0.37% )
    33,078,990,129      cycles                    #    3.003 GHz                      ( +-  1.85% )  (83.36%)
     1,350,443,611      stalled-cycles-frontend   #    4.08% frontend cycles idle     ( +-  5.02% )  (83.28%)
    15,194,401,728      stalled-cycles-backend    #   45.93% backend cycles idle      ( +-  2.51% )  (83.36%)
    40,703,130,455      instructions              #    1.23  insn per cycle
                                                  #    0.37  stalled cycles per insn  ( +-  0.62% )  (83.34%)
     7,667,870,489      branches                  #  696.014 M/sec                    ( +-  0.63% )  (83.39%)
        50,060,285      branch-misses             #    0.65% of all branches          ( +-  1.79% )  (83.27%)

            3.1815 +- 0.0289 seconds time elapsed  ( +-  0.91% )
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
