### PR TITLE
enhancement(splunk_hec source): add x-forwarded-for header support

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -353,7 +353,9 @@ impl<R: Read> EventIterator<R> {
                 DefaultExtractor::new_with(
                     "host",
                     log_schema().host_key(),
-                    remote_addr.or(remote.map(|addr| addr.to_string())).map(Value::from),
+                    remote_addr
+                        .or(remote.map(|addr| addr.to_string()))
+                        .map(Value::from),
                 ),
                 DefaultExtractor::new("index", &INDEX),
                 DefaultExtractor::new("source", &SOURCE),

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -346,7 +346,7 @@ impl<R: Read> EventIterator<R> {
             data,
             events: 0,
             channel: channel.map(Value::from),
-            remote_addr: remote_addr.map(Value::from),
+            remote_addr: remote_addr.or(remote.map(|addr| addr.to_string())).map(Value::from),
             time: Time::Now(Utc::now()),
             extractors: [
                 DefaultExtractor::new_with(
@@ -427,6 +427,7 @@ impl<R: Read> EventIterator<R> {
         }
 
         // Add host field from X-Forwarded-For header, if present.
+        // If not, `splunk_remote_addr` will be the remote: SocketAddr received from warp instead.
         if let Some(splunk_remote_addr) = self.remote_addr.as_ref() {
             log.insert(log_schema().host_key(), splunk_remote_addr.clone());
         }

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -354,7 +354,7 @@ impl<R: Read> EventIterator<R> {
                     "host",
                     log_schema().host_key(),
                     remote_addr
-                        .or(remote.map(|addr| addr.to_string()))
+                        .or_else(|| remote.map(|addr| addr.to_string()))
                         .map(Value::from),
                 ),
                 DefaultExtractor::new("index", &INDEX),


### PR DESCRIPTION
* enhancement: add x-forwarded-for support

- When an X-Forwarded-For HTTP Header is supplied with a request:
  - pull out the value
  - attempt to serialize it to an IpAddr
  - set as the value for a `splunk_remote_addr` field in the event

Closes https://github.com/timberio/vector/issues/6763