### PR TITLE
fix(kubernetes_logs source): k8s stream errors should be recoverable

### DIFF
--- a/src/kubernetes/api_watcher.rs
+++ b/src/kubernetes/api_watcher.rs
@@ -101,9 +101,9 @@ where
                 Err(watcher::stream::Error::desync(stream::Error::Desync))
             }
             Ok(val) => Ok(val),
-            Err(err) => Err(watcher::stream::Error::other(stream::Error::K8sStream {
-                source: err,
-            })),
+            Err(err) => Err(watcher::stream::Error::recoverable(
+                stream::Error::K8sStream { source: err },
+            )),
         }))
     }
 }

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -132,14 +132,9 @@ where
                             self.state_writer.resync().await;
                             continue 'outer;
                         }
-                        // Any other streaming error means the protocol is in
-                        // an unxpected state.
-                        // This is considered a fatal error, do not attempt
-                        // to retry and just quit.
-                        // TODO: retry these errors
-                        // https://github.com/timberio/vector/issues/7149
-                        Err(watcher::stream::Error::Other { source }) => {
-                            return Err(Error::Streaming { source });
+                        Err(watcher::stream::Error::Recoverable { source }) => {
+                            emit!(internal_events::InvocationHttpErrorReceived { error: source });
+                            continue 'outer;
                         }
                         // A fine watch respose arrived, we just pass it down.
                         Ok(val) => val,

--- a/src/kubernetes/watcher.rs
+++ b/src/kubernetes/watcher.rs
@@ -47,9 +47,9 @@ pub mod stream {
             /// The underlying error.
             source: T,
         },
-        /// Any other error that may have meaning for downstream but doesn't have
-        /// a semantics attached to it at the [`Watcher`] trait level.
-        Other {
+        /// Errors that signal a possibility they can be recovered and as such should be
+        /// logged and bubbled up but shouldn't stop processing.
+        Recoverable {
             /// The underlying error.
             source: T,
         },
@@ -65,10 +65,10 @@ pub mod stream {
             Self::Desync { source }
         }
 
-        /// Create an `Error::Other`.
+        /// Create an `Error::Recoverable`.
         #[inline]
-        pub fn other(source: T) -> Self {
-            Self::Other { source }
+        pub fn recoverable(source: T) -> Self {
+            Self::Recoverable { source }
         }
     }
 
@@ -79,7 +79,7 @@ pub mod stream {
         fn eq(&self, other: &Self) -> bool {
             match (self, other) {
                 (Error::Desync { source: a }, Error::Desync { source: b })
-                | (Error::Other { source: a }, Error::Other { source: b }) => a.eq(b),
+                | (Error::Recoverable { source: a }, Error::Recoverable { source: b }) => a.eq(b),
                 _ => false,
             }
         }


### PR DESCRIPTION
Closes #7401 
Ref #7149 

This changes the source so any stream errors that occur are retriable.

I haven't yet worked out a way to create tests for this scenario, but have replicated and fixed the error using the steps outlined [here](https://github.com/timberio/vector/issues/7401#issuecomment-840525864). 

Note there are still some invocation errors that can cause Vector to stop. I don't currently fully understand the causes of these, so have left as is. It would be a useful exercise to work these out.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>