### PR TITLE
fix(docker_logs source): ensure that docker labels are flattened

### DIFF
--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -271,6 +271,13 @@ impl Value {
         self.as_bytes()
     }
 
+    pub fn as_map(&self) -> Option<&BTreeMap<String, Value>> {
+        match &self {
+            Value::Map(map) => Some(map),
+            _ => None,
+        }
+    }
+
     pub fn as_timestamp(&self) -> Option<&DateTime<Utc>> {
         match &self {
             Value::Timestamp(ts) => Some(ts),


### PR DESCRIPTION
Fixes: #5716

Previously labels on docker containers were inserted in such a way that
dots in their names would end up creating a nested structure in the log
event due to the semantics of `LogEvent.insert`.

For example:

```json
{
  "container_created_at": "2021-04-16T18:53:19.946155600Z",
  "container_id": "d6bd69d4bc64bef20b4e992dcc23113741067e8268762694f92899504ae14319",
  "container_name": "docker_echo_1",
  "host": "COMP-C02DV25MML87",
  "image": "hashicorp/http-echo:latest",
  "label": {
    "com": {
      "docker": {
        "compose": {
          "config-hash": "e7e5ba19811180f27a7af36667652d0cd686599e6184cb023d9b71d791ff6a1e",
          "container-number": "1",
          "oneoff": "False",
          "project": {
            "config_files": "docker-compose.yml",
            "working_dir": "/private/tmp/docker"
          },
          "service": "echo",
          "version": "1.27.4"
        }
      }
    }
  },
  "message": "2021/04/16 19:14:10 localhost:5678 172.29.0.1:61824 \"GET / HTTP/1.1\" 200 6 \"curl/7.64.1\" 35.6µs",
  "source_type": "docker",
  "stream": "stdout",
  "timestamp": "2021-04-16T19:14:10.400790400Z"
}
```

This change ensures that labels are inserted as-is as keys:

```json
{
  "container_created_at": "2021-04-16T18:53:19.946155600Z",
  "container_id": "d6bd69d4bc64bef20b4e992dcc23113741067e8268762694f92899504ae14319",
  "container_name": "docker_echo_1",
  "host": "COMP-C02DV25MML87",
  "image": "hashicorp/http-echo:latest",
  "label": {
    "com.docker.compose.config-hash": "e7e5ba19811180f27a7af36667652d0cd686599e6184cb023d9b71d791ff6a1e",
    "com.docker.compose.container-number": "1",
    "com.docker.compose.oneoff": "False",
    "com.docker.compose.project": "docker",
    "com.docker.compose.project.config_files": "docker-compose.yml",
    "com.docker.compose.project.working_dir": "/private/tmp/docker",
    "com.docker.compose.service": "echo",
    "com.docker.compose.version": "1.27.4"
  },
  "message": "2021/04/16 19:12:01 localhost:5678 172.29.0.1:61820 \"GET / HTTP/1.1\" 200 6 \"curl/7.64.1\" 18.1µs",
  "source_type": "docker",
  "stream": "stdout",
  "timestamp": "2021-04-16T19:12:01.622769500Z"
}
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
