### PR TITLE
fix(dev): Optimistically add ubuntu to docker group

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -98,7 +98,8 @@ if ! [ -x "$(command -v docker)" ]; then
     apt update --yes
     apt install --yes docker-ce docker-ce-cli containerd.io
 
-    usermod --append --groups docker ubuntu
+    # ubuntu user doesn't exist in scripts/environment/Dockerfile which runs this
+    usermod --append --groups docker ubuntu || true
 fi
 
 # Apt cleanup


### PR DESCRIPTION
This script is run by the Dockererfile for `make environment` which
doesn't actually have an `ubuntu` user.

Failure: https://github.com/timberio/vector/runs/2665641110

This was broken by https://github.com/timberio/vector/pull/7564

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
