### PR TITLE
enhancement: Support Splunk channel via query parameter

### DIFF
--- a/docs/reference/components/sources/splunk_hec.cue
+++ b/docs/reference/components/sources/splunk_hec.cue
@@ -90,7 +90,7 @@ components: sources: splunk_hec: {
 		fields: {
 			message: fields._raw_line
 			splunk_channel: {
-				description: "The Splunk channel, value of the `X-Splunk-Request-Channel` header."
+				description: "The Splunk channel, value of the `X-Splunk-Request-Channel` header or `channel` query parameter, in that order of precedence."
 				required:    true
 				type: timestamp: {}
 			}

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -870,7 +870,7 @@ mod tests {
         api: &str,
         message: &str,
         token: &str,
-        channel: Channel,
+        channel: Channel<'_>,
     ) -> u16 {
         let wrap_with_channel =
             |c: Channel, b: reqwest::RequestBuilder| -> reqwest::RequestBuilder {
@@ -880,11 +880,10 @@ mod tests {
                 }
             };
 
-        let b = reqwest::Client::new()
+        let mut b = reqwest::Client::new()
             .post(&format!("http://{}/{}", address, api))
-            .header("Authorization", format!("Splunk {}", token))
-            .header("x-splunk-request-channel", "guid");
-        b = wrap_with_channel(Channel, b);
+            .header("Authorization", format!("Splunk {}", token));
+        b = wrap_with_channel(channel, b);
         b.body(message.to_owned())
             .send()
             .await

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -190,7 +190,7 @@ impl SplunkSource {
             .and_then(|header: Option<String>, query_param| async move {
                 header
                     .or(query_param)
-                    .ok_or(Rejection::from(ApiError::MissingChannel))
+                    .ok_or_else(|| Rejection::from(ApiError::MissingChannel))
             });
 
         warp::post()

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -864,7 +864,7 @@ mod tests {
         channel: Channel<'_>,
     ) -> u16 {
         let wrap_with_channel =
-            |c: Channel, b: reqwest::RequestBuilder| -> reqwest::RequestBuilder {
+            |b: reqwest::RequestBuilder, c: Channel| -> reqwest::RequestBuilder {
                 match c {
                     Channel::Header(v) => b.header("x-splunk-request-channel", v),
                     Channel::QueryParam(v) => b.query(&[("channel", v)]),
@@ -874,7 +874,7 @@ mod tests {
         let mut b = reqwest::Client::new()
             .post(&format!("http://{}/{}", address, api))
             .header("Authorization", format!("Splunk {}", token));
-        b = wrap_with_channel(channel, b);
+        b = wrap_with_channel(b, channel);
         b.body(message.to_owned())
             .send()
             .await


### PR DESCRIPTION
This addresses https://github.com/timberio/vector/issues/6524, where the Splunk HEC source does not support receiving a Splunk channel via a query parameter, which is a valid behavior according to the [spec](https://docs.splunk.com/Documentation/Splunk/8.1.2/Data/FormateventsforHTTPEventCollector).