### PR TITLE
fix(ci): Install git before checking out for verify jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -220,8 +220,6 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2.3.4
       - run: |
           apt-get update && \
           apt-get install -y \
@@ -230,6 +228,8 @@ jobs:
           git \
           systemd \
           make
+      - name: checkout
+        uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - uses: actions/download-artifact@v2
         with:
@@ -252,8 +252,6 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2.3.4
       - run: |
           yum update -y && \
           yum install -y \
@@ -263,6 +261,8 @@ jobs:
           systemd \
           tar \
           make
+      - name: checkout
+        uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,8 +221,6 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2.3.4
       - run: |
           apt-get update && \
           apt-get install -y \
@@ -231,6 +229,8 @@ jobs:
           git \
           systemd \
           make
+      - name: checkout
+        uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - uses: actions/download-artifact@v2
         with:
@@ -253,8 +253,6 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2.3.4
       - run: |
           yum update -y && \
           yum install -y \
@@ -264,6 +262,8 @@ jobs:
           systemd \
           tar \
           make
+      - name: checkout
+        uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Not having git causes the checkout action to fall back to using the REST
API which seems to require `tar`, likely after #7424, which the
amazonlinux:2 does not seem to have preinstalled.

Instead, just install the dependencies first.

See current nightly failure here: https://github.com/timberio/vector/runs/2589042546?check_suite_focus=true

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
