### PR TITLE
chore(config): Add a unique identifier to the source context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ toml = { version = "0.5.8", default-features = false }
 typetag = { version = "0.1.6", default-features = false }
 twox-hash = { version = "1.6", default-features = false }
 url = { version = "2.2.1", default-features = false }
-uuid = { version = "0.8", default-features = false, features = ["serde", "v4"], optional = true }
+uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
 warp = { version = "0.3.0", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", default-features = false }
 
@@ -386,7 +386,7 @@ sources-metrics = [
 sources-apache_metrics = []
 sources-aws_ecs_metrics = []
 sources-aws_kinesis_firehose = ["base64", "sources-utils-tls", "warp"]
-sources-aws_s3 = ["rusoto", "rusoto_s3", "rusoto_sqs", "semver", "uuid"]
+sources-aws_s3 = ["rusoto", "rusoto_s3", "rusoto_sqs", "semver"]
 sources-datadog = ["sources-utils-http"]
 sources-docker_logs = ["bollard", "dirs-next"]
 sources-file = ["bytesize", "file-source"]
@@ -540,7 +540,7 @@ sinks-aws_cloudwatch_logs = ["rusoto", "rusoto_logs"]
 sinks-aws_cloudwatch_metrics = ["rusoto", "rusoto_cloudwatch"]
 sinks-aws_kinesis_firehose = ["rusoto", "rusoto_firehose"]
 sinks-aws_kinesis_streams = ["rusoto", "rusoto_kinesis"]
-sinks-aws_s3 = ["bytesize", "rusoto", "rusoto_s3", "uuid"]
+sinks-aws_s3 = ["bytesize", "rusoto", "rusoto_s3"]
 sinks-aws_sqs = ["rusoto", "rusoto_sqs"]
 sinks-azure_monitor_logs = ["bytesize"]
 sinks-blackhole = []
@@ -549,14 +549,14 @@ sinks-console = []
 sinks-datadog = ["bytesize"]
 sinks-elasticsearch = ["bytesize", "rusoto"]
 sinks-file = []
-sinks-gcp = ["base64", "bytesize", "goauth", "gouth", "smpl_jwt", "uuid"]
+sinks-gcp = ["base64", "bytesize", "goauth", "gouth", "smpl_jwt"]
 sinks-honeycomb = ["bytesize"]
 sinks-http = ["bytesize"]
 sinks-humio = ["sinks-splunk_hec", "transforms-metric_to_log"]
 sinks-influxdb = ["bytesize"]
 sinks-kafka = []
 sinks-logdna = ["bytesize"]
-sinks-loki = ["bytesize", "uuid"]
+sinks-loki = ["bytesize"]
 sinks-nats = ["async-nats"]
 sinks-new_relic_logs = ["bytesize", "sinks-http"]
 sinks-papertrail = ["syslog"]

--- a/rfcs/2021-03-26-6517-end-to-end-acknowledgement.md
+++ b/rfcs/2021-03-26-6517-end-to-end-acknowledgement.md
@@ -45,8 +45,7 @@ transforms represented here are all those not listed explicitly
 below. When the destination sink finishes handling the event, a
 notification needs to be delivered to the source indicating the
 finalization status. Thus, the event needs to contain a reference to the
-source and a unique message identifier. Different sources will have
-varying requirements on the message identifier.
+source and a unique message identifier.
 
 ### Multiple sources to a single sink
 
@@ -214,7 +213,7 @@ struct EventFinalizer {
 struct BatchNotifier {
     status: Mutex<BatchStatus>,
     notifier: tokio::sync::oneshot::Sender<BatchStatus>,
-    identifier: Box<str>,
+    identifier: Uuid,
 }
 
 struct EventFinalization {
@@ -254,7 +253,7 @@ carry the data.
 ```rust
 struct SourceContext<'a> {
     name: &'a str,
-    identifier: Box<str>,
+    identifier: Uuid,
     globals: &'a GlobalOptions,
     shutdown: ShutdownSignal,
     out: Pipeline,

--- a/rfcs/2021-03-26-6517-end-to-end-acknowledgement.md
+++ b/rfcs/2021-03-26-6517-end-to-end-acknowledgement.md
@@ -143,8 +143,7 @@ configuration:
    be stopped while the event is buffered and then restarted with an
    identical configuration. At this point, the old source will be
    distinct from the current source, despite having the same configured
-   name. As such, the persisted identifier for the source must stay the
-   same across configuration reloads, but must be different for each run
+   name. As such, the source identifier must be different for each run
    of Vector.
 
 ## Internal Proposal

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -206,38 +206,60 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
 
 pub struct SourceContext {
     pub name: String,
+    pub identifier: Box<str>,
     pub globals: GlobalOptions,
     pub shutdown: ShutdownSignal,
     pub out: Pipeline,
 }
 
 impl SourceContext {
+    pub(crate) fn new(
+        name: &str,
+        globals: GlobalOptions,
+        shutdown: ShutdownSignal,
+        out: Pipeline,
+    ) -> Self {
+        let mut identifier = [b' '; 32];
+        let identifier = uuid::Uuid::new_v4()
+            .to_simple()
+            .encode_lower(&mut identifier)
+            .to_string()
+            .into_boxed_str();
+        Self {
+            name: name.into(),
+            identifier,
+            globals,
+            shutdown,
+            out,
+        }
+    }
+
     #[cfg(test)]
-    pub fn new_shutdown(
+    pub fn new_default(shutdown: ShutdownSignal, out: Pipeline) -> Self {
+        Self::new("default", GlobalOptions::default(), shutdown, out)
+    }
+
+    #[cfg(test)]
+    pub fn new_with_shutdown(
         name: &str,
         out: Pipeline,
     ) -> (Self, crate::shutdown::SourceShutdownCoordinator) {
-        let mut shutdown = crate::shutdown::SourceShutdownCoordinator::default();
-        let (shutdown_signal, _) = shutdown.register_source(name);
+        let mut coordinator = crate::shutdown::SourceShutdownCoordinator::default();
+        let (shutdown, _) = coordinator.register_source(name);
         (
-            Self {
-                name: name.into(),
-                globals: GlobalOptions::default(),
-                shutdown: shutdown_signal,
-                out,
-            },
-            shutdown,
+            Self::new(name, GlobalOptions::default(), shutdown, out),
+            coordinator,
         )
     }
 
     #[cfg(test)]
     pub fn new_test(out: Pipeline) -> Self {
-        Self {
-            name: "default".into(),
-            globals: GlobalOptions::default(),
-            shutdown: ShutdownSignal::noop(),
+        Self::new(
+            "default",
+            GlobalOptions::default(),
+            ShutdownSignal::noop(),
             out,
-        }
+        )
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@ use std::fs::DirBuilder;
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use uuid::Uuid;
 
 pub mod api;
 mod builder;
@@ -206,7 +207,7 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
 
 pub struct SourceContext {
     pub name: String,
-    pub identifier: Box<str>,
+    pub identifier: Uuid,
     pub globals: GlobalOptions,
     pub shutdown: ShutdownSignal,
     pub out: Pipeline,
@@ -219,15 +220,9 @@ impl SourceContext {
         shutdown: ShutdownSignal,
         out: Pipeline,
     ) -> Self {
-        let mut identifier = [b' '; 32];
-        let identifier = uuid::Uuid::new_v4()
-            .to_simple()
-            .encode_lower(&mut identifier)
-            .to_string()
-            .into_boxed_str();
         Self {
             name: name.into(),
-            identifier,
+            identifier: Uuid::new_v4(),
             globals,
             shutdown,
             out,

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -372,7 +372,7 @@ mod test {
         let source_name = "tcp_shutdown_simple";
         let (tx, mut rx) = Pipeline::new_test();
         let addr = next_addr();
-        let (cx, mut shutdown) = SourceContext::new_shutdown(source_name, tx);
+        let (cx, mut shutdown) = SourceContext::new_with_shutdown(source_name, tx);
 
         // Start TCP Source
         let server = SocketConfig::from(TcpConfig::from_address(addr.into()))
@@ -409,7 +409,7 @@ mod test {
         let source_name = "tcp_shutdown_infinite_stream";
 
         let addr = next_addr();
-        let (cx, mut shutdown) = SourceContext::new_shutdown(source_name, tx);
+        let (cx, mut shutdown) = SourceContext::new_with_shutdown(source_name, tx);
 
         // Start TCP Source
         let server = SocketConfig::from({
@@ -509,12 +509,12 @@ mod test {
         let address = next_addr();
 
         let server = SocketConfig::from(UdpConfig::from_address(address))
-            .build(SourceContext {
-                name: source_name.into(),
-                globals: GlobalOptions::default(),
-                shutdown: shutdown_signal,
-                out: sender,
-            })
+            .build(SourceContext::new(
+                source_name,
+                GlobalOptions::default(),
+                shutdown_signal,
+                sender,
+            ))
             .await
             .unwrap();
         let source_handle = tokio::spawn(server);

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -116,7 +116,7 @@ mod test {
     use super::VectorConfig;
     use crate::shutdown::ShutdownSignal;
     use crate::{
-        config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext},
+        config::{SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::{
             metric::{MetricKind, MetricValue},
             Metric,
@@ -231,12 +231,7 @@ mod test {
         let (trigger_shutdown, shutdown, shutdown_down) = ShutdownSignal::new_wired();
 
         let server = config
-            .build(SourceContext {
-                name: "default".into(),
-                globals: GlobalOptions::default(),
-                shutdown,
-                out: tx,
-            })
+            .build(SourceContext::new_default(shutdown, tx))
             .await
             .unwrap();
         tokio::spawn(server);
@@ -267,12 +262,7 @@ mod test {
         let (trigger_shutdown, shutdown, shutdown_down) = ShutdownSignal::new_wired();
 
         let server = config
-            .build(SourceContext {
-                name: "default".into(),
-                globals: GlobalOptions::default(),
-                shutdown,
-                out: tx,
-            })
+            .build(SourceContext::new_default(shutdown, tx))
             .await
             .unwrap();
         tokio::spawn(server);

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -61,12 +61,7 @@ pub async fn build_pieces(
 
         let (shutdown_signal, force_shutdown_tripwire) = shutdown_coordinator.register_source(name);
 
-        let context = SourceContext {
-            name: name.into(),
-            globals: config.global.clone(),
-            shutdown: shutdown_signal,
-            out: pipeline,
-        };
+        let context = SourceContext::new(name, config.global.clone(), shutdown_signal, pipeline);
         let server = match source.build(context).await {
             Err(error) => {
                 errors.push(format!("Source \"{}\": {}", name, error));


### PR DESCRIPTION
See the discussion in https://github.com/timberio/vector/pull/7098#discussion_r612834787

Reverting the changes described makes this pretty trivial, as nothing actually uses it (yet). This will be the basis for adding the source identifier to events.

Is it worth updating the RFC to correct the mistaken reload logic?

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #7066 
Obsoletes #7098