### PR TITLE
fix(external docs): Fix rendering of buffers/batches sections

### DIFF
--- a/docs/reference/components.cue
+++ b/docs/reference/components.cue
@@ -313,8 +313,8 @@ components: {
 			batch: {
 				enabled:      bool
 				common:       bool
-				max_bytes:    uint | null
-				max_events:   uint | null
+				max_bytes?:   uint | null
+				max_events?:  uint | null
 				timeout_secs: uint16 | null
 			}
 		}

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -19,7 +19,7 @@ components: sinks: [Name=string]: {
 					type: object: {
 						examples: []
 						options: {
-							if features.send.batch.max_bytes != null {
+							if features.send.batch.max_bytes != _|_ {
 								max_bytes: {
 									common:      true
 									description: "The maximum size of a batch, in bytes, before it is flushed."
@@ -30,7 +30,7 @@ components: sinks: [Name=string]: {
 									}
 								}
 							}
-							if features.send.batch.max_events != null {
+							if features.send.batch.max_events != _|_ {
 								max_events: {
 									common:      true
 									description: "The maximum size of a batch, in events, before it is flushed."
@@ -407,8 +407,18 @@ components: sinks: [Name=string]: {
 				if features.send.batch != _|_ {
 					if features.send.batch.enabled {
 						buffers_batches: {
+							_parameter: string
+							if features.send.batch.max_bytes != _|_ && features.send.batch.max_events == _|_ {
+								_parameter: "`max_bytes`"
+							}
+							if features.send.batch.max_bytes == _|_ && features.send.batch.max_events != _|_ {
+								_parameter: "`max_events`"
+							}
+							if features.send.batch.max_bytes != _|_ && features.send.batch.max_events != _|_ {
+								_parameter: "`max_bytes` or `max_events`"
+							}
 							title: "Buffers & batches"
-							body: #"""
+							body:  """
 									<SVG src="/optimized_svg/buffers-and-batches-serial_538_160.svg" />
 
 									This component buffers & batches data as shown in the diagram above. You'll notice that Vector treats these concepts
@@ -419,10 +429,10 @@ components: sinks: [Name=string]: {
 									*Batches* are flushed when 1 of 2 conditions are met:
 
 									1. The batch age meets or exceeds the configured `timeout_secs`.
-									2. The batch size meets or exceeds the configured <% if component.options.batch.children.respond_to?(:max_size) %>`max_size`<% else %>`max_events`<% end %>.
+									2. The batch meets or exceeds the configured \(_parameter)
 
 									*Buffers* are controlled via the [`buffer.*`](#buffer) options.
-									"""#
+									"""
 						}
 					}
 				}

--- a/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -19,7 +19,6 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    null
 				max_events:   20
 				timeout_secs: 1
 			}

--- a/docs/reference/components/sinks/aws_s3.cue
+++ b/docs/reference/components/sinks/aws_s3.cue
@@ -20,7 +20,6 @@ components: sinks: aws_s3: components._aws & {
 				enabled:      true
 				common:       true
 				max_bytes:    10000000
-				max_events:   null
 				timeout_secs: 300
 			}
 			compression: {

--- a/docs/reference/components/sinks/azure_monitor_logs.cue
+++ b/docs/reference/components/sinks/azure_monitor_logs.cue
@@ -20,7 +20,6 @@ components: sinks: azure_monitor_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    30000000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -20,7 +20,6 @@ components: sinks: clickhouse: {
 				enabled:      true
 				common:       false
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -13,7 +13,6 @@ components: sinks: datadog_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -12,7 +12,6 @@ components: sinks: datadog_metrics: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    null
 				max_events:   20
 				timeout_secs: 1
 			}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -20,7 +20,6 @@ components: sinks: elasticsearch: {
 				enabled:      true
 				common:       false
 				max_bytes:    10490000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/gcp_cloud_storage.cue
+++ b/docs/reference/components/sinks/gcp_cloud_storage.cue
@@ -20,7 +20,6 @@ components: sinks: gcp_cloud_storage: {
 				enabled:      true
 				common:       false
 				max_bytes:    10485760
-				max_events:   null
 				timeout_secs: 300
 			}
 			compression: {

--- a/docs/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/docs/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -20,7 +20,6 @@ components: sinks: gcp_stackdriver_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    5242880
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/docs/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -19,7 +19,6 @@ components: sinks: gcp_stackdriver_metrics: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    null
 				max_events:   1
 				timeout_secs: 1
 			}

--- a/docs/reference/components/sinks/honeycomb.cue
+++ b/docs/reference/components/sinks/honeycomb.cue
@@ -20,7 +20,6 @@ components: sinks: honeycomb: {
 				enabled:      true
 				common:       false
 				max_bytes:    5242880
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/http.cue
+++ b/docs/reference/components/sinks/http.cue
@@ -20,7 +20,6 @@ components: sinks: http: {
 				enabled:      true
 				common:       true
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/humio.cue
+++ b/docs/reference/components/sinks/humio.cue
@@ -34,7 +34,6 @@ components: sinks: _humio: {
 				enabled:      true
 				common:       false
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/influxdb_logs.cue
+++ b/docs/reference/components/sinks/influxdb_logs.cue
@@ -20,7 +20,6 @@ components: sinks: influxdb_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -19,7 +19,6 @@ components: sinks: influxdb_metrics: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    null
 				max_events:   20
 				timeout_secs: 1
 			}

--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -19,8 +19,8 @@ components: sinks: kafka: {
 			batch: {
 				enabled:      true
 				common:       true
-				max_bytes:    null
 				max_events:   null
+				max_bytes:    null
 				timeout_secs: null
 			}
 			compression: {

--- a/docs/reference/components/sinks/logdna.cue
+++ b/docs/reference/components/sinks/logdna.cue
@@ -20,7 +20,6 @@ components: sinks: logdna: {
 				enabled:      true
 				common:       false
 				max_bytes:    10490000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/loki.cue
+++ b/docs/reference/components/sinks/loki.cue
@@ -20,7 +20,6 @@ components: sinks: loki: {
 				enabled:      true
 				common:       false
 				max_events:   100000
-				max_bytes:    null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/new_relic_logs.cue
+++ b/docs/reference/components/sinks/new_relic_logs.cue
@@ -20,7 +20,6 @@ components: sinks: new_relic_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    5240000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/prometheus_remote_write.cue
+++ b/docs/reference/components/sinks/prometheus_remote_write.cue
@@ -19,7 +19,6 @@ components: sinks: prometheus_remote_write: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    null
 				max_events:   1000
 				timeout_secs: 1
 			}

--- a/docs/reference/components/sinks/sematext_logs.cue
+++ b/docs/reference/components/sinks/sematext_logs.cue
@@ -20,7 +20,6 @@ components: sinks: sematext_logs: {
 				enabled:      true
 				common:       false
 				max_bytes:    10490000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -20,7 +20,6 @@ components: sinks: sematext_metrics: {
 				enabled:      true
 				common:       false
 				max_bytes:    30000000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: enabled: false

--- a/docs/reference/components/sinks/splunk_hec.cue
+++ b/docs/reference/components/sinks/splunk_hec.cue
@@ -20,7 +20,6 @@ components: sinks: splunk_hec: {
 				enabled:      true
 				common:       false
 				max_bytes:    1049000
-				max_events:   null
 				timeout_secs: 1
 			}
 			compression: {


### PR DESCRIPTION
It was previously rendering ERB which appears directly in the docs
output. Instead, I do the equivalent string interpolation here in cue.

I'm curious if there is a better way to set `_parameter` than I found
which has a bunch of conditions due to the lack of an `else` clause.

I also fixed an issue that the `kafka` sink supports both `max_events`
and `max_bytes` but has a default of `null`. I updated the sink level
cue definition to let these keys be optional rather than assuming `null`
means unsupported.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
