### PR TITLE
chore(deps): revert goauth to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.2.0"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayref"
@@ -772,7 +772,7 @@ dependencies = [
  "serde_urlencoded 0.6.1",
  "thiserror",
  "tokio 0.2.25",
- "tokio-util 0.3.1",
+ "tokio-util",
  "url",
  "webpki-roots 0.20.0",
  "winapi 0.3.9",
@@ -1043,7 +1043,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.6",
  "serde_json",
- "tokio-util 0.3.1",
+ "tokio-util",
  "tracing 0.1.23",
 ]
 
@@ -2559,21 +2559,21 @@ dependencies = [
 
 [[package]]
 name = "goauth"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94101e84ede813c04773b0a43396c01b5a3a9376537dbce1125858ae090ae60"
+checksum = "877c55b7ac37895bd6e4ca0b357c074248358c95e20cf1cf2b462603121f7b87"
 dependencies = [
  "arc-swap",
  "futures 0.3.13",
  "log",
- "reqwest 0.11.1",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "simpl",
  "smpl_jwt",
  "time 0.2.25",
- "tokio 1.2.0",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2662,28 +2662,9 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.25",
- "tokio-util 0.3.1",
+ "tokio-util",
  "tracing 0.1.23",
  "tracing-futures 0.2.5",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
-dependencies = [
- "bytes 1.0.1",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 1.2.0",
- "tokio-util 0.6.3",
- "tracing 0.1.23",
 ]
 
 [[package]]
@@ -3083,7 +3064,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.7",
+ "h2",
  "http",
  "http-body 0.3.1",
  "httparse",
@@ -3107,7 +3088,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.1",
  "http",
  "http-body 0.4.0",
  "httparse",
@@ -3169,19 +3149,6 @@ dependencies = [
  "native-tls",
  "tokio 0.2.25",
  "tokio-tls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.0.1",
- "hyper 0.14.4",
- "native-tls",
- "tokio 1.2.0",
- "tokio-native-tls 0.3.0",
 ]
 
 [[package]]
@@ -3433,7 +3400,7 @@ dependencies = [
  "k8s-openapi",
  "k8s-test-framework",
  "regex",
- "reqwest 0.10.10",
+ "reqwest",
  "serde_json",
  "tokio 0.2.25",
 ]
@@ -4240,7 +4207,7 @@ dependencies = [
  "pbkdf2 0.3.0",
  "percent-encoding",
  "rand 0.7.3",
- "reqwest 0.10.10",
+ "reqwest",
  "rustls 0.17.0",
  "serde",
  "serde_bytes",
@@ -5373,8 +5340,8 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "tokio 0.2.25",
- "tokio-native-tls 0.1.0",
- "tokio-util 0.3.1",
+ "tokio-native-tls",
+ "tokio-util",
  "url",
 ]
 
@@ -5856,7 +5823,7 @@ dependencies = [
  "http-body 0.3.1",
  "hyper 0.13.10",
  "hyper-rustls",
- "hyper-tls 0.4.3",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -5878,41 +5845,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.20.0",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.0.1",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http",
- "http-body 0.4.0",
- "hyper 0.14.4",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite 0.2.4",
- "serde",
- "serde_json",
- "serde_urlencoded 0.7.0",
- "tokio 1.2.0",
- "tokio-native-tls 0.3.0",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
  "winreg 0.7.0",
 ]
 
@@ -5998,7 +5930,7 @@ dependencies = [
  "futures 0.3.13",
  "http",
  "hyper 0.13.10",
- "hyper-tls 0.4.3",
+ "hyper-tls",
  "lazy_static",
  "log",
  "md5",
@@ -6835,11 +6767,11 @@ dependencies = [
 
 [[package]]
 name = "smpl_jwt"
-version = "0.6.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4370044f8b20f944e05c35d77edd3518e6f21fc4de77e593919f287c6a3f428a"
+checksum = "547e9c1059500ce0fe6cfa325f868b5621214957922be60a49d86e3e844ee9dc"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.12.3",
  "log",
  "openssl",
  "serde",
@@ -7394,9 +7326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg 1.0.1",
- "bytes 1.0.1",
  "libc",
- "memchr",
  "mio 0.7.7",
  "num_cpus",
  "pin-project-lite 0.2.4",
@@ -7457,16 +7387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.2.0",
-]
-
-[[package]]
 name = "tokio-openssl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7495,7 +7415,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "tokio 0.2.25",
- "tokio-util 0.3.1",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7590,7 +7510,7 @@ dependencies = [
  "native-tls",
  "pin-project 0.4.27",
  "tokio 0.2.25",
- "tokio-native-tls 0.1.0",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -7606,20 +7526,6 @@ dependencies = [
  "log",
  "pin-project-lite 0.1.11",
  "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
-dependencies = [
- "bytes 1.0.1",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.2.4",
- "tokio 1.2.0",
 ]
 
 [[package]]
@@ -8304,7 +8210,7 @@ dependencies = [
  "rand_distr",
  "rdkafka",
  "regex",
- "reqwest 0.10.10",
+ "reqwest",
  "rlua",
  "rusoto_cloudwatch",
  "rusoto_core",
@@ -8340,7 +8246,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-postgres",
  "tokio-test 0.4.1",
- "tokio-util 0.3.1",
+ "tokio-util",
  "tokio01-test",
  "toml",
  "tower",
@@ -8376,7 +8282,7 @@ dependencies = [
  "chrono",
  "futures 0.3.13",
  "graphql_client",
- "reqwest 0.10.10",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio 0.2.25",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,8 +144,8 @@ prost = "0.6.1"
 prost-types = "0.6.1"
 
 # GCP
-goauth = { version = "0.9.0", optional = true }
-smpl_jwt = { version = "0.6.1", optional = true }
+goauth = { version = "0.8.1", optional = true }
+smpl_jwt = { version = "0.5.0", optional = true }
 
 # API
 async-graphql = { version = "=2.5.0", optional = true }


### PR DESCRIPTION
This reverts commit fc7c788b11ea46881d3c704404acd69eaa7bb450.

Fixes #6712

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
