### PR TITLE
feat(remap transform): Allow emitting multiple events from remap transform

### DIFF
--- a/src/event/log_event.rs
+++ b/src/event/log_event.rs
@@ -20,6 +20,10 @@ pub struct LogEvent {
 }
 
 impl LogEvent {
+    pub fn new(fields: BTreeMap<String, Value>, metadata: EventMetadata) -> Self {
+        Self { fields, metadata }
+    }
+
     pub fn new_with_metadata(metadata: EventMetadata) -> Self {
         Self {
             fields: Default::default(),


### PR DESCRIPTION
Working on #4908, I needed a way to emit multiple events (specifically: extract multiple logs from one AWS CloudTrail log object).

This implementation works by adding a `emit_multiple` flag to the `remap` transform, which expects the result of a VRL program to be an array when set. The objects of the array are then emitted as individual events.

The current implementation wouldn't be useful yet without having a `map` function on VRL arrays to parse the individual CloudTrail logs from the parent object.

Unfortunately, I did not discover https://github.com/timberio/vector/issues/6330, https://github.com/timberio/vector/issues/6031 and https://github.com/timberio/vector/pull/7038 before working on this, so I'll put this PR back as draft and maybe it can serve as an example in this discussion.