### PR TITLE
enhancement(ci): support in helm vector-agent to specify command

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -39,6 +39,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "libvector.image" . | quote }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
           args:
             - --config
             - /etc/vector/*.toml

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -14,6 +14,9 @@ image:
 # Image pull secrets to use at the `Pod`s managed by `DaemonSet`.
 imagePullSecrets: []
 
+# Command to use at the pods managed by DaemonSet
+command: []
+
 # Override the chart name used in templates.
 nameOverride: ""
 # Override the full chart name (name prefixed with release name) used in

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -143,6 +143,8 @@ spec:
             {}
           image: "timberio/vector:latest-debian"
           imagePullPolicy: "IfNotPresent"
+          command:
+            []
           args:
             - --config
             - /etc/vector/*.toml

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -252,6 +252,8 @@ spec:
             {}
           image: "timberio/vector:latest-debian"
           imagePullPolicy: "IfNotPresent"
+          command:
+            []
           args:
             - --config
             - /etc/vector/*.toml

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -162,6 +162,8 @@ spec:
             {}
           image: "timberio/vector:0.0.0-debian"
           imagePullPolicy: "IfNotPresent"
+          command:
+            []
           args:
             - --config
             - /etc/vector/*.toml

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -202,6 +202,8 @@ spec:
             {}
           image: "timberio/vector:0.0.0-debian"
           imagePullPolicy: "IfNotPresent"
+          command:
+            []
           args:
             - --config
             - /etc/vector/*.toml


### PR DESCRIPTION
Ability to specify a command to the daemonsets containers. This is required to pass secrets with berglas (https://github.com/GoogleCloudPlatform/berglas) with Google Secret Manager (see here https://github.com/GoogleCloudPlatform/berglas/tree/main/examples/kubernetes#limitations )

