### PR TITLE
chore: temporarily revert 7325

### DIFF
--- a/lib/vector-core/src/event/finalization.rs
+++ b/lib/vector-core/src/event/finalization.rs
@@ -2,7 +2,6 @@
 
 use atomig::{Atom, AtomInteger, Atomic, Ordering};
 use serde::{Deserialize, Serialize};
-use std::iter::{self, ExactSizeIterator};
 use std::{mem, sync::Arc};
 use tokio::sync::oneshot;
 
@@ -30,33 +29,19 @@ impl EventFinalizers {
         Self(vec![Arc::new(finalizer)].into())
     }
 
-    /// Add a single finalizer to this array.
-    pub fn add(&mut self, finalizer: EventFinalizer) {
-        self.add_generic(iter::once(Arc::new(finalizer)));
-    }
-
     /// Merge the given list of finalizers into this array.
     pub fn merge(&mut self, other: Self) {
-        // Box<[T]> is missing IntoIterator; this just adds a `capacity` value
-        let other: Vec<_> = other.0.into();
-        self.add_generic(other.into_iter());
-    }
-
-    fn add_generic<I>(&mut self, items: I)
-    where
-        I: ExactSizeIterator<Item = Arc<EventFinalizer>>,
-    {
-        if self.0.is_empty() {
-            self.0 = items.collect::<Vec<_>>().into();
-        } else if items.len() > 0 {
+        if !other.0.is_empty() {
             // This requires a bit of extra work both to avoid cloning
             // the actual elements and because `self.0` cannot be
             // mutated in place.
             let finalizers = mem::replace(&mut self.0, vec![].into());
             let mut result: Vec<_> = finalizers.into();
             // This is the only step that may cause a (re)allocation.
-            result.reserve_exact(items.len());
-            for entry in items {
+            result.reserve_exact(other.0.len());
+            // Box<[T]> is missing IntoIterator
+            let other: Vec<_> = other.0.into();
+            for entry in other {
                 // Deduplicate by hand, assume the list is trivially small
                 if !result.iter().any(|existing| Arc::ptr_eq(existing, &entry)) {
                     result.push(entry);

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -75,10 +75,6 @@ impl LogEvent {
         Self::from_parts(fields, metadata.with_finalizer(EventFinalizer::new(batch)))
     }
 
-    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
-        self.metadata.add_finalizer(finalizer);
-    }
-
     #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
     pub fn get(&self, key: impl AsRef<str>) -> Option<&Value> {
         util::log::get(self.as_map(), key.as_ref())

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -33,11 +33,6 @@ impl EventMetadata {
     pub fn update_sources(&mut self) {
         self.finalizers.update_sources();
     }
-
-    /// Add a new finalizer to the array
-    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
-        self.finalizers.add(finalizer);
-    }
 }
 
 impl EventDataEq for EventMetadata {

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1,4 +1,4 @@
-use super::{EventFinalizer, EventMetadata};
+use super::EventMetadata;
 use crate::metrics::Handle;
 use chrono::{DateTime, Utc};
 use derive_is_enum_variant::is_enum_variant;
@@ -273,10 +273,6 @@ impl Metric {
     pub fn with_timestamp(mut self, timestamp: Option<DateTime<Utc>>) -> Self {
         self.data.timestamp = timestamp;
         self
-    }
-
-    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
-        self.metadata.add_finalizer(finalizer);
     }
 
     pub fn with_tags(mut self, tags: Option<MetricTags>) -> Self {

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -12,7 +12,6 @@ use shared::EventDataEq;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
-use std::sync::Arc;
 use tracing::field::{Field, Visit};
 pub use util::log::PathComponent;
 pub use util::log::PathIter;
@@ -137,14 +136,6 @@ impl Event {
         match self {
             Self::Log(log) => log.metadata_mut(),
             Self::Metric(metric) => metric.metadata_mut(),
-        }
-    }
-
-    pub fn add_batch_notifier(&mut self, batch: Arc<BatchNotifier>) {
-        let finalizer = EventFinalizer::new(batch);
-        match self {
-            Self::Log(log) => log.add_finalizer(finalizer),
-            Self::Metric(metric) => metric.add_finalizer(finalizer),
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,11 +1,6 @@
-use crate::{internal_events::EventOut, transforms::FunctionTransform};
+use crate::{event::Event, internal_events::EventOut, transforms::FunctionTransform};
 use futures::{channel::mpsc, task::Poll, Sink};
-#[cfg(test)]
-use futures::{Stream, StreamExt};
 use std::{collections::VecDeque, fmt, pin::Pin, task::Context};
-use vector_core::event::Event;
-#[cfg(test)]
-use vector_core::event::EventStatus;
 
 #[derive(Debug)]
 pub struct ClosedError;
@@ -107,21 +102,6 @@ impl Pipeline {
     #[cfg(test)]
     pub fn new_test() -> (Self, mpsc::Receiver<Event>) {
         Self::new_with_buffer(100, vec![])
-    }
-
-    #[cfg(test)]
-    pub fn new_test_finalize(status: EventStatus) -> (Self, impl Stream<Item = Event> + Unpin) {
-        let (pipe, recv) = Self::new_with_buffer(100, vec![]);
-        // In a source test pipeline, there is no sink to acknowledge
-        // events, so we have to add a map to the receiver to handle the
-        // finalization.
-        let recv = recv.map(move |mut event| {
-            let metadata = event.metadata_mut();
-            metadata.update_status(status);
-            metadata.update_sources();
-            event
-        });
-        (pipe, recv)
     }
 
     pub fn new_with_buffer(

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -79,7 +79,7 @@ impl SourceConfig for DatadogLogsConfig {
 struct DatadogLogsSource {}
 
 impl HttpSource for DatadogLogsSource {
-    fn build_events(
+    fn build_event(
         &self,
         body: Bytes,
         header_map: HeaderMap,
@@ -100,7 +100,7 @@ impl HttpSource for DatadogLogsSource {
         decode_body(body, Encoding::Json).map(|mut events| {
             // Add source type & Datadog API key
             let key = log_schema().source_type_key();
-            for event in &mut events {
+            for event in events.iter_mut() {
                 let log = event.as_mut_log();
                 log.try_insert(key, Bytes::from("datadog_logs"));
                 if let Some(k) = &api_key {
@@ -128,11 +128,11 @@ mod tests {
 
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
-        event::{Event, EventStatus},
-        test_util::{next_addr, spawn_collect_n, trace_init, wait_for_tcp},
+        event::Event,
+        test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
         Pipeline,
     };
-    use futures::Stream;
+    use futures::channel::mpsc;
     use http::HeaderMap;
     use pretty_assertions::assert_eq;
     use std::net::SocketAddr;
@@ -142,8 +142,8 @@ mod tests {
         crate::test_util::test_generate_config::<DatadogLogsConfig>();
     }
 
-    async fn source(status: EventStatus) -> (impl Stream<Item = Event>, SocketAddr) {
-        let (sender, recv) = Pipeline::new_test_finalize(status);
+    async fn source() -> (mpsc::Receiver<Event>, SocketAddr) {
+        let (sender, recv) = Pipeline::new_test();
         let address = next_addr();
         tokio::spawn(async move {
             DatadogLogsConfig {
@@ -181,26 +181,20 @@ mod tests {
     #[tokio::test]
     async fn no_api_key() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
+        let (rx, addr) = source().await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        r#"[{"message":"foo", "timestamp": 123}]"#,
-                        HeaderMap::new(),
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
-            rx,
-            1,
-        )
-        .await;
+        assert_eq!(
+            200,
+            send_with_path(
+                addr,
+                r#"[{"message":"foo", "timestamp": 123}]"#,
+                HeaderMap::new(),
+                "/v1/input/"
+            )
+            .await
+        );
 
+        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -214,26 +208,20 @@ mod tests {
     #[tokio::test]
     async fn api_key_in_url() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
+        let (rx, addr) = source().await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        r#"[{"message":"bar", "timestamp": 456}]"#,
-                        HeaderMap::new(),
-                        "/v1/input/12345678abcdefgh12345678abcdefgh"
-                    )
-                    .await
-                );
-            },
-            rx,
-            1,
-        )
-        .await;
+        assert_eq!(
+            200,
+            send_with_path(
+                addr,
+                r#"[{"message":"bar", "timestamp": 456}]"#,
+                HeaderMap::new(),
+                "/v1/input/12345678abcdefgh12345678abcdefgh"
+            )
+            .await
+        );
 
+        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -247,7 +235,7 @@ mod tests {
     #[tokio::test]
     async fn api_key_in_header() {
         trace_init();
-        let (rx, addr) = source(EventStatus::Delivered).await;
+        let (rx, addr) = source().await;
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -255,24 +243,18 @@ mod tests {
             "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
         );
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        r#"[{"message":"baz", "timestamp": 789}]"#,
-                        headers,
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
-            rx,
-            1,
-        )
-        .await;
+        assert_eq!(
+            200,
+            send_with_path(
+                addr,
+                r#"[{"message":"baz", "timestamp": 789}]"#,
+                headers,
+                "/v1/input/"
+            )
+            .await
+        );
 
+        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -281,29 +263,5 @@ mod tests {
             assert_eq!(log["dd_api_key"], "12345678abcdefgh12345678abcdefgh".into());
             assert_eq!(log[log_schema().source_type_key()], "datadog_logs".into());
         }
-    }
-
-    #[tokio::test]
-    async fn delivery_failure() {
-        trace_init();
-        let (rx, addr) = source(EventStatus::Failed).await;
-
-        spawn_collect_n(
-            async move {
-                assert_eq!(
-                    400,
-                    send_with_path(
-                        addr,
-                        r#"[{"message":"foo", "timestamp": 123}]"#,
-                        HeaderMap::new(),
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
-            rx,
-            1,
-        )
-        .await;
     }
 }

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -55,7 +55,7 @@ struct LogplexSource {
 }
 
 impl HttpSource for LogplexSource {
-    fn build_events(
+    fn build_event(
         &self,
         body: Bytes,
         header_map: HeaderMap,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -91,7 +91,7 @@ impl RemoteWriteSource {
 }
 
 impl HttpSource for RemoteWriteSource {
-    fn build_events(
+    fn build_event(
         &self,
         mut body: Bytes,
         header_map: HeaderMap,
@@ -107,10 +107,10 @@ impl HttpSource for RemoteWriteSource {
         {
             body = decode(&Some("snappy".to_string()), body)?;
         }
-        let events = self.decode_body(body)?;
-        let count = events.len();
+        let result = self.decode_body(body)?;
+        let count = result.len();
         emit!(PrometheusRemoteWriteReceived { count });
-        Ok(events)
+        Ok(result)
     }
 }
 

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event::{BatchNotifier, BatchStatus, Event},
+    event::Event,
     internal_events::{HttpBadRequest, HttpDecompressError, HttpEventsReceived},
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
@@ -12,9 +12,7 @@ use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
 use headers::{Authorization, HeaderMapExt};
 use serde::{Deserialize, Serialize};
 use snap::raw::Decoder as SnappyDecoder;
-use std::{
-    collections::HashMap, convert::TryFrom, error::Error, fmt, io::Read, net::SocketAddr, sync::Arc,
-};
+use std::{collections::HashMap, convert::TryFrom, error::Error, fmt, io::Read, net::SocketAddr};
 use tracing_futures::Instrument;
 use warp::{
     filters::{path::FullPath, path::Tail, BoxedFilter},
@@ -177,7 +175,7 @@ fn handle_decode_error(encoding: &str, error: impl std::error::Error) -> ErrorMe
 
 #[async_trait]
 pub trait HttpSource: Clone + Send + Sync + 'static {
-    fn build_events(
+    fn build_event(
         &self,
         body: Bytes,
         header_map: HeaderMap,
@@ -238,25 +236,18 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                             .is_valid(&auth_header)
                             .and_then(|()| decode(&encoding_header, body))
                             .and_then(|body| {
-                                let body_len = body.len();
-                                self.build_events(body, headers, query_parameters, path.as_str())
-                                    .map(|events|(events, body_len))
+                                let body_len=body.len();
+                                self.build_event(body, headers, query_parameters, path.as_str())
+                                    .map(|events| (events, body_len))
                             });
 
                         async move {
                             match events {
-                                Ok((mut events, body_size)) => {
+                                Ok((events,body_size)) => {
                                     emit!(HttpEventsReceived {
                                         events_count: events.len(),
                                         byte_size: body_size,
                                     });
-
-                                    let (batch, receiver) = BatchNotifier::new_with_receiver();
-                                    for event in &mut events {
-                                        event.add_batch_notifier(Arc::clone(&batch));
-                                    }
-                                    drop(batch);
-
                                     out.send_all(&mut futures::stream::iter(events).map(Ok))
                                         .map_err(move |error: crate::pipeline::ClosedError| {
                                             // can only fail if receiving end disconnected, so we are shutting down,
@@ -265,23 +256,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                             error!(message = "Tried to send the following event.", %error);
                                             warp::reject::custom(RejectShuttingDown)
                                         })
-                                        .and_then(|_| async move {
-                                            match receiver.await.unwrap_or(BatchStatus::Delivered) {
-                                                BatchStatus::Delivered => Ok(warp::reply()),
-                                                BatchStatus::Errored => Err(warp::reject::custom(
-                                                    ErrorMessage::new(
-                                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                                        "Error delivering contents to sink".into(),
-                                                    ),
-                                                )),
-                                                BatchStatus::Failed => Err(warp::reject::custom(
-                                                    ErrorMessage::new(
-                                                        StatusCode::BAD_REQUEST,
-                                                        "Contents failed to deliver to sink".into(),
-                                                    ),
-                                                )),
-                                            }
-                                        })
+                                        .map_ok(|_| warp::reply())
                                         .await
                                 }
                                 Err(error) => {

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -545,19 +545,3 @@ pub async fn start_topology(
         .await
         .unwrap()
 }
-
-/// Collect the first `n` events from a stream while a future is spawned
-/// in the background. This is used for tests where the collect has to
-/// happen concurrent with the sending process (ie the stream is
-/// handling finalization, which is required for the future to receive
-/// an acknowledgement).
-pub async fn spawn_collect_n<F, S>(future: F, stream: S, n: usize) -> Vec<Event>
-where
-    F: Future<Output = ()> + Send + 'static,
-    S: Stream<Item = Event> + Unpin,
-{
-    let sender = tokio::spawn(future);
-    let events = collect_n(stream, n).await;
-    sender.await.expect("Failed to send data");
-    events
-}


### PR DESCRIPTION
Revert "enhancement(datadog source, http source): Add acknowledgement support (#7325)"

This appears to be causing CI to hang. I figured reverting was better
than letting it pile up until we can resolve.

This reverts commit 838bdb227c42ee42aee5f70e45706d5f0ae6d29a.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
