### PR TITLE
chore(ci): Add advisory RUSTSEC-2021-0013 back to  deny.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
               - "Cargo.toml"
               - "Makefile"
               - "rust-toolchain"
+            deny:
+              - 'deny.toml'
             docs:
               - 'docs/**'
             markdown:
@@ -284,12 +286,12 @@ jobs:
         if: needs.changes.outputs.source == 'true'
         run: make check-events
       - name: Check cargo deny advisories
-        if: needs.changes.outputs.dependencies == 'true'
+        if: needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.deny == 'true'
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check advisories
       - name: Check cargo deny licenses
-        if: needs.changes.outputs.dependencies == 'true'
+        if: needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.deny == 'true'
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check licenses

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,10 @@ ignore = [
     # https://github.com/timberio/vector/issues/6224
     "RUSTSEC-2020-0095",
 
+    # Soundness issues in `raw-cpuid`
+    # https://github.com/timberio/vector/issues/6223
+    "RUSTSEC-2021-0013",
+
     # arr! macro erases lifetimes
     # https://github.com/timberio/vector/issues/6584
     "RUSTSEC-2020-0146",


### PR DESCRIPTION
I neglected to enable all features. The `wasm` dependencies still depend
on an affected version of rust-cpuid.

This reverts commit f30d4c6ed43838b36769753f2a591c2378162e04.

I also modified the github workflow to run the `cargo deny` steps if `deny.toml` was modified, which would have caught this issue.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
