### PR TITLE
chore: Adjust import of `crate::Event` to `crate::event::Event`

### DIFF
--- a/benches/isolated_buffer.rs
+++ b/benches/isolated_buffer.rs
@@ -13,9 +13,9 @@ use vector::{
         disk::{leveldb_buffer, DiskBuffer},
         Acker,
     },
+    event::Event,
     sinks::util::StreamSink,
     test_util::{random_lines, runtime},
-    Event,
 };
 
 struct NullSink {

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -6,9 +6,9 @@ use std::pin::Pin;
 use transforms::lua::v2::LuaConfig;
 use vector::{
     config::{GlobalOptions, TransformConfig},
+    event::Event,
     test_util::{collect_ready, runtime},
     transforms::{self, Transform},
-    Event,
 };
 
 fn bench_add_fields(c: &mut Criterion) {

--- a/benches/wasm/mod.rs
+++ b/benches/wasm/mod.rs
@@ -5,8 +5,8 @@ use indoc::indoc;
 use serde_json::Value;
 use std::{collections::HashMap, fs, io::Read, path::Path, pin::Pin};
 use vector::{
+    event::Event,
     transforms::{wasm::Wasm, TaskTransform, Transform},
-    Event,
 };
 
 fn parse_event_artifact(path: impl AsRef<Path>) -> vector::Result<Event> {

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -1,5 +1,5 @@
 use super::EventEncodingType;
-use crate::{event, Value};
+use crate::event::{self, Value};
 
 use async_graphql::Object;
 use chrono::{DateTime, Utc};

--- a/src/api/schema/scalar.rs
+++ b/src/api/schema/scalar.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::event::Value;
 use async_graphql::scalar;
 
 // For raw JSON data.

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -1,4 +1,4 @@
-use crate::{config::Resource, internal_events::EventOut, Event};
+use crate::{config::Resource, event::Event, internal_events::EventOut};
 #[cfg(feature = "leveldb")]
 use futures::compat::{Sink01CompatExt, Stream01CompatExt};
 use futures::{channel::mpsc, Sink, SinkExt, Stream};

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -1,7 +1,6 @@
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription},
-    event::Value,
-    Event,
+    event::{Event, Value},
 };
 use cidr_utils::cidr::IpCidr;
 use indexmap::IndexMap;
@@ -583,7 +582,7 @@ impl Condition for CheckFields {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Event;
+    use crate::event::Event;
 
     #[test]
     fn generate_config() {

--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription},
-    Event,
+    event::Event,
 };
 
 //------------------------------------------------------------------------------
@@ -49,7 +49,7 @@ mod test {
     use super::*;
     use crate::{
         event::metric::{Metric, MetricKind, MetricValue},
-        Event,
+        event::Event,
     };
 
     #[test]

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription},
-    Event,
+    event::Event,
 };
 
 //------------------------------------------------------------------------------
@@ -49,7 +49,7 @@ mod test {
     use super::*;
     use crate::{
         event::metric::{Metric, MetricKind, MetricValue},
-        Event,
+        event::Event,
     };
 
     #[test]

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::component::ComponentDescription;
-use crate::Event;
+use crate::event::Event;
 use serde::{Deserialize, Serialize};
 
 pub mod check_fields;

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -1,8 +1,8 @@
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription},
     emit,
+    event::Event,
     internal_events::RemapConditionExecutionError,
-    Event,
 };
 use serde::{Deserialize, Serialize};
 use vrl::diagnostic::Formatter;

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -3,7 +3,7 @@ use metrics::counter;
 
 #[derive(Debug)]
 pub(crate) struct DedupeEventDiscarded {
-    pub event: crate::Event,
+    pub event: crate::event::Event,
 }
 
 impl InternalEvent for DedupeEventDiscarded {

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -1,5 +1,5 @@
 use super::InternalEvent;
-use crate::Event;
+use crate::event::Event;
 use metrics::counter;
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ pub mod validate;
 #[cfg(windows)]
 pub mod vector_windows;
 
-pub use event::{Event, Value};
 pub use pipeline::Pipeline;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -5,8 +5,8 @@ mod not;
 pub(in crate::mapping) use not::NotFn;
 
 use super::Function;
+use crate::event::Event;
 use crate::mapping::{query::query_value::QueryValue, Result};
-use crate::Event;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::str::FromStr;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,11 +5,11 @@ mod registry;
 #[cfg(test)]
 mod tests;
 
+use crate::event::{Event, Metric};
 pub use crate::metrics::handle::{Counter, Handle};
 use crate::metrics::label_filter::VectorLabelFilter;
 use crate::metrics::recorder::VectorRecorder;
 use crate::metrics::registry::VectorRegistry;
-use crate::{event::Metric, Event};
 use metrics::{Key, KeyData, SharedString};
 use metrics_tracing_context::TracingContextLayer;
 use metrics_util::layers::Layer;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::{internal_events::EventOut, transforms::FunctionTransform, Event};
+use crate::{event::Event, internal_events::EventOut, transforms::FunctionTransform};
 use futures::{channel::mpsc, task::Poll, Sink};
 use std::{collections::VecDeque, fmt, pin::Pin, task::Context};
 
@@ -130,9 +130,9 @@ impl Pipeline {
 mod test {
     use super::Pipeline;
     use crate::{
+        event::{Event, Value},
         test_util::collect_ready,
         transforms::{add_fields::AddFields, filter::Filter},
-        Event, Value,
     };
     use futures::SinkExt;
     use serde_json::json;

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -430,7 +430,11 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use crate::{event::metric::StatisticKind, event::MetricKind, test_util::random_string, Event};
+    use crate::{
+        event::metric::StatisticKind,
+        event::{Event, MetricKind},
+        test_util::random_string,
+    };
     use chrono::offset::TimeZone;
     use rand::seq::SliceRandom;
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     internal_events::TemplateRenderingFailed,
     rusoto::{self, AwsAuthentication, RegionOrEndpoint},
     serde::to_string,
@@ -11,7 +12,6 @@ use crate::{
         PartitionBuffer, PartitionInnerBuffer, ServiceBuilderExt, TowerRequestConfig,
     },
     template::Template,
-    Event,
 };
 use bytes::Bytes;
 use chrono::Utc;

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     internal_events::{AwsSqsEventSent, TemplateRenderingFailed},
     rusoto::{self, AwsAuthentication, RegionOrEndpoint},
     sinks::util::{
@@ -9,7 +10,6 @@ use crate::{
         BatchSettings, EncodedLength, TowerRequestConfig, VecBuffer,
     },
     template::{Template, TemplateParseError},
-    Event,
 };
 use futures::{future::BoxFuture, stream, FutureExt, Sink, SinkExt, StreamExt, TryFutureExt};
 use lazy_static::lazy_static;

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -2,9 +2,9 @@ use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     emit,
+    event::Event,
     internal_events::BlackholeEventReceived,
     sinks::util::StreamSink,
-    Event,
 };
 use async_trait::async_trait;
 use futures::{future, stream::BoxStream, FutureExt, StreamExt};

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricValue, Sample, StatisticKind},
+    event::Event,
     http::HttpClient,
     sinks::{
         util::{
@@ -12,7 +13,6 @@ use crate::{
         },
         Healthcheck, HealthcheckError, UriParseError, VectorSink,
     },
-    Event,
 };
 use chrono::{DateTime, Utc};
 use futures::{stream, FutureExt, SinkExt};

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -706,10 +706,10 @@ mod integration_tests {
     use super::*;
     use crate::{
         config::{SinkConfig, SinkContext},
+        event::Event,
         http::HttpClient,
         test_util::{random_events_with_stream, random_string, trace_init},
         tls::{self, TlsOptions},
-        Event,
     };
     use futures::{stream, StreamExt};
     use http::{Request, StatusCode};

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -527,7 +527,7 @@ fn maybe_set_id(key: Option<impl AsRef<str>>, doc: &mut serde_json::Value, event
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{sinks::util::retries::RetryAction, Event};
+    use crate::{event::Event, sinks::util::retries::RetryAction};
     use http::{Response, StatusCode};
     use pretty_assertions::assert_eq;
     use serde_json::json;

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -1,6 +1,7 @@
 use super::{healthcheck_response, GcpAuthConfig, GcpCredentials, Scope};
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     http::{HttpClient, HttpClientFuture, HttpError},
     internal_events::TemplateRenderingFailed,
     serde::to_string,
@@ -15,7 +16,6 @@ use crate::{
     },
     template::{Template, TemplateParseError},
     tls::{TlsOptions, TlsSettings},
-    Event,
 };
 use bytes::Bytes;
 use chrono::Utc;

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -1,5 +1,5 @@
 use crate::config::{DataType, SinkConfig, SinkContext, SinkDescription};
-use crate::event::{Metric, MetricValue};
+use crate::event::{Event, Metric, MetricValue};
 use crate::http::HttpClient;
 use crate::sinks::gcp;
 use crate::sinks::util::buffer::metrics::MetricsBuffer;
@@ -7,7 +7,6 @@ use crate::sinks::util::http::{BatchedHttpSink, HttpSink};
 use crate::sinks::util::{BatchConfig, BatchSettings, TowerRequestConfig};
 use crate::sinks::{Healthcheck, VectorSink};
 use crate::tls::{TlsOptions, TlsSettings};
-use crate::Event;
 use chrono::{DateTime, Utc};
 use futures::sink::SinkExt;
 use futures::FutureExt;

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -148,9 +148,9 @@ mod integration_tests {
     use super::*;
     use crate::{
         config::{log_schema, SinkConfig, SinkContext},
+        event::Event,
         sinks::util::Compression,
         test_util::random_string,
-        Event,
     };
     use chrono::Utc;
     use futures::stream;

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -107,10 +107,10 @@ mod tests {
     use crate::{
         event::{
             metric::{MetricKind, MetricValue, StatisticKind},
-            Metric,
+            Event, Metric,
         },
         sinks::util::test::{build_test_server, load_sink},
-        test_util, Event,
+        test_util,
     };
     use chrono::{offset::TimeZone, Utc};
     use indoc::indoc;

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -831,6 +831,7 @@ mod integration_tests {
     use crate::{
         config::{SinkConfig, SinkContext},
         event::metric::{Metric, MetricKind, MetricValue},
+        event::Event,
         http::HttpClient,
         sinks::influxdb::{
             metrics::{default_summary_quantiles, InfluxDbConfig, InfluxDbSvc},
@@ -841,7 +842,6 @@ mod integration_tests {
             InfluxDb1Settings, InfluxDb2Settings,
         },
         tls::{self, TlsOptions},
-        Event,
     };
     use chrono::{SecondsFormat, Utc};
     use futures::stream;

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -1,6 +1,7 @@
 use crate::{
     buffers::Acker,
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     internal_events::TemplateRenderingFailed,
     kafka::{KafkaAuthConfig, KafkaCompression},
     serde::to_string,
@@ -9,7 +10,6 @@ use crate::{
         BatchConfig,
     },
     template::{Template, TemplateParseError},
-    Event,
 };
 use futures::{
     channel::oneshot::Canceled, future::BoxFuture, ready, stream::FuturesUnordered, FutureExt,

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -423,8 +423,8 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::{
-        config::SinkConfig, sinks::util::test::load_sink, template::Template,
-        test_util::random_lines, Event,
+        config::SinkConfig, event::Event, sinks::util::test::load_sink, template::Template,
+        test_util::random_lines,
     };
     use bytes::Bytes;
     use chrono::{DateTime, Duration, Utc};

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -297,10 +297,10 @@ async fn healthcheck(config: LokiConfig, client: HttpClient) -> crate::Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::Event;
     use crate::sinks::util::http::HttpSink;
     use crate::sinks::util::test::{build_test_server, load_sink};
     use crate::test_util;
-    use crate::Event;
     use futures::StreamExt;
 
     #[test]

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::event::Event;
 use futures::{future::BoxFuture, Sink, Stream, StreamExt};
 use snafu::Snafu;
 use std::fmt;

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -2,13 +2,13 @@ use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     emit,
+    event::Event,
     internal_events::{NatsEventSendFail, NatsEventSendSuccess, TemplateRenderingFailed},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         StreamSink,
     },
     template::{Template, TemplateParseError},
-    Event,
 };
 use async_trait::async_trait;
 use futures::{stream::BoxStream, FutureExt, StreamExt, TryFutureExt};

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -168,9 +168,9 @@ mod tests {
     use super::*;
     use crate::{
         config::SinkConfig,
+        event::Event,
         sinks::util::{encoding::EncodingConfiguration, test::build_test_server, Concurrency},
         test_util::next_addr,
-        Event,
     };
     use bytes::Buf;
     use futures::{stream, StreamExt};

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         tcp::TcpSinkConfig,
@@ -7,7 +8,6 @@ use crate::{
     },
     tcp::TcpKeepaliveConfig,
     tls::TlsConfig,
-    Event,
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -2,13 +2,13 @@ use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, Resource, SinkConfig, SinkContext, SinkDescription},
     event::metric::MetricKind,
+    event::Event,
     internal_events::PrometheusServerRequestComplete,
     sinks::{
         util::{statistic::validate_quantiles, MetricEntry, StreamSink},
         Healthcheck, VectorSink,
     },
     tls::{MaybeTlsSettings, TlsConfig},
-    Event,
 };
 use async_trait::async_trait;
 use chrono::Utc;

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -444,9 +444,9 @@ mod integration_tests {
     use crate::{
         config::{SinkConfig, SinkContext},
         event::metric::MetricValue,
+        event::Event,
         sinks::influxdb::test_util::{cleanup_v1, format_timestamp, onboarding_v1, query_v1},
         tls::{self, TlsOptions},
-        Event,
     };
     use futures::stream;
     use serde_json::Value;

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -1,13 +1,13 @@
 use super::Region;
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::Event,
     sinks::elasticsearch::{ElasticSearchConfig, Encoding},
     sinks::util::{
         encoding::EncodingConfigWithDefault, http::RequestConfig, BatchConfig, Compression,
         TowerRequestConfig,
     },
     sinks::{Healthcheck, VectorSink},
-    Event,
 };
 use futures::{
     future::{self, BoxFuture},

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -450,9 +450,9 @@ mod integration_tests {
     use crate::{
         assert_downcast_matches,
         config::{SinkConfig, SinkContext},
+        event::Event,
         sinks,
         test_util::{random_lines_with_stream, random_string},
-        Event,
     };
     use futures::stream;
     use serde_json::Value as JsonValue;

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -3,6 +3,7 @@ use crate::sinks::util::unix::UnixSinkConfig;
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::metric::{Metric, MetricKind, MetricTags, MetricValue, StatisticKind},
+    event::Event,
     internal_events::StatsdInvalidMetricReceived,
     sinks::util::{
         encode_namespace,
@@ -10,7 +11,6 @@ use crate::{
         udp::{UdpService, UdpSinkConfig},
         BatchConfig, BatchSettings, BatchSink, Buffer, Compression,
     },
-    Event,
 };
 use futures::{future, stream, FutureExt, SinkExt, StreamExt, TryFutureExt};
 use serde::{Deserialize, Serialize};

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -1,7 +1,7 @@
 use crate::{
     event::metric::{Metric, MetricKind, MetricValue, Sample},
+    event::Event,
     sinks::util::batch::{Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult},
-    Event,
 };
 use std::{
     cmp::Ordering,

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -35,8 +35,8 @@ mod with_default;
 pub use with_default::EncodingConfigWithDefault;
 
 use crate::{
-    event::{PathComponent, PathIter, Value},
-    Event, Result,
+    event::{Event, PathComponent, PathIter, Value},
+    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, fmt::Debug};

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -5,8 +5,8 @@ use super::{
 };
 use crate::{
     buffers::Acker,
+    event::Event,
     http::{HttpClient, HttpError},
-    Event,
 };
 use bytes::{Buf, Bytes};
 use futures::{future::BoxFuture, ready, Sink};

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -36,7 +36,7 @@ use super::{
     buffer::{Partition, PartitionBuffer, PartitionInnerBuffer},
     service::{Map, ServiceBuilderExt},
 };
-use crate::{buffers::Acker, Event};
+use crate::{buffers::Acker, event::Event};
 use async_trait::async_trait;
 use futures::{
     future::BoxFuture,

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -2,6 +2,7 @@ use crate::{
     buffers::Acker,
     config::SinkContext,
     dns,
+    event::Event,
     internal_events::{
         ConnectionOpen, OpenGauge, SocketMode, TcpSocketConnectionEstablished,
         TcpSocketConnectionFailed, TcpSocketConnectionShutdown, TcpSocketError,
@@ -17,7 +18,6 @@ use crate::{
     },
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsSettings, MaybeTlsStream, TlsConfig, TlsError},
-    Event,
 };
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -4,6 +4,7 @@ use crate::{
     buffers::Acker,
     config::SinkContext,
     dns,
+    event::Event,
     internal_events::{
         SocketEventsSent, SocketMode, UdpSendIncomplete, UdpSocketConnectionEstablished,
         UdpSocketConnectionFailed, UdpSocketError,
@@ -12,7 +13,6 @@ use crate::{
         util::{retries::ExponentialBackoff, StreamSink},
         Healthcheck, VectorSink,
     },
-    Event,
 };
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -1,6 +1,7 @@
 use crate::{
     buffers::Acker,
     config::SinkContext,
+    event::Event,
     internal_events::{
         ConnectionOpen, OpenGauge, SocketMode, UnixSocketConnectionEstablished,
         UnixSocketConnectionFailed, UnixSocketError,
@@ -14,7 +15,6 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    Event,
 };
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/src/sinks/vector.rs
+++ b/src/sinks/vector.rs
@@ -1,10 +1,9 @@
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    event::proto,
+    event::{proto, Event},
     sinks::util::tcp::TcpSinkConfig,
     tcp::TcpKeepaliveConfig,
     tls::TlsConfig,
-    Event,
 };
 use bytes::{BufMut, Bytes, BytesMut};
 use getset::Setters;

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -1,13 +1,14 @@
 use crate::{
     config::{self, GenerateConfig, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
+    event::Event,
     http::HttpClient,
     internal_events::{
         ApacheMetricsErrorResponse, ApacheMetricsEventReceived, ApacheMetricsHttpError,
         ApacheMetricsParseError, ApacheMetricsRequestCompleted,
     },
     shutdown::ShutdownSignal,
-    Event, Pipeline,
+    Pipeline,
 };
 use chrono::Utc;
 use futures::{stream, FutureExt, SinkExt, StreamExt, TryFutureExt};

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -1,11 +1,12 @@
 use crate::{
     config::{self, GenerateConfig, SourceConfig, SourceContext, SourceDescription},
+    event::Event,
     internal_events::{
         AwsEcsMetricsErrorResponse, AwsEcsMetricsHttpError, AwsEcsMetricsParseError,
         AwsEcsMetricsReceived, AwsEcsMetricsRequestCompleted,
     },
     shutdown::ShutdownSignal,
-    Event, Pipeline,
+    Pipeline,
 };
 use futures::{stream, SinkExt, StreamExt};
 use hyper::{Body, Client, Request};

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -63,7 +63,7 @@ async fn run(out: Pipeline, mut shutdown: ShutdownSignal) -> Result<(), ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_util::collect_ready, trace, Event};
+    use crate::{event::Event, test_util::collect_ready, trace};
     use futures::channel::mpsc;
     use tokio::time::{sleep, Duration};
 

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -70,7 +70,11 @@ impl FunctionTransform for Picker {
 mod tests {
     use super::super::{cri, docker, test_util};
     use super::*;
-    use crate::{event::LogEvent, test_util::trace_init, transforms::Transform, Event};
+    use crate::{
+        event::{Event, LogEvent},
+        test_util::trace_init,
+        transforms::Transform,
+    };
 
     /// Picker has to work for all test cases for underlying parsers.
     fn cases() -> Vec<(String, Vec<LogEvent>)> {

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -4,8 +4,8 @@
 
 use super::path_helpers::{parse_log_file_path, LogFileInfo};
 use crate::{
-    event::{LogEvent, PathComponent, PathIter},
-    kubernetes as k8s, Event,
+    event::{Event, LogEvent, PathComponent, PathIter},
+    kubernetes as k8s,
 };
 use evmap::ReadHandle;
 use k8s_openapi::{

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
     config::{self, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
+    event::Event,
     internal_events::{
         MongoDbMetricsBsonParseError, MongoDbMetricsCollectCompleted, MongoDbMetricsEventsReceived,
         MongoDbMetricsRequestError,
     },
-    Event,
 };
 use chrono::Utc;
 use futures::{

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -1,13 +1,13 @@
 use crate::{
     config::{DataType, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
+    event::Event,
     http::{Auth, HttpClient},
     internal_events::{
         NginxMetricsCollectCompleted, NginxMetricsEventsReceived, NginxMetricsRequestError,
         NginxMetricsStubStatusParseError,
     },
     tls::{TlsOptions, TlsSettings},
-    Event,
 };
 use bytes::Bytes;
 use chrono::Utc;

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -1,8 +1,8 @@
 use crate::{
     config::{DataType, SourceConfig, SourceContext, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
+    event::Event,
     internal_events::{PostgresqlMetricsCollectCompleted, PostgresqlMetricsCollectFailed},
-    Event,
 };
 use chrono::{DateTime, Utc};
 use futures::{

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -1,13 +1,13 @@
 use super::parser;
 use crate::{
     config::{self, GenerateConfig, SourceConfig, SourceContext, SourceDescription},
+    event::Event,
     internal_events::{PrometheusRemoteWriteParseError, PrometheusRemoteWriteReceived},
     sources::{
         self,
         util::{decode, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     },
     tls::TlsConfig,
-    Event,
 };
 use bytes::Bytes;
 use prometheus_parser::proto;

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -162,13 +162,14 @@ mod test {
     use super::{tcp::TcpConfig, udp::UdpConfig, SocketConfig};
     use crate::{
         config::{log_schema, GlobalOptions, SinkContext, SourceConfig, SourceContext},
+        event::Event,
         shutdown::{ShutdownSignal, SourceShutdownCoordinator},
         sinks::util::tcp::TcpSinkConfig,
         test_util::{
             collect_n, next_addr, random_string, send_lines, send_lines_tls, wait_for_tcp,
         },
         tls::{self, TlsConfig, TlsOptions},
-        Event, Pipeline,
+        Pipeline,
     };
     use bytes::Bytes;
     use futures::{stream, StreamExt};

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,12 +1,13 @@
 use crate::udp;
 use crate::{
     config::{self, GenerateConfig, Resource, SourceConfig, SourceContext, SourceDescription},
+    event::Event,
     internal_events::{StatsdEventReceived, StatsdInvalidRecord, StatsdSocketError},
     shutdown::ShutdownSignal,
     sources::util::{SocketListenAddr, TcpSource},
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsSettings, TlsConfig},
-    Event, Pipeline,
+    Pipeline,
 };
 use bytes::Bytes;
 use codec::BytesDelimitedCodec;

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -1,6 +1,6 @@
 use crate::{
-    shutdown::ShutdownSignal, sources::util::build_unix_stream_source, sources::Source, Event,
-    Pipeline,
+    event::Event, shutdown::ShutdownSignal, sources::util::build_unix_stream_source,
+    sources::Source, Pipeline,
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -1,10 +1,11 @@
 use crate::{
     config::Resource,
+    event::Event,
     internal_events::{ConnectionOpen, OpenGauge, TcpSocketConnectionError},
     shutdown::ShutdownSignal,
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsIncomingStream, MaybeTlsListener, MaybeTlsSettings},
-    Event, Pipeline,
+    Pipeline,
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, FutureExt, Sink, SinkExt, StreamExt, TryFutureExt};

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -1,11 +1,10 @@
 use super::util::{SocketListenAddr, TcpSource};
 use crate::{
     config::{DataType, GenerateConfig, Resource, SourceConfig, SourceContext, SourceDescription},
-    event::proto,
+    event::{proto, Event},
     internal_events::{VectorEventReceived, VectorProtoDecodeError},
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsSettings, TlsConfig},
-    Event,
 };
 use bytes::{Bytes, BytesMut};
 use getset::Setters;
@@ -117,6 +116,7 @@ mod test {
     use crate::shutdown::ShutdownSignal;
     use crate::{
         config::{GlobalOptions, SinkConfig, SinkContext, SourceConfig, SourceContext},
+        event::Event,
         event::{
             metric::{MetricKind, MetricValue},
             Metric,
@@ -124,7 +124,7 @@ mod test {
         sinks::vector::VectorSinkConfig,
         test_util::{collect_ready, next_addr, trace_init, wait_for_tcp},
         tls::{TlsConfig, TlsOptions},
-        Event, Pipeline,
+        Pipeline,
     };
     use futures::stream;
     use shared::assert_event_data_eq;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,6 @@
 use crate::{
     config::log_schema,
-    event::{Metric, Value},
-    Event,
+    event::{Event, Metric, Value},
 };
 use bytes::Bytes;
 use chrono::{

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
     config::{Config, ConfigDiff, GenerateConfig},
+    event::Event,
     topology::{self, RunningTopology},
-    trace, Event,
+    trace,
 };
 use flate2::read::MultiGzDecoder;
 use futures::{

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::event::Event;
 use futures::{channel::mpsc, future, stream::Fuse, Sink, Stream, StreamExt};
 use std::{
     fmt,
@@ -191,7 +191,7 @@ impl Sink<Event> for Fanout {
 #[cfg(test)]
 mod tests {
     use super::{ControlMessage, Fanout};
-    use crate::{test_util::collect_ready, Event};
+    use crate::{event::Event, test_util::collect_ready};
     use futures::{channel::mpsc, stream, FutureExt, Sink, SinkExt, StreamExt};
     use std::{
         pin::Pin,

--- a/src/transforms/ansi_stripper.rs
+++ b/src/transforms/ansi_stripper.rs
@@ -1,9 +1,9 @@
 use crate::{
     config::{DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription},
-    event::Value,
+    event::{Event, Value},
     internal_events::{AnsiStripperFailed, AnsiStripperFieldInvalid, AnsiStripperFieldMissing},
     transforms::{FunctionTransform, Transform},
-    Event, Result,
+    Result,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -98,8 +98,7 @@ mod tests {
     use super::CoercerConfig;
     use crate::{
         config::{GlobalOptions, TransformConfig},
-        event::{LogEvent, Value},
-        Event,
+        event::{Event, LogEvent, Value},
     };
     use pretty_assertions::assert_eq;
 

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -81,7 +81,7 @@ impl FunctionTransform for FieldFilter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Event;
+    use crate::event::Event;
 
     #[test]
     fn generate_config() {

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -75,7 +75,7 @@ mod test {
     use super::*;
     use crate::{
         conditions::{is_log::IsLogConfig, ConditionConfig},
-        Event,
+        event::Event,
     };
 
     #[test]

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -151,9 +151,7 @@ mod tests {
     use super::GrokParserConfig;
     use crate::{
         config::{log_schema, GlobalOptions, TransformConfig},
-        event,
-        event::LogEvent,
-        Event,
+        event::{self, Event, LogEvent},
     };
     use pretty_assertions::assert_eq;
     use serde_json::json;

--- a/src/transforms/key_value_parser.rs
+++ b/src/transforms/key_value_parser.rs
@@ -187,8 +187,7 @@ mod tests {
     use super::KeyValueConfig;
     use crate::{
         config::{GlobalOptions, TransformConfig},
-        event::{LogEvent, Value},
-        Event,
+        event::{Event, LogEvent, Value},
     };
 
     async fn parse_log(

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -3,15 +3,13 @@ use crate::{
         log_schema, DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription,
     },
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
-    event::LogEvent,
-    event::Value,
+    event::{Event, LogEvent, Value},
     internal_events::{
         LogToMetricFieldNotFound, LogToMetricParseFloatError, LogToMetricTemplateParseError,
         TemplateRenderingFailed,
     },
     template::{Template, TemplateParseError, TemplateRenderingError},
     transforms::{FunctionTransform, Transform},
-    Event,
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -112,8 +112,7 @@ mod tests {
     use super::LogfmtConfig;
     use crate::{
         config::{GlobalOptions, TransformConfig},
-        event::{LogEvent, Value},
-        Event,
+        event::{Event, LogEvent, Value},
     };
 
     #[test]

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::event::Event;
 use futures::Stream;
 use snafu::Snafu;
 use std::pin::Pin;

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -425,7 +425,7 @@ pub fn get_value_merger(v: Value, m: &MergeStrategy) -> Result<Box<dyn ReduceVal
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Event;
+    use crate::event::Event;
     use serde_json::json;
 
     #[test]

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -307,8 +307,7 @@ mod tests {
     use super::RegexParserConfig;
     use crate::{
         config::{GlobalOptions, TransformConfig},
-        event::{LogEvent, Value},
-        Event,
+        event::{Event, LogEvent, Value},
     };
 
     #[test]

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -1,8 +1,8 @@
 use crate::{
     config::{DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription},
+    event::Event,
     internal_events::RemoveFieldsFieldMissing,
     transforms::{FunctionTransform, Transform},
-    Event,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription},
+    event::Event,
     transforms::{FunctionTransform, Transform},
-    Event,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -141,8 +141,8 @@ pub fn split(input: &str, separator: Option<String>) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{LogEvent, Value};
-    use crate::{config::TransformConfig, Event};
+    use crate::config::TransformConfig;
+    use crate::event::{Event, LogEvent, Value};
 
     #[test]
     fn generate_config() {

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -1,12 +1,12 @@
 use crate::transforms::TaskTransform;
 use crate::{
     config::{DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription},
+    event::Event,
     internal_events::{
         TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
         TagCardinalityValueLimitReached,
     },
     transforms::Transform,
-    Event,
 };
 use bloom::{BloomFilter, ASMS};
 use futures::{Stream, StreamExt};

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -127,8 +127,7 @@ mod tests {
     use super::TokenizerConfig;
     use crate::{
         config::{GlobalOptions, TransformConfig},
-        event::{LogEvent, Value},
-        Event,
+        event::{Event, LogEvent, Value},
     };
 
     #[test]

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -1,4 +1,4 @@
-use crate::{stats, Event};
+use crate::{event::Event, stats};
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use std::time::{Duration, Instant};

--- a/src/wasm/context.rs
+++ b/src/wasm/context.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::event::Event;
 use std::collections::LinkedList;
 
 #[derive(Default)]

--- a/src/wasm/hostcall/mod.rs
+++ b/src/wasm/hostcall/mod.rs
@@ -1,8 +1,8 @@
 //! Hostcall endpoints exposed to guests.
 use super::context::EventBuffer;
+use crate::event::Event;
 use crate::wasm::context::RaisedError;
 use crate::wasm::WasmModuleConfig;
-use crate::Event;
 use lucet_runtime::vmctx::Vmctx;
 use std::convert::TryInto;
 use vector_wasm::Registration;

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! **Note:** This code is experimental.
 
-use crate::{internal_events, Event, Result};
+use crate::{event::Event, internal_events, Result};
 use lucet_runtime::{DlModule, InstanceHandle, Limits, MmapRegion, Region};
 use lucet_wasi::WasiCtxBuilder;
 use lucetc::{Bindings, Lucetc, LucetcOpts};

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -12,10 +12,10 @@ use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use vector::{
     config::{self, SinkConfig, SinkContext, SourceConfig, SourceContext},
+    event::Event,
     sinks::{self, Healthcheck, VectorSink},
     sources,
     test_util::{next_addr, random_lines, send_lines, start_topology, wait_for_tcp, CountReceiver},
-    Event,
 };
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -34,13 +34,13 @@ use vector::{
     },
     event::{
         metric::{self, MetricValue},
-        Value,
+        Event, Value,
     },
     sinks::{util::StreamSink, Healthcheck, VectorSink},
     sources::Source,
     test_util::{temp_dir, temp_file},
     transforms::{FunctionTransform, Transform},
-    Event, Pipeline,
+    Pipeline,
 };
 
 pub fn sink(channel_size: usize) -> (mpsc::Receiver<Event>, MockSinkConfig<Pipeline>) {


### PR DESCRIPTION
My end goal here is to move the `Event` and related types into
`vector-core`. This is possible but trickier if we maintain a top-level `Event`
import in vector and so here I've adjusted all imports of the relevant type to
`crate::event::Event`, removing the top-level `Event`.

This is all mechanical work and I have intentionally not changed any logic, in
deference to the size of this PR.

REF #7148

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
