### PR TITLE
fix(external docs): Fix relevant_when for socket.path config

### DIFF
--- a/docs/reference/components/sinks/socket.cue
+++ b/docs/reference/components/sinks/socket.cue
@@ -94,7 +94,7 @@ components: sinks: socket: {
 		}
 		path: {
 			description:   "The unix socket path. This should be the absolute path."
-			relevant_when: "mode = `tcp` or `udp`"
+			relevant_when: "mode = `unix`"
 			required:      true
 			warnings: []
 			type: string: {


### PR DESCRIPTION
This config is only required when `mode` is `unix`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
