### PR TITLE
fix(releasing): Fix release-homebrew workflow dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,14 +516,10 @@ jobs:
   release-homebrew:
     runs-on: ubuntu-20.04
     needs:
-      - build-x86_64-apple-darwin-packages
+      - release-s3
     steps:
       - uses: actions/checkout@v1
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - uses: actions/download-artifact@v2
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz
-          path: target/artifacts
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: |

--- a/scripts/release-homebrew.sh
+++ b/scripts/release-homebrew.sh
@@ -17,7 +17,7 @@ git clone "https://$GITHUB_TOKEN:x-oauth-basic@github.com/timberio/homebrew-brew
 cd homebrew-brew
 
 PACKAGE_URL="https://packages.timber.io/vector/$VECTOR_VERSION/vector-$VECTOR_VERSION-x86_64-apple-darwin.tar.gz"
-PACKAGE_SHA256=$(curl -s "$PACKAGE_URL" | sha256sum | cut -d " " -f 1)
+PACKAGE_SHA256=$(curl -fsSL "$PACKAGE_URL" | sha256sum | cut -d " " -f 1)
 
 update-content() {
   sed "s|url \".*\"|url \"$PACKAGE_URL\"|" \


### PR DESCRIPTION
The script depends on the artifacts being in S3, but was not depending
on that step and so could run earlier resulting in it checksuming the
404 response from AWS leading to
    https://github.com/timberio/homebrew-brew/issues/6

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
