### PR TITLE
chore: Use our own metrics-rs Handle implementation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7941,6 +7941,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "pulsar",
+ "quickcheck",
  "rand 0.8.3",
  "rand_distr",
  "rdkafka",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,22 +3870,8 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e285601dcfb9f3a8f37a7093b9956a0df730b50848c8ac0117406aff06c851"
 dependencies = [
- "metrics-macros 0.2.0",
+ "metrics-macros",
  "proc-macro-hack",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.1.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0197e48db63aa8c28f9fbae021585b8f1b299a0b21640cf98853211ac39eb294"
-dependencies = [
- "lazy_static",
- "proc-macro-hack",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "regex",
- "syn 1.0.68",
 ]
 
 [[package]]
@@ -3896,10 +3882,10 @@ checksum = "11ac60cd4d3a869fd39d57baf0ed7f79fb677580d8d6655c4330d4f1126bc27b"
 dependencies = [
  "lazy_static",
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "regex",
- "syn 1.0.62",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -7931,7 +7917,6 @@ dependencies = [
  "matches",
  "maxminddb",
  "metrics",
- "metrics-macros 0.1.0-alpha.9",
  "metrics-tracing-context",
  "metrics-util",
  "mongodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,7 @@ tokio-test = "0.4.1"
 tokio01-test = "0.1.1"
 tower-test = "0.4.0"
 walkdir = "2.3.2"
+quickcheck = "1"
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,12 +112,9 @@ tracing-subscriber = "0.2.17"
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", rev = "f470db1b0354b368f62f9ee4d763595d16373231" }
 
 # Metrics
-metrics = "=0.14.2"
-metrics-tracing-context = "0.3.0"
-metrics-util = "0.6.2"
-# Indirect dependency; benchmark regression detected; pinning until
-# https://github.com/timberio/vector/issues/6412 is resolved
-metrics-macros = "=0.1.0-alpha.9"
+metrics = "0.14"
+metrics-tracing-context = "0.3"
+metrics-util = "0.6"
 
 # Aws
 rusoto_cloudwatch = { version = "0.46.0", optional = true }

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
+use criterion::{criterion_group, BenchmarkId, Criterion};
 
 fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("metrics_snapshot");

--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -12,7 +12,6 @@ fn benchmark(c: &mut Criterion) {
                 let controller = prepare_metrics(cardinality);
                 b.iter(|| {
                     let iter = vector::metrics::capture_metrics(controller);
-                    assert_cardinality_matches(&iter, cardinality);
                     iter
                 });
             },
@@ -30,18 +29,7 @@ fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
         metrics::counter!("test", 1, "idx" => format!("{}", idx));
     }
 
-    assert_cardinality_matches(&vector::metrics::capture_metrics(controller), cardinality);
-
     controller
-}
-
-/// This call has negligible (and cosistent) performance compared to the rest
-/// of the benches, however it performs the assertion over the data, effectively
-/// acting as an implicit blackbox.
-fn assert_cardinality_matches(iter: &impl Iterator, cardinality: usize) {
-    let iter = black_box(iter);
-    assert_eq!(iter.size_hint().0, cardinality);
-    assert_eq!(iter.size_hint().1.unwrap(), cardinality);
 }
 
 criterion_group!(benches, benchmark);

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -299,10 +299,8 @@ impl Metric {
                 value: gauge.gauge(),
             },
             Handle::Histogram(histogram) => {
-                let mut buckets: Vec<(f64, u32)> = Vec::with_capacity(32);
-                histogram.buckets(&mut buckets);
-                let buckets: Vec<Bucket> = buckets
-                    .into_iter()
+                let buckets: Vec<Bucket> = histogram
+                    .buckets()
                     .map(|(upper_limit, count)| Bucket { upper_limit, count })
                     .collect();
 

--- a/src/metrics/handle.rs
+++ b/src/metrics/handle.rs
@@ -28,10 +28,7 @@ impl AtomicF64 {
             opt.map(|i| i.to_bits())
         });
 
-        match res {
-            Ok(f) => Ok(f64::from_bits(f)),
-            Err(f) => Err(f64::from_bits(f)),
-        }
+        res.map(f64::from_bits).map_err(f64::from_bits)
     }
 
     fn load(&self, order: Ordering) -> f64 {

--- a/src/metrics/handle.rs
+++ b/src/metrics/handle.rs
@@ -121,7 +121,7 @@ impl Histogram {
         f64::from_bits(self.sum.load(Ordering::Relaxed))
     }
 
-    pub fn buckets<'a>(&'a self) -> BucketIter<'a> {
+    pub fn buckets(&self) -> BucketIter<'_> {
         BucketIter {
             inner: self.buckets.iter(),
         }

--- a/src/metrics/handle.rs
+++ b/src/metrics/handle.rs
@@ -1,0 +1,257 @@
+use metrics::GaugeValue;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+#[derive(Debug)]
+pub enum Handle {
+    Gauge(Gauge),
+    Counter(Counter),
+    Histogram(Histogram),
+}
+
+impl Handle {
+    pub(crate) fn counter() -> Self {
+        Handle::Counter(Counter::new())
+    }
+
+    pub(crate) fn increment_counter(&mut self, value: u64) {
+        match self {
+            Handle::Counter(counter) => counter.record(value),
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn gauge() -> Self {
+        Handle::Gauge(Gauge::new())
+    }
+
+    pub(crate) fn update_gauge(&mut self, value: GaugeValue) {
+        match self {
+            Handle::Gauge(gauge) => gauge.record(value),
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn histogram() -> Self {
+        Handle::Histogram(Histogram::new())
+    }
+
+    pub(crate) fn record_histogram(&mut self, value: f64) {
+        match self {
+            Handle::Histogram(h) => h.record(value),
+            _ => unreachable!(),
+        };
+    }
+}
+
+#[derive(Debug)]
+pub struct Histogram {
+    pub buckets: Box<[(f64, AtomicU32); 22]>,
+    pub count: AtomicU32,
+    pub sum: AtomicU64,
+}
+
+impl Histogram {
+    pub(crate) fn new() -> Self {
+        // Box to avoid having this large array inline to the structure, blowing
+        // out cache coherence.
+        //
+        // The sequence here is based on powers of two. Other sequences are more
+        // suitable for different distributions but since our present use case
+        // is mostly non-negative and measures smallish latencies we cluster
+        // around but never quite get to zero with an increasingly coarse
+        // long-tail.
+        let buckets = Box::new([
+            (f64::NEG_INFINITY, AtomicU32::new(0)),
+            (0.015625, AtomicU32::new(0)),
+            (0.03125, AtomicU32::new(0)),
+            (0.0625, AtomicU32::new(0)),
+            (0.125, AtomicU32::new(0)),
+            (0.25, AtomicU32::new(0)),
+            (0.5, AtomicU32::new(0)),
+            (0.0, AtomicU32::new(0)),
+            (1.0, AtomicU32::new(0)),
+            (2.0, AtomicU32::new(0)),
+            (4.0, AtomicU32::new(0)),
+            (8.0, AtomicU32::new(0)),
+            (16.0, AtomicU32::new(0)),
+            (32.0, AtomicU32::new(0)),
+            (32.0, AtomicU32::new(0)),
+            (128.0, AtomicU32::new(0)),
+            (256.0, AtomicU32::new(0)),
+            (512.0, AtomicU32::new(0)),
+            (1024.0, AtomicU32::new(0)),
+            (2048.0, AtomicU32::new(0)),
+            (4096.0, AtomicU32::new(0)),
+            (f64::INFINITY, AtomicU32::new(0)),
+        ]);
+        Self {
+            buckets,
+            count: AtomicU32::new(0),
+            sum: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn record(&mut self, value: f64) {
+        let mut prev_bound = f64::NEG_INFINITY;
+        assert!(self.buckets.len() == 22);
+        for (bound, bucket) in self.buckets.iter_mut() {
+            if value > prev_bound && value <= *bound {
+                bucket.fetch_add(1, Ordering::Relaxed);
+                break;
+            } else {
+                prev_bound = *bound;
+            }
+        }
+
+        self.count.fetch_add(1, Ordering::Relaxed);
+        let _ = self
+            .sum
+            .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |cur| {
+                let next_sum = f64::from_bits(cur) + value;
+                Some(next_sum.to_bits())
+            });
+    }
+
+    pub fn count(&self) -> u32 {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    pub fn sum(&self) -> f64 {
+        f64::from_bits(self.sum.load(Ordering::Relaxed))
+    }
+
+    pub fn buckets(&self, buf: &mut Vec<(f64, u32)>) {
+        for (k, v) in self.buckets.iter() {
+            buf.push((*k, v.load(Ordering::Relaxed)));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Counter {
+    inner: AtomicU64,
+}
+
+impl Counter {
+    pub(crate) fn with_count(count: u64) -> Self {
+        Self {
+            inner: AtomicU64::new(count),
+        }
+    }
+
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn record(&mut self, value: u64) {
+        self.inner.fetch_add(value, Ordering::Relaxed);
+    }
+
+    pub fn count(&self) -> u64 {
+        self.inner.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug)]
+pub struct Gauge {
+    inner: AtomicU64,
+}
+
+impl Gauge {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn record(&mut self, value: GaugeValue) {
+        // Because Rust lacks an atomic f64 we store gauges as AtomicU64
+        // and transmute back and forth to an f64 here. They have the
+        // same size so this operation is safe, just don't read the
+        // AtomicU64 directly.
+        let _ = self
+            .inner
+            .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |cur| {
+                let val = value.update_value(f64::from_bits(cur));
+                Some(val.to_bits())
+            });
+    }
+
+    pub fn gauge(&self) -> f64 {
+        f64::from_bits(self.inner.load(Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::metrics::handle::{Counter, Histogram};
+    use quickcheck::{QuickCheck, TestResult};
+
+    // Adapted from https://users.rust-lang.org/t/assert-eq-for-float-numbers/7034/4?u=blt
+    fn nearly_equal(a: f64, b: f64) -> bool {
+        let abs_a = a.abs();
+        let abs_b = b.abs();
+        let diff = (a - b).abs();
+
+        if a == b {
+            // Handle infinities.
+            true
+        } else if a == 0.0 || b == 0.0 || diff < f64::MIN_POSITIVE {
+            // One of a or b is zero (or both are extremely close to it,) use absolute error.
+            diff < (f64::EPSILON * f64::MIN_POSITIVE)
+        } else {
+            // Use relative error.
+            (diff / f64::min(abs_a + abs_b, f64::MAX)) < f64::EPSILON
+        }
+    }
+
+    #[test]
+    fn histogram() {
+        fn inner(values: Vec<f64>) -> TestResult {
+            let mut sut = Histogram::new();
+            let mut model_count: u32 = 0;
+            let mut model_sum: f64 = 0.0;
+
+            for val in &values {
+                if val.is_infinite() || val.is_nan() {
+                    continue;
+                }
+                sut.record(*val);
+                model_count = model_count.wrapping_add(1);
+                model_sum += *val;
+
+                assert_eq!(sut.count(), model_count);
+                assert!(nearly_equal(sut.sum(), model_sum));
+            }
+            TestResult::passed()
+        }
+
+        QuickCheck::new()
+            .tests(1_000)
+            .max_tests(2_000)
+            .quickcheck(inner as fn(Vec<f64>) -> TestResult);
+    }
+
+    #[test]
+    fn count() {
+        fn inner(values: Vec<u64>) -> TestResult {
+            let mut sut = Counter::new();
+            let mut model: u64 = 0;
+
+            for val in &values {
+                sut.record(*val);
+                model = model.wrapping_add(*val);
+
+                assert_eq!(sut.count(), model);
+            }
+            TestResult::passed()
+        }
+
+        QuickCheck::new()
+            .tests(1_000)
+            .max_tests(2_000)
+            .quickcheck(inner as fn(Vec<u64>) -> TestResult);
+    }
+}

--- a/src/metrics/handle.rs
+++ b/src/metrics/handle.rs
@@ -14,7 +14,7 @@ impl AtomicF64 {
         }
     }
 
-    pub fn fetch_update<F>(
+    fn fetch_update<F>(
         &self,
         set_order: Ordering,
         fetch_order: Ordering,
@@ -30,11 +30,11 @@ impl AtomicF64 {
 
         match res {
             Ok(f) => Ok(f64::from_bits(f)),
-            Err(f) => Ok(f64::from_bits(f)),
+            Err(f) => Err(f64::from_bits(f)),
         }
     }
 
-    pub fn load(&self, order: Ordering) -> f64 {
+    fn load(&self, order: Ordering) -> f64 {
         f64::from_bits(self.inner.load(order))
     }
 }
@@ -131,7 +131,6 @@ impl Histogram {
 
     pub(crate) fn record(&mut self, value: f64) {
         let mut prev_bound = f64::NEG_INFINITY;
-        assert!(self.buckets.len() == 22);
         for (bound, bucket) in self.buckets.iter_mut() {
             if value > prev_bound && value <= *bound {
                 bucket.fetch_add(1, Ordering::Relaxed);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -113,7 +113,7 @@ pub fn capture_metrics(controller: &Controller) -> impl Iterator<Item = Event> {
         .iter()
         .map(|kv| Metric::from_metric_kv(kv.key().key(), kv.value()).into())
         .collect::<Vec<Event>>();
-    let handle = Handle::Counter(Counter::with_count(events.len() as u64));
+    let handle = Handle::Counter(Counter::with_count(events.len() as u64 + 1));
     events.push(Metric::from_metric_kv(CARDINALITY_KEY.key(), &handle).into());
 
     events.into_iter()

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,9 +1,11 @@
+mod handle;
 mod label_filter;
 mod recorder;
 mod registry;
 #[cfg(test)]
 mod tests;
 
+pub use crate::metrics::handle::{Counter, Handle};
 use crate::metrics::label_filter::VectorLabelFilter;
 use crate::metrics::recorder::VectorRecorder;
 use crate::metrics::registry::VectorRegistry;
@@ -11,9 +13,8 @@ use crate::{event::Metric, Event};
 use metrics::{Key, KeyData, SharedString};
 use metrics_tracing_context::TracingContextLayer;
 use metrics_util::layers::Layer;
-use metrics_util::{CompositeKey, Handle, MetricKind};
+use metrics_util::{CompositeKey, MetricKind};
 use once_cell::sync::OnceCell;
-use std::sync::{atomic::AtomicU64, Arc};
 
 static CONTROLLER: OnceCell<Controller> = OnceCell::new();
 // Cardinality counter parameters, expose the internal metrics registry
@@ -52,17 +53,7 @@ pub fn init() -> crate::Result<()> {
     ////
     //// Prepare the registry
     ////
-
     let registry = VectorRegistry::default();
-    // We keep track of the total number of metrics tracked by vector, its
-    // "cardinality". This counter is an atomic so we can update it
-    // cross-thread. It is owned by the recorder.
-    let cardinality_counter = Arc::new(AtomicU64::new(1));
-    registry.op(
-        CARDINALITY_KEY.clone(),
-        |_| {},
-        || Handle::Counter(Arc::clone(&cardinality_counter)),
-    );
 
     ////
     //// Prepare the controller
@@ -86,7 +77,7 @@ pub fn init() -> crate::Result<()> {
     // The recorder is the interface between metrics-rs and our registry. In our
     // case it doesn't _do_ much other than shepherd into the registry and
     // update the cardinality counter, see above, as needed.
-    let recorder = VectorRecorder::new(registry, cardinality_counter);
+    let recorder = VectorRecorder::new(registry);
     let recorder: Box<dyn metrics::Recorder> = if tracing_context_layer_enabled() {
         // Apply a layer to capture tracing span fields as labels.
         Box::new(TracingContextLayer::new(VectorLabelFilter).layer(recorder))
@@ -116,11 +107,14 @@ pub fn get_controller() -> crate::Result<&'static Controller> {
 /// Take a snapshot of all gathered metrics and expose them as metric
 /// [`Event`]s.
 pub fn capture_metrics(controller: &Controller) -> impl Iterator<Item = Event> {
-    controller
+    let mut events = controller
         .registry
         .map
         .iter()
         .map(|kv| Metric::from_metric_kv(kv.key().key(), kv.value()).into())
-        .collect::<Vec<Event>>()
-        .into_iter()
+        .collect::<Vec<Event>>();
+    let handle = Handle::Counter(Counter::with_count(events.len() as u64));
+    events.push(Metric::from_metric_kv(CARDINALITY_KEY.key(), &handle).into());
+
+    events.into_iter()
 }

--- a/src/metrics/registry.rs
+++ b/src/metrics/registry.rs
@@ -40,10 +40,10 @@ where
     pub fn op<I, O, V>(&self, key: K, op: O, init: I) -> V
     where
         I: FnOnce() -> H,
-        O: FnOnce(&H) -> V,
+        O: FnOnce(&mut H) -> V,
     {
-        let valref = self.map.entry(key).or_insert_with(init);
-        op(valref.value())
+        let mut valref = self.map.entry(key).or_insert_with(init);
+        op(valref.value_mut())
     }
 }
 

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -411,7 +411,7 @@ async fn run_test(params: TestParams) -> TestResults {
             .unwrap()
             .data
             .value,
-        MetricValue::Distribution { .. }
+        MetricValue::AggregatedHistogram { .. }
     ));
     assert!(matches!(
         metrics
@@ -419,7 +419,7 @@ async fn run_test(params: TestParams) -> TestResults {
             .unwrap()
             .data
             .value,
-        MetricValue::Distribution { .. }
+        MetricValue::AggregatedHistogram { .. }
     ));
     if params.concurrency == Concurrency::Adaptive {
         assert!(matches!(
@@ -428,7 +428,7 @@ async fn run_test(params: TestParams) -> TestResults {
                 .unwrap()
                 .data
                 .value,
-            MetricValue::Distribution { .. }
+            MetricValue::AggregatedHistogram { .. }
         ));
     }
     assert!(matches!(
@@ -437,7 +437,7 @@ async fn run_test(params: TestParams) -> TestResults {
             .unwrap()
             .data
             .value,
-        MetricValue::Distribution { .. }
+        MetricValue::AggregatedHistogram { .. }
     ));
 
     TestResults { stats, cstats }

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -94,8 +94,8 @@ mod tests {
         counter!("bar", 4);
         histogram!("baz", 5.0);
         histogram!("baz", 6.0);
-        histogram!("quux", 7.0, "host" => "foo");
         histogram!("quux", 8.0, "host" => "foo");
+        histogram!("quux", 8.1, "host" => "foo");
 
         let controller = get_controller().expect("no controller");
 
@@ -142,9 +142,10 @@ mod tests {
                 // [`metrics::handle::Histogram::new`] are hard-coded. If this
                 // check fails you might look there and see if we've allowed
                 // users to set their own bucket widths.
-                assert_eq!(buckets[12].count, 2);
+                assert_eq!(buckets[11].count, 1);
+                assert_eq!(buckets[12].count, 1);
                 assert_eq!(*count, 2);
-                assert_eq!(*sum, 15.0);
+                assert_eq!(*sum, 16.1);
             }
             _ => panic!("wrong type"),
         }

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -71,7 +71,7 @@ async fn run(
 
 #[cfg(test)]
 mod tests {
-    use crate::event::metric::{Metric, MetricValue, StatisticKind};
+    use crate::event::metric::{Metric, MetricValue};
     use crate::metrics::{capture_metrics, get_controller};
     use metrics::{counter, gauge, histogram};
     use std::collections::BTreeMap;

--- a/tests/metrics_snapshot.rs
+++ b/tests/metrics_snapshot.rs
@@ -1,0 +1,26 @@
+fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
+    let _ = vector::metrics::init();
+    let controller = vector::metrics::get_controller().unwrap();
+    vector::metrics::reset(controller);
+
+    for idx in 0..cardinality {
+        metrics::counter!("test", 1, "idx" => format!("{}", idx));
+    }
+
+    assert_cardinality_matches(&vector::metrics::capture_metrics(controller), cardinality);
+
+    controller
+}
+
+fn assert_cardinality_matches(iter: &impl Iterator, cardinality: usize) {
+    assert_eq!(iter.size_hint(), (cardinality, Some(cardinality)));
+}
+
+#[test]
+fn cardinality_matches() {
+    for cardinality in &[0, 1, 10, 100, 1000, 10000] {
+        let controller = prepare_metrics(*cardinality);
+        let iter = vector::metrics::capture_metrics(controller);
+        assert_cardinality_matches(&iter, *cardinality);
+    }
+}

--- a/tests/metrics_snapshot.rs
+++ b/tests/metrics_snapshot.rs
@@ -7,7 +7,10 @@ fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
         metrics::counter!("test", 1, "idx" => format!("{}", idx));
     }
 
-    assert_cardinality_matches(&vector::metrics::capture_metrics(controller), cardinality);
+    assert_cardinality_matches(
+        &vector::metrics::capture_metrics(controller),
+        cardinality + 1,
+    );
 
     controller
 }
@@ -21,6 +24,6 @@ fn cardinality_matches() {
     for cardinality in &[0, 1, 10, 100, 1000, 10000] {
         let controller = prepare_metrics(*cardinality);
         let iter = vector::metrics::capture_metrics(controller);
-        assert_cardinality_matches(&iter, *cardinality);
+        assert_cardinality_matches(&iter, *cardinality + 1);
     }
 }


### PR DESCRIPTION
This commit introduces our own metrics-rs `Handle` implementation, one that takes constant space per metric type. This significantly reduces our happy path memory use under load and should resolve memory leaks noted in the closing issues. The leak culprit is metrics-rs `Histogram` combined with tracing integration. Their implementation relies on an atomic linked list of fixed-sized blocks to store samples. The storage required by this method grows until a quiescent period is found, a period that happens regularly when metrics-rs is not integrated with tracing and does not happen at present for reasons unknown. However, in our testing we've seen that a single histogram under heavy load can consume approximately 200Mb before being garbage collected, a burden vector doesn't need to bear as our own needs for histogram are served by a simple counting bucket arrangement. Own own histogram uses a fixed, boxed slice of atomic ints as buckets. This is the shape of the data that vector was exposing already and we remove a little internal translation. 

I believe this PR will significantly reduce the memory use of a loaded vector, leak not withstanding. I am unsure of the performance impact as yet. I will update the PR comments with massif results and an all-up benchmark run. 

REF #6673 
Closes #6461 #6456

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
