### PR TITLE
chore(dev): Configure cross to run correctly in `make environment`

### DIFF
--- a/scripts/environment/Dockerfile
+++ b/scripts/environment/Dockerfile
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH=/root/.cargo/bin:/root/.local/bin/:$PATH \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    CROSS_DOCKER_IN_DOCKER=true
 
 # Container junk
 RUN echo $TZ > /etc/timezone

--- a/scripts/environment/entrypoint.sh
+++ b/scripts/environment/entrypoint.sh
@@ -1,3 +1,7 @@
 #! /usr/bin/env bash
 
+# set HOSTNAME to container id for `cross`
+HOSTNAME="$(head -1 /proc/self/cgroup|cut -d/ -f3)"
+export HOSTNAME
+
 exec "$@"


### PR DESCRIPTION
This adds CROSS_DOCKER_IN_DOCKER as per
https://github.com/rust-embedded/cross#docker-in-docker and sets
`HOSTNAME` to the container ID as `cross` uses that with `docker
inspect` to fetch metadata and, since we use `--net=host`, HOSTNAME is
set to the hostname of docker host.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
