### PR TITLE
chore: Run cargo-hack on self-hosted machines

### DIFF
--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -26,7 +26,7 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: cargo install cargo-hack
-      - run: cargo hack check --each-feature --clean-per-run
+      - run: cargo hack check --each-feature
 
   cargo-hack-failure:
     name: cargo-hack-failure

--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -3,6 +3,7 @@
 name: cargo_hack
 
 on:
+  pull_request: {}
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -15,7 +16,7 @@ env:
 
 jobs:
   hack:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     name: Cargo Hack Check - Powerset
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -1,5 +1,6 @@
 # A workflow that runs [cargo-hack](https://github.com/taiki-e/cargo-hack)
-# across the powerset of our features.
+# across our feature flags. We do not run a powerset as there's too many
+# features to fit all that in memory.
 name: cargo_hack
 
 on:
@@ -17,7 +18,7 @@ env:
 jobs:
   hack:
     runs-on: [self-hosted, linux, x64, general]
-    name: Cargo Hack Check - Powerset
+    name: Cargo Hack Check
     steps:
       - uses: actions/checkout@v2
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -25,7 +26,7 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: cargo install cargo-hack
-      - run: cargo hack check --feature-powerset --clean-per-run
+      - run: cargo hack check --each-feature --clean-per-run
 
   cargo-hack-failure:
     name: cargo-hack-failure

--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   hack:
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x64, general]
     name: Cargo Hack Check - Powerset
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -4,7 +4,6 @@
 name: cargo_hack
 
 on:
-  pull_request: {}
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/cargo_hack.yml
+++ b/.github/workflows/cargo_hack.yml
@@ -27,16 +27,19 @@ jobs:
       - run: cargo install cargo-hack
       - run: cargo hack check --each-feature
 
-  cargo-hack-failure:
-    name: cargo-hack-failure
-    if: failure() && github.ref == 'refs/heads/master'
-    needs:
-      - hack
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Discord notification
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      uses: Ilshidur/action-discord@0.3.0
-      with:
-        args: "Master cargo-hack failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"
+  # Temporarily disabled until we achieve a clean nightly run of cargo-hack,
+  # which is blocked behind known failures.
+
+  # cargo-hack-failure:
+  #   name: cargo-hack-failure
+  #   if: failure() && github.ref == 'refs/heads/master'
+  #   needs:
+  #     - hack
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #   - name: Discord notification
+  #     env:
+  #       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+  #     uses: Ilshidur/action-discord@0.3.0
+  #     with:
+  #       args: "Master cargo-hack failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"


### PR DESCRIPTION
We found in the previous run of cargo-hack that it was OOM'ed. While we were
expecting a build failure -- see #7222 -- we did not expect _that_ failure.
Run on self-hosted hardware to get more memory for the build.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
