### PR TITLE
enhancement(datadog_logs sink): Use per-API key partitions for datadog logs sink

### DIFF
--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -58,8 +58,8 @@ components: sinks: datadog_logs: {
 	support: sinks._datadog.support
 
 	configuration: {
-		api_key: {
-			description: "Datadog [API key](https://docs.datadoghq.com/api/?lang=bash#authentication), if an event has a key set in its metadata it will prevail over the one set here."
+		default_api_key: {
+			description: "Default Datadog [API key](https://docs.datadoghq.com/api/?lang=bash#authentication), if an event has a key set in its metadata it will prevail over the one set here."
 			required:    true
 			warnings: []
 			type: string: {

--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -58,7 +58,15 @@ components: sinks: datadog_logs: {
 	support: sinks._datadog.support
 
 	configuration: {
-		api_key:  sinks._datadog.configuration.api_key
+		api_key: {
+			description: "Datadog [API key](https://docs.datadoghq.com/api/?lang=bash#authentication), if an event has a key set in its metadata it will prevail over the one set here."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
+				syntax: "literal"
+			}
+		}
 		endpoint: sinks._datadog.configuration.endpoint
 		region:   sinks._datadog.configuration.region
 		site:     sinks._datadog.configuration.site

--- a/docs/reference/components/sources/datadog_logs.cue
+++ b/docs/reference/components/sources/datadog_logs.cue
@@ -63,6 +63,12 @@ components: sources: datadog_logs: {
 
 	configuration: {
 		address: sources.http.configuration.address
+		save_api_key: {
+			common:      false
+			description: "When incoming events contain a Datadog API key, if this setting is set to `true` the key will kept in the event metadata and will be used if the event is sent to a Datadog sink."
+			required:    false
+			type: bool: default: true
+		}
 	}
 
 	output: logs: line: {
@@ -91,18 +97,6 @@ components: sources: datadog_logs: {
 				required:    true
 				type: string: {
 					examples: ["backend"]
-					syntax: "literal"
-				}
-			}
-
-			dd_api_key: {
-				description: """
-					The Datadog API key extracted from the event. This sensitive field may be removed
-					or obfuscated using the `remap` transform.
-					"""
-				required: true
-				type: string: {
-					examples: ["abcdefgh13245678abcdefgh13245678"]
 					syntax: "literal"
 				}
 			}

--- a/docs/reference/components/sources/datadog_logs.cue
+++ b/docs/reference/components/sources/datadog_logs.cue
@@ -63,7 +63,7 @@ components: sources: datadog_logs: {
 
 	configuration: {
 		address: sources.http.configuration.address
-		save_api_key: {
+		store_api_key: {
 			common:      false
 			description: "When incoming events contain a Datadog API key, if this setting is set to `true` the key will kept in the event metadata and will be used if the event is sent to a Datadog sink."
 			required:    false

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 /// The top-level metadata structure contained by both `struct Metric`
 /// and `struct LogEvent` types.
-#[derive(Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize, Setters)]
+#[derive(
+    Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize, Setters,
+)]
 pub struct EventMetadata {
     /// Used to store the datadog API from sources to sinks
     #[getset(get = "pub", set = "pub")]

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -1,18 +1,30 @@
 #![deny(missing_docs)]
 
 use super::{EventFinalizer, EventFinalizers, EventStatus};
+use getset::Getters;
 use serde::{Deserialize, Serialize};
 use shared::EventDataEq;
 
 /// The top-level metadata structure contained by both `struct Metric`
 /// and `struct LogEvent` types.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize)]
 pub struct EventMetadata {
+    #[serde(default, skip)]
+    #[get = "pub"]
+    datadog_api_key: Option<String>,
     #[serde(default, skip)]
     finalizers: EventFinalizers,
 }
 
 impl EventMetadata {
+    /// Build metadata with datadog api key only
+    pub fn with_datadog_api_key(api_key: String) -> Self {
+        Self {
+            datadog_api_key: Some(api_key),
+            finalizers: EventFinalizers::default(),
+        }
+    }
+
     /// Replace the finalizers array with the given one.
     pub fn with_finalizer(mut self, finalizer: EventFinalizer) -> Self {
         self.finalizers = EventFinalizers::new(finalizer);
@@ -22,6 +34,13 @@ impl EventMetadata {
     /// Merge the other `EventMetadata` into this.
     pub fn merge(&mut self, other: Self) {
         self.finalizers.merge(other.finalizers);
+        match (
+            self.datadog_api_key.as_ref(),
+            other.datadog_api_key.as_ref(),
+        ) {
+            (None, Some(_)) => self.datadog_api_key = other.datadog_api_key.clone(),
+            (_, _) => (),
+        }
     }
 
     /// Update the finalizer(s) status.

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -6,7 +6,7 @@ use shared::EventDataEq;
 
 /// The top-level metadata structure contained by both `struct Metric`
 /// and `struct LogEvent` types.
-#[derive(Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct EventMetadata {
     /// Used to store the datadog API from sources to sinks
     #[serde(default, skip)]

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -1,7 +1,6 @@
 #![deny(missing_docs)]
 
 use super::{EventFinalizer, EventFinalizers, EventStatus};
-use getset::Getters;
 use serde::{Deserialize, Serialize};
 use shared::EventDataEq;
 
@@ -9,17 +8,16 @@ use shared::EventDataEq;
 /// and `struct LogEvent` types.
 #[derive(Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize)]
 pub struct EventMetadata {
-    #[serde(default, skip)]
     /// Used to store the datadog API from sources to sinks
-    #[get = "pub"]
-    datadog_api_key: Option<String>,
+    #[serde(default, skip)]
+    pub datadog_api_key: Option<String>,
     #[serde(default, skip)]
     finalizers: EventFinalizers,
 }
 
 impl EventMetadata {
     /// Build metadata with datadog api key only
-    pub fn with_datadog_api_key(api_key: String) -> Self {
+    pub fn new_with_datadog_api_key(api_key: String) -> Self {
         Self {
             datadog_api_key: Some(api_key),
             finalizers: EventFinalizers::default(),
@@ -35,12 +33,8 @@ impl EventMetadata {
     /// Merge the other `EventMetadata` into this.
     pub fn merge(&mut self, other: Self) {
         self.finalizers.merge(other.finalizers);
-        match (
-            self.datadog_api_key.as_ref(),
-            other.datadog_api_key.as_ref(),
-        ) {
-            (None, Some(_)) => self.datadog_api_key = other.datadog_api_key.clone(),
-            (_, _) => (),
+        if self.datadog_api_key.is_none() {
+            self.datadog_api_key = other.datadog_api_key
         }
     }
 

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -10,6 +10,7 @@ use shared::EventDataEq;
 #[derive(Clone, Debug, Default, Deserialize, Getters, PartialEq, PartialOrd, Serialize)]
 pub struct EventMetadata {
     #[serde(default, skip)]
+    /// Used to store the datadog API from sources to sinks
     #[get = "pub"]
     datadog_api_key: Option<String>,
     #[serde(default, skip)]

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -259,9 +259,7 @@ impl HttpSink for DatadogLogsJsonService {
         let json_event = json!(fields);
 
         Some(EncodedEvent {
-            item: PartitionInnerBuffer::new(
-                json_event, api_key,
-            ),
+            item: PartitionInnerBuffer::new(json_event, api_key),
             metadata: Some(metadata),
         })
     }
@@ -304,7 +302,7 @@ impl HttpSink for DatadogLogsTextService {
                 count: 1,
             });
 
-            EncodedEvent{
+            EncodedEvent {
                 item: PartitionInnerBuffer::new(e.item, api_key),
                 metadata: e.metadata,
             }

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -240,8 +240,11 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["message"], "bar".into());
             assert_eq!(log["timestamp"], 456.into());
-            assert_eq!(log["dd_api_key"], "12345678abcdefgh12345678abcdefgh".into());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
+            assert_eq!(
+                event.metadata().datadog_api_key().as_ref().unwrap(),
+                "12345678abcdefgh12345678abcdefgh"
+            );
         }
     }
 
@@ -279,8 +282,11 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], 789.into());
-            assert_eq!(log["dd_api_key"], "12345678abcdefgh12345678abcdefgh".into());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
+            assert_eq!(
+                event.metadata().datadog_api_key().as_ref().unwrap(),
+                "12345678abcdefgh12345678abcdefgh"
+            );
         }
     }
 

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -105,7 +105,8 @@ impl HttpSource for DatadogLogsSource {
         let api_key = match self.store_api_key {
             true => extract_api_key(&header_map, request_path),
             false => None,
-        }.map(Arc::from);
+        }
+        .map(Arc::from);
 
         decode_body(body, Encoding::Json).map(|mut events| {
             // Datadog API key in metadata & source type field

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -98,14 +98,14 @@ impl HttpSource for DatadogLogsSource {
         let api_key = extract_api_key(&header_map, request_path);
 
         decode_body(body, Encoding::Json).map(|mut events| {
-            // Datadog API key in metadat & source type field
+            // Datadog API key in metadata & source type field
             let key = log_schema().source_type_key();
             for event in &mut events {
                 let log = event.as_mut_log();
                 log.try_insert(key, Bytes::from("datadog_logs"));
                 if let Some(k) = &api_key {
                     log.metadata_mut()
-                        .merge(EventMetadata::with_datadog_api_key(k.clone()));
+                        .merge(EventMetadata::new_with_datadog_api_key(k.clone()));
                 }
             }
             events
@@ -242,7 +242,7 @@ mod tests {
             assert_eq!(log["timestamp"], 456.into());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
             assert_eq!(
-                event.metadata().datadog_api_key().as_ref().unwrap(),
+                event.metadata().datadog_api_key.as_ref().unwrap(),
                 "12345678abcdefgh12345678abcdefgh"
             );
         }
@@ -284,7 +284,7 @@ mod tests {
             assert_eq!(log["timestamp"], 789.into());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
             assert_eq!(
-                event.metadata().datadog_api_key().as_ref().unwrap(),
+                event.metadata().datadog_api_key.as_ref().unwrap(),
                 "12345678abcdefgh12345678abcdefgh"
             );
         }

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -28,6 +28,8 @@ pub struct DatadogLogsConfig {
     address: SocketAddr,
     tls: Option<TlsConfig>,
     auth: Option<HttpSourceAuthConfig>,
+    #[serde(default = "crate::serde::default_true")]
+    save_api_key: bool,
 }
 
 inventory::submit! {
@@ -40,6 +42,7 @@ impl GenerateConfig for DatadogLogsConfig {
             address: "0.0.0.0:8080".parse().unwrap(),
             tls: None,
             auth: None,
+            save_api_key: true,
         })
         .unwrap()
     }
@@ -49,7 +52,9 @@ impl GenerateConfig for DatadogLogsConfig {
 #[typetag::serde(name = "datadog_logs")]
 impl SourceConfig for DatadogLogsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<sources::Source> {
-        let source = DatadogLogsSource {};
+        let source = DatadogLogsSource {
+            save_api_key: self.save_api_key,
+        };
         // We accept /v1/input & /v1/input/<API_KEY>
         source.run(
             self.address,
@@ -76,7 +81,9 @@ impl SourceConfig for DatadogLogsConfig {
 }
 
 #[derive(Clone, Default)]
-struct DatadogLogsSource {}
+struct DatadogLogsSource {
+    save_api_key: bool,
+}
 
 impl HttpSource for DatadogLogsSource {
     fn build_events(
@@ -95,7 +102,10 @@ impl HttpSource for DatadogLogsSource {
             return Ok(Vec::new());
         }
 
-        let api_key = extract_api_key(&header_map, request_path);
+        let api_key = match self.save_api_key {
+            true => extract_api_key(&header_map, request_path),
+            false => None,
+        };
 
         decode_body(body, Encoding::Json).map(|mut events| {
             // Datadog API key in metadata & source type field
@@ -143,7 +153,7 @@ mod tests {
         crate::test_util::test_generate_config::<DatadogLogsConfig>();
     }
 
-    async fn source(status: EventStatus) -> (impl Stream<Item = Event>, SocketAddr) {
+    async fn source(status: EventStatus, save_api_key: bool) -> (impl Stream<Item = Event>, SocketAddr) {
         let (sender, recv) = Pipeline::new_test_finalize(status);
         let address = next_addr();
         tokio::spawn(async move {
@@ -151,6 +161,7 @@ mod tests {
                 address,
                 tls: None,
                 auth: None,
+                save_api_key: save_api_key,
             }
             .build(SourceContext::new_test(sender))
             .await
@@ -182,8 +193,7 @@ mod tests {
     #[tokio::test]
     async fn no_api_key() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
-
+        let (rx, addr) = source(EventStatus::Delivered, true).await;
         let mut events = spawn_collect_n(
             async move {
                 assert_eq!(
@@ -207,7 +217,7 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], 123.into());
-            assert!(log.get("dd_api_key").is_none());
+            assert!(event.metadata().datadog_api_key.is_none());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
         }
     }
@@ -215,7 +225,7 @@ mod tests {
     #[tokio::test]
     async fn api_key_in_url() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
+        let (rx, addr) = source(EventStatus::Delivered, true).await;
 
         let mut events = spawn_collect_n(
             async move {
@@ -251,7 +261,7 @@ mod tests {
     #[tokio::test]
     async fn api_key_in_header() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
+        let (rx, addr) = source(EventStatus::Delivered, true).await;
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -293,7 +303,7 @@ mod tests {
     #[tokio::test]
     async fn delivery_failure() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Failed).await;
+        let (rx, addr) = source(EventStatus::Failed, true).await;
 
         spawn_collect_n(
             async move {
@@ -312,5 +322,35 @@ mod tests {
             1,
         )
         .await;
+    async fn ignore_api_key() {
+        trace_init();
+        let (rx, addr) = source(EventStatus::Delivered, false).await;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "dd-api-key",
+            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
+        );
+
+        assert_eq!(
+            200,
+            send_with_path(
+                addr,
+                r#"[{"message":"baz", "timestamp": 789}]"#,
+                headers,
+                "/v1/input/12345678abcdefgh12345678abcdefgh"
+            )
+            .await
+        );
+
+        let mut events = collect_n(rx, 1).await;
+        {
+            let event = events.remove(0);
+            let log = event.as_log();
+            assert_eq!(log["message"], "baz".into());
+            assert_eq!(log["timestamp"], 789.into());
+            assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
+            assert!(event.metadata().datadog_api_key.is_none());
+        }
     }
 }

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -164,7 +164,7 @@ mod tests {
                 address,
                 tls: None,
                 auth: None,
-                save_api_key: save_api_key,
+                save_api_key,
             }
             .build(SourceContext::new_test(sender))
             .await


### PR DESCRIPTION
It comes with:
* A few detail in the doc
* A flag not to save the API key in metadata
