### PR TITLE
chore: Make CI tests run a little more quiet

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -62,7 +62,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -62,11 +62,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -117,7 +121,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -138,7 +146,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -173,7 +185,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       # Why is this build, not check? Because we need to make sure the linking phase works.
@@ -200,7 +216,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -223,7 +243,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -250,6 +274,16 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug
+            target/release
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: |
           TEMP=$(mktemp -d)
           curl \
@@ -291,7 +325,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target/debug
+            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Make slim-builds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,27 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
+
+  # Remove this once https://github.com/timberio/vector/issues/3771 is closed.
+  # Then, modify the `cross-linux` job to run `test` instead of `build`.
+  test-benches-linux:
+    name: Unit - x86_64-unknown-linux-gnu
+    runs-on: [self-hosted, linux, x64, general]
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: make slim-builds
       - run: make test-benches
 
   test-misc:
@@ -185,8 +206,29 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
-      - run: make test-benches
       - run: make test-behavior
+
+  test-benches-mac:
+    name: Unit - Mac
+    # Full CI suites for this platform were only recently introduced.
+    # Some failures are permitted until we can properly correct them.
+    continue-on-error: true
+    runs-on: macos-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: bash scripts/environment/bootstrap-macos-10.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: make slim-builds
+      - run: make test-benches
 
   test-windows:
     name: Unit - Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,8 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
-      - run: make test-components
+      - run: make test
+      - run: make test-benches
 
   test-misc:
     name: Miscellaneous - Linux
@@ -183,7 +184,8 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
-      - run: make test-components
+      - run: make test
+      - run: make test-benches
       - run: make test-behavior
 
   test-windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,7 +347,9 @@ jobs:
       - cross-linux
       - test-misc
       - test-linux
+      - test-benches-linux
       - test-mac
+      - test-benches-mac
       - test-windows
       - test-vrl
       - check-component-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
   # Remove this once https://github.com/timberio/vector/issues/3771 is closed.
   # Then, modify the `cross-linux` job to run `test` instead of `build`.
   test-benches-linux:
-    name: Unit - x86_64-unknown-linux-gnu
+    name: Bench Unit - x86_64-unknown-linux-gnu
     runs-on: [self-hosted, linux, x64, general]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
@@ -209,7 +209,7 @@ jobs:
       - run: make test-behavior
 
   test-benches-mac:
-    name: Unit - Mac
+    name: Bench Unit - Mac
     # Full CI suites for this platform were only recently introduced.
     # Some failures are permitted until we can properly correct them.
     continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,11 +95,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -121,11 +117,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -146,11 +138,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -185,11 +173,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       # Why is this build, not check? Because we need to make sure the linking phase works.
@@ -216,11 +200,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -243,11 +223,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -274,16 +250,6 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2.1.5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/debug
-            target/release
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: |
           TEMP=$(mktemp -d)
           curl \
@@ -325,11 +291,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/debug
-            target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Make slim-builds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -658,48 +658,40 @@ wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-
 [[bench]]
 name = "default"
 harness = false
-test = true
 required-features = ["benches"]
 
 [[bench]]
 name = "wasm"
 path = "benches/wasm/mod.rs"
 harness = false
-test = true
 required-features = ["wasm-benches"]
 
 [[bench]]
 name = "remap"
 harness = false
-test = true
 required-features = ["remap-benches"]
 
 [[bench]]
 name = "languages"
 harness = false
-test = true
 required-features = ["language-benches"]
 
 [[bench]]
 name = "metrics_on"
 harness = false
-test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "metrics_no_tracing_integration"
 harness = false
-test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "metrics_off"
 harness = false
-test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "distribution_statistic"
 harness = false
-test = true
 required-features = ["statistic-benches"]

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,12 @@ cross-image-%:
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --workspace --no-fail-fast --no-default-features --features ${DEFAULT_FEATURES} ${SCOPE} -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --quiet --workspace --no-fail-fast --no-default-features --features ${DEFAULT_FEATURES} ${SCOPE}
+
+.PHONY: test-benches
+test-benches: ## Run benchmarks in debug mode to trigger debug_assertions
+test-benches: export DEFAULT_FEATURES:="benches metrics-benches remap-benches"
+test-benches: test
 
 .PHONY: test-components
 test-components: ## Test with all components enabled

--- a/Makefile
+++ b/Makefile
@@ -285,13 +285,6 @@ test-benches: ## Run benchmarks in debug mode to trigger debug_assertions
 test-benches: export DEFAULT_FEATURES:="benches metrics-benches remap-benches"
 test-benches: test
 
-.PHONY: test-components
-test-components: ## Test with all components enabled
-# TODO(jesse) add `language-benches wasm-benches` when https://github.com/timberio/vector/issues/5106 is fixed
-# test-components: $(WASM_MODULE_OUTPUTS)
-test-components: export DEFAULT_FEATURES:="${DEFAULT_FEATURES} benches metrics-benches remap-benches"
-test-components: test
-
 .PHONY: test-all
 test-all: test test-behavior test-integration ## Runs all tests, unit, behaviorial, and integration.
 

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -172,7 +172,7 @@ where
     ///                 println!("Expired: {}", val);
     ///                 break;
     ///             }
-    ///             Some(Err(error)) => panic!(format!("Timer error: {:?}", error)),
+    ///             Some(Err(error)) => panic!("Timer error: {:?}", error),
     ///         },
     ///         _ = tokio::time::sleep(Duration::from_millis(100)) => map.insert(
     ///             "key".to_owned(),


### PR DESCRIPTION
This commit was born out of a discussion
[here](https://github.com/timberio/vector/pull/7240#discussion_r622519274). This
changes the CI tests to only output the test name when the test fails, replacing
it with a simple dot, and does not capture test output, meaning individual tests
that `println` etc are now more terse. Notably this does not reduce output
entirely -- VRL tests print their name still, there's seemingly some debug
output that is present elsewhere -- but it's a start.

I wasn't clear from the original discussion if we wanted `--quiet` or not, so I
went ahead and included it here. Happy to back that out if folks feel strongly.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
