### PR TITLE
fix(cli): include error details in `vector vrl` output

### DIFF
--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -91,9 +91,7 @@ fn execute(object: &mut impl Target, program: &Program) -> Result<Value, Error> 
     let state = state::Runtime::default();
     let mut runtime = Runtime::new(state);
 
-    runtime
-        .resolve(object, program)
-        .map_err(|err| Error::Runtime(err))
+    runtime.resolve(object, program).map_err(Error::Runtime)
 }
 
 fn read_program(source: Option<&str>, file: Option<&PathBuf>) -> Result<String, Error> {

--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -17,7 +17,7 @@ pub struct Opts {
     #[structopt(name = "PROGRAM")]
     program: Option<String>,
 
-    /// The file containing the event object(s) to handle. The supported formats are JSON and jsonl.
+    /// The file containing the event object(s) to handle. JSON events should be one per line..
     #[structopt(short, long = "input", parse(from_os_str))]
     input_file: Option<PathBuf>,
 
@@ -93,7 +93,7 @@ fn execute(object: &mut impl Target, program: &Program) -> Result<Value, Error> 
 
     runtime
         .resolve(object, program)
-        .map_err(|err| Error::Runtime(err.to_string()))
+        .map_err(|err| Error::Runtime(err))
 }
 
 fn read_program(source: Option<&str>, file: Option<&PathBuf>) -> Result<String, Error> {

--- a/lib/vrl/cli/src/lib.rs
+++ b/lib/vrl/cli/src/lib.rs
@@ -9,7 +9,8 @@ pub enum Error {
     #[error("io error: {}", .0)]
     Io(#[from] std::io::Error),
 
-    #[error("{}",.0)]
+    // this is the set of rendered end-user diagnostic errors when a VRL program fails to compile
+    #[error("{}", .0)]
     Parse(String),
 
     #[error(transparent)]

--- a/lib/vrl/cli/src/lib.rs
+++ b/lib/vrl/cli/src/lib.rs
@@ -6,16 +6,16 @@ pub use cmd::{cmd, Opts};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("io error")]
+    #[error("io error: {}", .0)]
     Io(#[from] std::io::Error),
 
-    #[error("parse error")]
+    #[error("{}",.0)]
     Parse(String),
 
-    #[error("runtime error")]
-    Runtime(String),
+    #[error(transparent)]
+    Runtime(#[from] vrl::Terminate),
 
-    #[error("json error")]
+    #[error("input error: {}", .0)]
     Json(#[from] serde_json::Error),
 
     #[error("repl feature disabled, program input required")]


### PR DESCRIPTION
Currently, the actual details of the errors are masked so that users
just see things like: `parse error` and `json error` without additional
detail about what the issue is. This change ensures we display the
source of the error.

I also fixed the help doc for `--input` that was confusing a user as
they thought, understandably, that they could pass a pretty-printed JSON
object as a file; however `vector vrl` expects one JSON object per line.
We can improve this in the future to actually allow a prety printed
object here, but this at least makes the help doc accurate.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
