### PR TITLE
chore(ci): Fix deb verify steps

### DIFF
--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -10,5 +10,5 @@ then
   # Add Vector to systemd-journal to read journald logs
   usermod --append --groups systemd-journal vector || true
   # Reload the daemon to reflect new group membership
-  systemctl daemon-reload
+  systemctl daemon-reload || true
 fi


### PR DESCRIPTION
They verify installation in a container without systemd running so the
`systemctl daemon-reload` step fails.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
