### PR TITLE
fix(debian platform): Check the correct systemd-journal group before adding the vector user

### DIFF
--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -5,7 +5,7 @@ set -e
 usermod --append --groups adm vector || true
 
 # If the systemd-journal group is present
-if getent group | grep 'systemd-journald'
+if getent group | grep 'systemd-journal'
 then
   # Add Vector to systemd-journal to read journald logs
   usermod --append --groups systemd-journal vector || true


### PR DESCRIPTION
Right now, the postinst script is checking for `systemd-journald` group while the actual Debian group is `systemd-journal`. This PR fix this typo and will result in correctly adding the user `vector` to the `systemd-journal` group if present.