### PR TITLE
chore: Derive `Default` for `MakeLogEvent`

### DIFF
--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -153,7 +153,7 @@ fn decode_value(input: proto::Value) -> Option<Value> {
 impl From<&tracing::Event<'_>> for Event {
     fn from(event: &tracing::Event<'_>) -> Self {
         let now = chrono::Utc::now();
-        let mut maker = MakeLogEvent(LogEvent::default());
+        let mut maker = MakeLogEvent::default();
         event.record(&mut maker);
 
         let mut log = maker.0;
@@ -183,7 +183,7 @@ impl From<&tracing::Event<'_>> for Event {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct MakeLogEvent(LogEvent);
 
 impl Visit for MakeLogEvent {


### PR DESCRIPTION
As noted by @bruceg in #7240 we could avoid the explicit call to
`LogEvent::default` by deriving `Default` for `MakeLogEvent`. This is now done
and I've tidied up the relevant call-site.

Partially resolves #7327

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
