### PR TITLE
enhancement(kubernetes_logs source): Allow configuration of max_line_bytes

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -211,6 +211,15 @@ components: sources: kubernetes_logs: {
 				syntax: "literal"
 			}
 		}
+		max_line_bytes: {
+			common:      false
+			description: "The maximum number of a bytes a line can contain before being discarded. This protects against malformed lines or tailing incorrect files."
+			required:    false
+			type: uint: {
+				default: 32_768
+				unit:    "bytes"
+			}
+		}
 		timezone: configuration._timezone
 	}
 


### PR DESCRIPTION
Fixes: #6966

This is specifically to allow a user to workaround the too-low hardcoded
value that was being used.

We have https://github.com/timberio/vector/issues/6967 to address that.

I lost the logs that the user provided that ran over that limit but
I believe it was due to having a very large number of labels in the
metadata for each message which is not included in the normal 16 KB
docker limit.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
