### PR TITLE
chore(tests): Simplify `cargo test` usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - run: make test-components
+      - run: make test
 
   test-vrl:
     name: VRL - Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
-      - run: make test
+      - run: make test-components
       - run: make test-behavior
 
   test-windows:
@@ -196,9 +196,7 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: actions/checkout@v2
-      - env:
-          RUSTFLAGS: "-D warnings"
-        run: cargo test --no-fail-fast --no-default-features --features default-msvc
+      - run: make test-components
 
   test-vrl:
     name: VRL - Linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -657,40 +657,48 @@ wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-
 [[bench]]
 name = "default"
 harness = false
+test = true
 required-features = ["benches"]
 
 [[bench]]
 name = "wasm"
 path = "benches/wasm/mod.rs"
 harness = false
+test = true
 required-features = ["wasm-benches"]
 
 [[bench]]
 name = "remap"
 harness = false
+test = true
 required-features = ["remap-benches"]
 
 [[bench]]
 name = "languages"
 harness = false
+test = true
 required-features = ["language-benches"]
 
 [[bench]]
 name = "metrics_on"
 harness = false
+test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "metrics_no_tracing_integration"
 harness = false
+test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "metrics_off"
 harness = false
+test = true
 required-features = ["metrics-benches"]
 
 [[bench]]
 name = "distribution_statistic"
 harness = false
+test = true
 required-features = ["statistic-benches"]

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ cross-image-%:
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features ${DEFAULT_FEATURES} ${SCOPE} -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --workspace --no-fail-fast --no-default-features --features ${DEFAULT_FEATURES} ${SCOPE} -- --nocapture
 
 .PHONY: test-components
 test-components: ## Test with all components enabled

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ cross-image-%:
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --workspace --features ${DEFAULT_FEATURES} ${SCOPE} --all-targets -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features ${DEFAULT_FEATURES} ${SCOPE} -- --nocapture
 
 .PHONY: test-components
 test-components: ## Test with all components enabled
@@ -534,7 +534,7 @@ $(WASM_MODULE_OUTPUTS): ### Build a specific WASM module
 test-wasm: export TEST_THREADS=1
 test-wasm: export TEST_LOG=vector=trace
 test-wasm: $(WASM_MODULE_OUTPUTS)  ### Run engine tests
-	${MAYBE_ENVIRONMENT_EXEC} cargo test wasm --no-fail-fast --no-default-features --features "transforms-field_filter transforms-wasm transforms-lua transforms-add_fields" --lib --all-targets -- --nocapture
+	${MAYBE_ENVIRONMENT_EXEC} cargo test wasm --no-fail-fast --no-default-features --features "transforms-field_filter transforms-wasm transforms-lua transforms-add_fields" -- --nocapture
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 # Override this with any scopes for testing/benching.
-export SCOPE ?= ""
+export SCOPE ?=
 # Override this with any extra flags for cargo bench
 export CARGO_BENCH_FLAGS ?= ""
 # override this to put criterion output elsewhere

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -77,4 +77,5 @@ tempfile = "3.1.0"
 
 [[bench]]
 name = "buffer"
+test = true
 harness = false

--- a/lib/k8s-test-framework/src/reader.rs
+++ b/lib/k8s-test-framework/src/reader.rs
@@ -64,6 +64,7 @@ mod tests {
         list
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_reader_finite() {
         let mut command = Command::new("echo");
@@ -81,6 +82,7 @@ mod tests {
         assert!(exit_status.success());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_reader_infinite() {
         let mut command = Command::new("bash");

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -19,4 +19,5 @@ mock_instant = { version = "0.2" }
 
 [[bench]]
 name = "limit"
+test = true
 harness = false

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -29,4 +29,5 @@ shared = { path = "../../shared", default-features = false, features = ["btreema
 
 [[bench]]
 name = "kind"
+test = true
 harness = false

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -236,4 +236,5 @@ bench = false
 
 [[bench]]
 name = "benches"
+test = true
 harness = false


### PR DESCRIPTION
We currently use `--all-targets` to include benches (`--bench`), but `--all-targets` does not include `--doc` apparently (https://github.com/rust-lang/cargo/issues/6669). Instead of using `--all-targets` we just mark benches with `test = true` so that they will be tested along with the default targets (https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection)

Also:

* Avoid setting `SCOPE` by default in the `Makefile` as this causes examples to be skipped for some reason.
* Use `make test` for Windows to take advantage of existing make targets. I tried `make test-components` there too, but it failed to build krb5.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
