### PR TITLE
enhancement(kubernetes_logs source): Increase default for max_line_bytes

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -242,7 +242,7 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
 
     let test_namespace = framework.namespace("test-vector-test-pod").await?;
 
-    let test_message = generate_long_string(8, 8 * 1024); // 64 KiB
+    let test_message = generate_long_string(7, 16 * 1024); // 112 KiB
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
             "test-vector-test-pod",

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -437,7 +437,7 @@ fn default_max_line_bytes() -> usize {
     //
     // Per https://github.com/timberio/vector/issues/6966#issuecomment-830772097
     // The limit seems to be in the characters at the UTF-8 encoding.
-    // Line splitting is countered at theparsers, see the `partial_events_merger` logic.
+    // Line splitting is countered at the parsers, see the `partial_events_merger` logic.
 
     6 * 16 * 1024 // 96 KiB
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -432,16 +432,14 @@ fn default_max_read_bytes() -> usize {
 }
 
 fn default_max_line_bytes() -> usize {
-    // NOTE: The below comment documents an incorrect assumption, see
-    // https://github.com/timberio/vector/issues/6967
-    //
     // The 16KB is the maximum size of the payload at single line for both
     // docker and CRI log formats.
-    // We take a double of that to account for metadata and padding, and to
-    // have a power of two rounding. Line splitting is countered at the
-    // parsers, see the `partial_events_merger` logic.
+    //
+    // Per https://github.com/timberio/vector/issues/6966#issuecomment-830772097
+    // The limit seems to be in the characters at the UTF-8 encoding.
+    // Line splitting is countered at theparsers, see the `partial_events_merger` logic.
 
-    32 * 1024 // 32 KiB
+    6 * 16 * 1024 // 96 KiB
 }
 
 fn default_glob_minimum_cooldown_ms() -> usize {


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->

Closes #6967, based on this comment https://github.com/timberio/vector/issues/6966#issuecomment-830772097
