### PR TITLE
enhancement(remap): add match_any function

### DIFF
--- a/docs/reference/remap/functions/match_any.cue
+++ b/docs/reference/remap/functions/match_any.cue
@@ -1,0 +1,35 @@
+package metadata
+
+remap: functions: match_any: {
+	category: "String"
+	description: """
+		Determines whether the `value` matches any the given `patterns`.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The value to match."
+			required:    true
+			type: ["string"]
+		},
+		{
+			name:        "patterns"
+			description: "The array of regular expression patterns to match against."
+			required:    true
+			type: ["array"]
+		},
+	]
+	internal_failure_reasons: []
+	return: types: ["boolean"]
+
+	examples: [
+		{
+			title: "Regex match on a string"
+			source: """
+				match_any("I'm a little teapot", [r'frying pan', r'teapot'])
+				"""
+			return: true
+		},
+	]
+}

--- a/docs/reference/remap/functions/match_any.cue
+++ b/docs/reference/remap/functions/match_any.cue
@@ -3,7 +3,10 @@ package metadata
 remap: functions: match_any: {
 	category: "String"
 	description: """
-		Determines whether the `value` matches any the given `patterns`.
+		Determines whether the `value` matches any the given `patterns`. All
+		patterns are checked in a single pass over the target string, giving this
+		function a potentially significant performance advantage over multiple calls
+		to `match`.
 		"""
 
 	arguments: [

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -82,6 +82,7 @@ default = [
     "length",
     "log",
     "match",
+    "match_any",
     "md5",
     "merge",
     "now",
@@ -180,6 +181,7 @@ join = []
 length = []
 log = ["tracing"]
 match = ["regex"]
+match_any = ["regex"]
 md5 = ["md-5", "hex"]
 merge = []
 now = ["chrono"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -48,6 +48,7 @@ criterion_group!(
               length,
               log,
               r#match,
+              match_any,
               md5,
               merge,
               // TODO: value is dynamic so we cannot assert equality
@@ -585,6 +586,15 @@ bench_function! {
 
     simple {
         args: func_args![value: "foo 2 bar", pattern: Regex::new("foo \\d bar").unwrap()],
+        want: Ok(true),
+    }
+}
+
+bench_function! {
+    match_any => vrl_stdlib::MatchAny;
+
+    simple {
+        args: func_args![value: "foo 2 bar", patterns: vec![Regex::new(r"foo \d bar").unwrap()]],
         want: Ok(true),
     }
 }

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -90,6 +90,8 @@ mod log;
 mod log_util;
 #[cfg(feature = "match")]
 mod r#match;
+#[cfg(feature = "match")]
+mod match_any;
 #[cfg(feature = "md5")]
 mod md5;
 #[cfg(feature = "merge")]
@@ -289,6 +291,8 @@ pub use join::Join;
 pub use length::Length;
 #[cfg(feature = "log")]
 pub use log::Log;
+#[cfg(feature = "match")]
+pub use match_any::MatchAny;
 #[cfg(feature = "merge")]
 pub use merge::Merge;
 #[cfg(feature = "now")]
@@ -484,6 +488,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Log),
         #[cfg(feature = "match")]
         Box::new(Match),
+        #[cfg(feature = "match")]
+        Box::new(MatchAny),
         #[cfg(feature = "md5")]
         Box::new(Md5),
         #[cfg(feature = "merge")]
@@ -544,6 +550,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Push),
         #[cfg(feature = "match")]
         Box::new(Match),
+        #[cfg(feature = "match")]
+        Box::new(MatchAny),
         #[cfg(feature = "redact")]
         Box::new(Redact),
         #[cfg(feature = "replace")]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -90,7 +90,7 @@ mod log;
 mod log_util;
 #[cfg(feature = "match")]
 mod r#match;
-#[cfg(feature = "match")]
+#[cfg(feature = "match_any")]
 mod match_any;
 #[cfg(feature = "md5")]
 mod md5;
@@ -291,7 +291,7 @@ pub use join::Join;
 pub use length::Length;
 #[cfg(feature = "log")]
 pub use log::Log;
-#[cfg(feature = "match")]
+#[cfg(feature = "match_any")]
 pub use match_any::MatchAny;
 #[cfg(feature = "merge")]
 pub use merge::Merge;

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -52,8 +52,9 @@ impl Function for MatchAny {
                     expr,
                 })?;
 
-            // TODO: Why does `?` not work here?
-            let re = value.try_regex().unwrap();
+            let re = value
+                .try_regex()
+                .map_err(|e| Box::new(e) as Box<dyn DiagnosticError>)?;
             re_strings.push(re.to_string());
         }
 

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -1,0 +1,115 @@
+use regex::bytes::RegexSet;
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MatchAny;
+
+impl Function for MatchAny {
+    fn identifier(&self) -> &'static str {
+        "match_any"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "patterns",
+                kind: kind::ARRAY,
+                required: false,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "match",
+                source: r#"match_any("foo bar baz", patterns: [r'foo', r'123'])"#,
+                result: Ok("true"),
+            },
+            Example {
+                title: "no_match",
+                source: r#"match_any("My name is John Doe", patterns: [r'\d+', r'Jane'])"#,
+                result: Ok("false"),
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let patterns = arguments.required_array("patterns")?;
+
+        let mut re_strings = Vec::with_capacity(patterns.len());
+        for expr in patterns {
+            let value = expr
+                .as_value()
+                .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                    keyword: "patterns",
+                    expr,
+                })?;
+
+            // TODO: Why does `?` not work here?
+            let re = value.try_regex().unwrap();
+            re_strings.push(re.to_string());
+        }
+
+        let regex_set = RegexSet::new(re_strings).expect("regex were already valid");
+
+        Ok(Box::new(MatchAnyFn { value, regex_set }))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MatchAnyFn {
+    value: Box<dyn Expression>,
+    regex_set: RegexSet,
+}
+
+impl Expression for MatchAnyFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let bytes = value.try_bytes()?;
+
+        Ok(self.regex_set.is_match(&bytes).into())
+    }
+
+    fn type_def(&self, _state: &state::Compiler) -> TypeDef {
+        TypeDef::new().infallible().boolean()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::trivial_regex)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    test_function![
+        r#match_any => MatchAny;
+
+        yes {
+            args: func_args![value: "foobar",
+                             patterns: Value::Array(vec![
+                                 Value::Regex(Regex::new("foo").unwrap().into()),
+                                 Value::Regex(Regex::new("bar").unwrap().into()),
+                                 Value::Regex(Regex::new("baz").unwrap().into()),
+                             ])],
+            want: Ok(value!(true)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        no {
+            args: func_args![value: "foo 2 bar",
+                             patterns: Value::Array(vec![
+                                 Value::Regex(Regex::new("baz|quux").unwrap().into()),
+                                 Value::Regex(Regex::new("foobar").unwrap().into()),
+                             ])],
+            want: Ok(value!(false)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -19,7 +19,7 @@ impl Function for MatchAny {
             Parameter {
                 keyword: "patterns",
                 kind: kind::ARRAY,
-                required: false,
+                required: true,
             },
         ]
     }


### PR DESCRIPTION
This is currently built on top of #7250 to take advantage of some of @jszwedko additions there. ~~It's also not documented and has one `unwrap` that needs removed, but I'm opening it in this state to get some feedback since it's my first real work with VRL.~~

The goal here is to optimize the case of checking against multiple regexes. Instead of `match(.foo, ...) || match(.foo, ...) || ...`, you can simply pass an array of patterns that are compiled to a `RegexSet` and checked efficiently in one pass. This is also more ergonomic than asking users to combine patterns manually.