### PR TITLE
chore(ci): Revert "Remove unneeded advisory from deny.toml"

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,10 @@ ignore = [
     # https://github.com/timberio/vector/issues/6224
     "RUSTSEC-2020-0095",
 
+    # Soundness issues in `raw-cpuid`
+    # https://github.com/timberio/vector/issues/6223
+    "RUSTSEC-2021-0013",
+
     # arr! macro erases lifetimes
     # https://github.com/timberio/vector/issues/6584
     "RUSTSEC-2020-0146",


### PR DESCRIPTION
Reverts timberio/vector#7114

We are still depending on older versions of `raw-cpuid` through our dependencies. 
https://github.com/timberio/vector/pull/7131/checks?check_run_id=2349406600