### PR TITLE
chore(ci): Ignore RUSTSEC-2021-0067 while we try to fix it

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,6 @@ ignore = [
 
     # Type confusion if __private_get_type_id__ is overriden
     # https://github.com/timberio/vector/issues/5583
-    "RUSTSEC-2019-0036",
     "RUSTSEC-2020-0036",
 
     # stdweb is unmaintained
@@ -51,4 +50,8 @@ ignore = [
     # Soundness issues in `raw-cpuid`
     # https://github.com/timberio/vector/issues/6223
     "RUSTSEC-2021-0013",
+
+    # Memory access due to code generation flaw in Cranelift module
+    # https://github.com/timberio/vector/issues/7558
+    "RUSTSEC-2021-0067",
 ]


### PR DESCRIPTION
Also removed RUSTSEC-2019-0036 which was no longer applicable.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
