### PR TITLE
fix(remap): Preserve type defs when assigning fields

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -104,7 +104,7 @@ remap: #Remap & {
 				.tid = to_int!(.tid)
 
 				# Extract structured data
-				message_parts = split(.message, ", ", limit: 2) ?? []
+				message_parts = split(.message, ", ", limit: 2)
 				structured = parse_key_value(message_parts[1], key_value_delimiter: ":", field_delimiter: ",") ?? {}
 				.message = message_parts[0]
 				. = merge(., structured)

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -197,18 +197,12 @@ impl Target {
             new_type_def: TypeDef,
             path: &Option<Path>,
         ) -> TypeDef {
-            // If the assignment is into a specific index, we want to keep the
-            // existing type def, and only update the type def at the provided
-            // index.
-            let is_index_assignment = path
-                .as_ref()
-                .and_then(|p| p.segments().last().map(|s| s.is_index()))
-                .unwrap_or_default();
-
-            if is_index_assignment {
-                current_type_def.clone().merge_overwrite(new_type_def)
-            } else {
+            // If the assignment is onto root or has no path (root variable assignment), use the
+            // new type def, otherwise merge the type defs.
+            if path.as_ref().map(|path| path.is_root()).unwrap_or(true) {
                 new_type_def
+            } else {
+                current_type_def.clone().merge_overwrite(new_type_def)
             }
         }
 

--- a/lib/vrl/tests/tests/issues/6792_lost_type_defs.vrl
+++ b/lib/vrl/tests/tests/issues/6792_lost_type_defs.vrl
@@ -1,0 +1,7 @@
+# https://github.com/timberio/vector/issues/6792#issuecomment-817986771
+# result: {"timestamp": "2020-01-01", "field1": "2020-01-01T04:00:00Z", "timestamp": "2020-01-01 00:00:00", "field2": 1577851200}
+
+.timestamp = "2020-01-01 00:00:00"
+.field1 = parse_timestamp!(.timestamp, format: "%Y-%m-%d %H:%M:%S")
+.field2 = to_int(.field1)
+.

--- a/lib/vrl/tests/tests/issues/6792_lost_type_defs.vrl
+++ b/lib/vrl/tests/tests/issues/6792_lost_type_defs.vrl
@@ -1,7 +1,7 @@
 # https://github.com/timberio/vector/issues/6792#issuecomment-817986771
-# result: {"timestamp": "2020-01-01", "field1": "2020-01-01T04:00:00Z", "timestamp": "2020-01-01 00:00:00", "field2": 1577851200}
+# result: {"field1": "2020-01-01T00:00:00Z", "field2": 1577836800, "timestamp": "2020-01-01T00:00:00+00:00"}
 
-.timestamp = "2020-01-01 00:00:00"
-.field1 = parse_timestamp!(.timestamp, format: "%Y-%m-%d %H:%M:%S")
+.timestamp = "2020-01-01T00:00:00+00:00"
+.field1 = parse_timestamp!(.timestamp, format: "%+")
 .field2 = to_int(.field1)
 .


### PR DESCRIPTION
Previously, remap would overwrite the type def of `.` whenever a new
field was assigned. That is:

```
.foo = 5
.bar = 6
```

Would result in the compiler only having type info for `.bar`.

This change causes it to merge the typedefs whenever a list of path
segments appears.

Big thangs to @FungusHumungus for talking this one through with me.

This addresses the example that appears here: https://github.com/timberio/vector/issues/6792#issuecomment-817986771 . It may also resolve some of the other comments on that issue, but I'm not 100% sure until I get responses from the commenters since I couldn't reproduce the other cases.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
