### PR TITLE
fix(ci): Flag benchmark runs that fail to actually execute

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -52,9 +52,6 @@ jobs:
   bench:
     name: Bench - Linux
     runs-on: [self-hosted, linux, x64, benchmarks]
-    # Allow benchmarks show regressions until we can refine the thresholds for
-    # regression to reduce false positives.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.5


### PR DESCRIPTION
I had included `continue-on-error` originally since we didn't want to
flag regressions yet, but this also suppresses other errors (like the
benches couldn't run).

The `|| true` in `scripts/check-criterion-output.sh` should stop it from
flagging regressions as failed CI checks still.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
