### PR TITLE
chore: Introduce more aggressive caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
         name: Cache Cargo build
         with:
           path: |
-            ~/target/debug
+            target/debug
           key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ github.job_id }}
@@ -135,7 +135,7 @@ jobs:
         name: Cache Cargo build
         with:
           path: |
-            ~/target/debug
+            target/debug
           key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ github.job_id }}
@@ -181,7 +181,7 @@ jobs:
         name: Cache Cargo build
         with:
           path: |
-            ~/target/debug
+            target/debug
           key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ github.job_id }}
@@ -219,7 +219,7 @@ jobs:
         name: Cache Cargo build
         with:
           path: |
-            ~/target/debug
+            target/debug
           key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ github.job_id }}
@@ -299,7 +299,7 @@ jobs:
         name: Cache Cargo build
         with:
           path: |
-            ~/target/debug
+            target/debug
           key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ github.job_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,11 +91,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.5
+        name: Cache Cargo registry + index
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2.1.5
+        name: Cache Cargo build
+        with:
+          path: |
+            ~/target/debug
+          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -112,11 +123,22 @@ jobs:
       - uses: actions/checkout@v2
       - run: make ci-sweep
       - uses: actions/cache@v2.1.5
+        name: Cache Cargo registry + index
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2.1.5
+        name: Cache Cargo build
+        with:
+          path: |
+            ~/target/debug
+          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -147,11 +169,22 @@ jobs:
       - uses: actions/checkout@v2
       - run: make ci-sweep
       - uses: actions/cache@v2.1.5
+        name: Cache Cargo registry + index
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2.1.5
+        name: Cache Cargo build
+        with:
+          path: |
+            ~/target/debug
+          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       # Why is this build, not check? Because we need to make sure the linking phase works.
@@ -174,11 +207,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.5
+        name: Cache Cargo registry + index
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2.1.5
+        name: Cache Cargo build
+        with:
+          path: |
+            ~/target/debug
+          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -243,11 +287,22 @@ jobs:
           # check-version needs tags
           fetch-depth: 0 # fetch everything
       - uses: actions/cache@v2.1.5
+        name: Cache Cargo registry + index
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2.1.5
+        name: Cache Cargo build
+        with:
+          path: |
+            ~/target/debug
+          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Make slim-builds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,14 +99,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2.1.5
-        name: Cache Cargo build
-        with:
-          path: |
-            target/debug
-          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
@@ -131,14 +123,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2.1.5
-        name: Cache Cargo build
-        with:
-          path: |
-            target/debug
-          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -177,14 +161,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2.1.5
-        name: Cache Cargo build
-        with:
-          path: |
-            target/debug
-          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       # Why is this build, not check? Because we need to make sure the linking phase works.
@@ -215,14 +191,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2.1.5
-        name: Cache Cargo build
-        with:
-          path: |
-            target/debug
-          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -295,14 +263,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2.1.5
-        name: Cache Cargo build
-        with:
-          path: |
-            target/debug
-          key: ${{ runner.os }}-cargo-build-${{ github.job_id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ github.job_id }}
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Make slim-builds


### PR DESCRIPTION
This commit introduces caching of `target/debug` into our jobs as well as the
use of `restore-keys` to hit cache even when `Cargo.lock` has changed. This
commit is further work from #7269

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
