### PR TITLE
fix(external docs): Fix configure command in installation instructions

### DIFF
--- a/docs/reference/installation/_interfaces/apt.cue
+++ b/docs/reference/installation/_interfaces/apt.cue
@@ -23,7 +23,6 @@ installation: _interfaces: apt: {
 
 	role_implementations: [string]: {
 		commands: role_implementations._systemd_commands & {
-			_config_path: paths.config
 			add_repo:
 				#"""
 					curl -1sLf \

--- a/docs/reference/installation/_interfaces/docker-cli.cue
+++ b/docs/reference/installation/_interfaces/docker-cli.cue
@@ -20,24 +20,22 @@ installation: _interfaces: "docker-cli": {
 
 	role_implementations: [Name=string]: {
 		_api_port:         8686
-		_config_path:      paths.config
 		_docker_sock_path: "/var/run/docker.sock"
 		commands: {
-			_config_path: paths.config
-			install:      null
-			logs:         "docker logs -f $(docker ps -aqf \"name=vector\")"
-			reload:       "docker kill --signal=HUP timberio/vector"
-			restart:      "docker restart -f $(docker ps -aqf \"name=vector\")"
-			start:        #"""
+			install:   null
+			logs:      "docker logs -f $(docker ps -aqf \"name=vector\")"
+			reload:    "docker kill --signal=HUP timberio/vector"
+			restart:   "docker restart -f $(docker ps -aqf \"name=vector\")"
+			start:     #"""
 								docker run \
 								  -d \
 								  -v \#(paths.config):/etc/vector/vector.toml:ro \
 								  -p \#(_api_port):\#(_api_port) \{flags}
 								  timberio/vector:{version}-{variant}
 								"""#
-			stop:         "docker stop timberio/vector"
-			uninstall:    "docker rm timberio/vector timberio/vector"
-			upgrade:      null
+			stop:      "docker stop timberio/vector"
+			uninstall: "docker rm timberio/vector timberio/vector"
+			upgrade:   null
 		}
 		tutorials: {
 			installation: [

--- a/docs/reference/installation/_interfaces/dpkg.cue
+++ b/docs/reference/installation/_interfaces/dpkg.cue
@@ -19,7 +19,6 @@ installation: _interfaces: dpkg: {
 
 	role_implementations: [Name=string]: {
 		commands: role_implementations._systemd_commands & {
-			_config_path: paths.config
 			install: #"""
 				curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/{version}/vector-{version}-{arch}.deb && \
 					sudo dpkg -i vector-{version}-{arch}.deb

--- a/docs/reference/installation/_interfaces/homebrew.cue
+++ b/docs/reference/installation/_interfaces/homebrew.cue
@@ -19,15 +19,14 @@ installation: _interfaces: homebrew: {
 
 	role_implementations: [Name=string]: {
 		commands: {
-			_config_path: paths.config
-			install:      "brew tap timberio/brew && brew install vector"
-			logs:         "tail -f /usr/local/var/log/vector.log"
-			reload:       "killall -s SIGHUP vector"
-			restart:      "brew services restart vector"
-			start:        "brew services start vector"
-			stop:         "brew services stop vector"
-			uninstall:    "brew remove vector"
-			upgrade:      "brew update && brew upgrade vector"
+			install:   "brew tap timberio/brew && brew install vector"
+			logs:      "tail -f /usr/local/var/log/vector.log"
+			reload:    "killall -s SIGHUP vector"
+			restart:   "brew services restart vector"
+			start:     "brew services start vector"
+			stop:      "brew services stop vector"
+			uninstall: "brew remove vector"
+			upgrade:   "brew update && brew upgrade vector"
 		}
 		tutorials: {
 			installation: [

--- a/docs/reference/installation/_interfaces/nix.cue
+++ b/docs/reference/installation/_interfaces/nix.cue
@@ -21,15 +21,14 @@ installation: _interfaces: nix: {
 
 	role_implementations: [Name=string]: {
 		commands: {
-			_config_path: paths.config
-			install:      "nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --install --attr vector"
-			logs:         null
-			reload:       "killall -s SIGHUP vector"
-			restart:      null
-			start:        #"vector --config \#(paths.config)"#
-			stop:         null
-			uninstall:    "nix-env --uninstall vector"
-			upgrade:      "nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --upgrade vector"
+			install:   "nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --install --attr vector"
+			logs:      null
+			reload:    "killall -s SIGHUP vector"
+			restart:   null
+			start:     #"vector --config \#(paths.config)"#
+			stop:      null
+			uninstall: "nix-env --uninstall vector"
+			upgrade:   "nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --upgrade vector"
 		}
 
 		tutorials: {

--- a/docs/reference/installation/_interfaces/rpm.cue
+++ b/docs/reference/installation/_interfaces/rpm.cue
@@ -19,10 +19,9 @@ installation: _interfaces: rpm: {
 
 	role_implementations: [Name=string]: {
 		commands: role_implementations._systemd_commands & {
-			_config_path: paths.config
-			install:      "sudo rpm -i https://packages.timber.io/vector/{version}/vector-{version}-1.{arch}.rpm"
-			uninstall:    "sudo rpm -e vector"
-			upgrade:      null
+			install:   "sudo rpm -i https://packages.timber.io/vector/{version}/vector-{version}-1.{arch}.rpm"
+			uninstall: "sudo rpm -e vector"
+			upgrade:   null
 		}
 
 		tutorials: {

--- a/docs/reference/installation/_interfaces/vector-installer.cue
+++ b/docs/reference/installation/_interfaces/vector-installer.cue
@@ -18,15 +18,14 @@ installation: _interfaces: "vector-installer": {
 
 	role_implementations: [Name=string]: {
 		commands: {
-			_config_path: paths.config
-			install:      "curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | sh"
-			logs:         null
-			reload:       "killall -s SIGHUP vector"
-			restart:      null
-			start:        "vector --config \(paths.config)"
-			stop:         null
-			uninstall:    "rm -rf ./vector"
-			upgrade:      null
+			install:   "curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | sh"
+			logs:      null
+			reload:    "killall -s SIGHUP vector"
+			restart:   null
+			start:     "vector --config \(paths.config)"
+			stop:      null
+			uninstall: "rm -rf ./vector"
+			upgrade:   null
 		}
 
 		tutorials: {

--- a/docs/reference/installation/_interfaces/yum.cue
+++ b/docs/reference/installation/_interfaces/yum.cue
@@ -23,7 +23,6 @@ installation: _interfaces: yum: {
 
 	role_implementations: [Name=string]: {
 		commands: role_implementations._systemd_commands & {
-			_config_path: paths.config
 			add_repo: #"""
 				curl -1sLf \
 					'https://repositories.timber.io/public/vector/cfg/setup/bash.rpm.sh' \

--- a/docs/reference/installation/interfaces.cue
+++ b/docs/reference/installation/interfaces.cue
@@ -1,46 +1,8 @@
 package metadata
 
 installation: {
-	#Commands: {
-		{[Name=string]: string | null}
-	} & {
-		_config_path: string | *null
-		let ConfigPath = _config_path
-
-		_shell: string | *null
-		let Shell = _shell
-
-		configure: string | null | *"none"
-		install:   string | null
-		logs:      string | null
-		reload:    string | null
-		restart:   string | null
-		start:     string | null
-		stop:      string | null
-		top:       string | null | *"vector top"
-		uninstall: string
-		upgrade:   string | null
-
-		if Shell == "bash" {
-			configure: string | *#"""
-					cat <<-'VECTORCFG' > \#(ConfigPath)
-					{config}
-					VECTORCFG
-					"""#
-		}
-
-		if Shell == "powershell" {
-			configure: string | *#"""
-					@"
-					{config}
-					"@ | Out-File -FilePath \#(ConfigPath)
-					"""#
-		}
-	}
-
 	#Interface: {
-		_shell: string | *null
-		let Shell = _shell
+		_shell: string
 
 		archs: [#Arch, ...#Arch]
 		description: string
@@ -58,29 +20,59 @@ installation: {
 				stop:    "sudo systemctl stop vector"
 			}
 		}
-		role_implementations:  #RoleImplementations & {_shell: Shell}
+		role_implementations:  #RoleImplementations
 		name:                  string
 		package_manager_name?: string
 		platform_name?:        string
 		title:                 string
+
+		#RoleImplementation: {
+			commands:    #Commands
+			description: string
+			name:        string
+			title:       string
+			tutorials:   #Tutorials
+			variables:   #Variables
+		}
+
+		#RoleImplementations: [Name=string]: #RoleImplementation & {
+			name: Name
+		}
+
+		#Commands: {
+			{[Name=string]: string | null}
+		} & {
+			configure: string | null
+			install:   string | null
+			logs:      string | null
+			reload:    string | null
+			restart:   string | null
+			start:     string | null
+			stop:      string | null
+			top:       string | null | *"vector top"
+			uninstall: string
+			upgrade:   string | null
+
+			if _shell == "bash" {
+				configure: string | *#"""
+					cat <<-'VECTORCFG' > \#(paths.config)
+					{config}
+					VECTORCFG
+					"""#
+			}
+
+			if _shell == "powershell" {
+				configure: string | *#"""
+					@"
+					{config}
+					"@ | Out-File -FilePath \#(paths.config)
+					"""#
+			}
+		}
+
 	}
 
 	#Interfaces: [Name=string]: #Interface & {
-		name: Name
-	}
-
-	#RoleImplementation: {
-		_shell: string | *null
-		let Shell = _shell
-		commands:    #Commands & {_shell: Shell}
-		description: string
-		name:        string
-		title:       string
-		tutorials:   #Tutorials
-		variables:   #Variables
-	}
-
-	#RoleImplementations: [Name=string]: #RoleImplementation & {
 		name: Name
 	}
 

--- a/docs/reference/installation/operating_systems.cue
+++ b/docs/reference/installation/operating_systems.cue
@@ -4,7 +4,7 @@ installation: {
 	#OperatingSystem: {
 		description: string
 		family:      #OperatingSystemFamily
-		interfaces: [...installation.#Interface & {_shell: shell}]
+		interfaces: [installation.#Interface & {_shell: shell}, ...installation.#Interface & {_shell: shell}]
 		minimum_supported_version: string | null
 		name:                      string
 		shell:                     string

--- a/docs/reference/installation/operating_systems.cue
+++ b/docs/reference/installation/operating_systems.cue
@@ -4,7 +4,7 @@ installation: {
 	#OperatingSystem: {
 		description: string
 		family:      #OperatingSystemFamily
-		interfaces: [installation.#Interface & {_shell: shell}, ...installation.#Interface & {_shell: shell}]
+		interfaces: [...installation.#Interface & {_shell: shell}]
 		minimum_supported_version: string | null
 		name:                      string
 		shell:                     string


### PR DESCRIPTION
Currently always renders as "none" due to `_shell` not propagating all
the way down. I was able to refactor this a bit to avoid needing to pass
_shell around based on the suggestion in
https://github.com/cuelang/cue/discussions/975#discussioncomment-752611
to use nested field definitions.

Closes: #7397

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
