### PR TITLE
fix(external docs): Fix example for AWS_SESSION_TOKEN

### DIFF
--- a/docs/reference/components/aws.cue
+++ b/docs/reference/components/aws.cue
@@ -146,7 +146,7 @@ components: _aws: {
 			description: "The AWS session token. Used for AWS authentication when communicating with AWS services."
 			type: string: {
 				default: null
-				examples: ["/path/to/credentials.json"]
+				examples: ["AQoEXAMPLEH4aoAH0gNCAPy...truncated...zrkuWJOgQs8IZZaIv2BXIa2R4Olgk"]
 				syntax: "literal"
 			}
 		}


### PR DESCRIPTION
Fixes #7009

Example is from https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-aws_session_token.html

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
