### PR TITLE
chore(ci): Try running Linux unit tests with less parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,8 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make slim-builds
       - run: make test
+        env:
+          CARGO_BUILD_JOBS: 6
 
   test-misc:
     name: Miscellaneous - Linux


### PR DESCRIPTION
Since we seem to be running out of memory during the build phase.

I'll see if CI passes here and maybe rerun a few times.

Example failure: https://github.com/timberio/vector/runs/2658803781

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
