### PR TITLE
fix(ci): Update homebrew when bootstrapping OSX

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 set -e -o verbose
 
+brew update
+
 brew install ruby@2.7 coreutils cuelang/tap/cue
 
 echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"


### PR DESCRIPTION
Otherwise it tries to pull from bintray which is going away.

Example failure: https://github.com/timberio/vector/pull/7091/checks?check_run_id=2325858722

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
