### PR TITLE
fix(external docs): Document additional encoding fields

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -161,9 +161,9 @@ components: sinks: [Name=string]: {
 							}
 						}
 
-						if features.healthcheck.enabled {except_fields: {
+						except_fields: {
 							common:      false
-							description: "Prevent the sink from encoding the specified labels."
+							description: "Prevent the sink from encoding the specified fields."
 							required:    false
 							type: array: {
 								default: null
@@ -174,31 +174,30 @@ components: sinks: [Name=string]: {
 							}
 						}
 
-							only_fields: {
-								common:      false
-								description: "Prevent the sink from encoding the specified labels."
-								required:    false
-								type: array: {
-									default: null
-									items: type: string: {
-										examples: ["message", "parent.child"]
-										syntax: "field_path"
-									}
+						only_fields: {
+							common:      false
+							description: "Prevent the sink from encoding the specified fields."
+							required:    false
+							type: array: {
+								default: null
+								items: type: string: {
+									examples: ["message", "parent.child"]
+									syntax: "field_path"
 								}
 							}
+						}
 
-							timestamp_format: {
-								common:      false
-								description: "How to format event timestamps."
-								required:    false
-								type: string: {
-									default: "rfc3339"
-									enum: {
-										rfc3339: "Formats as a RFC3339 string"
-										unix:    "Formats as a unix timestamp"
-									}
-									syntax: "literal"
+						timestamp_format: {
+							common:      false
+							description: "How to format event timestamps."
+							required:    false
+							type: string: {
+								default: "rfc3339"
+								enum: {
+									rfc3339: "Formats as a RFC3339 string"
+									unix:    "Formats as a unix timestamp"
 								}
+								syntax: "literal"
 							}
 						}
 					}


### PR DESCRIPTION
Ensure `except_fields`, `only_fields`, and `timestamp_format` appear on
all sinks supporting `encoding`. Previously they only appeared on sinks
that had healthchecks.

Fixes: #6949

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
