### PR TITLE
fix(remap): Parse µs durations

### DIFF
--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -164,7 +164,7 @@ mod tests {
             tdef: TypeDef::new().fallible().float(),
         }
 
-        us_s {
+        us_ms {
             args: func_args![value: "1 µs",
                              unit: "ms"],
             want: Ok(0.001),

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -11,7 +11,7 @@ lazy_static! {
             \A
             (?P<value>[0-9]*\.?[0-9]+) # value: integer or float
             \s?                        # optional space between value and unit
-            (?P<unit>[µa-z]{1,2})       # unit: one or two letters
+            (?P<unit>[µa-z]{1,2})      # unit: one or two letters
             \z"
     )
     .unwrap();

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -11,7 +11,7 @@ lazy_static! {
             \A
             (?P<value>[0-9]*\.?[0-9]+) # value: integer or float
             \s?                        # optional space between value and unit
-            (?P<unit>[a-z]{1,2})       # unit: one or two letters
+            (?P<unit>[µa-z]{1,2})       # unit: one or two letters
             \z"
     )
     .unwrap();
@@ -164,9 +164,16 @@ mod tests {
             tdef: TypeDef::new().fallible().float(),
         }
 
-        error_us {
+        us_s {
+            args: func_args![value: "1 µs",
+                             unit: "ms"],
+            want: Ok(0.001),
+            tdef: TypeDef::new().fallible().float(),
+        }
+
+        error_invalid {
             args: func_args![value: "foo",
-                             unit: "µs"],
+                             unit: "ms"],
             want: Err("unable to parse duration: 'foo'"),
             tdef: TypeDef::new().fallible().float(),
         }


### PR DESCRIPTION
Fixes #6884 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
