### PR TITLE
chore(metrics): Remove emits & alias `processed_events_total` metric

### DIFF
--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -350,12 +350,15 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		processed_events_total: {
-			description:       "The total number of events processed by this component."
+			description:       """
+				The total number of events processed by this component.
+				This metric is deprecated in place of using
+				[`events_in_total`][docs.sources.internal_metrics.events_in_total] and
+				[`events_out_total`][docs.sources.internal_metrics.events_out_total] metrics.
+				"""
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags & {
-				file: _file
-			}
+			tags:              _component_tags
 		}
 		kafka_queue_messages: {
 			description:       "Current number of messages in producer queues."

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -350,7 +350,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		processed_events_total: {
-			description:       """
+			description: """
 				The total number of events processed by this component.
 				This metric is deprecated in place of using
 				[`events_in_total`][docs.sources.internal_metrics.events_in_total] and

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -260,6 +260,11 @@ impl Metric {
         }
     }
 
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.series.name.name = name.into();
+        self
+    }
+
     pub fn with_namespace<T: Into<String>>(mut self, namespace: Option<T>) -> Self {
         self.series.name.namespace = namespace.map(Into::into);
         self

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -111,6 +111,16 @@ pub fn capture_metrics(controller: &Controller) -> impl Iterator<Item = Event> {
         .iter()
         .map(|kv| Metric::from_metric_kv(kv.key().key(), kv.value()).into())
         .collect::<Vec<Event>>();
+
+    // Add alias `events_processed_total` for `events_out_total`.
+    for i in 0..events.len() {
+        let metric = events[i].as_metric();
+        if metric.name() == "events_out_total" {
+            let alias = metric.clone().with_name("events_processed_total");
+            events.push(alias.into());
+        }
+    }
+
     let handle = Handle::Counter(Counter::with_count(events.len() as u64 + 1));
     events.push(Metric::from_metric_kv(CARDINALITY_KEY.key(), &handle).into());
 

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -16,7 +16,6 @@ impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
         counter!(
             "events_in_total", self.count as u64,
             "uri" => self.uri.to_owned(),

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -15,7 +15,6 @@ impl InternalEvent for AwsEcsMetricsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
         counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -8,7 +8,6 @@ pub struct AwsKinesisStreamsEventSent {
 
 impl InternalEvent for AwsKinesisStreamsEventSent {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -13,7 +13,6 @@ impl InternalEvent for AwsSqsEventSent<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/blackhole.rs
+++ b/src/internal_events/blackhole.rs
@@ -8,7 +8,6 @@ pub struct BlackholeEventReceived {
 
 impl InternalEvent for BlackholeEventReceived {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -8,7 +8,6 @@ pub struct ConsoleEventProcessed {
 
 impl InternalEvent for ConsoleEventProcessed {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/datadog_logs.rs
+++ b/src/internal_events/datadog_logs.rs
@@ -9,7 +9,6 @@ pub struct DatadogLogEventProcessed {
 
 impl InternalEvent for DatadogLogEventProcessed {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -20,7 +20,6 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!(
             "events_in_total", 1,
             "container_name" => self.container_name.to_owned()

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -13,7 +13,6 @@ impl InternalEvent for ElasticSearchEventEncoded {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -18,10 +18,6 @@ impl InternalEvent for ExecEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!(
-            "processed_events_total", 1,
-            "command" => self.command.to_owned(),
-        );
-        counter!(
             "events_in_total", 1,
             "command" => self.command.to_owned(),
         );

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -39,10 +39,6 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "processed_events_total", 1,
-                "file" => self.file.to_owned(),
-            );
-            counter!(
                 "events_in_total", 1,
                 "file" => self.file.to_owned(),
             );

--- a/src/internal_events/generator.rs
+++ b/src/internal_events/generator.rs
@@ -1,5 +1,4 @@
 use super::InternalEvent;
-use metrics::counter;
 
 #[derive(Debug)]
 pub struct GeneratorEventProcessed;
@@ -7,9 +6,5 @@ pub struct GeneratorEventProcessed;
 impl InternalEvent for GeneratorEventProcessed {
     fn emit_logs(&self) {
         trace!(message = "Received one event.");
-    }
-
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
     }
 }

--- a/src/internal_events/host_metrics.rs
+++ b/src/internal_events/host_metrics.rs
@@ -1,5 +1,4 @@
 use super::InternalEvent;
-use metrics::counter;
 
 #[derive(Debug)]
 pub(crate) struct HostMetricsEventReceived {
@@ -9,9 +8,5 @@ pub(crate) struct HostMetricsEventReceived {
 impl InternalEvent for HostMetricsEventReceived {
     fn emit_logs(&self) {
         debug!(message = "Scraped host metrics.", count = ?self.count);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
     }
 }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -18,7 +18,6 @@ impl InternalEvent for HttpEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.events_count as u64);
         counter!("events_in_total", self.events_count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
@@ -72,7 +71,6 @@ impl InternalEvent for HttpEventEncoded {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -12,7 +12,6 @@ impl InternalEvent for JournaldEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -13,7 +13,6 @@ impl InternalEvent for KafkaEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -18,7 +18,6 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         match self.pod_name {
             Some(name) => {
                 counter!("events_in_total", 1, "pod_name" => name.to_owned());

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -13,7 +13,6 @@ impl InternalEvent for NatsEventSendSuccess {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -20,7 +20,6 @@ impl InternalEvent for PrometheusEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count as u64);
         counter!(
             "events_in_total", self.count as u64,
             "uri" => format!("{}",self.uri),

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -31,7 +31,6 @@ impl InternalEvent for SocketEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1, "mode" => self.mode.as_str());
         counter!("events_in_total", 1, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
@@ -50,7 +49,6 @@ impl InternalEvent for SocketEventsSent {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", self.count, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -12,7 +12,6 @@ pub(crate) struct SplunkEventSent {
 
 impl InternalEvent for SplunkEventSent {
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
@@ -51,7 +50,6 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("processed_events_total", 1);
             counter!("events_in_total", 1);
         }
     }

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -12,7 +12,6 @@ impl InternalEvent for StatsdEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64,);
     }

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -12,7 +12,6 @@ impl InternalEvent for StdinEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -12,7 +12,6 @@ impl InternalEvent for SyslogEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -2,15 +2,6 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
-pub struct EventProcessed;
-
-impl InternalEvent for EventProcessed {
-    fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
-    }
-}
-
-#[derive(Debug)]
 pub struct EventIn;
 
 impl InternalEvent for EventIn {

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -13,7 +13,6 @@ impl InternalEvent for VectorEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,7 +23,7 @@
 // SOFTWARE.
 
 use futures::{future, stream::Fuse, Stream, StreamExt};
-use pin_project::{pin_project, pinned_drop};
+use pin_project::pin_project;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -52,22 +52,6 @@ pub trait VecStreamExt: Stream {
             stream1: self.fuse(),
             stream2: stream2.fuse(),
             flag: false,
-        }
-    }
-
-    /// Calls function F after an item from this stream has been processed
-    /// by the consumer while the assumption holds.
-    /// This assumes that the stream is being consumed in a loop, so when
-    /// the consumer get's an item and then comes for another one
-    /// we assume that it has processed the first item.
-    fn on_processed<F: Fn()>(self, after: F) -> OnProcessed<Self, F>
-    where
-        Self: Sized,
-    {
-        OnProcessed {
-            stream: self,
-            after,
-            processing: false,
         }
     }
 }
@@ -134,52 +118,4 @@ pub(crate) async fn tripwire_handler(closed: bool) {
         }
     })
     .await
-}
-
-/// Calls function F after an item from stream has been processed
-/// by the consumer.
-///
-/// This assumes that the stream is being consumed in a loop, so when
-/// the consumer get's an item and then comes for another one
-/// we assume that it has processed the first item.
-/// This should hold in most cases. One example of when this doesn't
-/// hold is when the consumer batches items, or if it goes away and
-/// does something unrelated to the item which it has already processed.
-/// In such cases this construct can still be used, but it won't be accurate.
-#[pin_project(PinnedDrop)]
-pub struct OnProcessed<S: Stream, F: Fn()> {
-    #[pin]
-    stream: S,
-    after: F,
-    processing: bool,
-}
-
-impl<S: Stream, F: Fn()> Stream for OnProcessed<S, F> {
-    type Item = S::Item;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {
-        let this = self.project();
-        if *this.processing {
-            *this.processing = false;
-            (this.after)();
-        }
-        match this.stream.poll_next(cx) {
-            Poll::Ready(Some(item)) => {
-                *this.processing = true;
-                Poll::Ready(Some(item))
-            }
-            poll => poll,
-        }
-    }
-}
-
-#[pinned_drop]
-impl<S: Stream, F: Fn()> PinnedDrop for OnProcessed<S, F> {
-    fn drop(self: Pin<&mut Self>) {
-        let this = self.project();
-        if *this.processing {
-            *this.processing = false;
-            (this.after)();
-        }
-    }
 }


### PR DESCRIPTION
Closes #6367

Removes emits of `processed_events_total` metric and instead adds it as an alias for `event_out_total` metric.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
