### PR TITLE
chore(external docs): Document VRL |= operator

### DIFF
--- a/docs/reference/remap/expressions/assignment.cue
+++ b/docs/reference/remap/expressions/assignment.cue
@@ -40,6 +40,21 @@ remap: expressions: assignment: {
 						.field = "value"
 						```
 						"""
+					"|=": """
+						Object merge assignment operator. Assigns the result of the right-hand side, merged with the left-hand side, to the left-hand side:
+
+						```vrl
+						.field |= {"foo": "bar"}
+						```
+
+						This is equivalent to using the `merge` function:
+
+						```vrl
+						.field = merge(.field, {"foo": "bar"})
+						```
+
+						This can only be used if both the left-hand side and right-hand side are objects.
+						"""
 					"??=": """
 						Assigns _only_ if the right-hand side doesn't error. This is useful when invoking fallible
 						functions on the right-hand side:
@@ -99,6 +114,14 @@ remap: expressions: assignment: {
 				my_variable = "Hello, World!"
 				"""#
 			return: "Hello, World!"
+		},
+		{
+			title: "Object merge assignment"
+			source: #"""
+				my_variable = {"message": "Hello, World!"}
+				my_variable |= {"level": "info"}
+				"""#
+			return: {"level": "info", "message": "Hello, World!"}
 		},
 		{
 			title: "Fallible assignment (success)"


### PR DESCRIPTION
Closes #6900

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
