### PR TITLE
chore(ci): Remove unneeded advisory from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,10 +52,6 @@ ignore = [
     # https://github.com/timberio/vector/issues/6224
     "RUSTSEC-2020-0095",
 
-    # Soundness issues in `raw-cpuid`
-    # https://github.com/timberio/vector/issues/6223
-    "RUSTSEC-2021-0013",
-
     # arr! macro erases lifetimes
     # https://github.com/timberio/vector/issues/6584
     "RUSTSEC-2020-0146",


### PR DESCRIPTION
This advisory seems to no longer be valid.

Closes: #6223

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
