### PR TITLE
fix(aws_s3 source): Properly handle urlencoded S3 object keys

### DIFF
--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -282,6 +282,14 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn s3_process_message_special_characters() {
+        let key = format!("special:{}", uuid::Uuid::new_v4().to_string());
+        let logs: Vec<String> = random_lines(100).take(10).collect();
+
+        test_event(key, None, None, None, logs.join("\n").into_bytes(), logs).await;
+    }
+
+    #[tokio::test]
     async fn s3_process_message_gzip() {
         use std::io::Read;
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -582,7 +582,9 @@ mod urlencoded_string {
             percent_decode(s)
                 .decode_utf8()
                 .map(Into::into)
-                .map_err(|err| D::Error::custom(format!("error decoding S3 object key: {}", err)))
+                .map_err(|err| {
+                    D::Error::custom(format!("error url decoding S3 object key: {}", err))
+                })
         })
     }
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -563,5 +563,35 @@ struct S3Bucket {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct S3Object {
+    // S3ObjectKeys are URL encoded
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
+    #[serde(with = "urlencoded_string")]
     key: String,
+}
+
+mod urlencoded_string {
+    use percent_encoding::{percent_decode, utf8_percent_encode};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        serde::de::Deserialize::deserialize(deserializer).and_then(|s| {
+            percent_decode(s)
+                .decode_utf8()
+                .map(Into::into)
+                .map_err(|err| D::Error::custom(format!("error decoding S3 object key: {}", err)))
+        })
+    }
+
+    pub fn serialize<S>(s: &str, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(
+            &utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).collect::<String>(),
+        )
+    }
 }


### PR DESCRIPTION
Fixes: #7437 

Per
https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
the object key names in the SQS notification are URL encoded.

Notably

> Amazon S3 returns "application/x-www-form-urlencoded" as the content type in the response

is a lie. It returns `application/xml`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
