### PR TITLE
chore(external docs): Document codec behavior for `console` sink

### DIFF
--- a/docs/reference/components/sinks/console.cue
+++ b/docs/reference/components/sinks/console.cue
@@ -22,7 +22,10 @@ components: sinks: console: {
 				codec: {
 					enabled: true
 					default: null
-					enum: ["json", "text"]
+					enum: {
+						json: "Whole event will be encoded"
+						text: "For logs, only message field will be encoded"
+					}
 				}
 			}
 			request: enabled: false


### PR DESCRIPTION
Clarifies potentially surprising behavior.

https://discord.com/channels/742820443487993987/746070591097798688/826382895908257802

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
