### PR TITLE
fix(ci): Ensure all benchmark artifacts are included

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -93,7 +93,6 @@ jobs:
           mkdir -p target/criterion
           setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench-all | tee target/criterion/out
 
-      - run: zip --recurse-paths target/criterion.zip target/criterion
       - uses: actions/upload-artifact@v2
         with:
           name: "criterion"

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: "criterion"
-          path: "./target/criterion.zip"
+          path: "./target/criterion"
       - name: Upload criterion data to S3
         run: scripts/upload-benchmarks-s3.sh
         if: github.ref == 'refs/heads/master'

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export SCOPE ?= ""
 # Override this with any extra flags for cargo bench
 export CARGO_BENCH_FLAGS ?= ""
 # override this to put criterion output elsewhere
-export CRITERION_HOME ?= "$(mkfile_dir)target/criterion"
+export CRITERION_HOME ?= $(mkfile_dir)target/criterion
 # Override to false to disable autospawning services on integration tests.
 export AUTOSPAWN ?= true
 # Override to control if services are turned off after integration tests.


### PR DESCRIPTION
CRITERION_HOME having "s was causing it to put it in the wrong place
(locally it created a directory called " and created the directory structure
under there).

Also just upload `./target/criterion` since Github does the
zipping for us. We did need to zip when previously downloading the
artifact in the same workflow as this was not zipped yet and so we were
hitting limits trying to individually pull a very large number of files.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
