### PR TITLE
enhancement(aws_s3 sink): Change healthcheck from `head_bucket` to `put_object`

### DIFF
--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -20,7 +20,7 @@ use http::StatusCode;
 use lazy_static::lazy_static;
 use rusoto_core::RusotoError;
 use rusoto_s3::{
-    HeadBucketRequest, PutObjectError, PutObjectOutput, PutObjectRequest, S3Client, S3,
+    PutObjectError, PutObjectOutput, PutObjectRequest, S3Client, S3,
 };
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -237,9 +237,11 @@ impl S3SinkConfig {
     }
 
     pub async fn healthcheck(self, client: S3Client) -> crate::Result<()> {
-        let req = client.head_bucket(HeadBucketRequest {
+        let req = client.put_object(PutObjectRequest{
             bucket: self.bucket.clone(),
-            expected_bucket_owner: None,
+            key: ".healthcheck".to_string(),
+            body: None,
+            ..Default::default()
         });
 
         match req.await {


### PR DESCRIPTION
This PR intends to resolve https://github.com/timberio/vector/issues/620 by implementing the proposed solution here: https://github.com/timberio/vector/issues/620#issuecomment-510490268.

I've tested this new healthcheck with AWS permissions limited to `s3:PutObject`:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:PutObject"
            ],
            "Resource": [
                "arn:aws:s3:::<bucket_name>/*"
            ]
        }
    ]
}
```

Output from vector:
```
INFO vector::topology::builder: Healthcheck: Passed.
```

Additionally, I verified the `.healthcheck` object existed in the bucket.