### PR TITLE
chore(data model): Add "generation" item to metadata

### DIFF
--- a/src/event/metadata.rs
+++ b/src/event/metadata.rs
@@ -1,12 +1,49 @@
 use serde::{Deserialize, Serialize};
 use shared::EventDataEq;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct EventMetadata;
+#[cfg(test)]
+lazy_static::lazy_static! {
+    // This is a non-zero sample value for `EventMetadata::generation`
+    // that will be constant across all test data, causing event
+    // metadata to compare equal when using it, but different on each
+    // run to prevent hard-coding in tests to work. Additionally, it
+    // will be large enough that no test will ever generate enough
+    // events to reach it normally, preventing accidental collisions.
+    static ref TEST_GENERATION: u32 = {
+        use rand::distributions::{Distribution, Uniform};
+        Uniform::from(2^30..=u32::MAX).sample(&mut rand::thread_rng())
+    };
+}
+
+static GENERATION: AtomicU32 = AtomicU32::new(1);
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct EventMetadata {
+    /// Simple generation counter, different for every new event.
+    generation: u32,
+}
+
+impl Default for EventMetadata {
+    fn default() -> Self {
+        Self {
+            // Ordering can be relaxed because this isn't a sequence
+            // point for other operations.
+            generation: GENERATION.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+}
 
 impl EventMetadata {
-    pub fn merge(&mut self, _other: &Self) {
-        // Just a stub function for when there is actual metadata
+    #[cfg(test)]
+    pub fn test_default() -> Self {
+        Self {
+            generation: *TEST_GENERATION,
+        }
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        self.generation = self.generation.min(other.generation)
     }
 }
 

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -354,7 +354,10 @@ fn compress_distribution(mut samples: Vec<Sample>) -> Vec<Sample> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::event::metric::{MetricKind::*, MetricValue, StatisticKind};
+    use crate::event::{
+        metric::{MetricKind::*, MetricValue, StatisticKind},
+        EventMetadata,
+    };
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
 
@@ -889,36 +892,44 @@ mod test {
     }
 
     fn sample_counter(num: usize, tagstr: &str, kind: MetricKind, value: f64) -> Metric {
-        Metric::new(
+        Metric::new_with_metadata(
             format!("counter-{}", num),
             kind,
             MetricValue::Counter { value },
+            EventMetadata::test_default(),
         )
         .with_tags(Some(tag(tagstr)))
     }
 
     fn sample_gauge(num: usize, kind: MetricKind, value: f64) -> Metric {
-        Metric::new(format!("gauge-{}", num), kind, MetricValue::Gauge { value })
+        Metric::new_with_metadata(
+            format!("gauge-{}", num),
+            kind,
+            MetricValue::Gauge { value },
+            EventMetadata::test_default(),
+        )
     }
 
     fn sample_set<T: ToString>(num: usize, kind: MetricKind, values: &[T]) -> Metric {
-        Metric::new(
+        Metric::new_with_metadata(
             format!("set-{}", num),
             kind,
             MetricValue::Set {
                 values: values.iter().map(|s| s.to_string()).collect(),
             },
+            EventMetadata::test_default(),
         )
     }
 
     fn sample_distribution_histogram(num: u32, kind: MetricKind, rate: u32) -> Metric {
-        Metric::new(
+        Metric::new_with_metadata(
             format!("dist-{}", num),
             kind,
             MetricValue::Distribution {
                 samples: crate::samples![num as f64 => rate],
                 statistic: StatisticKind::Histogram,
             },
+            EventMetadata::test_default(),
         )
     }
 
@@ -929,7 +940,7 @@ mod test {
         cfactor: u32,
         sum: f64,
     ) -> Metric {
-        Metric::new(
+        Metric::new_with_metadata(
             format!("buckets-{}", num),
             kind,
             MetricValue::AggregatedHistogram {
@@ -941,11 +952,12 @@ mod test {
                 count: 7 * cfactor,
                 sum,
             },
+            EventMetadata::test_default(),
         )
     }
 
     fn sample_aggregated_summary(num: u32, kind: MetricKind, factor: f64) -> Metric {
-        Metric::new(
+        Metric::new_with_metadata(
             format!("quantiles-{}", num),
             kind,
             MetricValue::AggregatedSummary {
@@ -957,6 +969,7 @@ mod test {
                 count: factor as u32 * 10,
                 sum: factor * 7.0,
             },
+            EventMetadata::test_default(),
         )
     }
 }


### PR DESCRIPTION
This prevents the metadata from being created without calling default,
and causes tests that compare events for equality without handling the
metadata to fail.

I have used this as a base commit for the event metadata work to ensure it is handled properly. This cannot be merged as-is, as it breaks numerous tests *on purpose*. This will be used as a testing base for future event metadata work until something like timestamps are added to the metadata. I have put this up as a pull request just to surface the idea and in case this exposes some obvious red flags that I have not considered.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>