### PR TITLE
fix(remap): prevent lexer getting stuck on an unterminated literal

### DIFF
--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -776,7 +776,7 @@ impl<'input> Lexer<'input> {
                                 match literal_check(r, &mut chars) {
                                     Ok(ch) => ch,
                                     Err(_) => {
-                                        // The call to lexer about should have raised an appropriate error by now,
+                                        // The call to lexer above should have raised an appropriate error by now,
                                         // so these errors should only occur if there is a bug somewhere previously.
                                         return Err(Error::UnexpectedParseError(
                                             "Expected characters at end of string literal."

--- a/lib/vrl/tests/tests/diagnostics/invalid_escape_char.vrl
+++ b/lib/vrl/tests/tests/diagnostics/invalid_escape_char.vrl
@@ -1,0 +1,13 @@
+# result:
+#
+# error[E202]: syntax error
+#   ┌─ :1:1
+#   │
+# 1 │ ╭
+# 2 │ │ . |= parse_grok!("1.2.3.4 - - [23/Mar/2021:06:46:35 +0000]", "%{IPORHOST:remote_ip} %{USER:ident} %{USER:user_name} \[%{HTTPDATE:timestamp}\]"
+# 3 │ │
+#   │ ╰^ unexpected error: invalid escape character: \[
+#   │
+#   = see language documentation at https://vrl.dev
+
+. |= parse_grok!("1.2.3.4 - - [23/Mar/2021:06:46:35 +0000]", "%{IPORHOST:remote_ip} %{USER:ident} %{USER:user_name} \[%{HTTPDATE:timestamp}\]"

--- a/lib/vrl/tests/tests/diagnostics/unterminated_literal.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unterminated_literal.vrl
@@ -1,0 +1,13 @@
+# result:
+#
+# error[E202]: syntax error
+#   ┌─ :1:1
+#   │
+# 1 │ ╭
+# 2 │ │ . = parse_regex!(.message, r'(?P<syslog_pri><\d+>)(?P<syslog_seqnum>\d+)(?:\W+)(?P<syslog_host>\w+-\w+-\w+)(?:\W+)(?P<syslog_datetime>.*?)(?:\W+)(?P<message_type>\.*?)(?:\W+)(?P<syslog_message>.*))
+# 3 │ │
+#   │ ╰^ unexpected error: unterminated literal
+#   │
+#   = see language documentation at https://vrl.dev
+
+. = parse_regex!(.message, r'(?P<syslog_pri><\d+>)(?P<syslog_seqnum>\d+)(?:\W+)(?P<syslog_host>\w+-\w+-\w+)(?:\W+)(?P<syslog_datetime>.*?)(?:\W+)(?P<message_type>\.*?)(?:\W+)(?P<syslog_message>.*))

--- a/lib/vrl/tests/tests/diagnostics/unterminated_literal.vrl
+++ b/lib/vrl/tests/tests/diagnostics/unterminated_literal.vrl
@@ -6,7 +6,7 @@
 # 1 │ ╭
 # 2 │ │ . = parse_regex!(.message, r'(?P<syslog_pri><\d+>)(?P<syslog_seqnum>\d+)(?:\W+)(?P<syslog_host>\w+-\w+-\w+)(?:\W+)(?P<syslog_datetime>.*?)(?:\W+)(?P<message_type>\.*?)(?:\W+)(?P<syslog_message>.*))
 # 3 │ │
-#   │ ╰^ unexpected error: unterminated literal
+#   │ ╰^ unexpected error: invalid literal
 #   │
 #   = see language documentation at https://vrl.dev
 


### PR DESCRIPTION
Closes #6879 
Closes #6875 

The lexer was getting stuck in an infinite loop when it reached an unclosed quote. This changes the `query_start` function so that it returns a `Result` which allows the function to return an error in that situation.

Turns out the lexer was getting stuck whenever it was lexing a literal from within function arguments as it was ignoring any errors raised from lexing the literals and got stuck lexing the same text repeatedly.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

