### PR TITLE
fix(kafka source): Fix runaway memory usage of kafka source

### DIFF
--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -160,7 +160,7 @@ impl Ingestor {
         let mut stream =
             IntervalStream::new(time::interval(self.poll_interval)).take_until(shutdown);
 
-        while stream.next().await {
+        while stream.next().await.is_some() {
             self.run_once(&mut out).await
         }
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -160,7 +160,7 @@ impl Ingestor {
         let mut stream =
             IntervalStream::new(time::interval(self.poll_interval)).take_until(shutdown);
 
-        while let Some(_) = stream.next().await {
+        while stream.next().await {
             self.run_once(&mut out).await
         }
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -156,16 +156,18 @@ impl Ingestor {
         })
     }
 
-    pub(super) async fn run(self, out: Pipeline, shutdown: ShutdownSignal) -> Result<(), ()> {
-        IntervalStream::new(time::interval(self.poll_interval))
-            .take_until(shutdown)
-            .for_each(|_| self.run_once(&out))
-            .await;
+    pub(super) async fn run(self, mut out: Pipeline, shutdown: ShutdownSignal) -> Result<(), ()> {
+        let mut stream =
+            IntervalStream::new(time::interval(self.poll_interval)).take_until(shutdown);
+
+        while let Some(_) = stream.next().await {
+            self.run_once(&mut out).await
+        }
 
         Ok(())
     }
 
-    async fn run_once(&self, out: &Pipeline) {
+    async fn run_once(&self, out: &mut Pipeline) {
         let messages = self
             .receive_messages()
             .inspect_ok(|messages| {
@@ -196,7 +198,7 @@ impl Ingestor {
                 .clone()
                 .unwrap_or_else(|| "<unknown>".to_owned());
 
-            match self.handle_sqs_message(message, out.clone()).await {
+            match self.handle_sqs_message(message, out).await {
                 Ok(()) => {
                     emit!(SqsMessageProcessingSucceeded {
                         message_id: &message_id
@@ -230,7 +232,7 @@ impl Ingestor {
     async fn handle_sqs_message(
         &self,
         message: Message,
-        out: Pipeline,
+        out: &mut Pipeline,
     ) -> Result<(), ProcessingError> {
         let s3_event: S3Event = serde_json::from_str(message.body.unwrap_or_default().as_ref())
             .context(InvalidSqsMessage {
@@ -243,10 +245,10 @@ impl Ingestor {
     async fn handle_s3_event(
         &self,
         s3_event: S3Event,
-        mut out: Pipeline,
+        out: &mut Pipeline,
     ) -> Result<(), ProcessingError> {
         for record in s3_event.records {
-            self.handle_s3_event_record(record, &mut out).await?
+            self.handle_s3_event_record(record, out).await?
         }
         Ok(())
     }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -144,11 +144,6 @@ async fn kafka_source(
     let mut stream = consumer.stream().take_until(shutdown);
 
     while let Some(message) = stream.next().await {
-        let key_field = key_field.clone();
-        let topic_key = topic_key.clone();
-        let partition_key = partition_key.clone();
-        let offset_key = offset_key.clone();
-
         match message {
             Err(error) => {
                 emit!(KafkaEventFailed { error });

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -203,10 +203,10 @@ async fn kafka_source(
                 }
                 log.insert(&headers_key, Value::from(headers_map));
 
-                // TODO what should we do if we encounter an error here?
-                let _ = consumer.store_offset(&msg).map_err(|error| {
+                if let Err(error) = consumer.store_offset(&msg) {
                     emit!(KafkaOffsetUpdateFailed { error });
-                });
+                    continue;
+                }
 
                 let _ = out
                     .send(event)

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -17,7 +17,7 @@ use rdkafka::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::{collections::BTreeMap, collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, collections::HashMap};
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -108,7 +108,18 @@ impl_generate_config_from_default!(KafkaSourceConfig);
 #[typetag::serde(name = "kafka")]
 impl SourceConfig for KafkaSourceConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        kafka_source(self, cx.shutdown, cx.out)
+        let consumer = create_consumer(self)?;
+
+        Ok(Box::pin(kafka_source(
+            consumer,
+            self.key_field.clone(),
+            self.topic_key.clone(),
+            self.partition_key.clone(),
+            self.offset_key.clone(),
+            self.headers_key.clone(),
+            cx.shutdown,
+            cx.out,
+        )))
     }
 
     fn output_type(&self) -> DataType {
@@ -120,121 +131,97 @@ impl SourceConfig for KafkaSourceConfig {
     }
 }
 
-fn kafka_source(
-    config: &KafkaSourceConfig,
+async fn kafka_source(
+    consumer: StreamConsumer,
+    key_field: String,
+    topic_key: String,
+    partition_key: String,
+    offset_key: String,
+    headers_key: String,
     shutdown: ShutdownSignal,
-    out: Pipeline,
-) -> crate::Result<super::Source> {
-    let key_field = config.key_field.clone();
-    let topic_key = config.topic_key.clone();
-    let partition_key = config.partition_key.clone();
-    let offset_key = config.offset_key.clone();
-    let headers_key = config.headers_key.clone();
-    let consumer = Arc::new(create_consumer(config)?);
+    mut out: Pipeline,
+) -> Result<(), ()> {
+    let mut stream = consumer.stream().take_until(shutdown);
 
-    Ok(Box::pin(async move {
-        let shutdown = shutdown;
+    while let Some(message) = stream.next().await {
+        let key_field = key_field.clone();
+        let topic_key = topic_key.clone();
+        let partition_key = partition_key.clone();
+        let offset_key = offset_key.clone();
 
-        Arc::clone(&consumer)
-            .stream()
-            .take_until(shutdown)
-            .then(move |message| {
-                let key_field = key_field.clone();
-                let topic_key = topic_key.clone();
-                let partition_key = partition_key.clone();
-                let offset_key = offset_key.clone();
-                let headers_key = headers_key.clone();
-                let consumer = Arc::clone(&consumer);
+        match message {
+            Err(error) => {
+                emit!(KafkaEventFailed { error });
+            }
+            Ok(msg) => {
+                emit!(KafkaEventReceived {
+                    byte_size: msg.payload_len()
+                });
 
-                async move {
-                    match message {
-                        Err(error) => {
-                            emit!(KafkaEventFailed { error });
-                            Err(())
-                        }
-                        Ok(msg) => {
-                            emit!(KafkaEventReceived {
-                                byte_size: msg.payload_len()
-                            });
+                let payload = match msg.payload() {
+                    None => continue, // skip messages with empty payload
+                    Some(payload) => payload,
+                };
+                let mut event = Event::new_empty_log();
+                let log = event.as_mut_log();
 
-                            let payload = match msg.payload() {
-                                None => return Err(()), // skip messages with empty payload
-                                Some(payload) => payload,
-                            };
-                            let mut event = Event::new_empty_log();
-                            let log = event.as_mut_log();
+                log.insert(
+                    log_schema().message_key(),
+                    Value::from(Bytes::from(payload.to_owned())),
+                );
 
-                            log.insert(
-                                log_schema().message_key(),
-                                Value::from(Bytes::from(payload.to_owned())),
+                // Extract timestamp from kafka message
+                let timestamp = msg
+                    .timestamp()
+                    .to_millis()
+                    .and_then(|millis| Utc.timestamp_millis_opt(millis).latest())
+                    .unwrap_or_else(Utc::now);
+                log.insert(log_schema().timestamp_key(), timestamp);
+
+                // Add source type
+                log.insert(log_schema().source_type_key(), Bytes::from("kafka"));
+
+                let msg_key = msg
+                    .key()
+                    .map(|key| Value::from(String::from_utf8_lossy(key).to_string()))
+                    .unwrap_or(Value::Null);
+                log.insert(&key_field, msg_key);
+
+                log.insert(&topic_key, Value::from(msg.topic().to_string()));
+
+                log.insert(&partition_key, Value::from(msg.partition()));
+
+                log.insert(&offset_key, Value::from(msg.offset()));
+
+                let mut headers_map = BTreeMap::new();
+                if let Some(headers) = msg.headers() {
+                    // Using index-based for loop because rdkafka's `Headers` trait
+                    // does not provide Iterator-based API
+                    for i in 0..headers.count() {
+                        if let Some(header) = headers.get(i) {
+                            headers_map.insert(
+                                header.0.to_string(),
+                                Bytes::from(header.1.to_owned()).into(),
                             );
-
-                            // Extract timestamp from kafka message
-                            let timestamp = msg
-                                .timestamp()
-                                .to_millis()
-                                .and_then(|millis| Utc.timestamp_millis_opt(millis).latest())
-                                .unwrap_or_else(Utc::now);
-                            log.insert(log_schema().timestamp_key(), timestamp);
-
-                            // Add source type
-                            log.insert(log_schema().source_type_key(), Bytes::from("kafka"));
-
-                            let msg_key = msg
-                                .key()
-                                .map(|key| Value::from(String::from_utf8_lossy(key).to_string()))
-                                .unwrap_or(Value::Null);
-                            log.insert(&key_field, msg_key);
-
-                            log.insert(&topic_key, Value::from(msg.topic().to_string()));
-
-                            log.insert(&partition_key, Value::from(msg.partition()));
-
-                            log.insert(&offset_key, Value::from(msg.offset()));
-
-                            let mut headers_map = BTreeMap::new();
-                            if let Some(headers) = msg.headers() {
-                                // Using index-based for loop because rdkafka's `Headers` trait
-                                // does not provide Iterator-based API
-                                for i in 0..headers.count() {
-                                    if let Some(header) = headers.get(i) {
-                                        headers_map.insert(
-                                            header.0.to_string(),
-                                            Bytes::from(header.1.to_owned()).into(),
-                                        );
-                                    }
-                                }
-                            }
-                            log.insert(headers_key, Value::from(headers_map));
-
-                            consumer.store_offset(&msg).map_err(|error| {
-                                emit!(KafkaOffsetUpdateFailed { error });
-                            })?;
-
-                            Ok(event)
                         }
                     }
                 }
-            })
-            // Try `forward` after removing old futures.
-            // Error: implementation of `futures_core::stream::Stream` is not general enough
-            // .forward(
-            //     out.sink_compat()
-            //         .sink_map_err(|error| error!(message = "Error sending to sink.", %error)),
-            // )
-            .for_each(|item| {
-                let mut out = out.clone();
-                async move {
-                    if let Ok(item) = item {
-                        if let Err(error) = out.send(item).await {
-                            error!(message = "Error sending to sink.", %error);
-                        }
-                    }
-                }
-            })
-            .await;
-        Ok(())
-    }))
+                log.insert(&headers_key, Value::from(headers_map));
+
+                // TODO what should we do if we encounter an error here?
+                let _ = consumer.store_offset(&msg).map_err(|error| {
+                    emit!(KafkaOffsetUpdateFailed { error });
+                });
+
+                let _ = out
+                    .send(event)
+                    .await
+                    .map_err(|error| error!(message = "Error sending to sink.", %error));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn create_consumer(config: &KafkaSourceConfig) -> crate::Result<StreamConsumer> {
@@ -272,8 +259,7 @@ fn create_consumer(config: &KafkaSourceConfig) -> crate::Result<StreamConsumer> 
 
 #[cfg(test)]
 mod test {
-    use super::{kafka_source, KafkaSourceConfig};
-    use crate::{shutdown::ShutdownSignal, Pipeline};
+    use super::*;
 
     #[test]
     fn generate_config() {
@@ -300,18 +286,18 @@ mod test {
     }
 
     #[tokio::test]
-    async fn kafka_source_create_ok() {
+    async fn consumer_create_ok() {
         let config = make_config();
-        assert!(kafka_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_ok());
+        assert!(create_consumer(&config).is_ok());
     }
 
     #[tokio::test]
-    async fn kafka_source_create_incorrect_auto_offset_reset() {
+    async fn consumer_create_incorrect_auto_offset_reset() {
         let config = KafkaSourceConfig {
             auto_offset_reset: "incorrect-auto-offset-reset".to_string(),
             ..make_config()
         };
-        assert!(kafka_source(&config, ShutdownSignal::noop(), Pipeline::new_test().0).is_err());
+        assert!(create_consumer(&config).is_err());
     }
 }
 
@@ -397,7 +383,17 @@ mod integration_test {
 
         println!("Receiving event...");
         let (tx, rx) = Pipeline::new_test();
-        tokio::spawn(kafka_source(&config, ShutdownSignal::noop(), tx).unwrap());
+        let consumer = create_consumer(&config).unwrap();
+        tokio::spawn(kafka_source(
+            consumer,
+            config.key_field,
+            config.topic_key,
+            config.partition_key,
+            config.offset_key,
+            config.headers_key,
+            ShutdownSignal::noop(),
+            tx,
+        ));
         let events = collect_n(rx, 1).await;
         println!("Received event  {:?}", events[0].as_log());
 


### PR DESCRIPTION
Fixes: #7258

Previously, we were cloning the `Pipeline` for each message which, due
to the behavior of futures::sync::mpsc::channel resulted in the
effective channel buffer growing by one for each message rather than any
back pressure.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
