### PR TITLE
fix(external docs): Fix the API port in the docker docs

### DIFF
--- a/docs/reference/installation/_interfaces/docker-cli.cue
+++ b/docs/reference/installation/_interfaces/docker-cli.cue
@@ -19,7 +19,7 @@ installation: _interfaces: "docker-cli": {
 	platform_name: "docker"
 
 	role_implementations: [Name=string]: {
-		_api_port:         8383
+		_api_port:         8686
 		_config_path:      paths.config
 		_docker_sock_path: "/var/run/docker.sock"
 		commands: {


### PR DESCRIPTION
The configuration we ship has it listen on 8686 by default.

Closes: https://github.com/timberio/vector/issues/7312

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
