### PR TITLE
fix(tests): Fix aws_ec2_metadata transform test

### DIFF
--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -614,14 +614,14 @@ mod integration_tests {
             sleep(Duration::from_secs(1)).await;
 
             let log = LogEvent::default();
-            let mut expected = log.clone();
             tx.send(log.into()).await.unwrap();
 
             let event = stream.next().await.unwrap();
 
-            expected.insert("ec2.metadata.availability-zone", "ww-region-1a");
-            expected.insert("ec2.metadata.public-ipv4", "192.1.1.1");
-            assert_eq!(event.into_log(), expected);
+            assert_eq!(
+                event.as_log().get("ec2.metadata.availability-zone"),
+                Some(&"ww-region-1a".into())
+            );
         }
 
         {
@@ -644,14 +644,14 @@ mod integration_tests {
             sleep(Duration::from_secs(1)).await;
 
             let log = LogEvent::default();
-            let mut expected = log.clone();
             tx.send(log.into()).await.unwrap();
 
             let event = stream.next().await.unwrap();
 
-            expected.insert("availability-zone", "ww-region-1a");
-            expected.insert("public-ipv4", "192.1.1.1");
-            assert_eq!(event.into_log(), expected);
+            assert_eq!(
+                event.as_log().get("availability-zone"),
+                Some(&"ww-region-1a".into())
+            );
         }
     }
 }


### PR DESCRIPTION
Broken by 0135730ee37bc4113c03db5fb8db008a44ea997a

This replaces the partial assertions for the namespace test which
I think is sufficient to test that part of the functionality. It was
previously failing because it matching two log events where the actual
log event had many more fields enriched than the expected event.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
