### PR TITLE
fix(debian platform): Add debhelper include tags to Debian scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ assets = [
 license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"
 
+[package.metadata.deb.systemd-units]
+unit-scripts = "distribution/systemd/"
+enable = false
+
 # libc requirements are defined by `cross`
 # https://github.com/rust-embedded/cross#supported-targets
 # Though, it seems like aarch64 libc is actually 2.18 and not 2.19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ extended-description-file = "target/debian-extended-description.txt"
 
 [package.metadata.deb.systemd-units]
 unit-scripts = "distribution/systemd/"
-enable = false
 
 # libc requirements are defined by `cross`
 # https://github.com/rust-embedded/cross#supported-targets

--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -12,3 +12,5 @@ then
   # Reload the daemon to reflect new group membership
   systemctl daemon-reload
 fi
+
+#DEBHELPER#

--- a/distribution/debian/scripts/preinst
+++ b/distribution/debian/scripts/preinst
@@ -9,3 +9,5 @@ mkdir -p /var/lib/vector
 
 # Make vector:vector the owner of the Vector data directory
 chown -R vector:vector /var/lib/vector
+
+#DEBHELPER#


### PR DESCRIPTION
Signed-off-by: Johann Queuniet <sub_code.git@queuniet.fr>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->

Those tags allow debhelper scripts to hook into your custom Debian scripts and add their own logic to it. Right now the vector service isn't properly enabled by the Debian package as it should be, and it is likely because of missing postinst code from `dh_systemd`.

```
● vector.service - Vector
   Loaded: loaded (/lib/systemd/system/vector.service; disabled; vendor preset: enabled)
   Active: active (running) since Wed 2021-05-05 16:16:54 UTC; 24h ago
```

The final postinst script compiled into the deb file should have a section like this one:

```
# Automatically added by dh_systemd_enable/13.2
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
	# This will only remove masks created by d-s-h on package removal.
	deb-systemd-helper unmask 'vector.service' >/dev/null || true

	# was-enabled defaults to true, so new installations run enable.
	if deb-systemd-helper --quiet was-enabled 'vector.service'; then
		# Enables the unit on first installation, creates new
		# symlinks on upgrades if the unit file has changed.
		deb-systemd-helper enable 'vector.service' >/dev/null || true
	else
		# Update the statefile to add new symlinks (if any), which need to be
		# cleaned up on purge. Also remove old symlinks.
		deb-systemd-helper update-state 'vector.service' >/dev/null || true
	fi
fi
# End automatically added section
# Automatically added by dh_systemd_start/13.2
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
	if [ -d /run/systemd/system ]; then
		systemctl --system daemon-reload >/dev/null || true
		if [ -n "$2" ]; then
			_dh_action=restart
		else
			_dh_action=start
		fi
		deb-systemd-invoke $_dh_action 'vector.service' >/dev/null || true
	fi
fi
# End automatically added section
```

For more details about this, please refer to the debhelper manual: https://manpages.debian.org/buster/debhelper/debhelper.7.en.html#Automatic_generation_of_Debian_install_scripts