### PR TITLE
fix(cli): Enable use of delimiters

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,22 +64,43 @@ pub struct RootOpts {
     /// File format is detected from the file name.
     /// If zero files are specified the default config path
     /// `/etc/vector/vector.toml` will be targeted.
-    #[structopt(name = "config", short, long, env = "VECTOR_CONFIG")]
+    #[structopt(
+        name = "config",
+        short,
+        long,
+        env = "VECTOR_CONFIG",
+        use_delimiter(true)
+    )]
     pub config_paths: Vec<PathBuf>,
 
     /// Read configuration from one or more files. Wildcard paths are supported.
     /// TOML file format is expected.
-    #[structopt(name = "config-toml", long, env = "VECTOR_CONFIG_TOML")]
+    #[structopt(
+        name = "config-toml",
+        long,
+        env = "VECTOR_CONFIG_TOML",
+        use_delimiter(true)
+    )]
     pub config_paths_toml: Vec<PathBuf>,
 
     /// Read configuration from one or more files. Wildcard paths are supported.
     /// JSON file format is expected.
-    #[structopt(name = "config-json", long, env = "VECTOR_CONFIG_JSON")]
+    #[structopt(
+        name = "config-json",
+        long,
+        env = "VECTOR_CONFIG_JSON",
+        use_delimiter(true)
+    )]
     pub config_paths_json: Vec<PathBuf>,
 
     /// Read configuration from one or more files. Wildcard paths are supported.
     /// YAML file format is expected.
-    #[structopt(name = "config-yaml", long, env = "VECTOR_CONFIG_YAML")]
+    #[structopt(
+        name = "config-yaml",
+        long,
+        env = "VECTOR_CONFIG_YAML",
+        use_delimiter(true)
+    )]
     pub config_paths_yaml: Vec<PathBuf>,
 
     /// Exit on startup if any sinks fail healthchecks

--- a/src/service.rs
+++ b/src/service.rs
@@ -27,20 +27,20 @@ struct InstallOpts {
     display_name: Option<String>,
 
     /// Vector config files in TOML format to be used by the service.
-    #[structopt(name = "config-toml", long)]
+    #[structopt(name = "config-toml", long, use_delimiter(true))]
     config_paths_toml: Vec<PathBuf>,
 
     /// Vector config files in JSON format to be used by the service.
-    #[structopt(name = "config-json", long)]
+    #[structopt(name = "config-json", long, use_delimiter(true))]
     config_paths_json: Vec<PathBuf>,
 
     /// Vector config files in YAML format to be used by the service.
-    #[structopt(name = "config-yaml", long)]
+    #[structopt(name = "config-yaml", long, use_delimiter(true))]
     config_paths_yaml: Vec<PathBuf>,
 
     /// The configuration files that will be used by the service.
     /// If no configuration file is specified, will target default configuration file.
-    #[structopt(name = "config", short, long)]
+    #[structopt(name = "config", short, long, use_delimiter(true))]
     config_paths: Vec<PathBuf>,
 }
 

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -7,19 +7,20 @@ use structopt::StructOpt;
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
     /// Vector config files in TOML format to test.
-    #[structopt(name = "config-toml", long)]
+    #[structopt(name = "config-toml", long, use_delimiter(true))]
     paths_toml: Vec<PathBuf>,
 
     /// Vector config files in JSON format to test.
-    #[structopt(name = "config-json", long)]
+    #[structopt(name = "config-json", long, use_delimiter(true))]
     paths_json: Vec<PathBuf>,
 
     /// Vector config files in YAML format to test.
-    #[structopt(name = "config-yaml", long)]
+    #[structopt(name = "config-yaml", long, use_delimiter(true))]
     paths_yaml: Vec<PathBuf>,
 
     /// Any number of Vector config files to test. If none are specified the
     /// default config path `/etc/vector/vector.toml` will be targeted.
+    #[structopt(use_delimiter(true))]
     paths: Vec<PathBuf>,
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -23,21 +23,22 @@ pub struct Opts {
     deny_warnings: bool,
 
     /// Vector config files in TOML format to validate.
-    #[structopt(name = "config-toml", long)]
+    #[structopt(name = "config-toml", long, use_delimiter(true))]
     paths_toml: Vec<PathBuf>,
 
     /// Vector config files in JSON format to validate.
-    #[structopt(name = "config-json", long)]
+    #[structopt(name = "config-json", long, use_delimiter(true))]
     paths_json: Vec<PathBuf>,
 
     /// Vector config files in YAML format to validate.
-    #[structopt(name = "config-yaml", long)]
+    #[structopt(name = "config-yaml", long, use_delimiter(true))]
     paths_yaml: Vec<PathBuf>,
 
     /// Any number of Vector config files to validate.
     /// Format is detected from the file name.
     /// If none are specified the default config path `/etc/vector/vector.toml`
     /// will be targeted.
+    #[structopt(use_delimiter(true))]
     paths: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
Closes #7242

It turned out that the use of delimiters needed to be enabled. 

This was affecting all cli arguments with multiple values, except for one.

This is now possible
```
vector -c "generate.toml,host_metrics.toml"
vector -c generate.toml,host_metrics.toml
vector validate "generate.toml,host_metrics.toml"
vector validate generate.toml,host_metrics.toml
VECTOR_CONFIG='generate.toml,host_metrics.toml' vector
...
```
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
