### PR TITLE
fix(codecs): Ensure that flat dotted paths are removed by only_fields

### DIFF
--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -70,7 +70,7 @@ impl<'a> FieldsIter<'a> {
             match path_iter.next() {
                 None => return res,
                 Some(PathComponent::Key(key)) => {
-                    if key.contains(".") {
+                    if key.contains('.') {
                         res.push_str(&key.replace(".", "\\."))
                     } else {
                         res.push_str(&key)

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -69,7 +69,13 @@ impl<'a> FieldsIter<'a> {
         loop {
             match path_iter.next() {
                 None => return res,
-                Some(PathComponent::Key(key)) => res.push_str(&key.replace(".", "\\.")),
+                Some(PathComponent::Key(key)) => {
+                    if key.contains(".") {
+                        res.push_str(&key.replace(".", "\\."))
+                    } else {
+                        res.push_str(&key)
+                    }
+                }
                 Some(PathComponent::Index(index)) => res.push_str(&format!("[{}]", index)),
             }
             if let Some(PathComponent::Key(_)) = path_iter.peek() {

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -69,7 +69,7 @@ impl<'a> FieldsIter<'a> {
         loop {
             match path_iter.next() {
                 None => return res,
-                Some(PathComponent::Key(key)) => res.push_str(&key),
+                Some(PathComponent::Key(key)) => res.push_str(&key.replace(".", "\\.")),
                 Some(PathComponent::Index(index)) => res.push_str(&format!("[{}]", index)),
             }
             if let Some(PathComponent::Key(_)) = path_iter.peek() {
@@ -156,7 +156,8 @@ mod test {
                 "array": [null, 3, {
                     "x": 1
                 }, [2]]
-            }
+            },
+            "a.b.c": 6,
         }));
         let expected: Vec<_> = vec![
             ("a.a", &Value::Integer(4)),
@@ -165,6 +166,7 @@ mod test {
             ("a.array[2].x", &Value::Integer(1)),
             ("a.array[3][0]", &Value::Integer(2)),
             ("a.b.c", &Value::Integer(5)),
+            ("a\\.b\\.c", &Value::Integer(6)),
         ]
         .into_iter()
         .map(|(k, v)| (k.into(), v))

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -67,8 +67,6 @@ pub trait EncodingConfiguration<E> {
                         })
                         .collect::<Vec<_>>();
 
-                    dbg!(&to_remove);
-
                     // reverse sort so that we delete array elements at the end first rather than
                     // the start so that any `nulls` at the end are dropped and empty arrays are
                     // pruned

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -67,6 +67,8 @@ pub trait EncodingConfiguration<E> {
                         })
                         .collect::<Vec<_>>();
 
+                    dbg!(&to_remove);
+
                     // reverse sort so that we delete array elements at the end first rather than
                     // the start so that any `nulls` at the end are dropped and empty arrays are
                     // pruned
@@ -219,7 +221,7 @@ mod tests {
 
     const TOML_EXCEPT_FIELD: &str = indoc! {r#"
         encoding.codec = "Snoot"
-        encoding.except_fields = ["a.b.c", "b", "c[0].y"]
+        encoding.except_fields = ["a.b.c", "b", "c[0].y", "d\\.z", "e"]
     "#};
     #[test]
     fn test_except() {
@@ -236,12 +238,17 @@ mod tests {
             log.insert("b[1].x", 1);
             log.insert("c[0].x", 1);
             log.insert("c[0].y", 1);
+            log.insert("d\\.z", 1);
+            log.insert("e.a", 1);
+            log.insert("e.b", 1);
         }
         config.encoding.apply_rules(&mut event);
         assert!(!event.as_mut_log().contains("a.b.c"));
         assert!(!event.as_mut_log().contains("b"));
         assert!(!event.as_mut_log().contains("b[1].x"));
         assert!(!event.as_mut_log().contains("c[0].y"));
+        assert!(!event.as_mut_log().contains("d\\.z"));
+        assert!(!event.as_mut_log().contains("e.a"));
 
         assert!(event.as_mut_log().contains("a.b.d"));
         assert!(event.as_mut_log().contains("c[0].x"));
@@ -249,7 +256,7 @@ mod tests {
 
     const TOML_ONLY_FIELD: &str = indoc! {r#"
         encoding.codec = "Snoot"
-        encoding.only_fields = ["a.b.c", "b", "c[0].y"]
+        encoding.only_fields = ["a.b.c", "b", "c[0].y", "g\\.z"]
     "#};
     #[test]
     fn test_only() {
@@ -270,17 +277,21 @@ mod tests {
             log.insert("d.z", 1);
             log.insert("e[0]", 1);
             log.insert("e[1]", 1);
+            log.insert("f\\.z", 1);
+            log.insert("g\\.z", 1);
         }
         config.encoding.apply_rules(&mut event);
         assert!(event.as_mut_log().contains("a.b.c"));
         assert!(event.as_mut_log().contains("b"));
         assert!(event.as_mut_log().contains("b[1].x"));
         assert!(event.as_mut_log().contains("c[0].y"));
+        assert!(event.as_mut_log().contains("g\\.z"));
 
         assert!(!event.as_mut_log().contains("a.b.d"));
         assert!(!event.as_mut_log().contains("c[0].x"));
         assert!(!event.as_mut_log().contains("d"));
         assert!(!event.as_mut_log().contains("e"));
+        assert!(!event.as_mut_log().contains("f\\.z"));
     }
 
     const TOML_TIMESTAMP_FORMAT: &str = indoc! {r#"


### PR DESCRIPTION
Currently, if the log event has a flattened dotted path like
`label.com\.docker\.stack\.namespace` it fails to be removed by
`only_fields` because fetching the keys for the event previously
returned unescaped keys. That is, it returned
`label.com.docker.stack.namespace` instead of
`label.com\.docker\.stack\.namespace`.

Notably, the keys syntax here is still using the legacy `.` escaping
rather than the path quoting that VRL supports (like
`label."com.docker.stack.namespace"`). Eventually we'd like to unify
these still.

Fixes: #7546

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
