### PR TITLE
fix(route transform): enable LaneConfig to be serialized

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -38,6 +38,26 @@ pub type ConditionDescription = ComponentDescription<Box<dyn ConditionConfig>>;
 
 inventory::collect!(ConditionDescription);
 
+/// A condition can either be a raw string such as
+/// `condition = '.message == "hooray"'`.
+/// In this case it is turned into a Remap condition.
+/// Otherwise it is a condition such as:
+/// ```
+/// condition.type = 'check_fields'
+/// condition."message.equals" = 'hooray'
+/// ```
+///
+/// It is important to note that because the way this is
+/// structured, it is wrong to flatten a field that contains
+/// an AnyCondition:
+/// ```
+/// #[serde(flatten)]
+/// condition: AnyCondition,
+/// ```
+///
+/// This will result in an error when serializing to json
+/// which we need to do when determining which transforms have changed
+/// when a config is reloaded.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
 pub enum AnyCondition {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -42,18 +42,17 @@ inventory::collect!(ConditionDescription);
 /// `condition = '.message == "hooray"'`.
 /// In this case it is turned into a Remap condition.
 /// Otherwise it is a condition such as:
-/// ```
+///
 /// condition.type = 'check_fields'
 /// condition."message.equals" = 'hooray'
-/// ```
+///
 ///
 /// It is important to note that because the way this is
 /// structured, it is wrong to flatten a field that contains
 /// an AnyCondition:
-/// ```
+///
 /// #[serde(flatten)]
 /// condition: AnyCondition,
-/// ```
 ///
 /// This will result in an error when serializing to json
 /// which we need to do when determining which transforms have changed

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -152,7 +152,7 @@ impl TransformConfig for RouteCompatConfig {
 
 #[cfg(test)]
 mod test {
-    use super::{AnyCondition, LaneConfig, RouteConfig};
+    use super::*;
 
     #[test]
     fn generate_config() {
@@ -171,13 +171,37 @@ mod test {
     }
 
     #[test]
-    fn can_serialize() {
+    fn can_serialize_remap() {
         // We need to serialize the config to check if a config has
         // changed when reloading.
         let config = LaneConfig {
             condition: AnyCondition::String("foo".to_string()),
         };
 
-        assert!(serde_json::to_vec(&config).is_ok());
+        assert_eq!(
+            serde_json::to_string(&config).unwrap(),
+            r#"{"condition":"foo"}"#
+        );
+    }
+
+    #[test]
+    fn can_serialize_check_fields() {
+        // We need to serialize the config to check if a config has
+        // changed when reloading.
+        let config = toml::from_str::<RouteConfig>(
+            r#"
+            lanes.first.type = "check_fields"
+            lanes.first."message.eq" = "foo"
+        "#,
+        )
+        .unwrap()
+        .expand()
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_string(&config).unwrap(),
+            r#"{"first":{"type":"lane","condition":{"type":"check_fields","message.eq":"foo"}}}"#
+        );
     }
 }

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct LaneConfig {
-    #[serde(flatten)]
     condition: AnyCondition,
 }
 
@@ -153,7 +152,7 @@ impl TransformConfig for RouteCompatConfig {
 
 #[cfg(test)]
 mod test {
-    use super::RouteConfig;
+    use super::{AnyCondition, LaneConfig, RouteConfig};
 
     #[test]
     fn generate_config() {
@@ -169,5 +168,16 @@ mod test {
         "#,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn can_serialize() {
+        // We need to serialize the config to check if a config has
+        // changed when reloading.
+        let config = LaneConfig {
+            condition: AnyCondition::String("foo".to_string()),
+        };
+
+        assert!(serde_json::to_vec(&config).is_ok());
     }
 }


### PR DESCRIPTION
Closes: https://github.com/timberio/vector/issues/6821

If trying to serialize an object with a single String that also has `serde(flatten)`, the serialization throws an error.

This causes an error when attempting to serialize the object. This occurs when reloading the config to see what transforms have changed.

The flatten isn't needed, so removing it doesn't cause any issues.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
