### PR TITLE
chore(splunk_hec sink): Document templatable fields

### DIFF
--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -110,13 +110,13 @@ components: sinks: splunk_hec: {
 		}
 		index: {
 			common:      false
-			description: "The name of the index where send the events to. If not specified, the default index is used.\n"
+			description: "The name of the index where send the events to. If not specified, the default index is used."
 			required:    false
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["custom_index"]
-				syntax: "literal"
+				examples: ["{{ host }}", "custom_index"]
+				syntax: "template"
 			}
 		}
 		indexed_fields: {
@@ -134,24 +134,24 @@ components: sinks: splunk_hec: {
 		}
 		source: {
 			common:      false
-			description: "The source of events sent to this sink. Typically the filename the logs originated from. If unset, the Splunk collector will set it.\n"
+			description: "The source of events sent to this sink. Typically the filename the logs originated from. If unset, the Splunk collector will set it."
 			required:    false
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["/var/log/syslog", "UDP:514"]
-				syntax: "literal"
+				examples: ["{{ file }}", "/var/log/syslog", "UDP:514"]
+				syntax: "template"
 			}
 		}
 		sourcetype: {
 			common:      false
-			description: "The sourcetype of events sent to this sink. If unset, Splunk will default to httpevent.\n"
+			description: "The sourcetype of events sent to this sink. If unset, Splunk will default to httpevent."
 			required:    false
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["_json", "httpevent"]
-				syntax: "literal"
+				examples: ["{{ sourcetype }}", "_json", "httpevent"]
+				syntax: "template"
 			}
 		}
 		token: {


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
