### PR TITLE
chore(deps, security): Remove RUSTSEC-2020-0053 from ignore list since `dirs` is maintained again

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,10 +40,6 @@ ignore = [
     "RUSTSEC-2019-0036",
     "RUSTSEC-2020-0036",
 
-    # dirs is unmaintained, use dirs-next instead
-    # https://github.com/timberio/vector/issues/5584
-    "RUSTSEC-2020-0053",
-
     # stdweb is unmaintained
     # https://github.com/timberio/vector/issues/5585
     "RUSTSEC-2020-0056",


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/5584.