### PR TITLE
chore(kubernetes platform): Revert config map hash (#7060)

### DIFF
--- a/distribution/helm/vector-shared/templates/_reroll.tpl
+++ b/distribution/helm/vector-shared/templates/_reroll.tpl
@@ -20,7 +20,7 @@ rollme: {{ randAlphaNum 5 | quote }}
 */}}
 {{- define "libvector.configTemplateChecksumAnnotation" -}}
 {{- if not .Values.externalConfigMap }}
-checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+checksum/config: {{ tpl (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
 

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -127,7 +127,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 18649de5d66ff1f9f3f731d56607eac9dc17e021fde79c0a21b1dcac495a4cb0
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -132,7 +132,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 6d0939d1c4b59ca1a78c54228d7acb4ab38eebea0f8ec1822048eae1992b334a
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -236,7 +236,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 3deef1aa10679d2ab3a93eba6c1856607a6886382b006ccd903304f71737f67b
+        checksum/config: fa3deb906e02ab211d86aa37249d2f7d73dce9e771d68ed0679c7a0cab9eb54c
         
       labels:
         app.kubernetes.io/name: vector-agent
@@ -366,7 +366,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 6d0939d1c4b59ca1a78c54228d7acb4ab38eebea0f8ec1822048eae1992b334a
+        checksum/config: a67c40b917e758700bf0df9b0719a84da8ee3828ec3a5d651baf78dcb02fb68a
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -146,7 +146,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: f50cafe8069c3ed3be6a945818694ae493869907e7991b688a00cdf037dc7d2c
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -139,7 +139,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 89595b0aad0626e6e3bec64c1dbc11514a3a0fafc1ef3620d3c1e915b5becef5
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
         
       labels:
         app.kubernetes.io/name: vector-aggregator

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -72,12 +72,16 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [sources.source2]
       optionA = "valueA"
       type = "type2"
       [sources.source2.optionB]
         suboption = "valueB"
+    [sources.source2]
+      arbitrary text 2
     
     [sources.source3]
       type = "type3"
@@ -87,6 +91,8 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [transforms.transform2]
       inputs = ["input2", "input1"]
@@ -94,6 +100,8 @@ data:
       type = "type2"
       [transforms.transform2.optionB]
         suboption = "valueB"
+    [transforms.transform2]
+      arbitrary text 2
     
     [transforms.transform3]
       inputs = []
@@ -104,6 +112,8 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [sinks.sink2]
       inputs = ["input2", "input1"]
@@ -111,6 +121,8 @@ data:
       type = "type2"
       [sinks.sink2.optionB]
         suboption = "valueB"
+    [sinks.sink2]
+      arbitrary text 2
     
     [sinks.sink3]
       inputs = []
@@ -174,7 +186,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 79f6b7f5a91c11ef2f84028d3c06c95b36190bca6cd539451afab66908c9287b
+        checksum/config: 75958f6034a2d836d57468a572df3af05ea5d4eaf4b8b5cbd6371e6ec319a696
         
       labels:
         app.kubernetes.io/name: vector-agent

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -69,12 +69,16 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [sources.source2]
       optionA = "valueA"
       type = "type2"
       [sources.source2.optionB]
         suboption = "valueB"
+    [sources.source2]
+      arbitrary text 2
     
     [sources.source3]
       type = "type3"
@@ -84,6 +88,8 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [transforms.transform2]
       inputs = ["input2", "input1"]
@@ -91,6 +97,8 @@ data:
       type = "type2"
       [transforms.transform2.optionB]
         suboption = "valueB"
+    [transforms.transform2]
+      arbitrary text 2
     
     [transforms.transform3]
       inputs = []
@@ -101,6 +109,8 @@ data:
       option1 = "value1"
       option2 = "value2"
       type = "type1"
+      option = "value"
+      arbitrary text
     
     [sinks.sink2]
       inputs = ["input2", "input1"]
@@ -108,6 +118,8 @@ data:
       type = "type2"
       [sinks.sink2.optionB]
         suboption = "valueB"
+    [sinks.sink2]
+      arbitrary text 2
     
     [sinks.sink3]
       inputs = []
@@ -179,7 +191,7 @@ spec:
     metadata:
       annotations:
         
-        checksum/config: 7e0405b9b931bef02fd2a4d2c508e0a3de7038879cd64a3a08332b20f9bba6e3
+        checksum/config: 2e32b2eca9854ebc0d3877ff9cb719ac16698a6e976a05151945729a41eb058d
         
       labels:
         app.kubernetes.io/name: vector-aggregator


### PR DESCRIPTION
This reverts commit 27bb756f2c815efc5bf3bf363c705810431a0853.

This broke the k8s end-to-end tests. I'll reopen as a PR for
investigation to keep master green.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
