### PR TITLE
fix(codecs): Filter object and array fields with only_fields

### DIFF
--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     Result,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, fmt::Debug};
+use std::fmt::Debug;
 
 /// The behavior of a encoding configuration.
 pub trait EncodingConfiguration<E> {
@@ -65,12 +65,12 @@ pub trait EncodingConfiguration<E> {
                                 field_path.starts_with(&only[..])
                             })
                         })
-                        .collect::<VecDeque<_>>();
+                        .collect::<Vec<_>>();
 
                     // reverse sort so that we delete array elements at the end first rather than
                     // the start so that any `nulls` at the end are dropped and empty arrays are
                     // pruned
-                    to_remove.make_contiguous().sort_by(|a, b| b.cmp(a));
+                    to_remove.sort_by(|a, b| b.cmp(a));
 
                     for removal in to_remove {
                         log_event.remove_prune(removal, true);

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -67,7 +67,7 @@ pub trait EncodingConfiguration<E> {
                         })
                         .collect::<VecDeque<_>>();
                     for removal in to_remove {
-                        log_event.remove(removal);
+                        log_event.remove_prune(removal, true);
                     }
                 }
                 Event::Metric(_) => {
@@ -260,6 +260,8 @@ mod tests {
             log.insert("b[1].x", 1);
             log.insert("c[0].x", 1);
             log.insert("c[0].y", 1);
+            log.insert("d.y", 1);
+            log.insert("e[0]", 1);
         }
         config.encoding.apply_rules(&mut event);
         assert!(event.as_mut_log().contains("a.b.c"));
@@ -269,6 +271,8 @@ mod tests {
 
         assert!(!event.as_mut_log().contains("a.b.d"));
         assert!(!event.as_mut_log().contains("c[0].x"));
+        assert!(!event.as_mut_log().contains("d"));
+        assert!(!event.as_mut_log().contains("e"));
     }
 
     const TOML_TIMESTAMP_FORMAT: &str = indoc! {r#"


### PR DESCRIPTION
Fixes: #7322

Currently, vector drops all subkeys from structured fields that don't
appear in `only_fields`, but it leaves the parent key. This fixes that
by pruning the parent if all subkeys were deleted.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
