### PR TITLE
chore(dev): Pre-install cross in `make environment` image

### DIFF
--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -8,7 +8,8 @@ rustup default "$(cat rust-toolchain)"
 rustup component add rustfmt
 rustup component add clippy
 rustup target add wasm32-wasi
-rustup run stable cargo install cargo-deb --git https://github.com/mmstick/cargo-deb.git --rev b06dc4e635e07c0566446a0e91faf42ab868e634
+rustup run stable cargo install cargo-deb --version 1.29.2
+rustup run stable cargo install cross --version 0.2.1
 
 cd scripts
 bundle update --bundler


### PR DESCRIPTION
A couple of people have been confused by its lack.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
