### PR TITLE
chore: Move `Result` and `Error` into vector-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7799,6 +7799,7 @@ dependencies = [
  "uuid 0.8.2",
  "vector-api-client",
  "vector-wasm",
+ "vector_core",
  "vrl",
  "vrl-cli",
  "vrl-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ prometheus-parser = { path = "lib/prometheus-parser", optional = true }
 shared = { path = "lib/shared" }
 tracing-limit = { path = "lib/tracing-limit" }
 vector-api-client = { path = "lib/vector-api-client", optional = true }
+vector_core = { path = "lib/vector-core" }
 vrl-cli = { path = "lib/vrl/cli", optional = true }
 
 # Tokio / Futures

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -12,6 +12,14 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 
+/// Vector's basic error type, dynamically dispatched and safe to send across
+/// threads.
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Vector's basic result type, defined in terms of [`Error`] and generic over
+/// `T`.
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,7 @@ pub mod vector_windows;
 pub use event::{Event, Value};
 pub use pipeline::Pipeline;
 
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
-pub type Result<T> = std::result::Result<T, Error>;
+pub use vector_core::{Error, Result};
 
 pub fn vector_version() -> impl std::fmt::Display {
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
These two types are required for the `Event` interface. I have re-exported them
back in the top-level package so no code changes are necessary at that level.

REF #7148 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
