### PR TITLE
enhancement(datadog sinks): Generic site support

### DIFF
--- a/docs/reference/components/sinks/datadog.cue
+++ b/docs/reference/components/sinks/datadog.cue
@@ -39,7 +39,7 @@ components: sinks: _datadog: {
 		endpoint: {
 			common:        false
 			description:   "The endpoint to send data to."
-			relevant_when: "region is not set"
+			relevant_when: "site is not set"
 			required:      false
 			type: string: {
 				default: null
@@ -52,13 +52,25 @@ components: sinks: _datadog: {
 			description:   "The region to send data to."
 			required:      false
 			relevant_when: "endpoint is not set"
-			warnings: []
+			warnings: ["This option has been deprecated, the `site` option should be used."]
 			type: string: {
 				default: null
 				enum: {
 					us: "United States"
 					eu: "Europe"
 				}
+				syntax: "literal"
+			}
+		}
+		site: {
+			common:        false
+			description:   "The (Datadog site)[https://docs.datadoghq.com/getting_started/site/] to send data to. "
+			required:      false
+			relevant_when: "endpoint is not set"
+			warnings: []
+			type: string: {
+				default: "datadoghq.com"
+				examples: ["us3.datadoghq.com", "datadoghq.com", "datadoghq.eu"]
 				syntax: "literal"
 			}
 		}

--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -62,6 +62,7 @@ components: sinks: datadog_logs: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
 		region:   sinks._datadog.configuration.region
+		site:     sinks._datadog.configuration.site
 	}
 
 	input: {

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -30,7 +30,9 @@ use std::{io::Write, time::Duration};
 #[serde(deny_unknown_fields)]
 pub struct DatadogLogsConfig {
     endpoint: Option<String>,
+    // Deprecated, replaced by the site option
     region: Option<super::Region>,
+    site: Option<String>,
     api_key: String,
     encoding: EncodingConfig<Encoding>,
     tls: Option<TlsConfig>,
@@ -48,11 +50,13 @@ pub struct DatadogLogsConfig {
 #[derive(Clone)]
 pub struct DatadogLogsJsonService {
     config: DatadogLogsConfig,
+    uri: String,
 }
 
 #[derive(Clone)]
 pub struct DatadogLogsTextService {
     config: DatadogLogsConfig,
+    uri: String,
 }
 
 inventory::submit! {
@@ -70,13 +74,20 @@ impl GenerateConfig for DatadogLogsConfig {
 }
 
 impl DatadogLogsConfig {
-    fn get_endpoint(&self) -> &str {
-        self.endpoint
-            .as_deref()
-            .unwrap_or_else(|| match self.region {
-                Some(super::Region::Eu) => "https://http-intake.logs.datadoghq.eu",
-                None | Some(super::Region::Us) => "https://http-intake.logs.datadoghq.com",
-            })
+    fn get_uri(&self) -> String {
+        self.endpoint.clone().unwrap_or_else(|| {
+            self.site
+                .as_ref()
+                .map(|s| format!("https://http-intake.logs.{}/v1/input", s))
+                .unwrap_or_else(|| match self.region {
+                    Some(super::Region::Eu) => {
+                        "https://http-intake.logs.datadoghq.eu/v1/input".to_string()
+                    }
+                    None | Some(super::Region::Us) => {
+                        "https://http-intake.logs.datadoghq.com/v1/input".to_string()
+                    }
+                })
+        })
     }
 
     fn batch_settings<T: Batch>(&self) -> Result<BatchSettings<T>, BatchError> {
@@ -129,10 +140,10 @@ impl DatadogLogsConfig {
     /// Build the request, GZipping the contents if the config specifies.
     fn build_request(
         &self,
+        uri: &str,
         content_type: &str,
         body: Vec<u8>,
     ) -> crate::Result<http::Request<Vec<u8>>> {
-        let uri = format!("{}/v1/input", self.get_endpoint());
         let request = Request::post(uri)
             .header("Content-Type", content_type)
             .header("DD-API-KEY", self.api_key.clone());
@@ -177,6 +188,7 @@ impl SinkConfig for DatadogLogsConfig {
                     cx,
                     DatadogLogsJsonService {
                         config: self.clone(),
+                        uri: self.get_uri(),
                     },
                     JsonArrayBuffer::new(batch_settings.size),
                     batch_settings.timeout,
@@ -188,6 +200,7 @@ impl SinkConfig for DatadogLogsConfig {
                     cx,
                     DatadogLogsTextService {
                         config: self.clone(),
+                        uri: self.get_uri(),
                     },
                     VecBuffer::new(batch_settings.size),
                     batch_settings.timeout,
@@ -239,7 +252,8 @@ impl HttpSink for DatadogLogsJsonService {
                 count: events.len(),
             });
         }
-        self.config.build_request("application/json", body)
+        self.config
+            .build_request(self.uri.as_str(), "application/json", body)
     }
 }
 
@@ -260,7 +274,8 @@ impl HttpSink for DatadogLogsTextService {
 
     async fn build_request(&self, events: Self::Output) -> crate::Result<http::Request<Vec<u8>>> {
         let body: Vec<u8> = events.into_iter().flat_map(Bytes::into_iter).collect();
-        self.config.build_request("text/plain", body)
+        self.config
+            .build_request(self.uri.as_str(), "text/plain", body)
     }
 }
 

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -50,12 +50,14 @@ pub struct DatadogLogsConfig {
 #[derive(Clone)]
 pub struct DatadogLogsJsonService {
     config: DatadogLogsConfig,
+    // Used to store the complete URI and avoid calling `get_uri` for each request
     uri: String,
 }
 
 #[derive(Clone)]
 pub struct DatadogLogsTextService {
     config: DatadogLogsConfig,
+    // Used to store the complete URI and avoid calling `get_uri` for each request
     uri: String,
 }
 
@@ -75,19 +77,21 @@ impl GenerateConfig for DatadogLogsConfig {
 
 impl DatadogLogsConfig {
     fn get_uri(&self) -> String {
-        self.endpoint.clone().unwrap_or_else(|| {
-            self.site
-                .as_ref()
-                .map(|s| format!("https://http-intake.logs.{}/v1/input", s))
-                .unwrap_or_else(|| match self.region {
-                    Some(super::Region::Eu) => {
-                        "https://http-intake.logs.datadoghq.eu/v1/input".to_string()
-                    }
-                    None | Some(super::Region::Us) => {
-                        "https://http-intake.logs.datadoghq.com/v1/input".to_string()
-                    }
-                })
-        })
+        self.endpoint
+            .clone()
+            .or_else(|| {
+                self.site
+                    .as_ref()
+                    .map(|s| format!("https://http-intake.logs.{}/v1/input", s))
+            })
+            .unwrap_or_else(|| match self.region {
+                Some(super::Region::Eu) => {
+                    "https://http-intake.logs.datadoghq.eu/v1/input".to_string()
+                }
+                None | Some(super::Region::Us) => {
+                    "https://http-intake.logs.datadoghq.com/v1/input".to_string()
+                }
+            })
     }
 
     fn batch_settings<T: Batch>(&self) -> Result<BatchSettings<T>, BatchError> {

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -78,6 +78,8 @@ struct DatadogRequest<T> {
 impl DatadogConfig {
     fn get_endpoint(&self) -> String {
         self.endpoint.clone().unwrap_or_else(|| {
+            // Follow the official Datadog agent convention:
+            // <sender-id>.agent.<site>
             let version = str::replace(crate::built_info::PKG_VERSION, ".", "-");
             format!("https://{}-vector.agent.{}", version, &self.get_site())
         })

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -46,7 +46,9 @@ pub struct DatadogConfig {
     // Deprecated name
     #[serde(alias = "host")]
     pub endpoint: Option<String>,
+    // Deprecated, replaced by the site option
     pub region: Option<super::Region>,
+    pub site: Option<String>,
     pub api_key: String,
     #[serde(default)]
     pub batch: BatchConfig,
@@ -74,13 +76,24 @@ struct DatadogRequest<T> {
 }
 
 impl DatadogConfig {
-    fn get_endpoint(&self) -> &str {
+    fn get_endpoint(&self) -> String {
+        self.endpoint.clone().unwrap_or_else(|| {
+            let version = str::replace(crate::built_info::PKG_VERSION, ".", "-");
+            format!("https://{}-vector.agent.{}", version, &self.get_site())
+        })
+    }
+
+    fn get_api_endpoint(&self) -> String {
         self.endpoint
-            .as_deref()
-            .unwrap_or_else(|| match self.region {
-                Some(super::Region::Eu) => "https://api.datadoghq.eu",
-                None | Some(super::Region::Us) => "https://api.datadoghq.com",
-            })
+            .clone()
+            .unwrap_or_else(|| format!("https://api.{}", &self.get_site()))
+    }
+
+    fn get_site(&self) -> &str {
+        self.site.as_deref().unwrap_or_else(|| match self.region {
+            Some(super::Region::Eu) => "datadoghq.eu",
+            None | Some(super::Region::Us) => "datadoghq.com",
+        })
     }
 }
 
@@ -259,7 +272,7 @@ fn build_uri(host: &str, endpoint: &'static str) -> crate::Result<Uri> {
 }
 
 async fn healthcheck(config: DatadogConfig, client: HttpClient) -> crate::Result<()> {
-    let uri = format!("{}/api/v1/validate", config.get_endpoint())
+    let uri = format!("{}/api/v1/validate", config.get_api_endpoint())
         .parse::<Uri>()
         .context(UriParseError)?;
 
@@ -507,6 +520,7 @@ mod tests {
     use chrono::offset::TimeZone;
     use http::Method;
     use pretty_assertions::assert_eq;
+    use regex::Regex;
     use std::sync::atomic::AtomicI64;
 
     #[test]
@@ -532,6 +546,7 @@ mod tests {
     async fn test_request() {
         let (sink, _cx) = load_sink::<DatadogConfig>(
             r#"
+            site = "us3.datadoghq.com"
             api_key = "test"
         "#,
         )
@@ -576,10 +591,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(req.method(), Method::POST);
-        assert_eq!(
-            req.uri(),
-            &Uri::from_static("https://api.datadoghq.com/api/v1/series")
-        );
+        let uri_validator =
+            Regex::new(r"^https://\d+-\d+-\d+-vector.agent.us3.datadoghq.com/api/v1/series$")
+                .unwrap();
+        assert!(uri_validator.is_match(&req.uri().to_string()));
     }
 
     #[test]

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -83,6 +83,9 @@ impl DatadogConfig {
         })
     }
 
+    // The API endpoint is used for healtcheck/API key validation, it is derived from the `site` or `region` option
+    // the same way the offical Datadog Agent does but the `endpoint` option still override both the main and the
+    // API endpoint.
     fn get_api_endpoint(&self) -> String {
         self.endpoint
             .clone()


### PR DESCRIPTION
As per Datadog documentation https://docs.datadoghq.com/getting_started/site/, Datadog now support several sites, at least:
* datadoghq.com
* us3.datadoghq.com
* datadoghq.eu
* ddgov-gov.com (us govcloud)

That being said a new site will be automatically supported by vector. This setting shall be prefered over the region one (it has precedence) but the ultimate endpoint can always be overiden using the `endpoint` option that supersedes both `site` and `region`. 

Closes #7303