### PR TITLE
chore(tests): Exec integration setup sub-script

### DIFF
--- a/scripts/setup_integration_env.sh
+++ b/scripts/setup_integration_env.sh
@@ -27,4 +27,4 @@ fi
 
 echo "Setting up Test Integration environment for ${INTEGRATION}..."
 
-(  ./scripts/setup_integration/"${INTEGRATION}"_integration_env.sh "${ACTION}" )
+exec ./scripts/setup_integration/"${INTEGRATION}"_integration_env.sh "${ACTION}"


### PR DESCRIPTION
The integration setup wrapper ran the sub-script in a subshell, to no
real effect. This execs it directly, as it is the last command in the
script.

I separated from #6954 as it could potentially break tests if the subshell was required for some shell specific behavior, so I'll be watching for breakage.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>