### PR TITLE
chore: RFC for emitting multiple log events from remap

### DIFF
--- a/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
+++ b/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
@@ -90,6 +90,8 @@ This would modify remap to allow setting `.` to an array of objects to have each
 
 This turned out to require a bigger change than I expected in that `.` is linked to mutating the underlying event (metric or log). It's definitely doable, but would require a substantial refactoring and so caused me to take a step back and consider the alternatives, prompting this RFC.
 
+I also don't see an easy way to extend this to deal with emitting multiple metrics without requiring users to create objects with a known format (like `{ "name": "foo", "namespace": "bar", "type = "counter", "value": 1 ...}`) whereas it seems more straightforward to extend the proposed approach with functions like `emit_counter`
+
 ### An `explode` transformation
 
 https://github.com/timberio/vector/pull/6545

--- a/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
+++ b/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
@@ -1,0 +1,100 @@
+# RFC 6330 - 2021-04-07 - Emitting multiple log events from remap transform
+
+This RFC describes an apporach for emitting multiple log events from a remap transform.
+
+## Scope
+
+In:
+- Emitting multiple log events from a remap transform
+
+Out:
+- Emitting multiple metrics from a remap transform
+
+## Motivation
+
+Currently the remap transform can only modify an event as it is passing through. Users have asked [1][] [2][] to be able to transform an incoming event into multiple events. This is useful, for example, when parsing an incoming JSON payload that contains an array for which you'd like to publish an event for each element.
+
+Currently, users are restricted to using the Lua or WASM transform for this, [introducing a substantial bottleneck](https://user-images.githubusercontent.com/316880/105531520-d3643200-5cbf-11eb-8b35-fe1c99e5c254.png).
+
+Additionally, I think we can leverage the approach I describe here in the future to allow users to emit different data types than the incoming type. For example, users could emit logs related to an incoming metric, or metrics from an incoming log.
+
+## Internal Proposal
+
+This is roughly the same as https://github.com/timberio/vector/issues/6330#issuecomment-772562955 with some slight tweaks.
+
+A new `emit_log` function will be added to the VRL stdlib:
+
+```
+emit_log(value: Object)
+```
+
+This function will cause the object passed as value to be emitted at that point and flushed downstream. The emitted log will have its metadata copied from the input event.
+
+Additionally, an `emit_root` (we can work on the naming) config option will be added to the `remap` transform to configure whether `.` is emitted after the transform runs. It will default to `true` to preserve the current behavior but can be set to `false` by users to supress this behavior. Admittedly, I'm not wild about introducing this additional config option, but I'm not seeing another great alternative.
+
+In the future we can also add functions for emitting metrics like:
+
+```
+emit_counter(namespace: String, name: String, timestamp: Timestamp, value: Float, kind: "absolute"|"relative")
+```
+
+I considered having just an `emit_metric()` but it would require users to pass in objects that match exactly the internal representation we have for metrics.
+
+## Doc-level Proposal
+
+The `remap` tranform would gain an extra configuration option:
+
+```
+emit_root = true/false # default false
+```
+
+When `emit_root` is `true`, the value of `.` will be emitted at the end of the remap program. When `emit_root` is false, the value of `.` will not be emitted. Instead users should use the `emit_log` function to emit.
+
+## Rationale
+
+This enhances remap to support additional transformation use-cases of splitting up an event into multiple events. Without this, users will continue to have to use Lua to acheive this, which introduces a performance bottleneck compared to remap
+
+## Prior Art
+
+- [fluent-plugin-record_splitter](https://github.com/ixixi/fluent-plugin-record_splitter)
+- [Logstash split](https://www.elastic.co/guide/en/logstash/current/plugins-filters-split.html)
+
+These are similar to the `explode` transform PR we have: https://github.com/timberio/vector/pull/6545
+
+## Drawbacks
+
+- It makes the remap transform more complicated to understand and adds an additional configuration option that users need to be aware of
+- Ongoing maintenance burden should be minimal
+
+## Alternatives
+
+### Not emitting . if an `emit_log` is present in the program
+
+We could avoid having an `emit_root` config option on the remap transform by just not emitting automatically if we see an `emit_log` function in the user-provided source. I personally think this would be a bit suprising, but it is an option.
+
+### Modifying remap to accept setting the root object to an array
+
+https://github.com/timberio/vector/issues/6988
+
+This would modify remap to allow setting `.` to an array of objects to have each element emitted independently.
+
+This turned out to require a bigger change than I expected in that `.` is linked to mutating the underlying event (metric or log). It's definitely doable, but would require a substantial refactoring and so caused me to take a step back and consider the alternatives, prompting this RFC.
+
+### An `explode` transformation
+
+https://github.com/timberio/vector/pull/6545
+
+Have a separate, special purpose, transform for converting a single log event into multiple log events.
+
+This would work, but I think the downsides are:
+
+* Introduces a new transform rather than just leveraging an existing one, remap. There is some precedence for this with the `route` and `reduce` transforms though.
+* It is less flexible than letting users emit arbitrary events
+* There isn't a clear path to emitting, say, multiple metrics from an input log event
+
+## Plan Of Attack
+
+TODO, but [something like what Jean wrote](https://github.com/timberio/vector/issues/6330#issuecomment-772562955).
+
+[1]: https://github.com/timberio/vector/issues/6330#issue-799809382
+[2]: https://discord.com/channels/742820443487993987/764187584452493323/808744293945704479

--- a/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
+++ b/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
@@ -34,6 +34,14 @@ This function will cause the object passed as value to be emitted at that point 
 
 Additionally, an `emit_root` (we can work on the naming) config option will be added to the `remap` transform to configure whether `.` is emitted after the transform runs. It will default to `true` to preserve the current behavior but can be set to `false` by users to supress this behavior. Admittedly, I'm not wild about introducing this additional config option, but I'm not seeing another great alternative.
 
+This will be able to be combined with the iteration mechanism that will be introduced [#6031](https://github.com/timberio/vector/issues/6031) to emit an unknown number of events. Naively this might look something like:
+
+```text
+for stooge in .stooges
+   emit(stooge)
+end
+```
+
 In the future we can also add functions for emitting metrics like:
 
 ```text

--- a/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
+++ b/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
@@ -1,16 +1,20 @@
 # RFC 6330 - 2021-04-07 - Emitting multiple log events from remap transform
 
-This RFC describes an apporach for emitting multiple log events from a remap transform.
+This RFC describes an approach for emitting multiple log events from a remap transform.
+
+[Credit to @JeanMertz](https://github.com/timberio/vector/pull/7038#discussion_r609476064) for this revised approach.
 
 ## Scope
 
 In:
 
-- Emitting multiple log events from a remap transform
+- Turning a log event into multiple log events
 
 Out:
 
-- Emitting multiple metrics from a remap transform
+- Turning a log event into multiple metrics
+- Turning a metric into multiple metrics
+- Turning a metric into multiple logs
 
 ## Motivation
 
@@ -18,13 +22,109 @@ Currently the remap transform can only modify an event as it is passing through.
 
 Currently, users are restricted to using the Lua or WASM transform for this, [introducing a substantial bottleneck](https://user-images.githubusercontent.com/316880/105531520-d3643200-5cbf-11eb-8b35-fe1c99e5c254.png).
 
-Additionally, I think we can leverage the approach I describe here in the future to allow users to emit different data types than the incoming type. For example, users could emit logs related to an incoming metric, or metrics from an incoming log.
-
 ## Internal Proposal
+
+The proposal is to add an `explode` transform that makes use of remap to emit a set of events from one input event by requiring the remap script to resolve to an array. For each element of the array, a separate event will be published.
+
+Example input:
+
+```json
+{ "events": [{ "message": "foo" }, { "message": "bar" }] }
+```
+
+Transform config:
+
+```toml
+[transforms.explode]
+type = "explode"
+source = "array!(.events) ?? []" # will be typechecked at compile-time
+```
+
+Ouput:
+
+```json
+{"message": "foo"}
+{"message": "bar"}
+```
+
+Support for iteration as part of [#6031](https://github.com/timberio/vector/issues/6031) will allow for users to do things like map fields onto each element. An example might look something like:
+
+Input:
+
+```json
+{ "host": "foobar", "events": [{ "message": "foo" }, { "message": "bar" }] }
+```
+
+Transform config (actual mapping syntax TBA):
+
+```toml
+[transforms.explode]
+type = "explode"
+source = "map(array!(.events), |event| event.host = .host) ?? []"
+```
+
+Output:
+
+```json
+{"host": "foobar", "message": "foo"}
+{"host": "foobar", "message": "bar"}
+```
+
+This is similar to the support that the current [`explode` transform PR](https://github.com/timberio/vector/pull/6545) has for merging in top-level fields when creating events from a subfield that has an array.
+
+
+## Doc-level Proposal
+
+To convert an incoming event into multiple events, the `explode` transform can be used. This transform takes a VRL script where it expects the last expression to return an array.
+
+For example, given an input of:
+
+```json
+{ "events": [{ "message": "foo" }, { "message": "bar" }] }
+```
+
+And a transform of:
+
+```toml
+[transforms.explode]
+type = "explode"
+source = "array!(.events) ?? []"
+```
+
+The following events will be output:
+
+```json
+{"message": "foo"}
+{"message": "bar"}
+```
+
+## Rationale
+
+This enhances vector with a native transform capable of an event into multiple events. Without this, users will continue to have to use Lua or WASM to acheive this, which introduces a performance bottleneck compared to remap
+
+## Prior Art
+
+- [fluent-plugin-record_splitter](https://github.com/ixixi/fluent-plugin-record_splitter)
+- [Logstash split](https://www.elastic.co/guide/en/logstash/current/plugins-filters-split.html)
+
+These are similar to the proposed approach.
+
+## Drawbacks
+
+- Adds an additional transform to be aware of.
+- Less flexible than `emit_log` alternative which could emit arbitrary events from `remap` transform.
+- This idea of the last line of the remap script being the "return value" could be a bit confusing to users in how it differs from `remap` which uses whatever `.` is at the end of the script.
+- Ongoing maintenance burden should be minimal.
+
+## Alternatives
+
+### emit_log function
+
+(previous proposal)
 
 This is roughly the same as https://github.com/timberio/vector/issues/6330#issuecomment-772562955 with some slight tweaks.
 
-A new `emit_log` function will be added to the VRL stdlib:
+A new `emit_log` function will be added to the VRL stdlib
 
 ```text
 emit_log(value: Object)
@@ -38,7 +138,7 @@ This will be able to be combined with the iteration mechanism that will be intro
 
 ```text
 for stooge in .stooges
-   emit(stooge)
+   emit_log(stooge)
 end
 ```
 
@@ -50,8 +150,6 @@ emit_counter(namespace: String, name: String, timestamp: Timestamp, value: Float
 
 I considered having just an `emit_metric()` but it would require users to pass in objects that match exactly the internal representation we have for metrics.
 
-## Doc-level Proposal
-
 The `remap` tranform would gain an extra configuration option:
 
 ```text
@@ -59,26 +157,6 @@ emit_root = true/false # default false
 ```
 
 When `emit_root` is `true`, the value of `.` will be emitted at the end of the remap program. When `emit_root` is false, the value of `.` will not be emitted. Instead users should use the `emit_log` function to emit.
-
-## Rationale
-
-This enhances remap to support additional transformation use-cases of splitting up an event into multiple events. Without this, users will continue to have to use Lua to acheive this, which introduces a performance bottleneck compared to remap
-
-## Prior Art
-
-- [fluent-plugin-record_splitter](https://github.com/ixixi/fluent-plugin-record_splitter)
-- [Logstash split](https://www.elastic.co/guide/en/logstash/current/plugins-filters-split.html)
-
-These are similar to the `explode` transform PR we have: https://github.com/timberio/vector/pull/6545
-
-## Drawbacks
-
-- It makes the remap transform more complicated to understand and adds an additional configuration option that users need to be aware of
-- Ongoing maintenance burden should be minimal
-
-## Alternatives
-
-### Not emitting . if an `emit_log` is present in the program
 
 We could avoid having an `emit_root` config option on the remap transform by just not emitting automatically if we see an `emit_log` function in the user-provided source. I personally think this would be a bit suprising, but it is an option.
 
@@ -90,23 +168,15 @@ This would modify remap to allow setting `.` to an array of objects to have each
 
 This turned out to require a bigger change than I expected in that `.` is linked to mutating the underlying event (metric or log). It's definitely doable, but would require a substantial refactoring and so caused me to take a step back and consider the alternatives, prompting this RFC.
 
-I also don't see an easy way to extend this to deal with emitting multiple metrics without requiring users to create objects with a known format (like `{ "name": "foo", "namespace": "bar", "type = "counter", "value": 1 ...}`) whereas it seems more straightforward to extend the proposed approach with functions like `emit_counter`
+Using a separate `explode` transform keeps the responsibilities of the transform more clear and avoids having to refactor the `remap` transform to decouple `.` from the underlying Vector `Event` object; though we may still want to do this in the future anyway.
 
-### An `explode` transformation
+## Open Questions
 
-https://github.com/timberio/vector/pull/6545
-
-Have a separate, special purpose, transform for converting a single log event into multiple log events.
-
-This would work, but I think the downsides are:
-
-- Introduces a new transform rather than just leveraging an existing one, remap. There is some precedence for this with the `route` and `reduce` transforms though.
-- It is less flexible than letting users emit arbitrary events
-- There isn't a clear path to emitting, say, multiple metrics from an input log event
+1. How should we handle the case where the user returns an array where one or more elements is not an object? My instinct for now is just to log and drop them.
 
 ## Plan Of Attack
 
-TODO, but [something like what Jean wrote](https://github.com/timberio/vector/issues/6330#issuecomment-772562955).
+1. Implement `explode` transform
 
 [1]: https://github.com/timberio/vector/issues/6330#issue-799809382
 [2]: https://discord.com/channels/742820443487993987/764187584452493323/808744293945704479

--- a/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
+++ b/rfcs/2021-04-07-6330-emitting-multiple-log-events-from-remap-transform.md
@@ -5,9 +5,11 @@ This RFC describes an apporach for emitting multiple log events from a remap tra
 ## Scope
 
 In:
+
 - Emitting multiple log events from a remap transform
 
 Out:
+
 - Emitting multiple metrics from a remap transform
 
 ## Motivation
@@ -24,7 +26,7 @@ This is roughly the same as https://github.com/timberio/vector/issues/6330#issue
 
 A new `emit_log` function will be added to the VRL stdlib:
 
-```
+```text
 emit_log(value: Object)
 ```
 
@@ -34,7 +36,7 @@ Additionally, an `emit_root` (we can work on the naming) config option will be a
 
 In the future we can also add functions for emitting metrics like:
 
-```
+```text
 emit_counter(namespace: String, name: String, timestamp: Timestamp, value: Float, kind: "absolute"|"relative")
 ```
 
@@ -44,7 +46,7 @@ I considered having just an `emit_metric()` but it would require users to pass i
 
 The `remap` tranform would gain an extra configuration option:
 
-```
+```text
 emit_root = true/false # default false
 ```
 
@@ -88,9 +90,9 @@ Have a separate, special purpose, transform for converting a single log event in
 
 This would work, but I think the downsides are:
 
-* Introduces a new transform rather than just leveraging an existing one, remap. There is some precedence for this with the `route` and `reduce` transforms though.
-* It is less flexible than letting users emit arbitrary events
-* There isn't a clear path to emitting, say, multiple metrics from an input log event
+- Introduces a new transform rather than just leveraging an existing one, remap. There is some precedence for this with the `route` and `reduce` transforms though.
+- It is less flexible than letting users emit arbitrary events
+- There isn't a clear path to emitting, say, multiple metrics from an input log event
 
 ## Plan Of Attack
 


### PR DESCRIPTION
RFC for https://github.com/timberio/vector/issues/6330

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
