### PR TITLE
enhancement(remap)!: added numeric_groups parameter to parse_regex functions

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -110,13 +110,6 @@ remap: #Remap & {
 				. = merge(., structured)
 				"""#
 			output: log: {
-				"0":       "2021/01/20 06:39:15 +0000 [error] 17755#17755: *3569904 open() \"/usr/share/nginx/html/test.php\" failed (2: No such file or directory), client: xxx.xxx.xxx.xxx, server: localhost, request: \"GET /test.php HTTP/1.1\", host: \"yyy.yyy.yyy.yyy\""
-				"1":       "2021/01/20 06:39:15 +0000"
-				"2":       "error"
-				"3":       "17755"
-				"4":       "17755"
-				"5":       "3569904"
-				"6":       "open() \"/usr/share/nginx/html/test.php\" failed (2: No such file or directory), client: xxx.xxx.xxx.xxx, server: localhost, request: \"GET /test.php HTTP/1.1\", host: \"yyy.yyy.yyy.yyy\""
 				timestamp: "2021-01-20T06:39:15Z"
 				severity:  "error"
 				pid:       17755

--- a/docs/reference/remap/functions/parse_regex.cue
+++ b/docs/reference/remap/functions/parse_regex.cue
@@ -32,6 +32,16 @@ remap: functions: parse_regex: {
 			required:    true
 			type: ["regex"]
 		},
+		{
+			name: "numeric_groups"
+			description: """
+				If true, the index of each group in the regular expression is also captured. The 0th index
+				will contain the whole match.
+				"""
+			required: false
+			default:  false
+			type: ["regex"]
+		},
 	]
 	internal_failure_reasons: [
 		"`value` fails to parse using the provided `pattern`",
@@ -52,14 +62,12 @@ remap: functions: parse_regex: {
 				"""
 			return: {
 				number: "first"
-				"0":    "first group"
-				"1":    "first"
 			}
 		},
 		{
 			title: "Parse using Regex (without capture groups)"
 			source: """
-				parse_regex!("first group and second group.", r'(\\w+) group')
+				parse_regex!("first group and second group.", r'(\\w+) group', numeric_groups: true)
 				"""
 			return: {
 				"0": "first group"

--- a/docs/reference/remap/functions/parse_regex_all.cue
+++ b/docs/reference/remap/functions/parse_regex_all.cue
@@ -22,6 +22,16 @@ remap: functions: parse_regex_all: {
 			required:    true
 			type: ["regex"]
 		},
+		{
+			name: "numeric_groups"
+			description: """
+					If true, the index of each group in the regular expression is also captured. The 0th index
+					will contain the whole match.
+				"""
+			required: false
+			default:  false
+			type: ["regex"]
+		},
 	]
 	internal_failure_reasons: [
 		"`value` fails to parse via the provided `pattern`",
@@ -38,7 +48,7 @@ remap: functions: parse_regex_all: {
 		{
 			title: "Parse using Regex (all matches)"
 			source: """
-				parse_regex_all!("first group and second group.", r'(?P<number>\\w+) group')
+				parse_regex_all!("first group and second group.", r'(?P<number>\\w+) group', numeric_groups: true)
 				"""
 			return: [
 				{

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -962,7 +962,8 @@ bench_function! {
         args: func_args! [
             value: "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574",
             pattern: Regex::new(r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#)
-                .unwrap()
+                .unwrap(),
+            numeric_groups: true
         ],
         want: Ok(value!({
             "bytes_in": "5667",
@@ -1004,7 +1005,8 @@ bench_function! {
     matches {
         args: func_args![
             value: "apples and carrots, peaches and peas",
-            pattern: Regex::new(r#"(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)"#).unwrap()
+            pattern: Regex::new(r#"(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)"#).unwrap(),
+            numeric_groups: true
         ],
         want: Ok(value!([
                 {

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -993,8 +993,6 @@ bench_function! {
         ],
         want: Ok(value!({
             "number": "first",
-            "0": "first group",
-            "1": "first"
         }))
     }
 }

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -23,28 +23,50 @@ impl Function for ParseRegex {
                 kind: kind::REGEX,
                 required: true,
             },
+            Parameter {
+                keyword: "numeric_groups",
+                kind: kind::BOOLEAN,
+                required: false,
+            },
         ]
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;
+        let numeric_groups = arguments
+            .optional("numeric_groups")
+            .unwrap_or_else(|| expr!(false));
 
-        Ok(Box::new(ParseRegexFn { value, pattern }))
+        Ok(Box::new(ParseRegexFn {
+            value,
+            pattern,
+            numeric_groups,
+        }))
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "simple match",
-            source: r#"parse_regex!("8.7.6.5 - zorp", r'^(?P<host>[\w\.]+) - (?P<user>[\w]+)')"#,
-            result: Ok(indoc! { r#"{
+        &[
+            Example {
+                title: "simple match",
+                source: r#"parse_regex!("8.7.6.5 - zorp", r'^(?P<host>[\w\.]+) - (?P<user>[\w]+)')"#,
+                result: Ok(indoc! { r#"{
+                "host": "8.7.6.5",
+                "user": "zorp"
+            }"# }),
+            },
+            Example {
+                title: "numeric groups",
+                source: r#"parse_regex!("8.7.6.5 - zorp", r'^(?P<host>[\w\.]+) - (?P<user>[\w]+)', numeric_groups: true)"#,
+                result: Ok(indoc! { r#"{
                 "0": "8.7.6.5 - zorp",
                 "1": "8.7.6.5",
                 "2": "zorp",
                 "host": "8.7.6.5",
                 "user": "zorp"
             }"# }),
-        }]
+            },
+        ]
     }
 }
 
@@ -52,17 +74,19 @@ impl Function for ParseRegex {
 pub(crate) struct ParseRegexFn {
     value: Box<dyn Expression>,
     pattern: Regex,
+    numeric_groups: Box<dyn Expression>,
 }
 
 impl Expression for ParseRegexFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
+        let numeric_groups = self.numeric_groups.resolve(ctx)?.try_boolean()?;
 
         let parsed = self
             .pattern
             .captures(&value)
-            .map(|capture| util::capture_regex_to_map(&self.pattern, capture))
+            .map(|capture| util::capture_regex_to_map(&self.pattern, capture, numeric_groups))
             .ok_or("could not find any pattern matches")?;
 
         Ok(parsed.into())
@@ -83,11 +107,12 @@ mod tests {
     test_function![
         find => ParseRegex;
 
-        matches {
+        numeric_groups {
             args: func_args! [
                 value: "5.86.210.12 - zieme4647 5667 [19/06/2019:17:20:49 -0400] \"GET /embrace/supply-chains/dynamic/vertical\" 201 20574",
                 pattern: Regex::new(r#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#)
-                    .unwrap()
+                    .unwrap(),
+                numeric_groups: true,
             ],
             want: Ok(value!({"bytes_in": "5667",
                              "host": "5.86.210.12",
@@ -118,15 +143,15 @@ mod tests {
                     "path": Kind::Bytes,
                     "status": Kind::Bytes,
                     "bytes_out": Kind::Bytes,
-                    "0": Kind::Bytes,
-                    "1": Kind::Bytes,
-                    "2": Kind::Bytes,
-                    "3": Kind::Bytes,
-                    "4": Kind::Bytes,
-                    "5": Kind::Bytes,
-                    "6": Kind::Bytes,
-                    "7": Kind::Bytes,
-                    "8": Kind::Bytes,
+                    "0": Kind::Bytes | Kind::Null,
+                    "1": Kind::Bytes | Kind::Null,
+                    "2": Kind::Bytes | Kind::Null,
+                    "3": Kind::Bytes | Kind::Null,
+                    "4": Kind::Bytes | Kind::Null,
+                    "5": Kind::Bytes | Kind::Null,
+                    "6": Kind::Bytes | Kind::Null,
+                    "7": Kind::Bytes | Kind::Null,
+                    "8": Kind::Bytes | Kind::Null,
                 }),
         }
 
@@ -135,16 +160,13 @@ mod tests {
                 value: "first group and second group",
                 pattern: Regex::new(r#"(?P<number>.*?) group"#).unwrap()
             ],
-            want: Ok(value!({"number": "first",
-                             "0": "first group",
-                             "1": "first"
-            })),
+            want: Ok(value!({"number": "first"})),
             tdef: TypeDef::new()
                 .fallible()
                 .object::<&str, Kind>(map! {
                         "number": Kind::Bytes,
-                        "0": Kind::Bytes,
-                        "1": Kind::Bytes,
+                        "0": Kind::Bytes | Kind::Null,
+                        "1": Kind::Bytes | Kind::Null,
                 }),
         }
 
@@ -166,15 +188,15 @@ mod tests {
                     "path": Kind::Bytes,
                     "status": Kind::Bytes,
                     "bytes_out": Kind::Bytes,
-                    "0": Kind::Bytes,
-                    "1": Kind::Bytes,
-                    "2": Kind::Bytes,
-                    "3": Kind::Bytes,
-                    "4": Kind::Bytes,
-                    "5": Kind::Bytes,
-                    "6": Kind::Bytes,
-                    "7": Kind::Bytes,
-                    "8": Kind::Bytes,
+                    "0": Kind::Bytes | Kind::Null,
+                    "1": Kind::Bytes | Kind::Null,
+                    "2": Kind::Bytes | Kind::Null,
+                    "3": Kind::Bytes | Kind::Null,
+                    "4": Kind::Bytes | Kind::Null,
+                    "5": Kind::Bytes | Kind::Null,
+                    "6": Kind::Bytes | Kind::Null,
+                    "7": Kind::Bytes | Kind::Null,
+                    "8": Kind::Bytes | Kind::Null,
                 }),
         }
     ];

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -57,7 +57,7 @@ impl Function for ParseRegexAll {
                 "veg": "peas"}]"# }),
             },
             Example {
-                title: "Simple match",
+                title: "Numeric groups",
                 source: r#"parse_regex_all!("apples and carrots, peaches and peas", r'(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)', numeric_groups: true)"#,
                 result: Ok(indoc! { r#"[
                {"fruit": "apples",

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -23,21 +23,43 @@ impl Function for ParseRegexAll {
                 kind: kind::ANY,
                 required: true,
             },
+            Parameter {
+                keyword: "numeric_groups",
+                kind: kind::BOOLEAN,
+                required: false,
+            },
         ]
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;
+        let numeric_groups = arguments
+            .optional("numeric_groups")
+            .unwrap_or_else(|| expr!(false));
 
-        Ok(Box::new(ParseRegexAllFn { value, pattern }))
+        Ok(Box::new(ParseRegexAllFn {
+            value,
+            pattern,
+            numeric_groups,
+        }))
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "Simple match",
-            source: r#"parse_regex_all!("apples and carrots, peaches and peas", r'(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)')"#,
-            result: Ok(indoc! { r#"[
+        &[
+            Example {
+                title: "Simple match",
+                source: r#"parse_regex_all!("apples and carrots, peaches and peas", r'(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)')"#,
+                result: Ok(indoc! { r#"[
+               {"fruit": "apples",
+                "veg": "carrots"},
+               {"fruit": "peaches",
+                "veg": "peas"}]"# }),
+            },
+            Example {
+                title: "Simple match",
+                source: r#"parse_regex_all!("apples and carrots, peaches and peas", r'(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)', numeric_groups: true)"#,
+                result: Ok(indoc! { r#"[
                {"fruit": "apples",
                 "veg": "carrots",
                 "0": "apples and carrots",
@@ -48,7 +70,8 @@ impl Function for ParseRegexAll {
                 "0": "peaches and peas",
                 "1": "peaches",
                 "2": "peas"}]"# }),
-        }]
+            },
+        ]
     }
 }
 
@@ -56,17 +79,21 @@ impl Function for ParseRegexAll {
 pub(crate) struct ParseRegexAllFn {
     value: Box<dyn Expression>,
     pattern: Regex,
+    numeric_groups: Box<dyn Expression>,
 }
 
 impl Expression for ParseRegexAllFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let bytes = self.value.resolve(ctx)?.try_bytes()?;
         let value = String::from_utf8_lossy(&bytes);
+        let numeric_groups = self.numeric_groups.resolve(ctx)?.try_boolean()?;
 
         Ok(self
             .pattern
             .captures_iter(&value)
-            .map(|capture| util::capture_regex_to_map(&self.pattern, capture).into())
+            .map(|capture| {
+                util::capture_regex_to_map(&self.pattern, capture, numeric_groups).into()
+            })
             .collect::<Vec<Value>>()
             .into())
     }
@@ -88,12 +115,36 @@ mod tests {
     use super::*;
 
     test_function![
-        find_all => ParseRegexAll;
+        parse_regex_all => ParseRegexAll;
 
         matches {
             args: func_args![
                 value: "apples and carrots, peaches and peas",
-                pattern: Regex::new(r#"(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)"#).unwrap()
+                pattern: Regex::new(r#"(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)"#).unwrap(),
+            ],
+            want: Ok(value!([{"fruit": "apples",
+                              "veg": "carrots"},
+                             {"fruit": "peaches",
+                              "veg": "peas"}])),
+            tdef: TypeDef::new()
+                .fallible()
+                .array_mapped::<(), TypeDef>(map![(): TypeDef::new()
+                                                  .object::<&str, Kind>(map! {
+                                                      "fruit": Kind::Bytes,
+                                                      "veg": Kind::Bytes,
+                                                      "0": Kind::Bytes | Kind::Null,
+                                                      "1": Kind::Bytes | Kind::Null,
+                                                      "2": Kind::Bytes | Kind::Null,
+                                                  })
+                                                  .add_null()
+            ]),
+        }
+
+        numeric_groups {
+            args: func_args![
+                value: "apples and carrots, peaches and peas",
+                pattern: Regex::new(r#"(?P<fruit>[\w\.]+) and (?P<veg>[\w]+)"#).unwrap(),
+                numeric_groups: true
             ],
             want: Ok(value!([{"fruit": "apples",
                               "veg": "carrots",
@@ -111,9 +162,9 @@ mod tests {
                                                   .object::<&str, Kind>(map! {
                                                       "fruit": Kind::Bytes,
                                                       "veg": Kind::Bytes,
-                                                      "0": Kind::Bytes,
-                                                      "1": Kind::Bytes,
-                                                      "2": Kind::Bytes,
+                                                      "0": Kind::Bytes | Kind::Null,
+                                                      "1": Kind::Bytes | Kind::Null,
+                                                      "2": Kind::Bytes | Kind::Null,
                                                   })
                                                   .add_null()
             ]),
@@ -131,9 +182,9 @@ mod tests {
                                                   .object::<&str, Kind>(map! {
                                                       "fruit": Kind::Bytes,
                                                       "veg": Kind::Bytes,
-                                                      "0": Kind::Bytes,
-                                                      "1": Kind::Bytes,
-                                                      "2": Kind::Bytes,
+                                                      "0": Kind::Bytes | Kind::Null,
+                                                      "1": Kind::Bytes | Kind::Null,
+                                                      "2": Kind::Bytes | Kind::Null,
                                                   })
                                                   .add_null()
                 ]),

--- a/lib/vrl/stdlib/src/util.rs
+++ b/lib/vrl/stdlib/src/util.rs
@@ -27,13 +27,8 @@ where
 pub(crate) fn capture_regex_to_map(
     regex: &regex::Regex,
     capture: regex::Captures,
+    numeric_groups: bool,
 ) -> std::collections::BTreeMap<String, Value> {
-    let indexed = capture
-        .iter()
-        .flatten()
-        .enumerate()
-        .map(|(idx, c)| (idx.to_string(), c.as_str().into()));
-
     let names = regex.capture_names().flatten().map(|name| {
         (
             name.to_owned(),
@@ -41,7 +36,17 @@ pub(crate) fn capture_regex_to_map(
         )
     });
 
-    indexed.chain(names).collect()
+    if numeric_groups {
+        let indexed = capture
+            .iter()
+            .flatten()
+            .enumerate()
+            .map(|(idx, c)| (idx.to_string(), c.as_str().into()));
+
+        indexed.chain(names).collect()
+    } else {
+        names.collect()
+    }
 }
 
 #[cfg(any(feature = "parse_regex", feature = "parse_regex_all"))]
@@ -50,7 +55,7 @@ pub(crate) fn regex_type_def(regex: &regex::Regex) -> BTreeMap<String, Kind> {
 
     // Add typedefs for each capture by numerical index.
     for num in 0..regex.captures_len() {
-        inner_type.insert(num.to_string(), Kind::Bytes);
+        inner_type.insert(num.to_string(), Kind::Bytes | Kind::Null);
     }
 
     // Add a typedef for each capture name.

--- a/lib/vrl/tests/tests/examples/successful_parse_regex_type.vrl
+++ b/lib/vrl/tests/tests/examples/successful_parse_regex_type.vrl
@@ -2,8 +2,8 @@
 # result: "anaana"
 
 .message = to_string!(.message)
-.result = parse_regex!(.message, r'(?P<an>an.)')
+.result = parse_regex!(.message, r'(?P<an>an.)', numeric_groups: true)
 a = strip_whitespace(.result.an)
-b = strip_whitespace(.result."1")
+b = strip_whitespace(.result."1" || "")
 
 a + b


### PR DESCRIPTION
Closes #6721 

This pr adds a `numeric_groups` parameter to the `parse_regex` and `parse_regex_all` remap functions - defaulting to false - that if true the result will contain the indexes of the groups parsed by the regular expression - index 0 contains the whole match.

Without the flag set, only named groups are returned.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
