### PR TITLE
fix(datadog service): Document region parameter

### DIFF
--- a/docs/reference/components/sinks/datadog.cue
+++ b/docs/reference/components/sinks/datadog.cue
@@ -48,11 +48,13 @@ components: sinks: _datadog: {
 			}
 		}
 		region: {
+			common:        false
 			description:   "The region to send data to."
 			required:      false
 			relevant_when: "endpoint is not set"
 			warnings: []
 			type: string: {
+				default: null
 				enum: {
 					us: "United States"
 					eu: "Europe"

--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -61,6 +61,7 @@ components: sinks: datadog_logs: {
 	configuration: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
+		region:   sinks._datadog.configuration.region
 	}
 
 	input: {

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -52,6 +52,7 @@ components: sinks: datadog_metrics: {
 	configuration: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
+		region:   sinks._datadog.configuration.region
 		default_namespace: {
 			common: true
 			description: """


### PR DESCRIPTION
Closes #7079

This was added to the shared Datadog documentation in
https://github.com/timberio/vector/pull/4174 but never added
specifically to the sinks.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
