### PR TITLE
chore(releasing): Ensure latest artifacts are also published with version number

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -30,15 +30,6 @@ for f in "$td_nightly"/*; do
 done
 ls "$td_nightly"
 
-td_latest="$(mktemp -d)"
-cp -av "target/artifacts/." "$td_latest"
-
-for f in "$td_latest"/*; do
-    a="$(echo "$f" | sed -r -e "s/$VERSION/latest/")"
-    mv "$f" "$a"
-done
-ls "$td_latest"
-
 #
 # A helper function for verifying a published artifact.
 #
@@ -96,13 +87,9 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   for i in "$VERSION_EXACT" "$VERSION_MINOR_X" "$VERSION_MAJOR_X" "latest"; do
     # Upload the specific version
     echo "Uploading artifacts to s3://packages.timber.io/vector/$i/"
-    if [[ "$i" == "latest" ]] ; then
-      aws s3 cp "$td_latest" "s3://packages.timber.io/vector/$i/" --recursive --sse --acl public-read
-    else
-      aws s3 cp "$td" "s3://packages.timber.io/vector/$i/" --recursive --sse --acl public-read
-    fi
+    aws s3 cp "$td" "s3://packages.timber.io/vector/$i/" --recursive --sse --acl public-read
 
-    if [[ "$i" == "${VERSION_MAJOR_X}" || "$i" == "${VERSION_MINOR_X}"  ]] ; then
+    if [[ "$i" == "${VERSION_MAJOR_X}" || "$i" == "${VERSION_MINOR_X}" || "$i" == "latest" ]] ; then
       # Delete anything that isn't the current version
       echo "Deleting old artifacts from s3://packages.timber.io/vector/$i/"
       aws s3 rm "s3://packages.timber.io/vector/$i/" --recursive --exclude "*$VERSION_EXACT*"
@@ -119,17 +106,25 @@ elif [[ "$CHANNEL" == "latest" ]]; then
     echo "Redirected old artifact names"
   done
 
+  echo "Add latest symlinks"
+  find "$td" -maxdepth 1 -type f -print0 | while read -r -d $'\0' file  ; do
+    file=$(basename "$file")
+    # vector-$version-amd64.deb -> vector-latest-amd64.deb
+    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/latest/${file/$i/latest}" --website-redirect "/vector/$i/$file" --acl public-read
+  done
+  echo "Added latest symlinks"
+
   # Verify that the files exist and can be downloaded
-  sleep "$VERIFY_TIMEOUT"
   echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
-  for i in "$VERSION_EXACT" "$VERSION_MINOR_X" "$VERSION_MAJOR_X"; do
+  sleep "$VERIFY_TIMEOUT"
+  for i in "$VERSION_EXACT" "$VERSION_MINOR_X" "$VERSION_MAJOR_X" "latest"; do
     verify_artifact \
       "https://packages.timber.io/vector/$i/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
       "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
   done
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
-    "$td_latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz"
+    "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
 fi
 
 #
@@ -138,4 +133,3 @@ fi
 
 rm -rf "$td"
 rm -rf "$td_nightly"
-rm -rf "$td_latest"

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -101,7 +101,6 @@ elif [[ "$CHANNEL" == "latest" ]]; then
       file=$(basename "$file")
       # vector-$version-amd64.deb -> vector-amd64.deb
       echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/$i/${file/-$VERSION_EXACT/}" --website-redirect "/vector/$i/$file" --acl public-read
-      echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/latest/${file/-$VERSION_EXACT/}" --website-redirect "/vector/latest/$file" --acl public-read
     done
     echo "Redirected old artifact names"
   done


### PR DESCRIPTION
Ensures we publish latest artifacts as, for example:

https://packages.timber.io/vector/latest/vector-0.13.0-x86_64-unknown-linux-gnu.tar.gz

in addition to

https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz

The install script depends on them being there.

Fixes: #7206

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
