### PR TITLE
chore: Move `benches/lookup` into vector-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7823,6 +7823,7 @@ dependencies = [
  "async-graphql",
  "bytes 1.0.1",
  "chrono",
+ "criterion",
  "dashmap",
  "derivative 2.2.0",
  "derive_is_enum_variant",

--- a/benches/default.rs
+++ b/benches/default.rs
@@ -6,7 +6,6 @@ mod event;
 mod files;
 mod http;
 mod isolated_buffer;
-mod lookup;
 mod lua;
 mod metrics_snapshot;
 mod regex;
@@ -20,7 +19,6 @@ criterion_main!(
     files::benches,
     http::benches,
     isolated_buffer::benches,
-    lookup::benches,
     lua::benches,
     metrics_snapshot::benches,
     regex::benches,

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -45,6 +45,7 @@ derivative = { version = "2.2.0", default-features = false }
 prost-build = "0.7.0"
 
 [dev-dependencies]
+criterion = { version = "0.3.4", features = ["html_reports"] }
 quickcheck = "1.0.3"
 pretty_assertions = "0.7.2"
 
@@ -52,3 +53,7 @@ pretty_assertions = "0.7.2"
 default = []
 api = ["async-graphql"]
 lua = ["rlua"]
+
+[[bench]]
+name = "lookup"
+harness = false

--- a/lib/vector-core/benches/lookup.rs
+++ b/lib/vector-core/benches/lookup.rs
@@ -1,8 +1,8 @@
-use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use indexmap::map::IndexMap;
 use std::convert::TryFrom;
 use std::{fs, io::Read, path::Path};
-use vector::event::Lookup;
+use vector_core::event::Lookup;
 
 const FIXTURE_ROOT: &str = "tests/data/fixtures/lookup";
 
@@ -21,7 +21,6 @@ fn parse_artifact(path: impl AsRef<Path>) -> std::io::Result<String> {
 // This test iterates over the `tests/data/fixtures/lookup` folder and ensures the lookup parsed,
 // then turned into a string again is the same.
 fn lookup_to_string(c: &mut Criterion) {
-    vector::test_util::trace_init();
     let mut fixtures = IndexMap::new();
 
     std::fs::read_dir(FIXTURE_ROOT)
@@ -29,7 +28,6 @@ fn lookup_to_string(c: &mut Criterion) {
         .for_each(|fixture_file| match fixture_file {
             Ok(fixture_file) => {
                 let path = fixture_file.path();
-                tracing::trace!(?path, "Opening.");
                 let buf = parse_artifact(&path).unwrap();
                 fixtures.insert(path, buf);
             }
@@ -116,3 +114,4 @@ criterion_group!(
     config = Criterion::default().noise_threshold(0.05);
     targets = lookup_to_string
 );
+criterion_main!(benches);


### PR DESCRIPTION
While the fixture data for this benchmark was moved into `vector-core` as a part
of #7240 the benchmark itself was not. This broke the build.

Resolves #7329

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
