### PR TITLE
chore(deps): Remove thread_local pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8336,7 +8336,6 @@ dependencies = [
  "syslog",
  "syslog_loose",
  "tempfile",
- "thread_local",
  "tokio 0.2.25",
  "tokio-openssl",
  "tokio-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,9 +233,6 @@ strip-ansi-escapes = "0.1.0"
 structopt = "0.3.21"
 syslog = { version = "5", optional = true }
 syslog_loose = { version = "0.10.0", optional = true }
-# Indirect dependency; pinning until
-# https://github.com/timberio/vector/issues/6005 is resolved
-thread_local = "=1.1.3"
 tokio-postgres = { version = "0.5.5", features = ["runtime", "with-chrono-0_4"], optional = true }
 toml = "0.5.8"
 typetag = "0.1.6"

--- a/src/mapping/query/query_value.rs
+++ b/src/mapping/query/query_value.rs
@@ -2,7 +2,6 @@ use super::regex::Regex;
 use crate::event::Value;
 
 #[derive(PartialEq, Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
 pub(in crate::mapping) enum QueryValue {
     Value(Value),
 


### PR DESCRIPTION
Follow up to https://github.com/timberio/vector/issues/6005 where it was
upgraded as the size of the struct was reduced.

Removed unnecessary allow(clippy::large_enum_variant)

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
