### PR TITLE
enhancement(heroku_logs source, http source): Add end-to-end acknowledgements

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -75,6 +75,10 @@ impl LogEvent {
         Self::from_parts(fields, metadata.with_finalizer(EventFinalizer::new(batch)))
     }
 
+    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
+        self.metadata.add_finalizer(finalizer);
+    }
+
     #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
     pub fn get(&self, key: impl AsRef<str>) -> Option<&Value> {
         util::log::get(self.as_map(), key.as_ref())

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -33,6 +33,11 @@ impl EventMetadata {
     pub fn update_sources(&mut self) {
         self.finalizers.update_sources();
     }
+
+    /// Add a new finalizer to the array
+    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
+        self.finalizers.add(finalizer);
+    }
 }
 
 impl EventDataEq for EventMetadata {

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1,4 +1,4 @@
-use super::EventMetadata;
+use super::{EventFinalizer, EventMetadata};
 use crate::metrics::Handle;
 use chrono::{DateTime, Utc};
 use derive_is_enum_variant::is_enum_variant;
@@ -273,6 +273,10 @@ impl Metric {
     pub fn with_timestamp(mut self, timestamp: Option<DateTime<Utc>>) -> Self {
         self.data.timestamp = timestamp;
         self
+    }
+
+    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
+        self.metadata.add_finalizer(finalizer);
     }
 
     pub fn with_tags(mut self, tags: Option<MetricTags>) -> Self {

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -12,6 +12,7 @@ use shared::EventDataEq;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
+use std::sync::Arc;
 use tracing::field::{Field, Visit};
 pub use util::log::PathComponent;
 pub use util::log::PathIter;
@@ -136,6 +137,14 @@ impl Event {
         match self {
             Self::Log(log) => log.metadata_mut(),
             Self::Metric(metric) => metric.metadata_mut(),
+        }
+    }
+
+    pub fn add_batch_notifier(&mut self, batch: Arc<BatchNotifier>) {
+        let finalizer = EventFinalizer::new(batch);
+        match self {
+            Self::Log(log) => log.add_finalizer(finalizer),
+            Self::Metric(metric) => metric.add_finalizer(finalizer),
         }
     }
 }

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -3,10 +3,12 @@ use crate::{
         log_schema, DataType, GenerateConfig, Resource, SourceConfig, SourceContext,
         SourceDescription,
     },
-    event::Event,
+    event::BatchNotifier,
     sources::{
         self,
-        util::{decode_body, Encoding, ErrorMessage, HttpSource, HttpSourceAuthConfig},
+        util::{
+            decode_body, BuiltEvents, Encoding, ErrorMessage, HttpSource, HttpSourceAuthConfig,
+        },
     },
     tls::TlsConfig,
 };
@@ -79,25 +81,29 @@ impl SourceConfig for DatadogLogsConfig {
 struct DatadogLogsSource {}
 
 impl HttpSource for DatadogLogsSource {
-    fn build_event(
+    fn build_events(
         &self,
         body: Bytes,
         header_map: HeaderMap,
         _query_parameters: HashMap<String, String>,
         request_path: &str,
-    ) -> Result<Vec<Event>, ErrorMessage> {
+    ) -> Result<BuiltEvents, ErrorMessage> {
         if body.is_empty() {
             // The datadog agent may sent empty payload as keep alive
             debug!(
                 message = "Empty payload ignored.",
                 internal_log_rate_secs = 30
             );
-            return Ok(Vec::new());
+            return Ok(BuiltEvents {
+                events: Vec::new(),
+                receiver: None,
+            });
         }
 
         let api_key = extract_api_key(&header_map, request_path);
 
-        decode_body(body, Encoding::Json).map(|mut events| {
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+        decode_body(body, Encoding::Json, batch).map(|mut events| {
             // Add source type & Datadog API key
             let key = log_schema().source_type_key();
             for event in events.iter_mut() {
@@ -107,7 +113,8 @@ impl HttpSource for DatadogLogsSource {
                     log.insert("dd_api_key", k.clone());
                 }
             }
-            events
+            let receiver = Some(receiver);
+            BuiltEvents { events, receiver }
         })
     }
 }
@@ -128,11 +135,11 @@ mod tests {
 
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
-        event::Event,
-        test_util::{collect_n, next_addr, trace_init, wait_for_tcp},
+        event::{Event, EventStatus},
+        test_util::{next_addr, spawn_collect_n, stream_update_status, trace_init, wait_for_tcp},
         Pipeline,
     };
-    use futures::channel::mpsc;
+    use futures::Stream;
     use http::HeaderMap;
     use pretty_assertions::assert_eq;
     use std::net::SocketAddr;
@@ -142,7 +149,7 @@ mod tests {
         crate::test_util::test_generate_config::<DatadogLogsConfig>();
     }
 
-    async fn source() -> (mpsc::Receiver<Event>, SocketAddr) {
+    async fn source() -> (impl Stream<Item = Event>, SocketAddr) {
         let (sender, recv) = Pipeline::new_test();
         let address = next_addr();
         tokio::spawn(async move {
@@ -158,6 +165,7 @@ mod tests {
             .unwrap();
         });
         wait_for_tcp(address).await;
+        let recv = stream_update_status(recv, EventStatus::Delivered);
         (recv, address)
     }
 
@@ -183,18 +191,24 @@ mod tests {
         trace_init();
         let (rx, addr) = source().await;
 
-        assert_eq!(
-            200,
-            send_with_path(
-                addr,
-                r#"[{"message":"foo", "timestamp": 123}]"#,
-                HeaderMap::new(),
-                "/v1/input/"
-            )
-            .await
-        );
+        let mut events = spawn_collect_n(
+            async move {
+                assert_eq!(
+                    200,
+                    send_with_path(
+                        addr,
+                        r#"[{"message":"foo", "timestamp": 123}]"#,
+                        HeaderMap::new(),
+                        "/v1/input/"
+                    )
+                    .await
+                );
+            },
+            rx,
+            1,
+        )
+        .await;
 
-        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -210,18 +224,24 @@ mod tests {
         trace_init();
         let (rx, addr) = source().await;
 
-        assert_eq!(
-            200,
-            send_with_path(
-                addr,
-                r#"[{"message":"bar", "timestamp": 456}]"#,
-                HeaderMap::new(),
-                "/v1/input/12345678abcdefgh12345678abcdefgh"
-            )
-            .await
-        );
+        let mut events = spawn_collect_n(
+            async move {
+                assert_eq!(
+                    200,
+                    send_with_path(
+                        addr,
+                        r#"[{"message":"bar", "timestamp": 456}]"#,
+                        HeaderMap::new(),
+                        "/v1/input/12345678abcdefgh12345678abcdefgh"
+                    )
+                    .await
+                );
+            },
+            rx,
+            1,
+        )
+        .await;
 
-        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();
@@ -243,18 +263,24 @@ mod tests {
             "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
         );
 
-        assert_eq!(
-            200,
-            send_with_path(
-                addr,
-                r#"[{"message":"baz", "timestamp": 789}]"#,
-                headers,
-                "/v1/input/"
-            )
-            .await
-        );
+        let mut events = spawn_collect_n(
+            async move {
+                assert_eq!(
+                    200,
+                    send_with_path(
+                        addr,
+                        r#"[{"message":"baz", "timestamp": 789}]"#,
+                        headers,
+                        "/v1/input/"
+                    )
+                    .await
+                );
+            },
+            rx,
+            1,
+        )
+        .await;
 
-        let mut events = collect_n(rx, 1).await;
         {
             let event = events.remove(0);
             let log = event.as_log();

--- a/src/sources/datadog/logs.rs
+++ b/src/sources/datadog/logs.rs
@@ -136,7 +136,7 @@ mod tests {
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
         event::{Event, EventStatus},
-        test_util::{next_addr, spawn_collect_n, stream_update_status, trace_init, wait_for_tcp},
+        test_util::{next_addr, spawn_collect_n, trace_init, wait_for_tcp},
         Pipeline,
     };
     use futures::Stream;
@@ -150,7 +150,7 @@ mod tests {
     }
 
     async fn source() -> (impl Stream<Item = Event>, SocketAddr) {
-        let (sender, recv) = Pipeline::new_test();
+        let (sender, recv) = Pipeline::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
         tokio::spawn(async move {
             DatadogLogsConfig {
@@ -165,7 +165,6 @@ mod tests {
             .unwrap();
         });
         wait_for_tcp(address).await;
-        let recv = stream_update_status(recv, EventStatus::Delivered);
         (recv, address)
     }
 

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -5,7 +5,9 @@ use crate::{
     },
     event::Event,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
-    sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
+    sources::util::{
+        add_query_parameters, BuiltEvents, ErrorMessage, HttpSource, HttpSourceAuthConfig,
+    },
     tls::TlsConfig,
 };
 use bytes::{Buf, Bytes};
@@ -55,15 +57,17 @@ struct LogplexSource {
 }
 
 impl HttpSource for LogplexSource {
-    fn build_event(
+    fn build_events(
         &self,
         body: Bytes,
         header_map: HeaderMap,
         query_parameters: HashMap<String, String>,
         _full_path: &str,
-    ) -> Result<Vec<Event>, ErrorMessage> {
-        decode_message(body, header_map)
-            .map(|events| add_query_parameters(events, &self.query_parameters, query_parameters))
+    ) -> Result<BuiltEvents, ErrorMessage> {
+        decode_message(body, header_map).map(|events| BuiltEvents {
+            events: add_query_parameters(events, &self.query_parameters, query_parameters),
+            receiver: None,
+        })
     }
 }
 

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -230,7 +230,7 @@ mod tests {
     use super::{HttpSourceAuthConfig, LogplexConfig};
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
-        test_util::{next_addr, spawn_collect_n, trace_init, wait_for_tcp},
+        test_util::{next_addr, random_string, spawn_collect_n, trace_init, wait_for_tcp},
         Pipeline,
     };
     use chrono::{DateTime, Utc};
@@ -247,8 +247,9 @@ mod tests {
     async fn source(
         auth: Option<HttpSourceAuthConfig>,
         query_parameters: Vec<String>,
+        status: EventStatus,
     ) -> (impl Stream<Item = Event>, SocketAddr) {
-        let (sender, recv) = Pipeline::new_test_finalize(EventStatus::Delivered);
+        let (sender, recv) = Pipeline::new_test_finalize(status);
         let address = next_addr();
         tokio::spawn(async move {
             LogplexConfig {
@@ -289,20 +290,25 @@ mod tests {
             .as_u16()
     }
 
+    fn make_auth() -> HttpSourceAuthConfig {
+        HttpSourceAuthConfig {
+            username: random_string(16),
+            password: random_string(16),
+        }
+    }
+
+    const SAMPLE_BODY: &str = r#"267 <158>1 2020-01-08T22:33:57.353034+00:00 host heroku router - at=info method=GET path="/cart_link" host=lumberjack-store.timber.io request_id=05726858-c44e-4f94-9a20-37df73be9006 fwd="73.75.38.87" dyno=web.1 connect=1ms service=22ms status=304 bytes=656 protocol=http"#;
+
     #[tokio::test]
     async fn logplex_handles_router_log() {
         trace_init();
 
-        let body = r#"267 <158>1 2020-01-08T22:33:57.353034+00:00 host heroku router - at=info method=GET path="/cart_link" host=lumberjack-store.timber.io request_id=05726858-c44e-4f94-9a20-37df73be9006 fwd="73.75.38.87" dyno=web.1 connect=1ms service=22ms status=304 bytes=656 protocol=http"#;
-
-        let auth = HttpSourceAuthConfig {
-            username: "vector_user".to_owned(),
-            password: "vector_pass".to_owned(),
-        };
+        let auth = make_auth();
 
         let (rx, addr) = source(
             Some(auth.clone()),
             vec!["appname".to_string(), "absent".to_string()],
+            EventStatus::Delivered,
         )
         .await;
 
@@ -310,11 +316,11 @@ mod tests {
             async move {
                 assert_eq!(
                     200,
-                    send(addr, body, Some(auth), "appname=lumberjack-store").await
+                    send(addr, SAMPLE_BODY, Some(auth), "appname=lumberjack-store").await
                 )
             },
             rx,
-            body.lines().count(),
+            SAMPLE_BODY.lines().count(),
         )
         .await;
 
@@ -336,6 +342,47 @@ mod tests {
         assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
         assert_eq!(log["appname"], "lumberjack-store".into());
         assert_eq!(log["absent"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn logplex_handles_failures() {
+        trace_init();
+
+        let auth = make_auth();
+
+        let (rx, addr) = source(Some(auth.clone()), vec![], EventStatus::Failed).await;
+
+        let events = spawn_collect_n(
+            async move {
+                assert_eq!(
+                    400,
+                    send(addr, SAMPLE_BODY, Some(auth), "appname=lumberjack-store").await
+                )
+            },
+            rx,
+            SAMPLE_BODY.lines().count(),
+        )
+        .await;
+
+        assert_eq!(events.len(), SAMPLE_BODY.lines().count());
+    }
+
+    #[tokio::test]
+    async fn logplex_auth_failure() {
+        trace_init();
+
+        let (_rx, addr) = source(Some(make_auth()), vec![], EventStatus::Delivered).await;
+
+        assert_eq!(
+            401,
+            send(
+                addr,
+                SAMPLE_BODY,
+                Some(make_auth()),
+                "appname=lumberjack-store"
+            )
+            .await
+        );
     }
 
     #[test]

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -166,7 +166,7 @@ mod tests {
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
         event::{Event, EventStatus, Value},
-        test_util::{next_addr, spawn_collect_n, stream_update_status, trace_init, wait_for_tcp},
+        test_util::{next_addr, spawn_collect_n, trace_init, wait_for_tcp},
         Pipeline,
     };
     use flate2::{
@@ -193,7 +193,7 @@ mod tests {
         path: &str,
         strict_path: bool,
     ) -> (impl Stream<Item = Event>, SocketAddr) {
-        let (sender, recv) = Pipeline::new_test();
+        let (sender, recv) = Pipeline::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
         let path = path.to_owned();
         let path_key = path_key.to_owned();
@@ -216,7 +216,6 @@ mod tests {
             .unwrap();
         });
         wait_for_tcp(address).await;
-        let recv = stream_update_status(recv, EventStatus::Delivered);
         (recv, address)
     }
 

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -5,7 +5,7 @@ use crate::{
     internal_events::{PrometheusRemoteWriteParseError, PrometheusRemoteWriteReceived},
     sources::{
         self,
-        util::{decode, BuiltEvents, ErrorMessage, HttpSource, HttpSourceAuthConfig},
+        util::{decode, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     },
     tls::TlsConfig,
 };
@@ -97,7 +97,7 @@ impl HttpSource for RemoteWriteSource {
         header_map: HeaderMap,
         _query_parameters: HashMap<String, String>,
         _full_path: &str,
-    ) -> Result<BuiltEvents, ErrorMessage> {
+    ) -> Result<Vec<Event>, ErrorMessage> {
         // If `Content-Encoding` header isn't `snappy` HttpSource won't decode it for us
         // se we need to.
         if header_map
@@ -110,10 +110,7 @@ impl HttpSource for RemoteWriteSource {
         let events = self.decode_body(body)?;
         let count = events.len();
         emit!(PrometheusRemoteWriteReceived { count });
-        Ok(BuiltEvents {
-            events,
-            receiver: None,
-        })
+        Ok(events)
     }
 }
 

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event::{BatchStatus, BatchStatusReceiver, Event},
+    event::{BatchNotifier, BatchStatus, Event},
     internal_events::{HttpBadRequest, HttpDecompressError, HttpEventsReceived},
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
@@ -12,7 +12,9 @@ use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
 use headers::{Authorization, HeaderMapExt};
 use serde::{Deserialize, Serialize};
 use snap::raw::Decoder as SnappyDecoder;
-use std::{collections::HashMap, convert::TryFrom, error::Error, fmt, io::Read, net::SocketAddr};
+use std::{
+    collections::HashMap, convert::TryFrom, error::Error, fmt, io::Read, net::SocketAddr, sync::Arc,
+};
 use tracing_futures::Instrument;
 use warp::{
     filters::{path::FullPath, path::Tail, BoxedFilter},
@@ -173,11 +175,6 @@ fn handle_decode_error(encoding: &str, error: impl std::error::Error) -> ErrorMe
     )
 }
 
-pub struct BuiltEvents {
-    pub events: Vec<Event>,
-    pub receiver: Option<BatchStatusReceiver>,
-}
-
 #[async_trait]
 pub trait HttpSource: Clone + Send + Sync + 'static {
     fn build_events(
@@ -186,7 +183,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         header_map: HeaderMap,
         query_parameters: HashMap<String, String>,
         path: &str,
-    ) -> Result<BuiltEvents, ErrorMessage>;
+    ) -> Result<Vec<Event>, ErrorMessage>;
 
     fn run(
         self,
@@ -243,17 +240,23 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                             .and_then(|body| {
                                 let body_len = body.len();
                                 self.build_events(body, headers, query_parameters, path.as_str())
-                                    .map(|built| (built, body_len))
+                                    .map(|events| (events, body_len))
                             });
 
                         async move {
                             match events {
-                                Ok((built, body_size)) => {
-                                    let BuiltEvents { events, receiver } = built;
+                                Ok((mut events, body_size)) => {
                                     emit!(HttpEventsReceived {
                                         events_count: events.len(),
                                         byte_size: body_size,
                                     });
+
+                                    let (batch, receiver) = BatchNotifier::new_with_receiver();
+                                    for event in &mut events {
+                                        event.add_batch_notifier(Arc::clone(&batch));
+                                    }
+                                    drop(batch);
+
                                     out.send_all(&mut futures::stream::iter(events).map(Ok))
                                         .map_err(move |error: crate::pipeline::ClosedError| {
                                             // can only fail if receiving end disconnected, so we are shutting down,
@@ -263,11 +266,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                             warp::reject::custom(RejectShuttingDown)
                                         })
                                         .and_then(|_| async move {
-                                            let status = match receiver {
-                                                None => BatchStatus::Delivered,
-                                                Some(receiver) => receiver.await.unwrap_or(BatchStatus::Delivered),
-                                            };
-                                            match status {
+                                            match receiver.await.unwrap_or(BatchStatus::Delivered) {
                                                 BatchStatus::Delivered => Ok(warp::reply()),
                                                 BatchStatus::Errored => Err(warp::reject::custom(
                                                     ErrorMessage::new(

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use self::http::add_query_parameters;
 #[cfg(feature = "sources-prometheus")]
 pub(crate) use self::http::decode;
 #[cfg(feature = "sources-utils-http")]
-pub(crate) use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig};
+pub(crate) use self::http::{BuiltEvents, ErrorMessage, HttpSource, HttpSourceAuthConfig};
 pub use encoding_config::EncodingConfig;
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use self::http::add_query_parameters;
 #[cfg(feature = "sources-prometheus")]
 pub(crate) use self::http::decode;
 #[cfg(feature = "sources-utils-http")]
-pub(crate) use self::http::{BuiltEvents, ErrorMessage, HttpSource, HttpSourceAuthConfig};
+pub(crate) use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig};
 pub use encoding_config::EncodingConfig;
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -39,7 +39,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
 use tokio_util::codec::{Encoder, FramedRead, FramedWrite, LinesCodec};
-use vector_core::event::{BatchNotifier, Event, EventStatus, LogEvent};
+use vector_core::event::{BatchNotifier, Event, LogEvent};
 
 const WAIT_FOR_SECS: u64 = 5; // The default time to wait in `wait_for`
 const WAIT_FOR_MIN_MILLIS: u64 = 5; // The minimum time to pause before retrying
@@ -544,18 +544,6 @@ pub async fn start_topology(
     topology::start_validated(config, diff, pieces)
         .await
         .unwrap()
-}
-
-pub fn stream_update_status(
-    stream: impl Stream<Item = Event>,
-    status: EventStatus,
-) -> impl Stream<Item = Event> {
-    stream.map(move |mut event| {
-        let metadata = event.metadata_mut();
-        metadata.update_status(status);
-        metadata.update_sources();
-        event
-    })
 }
 
 /// Collect the first `n` events from a stream while a future is spawned


### PR DESCRIPTION
Closes #7202 

This is a repeat issue of #7325 that was reverted in #7426 because of a broken test. This fixes the broken test case in the `heroku_logs` source, caused because this move actually added support for acknowledgements to that source as well. We will definitely want to make sure all tests pass before merging this one.

Note that this also enhances the `datadog_logs` source, but that tag is not in the semantic list so I cannot use it in the PR title.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>