### PR TITLE
fix(releasing): Ensure /etc/default/vector is not automatically overwritten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ debug = true
 [package.metadata.deb]
 name = "vector"
 maintainer-scripts = "distribution/debian/scripts/"
-conf-files = ["/etc/vector/vector.toml"]
+conf-files = ["/etc/vector/vector.toml", "/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
   ["config/vector.toml", "/etc/vector/vector.toml", "644"],
   ["config/examples/*", "/etc/vector/examples/", "644"],
-  ["distribution/systemd/vector.service", "/etc/systemd/system/vector.service", "644"],
+  ["distribution/systemd/vector.service", "/lib/systemd/system/vector.service", "644"],
   ["distribution/systemd/vector.default", "/etc/default/vector", "600"]
 ]
 license-file = ["target/debian-license.txt"]


### PR DESCRIPTION
Fixes #6987 

Also move the systemd config file to
`/lib/systemd/system/vector.service` as this seems to be more customary
for debian
(https://manpages.debian.org/jessie/systemd/systemd.unit.5.en.html).
I spot checked a few other packages:

* haproxy
* openssh-server
* nginx
* datadog-agent

And they all put their systemd configs in `/lib/systemd/system`.
`/etc/systemd/system` is for users to put system specific systemd
configuration.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
