### PR TITLE
chore(ci): fix bench-wasm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # Override this with any scopes for testing/benching.
 export SCOPE ?=
 # Override this with any extra flags for cargo bench
-export CARGO_BENCH_FLAGS ?= ""
+export CARGO_BENCH_FLAGS ?=
 # override this to put criterion output elsewhere
 export CRITERION_HOME ?= $(mkfile_dir)target/criterion
 # Override to false to disable autospawning services on integration tests.
@@ -548,7 +548,7 @@ bench-remap: ## Run remap benches
 
 .PHONY: bench-wasm
 bench-wasm: $(WASM_MODULE_OUTPUTS)  ### Run WASM benches
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm wasm ${CARGO_BENCH_FLAGS}
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "wasm-benches" --bench wasm ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 .PHONY: bench-languages


### PR DESCRIPTION
As is, the `bench-wasm` target has one argument too many and doesn't actually run cleanly.  I've also tweaked how the bench flags are included so that there's no extra empty argument present when the flags aren't set, which just makes the output a little cleaner.

Signed-off-by: Toby Lawrence <toby.lawrence@datadoghq.com>