### PR TITLE
chore(sinks): Drop unnecessary `Request` parameter from types

### DIFF
--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -61,7 +61,6 @@ where
         HttpBatchService<BoxFuture<'static, crate::Result<hyper::Request<Vec<u8>>>>, B::Output>,
         B,
         L,
-        B::Output,
     >,
     // An empty slot is needed to buffer an item where we encoded it but
     // the inner sink is applying back pressure. This trick is used in the `WithFlatMap`
@@ -197,7 +196,6 @@ where
         B,
         L,
         K,
-        B::Output,
     >,
     slot: Option<B::Input>,
 }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -22,8 +22,8 @@ use tower::{
 };
 
 pub type Svc<S, L> = RateLimit<Retry<FixedRetryPolicy<L>, AdaptiveConcurrencyLimit<Timeout<S>, L>>>;
-pub type TowerBatchedSink<S, B, L, Request> = BatchSink<Svc<S, L>, B, Request>;
-pub type TowerPartitionSink<S, B, L, K, Request> = PartitionBatchSink<Svc<S, L>, B, K, Request>;
+pub type TowerBatchedSink<S, B, L> = BatchSink<Svc<S, L>, B>;
+pub type TowerPartitionSink<S, B, L, K> = PartitionBatchSink<Svc<S, L>, B, K>;
 
 pub trait ServiceBuilderExt<L> {
     fn map<R1, R2, F>(self, f: F) -> ServiceBuilder<Stack<MapLayer<R1, R2>, L>>
@@ -248,24 +248,24 @@ impl TowerRequestSettings {
         )
     }
 
-    pub fn partition_sink<B, L, S, K, Request>(
+    pub fn partition_sink<B, L, S, K>(
         &self,
         retry_logic: L,
         service: S,
         batch: B,
         batch_timeout: Duration,
         acker: Acker,
-    ) -> TowerPartitionSink<S, B, L, K, Request>
+    ) -> TowerPartitionSink<S, B, L, K>
     where
         L: RetryLogic<Response = S::Response>,
-        S: Service<Request> + Clone + Send + 'static,
+        S: Service<B::Output> + Clone + Send + 'static,
         S::Error: Into<crate::Error> + Send + Sync + 'static,
         S::Response: Send + Response,
         S::Future: Send + 'static,
-        B: Batch<Output = Request>,
+        B: Batch,
         B::Input: Partition<K>,
+        B::Output: Send + Clone + 'static,
         K: Hash + Eq + Clone + Send + 'static,
-        Request: Send + Clone + 'static,
     {
         PartitionBatchSink::new(
             self.service(retry_logic, service),
@@ -275,22 +275,22 @@ impl TowerRequestSettings {
         )
     }
 
-    pub fn batch_sink<B, L, S, Request>(
+    pub fn batch_sink<B, L, S>(
         &self,
         retry_logic: L,
         service: S,
         batch: B,
         batch_timeout: Duration,
         acker: Acker,
-    ) -> TowerBatchedSink<S, B, L, Request>
+    ) -> TowerBatchedSink<S, B, L>
     where
         L: RetryLogic<Response = S::Response>,
-        S: Service<Request> + Clone + Send + 'static,
+        S: Service<B::Output> + Clone + Send + 'static,
         S::Error: Into<crate::Error> + Send + Sync + 'static,
         S::Response: Send + Response,
         S::Future: Send + 'static,
-        B: Batch<Output = Request>,
-        Request: Send + Clone + 'static,
+        B: Batch,
+        B::Output: Send + Clone + 'static,
     {
         BatchSink::new(
             self.service(retry_logic, service),


### PR DESCRIPTION
Just a code simplification I pulled out of my current work.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>