### PR TITLE
enhancement(socket source): Added `one_event_per_datagram` for UDP source

### DIFF
--- a/docs/reference/components/sources/socket.cue
+++ b/docs/reference/components/sources/socket.cue
@@ -106,6 +106,13 @@ components: sources: socket: {
 				syntax: "literal"
 			}
 		}
+		one_event_per_datagram: {
+			common:        false
+			description:   "If set to `true` a single event will be generated for each UDP datagram, the event will then contain the entire datagram payload. If set to `false` datagram will be split every new line character and an several events (one per line) will be generated."
+			relevant_when: "mode = `udp`"
+			required:      false
+			type: bool: default: false
+		}
 		path: {
 			description:   "The unix socket path. *This should be an absolute path*."
 			relevant_when: "mode = `unix`"


### PR DESCRIPTION
It allows to choose between one event per datagram or one event every new line (old behaviour, kept as default).
This also aim to help to cover usecase like syslog receiving on UDP (single message per datagram as stated in the RFC) and do the parsing in VRL.

Signed-off-by: prognant <pierre.rognant@datadoghq.com>

