### PR TITLE
enhancement(setup): helm chart make volume for data-dir configurable

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -126,8 +126,7 @@ spec:
             path: /var/lib/
         # Vector will store it's data here.
         - name: data-dir
-          hostPath:
-            path: /var/lib/vector/
+          {{- toYaml .Values.dataVolume | nindent 10 }}
         # Vector config dir.
         - name: config-dir
           projected:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -96,6 +96,11 @@ extraVolumes: []
 # managed by `DaemonSet`.
 extraVolumeMounts: []
 
+# Vector will store it's data here.
+dataVolume:
+  hostPath:
+    path: /var/lib/vector/
+
 rbac:
   # Whether to create rbac resources or not. Disable for non-rbac clusters.
   enabled: true


### PR DESCRIPTION
This makes it possible to change the `data-dir` for a helm deployment on the host for vector or use different volumes to fit more setups.

Signed-off-by: Tobias Breitwieser <tobias@breitwieser.biz>