### PR TITLE
fix(kubernetes platform): Config map hash

### DIFF
--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -20,7 +20,7 @@ rollme: {{ randAlphaNum 5 | quote }}
 */}}
 {{- define "libvector.configTemplateChecksumAnnotation" -}}
 {{- if not .Values.externalConfigMap }}
-checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
 

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -127,7 +127,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
+        checksum/config: 18649de5d66ff1f9f3f731d56607eac9dc17e021fde79c0a21b1dcac495a4cb0
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -132,7 +132,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
+        checksum/config: 6d0939d1c4b59ca1a78c54228d7acb4ab38eebea0f8ec1822048eae1992b334a
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -236,7 +236,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: fa3deb906e02ab211d86aa37249d2f7d73dce9e771d68ed0679c7a0cab9eb54c
+        checksum/config: 3deef1aa10679d2ab3a93eba6c1856607a6886382b006ccd903304f71737f67b
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -366,7 +366,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: a67c40b917e758700bf0df9b0719a84da8ee3828ec3a5d651baf78dcb02fb68a
+        checksum/config: 6d0939d1c4b59ca1a78c54228d7acb4ab38eebea0f8ec1822048eae1992b334a
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -146,7 +146,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
+        checksum/config: f50cafe8069c3ed3be6a945818694ae493869907e7991b688a00cdf037dc7d2c
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -139,7 +139,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
+        checksum/config: 89595b0aad0626e6e3bec64c1dbc11514a3a0fafc1ef3620d3c1e915b5becef5
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -72,16 +72,12 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [sources.source2]
       optionA = "valueA"
       type = "type2"
       [sources.source2.optionB]
         suboption = "valueB"
-    [sources.source2]
-      arbitrary text 2
     
     [sources.source3]
       type = "type3"
@@ -91,8 +87,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [transforms.transform2]
       inputs = ["input2", "input1"]
@@ -100,8 +94,6 @@ data:
       type = "type2"
       [transforms.transform2.optionB]
         suboption = "valueB"
-    [transforms.transform2]
-      arbitrary text 2
     
     [transforms.transform3]
       inputs = []
@@ -112,8 +104,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [sinks.sink2]
       inputs = ["input2", "input1"]
@@ -121,8 +111,6 @@ data:
       type = "type2"
       [sinks.sink2.optionB]
         suboption = "valueB"
-    [sinks.sink2]
-      arbitrary text 2
     
     [sinks.sink3]
       inputs = []
@@ -186,7 +174,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
+        checksum/config: 79f6b7f5a91c11ef2f84028d3c06c95b36190bca6cd539451afab66908c9287b
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -69,16 +69,12 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [sources.source2]
       optionA = "valueA"
       type = "type2"
       [sources.source2.optionB]
         suboption = "valueB"
-    [sources.source2]
-      arbitrary text 2
     
     [sources.source3]
       type = "type3"
@@ -88,8 +84,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [transforms.transform2]
       inputs = ["input2", "input1"]
@@ -97,8 +91,6 @@ data:
       type = "type2"
       [transforms.transform2.optionB]
         suboption = "valueB"
-    [transforms.transform2]
-      arbitrary text 2
     
     [transforms.transform3]
       inputs = []
@@ -109,8 +101,6 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
-      option = "value"
-      arbitrary text
     
     [sinks.sink2]
       inputs = ["input2", "input1"]
@@ -118,8 +108,6 @@ data:
       type = "type2"
       [sinks.sink2.optionB]
         suboption = "valueB"
-    [sinks.sink2]
-      arbitrary text 2
     
     [sinks.sink3]
       inputs = []
@@ -191,7 +179,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
+        checksum/config: 7e0405b9b931bef02fd2a4d2c508e0a3de7038879cd64a3a08332b20f9bba6e3
         
       labels:
         app.kubernetes.io/name: vector-aggregator


### PR DESCRIPTION
We discovered that the config hash included in the daemonset of the vector-agent chart does not change as the configuration is changed. Therefore the pods are not re-created. This can be validated in the current code base running:

```
helm template vector-agent
...
      annotations:
        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
```

and then adding some parameter which should change the configuration to yield another hash, e.g.:
```
helm template vector-agent --set internalMetricsSource.enabled=false
...
      annotations:
        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
```

The hash of the configuration should differ as the content of the config map differs - however the hash is the same.

The problem is this in `_reroll.tpl` of `vector-shared` library Helm chart:
```
checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
```

This will actually generate a hash of the file _path_ rather than the file _content_. By doing an `include` instead of a `tpl` Helm will do a hash of the rendered file instead of just the (constant) file path.