### PR TITLE
fix(ci): Try building release artifacts on self-hosted runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,6 @@ env:
   VERBOSE: true
   CI: true
   DEBIAN_FRONTEND: noninteractive
-  CONTAINER_TOOL: docker
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
@@ -37,7 +36,6 @@ jobs:
       - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: bash scripts/environment/prepare.sh
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ env:
   VERBOSE: true
   CI: true
   DEBIAN_FRONTEND: noninteractive
+  CONTAINER_TOOL: docker
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default-cmake"
@@ -30,6 +33,10 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default"
@@ -51,6 +58,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -65,6 +75,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -87,6 +100,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -108,6 +124,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - run: make ci-sweep
       - env:
           PASS_FEATURES: "default-cmake"
         run: make package-x86_64-unknown-linux-musl-all
@@ -31,7 +30,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default"
@@ -53,7 +51,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -68,7 +65,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -91,7 +87,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -114,7 +109,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - run: make ci-sweep
       - env:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-musleabihf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -28,7 +28,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -50,7 +50,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -65,7 +65,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -88,7 +88,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -110,7 +110,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ env:
   VERBOSE: true
   CI: true
   DEBIAN_FRONTEND: noninteractive
+  CONTAINER_TOOL: docker
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - run: make ci-sweep
       - env:
           PASS_FEATURES: "default-cmake"
         run: make package-x86_64-unknown-linux-musl-all
@@ -32,7 +31,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default"
@@ -54,7 +52,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -69,7 +66,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -92,7 +88,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
-      - run: make ci-sweep
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -115,7 +110,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - run: make ci-sweep
       - env:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-musleabihf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
@@ -29,7 +29,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -51,7 +51,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
 
   build-aarch64-unknown-linux-musl-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -66,7 +66,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl.tar.gz"
 
   build-aarch64-unknown-linux-gnu-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -89,7 +89,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
 
   build-armv7-unknown-linux-gnueabihf-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: make ci-sweep
@@ -111,7 +111,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
 
   build-armv7-unknown-linux-musleabihf-packages:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default-cmake"
@@ -31,6 +34,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           PASS_FEATURES: "default"
@@ -52,6 +58,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -66,6 +75,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -88,6 +100,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"
@@ -109,6 +124,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: sudo bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
       - env:
           DOCKER_PRIVILEGED: "true"

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -97,9 +97,9 @@ if ! [ -x "$(command -v docker)" ]; then
     # Install those new things
     apt update --yes
     apt install --yes docker-ce docker-ce-cli containerd.io
-fi
 
-usermod --append --groups docker ubuntu
+    usermod --append --groups docker ubuntu
+fi
 
 # Apt cleanup
 apt clean

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -99,5 +99,7 @@ if ! [ -x "$(command -v docker)" ]; then
     apt install --yes docker-ce docker-ce-cli containerd.io
 fi
 
+usermod --append --groups docker ubuntu
+
 # Apt cleanup
 apt clean


### PR DESCRIPTION
We seem to be running out of memory on some builds.

Example failure:
https://github.com/timberio/vector/runs/2652886513?check_suite_focus=true

This PR runs the release builds on the self-hosted runners. Since they are now on the self-hosted runners, they need some more setup steps (copied from the Linux unit test workflow) and no longer need to run the `ci-sweep` job which was to free up resources on the hosted runners.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
