### PR TITLE
feat(remap): Add `encode_logfmt` function

### DIFF
--- a/docs/reference/remap/functions/encode_logfmt.cue
+++ b/docs/reference/remap/functions/encode_logfmt.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: functions: encode_logfmt: {
-	category: "Codec"
+	category:    "Codec"
 	description: #"""
 		Encodes the `value` to [logfmt](\#(urls.logfmt)).
 		"""#
@@ -13,26 +13,26 @@ remap: functions: encode_logfmt: {
 			required:    true
 			type: ["object"]
 		},
-        {
-            name:        "fields_ordering"
-            description: "The ordering of fields to preserve. Any fields not in this list will appear unordered, after any ordered fields."
-            required: false
-            type: ["array"]
-        },
+		{
+			name:        "fields_ordering"
+			description: "The ordering of fields to preserve. Any fields not in this list will appear unordered, after any ordered fields."
+			required:    false
+			type: ["array"]
+		},
 	]
 	internal_failure_reasons: [
-        "`fields_ordering` contains a non-string element"
-    ]
+		"`fields_ordering` contains a non-string element",
+	]
 	return: types: ["string"]
 
 	examples: [
-        {
-            title: "Encode to logfmt (no ordering)"
-            source: """
-                encode_logfmt!({"ts": "2021-06-05T17:20:00Z", "msg": "This is a message", "lvl": "info"}) 
-                """
-            return: #"lvl=info msg="This is a message" ts=2021-06-05T17:20:00Z"#
-        },
+		{
+			title: "Encode to logfmt (no ordering)"
+			source: """
+				encode_logfmt!({"ts": "2021-06-05T17:20:00Z", "msg": "This is a message", "lvl": "info"})
+				"""
+			return: #"lvl=info msg="This is a message" ts=2021-06-05T17:20:00Z"#
+		},
 		{
 			title: "Encode to logfmt (fields ordering)"
 			source: """
@@ -40,19 +40,19 @@ remap: functions: encode_logfmt: {
 				"""
 			return: #"ts=2021-06-05T17:20:00Z lvl=info msg="This is a message" log_id=12345"#
 		},
-        {
-            title: "Encode to logfmt (nested fields)"
-            source: """
-                encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log") 
-                """
-            return: #"agent.name=vector event=log log.file.path=my.log"#
-        },
-        {
-            title: "Encode to logfmt (nested fields ordering)"
-            source: """
-                encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log", ["event", "log.file.path", "agent.name"]) 
-                """
-            return: #"event=log log.file.path=my.log agent.name=vector"#
-        },
+		{
+			title: "Encode to logfmt (nested fields)"
+			source: """
+				encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"})
+				"""
+			return: #"agent.name=vector event=log log.file.path=my.log"#
+		},
+		{
+			title: "Encode to logfmt (nested fields ordering)"
+			source: """
+				encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"}, ["event", "log.file.path", "agent.name"])
+				"""
+			return: #"event=log log.file.path=my.log agent.name=vector"#
+		},
 	]
 }

--- a/docs/reference/remap/functions/encode_logfmt.cue
+++ b/docs/reference/remap/functions/encode_logfmt.cue
@@ -2,9 +2,9 @@ package metadata
 
 remap: functions: encode_logfmt: {
 	category: "Codec"
-	description: """
+	description: #"""
 		Encodes the `value` to [logfmt](\#(urls.logfmt)).
-		"""
+		"""#
 
 	arguments: [
 		{

--- a/docs/reference/remap/functions/encode_logfmt.cue
+++ b/docs/reference/remap/functions/encode_logfmt.cue
@@ -1,0 +1,56 @@
+package metadata
+
+remap: functions: encode_logfmt: {
+	category: "Codec"
+	description: """
+		Encodes the `value` to logfmt.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The value to convert to a JSON string."
+			required:    true
+			type: ["object"]
+		},
+        {
+            name:        "fields_ordering"
+            description: "The ordering of fields to preserve."
+            required: false
+            type: ["array"]
+        },
+	]
+	internal_failure_reasons: []
+	return: types: ["string"]
+
+	examples: [
+        {
+            title: "Encode to logfmt (no ordering)"
+            source: """
+                encode_logfmt!({"ts": "2021-06-05T17:20:00Z", "msg": "This is a message", "lvl": "info"}) 
+                """
+            return: #"lvl=info msg="This is a message" ts=2021-06-05T17:20:00Z"#
+        },
+		{
+			title: "Encode to logfmt (fields ordering)"
+			source: """
+				encode_logfmt!({"ts": "2021-06-05T17:20:00Z", "msg": "This is a message", "lvl": "info", "log_id": 12345}, ["ts", "lvl", "msg"])
+				"""
+			return: #"ts=2021-06-05T17:20:00Z lvl=info msg="This is a message" log_id=12345"#
+		},
+        {
+            title: "Encode to logfmt (nested fields)"
+            source: """
+                encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log") 
+                """
+            return: #"agent.name=vector event=log log.file.path=my.log"#
+        },
+        {
+            title: "Encode to logfmt (nested fields ordering)"
+            source: """
+                encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log", ["event", "log.file.path", "agent.name"]) 
+                """
+            return: #"event=log log.file.path=my.log agent.name=vector"#
+        },
+	]
+}

--- a/docs/reference/remap/functions/encode_logfmt.cue
+++ b/docs/reference/remap/functions/encode_logfmt.cue
@@ -3,24 +3,26 @@ package metadata
 remap: functions: encode_logfmt: {
 	category: "Codec"
 	description: """
-		Encodes the `value` to logfmt.
+		Encodes the `value` to [logfmt](\#(urls.logfmt)).
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value to convert to a JSON string."
+			description: "The value to convert to a logfmt string."
 			required:    true
 			type: ["object"]
 		},
         {
             name:        "fields_ordering"
-            description: "The ordering of fields to preserve."
+            description: "The ordering of fields to preserve. Any fields not in this list will appear unordered, after any ordered fields."
             required: false
             type: ["array"]
         },
 	]
-	internal_failure_reasons: []
+	internal_failure_reasons: [
+        "`fields_ordering` contains a non-string element"
+    ]
 	return: types: ["string"]
 
 	examples: [

--- a/lib/vrl/compiler/src/value/convert.rs
+++ b/lib/vrl/compiler/src/value/convert.rs
@@ -225,8 +225,8 @@ impl Value {
         match self.as_bytes() {
             Some(bytes) => Ok(String::from_utf8_lossy(&bytes)),
             None => Err(Error::Expected {
-                got: Kind::Bytes,
-                expected: self.kind(),
+                got: self.kind(),
+                expected: Kind::Bytes,
             }),
         }
     }

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -51,6 +51,7 @@ default = [
     "downcase",
     "encode_base64",
     "encode_json",
+    "encode_logfmt",
     "ends_with",
     "exists",
     "flatten",
@@ -145,6 +146,7 @@ del = []
 downcase = []
 encode_base64 = ["base64"]
 encode_json = ["serde_json"]
+encode_logfmt = []
 ends_with = []
 exists = []
 flatten = []

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -19,6 +19,7 @@ criterion_group!(
               downcase,
               encode_base64,
               encode_json,
+              encode_logfmt,
               ends_with,
               // TODO: Cannot pass a Path to bench_function
               //exists
@@ -190,6 +191,30 @@ bench_function! {
     map {
         args: func_args![value: value![{"field": "value"}]],
         want: Ok(r#"{"field":"value"}"#),
+    }
+}
+
+bench_function! {
+    encode_logfmt => vrl_stdlib::EncodeLogfmt;
+
+    map {
+        args: func_args![value: value!(
+                  vec![
+                      value!(vec![value!("lvl"), value!("info")]),
+                      value!(vec![value!("msg"), value!("This is a log message")]),
+                  ]
+              )],
+        want: Ok(r#"lvl=info msg="This is a log message""#),
+    }
+
+    array {
+        args: func_args![value: value!(
+                  vec![
+                      value!(vec![value!("lvl"), value!("info")]),
+                      value!(vec![value!("log_id"), value!(12345)]),
+                  ]
+              )],
+        want: Ok("lvl=info log_id=12345"),
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -197,24 +197,25 @@ bench_function! {
 bench_function! {
     encode_logfmt => vrl_stdlib::EncodeLogfmt;
 
-    map {
-        args: func_args![value: value!(
-                  vec![
-                      value!(vec![value!("lvl"), value!("info")]),
-                      value!(vec![value!("msg"), value!("This is a log message")]),
-                  ]
-              )],
-        want: Ok(r#"lvl=info msg="This is a log message""#),
+    string_with_characters_to_escape {
+        args: func_args![value:
+            btreemap! {
+                "lvl" => "info",
+                "msg" => r#"payload: {"code": 200}\n"#
+            }],
+        want: Ok(r#"lvl=info msg="payload: {\"code\": 200}\\n""#),
     }
 
-    array {
-        args: func_args![value: value!(
-                  vec![
-                      value!(vec![value!("lvl"), value!("info")]),
-                      value!(vec![value!("log_id"), value!(12345)]),
-                  ]
-              )],
-        want: Ok("lvl=info log_id=12345"),
+    fields_ordering {
+        args: func_args![value:
+            btreemap! {
+                "lvl" => "info",
+                "msg" => "This is a log message",
+                "log_id" => 12345,
+            },
+            fields_ordering: value!(["lvl", "msg"])
+        ],
+        want: Ok(r#"lvl=info msg="This is a log message" log_id=12345"#),
     }
 }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -84,12 +84,13 @@ impl Expression for EncodeLogfmtFn {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.value.type_def(state).fallible().bytes()
+        TypeDef::new().bytes().fallible()
     }
 }
 
 fn encode_string(output: &mut String, str: &str) {
-    let needs_quoting = str.find(' ').is_some();
+    let needs_quoting = str.chars().any(char::is_whitespace);
+
     if needs_quoting {
         output.write_char('"').unwrap();
     }

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -83,7 +83,7 @@ impl Expression for EncodeLogfmtFn {
         Ok(encode(object, &fields[..]).into())
     }
 
-    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+    fn type_def(&self, _state: &state::Compiler) -> TypeDef {
         TypeDef::new().bytes().fallible()
     }
 }

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -96,7 +96,7 @@ fn encode_string(output: &mut String, str: &str) {
 
     for c in str.chars() {
         match c {
-            '\\' => output.write_str("\\").unwrap(),
+            '\\' => output.write_str(r#"\\"#).unwrap(),
             '"' => output.write_str(r#"\""#).unwrap(),
             '\n' => output.write_str(r#"\\n"#).unwrap(),
             _ => output.write_char(c).unwrap(),
@@ -175,7 +175,7 @@ pub fn encode(input: BTreeMap<String, Value>, fields: &[String]) -> String {
         output.write_char(' ').unwrap();
     }
 
-    if output.ends_with(" ") {
+    if output.ends_with(' ') {
         output.truncate(output.len() - 1)
     }
 
@@ -225,9 +225,10 @@ mod tests {
             args: func_args![value:
                 btreemap! {
                     "lvl" => "info",
-                    "msg" => r#"payload: {"code": 200}\n"#
+                    "msg" => r#"payload: {"code": 200}\n"#,
+                    "another_field" => "some\nfield\\and things"
                 }],
-            want: Ok(r#"lvl=info msg="payload: {\"code\": 200}\\n""#),
+            want: Ok(r#"another_field="some\\nfield\\and things" lvl=info msg="payload: {\"code\": 200}\\n""#),
             tdef: TypeDef::new().bytes().fallible(),
         }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -226,9 +226,10 @@ mod tests {
                 btreemap! {
                     "lvl" => "info",
                     "msg" => r#"payload: {"code": 200}\n"#,
-                    "another_field" => "some\nfield\\and things"
+                    "another_field" => "some\nfield\\and things",
+                    "space key" => "foo"
                 }],
-            want: Ok(r#"another_field="some\\nfield\\and things" lvl=info msg="payload: {\"code\": 200}\\n""#),
+            want: Ok(r#"another_field="some\\nfield\\and things" lvl=info msg="payload: {\"code\": 200}\\n" "space key"=foo"#),
             tdef: TypeDef::new().bytes().fallible(),
         }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -267,9 +267,9 @@ mod tests {
                         "ip" => value!([127, 0, 0, 1]),
                         "proto" => "tcp"
                     },
-                    "type" => "nested"
+                    "event" => "log"
                 }],
-                want: Ok("agent.id=1234 agent.name=vector log.file.path=encode_logfmt.rs network.ip.0=127 network.ip.1=0 network.ip.2=0 network.ip.3=1 network.proto=tcp type=nested"),
+                want: Ok("agent.id=1234 agent.name=vector event=log log.file.path=encode_logfmt.rs network.ip.0=127 network.ip.1=0 network.ip.2=0 network.ip.3=1 network.proto=tcp"),
                 tdef: TypeDef::new().bytes().fallible(),
         }
 
@@ -283,6 +283,25 @@ mod tests {
                 fields_ordering: value!(["lvl", "msg"])
             ],
             want: Ok(r#"lvl=info msg="This is a log message" log_id=12345"#),
+            tdef: TypeDef::new().bytes().fallible(),
+        }
+
+        nested_fields_ordering {
+            args: func_args![value:
+                btreemap! {
+                    "log" => btreemap! {
+                        "file" => btreemap! {
+                            "path" => "encode_logfmt.rs"
+                        },
+                    },
+                    "agent" => btreemap! {
+                        "name" => "vector",
+                    },
+                    "event" => "log"
+                },
+                fields_ordering:  value!(["event", "log.file.path", "agent.name"])
+            ],
+            want: Ok("event=log log.file.path=encode_logfmt.rs agent.name=vector"),
             tdef: TypeDef::new().bytes().fallible(),
         }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -16,14 +16,13 @@ mod logfmt {
             output.write_char('"').unwrap();
         }
 
-        for c in str.chars() {
-            let needs_escaping = matches!(c, '\\' | '"');
-            if needs_escaping {
-                output.write_char('\\').expect("");
-            }
+        let escaped = str
+            .to_string()
+            .replace(r#"\"#, r#"\\"#)
+            .replace(r#"""#, r#"\""#)
+            .replace("\n", r#"\\n"#);
 
-            output.write_char(c).unwrap();
-        }
+        output.write_str(&escaped).unwrap();
 
         if needs_quotting {
             output.write_char('"').unwrap();

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -115,10 +115,7 @@ fn encode_value(output: &mut String, value: &Value) {
             let val = String::from_utf8_lossy(b);
             encode_string(output, &val)
         }
-        _ => {
-            let val = format!("{}", value);
-            encode_string(output, &val)
-        }
+        _ => encode_string(output, &value.to_string()),
     }
 }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -26,12 +26,12 @@ impl Function for EncodeLogfmt {
         &[
             Example {
                 title: "encode object",
-                source: r#"encode_logfmt({"lvl": "info", "msg": "This is a message", "log_id": 12345}"#,
+                source: r#"encode_logfmt({"lvl": "info", "msg": "This is a message", "log_id": 12345})"#,
                 result: Ok(r#"s'log_id=12345 lvl=info msg="This is a message"'"#),
             },
             Example {
                 title: "encode array",
-                source: r#"encode_logfmt([ ["lvl", "info"], ["msg", "This is a message"], ["log_id", 12345]]"#,
+                source: r#"encode_logfmt([["lvl", "info"], ["msg", "This is a message"], ["log_id", 12345]])"#,
                 result: Ok(r#"s'lvl=info msg="This is a message" log_id=12345'"#),
             },
         ]

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -1,0 +1,227 @@
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct EncodeLogfmt;
+
+impl Function for EncodeLogfmt {
+    fn identifier(&self) -> &'static str {
+        "encode_logfmt"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::OBJECT | kind::ARRAY,
+            required: true,
+        }]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(EncodeLogfmtFn { value }))
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "encode object",
+                source: r#"encode_logfmt({"lvl": "info", "msg": "This is a message", "log_id": 12345}"#,
+                result: Ok(r#"s'log_id=12345 lvl=info msg="This is a message"'"#),
+            },
+            Example {
+                title: "encode array",
+                source: r#"encode_logfmt([ ["lvl", "info"], ["msg", "This is a message"], ["log_id", 12345]]"#,
+                result: Ok(r#"s'lvl=info msg="This is a message" log_id=12345'"#),
+            },
+        ]
+    }
+}
+
+fn format_logfmt_string(f: &mut fmt::Formatter<'_>, str: &str) -> fmt::Result {
+    match str.find(' ') {
+        Some(_) => write!(f, r#""{}""#, str),
+        None => write!(f, "{}", str),
+    }
+}
+
+struct LogFmtFieldValueFormatter<'a> {
+    value: &'a Value,
+}
+
+impl std::fmt::Display for LogFmtFieldValueFormatter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
+            Value::Bytes(b) => {
+                let val = String::from_utf8_lossy(b);
+                format_logfmt_string(f, &val)
+            }
+            _ => {
+                let val = format!("{}", self.value);
+                format_logfmt_string(f, &val)
+            }
+        }
+    }
+}
+
+struct LogFmtFieldFormatter<'a> {
+    key: &'a str,
+    value: &'a Value,
+}
+
+impl std::fmt::Display for LogFmtFieldFormatter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_logfmt_string(f, self.key)?;
+        let value_format = LogFmtFieldValueFormatter { value: self.value };
+        write!(f, "={}", value_format)
+    }
+}
+
+struct LogFmtFormatter {
+    value: Value,
+}
+
+impl std::fmt::Display for LogFmtFormatter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.value {
+            Value::Object(map) => {
+                for (idx, (key, value)) in map.iter().enumerate() {
+                    let field_formatter = LogFmtFieldFormatter { key, value };
+                    if idx > 0 {
+                        f.write_str(" ")?;
+                    }
+                    write!(f, "{}", field_formatter)?;
+                }
+
+                Ok(())
+            }
+            Value::Array(arr) => {
+                for (idx, value) in arr.iter().enumerate() {
+                    if idx > 0 {
+                        f.write_str(" ")?;
+                    }
+
+                    match value {
+                        Value::Array(arr) if arr.len() == 2 => {
+                            let (key, value) = (&arr[0], &arr[1]);
+                            if let Value::Bytes(b) = key {
+                                let key_str = String::from_utf8_lossy(b);
+                                let field_formatter = LogFmtFieldFormatter {
+                                    key: &key_str,
+                                    value,
+                                };
+                                write!(f, "{}", field_formatter)?;
+                            }
+                        }
+                        _ => return Err(fmt::Error),
+                    }
+                }
+
+                Ok(())
+            }
+            _ => Err(fmt::Error),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EncodeLogfmtFn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for EncodeLogfmtFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let formatter = LogFmtFormatter { value };
+
+        let mut output = String::new();
+        match std::fmt::write(&mut output, format_args!("{}", formatter)) {
+            Ok(_) => Ok(output.into()),
+            Err(_) => Err("Failed to encode logfmt".into()),
+        }
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.value.type_def(state).infallible().bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        encode_logfmt  => EncodeLogfmt;
+
+        array_with_single_element_type {
+            args: func_args![value: value!(
+                      vec![value!(vec!["lvl", "info"])]
+                      )
+                    ],
+            want: Ok("lvl=info"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        array_with_multiple_element_types {
+            args: func_args![value: value!(
+                      vec![
+                          value!(vec![value!("lvl"), value!("info")]),
+                          value!(vec![value!("log_id"), value!(12345)]),
+                      ]
+                  )],
+            want: Ok("lvl=info log_id=12345"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        array_with_too_many_items_in_sub_array_error {
+            args: func_args![value: value!(
+                      vec![
+                          value!(vec![value!("lvl"), value!("info"), value!("error")]),
+                          value!(vec![value!("log_id"), value!(12345)]),
+                      ]
+                  )],
+            want: Err("Failed to encode logfmt"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        array_with_missing_items_in_sub_array_error {
+            args: func_args![value: value!(
+                      vec![
+                          value!(vec![value!("log_id"), value!(12345)]),
+                          value!(vec![value!("lvl")]),
+                      ]
+                  )],
+            want: Err("Failed to encode logfmt"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        array_with_string_and_spaces {
+            args: func_args![value: value!(
+                      vec![
+                          value!(vec![value!("lvl"), value!("info")]),
+                          value!(vec![value!("msg"), value!("This is a log message")]),
+                      ]
+                  )],
+            want: Ok(r#"lvl=info msg="This is a log message""#),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        map_with_single_element_type {
+            args: func_args![value: value!(map!["lvl": value!("info")])],
+            want: Ok("lvl=info"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        map_with_multiple_element_types {
+            args: func_args![value: value!(map!["lvl": value!("info"), "log_id": value!(12345)])],
+            want: Ok("log_id=12345 lvl=info"),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+        map_with_string_and_spaces {
+            args: func_args![value: value!(map!["lvl": value!("info"), "msg": value!("This is a log message")])],
+            want: Ok(r#"lvl=info msg="This is a log message""#),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -124,7 +124,7 @@ impl Function for EncodeLogfmt {
             },
             Example {
                 title: "encode object with fields ordering",
-                source: r#"encode_logfmt!({"msg": "This is a message", "lod_id": 12345, "lvl": "info"}, ["lvl", "msg"])"#,
+                source: r#"encode_logfmt!({"msg": "This is a message", "lvl": "info", "log_id": 12345}, ["lvl", "msg"])"#,
                 result: Ok(r#"s'lvl=info msg="This is a message" log_id=12345'"#),
             },
         ]

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -8,21 +8,13 @@ mod logfmt {
     use vrl::prelude::*;
 
     fn encode_string(output: &mut String, str: &str) -> fmt::Result {
-        let needs_quotting = match str.find(' ') {
-            Some(_) => true,
-            None => false,
-        };
-
+        let needs_quotting = str.find(' ').is_some();
         if needs_quotting {
             output.write_char('"')?;
         }
 
         for c in str.chars() {
-            let needs_escaping = match c {
-                '\\' | '"' => true,
-                _ => false,
-            };
-
+            let needs_escaping = matches!(c, '\\' | '"');
             if needs_escaping {
                 output.write_char('\\')?;
             }
@@ -75,7 +67,7 @@ mod logfmt {
                 continue;
             }
 
-            if idx > 0 || seen_fields.len() > 0 {
+            if idx > 0 || !seen_fields.is_empty() {
                 output.write_char(' ').map_err(|_| "write error")?;
             }
             encode_field(&mut output, key, value).map_err(|_| "write error")?;

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -1,45 +1,7 @@
 use vrl::prelude::*;
 
-#[derive(Clone, Copy, Debug)]
-pub struct EncodeLogfmt;
-
-impl Function for EncodeLogfmt {
-    fn identifier(&self) -> &'static str {
-        "encode_logfmt"
-    }
-
-    fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            kind: kind::OBJECT | kind::ARRAY,
-            required: true,
-        }]
-    }
-
-    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
-        let value = arguments.required("value");
-
-        Ok(Box::new(EncodeLogfmtFn { value }))
-    }
-
-    fn examples(&self) -> &'static [Example] {
-        &[
-            Example {
-                title: "encode object",
-                source: r#"encode_logfmt({"lvl": "info", "msg": "This is a message", "log_id": 12345})"#,
-                result: Ok(r#"s'log_id=12345 lvl=info msg="This is a message"'"#),
-            },
-            Example {
-                title: "encode array",
-                source: r#"encode_logfmt([["lvl", "info"], ["msg", "This is a message"], ["log_id", 12345]])"#,
-                result: Ok(r#"s'lvl=info msg="This is a message" log_id=12345'"#),
-            },
-        ]
-    }
-}
-
 mod logfmt {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashSet};
     use std::fmt::{self, Write};
     use std::result::Result;
 
@@ -94,63 +56,114 @@ mod logfmt {
         encode_value(output, value)
     }
 
-    pub fn encode_object(input: &BTreeMap<String, Value>) -> Result<String, String> {
+    pub fn encode(input: &BTreeMap<String, Value>, fields: &[String]) -> Result<String, String> {
         let mut output = String::new();
+        let mut seen_fields = HashSet::new();
+
+        for (idx, field) in fields.iter().enumerate() {
+            if let Some(val) = input.get(field) {
+                if idx > 0 {
+                    output.write_char(' ').map_err(|_| "write error")?;
+                }
+                encode_field(&mut output, field, val).map_err(|_| "write error")?;
+                seen_fields.insert(field);
+            }
+        }
 
         for (idx, (key, value)) in input.iter().enumerate() {
-            if idx > 0 {
-                output.write_char(' ').map_err(|_| "write error")?;
+            if seen_fields.contains(key) {
+                continue;
             }
 
+            if idx > 0 || seen_fields.len() > 0 {
+                output.write_char(' ').map_err(|_| "write error")?;
+            }
             encode_field(&mut output, key, value).map_err(|_| "write error")?;
         }
 
         Ok(output)
     }
+}
 
-    pub fn encode_array(input: &Vec<Value>) -> std::result::Result<String, String> {
-        let mut output = String::new();
+#[derive(Clone, Copy, Debug)]
+pub struct EncodeLogfmt;
 
-        for (idx, value) in input.iter().enumerate() {
-            if idx > 0 {
-                output.write_char(' ').map_err(|_| "write error")?;
-            }
+impl Function for EncodeLogfmt {
+    fn identifier(&self) -> &'static str {
+        "encode_logfmt"
+    }
 
-            match value {
-                Value::Array(arr) if arr.len() == 2 => {
-                    let (key, value) = (&arr[0], &arr[1]);
-                    if let Value::Bytes(b) = key {
-                        let key_str = String::from_utf8_lossy(b);
-                        encode_field(&mut output, &key_str, value).map_err(|_| "write error")?;
-                    } else {
-                        return Err(format!("invalid key type at index {} ({})", idx, key));
-                    }
-                }
-                _ => {
-                    return Err(format!(
-                        "invalid key-value pair at index {} ({})",
-                        idx, value
-                    ))
-                }
-            }
-        }
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::OBJECT,
+                required: true,
+            },
+            Parameter {
+                keyword: "fields_ordering",
+                kind: kind::ARRAY,
+                required: false,
+            },
+        ]
+    }
 
-        Ok(output)
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let fields = arguments.optional("fields_ordering");
+
+        Ok(Box::new(EncodeLogfmtFn { value, fields }))
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "encode object",
+                source: r#"encode_logfmt!({"lvl": "info", "msg": "This is a message", "log_id": 12345})"#,
+                result: Ok(r#"s'log_id=12345 lvl=info msg="This is a message"'"#),
+            },
+            Example {
+                title: "encode object with fields ordering",
+                source: r#"encode_logfmt!({"msg": "This is a message", "lod_id": 12345, "lvl": "info"}, ["lvl", "msg"])"#,
+                result: Ok(r#"s'lvl=info msg="This is a message" log_id=12345'"#),
+            },
+        ]
     }
 }
 
 #[derive(Clone, Debug)]
 struct EncodeLogfmtFn {
     value: Box<dyn Expression>,
+    fields: Option<Box<dyn Expression>>,
+}
+
+fn resolve_fields(fields: &Value) -> Vec<String> {
+    match fields {
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| match v {
+                Value::Bytes(bytes) => Some(String::from_utf8_lossy(&bytes)),
+                _ => None,
+            })
+            .map(Into::into)
+            .collect(),
+        _ => vec![],
+    }
 }
 
 impl Expression for EncodeLogfmtFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
+        let fields = match &self.fields {
+            None => vec![],
+            Some(expr) => match expr.resolve(ctx) {
+                Ok(val) => resolve_fields(&val),
+                Err(_) => vec![],
+            },
+        };
 
         let logfmt = match value {
-            Value::Object(map) => logfmt::encode_object(&map),
-            Value::Array(arr) => logfmt::encode_array(&arr),
+            Value::Object(map) => logfmt::encode(&map, &fields[..]),
             _ => Err("unsupported value-type".into()),
         };
 
@@ -167,106 +180,62 @@ impl Expression for EncodeLogfmtFn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use shared::btreemap;
 
     test_function![
         encode_logfmt  => EncodeLogfmt;
 
-        array_with_single_element_type {
-            args: func_args![value: value!(
-                      vec![value!(vec!["lvl", "info"])]
-                      )
-                    ],
+        single_element {
+            args: func_args![value:
+                btreemap! {
+                    "lvl" => "info"
+                }
+            ],
             want: Ok("lvl=info"),
             tdef: TypeDef::new().bytes().fallible(),
         }
 
-        array_with_multiple_element_types {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("lvl"), value!("info")]),
-                          value!(vec![value!("log_id"), value!(12345)]),
-                      ]
-                  )],
-            want: Ok("lvl=info log_id=12345"),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        array_with_string_and_spaces {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("lvl"), value!("info")]),
-                          value!(vec![value!("msg"), value!("This is a log message")]),
-                      ]
-                  )],
-            want: Ok(r#"lvl=info msg="This is a log message""#),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        array_with_string_and_characters_to_escape {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("lvl"), value!("info")]),
-                          value!(vec![value!("msg"), value!(r#"payload: {"code": 200}\n"#)]),
-                      ]
-                  )],
-            want: Ok(r#"lvl=info msg="payload: {\"code\": 200}\\n""#),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        array_with_too_many_items_in_key_pair_error {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("lvl"), value!("info"), value!("error")]),
-                          value!(vec![value!("log_id"), value!(12345)]),
-                      ]
-                  )],
-            want: Err(r#"failed to encode logfmt: invalid key-value pair at index 0 (["lvl", "info", "error"])"#),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        array_with_missing_items_key_pair_error {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("log_id"), value!(12345)]),
-                          value!(vec![value!("lvl")]),
-                      ]
-                  )],
-            want: Err(r#"failed to encode logfmt: invalid key-value pair at index 1 (["lvl"])"#),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        array_with_invalid_key_type_error {
-            args: func_args![value: value!(
-                      vec![
-                          value!(vec![value!("lvl"), value!("info")]),
-                          value!(vec![value!(10), value!(20)]),
-                      ]
-                  )],
-            want: Err("failed to encode logfmt: invalid key type at index 1 (10)"),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        map_with_single_element_type {
-            args: func_args![value: value!(map!["lvl": value!("info")])],
-            want: Ok("lvl=info"),
-            tdef: TypeDef::new().bytes().fallible(),
-        }
-
-        map_with_multiple_element_types {
-            args: func_args![value: value!(map!["lvl": value!("info"), "log_id": value!(12345)])],
+        multiple_elements {
+            args: func_args![value:
+                btreemap! {
+                    "lvl" => "info",
+                    "log_id" => 12345
+                }
+            ],
             want: Ok("log_id=12345 lvl=info"),
             tdef: TypeDef::new().bytes().fallible(),
         }
 
-        map_with_string_and_spaces {
-            args: func_args![value: value!(map!["lvl": value!("info"), "msg": value!("This is a log message")])],
+        string_with_spaces {
+            args: func_args![value:
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => "This is a log message"
+                }],
             want: Ok(r#"lvl=info msg="This is a log message""#),
             tdef: TypeDef::new().bytes().fallible(),
         }
 
-        map_with_string_and_characters_to_escape {
-            args: func_args![value: value!(map!["lvl": value!("info"), "msg": value!(r#"payload: {"code": 200}\n"#)])],
+        string_with_characters_to_escape {
+            args: func_args![value:
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => r#"payload: {"code": 200}\n"#
+                }],
             want: Ok(r#"lvl=info msg="payload: {\"code\": 200}\\n""#),
+            tdef: TypeDef::new().bytes().fallible(),
+        }
+
+        fields_ordering {
+            args: func_args![value:
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => "This is a log message",
+                    "log_id" => 12345,
+                },
+                fields_ordering: value!(["lvl", "msg"])
+            ],
+            want: Ok(r#"lvl=info msg="This is a log message" log_id=12345"#),
             tdef: TypeDef::new().bytes().fallible(),
         }
     ];

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -24,6 +24,8 @@ mod downcase;
 mod encode_base64;
 #[cfg(feature = "encode_json")]
 mod encode_json;
+#[cfg(feature = "encode_logfmt")]
+mod encode_logfmt;
 #[cfg(feature = "ends_with")]
 mod ends_with;
 #[cfg(feature = "exists")]
@@ -219,6 +221,8 @@ pub use downcase::Downcase;
 pub use encode_base64::EncodeBase64;
 #[cfg(feature = "encode_json")]
 pub use encode_json::EncodeJson;
+#[cfg(feature = "encode_logfmt")]
+pub use encode_logfmt::EncodeLogfmt;
 #[cfg(feature = "ends_with")]
 pub use ends_with::EndsWith;
 #[cfg(feature = "exists")]
@@ -404,6 +408,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(EncodeBase64),
         #[cfg(feature = "encode_json")]
         Box::new(EncodeJson),
+        #[cfg(feature = "encode_logfmt")]
+        Box::new(EncodeLogfmt),
         #[cfg(feature = "ends_with")]
         Box::new(EndsWith),
         #[cfg(feature = "exists")]


### PR DESCRIPTION
Fixes #6972

This PR introduces a new `encode_logfmt` function, which is the opposite of `parse_logfmt`.