### PR TITLE
chore: Reference RFC template in RFC readme

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -40,7 +40,7 @@ Examples of changes that do not require a RFC:
 
 ### Creating a RFC
 
-1. Create a new branch with the `rfcs/YYYY-MM-DD-issue#-title.md` file.
+1. Create a new branch, copy the [`rfcs/_YYYY-MM-DD-issue#-title.md`](https://github.com/timberio/vector/blob/master/rfcs/_YYYY-MM-DD-issue%23-title.md) template and rename/fill it in accordingly.
    * Example: `rfcs/2020-02-10-445-internal-observability.md`
 2. Submit your RFC as a pull request for discussion.
 3. At least 3 other team members must approve your RFC.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -40,7 +40,7 @@ Examples of changes that do not require a RFC:
 
 ### Creating a RFC
 
-1. Create a new branch, copy the [`rfcs/_YYYY-MM-DD-issue#-title.md`](https://github.com/timberio/vector/blob/master/rfcs/_YYYY-MM-DD-issue%23-title.md) template and rename/fill it in accordingly.
+1. Create a new branch, copy the [`rfcs/_YYYY-MM-DD-issue#-title.md`](rfcs/_YYYY-MM-DD-issue%23-title.md) template and rename/fill it in accordingly.
    * Example: `rfcs/2020-02-10-445-internal-observability.md`
 2. Submit your RFC as a pull request for discussion.
 3. At least 3 other team members must approve your RFC.


### PR DESCRIPTION
First thought the Readme was instructing to copy the RFC `rfcs/2020-02-10-445-internal-observability.md` (which doesn't exist) as an example, and noticed there's a dedicated template.

Adding a reference to that for (even) easier discoverability.