### PR TITLE
fix(external docs): typo

### DIFF
--- a/docs/reference/components/transforms/reduce.cue
+++ b/docs/reference/components/transforms/reduce.cue
@@ -208,7 +208,7 @@ components: transforms: reduce: {
 			]
 			configuration: {
 				group_by: ["host", "pid", "tid"]
-				marge_strategies: message: "concat_newline"
+				merge_strategies: message: "concat_newline"
 				starts_when: #"match(.message, /^[^\s]/)"#
 			}
 			output: [


### PR DESCRIPTION
Can be seen [here](https://vector.dev/docs/reference/configuration/transforms/reduce/). I believe this is the right place to fix but am not super familiar with how docs are generated.