### PR TITLE
chore(syslog source): Needed clippy changes for 1.51

### DIFF
--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -200,7 +200,7 @@ impl TcpSource for SyslogTcpSource {
 enum State {
     NotDiscarding,
     Discarding(usize),
-    DiscardingToEOL,
+    DiscardingToEol,
 }
 
 /// Decodes according to `Octet Counting` in https://tools.ietf.org/html/rfc6587
@@ -258,7 +258,7 @@ impl SyslogDecoder {
                 Ok(None)
             }
 
-            (State::DiscardingToEOL, Some(offset), _) => {
+            (State::DiscardingToEol, Some(offset), _) => {
                 // When discarding we keep discarding to the next newline.
                 src.advance(offset + 1);
                 self.octet_decoding = None;
@@ -268,7 +268,7 @@ impl SyslogDecoder {
                 )))
             }
 
-            (State::DiscardingToEOL, None, _) => {
+            (State::DiscardingToEol, None, _) => {
                 // There is no newline in this frame. Since we don't have a set number of
                 // chars we want to discard, we need to discard to the next newline.
                 // Advance as far as we can to discard the entire frame.
@@ -355,7 +355,7 @@ impl SyslogDecoder {
             (State::NotDiscarding, None, _) => {
                 // There is no newline in this frame and we have more data than we want to handle.
                 // Advance as far as we can to discard the entire frame.
-                self.octet_decoding = Some(State::DiscardingToEOL);
+                self.octet_decoding = Some(State::DiscardingToEol);
                 src.advance(src.len());
                 Ok(None)
             }
@@ -1028,7 +1028,7 @@ mod test {
         buffer.put(&b"32thisshouldbelongerthanthmaxframeasizewhichmeansthesyslogparserwillnotbeabletodecodeit"[..]);
         let _ = decoder.decode(&mut buffer);
 
-        assert_eq!(decoder.octet_decoding, Some(State::DiscardingToEOL));
+        assert_eq!(decoder.octet_decoding, Some(State::DiscardingToEol));
         buffer.put(&b"wemustcontinuetodiscard\n32 something valid"[..]);
         let result = decoder.decode(&mut buffer);
 


### PR DESCRIPTION
This was a silent merge conflict between
https://github.com/timberio/vector/pull/6890
and https://github.com/timberio/vector/pull/6864

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
