### PR TITLE
chore(ci): parallelize benchmarks

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -50,8 +50,11 @@ jobs:
           all_but_latest: true # can cancel workflows scheduled later
 
   bench:
-    name: Bench - Linux
+    name: Bench - Linux (${{ matrix.target }})
     runs-on: [self-hosted, linux, x64, benchmarks]
+    strategy:
+      matrix:
+        target: [bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.5
@@ -66,41 +69,39 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
 
-      - name: Checkout master to build first
+      # First, we run the benchmarks against master to establish our baseline numbers. Our benchmark
+      # runners are configured to isolate CPU 0 from OS scheduling so that benchmarks aren't subject
+      # to scheduling noise.  We make sure to utilize all CPUs for compiling the benchmark binaries,
+      # but only utilize CPU 0 when actually running them.
+      - name: Checkout master
         run: |
           git fetch --depth 1 origin master
           git checkout --force origin/master
-        # build benchmarks on all CPUs, including isolated benchmarking CPU
-      - name: Prebuild master benchmarks
-        run: taskset -c "0-$(nproc)" make bench-all CARGO_BENCH_FLAGS="--no-run"
-        # run benchmarks on isolated CPU and with address randomization
-        # disabled
+      - name: Build master benchmarks
+        run: taskset -c "0-$(nproc)" make ${{ matrix.target }} CARGO_BENCH_FLAGS="--no-run"
       - name: Run master benchmarks
-        run: setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench-all
-
-      - name: Checkout current SHA
+        run: setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make ${{ matrix.target }}
+      - name: Checkout PR branch
         run: git clean --force && git checkout --force $GITHUB_SHA
-        # build benchmarks on all CPUs, including isolated benchmarking CPU
-      - name: Prebuild benchmarks
-        run: taskset -c "0-$(nproc)" make bench-all CARGO_BENCH_FLAGS="--no-run"
-        # run benchmarks on isolated CPU and with address randomization
-        # disabled
-      - name: Run benchmarks
+      - name: Build PR benchmarks
+        run: taskset -c "0-$(nproc)" make ${{ matrix.target }} CARGO_BENCH_FLAGS="--no-run"
+      - name: Run PR benchmarks
         run: |
           mkdir -p target/criterion
-          setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make bench-all | tee target/criterion/out
-
+          setarch $(uname -m) -R taskset -c "$(cat /sys/devices/system/cpu/isolated)" make ${{ matrix.target }} | tee target/criterion/out
+      # We keep the Criterion results no matter what, but where they're uploaded depends on whether
+      # this is a PR run or a master run.
       - uses: actions/upload-artifact@v2
         with:
           name: "criterion"
           path: "./target/criterion"
-      - name: Upload criterion data to S3
-        run: scripts/upload-benchmarks-s3.sh
+      - name: Upload Criterion data to S3
+        run: scripts/upload-benchmarks-s3.sh ${{ matrix.target }}
         if: github.ref == 'refs/heads/master'
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
-      # note: should run last to flag regressions
+      # Finally, run the comparison to see if we've hit any regressions.
       - name: Compare benchmarks
         run: |
           echo "Comparing $(git rev-parse HEAD) with $(git rev-parse origin/master)"

--- a/scripts/upload-benchmarks-s3.sh
+++ b/scripts/upload-benchmarks-s3.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #   environment is consistent.
 
 if ! (${CI:-false}); then
-  echo "Aborted: this script is for use in CI, bencmark analysis depends on a consistent bench environment" >&2
+  echo "Aborted: this script is for use in CI, benchmark analysis depends on a consistent bench environment" >&2
   exit 1
 fi
 
@@ -22,11 +22,12 @@ escape() {
 }
 
 S3_BUCKET=${S3_BUCKET:-test-artifacts.vector.dev}
-BENCHES_VERSION="1" # bump if S3 schema changes
+BENCHES_VERSION="2" # bump if S3 schema changes
 ENVIRONMENT_VERSION="1" # bump if bench environment changes
 VECTOR_THREADS=${VECTOR_THREADS:-$(nproc)}
 LIBC="gnu"
 
+target="$1"
 git_branch=$(git branch --show-current)
 git_rev_count=$(git rev-list --count HEAD)
 git_sha=$(git rev-parse HEAD)
@@ -40,7 +41,8 @@ timestamp=$(date +"%s")
 object_name="$(echo "s3://$S3_BUCKET/benches/\
 benches_version=${BENCHES_VERSION}/\
 environment_version=${ENVIRONMENT_VERSION}/\
-branch=$(escape "${git_branch}") /\
+branch=$(escape "${git_branch}")/\
+target=${target}/\
 machine=${machine}/\
 operating_system=${operating_system}/\
 libc=${LIBC}/\


### PR DESCRIPTION
This is a simplistic attempt at splitting up the benchmark runs in CI. Normally, we would invoke `make bench-all` which runs the sum of six otherwise individual/distinct benchmark groups. Now, we use a matrix build over those six individual benchmarks to run them in parallel, subject to runner availability. This should conceivably bring down the benchmark time to somewhere around the duration of the longest benchmark group, which should still be far below the current ~4 hour duration for benchmarks.

Signed-off-by: Toby Lawrence <toby.lawrence@datadoghq.com>