### PR TITLE
feat(remap): create parser for nginx access and error logs

### DIFF
--- a/docs/reference/remap/functions/parse_nginx_log.cue
+++ b/docs/reference/remap/functions/parse_nginx_log.cue
@@ -1,0 +1,97 @@
+package metadata
+
+remap: functions: parse_nginx_log: {
+	category:    "Parse"
+	description: """
+        Parses Nginx access and error log lines. Lines can be in [`combined`](\(urls.nginx_combined)), or [`error`](\(urls.nginx_error)) format.
+        """
+	notices: [
+		"""
+			Missing information in the log message may be indicated by `-`. These fields are omitted in the result.
+			""",
+	]
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to parse."
+			required:    true
+			type: ["string"]
+		},
+		{
+			name: "timestamp_format"
+			description: """
+				The [date/time format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) to use for
+				encoding the timestamp. The time is parsed in local time if the timestamp doesn't specify a timezone.
+				The default %d/%b/%Y:%T %z format for the combined logs and %Y/%m/%d %H:%M:%S for the error logs.
+				"""
+			required: false
+			default:  "%d/%b/%Y:%T %z"
+			type: ["string"]
+		},
+		{
+			name:        "format"
+			description: "The format to use for parsing the log."
+			required:    true
+			enum: {
+				"combined": "Nginx combined format"
+				"error":    "Default Nginx error format"
+			}
+			type: ["string"]
+		},
+	]
+
+	internal_failure_reasons: [
+		"`value` doesn't match the specified format",
+		"`timestamp_format` isn't a valid format string",
+		"The timestamp in `value` fails to parse using the provided `timestamp_format`",
+	]
+	return: types: ["object"]
+
+	examples: [
+		{
+			title: "Parse via Nginx log format (combined)"
+			source: #"""
+				parse_nginx_log!(
+				    s'172.17.0.1 alice - [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75"',
+				    "combined",
+				)
+				"""#
+			return: {
+				client:      "172.17.0.1"
+				user:        "alice"
+				timestamp:   "2021-04-01T12:02:31Z"
+				request:     "POST /not-found HTTP/1.1"
+				method:      "POST"
+				path:        "/not-found"
+				protocol:    "HTTP/1.1"
+				status:      404
+				size:        153
+				referer:     "http://localhost/somewhere"
+				agent:       "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36"
+				compression: "2.75"
+			}
+		},
+		{
+			title: "Parse via Nginx log format (error)"
+			source: #"""
+				parse_nginx_log!(
+				    s'2021/04/01 13:02:31 [error] 31#31: *1 open() "/usr/share/nginx/html/not-found" failed (2: No such file or directory), client: 172.17.0.1, server: localhost, request: "POST /not-found HTTP/1.1", host: "localhost:8081"',
+				    "error"
+				)
+				"""#
+			return: {
+				timestamp: "2021-04-01T13:02:31Z"
+				severity:  "error"
+				pid:       31
+				tid:       31
+				cid:       1
+				message:   "open() \"/usr/share/nginx/html/not-found\" failed (2: No such file or directory)"
+				client:    "172.17.0.1"
+				server:    "localhost"
+				request:   "POST /not-found HTTP/1.1"
+				host:      "localhost:8081"
+			}
+		},
+	]
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -303,6 +303,8 @@ urls: {
 	new_target:                                               "\(vector_repo)/issues/new?labels=type%3A+task&labels=domain%3A+operations"
 	new_transform:                                            "\(vector_repo)/issues/new?labels=type%3A+new+feature"
 	nginx:                                                    "https://www.nginx.com/"
+	nginx_combined:                                           "https://nginx.org/en/docs/http/ngx_http_log_module.html"
+	nginx_error:                                              "https://github.com/nginx/nginx/blob/branches/stable-1.18/src/core/ngx_log.c#L102"
 	nginx_stub_status_module:                                 "http://nginx.org/en/docs/http/ngx_http_stub_status_module.html"
 	nix:                                                      "https://nixos.org/nix/"
 	nixos:                                                    "https://nixos.org/"

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -97,6 +97,7 @@ default = [
     "parse_key_value",
     "parse_linux_authorization",
     "parse_logfmt",
+    "parse_nginx_log",
     "parse_query_string",
     "parse_regex",
     "parse_regex_all",
@@ -191,6 +192,7 @@ parse_json = ["serde_json"]
 parse_key_value = ["nom"]
 parse_linux_authorization = ["parse_syslog"]
 parse_logfmt = ["parse_key_value"]
+parse_nginx_log = ["chrono", "regex"]
 parse_query_string = []
 parse_regex = ["regex"]
 parse_regex_all = ["regex"]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -315,6 +315,8 @@ pub use parse_key_value::ParseKeyValue;
 pub use parse_linux_authorization::ParseLinuxAuthorization;
 #[cfg(feature = "parse_logfmt")]
 pub use parse_logfmt::ParseLogFmt;
+#[cfg(feature = "parse_nginx_log")]
+pub use parse_nginx_log::ParseNginxLog;
 #[cfg(feature = "parse_query_string")]
 pub use parse_query_string::ParseQueryString;
 #[cfg(feature = "parse_regex")]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -80,7 +80,11 @@ mod join;
 mod length;
 #[cfg(feature = "log")]
 mod log;
-#[cfg(any(feature = "parse_common_log", feature = "parse_apache_log"))]
+#[cfg(any(
+    feature = "parse_common_log",
+    feature = "parse_apache_log",
+    feature = "parse_nginx_log"
+))]
 mod log_util;
 #[cfg(feature = "match")]
 mod r#match;
@@ -120,6 +124,8 @@ mod parse_key_value;
 mod parse_linux_authorization;
 #[cfg(feature = "parse_logfmt")]
 mod parse_logfmt;
+#[cfg(feature = "parse_nginx_log")]
+mod parse_nginx_log;
 #[cfg(feature = "parse_regex")]
 mod parse_regex;
 #[cfg(feature = "parse_regex_all")]
@@ -500,6 +506,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ParseLinuxAuthorization),
         #[cfg(feature = "parse_logfmt")]
         Box::new(ParseLogFmt),
+        #[cfg(feature = "parse_nginx_log")]
+        Box::new(ParseNginxLog),
         #[cfg(feature = "parse_query_string")]
         Box::new(ParseQueryString),
         #[cfg(feature = "parse_regex")]

--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -73,6 +73,27 @@ lazy_static! {
     "#)
     .expect("failed compiling regex for error log");
 
+    // - Nginx HTTP Server docs: http://nginx.org/en/docs/http/ngx_http_log_module.html
+    pub static ref REGEX_NGINX_COMBINED_LOG: Regex = Regex::new(
+        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+        ^\s*                                    # Start with any number of whitespaces.
+        (-|(?P<client>\S+))\s+                  # Match `-` or any non space character
+        (-|(?P<user>\S+))\s+                    # Match `-` or any non space character
+        \-\s+                                   # Always a dash
+        \[(?P<timestamp>.+)\]\s+                # Match date between brackets
+        "(?P<request>
+        (?P<method>\w+)\s+                      # Match at least a word
+        (?P<path>\S+)\s+                        # Match any non space character
+        (?P<protocol>\S+)
+        )"\s+                                   # Match any non space character
+        (?P<status>\d+)\s+                      # Match numbers
+        (?P<size>\d+)\s+                        # Match numbers
+        "(-|(?P<referer>.+))"\s+                # Match `-` or any non space character
+        "(-|(?P<agent>.+))"\s+                  # Match `-` or any non space character
+        "(-|(?P<compression>\S+))"              # Match `-` or any non space character
+        \s*$                                    # Match any number of whitespaces (to be discarded).
+    "#)
+    .expect("failed compiling regex for Nginx combined log");
 }
 
 // Parse the time as Utc if we can extract the timezone.

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -1,0 +1,188 @@
+use crate::log_util;
+use std::collections::BTreeMap;
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ParseNginxLog;
+
+impl Function for ParseNginxLog {
+    fn identifier(&self) -> &'static str {
+        "parse_nginx_log"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "format",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "timestamp_format",
+                kind: kind::BYTES,
+                required: false,
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let variants = vec![value!("combined"), value!("error")];
+
+        let value = arguments.required("value");
+        let format = arguments
+            .required_enum("format", &variants)?
+            .try_bytes()
+            .expect("format not bytes");
+
+        let timestamp_format = arguments.optional("timestamp_format");
+
+        Ok(Box::new(ParseNginxLogFn {
+            value,
+            format,
+            timestamp_format,
+        }))
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "parse nginx combined log",
+                source: r#"encode_json(parse_nginx_log!(s'172.17.0.1 - - [31/Mar/2021:12:04:07 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.75.0" "-"', "combined"))"#,
+                result: Ok(
+                    r#"s'{"client":"172.17.0.1","timestamp":"2032-03-31T12:04:07Z","method":"GET","path":"/","protocol":"HTTP/1.0","status":200,"size":612,"agent":"curl/7.75.0"}'"#,
+                ),
+            },
+            Example {
+                title: "parse nginx error log",
+                source: r#"encode_json(parse_nginx_log!(s'2021/03/31 12:07:30 [error] 31#31: *6 open() "/usr/share/nginx/html/not-found" failed (2: No such file or directory), client: 172.17.0.1, server: localhost, request: "POST /not-found HTTP/1.1", host: "localhost:8081"', "error"))"#,
+                result: Ok(
+                    r#"s'{"client":"172.17.0.1","message":"I will bypass the haptic COM bandwidth, that should matrix the CSS driver!","module":"ab","pid":4803,"port":24259,"severity":"alert","thread":"3814","timestamp":"2021-03-01T12:00:19Z"}'"#,
+                ),
+            },
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseNginxLogFn {
+    value: Box<dyn Expression>,
+    format: Bytes,
+    timestamp_format: Option<Box<dyn Expression>>,
+}
+
+impl Expression for ParseNginxLogFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let bytes = self.value.resolve(ctx)?;
+        let message = bytes.try_bytes_utf8_lossy()?;
+        let timestamp_format = match &self.timestamp_format {
+            None => "%d/%b/%Y:%T %z".to_owned(),
+            Some(timestamp_format) => timestamp_format
+                .resolve(ctx)?
+                .try_bytes_utf8_lossy()?
+                .to_string(),
+        };
+
+        let regex = match self.format.as_ref() {
+            b"combined" => &*log_util::REGEX_NGINX_COMBINED_LOG,
+            b"error" => &*log_util::REGEX_APACHE_ERROR_LOG,
+            _ => unreachable!(),
+        };
+
+        let captures = regex.captures(&message).ok_or("failed parsing log line")?;
+
+        log_util::log_fields(&regex, &captures, &timestamp_format).map_err(Into::into)
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new()
+            .fallible()
+            .object(match self.format.as_ref() {
+                b"combined" => type_def_combined(),
+                b"error" => type_def_error(),
+                _ => unreachable!(),
+            })
+    }
+}
+
+fn type_def_combined() -> BTreeMap<&'static str, TypeDef> {
+    map! {
+         "client": Kind::Bytes | Kind::Null,
+         "user": Kind::Bytes | Kind::Null,
+         "timestamp": Kind::Timestamp | Kind::Null,
+         "request": Kind::Bytes | Kind::Null,
+         "method": Kind::Bytes | Kind::Null,
+         "path": Kind::Bytes | Kind::Null,
+         "protocol": Kind::Bytes | Kind::Null,
+         "status": Kind::Integer | Kind::Null,
+         "size": Kind::Integer | Kind::Null,
+         "referrer": Kind::Bytes | Kind::Null,
+         "agent": Kind::Bytes | Kind::Null,
+         "compression": Kind::Bytes | Kind::Null,
+    }
+}
+
+fn type_def_error() -> BTreeMap<&'static str, TypeDef> {
+    map! {
+         "timestamp": Kind::Timestamp | Kind::Null,
+         "severity": Kind::Bytes | Kind::Null,
+         "module": Kind::Bytes | Kind::Null,
+         "thread": Kind::Bytes | Kind::Null,
+         "port": Kind::Bytes | Kind::Null,
+         "message": Kind::Bytes | Kind::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::prelude::*;
+    use shared::btreemap;
+
+    test_function![
+        parse_combined_log => ParseNginxLog;
+
+        combined_line_valid {
+            args: func_args![value: r#"172.17.0.1 - - [31/Mar/2021:12:04:07 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.75.0" "-""#,
+                             format: "combined"
+            ],
+            want: Ok(btreemap! {
+                "client" => "172.17.0.1",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-03-31T12:04:07Z").unwrap().into()),
+                "request" => "GET / HTTP/1.1",
+                "method" => "GET",
+                "path" => "/",
+                "protocol" => "HTTP/1.1",
+                "status" => 200,
+                "size" => 612,
+                "agent" => "curl/7.75.0",
+            }),
+            tdef: TypeDef::new().fallible().object(type_def_combined()),
+        }
+
+        combined_line_valid_all_fields {
+            args: func_args![value: r#"172.17.0.1 alice - [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75""#,
+                             format: "combined"
+            ],
+            want: Ok(btreemap! {
+                "client" => "172.17.0.1",
+                "user" => "alice",
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-04-01T12:02:31Z").unwrap().into()),
+                "request" => "POST /not-found HTTP/1.1",
+                "method" => "POST",
+                "path" => "/not-found",
+                "protocol" => "HTTP/1.1",
+                "status" => 404,
+                "size" => 153,
+                "referer" => "http://localhost/somewhere",
+                "agent" => "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36",
+                "compression" => "2.75",
+            }),
+            tdef: TypeDef::new().fallible().object(type_def_combined()),
+        }
+    ];
+}


### PR DESCRIPTION
Create a parse for nginx access logs and error logs.
It's mainly a copy of `parse_apache_log`.

https://github.com/timberio/vector/issues/6103