### PR TITLE
chore: Compare floating points with approximate equality

### DIFF
--- a/src/sinks/util/adaptive_concurrency/service.rs
+++ b/src/sinks/util/adaptive_concurrency/service.rs
@@ -275,10 +275,10 @@ mod tests {
 
         let in_flight = stats.in_flight.stats().unwrap();
         assert_eq!(in_flight.max, 1);
-        assert_eq!(in_flight.mean, 1.0);
+        approx::assert_relative_eq!(in_flight.mean, 1.0);
 
         let observed_rtt = stats.observed_rtt.stats().unwrap();
-        assert_eq!(observed_rtt.mean, 1.0);
+        approx::assert_relative_eq!(observed_rtt.mean, 1.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
In https://github.com/timberio/vector/pull/7522/checks?check_run_id=2632747234
we observed test failure because:

```
---- sinks::util::adaptive_concurrency::service::tests::increases_limit stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1.001`,
 right: `1.0`', src/sinks/util/adaptive_concurrency/service.rs:281:9
```

`assert_eq` is a mixed bag when testing for equality of floating points. The
approx crate, which we already use, takes into account the nature of floats in
its assertions.

That said, I'm not totally sure if this is a "floating points do unexpected
things" issue or a bug manifesting as what looks like a floating point
weirdness. Still, introducing approx here strikes me as a positive.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
