### PR TITLE
chore: Make vrl optional in vector-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ prometheus-parser = { path = "lib/prometheus-parser", optional = true }
 shared = { path = "lib/shared" }
 tracing-limit = { path = "lib/tracing-limit" }
 vector-api-client = { path = "lib/vector-api-client", optional = true }
-vector_core = { path = "lib/vector-core", default-features = false, features = [] }
+vector_core = { path = "lib/vector-core", default-features = false, features = ["vrl"] }
 vrl-cli = { path = "lib/vrl/cli", optional = true }
 
 # Tokio / Futures

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -37,7 +37,7 @@ tracing-log = { version = "0.1.2", default-features = false }
 tracing-subscriber = { version = "0.2.17", default-features = false }
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", default-features = false, rev = "f470db1b0354b368f62f9ee4d763595d16373231", optional = true }
 twox-hash = { version = "1.6.0", default-features = false }
-vrl-core = { package = "vrl", path = "../vrl/core" }
+vrl-core = { package = "vrl", path = "../vrl/core", optional = true }
 lookup = { path = "../lookup", features = ["arbitrary"] }
 derivative = { version = "2.2.0", default-features = false }
 
@@ -53,6 +53,7 @@ pretty_assertions = "0.7.2"
 default = []
 api = ["async-graphql"]
 lua = ["rlua"]
+vrl = ["vrl-core"]
 
 [[bench]]
 name = "lookup"

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use derivative::Derivative;
 use getset::Getters;
+#[cfg(feature = "vrl")]
 use lookup::LookupBuf;
 use serde::{Deserialize, Serialize, Serializer};
 use shared::EventDataEq;
@@ -337,6 +338,7 @@ impl Serialize for LogEvent {
     }
 }
 
+#[cfg(feature = "vrl")]
 impl vrl_core::Target for LogEvent {
     fn get(&self, path: &LookupBuf) -> Result<Option<vrl_core::Value>, String> {
         if path.is_root() {

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -3,16 +3,20 @@ use crate::metrics::Handle;
 use chrono::{DateTime, Utc};
 use derive_is_enum_variant::is_enum_variant;
 use getset::Getters;
+#[cfg(feature = "vrl")]
 use lookup::LookupBuf;
 use serde::{Deserialize, Serialize};
 use shared::EventDataEq;
 use snafu::Snafu;
+#[cfg(feature = "vrl")]
+use std::convert::TryFrom;
+#[cfg(feature = "vrl")]
+use std::iter::FromIterator;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    convert::TryFrom,
     fmt::{self, Display, Formatter},
-    iter::FromIterator,
 };
+#[cfg(feature = "vrl")]
 use vrl_core::Target;
 
 #[derive(Clone, Debug, Deserialize, Getters, PartialEq, Serialize)]
@@ -62,6 +66,7 @@ pub enum MetricKind {
     Absolute,
 }
 
+#[cfg(feature = "vrl")]
 impl TryFrom<vrl_core::Value> for MetricKind {
     type Error = String;
 
@@ -78,6 +83,7 @@ impl TryFrom<vrl_core::Value> for MetricKind {
     }
 }
 
+#[cfg(feature = "vrl")]
 impl From<MetricKind> for vrl_core::Value {
     fn from(kind: MetricKind) -> Self {
         match kind {
@@ -209,6 +215,7 @@ pub fn zip_quantiles(
 /// Convert the Metric value into a vrl value.
 /// Currently vrl can only read the type of the value and doesn't consider
 /// any actual metric values.
+#[cfg(feature = "vrl")]
 impl From<MetricValue> for vrl_core::Value {
     fn from(value: MetricValue) -> Self {
         match value {
@@ -737,9 +744,11 @@ impl Display for Metric {
     }
 }
 
+#[cfg(feature = "vrl")]
 const VALID_METRIC_PATHS_SET: &str = ".name, .namespace, .timestamp, .kind, .tags";
 
 /// We can get the `type` of the metric in Remap, but can't set  it.
+#[cfg(feature = "vrl")]
 const VALID_METRIC_PATHS_GET: &str = ".name, .namespace, .timestamp, .kind, .tags, .type";
 
 #[derive(Debug, Snafu)]
@@ -754,8 +763,10 @@ enum MetricPathError<'a> {
 /// Metrics aren't interested in paths that have a length longer than 3
 /// The longest path is 2, and we need to check that a third segment doesn't exist as we don't want
 /// fields such as `.tags.host.thing`.
+#[cfg(feature = "vrl")]
 const MAX_METRIC_PATH_DEPTH: usize = 3;
 
+#[cfg(feature = "vrl")]
 impl Target for Metric {
     fn insert(&mut self, path: &LookupBuf, value: vrl_core::Value) -> Result<(), String> {
         if path.is_root() {

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -200,6 +200,7 @@ impl TryInto<serde_json::Value> for Value {
     }
 }
 
+#[cfg(feature = "vrl")]
 impl From<vrl_core::Value> for Value {
     fn from(v: vrl_core::Value) -> Self {
         use vrl_core::Value::*;
@@ -218,6 +219,7 @@ impl From<vrl_core::Value> for Value {
     }
 }
 
+#[cfg(feature = "vrl")]
 impl From<Value> for vrl_core::Value {
     fn from(v: Value) -> Self {
         use vrl_core::Value::*;


### PR DESCRIPTION
While VRL is essential to vector it is not a part of core. Allowing core to be
built without linking to VRL was originally a feature of #7240 but was removed
as it increased the testing surface overmuch.

By default, now, vector-core will not link with VRL.

Partially addresses #7327

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
