### PR TITLE
fix(remap): Fix case_sensitive defaults for string matching functions

### DIFF
--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -31,18 +31,18 @@ impl Function for StartsWith {
     fn examples(&self) -> &'static [Example] {
         &[
             Example {
-                title: "match",
-                source: r#"starts_with("foobar", "foo")"#,
+                title: "case sensitive",
+                source: r#"starts_with("foobar", "F")"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "case insensitive",
+                source: r#"starts_with("foobar", "F", false)"#,
                 result: Ok("true"),
             },
             Example {
                 title: "mismatch",
-                source: r#"starts_with("foobar", "baz")"#,
-                result: Ok("false"),
-            },
-            Example {
-                title: "case sensitive",
-                source: r#"starts_with("foobar", "F", true)"#,
+                source: r#"starts_with("foobar", "bar")"#,
                 result: Ok("false"),
             },
         ]
@@ -51,7 +51,7 @@ impl Function for StartsWith {
     fn compile(&self, mut arguments: ArgumentList) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
-        let case_sensitive = arguments.optional("case_sensitive").unwrap_or(expr!(false));
+        let case_sensitive = arguments.optional("case_sensitive").unwrap_or(expr!(true));
 
         Ok(Box::new(StartsWithFn {
             value,
@@ -158,8 +158,7 @@ mod tests {
 
         case_sensitive_same_case {
             args: func_args![value: "FOObar",
-                             substring: "FOO",
-                             case_sensitive: true
+                             substring: "FOO"
             ],
             want: Ok(true),
             tdef: TypeDef::new().infallible().boolean(),
@@ -167,8 +166,7 @@ mod tests {
 
         case_sensitive_different_case {
             args: func_args![value: "foobar",
-                             substring: "FOO",
-                             case_sensitive: true
+                             substring: "FOO"
             ],
             want: Ok(false),
             tdef: TypeDef::new().infallible().boolean(),


### PR DESCRIPTION
Fixes #7044

The docs and examples indicated that it should default to case
sensitive; however, `contains`, `starts_with`, and `ends_with`,
defaulted to case insensitive matching. This updates the
implementation to use case sensitive matching by default.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
