### PR TITLE
fix(host_metrics source): Fix filtering of filesystem by device

### DIFF
--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -839,7 +839,6 @@ mod tests {
     #[test]
     fn filterlist_default_includes_everything() {
         let filters = FilterList::default();
-        assert!(filters.is_empty());
         assert!(filters.contains_test("anything"));
         assert!(filters.contains_test("should"));
         assert!(filters.contains_test("work"));

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -1229,7 +1229,7 @@ mod tests {
             .await;
 
             assert!(filtered_metrics_with.len() <= all_metrics.len());
-            assert!(filtered_metrics_with.len() > 0);
+            assert!(!filtered_metrics_with.is_empty());
             assert!(all_tags_match(&filtered_metrics_with, tag, |s| s == key));
 
             let filtered_metrics_with_match = get_metrics(FilterList {

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -762,7 +762,7 @@ impl FilterList {
             // No excludes, list excludes nothing
             (None, _) => true,
             // No value, never excluded
-            (_, None) => true,
+            (Some(_), None) => true,
             // Otherwise find the given value
             (Some(excludes), Some(value)) => {
                 !excludes.iter().any(|pattern| pattern.matches_str(value))
@@ -784,7 +784,7 @@ impl FilterList {
             // No excludes, list excludes nothing
             (None, _) => true,
             // No value, never excluded
-            (_, None) => true,
+            (Some(_), None) => true,
             // Otherwise find the given value
             (Some(excludes), Some(value)) => {
                 !excludes.iter().any(|pattern| pattern.matches_path(value))

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -546,13 +546,10 @@ impl HostMetricsConfig {
                     .filter_map(|partition| async { partition })
                     // Filter on configured devices
                     .map(|partition| {
-                        (self.filesystem.devices.is_empty()
-                            && partition
-                                .device()
-                                .map(|device| {
-                                    self.filesystem.devices.contains_path(device.as_ref())
-                                })
-                                .unwrap_or(true))
+                        (partition
+                            .device()
+                            .map(|device| self.filesystem.devices.contains_path(device.as_ref()))
+                            .unwrap_or(true))
                         .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
@@ -1215,6 +1212,7 @@ mod tests {
             .await;
 
             assert!(filtered_metrics_with.len() <= all_metrics.len());
+            assert!(filtered_metrics_with.len() > 0);
             assert!(all_tags_match(&filtered_metrics_with, tag, |s| s == key));
 
             let filtered_metrics_with_match = get_metrics(FilterList {

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -461,7 +461,7 @@ impl HostMetricsConfig {
                     .map(|counter| {
                         self.network
                             .devices
-                            .contains_str(counter.interface())
+                            .contains_str(Some(counter.interface()))
                             .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
@@ -540,24 +540,23 @@ impl HostMetricsConfig {
                     .map(|partition| {
                         self.filesystem
                             .mountpoints
-                            .contains_path(partition.mount_point())
+                            .contains_path(Some(partition.mount_point()))
                             .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
                     // Filter on configured devices
                     .map(|partition| {
-                        (partition
-                            .device()
-                            .map(|device| self.filesystem.devices.contains_path(device.as_ref()))
-                            .unwrap_or(true))
-                        .then(|| partition)
+                        self.filesystem
+                            .devices
+                            .contains_path(partition.device().map(|d| d.as_ref()))
+                            .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
                     // Filter on configured filesystems
                     .map(|partition| {
                         self.filesystem
                             .filesystems
-                            .contains_str(partition.file_system().as_str())
+                            .contains_str(Some(partition.file_system().as_str()))
                             .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
@@ -631,7 +630,7 @@ impl HostMetricsConfig {
                     .map(|counter| {
                         self.disk
                             .devices
-                            .contains_path(counter.device_name().as_ref())
+                            .contains_path(Some(counter.device_name().as_ref()))
                             .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
@@ -749,38 +748,57 @@ pub fn init_roots() {
 }
 
 impl FilterList {
-    fn contains_str(&self, value: &str) -> bool {
-        (match &self.includes {
+    fn contains_str(&self, value: Option<&str>) -> bool {
+        (match (&self.includes, value) {
             // No includes list includes everything
-            None => true,
+            (None, _) => true,
+            // Includes list matched against empty value returns false
+            (Some(_), None) => false,
             // Otherwise find the given value
-            Some(includes) => includes.iter().any(|pattern| pattern.matches_str(value)),
-        }) && match &self.excludes {
+            (Some(includes), Some(value)) => {
+                includes.iter().any(|pattern| pattern.matches_str(value))
+            }
+        }) && match (&self.excludes, value) {
             // No excludes, list excludes nothing
-            None => true,
+            (None, _) => true,
+            // No value, never excluded
+            (_, None) => true,
             // Otherwise find the given value
-            Some(excludes) => !excludes.iter().any(|pattern| pattern.matches_str(value)),
+            (Some(excludes), Some(value)) => {
+                !excludes.iter().any(|pattern| pattern.matches_str(value))
+            }
         }
     }
 
-    fn contains_path(&self, value: &Path) -> bool {
-        (match &self.includes {
+    fn contains_path(&self, value: Option<&Path>) -> bool {
+        (match (&self.includes, value) {
             // No includes list includes everything
-            None => true,
+            (None, _) => true,
+            // Includes list matched against empty value returns false
+            (Some(_), None) => false,
             // Otherwise find the given value
-            Some(includes) => includes.iter().any(|pattern| pattern.matches_path(value)),
-        }) && match &self.excludes {
+            (Some(includes), Some(value)) => {
+                includes.iter().any(|pattern| pattern.matches_path(value))
+            }
+        }) && match (&self.excludes, value) {
             // No excludes, list excludes nothing
-            None => true,
+            (None, _) => true,
+            // No value, never excluded
+            (_, None) => true,
             // Otherwise find the given value
-            Some(excludes) => !excludes.iter().any(|pattern| pattern.matches_path(value)),
+            (Some(excludes), Some(value)) => {
+                !excludes.iter().any(|pattern| pattern.matches_path(value))
+            }
         }
     }
 
     #[cfg(test)]
-    fn contains_test(&self, value: &str) -> bool {
+    fn contains_test(&self, value: Option<&str>) -> bool {
         let result = self.contains_str(value);
-        assert_eq!(result, self.contains_path(&std::path::PathBuf::from(value)));
+        assert_eq!(
+            result,
+            self.contains_path(value.map(|value| std::path::Path::new(value)))
+        );
         result
     }
 }
@@ -839,9 +857,10 @@ mod tests {
     #[test]
     fn filterlist_default_includes_everything() {
         let filters = FilterList::default();
-        assert!(filters.contains_test("anything"));
-        assert!(filters.contains_test("should"));
-        assert!(filters.contains_test("work"));
+        assert!(filters.contains_test(Some("anything")));
+        assert!(filters.contains_test(Some("should")));
+        assert!(filters.contains_test(Some("work")));
+        assert!(filters.contains_test(None));
     }
 
     #[test]
@@ -853,12 +872,13 @@ mod tests {
             ]),
             excludes: None,
         };
-        assert!(!filters.contains_test("sd"));
-        assert!(filters.contains_test("sda"));
-        assert!(!filters.contains_test("sda1"));
-        assert!(filters.contains_test("dm-"));
-        assert!(filters.contains_test("dm-5"));
-        assert!(!filters.contains_test("xda"));
+        assert!(!filters.contains_test(Some("sd")));
+        assert!(filters.contains_test(Some("sda")));
+        assert!(!filters.contains_test(Some("sda1")));
+        assert!(filters.contains_test(Some("dm-")));
+        assert!(filters.contains_test(Some("dm-5")));
+        assert!(!filters.contains_test(Some("xda")));
+        assert!(!filters.contains_test(None));
     }
 
     #[test]
@@ -870,12 +890,13 @@ mod tests {
                 PatternWrapper::new("dm-*").unwrap(),
             ]),
         };
-        assert!(filters.contains_test("sd"));
-        assert!(!filters.contains_test("sda"));
-        assert!(filters.contains_test("sda1"));
-        assert!(!filters.contains_test("dm-"));
-        assert!(!filters.contains_test("dm-5"));
-        assert!(filters.contains_test("xda"));
+        assert!(filters.contains_test(Some("sd")));
+        assert!(!filters.contains_test(Some("sda")));
+        assert!(filters.contains_test(Some("sda1")));
+        assert!(!filters.contains_test(Some("dm-")));
+        assert!(!filters.contains_test(Some("dm-5")));
+        assert!(filters.contains_test(Some("xda")));
+        assert!(filters.contains_test(None));
     }
 
     #[test]
@@ -887,13 +908,14 @@ mod tests {
             ]),
             excludes: Some(vec![PatternWrapper::new("dm-5").unwrap()]),
         };
-        assert!(!filters.contains_test("sd"));
-        assert!(filters.contains_test("sda"));
-        assert!(!filters.contains_test("sda1"));
-        assert!(filters.contains_test("dm-"));
-        assert!(filters.contains_test("dm-1"));
-        assert!(!filters.contains_test("dm-5"));
-        assert!(!filters.contains_test("xda"));
+        assert!(!filters.contains_test(Some("sd")));
+        assert!(filters.contains_test(Some("sda")));
+        assert!(!filters.contains_test(Some("sda1")));
+        assert!(filters.contains_test(Some("dm-")));
+        assert!(filters.contains_test(Some("dm-1")));
+        assert!(!filters.contains_test(Some("dm-5")));
+        assert!(!filters.contains_test(Some("xda")));
+        assert!(!filters.contains_test(None));
     }
 
     #[tokio::test]

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -749,10 +749,6 @@ pub fn init_roots() {
 }
 
 impl FilterList {
-    fn is_empty(&self) -> bool {
-        self.includes.is_none() && self.excludes.is_none()
-    }
-
     fn contains_str(&self, value: &str) -> bool {
         (match &self.includes {
             // No includes list includes everything

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -461,7 +461,7 @@ impl HostMetricsConfig {
                     .map(|counter| {
                         self.network
                             .devices
-                            .contains_str(Some(counter.interface()))
+                            .contains(Some(counter.interface().into()))
                             .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
@@ -540,7 +540,7 @@ impl HostMetricsConfig {
                     .map(|partition| {
                         self.filesystem
                             .mountpoints
-                            .contains_path(Some(partition.mount_point()))
+                            .contains(Some(partition.mount_point().into()))
                             .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
@@ -548,7 +548,7 @@ impl HostMetricsConfig {
                     .map(|partition| {
                         self.filesystem
                             .devices
-                            .contains_path(partition.device().map(|d| d.as_ref()))
+                            .contains(partition.device().map(|d| FilterValue::Path(d.as_ref())))
                             .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
@@ -556,7 +556,7 @@ impl HostMetricsConfig {
                     .map(|partition| {
                         self.filesystem
                             .filesystems
-                            .contains_str(Some(partition.file_system().as_str()))
+                            .contains(Some(partition.file_system().as_str().into()))
                             .then(|| partition)
                     })
                     .filter_map(|partition| async { partition })
@@ -630,7 +630,7 @@ impl HostMetricsConfig {
                     .map(|counter| {
                         self.disk
                             .devices
-                            .contains_path(Some(counter.device_name().as_ref()))
+                            .contains(Some(FilterValue::Path(counter.device_name().as_ref())))
                             .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
@@ -747,59 +747,46 @@ pub fn init_roots() {
     };
 }
 
+enum FilterValue<'a> {
+    String(&'a str),
+    Path(&'a Path),
+}
+
+impl<'a> From<&'a str> for FilterValue<'a> {
+    fn from(s: &'a str) -> Self {
+        FilterValue::String(s)
+    }
+}
+
+impl<'a> From<&'a Path> for FilterValue<'a> {
+    fn from(path: &'a Path) -> Self {
+        FilterValue::Path(path)
+    }
+}
+
 impl FilterList {
-    fn contains_str(&self, value: Option<&str>) -> bool {
-        (match (&self.includes, value) {
+    fn contains(&self, value: Option<FilterValue>) -> bool {
+        (match (&self.includes, &value) {
             // No includes list includes everything
             (None, _) => true,
             // Includes list matched against empty value returns false
             (Some(_), None) => false,
             // Otherwise find the given value
-            (Some(includes), Some(value)) => {
-                includes.iter().any(|pattern| pattern.matches_str(value))
-            }
-        }) && match (&self.excludes, value) {
+            (Some(includes), Some(value)) => includes.iter().any(|pattern| match value {
+                FilterValue::String(s) => pattern.matches_str(s),
+                FilterValue::Path(path) => pattern.matches_path(path),
+            }),
+        }) && match (&self.excludes, &value) {
             // No excludes, list excludes nothing
             (None, _) => true,
             // No value, never excluded
             (Some(_), None) => true,
             // Otherwise find the given value
-            (Some(excludes), Some(value)) => {
-                !excludes.iter().any(|pattern| pattern.matches_str(value))
-            }
+            (Some(excludes), Some(value)) => !excludes.iter().any(|pattern| match value {
+                FilterValue::String(s) => pattern.matches_str(s),
+                FilterValue::Path(path) => pattern.matches_path(path),
+            }),
         }
-    }
-
-    fn contains_path(&self, value: Option<&Path>) -> bool {
-        (match (&self.includes, value) {
-            // No includes list includes everything
-            (None, _) => true,
-            // Includes list matched against empty value returns false
-            (Some(_), None) => false,
-            // Otherwise find the given value
-            (Some(includes), Some(value)) => {
-                includes.iter().any(|pattern| pattern.matches_path(value))
-            }
-        }) && match (&self.excludes, value) {
-            // No excludes, list excludes nothing
-            (None, _) => true,
-            // No value, never excluded
-            (Some(_), None) => true,
-            // Otherwise find the given value
-            (Some(excludes), Some(value)) => {
-                !excludes.iter().any(|pattern| pattern.matches_path(value))
-            }
-        }
-    }
-
-    #[cfg(test)]
-    fn contains_test(&self, value: Option<&str>) -> bool {
-        let result = self.contains_str(value);
-        assert_eq!(
-            result,
-            self.contains_path(value.map(|value| std::path::Path::new(value)))
-        );
-        result
     }
 }
 
@@ -857,10 +844,10 @@ mod tests {
     #[test]
     fn filterlist_default_includes_everything() {
         let filters = FilterList::default();
-        assert!(filters.contains_test(Some("anything")));
-        assert!(filters.contains_test(Some("should")));
-        assert!(filters.contains_test(Some("work")));
-        assert!(filters.contains_test(None));
+        assert!(filters.contains(Some("anything")));
+        assert!(filters.contains(Some("should")));
+        assert!(filters.contains(Some("work")));
+        assert!(filters.contains(None));
     }
 
     #[test]
@@ -872,13 +859,13 @@ mod tests {
             ]),
             excludes: None,
         };
-        assert!(!filters.contains_test(Some("sd")));
-        assert!(filters.contains_test(Some("sda")));
-        assert!(!filters.contains_test(Some("sda1")));
-        assert!(filters.contains_test(Some("dm-")));
-        assert!(filters.contains_test(Some("dm-5")));
-        assert!(!filters.contains_test(Some("xda")));
-        assert!(!filters.contains_test(None));
+        assert!(!filters.contains(Some("sd")));
+        assert!(filters.contains(Some("sda")));
+        assert!(!filters.contains(Some("sda1")));
+        assert!(filters.contains(Some("dm-")));
+        assert!(filters.contains(Some("dm-5")));
+        assert!(!filters.contains(Some("xda")));
+        assert!(!filters.contains(None));
     }
 
     #[test]
@@ -890,13 +877,13 @@ mod tests {
                 PatternWrapper::new("dm-*").unwrap(),
             ]),
         };
-        assert!(filters.contains_test(Some("sd")));
-        assert!(!filters.contains_test(Some("sda")));
-        assert!(filters.contains_test(Some("sda1")));
-        assert!(!filters.contains_test(Some("dm-")));
-        assert!(!filters.contains_test(Some("dm-5")));
-        assert!(filters.contains_test(Some("xda")));
-        assert!(filters.contains_test(None));
+        assert!(filters.contains(Some("sd")));
+        assert!(!filters.contains(Some("sda")));
+        assert!(filters.contains(Some("sda1")));
+        assert!(!filters.contains(Some("dm-")));
+        assert!(!filters.contains(Some("dm-5")));
+        assert!(filters.contains(Some("xda")));
+        assert!(filters.contains(None));
     }
 
     #[test]
@@ -908,14 +895,14 @@ mod tests {
             ]),
             excludes: Some(vec![PatternWrapper::new("dm-5").unwrap()]),
         };
-        assert!(!filters.contains_test(Some("sd")));
-        assert!(filters.contains_test(Some("sda")));
-        assert!(!filters.contains_test(Some("sda1")));
-        assert!(filters.contains_test(Some("dm-")));
-        assert!(filters.contains_test(Some("dm-1")));
-        assert!(!filters.contains_test(Some("dm-5")));
-        assert!(!filters.contains_test(Some("xda")));
-        assert!(!filters.contains_test(None));
+        assert!(!filters.contains(Some("sd")));
+        assert!(filters.contains(Some("sda")));
+        assert!(!filters.contains(Some("sda1")));
+        assert!(filters.contains(Some("dm-")));
+        assert!(filters.contains(Some("dm-1")));
+        assert!(!filters.contains(Some("dm-5")));
+        assert!(!filters.contains(Some("xda")));
+        assert!(!filters.contains(None));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #6920

Previously specifying any `includes` for device would cause no matches
due to bad boolean logic.