### PR TITLE
fix(external docs): Fix batches and buffer SVG

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -410,7 +410,7 @@ components: sinks: [Name=string]: {
 						buffers_batches: {
 							title: "Buffers & batches"
 							body: #"""
-									![Buffers and Batches](/optimized_svg/buffers-and-batches-serial_538_160.svg)
+									<SVG src="/optimized_svg/buffers-and-batches-serial_538_160.svg" />
 
 									This component buffers & batches data as shown in the diagram above. You'll notice that Vector treats these concepts
 									differently, instead of treating them as global concepts, Vector treats them


### PR DESCRIPTION
This reverts commit 4c42b7d9d259114251a1a1b3c2b7fb213cc04c49.

I'm not sure why it doesn't work, but currently it doesn't render the
image. The previous, and reinstated, syntax seems to embed the SVG
directly. This is how the other SVGs are used.

```
➜  vector git:(fix-svg) rg 'SVG src='
docs/manual/setup/deployment/topologies.md
16:<SVG src="/optimized_svg/topologies-distributed_453_298.svg" />
47:<SVG src="/optimized_svg/topologies-centralized_1564_502.svg" />
79:<SVG src="/optimized_svg/topologies-stream-based_1516_506.svg" />

docs/reference/components/sinks.cue
413:                                                                    <SVG src="/optimized_svg/buffers-and-batches-serial_538_160.svg" />
436:                                            <SVG src="/img/buffers.svg" />

docs/manual/about/concepts.md
6:<SVG src="/optimized_svg/concepts_687_357.svg" />

docs/manual/about/under-the-hood/architecture.md
8:<SVG src="/optimized_svg/architecture_840_293.svg" />

docs/manual/about/under-the-hood/architecture/data-model.md
7:<SVG src="/optimized_svg/data-model-event_808_359.svg" />

docs/manual/about/under-the-hood/architecture/runtime-model.md
6:<SVG src="/optimized_svg/runtime-model_770_325.svg" />

docs/manual/about/under-the-hood/architecture/concurrency-model.md
6:<SVG src="/optimized_svg/concurrency-model_842_494.svg" />

docs/manual/about/under-the-hood/architecture/data-model/metric.md
6:<SVG src="/optimized_svg/data-model-metric_1513_942.svg" />

docs/manual/about/under-the-hood/architecture/pipeline-model.md
6:<SVG src="/optimized_svg/pipeline-model_1350_760.svg" />

docs/manual/about/under-the-hood/architecture/data-model/log.md
6:<SVG src="/optimized_svg/data-model-log_1526_907.svg" />

docs/manual/about/what-is-vector.md
6:<SVG src="/optimized_svg/components_683_294.svg" />
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
