### PR TITLE
chore(deps): Remove RUSTSEC-2020-0146 from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -55,8 +55,4 @@ ignore = [
     # Soundness issues in `raw-cpuid`
     # https://github.com/timberio/vector/issues/6223
     "RUSTSEC-2021-0013",
-
-    # arr! macro erases lifetimes
-    # https://github.com/timberio/vector/issues/6584
-    "RUSTSEC-2020-0146",
 ]


### PR DESCRIPTION
Appears to no longer be relevant.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
