### PR TITLE
enhancement(tests): specify the namespace to run k8s test in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ Since not everyone has a full working native environment, we took our environmen
 
 This is ideal for users who want it to "Just work" and just want to start contributing. It's also what we use for our CI, so you know if it breaks we can't do anything else until we fix it. 😉
 
-**Before you go farther, install Docker or Podman through your official package manager, or from the [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/) sites.**
+**Before you go further, install Docker or Podman through your official package manager, or from the [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/) sites.**
 
 ```bash
 # Optional: Only if you use `podman`
@@ -745,6 +745,21 @@ Vector:
 - [`minikube`](https://minikube.sigs.k8s.io/)-powered or other k8s cluster
 - [`cargo watch`](https://github.com/passcod/cargo-watch)
 
+
+#### Installing on mac
+Note, it currently doesn't work properly on the mac. These are just some 
+preliminary notes.
+
+Install docker for mac
+In docker for mac enable Kubernetes
+
+Run this to ensure our kubectl points to docker destop
+❯ kubectl config get-contexts
+CURRENT   NAME             CLUSTER          AUTHINFO         NAMESPACE
+*         docker-desktop   docker-desktop   docker-desktop
+
+
+
 ##### The dev flow
 
 Once you have the requirements, use the `scripts/skaffold.sh dev` command.
@@ -819,6 +834,8 @@ E2E (end-to-end) tests.
 - `docker`
 - `kubectl`
 - `bash`
+- `cross` - `cargo install cross`
+- [`helm`](https://helm.sh/) 
 
 Vector release artifacts are prepared for E2E tests, so the ability to do that
 is required too, see Vector [docs](https://vector.dev) for more details.
@@ -875,6 +892,9 @@ You can also pass additional parameters to adjust the behavior of the test:
 
 - `SCOPE` - pass a filter to the `cargo test` command to filter out the tests,
   effectively equivalent to `cargo test -- $SCOPE`.
+
+- `NAMESPACE` - specifies the k8s namespace to run the tests in. Some tests are 
+  run in another namespace with this one prepended: `<NAMESPACE>-test-pod`.
 
 Passing additional commands is done like so:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -745,21 +745,6 @@ Vector:
 - [`minikube`](https://minikube.sigs.k8s.io/)-powered or other k8s cluster
 - [`cargo watch`](https://github.com/passcod/cargo-watch)
 
-
-#### Installing on mac
-Note, it currently doesn't work properly on the mac. These are just some 
-preliminary notes.
-
-Install docker for mac
-In docker for mac enable Kubernetes
-
-Run this to ensure our kubectl points to docker destop
-❯ kubectl config get-contexts
-CURRENT   NAME             CLUSTER          AUTHINFO         NAMESPACE
-*         docker-desktop   docker-desktop   docker-desktop
-
-
-
 ##### The dev flow
 
 Once you have the requirements, use the `scripts/skaffold.sh dev` command.
@@ -835,7 +820,7 @@ E2E (end-to-end) tests.
 - `kubectl`
 - `bash`
 - `cross` - `cargo install cross`
-- [`helm`](https://helm.sh/) 
+- [`helm`](https://helm.sh/)
 
 Vector release artifacts are prepared for E2E tests, so the ability to do that
 is required too, see Vector [docs](https://vector.dev) for more details.
@@ -893,7 +878,7 @@ You can also pass additional parameters to adjust the behavior of the test:
 - `SCOPE` - pass a filter to the `cargo test` command to filter out the tests,
   effectively equivalent to `cargo test -- $SCOPE`.
 
-- `NAMESPACE` - specifies the k8s namespace to run the tests in. Some tests are 
+- `NAMESPACE` - specifies the k8s namespace to run the tests in. Some tests are
   run in another namespace with this one prepended: `<NAMESPACE>-test-pod`.
 
 Passing additional commands is done like so:

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -17,6 +17,18 @@ pub fn get_namespace_appended(suffix: &str) -> String {
     format!("{}-{}", get_namespace(), suffix)
 }
 
+/// Gets a name we can use for roles to prevent them conflicting with other tests.
+/// Uses the provided namespace as the root.
+pub fn get_override_name(suffix: &str) -> String {
+    format!("{}-{}", get_namespace(), suffix)
+}
+
+/// Adds a fullnameOverride entry to the given config. This allows multiple tests
+/// to be run against the same cluster without the role anmes clashing.
+pub fn config_override_name(config: &str, name: &str) -> String {
+    format!("fullnameOverride: \"{}\"\n{}", name, config)
+}
+
 pub fn make_framework() -> Framework {
     let interface = Interface::from_env().expect("interface is not ready");
     Framework::new(interface)

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -3,10 +3,19 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
 use k8s_test_framework::{Framework, Interface, Reader};
+use std::env;
 
 pub mod metrics;
 
 pub const BUSYBOX_IMAGE: &str = "busybox:1.28";
+
+pub fn get_namespace() -> String {
+    env::var("NAMESPACE").unwrap_or_else(|_| "test-vector".to_string())
+}
+
+pub fn get_namespace_appended(suffix: &str) -> String {
+    format!("{}-{}", get_namespace(), suffix)
+}
 
 pub fn make_framework() -> Framework {
     let interface = Interface::from_env().expect("interface is not ready");

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -54,11 +54,13 @@ const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = indoc! {r#"
 #[tokio::test]
 async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -66,41 +68,39 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
             },
         )
         .await?;
+
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![],
             vec![],
         ))?)
         .await?;
+
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -138,11 +138,13 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK_RAW_CONFIG,
@@ -151,18 +153,14 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![],
@@ -171,20 +169,20 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -220,11 +218,13 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -233,19 +233,15 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_message = generate_long_string(8, 8 * 1024); // 64 KiB
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             &format!("echo {}", test_message),
             vec![],
@@ -254,20 +250,20 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_expected_line = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -305,11 +301,13 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let pod_namespace = get_namespace_appended("test-pod");
+
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![],
@@ -318,7 +316,7 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
@@ -328,9 +326,11 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     // Wait for some extra time to ensure pod completes.
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
+    let namespace = get_namespace();
+
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -339,20 +339,16 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -388,11 +384,14 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
+
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -401,19 +400,15 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_messages = vec!["MARKER1", "MARKER2", "MARKER3", "MARKER4", "MARKER5"];
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             &format!("echo -e {}", test_messages.join(r"\\n")),
             vec![],
@@ -422,20 +417,20 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut test_messages_iter = test_messages.into_iter().peekable();
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -472,11 +467,13 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -485,18 +482,14 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![("label1", "hello"), ("label2", "world")],
@@ -505,14 +498,14 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
     let k8s_version = framework.kubernetes_version().await?;
     let minor = u8::from_str(&k8s_version.minor()).expect("Couldn't get u8 from String!");
@@ -520,7 +513,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -541,7 +534,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         // Assert pod the event is properly annotated with pod metadata.
         assert_eq!(val["kubernetes"]["pod_name"], "test-pod");
         // We've already asserted this above, but repeat for completeness.
-        assert_eq!(val["kubernetes"]["pod_namespace"], "test-vector-test-pod");
+        assert_eq!(val["kubernetes"]["pod_namespace"], pod_namespace.as_str());
         assert_eq!(val["kubernetes"]["pod_uid"].as_str().unwrap().len(), 36); // 36 is a standard UUID string length
         assert_eq!(val["kubernetes"]["pod_labels"]["label1"], "hello");
         assert_eq!(val["kubernetes"]["pod_labels"]["label2"], "world");
@@ -586,11 +579,13 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -599,18 +594,14 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let excluded_test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod-excluded",
             "echo EXCLUDED_MARKER",
             vec![("vector.dev/exclude", "true")],
@@ -619,7 +610,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod-excluded"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
@@ -628,7 +619,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
 
     let control_test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod-control",
             "echo CONTROL_MARKER",
             vec![],
@@ -637,14 +628,14 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod-control"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -682,7 +673,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
 
         let val = parse_json(&line)?;
 
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             continue;
@@ -741,6 +732,8 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     const CONFIG: &str = indoc! {r#"
@@ -752,7 +745,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
@@ -761,14 +754,10 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let label_sets = vec![
         ("test-pod-excluded-1", vec![("vector.dev/exclude", "true")]),
@@ -784,7 +773,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         excluded_test_pods.push(
             framework
                 .test_pod(test_pod::Config::from_pod(&make_test_pod(
-                    "test-vector-test-pod",
+                    &pod_namespace,
                     name,
                     "echo EXCLUDED_MARKER",
                     label_set,
@@ -798,7 +787,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         let name = format!("pods/{}", name);
         framework
             .wait(
-                "test-vector-test-pod",
+                &pod_namespace,
                 vec![name.as_ref()],
                 WaitFor::Condition("initialized"),
                 vec!["--timeout=60s"],
@@ -808,7 +797,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
 
     let control_test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod-control",
             "echo CONTROL_MARKER",
             vec![],
@@ -817,14 +806,14 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod-control"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -862,7 +851,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
 
         let val = parse_json(&line)?;
 
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             continue;
@@ -922,11 +911,13 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -935,18 +926,15 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
+    println!("Doin da groove");
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod_with_containers(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             vec![],
             vec![("vector.dev/exclude-containers", "excluded")],
@@ -958,14 +946,14 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -1003,7 +991,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
 
         let val = parse_json(&line)?;
 
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             continue;
@@ -1066,17 +1054,22 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
-    const CONFIG: &str = indoc! {r#"
+    let CONFIG: &str = &format!(
+        indoc! {r#"
         kubernetesLogsSource:
           rawConfig: |
-            exclude_paths_glob_patterns = ["/var/log/pods/test-vector-test-pod_test-pod_*/excluded/**"]
-    "#};
+            exclude_paths_glob_patterns = ["/var/log/pods/{}_test-pod_*/excluded/**"]
+    "#},
+        pod_namespace
+    );
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
@@ -1085,18 +1078,14 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod_with_containers(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             vec![],
             vec![],
@@ -1108,14 +1097,14 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -1153,7 +1142,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
 
         let val = parse_json(&line)?;
 
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
             // A log from something other than our test pod, pretend we don't
             // see it.
             continue;
@@ -1214,11 +1203,13 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -1227,19 +1218,13 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
-
-    const NS_PREFIX: &str = "test-vector-test-pod";
 
     let mut test_namespaces = vec![];
     let mut expected_namespaces = HashSet::new();
     for i in 0..10 {
-        let name = format!("{}-{}", NS_PREFIX, i);
+        let name = format!("{}-{}", pod_namespace, i);
         test_namespaces.push(framework.namespace(&name).await?);
         expected_namespaces.insert(name);
     }
@@ -1266,13 +1251,13 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
         test_pods.push(test_pod);
     }
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     look_for_log_line(&mut log_reader, |val| {
         let ns = match val["kubernetes"]["pod_namespace"].as_str() {
-            Some(val) if val.starts_with(NS_PREFIX) => val,
+            Some(val) if val.starts_with(&pod_namespace) => val,
             _ => {
                 // A log from something other than our test pod, pretend we
                 // don't see it.
@@ -1313,11 +1298,13 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_ADDITIONAL_CONFIGMAP,
@@ -1326,18 +1313,14 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![],
@@ -1346,20 +1329,20 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -1395,11 +1378,13 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
     let vector = framework
         .vector(
-            "test-vector",
+            &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
                 custom_helm_values: HELM_VALUES_STDOUT_SINK,
@@ -1408,15 +1393,11 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
     let mut vector_metrics_port_forward =
-        framework.port_forward("test-vector", "daemonset/vector-agent", 9090, 9090)?;
+        framework.port_forward(&namespace, "daemonset/vector-agent", 9090, 9090)?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",
@@ -1445,11 +1426,11 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     // Capture events processed before deploying the test pod.
     let processed_events_before = metrics::get_processed_events(&vector_metrics_url).await?;
 
-    let test_namespace = framework.namespace("test-vector-test-pod").await?;
+    let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
-            "test-vector-test-pod",
+            &pod_namespace,
             "test-pod",
             "echo MARKER",
             vec![],
@@ -1458,20 +1439,20 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     framework
         .wait(
-            "test-vector-test-pod",
+            &pod_namespace,
             vec!["pods/test-pod"],
             WaitFor::Condition("initialized"),
             vec!["--timeout=60s"],
         )
         .await?;
 
-    let mut log_reader = framework.logs("test-vector", "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if val["kubernetes"]["pod_namespace"] != "test-vector-test-pod" {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace {
             // A log from something other than our test pod, pretend we don't
             // see it.
             return FlowControlCommand::GoOn;
@@ -1525,25 +1506,18 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    let namespace = get_namespace();
     let framework = make_framework();
 
     let vector = framework
-        .vector(
-            "test-vector",
-            HELM_CHART_VECTOR_AGENT,
-            VectorConfig::default(),
-        )
+        .vector(&namespace, HELM_CHART_VECTOR_AGENT, VectorConfig::default())
         .await?;
     framework
-        .wait_for_rollout(
-            "test-vector",
-            "daemonset/vector-agent",
-            vec!["--timeout=60s"],
-        )
+        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
         .await?;
 
     let mut vector_metrics_port_forward =
-        framework.port_forward("test-vector", "daemonset/vector-agent", 9090, 9090)?;
+        framework.port_forward(&namespace, "daemonset/vector-agent", 9090, 9090)?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1058,7 +1058,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
 
-    let CONFIG: &str = &format!(
+    let config: &str = &format!(
         indoc! {r#"
         kubernetesLogsSource:
           rawConfig: |
@@ -1072,7 +1072,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
+                custom_helm_values: &format!("{}\n{}", config, HELM_VALUES_STDOUT_SINK),
                 ..Default::default()
             },
         )

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -57,20 +57,25 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
 
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -94,7 +99,7 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -141,19 +146,27 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK_RAW_CONFIG,
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK_RAW_CONFIG,
+                    &override_name,
+                ),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -176,7 +189,7 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -221,13 +234,14 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
@@ -257,7 +271,7 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -302,7 +316,7 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     let framework = make_framework();
 
     let pod_namespace = get_namespace_appended("test-pod");
-
+    let override_name = get_override_name("vector-agent");
     let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
@@ -333,16 +347,20 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -386,6 +404,7 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
+    let override_name = get_override_name("vector-agent");
 
     let framework = make_framework();
 
@@ -394,13 +413,17 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -424,7 +447,7 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -469,6 +492,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
+    let override_name = get_override_name("vector-agent");
     let framework = make_framework();
 
     let vector = framework
@@ -476,13 +500,17 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -505,7 +533,7 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
     let k8s_version = framework.kubernetes_version().await?;
     let minor = u8::from_str(&k8s_version.minor()).expect("Couldn't get u8 from String!");
@@ -582,19 +610,24 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -635,7 +668,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -735,6 +768,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     const CONFIG: &str = indoc! {r#"
         kubernetesLogsSource:
@@ -748,13 +782,20 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
+                custom_helm_values: &config_override_name(
+                    &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
+                    &override_name,
+                ),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -813,7 +854,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -914,19 +955,24 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -953,7 +999,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -1057,6 +1103,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let config: &str = &format!(
         indoc! {r#"
@@ -1072,7 +1119,10 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &format!("{}\n{}", config, HELM_VALUES_STDOUT_SINK),
+                custom_helm_values: &config_override_name(
+                    &format!("{}\n{}", config, HELM_VALUES_STDOUT_SINK),
+                    &override_name,
+                ),
                 ..Default::default()
             },
         )
@@ -1104,7 +1154,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the log lines until the reasonable amount of time passes for us
@@ -1206,19 +1256,24 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let mut test_namespaces = vec![];
@@ -1251,7 +1306,7 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
         test_pods.push(test_pod);
     }
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -1301,19 +1356,27 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_ADDITIONAL_CONFIGMAP,
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_ADDITIONAL_CONFIGMAP,
+                    &override_name,
+                ),
                 custom_resource: CUSTOM_RESOURCE_VECTOR_CONFIG,
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
     let test_namespace = framework.namespace(&pod_namespace).await?;
@@ -1336,7 +1399,7 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -1381,23 +1444,32 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: HELM_VALUES_STDOUT_SINK,
+                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
                 ..Default::default()
             },
         )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
-    let mut vector_metrics_port_forward =
-        framework.port_forward(&namespace, "daemonset/vector-agent", 9090, 9090)?;
+    let mut vector_metrics_port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{}", override_name),
+        9090,
+        9090,
+    )?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",
@@ -1446,7 +1518,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, "daemonset/vector-agent")?;
+    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -1508,16 +1580,32 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
     let framework = make_framework();
+    let override_name = get_override_name("vector-agent");
 
     let vector = framework
-        .vector(&namespace, HELM_CHART_VECTOR_AGENT, VectorConfig::default())
+        .vector(
+            &namespace,
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: &config_override_name("", &override_name),
+                ..Default::default()
+            },
+        )
         .await?;
     framework
-        .wait_for_rollout(&namespace, "daemonset/vector-agent", vec!["--timeout=60s"])
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
         .await?;
 
-    let mut vector_metrics_port_forward =
-        framework.port_forward(&namespace, "daemonset/vector-agent", 9090, 9090)?;
+    let mut vector_metrics_port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{}", override_name),
+        9090,
+        9090,
+    )?;
     vector_metrics_port_forward.wait_until_ready().await?;
     let vector_metrics_url = format!(
         "http://{}/metrics",


### PR DESCRIPTION
This allows you to specify thet namespace to run the kubernetes tests in by specifying a `NAMESPACE` environment variable:

If one isn't specified it defaults to `test-vector`.

eg.

```
NAMESPACE=florkshnoog CONTAINER_IMAGE_REPO=plork/vector-test SCOPE=glob_pattern_filtering  make test-e2e-kubernetes
```



Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
