### PR TITLE
chore: Reorganize event proto module

### DIFF
--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -1,6 +1,6 @@
 use buffers::bytes::{DecodeBytes, EncodeBytes};
 use bytes::{Buf, BufMut, Bytes};
-use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 pub use finalization::{
     BatchNotifier, BatchStatus, BatchStatusReceiver, EventFinalizer, EventFinalizers, EventStatus,
 };
@@ -31,36 +31,13 @@ pub mod lua;
 pub mod merge_state;
 mod metadata;
 pub mod metric;
+pub mod proto;
 #[cfg(test)]
 mod test;
 pub mod util;
 mod value;
 #[cfg(feature = "vrl")]
 mod vrl_target;
-
-pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/event.rs"));
-    pub use event_wrapper::Event;
-    pub use metric::Value as MetricValue;
-
-    impl From<Event> for EventWrapper {
-        fn from(event: Event) -> Self {
-            Self { event: Some(event) }
-        }
-    }
-
-    impl From<Log> for Event {
-        fn from(log: Log) -> Self {
-            Self::Log(log)
-        }
-    }
-
-    impl From<Metric> for Event {
-        fn from(metric: Metric) -> Self {
-            Self::Metric(metric)
-        }
-    }
-}
 
 pub const PARTIAL: &str = "_partial";
 
@@ -185,49 +162,6 @@ fn timestamp_to_string(timestamp: &DateTime<Utc>) -> String {
     timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true)
 }
 
-fn decode_map(fields: BTreeMap<String, proto::Value>) -> Option<Value> {
-    let mut accum: BTreeMap<String, Value> = BTreeMap::new();
-    for (key, value) in fields {
-        match decode_value(value) {
-            Some(value) => {
-                accum.insert(key, value);
-            }
-            None => return None,
-        }
-    }
-    Some(Value::Map(accum))
-}
-
-fn decode_array(items: Vec<proto::Value>) -> Option<Value> {
-    let mut accum = Vec::with_capacity(items.len());
-    for value in items {
-        match decode_value(value) {
-            Some(value) => accum.push(value),
-            None => return None,
-        }
-    }
-    Some(Value::Array(accum))
-}
-
-fn decode_value(input: proto::Value) -> Option<Value> {
-    match input.kind {
-        Some(proto::value::Kind::RawBytes(data)) => Some(Value::Bytes(data.into())),
-        Some(proto::value::Kind::Timestamp(ts)) => Some(Value::Timestamp(
-            chrono::Utc.timestamp(ts.seconds, ts.nanos as u32),
-        )),
-        Some(proto::value::Kind::Integer(value)) => Some(Value::Integer(value)),
-        Some(proto::value::Kind::Float(value)) => Some(Value::Float(value)),
-        Some(proto::value::Kind::Boolean(value)) => Some(Value::Boolean(value)),
-        Some(proto::value::Kind::Map(map)) => decode_map(map.fields),
-        Some(proto::value::Kind::Array(array)) => decode_array(array.items),
-        Some(proto::value::Kind::Null(_)) => Some(Value::Null),
-        None => {
-            error!("Encoded event contains unknown value kind.");
-            None
-        }
-    }
-}
-
 impl From<&tracing::Event<'_>> for Event {
     fn from(event: &tracing::Event<'_>) -> Self {
         let now = chrono::Utc::now();
@@ -328,226 +262,6 @@ impl TryInto<serde_json::Value> for Event {
             Event::Log(fields) => serde_json::to_value(fields),
             Event::Metric(metric) => serde_json::to_value(metric),
         }
-    }
-}
-
-impl From<proto::EventWrapper> for Event {
-    fn from(proto: proto::EventWrapper) -> Self {
-        let event = proto.event.unwrap();
-
-        match event {
-            proto::Event::Log(proto) => {
-                let fields = proto
-                    .fields
-                    .into_iter()
-                    .filter_map(|(k, v)| decode_value(v).map(|value| (k, value)))
-                    .collect::<BTreeMap<_, _>>();
-
-                Event::Log(LogEvent::from(fields))
-            }
-            proto::Event::Metric(proto) => {
-                let kind = match proto.kind() {
-                    proto::metric::Kind::Incremental => MetricKind::Incremental,
-                    proto::metric::Kind::Absolute => MetricKind::Absolute,
-                };
-
-                let name = proto.name;
-
-                let namespace = if proto.namespace.is_empty() {
-                    None
-                } else {
-                    Some(proto.namespace)
-                };
-
-                let timestamp = proto
-                    .timestamp
-                    .map(|ts| chrono::Utc.timestamp(ts.seconds, ts.nanos as u32));
-
-                let tags = if proto.tags.is_empty() {
-                    None
-                } else {
-                    Some(proto.tags)
-                };
-
-                let value = match proto.value.unwrap() {
-                    proto::MetricValue::Counter(counter) => MetricValue::Counter {
-                        value: counter.value,
-                    },
-                    proto::MetricValue::Gauge(gauge) => MetricValue::Gauge { value: gauge.value },
-                    proto::MetricValue::Set(set) => MetricValue::Set {
-                        values: set.values.into_iter().collect(),
-                    },
-                    proto::MetricValue::Distribution1(dist) => MetricValue::Distribution {
-                        statistic: dist.statistic().into(),
-                        samples: metric::zip_samples(dist.values, dist.sample_rates),
-                    },
-                    proto::MetricValue::Distribution2(dist) => MetricValue::Distribution {
-                        statistic: dist.statistic().into(),
-                        samples: dist.samples.into_iter().map(Into::into).collect(),
-                    },
-                    proto::MetricValue::AggregatedHistogram1(hist) => {
-                        MetricValue::AggregatedHistogram {
-                            buckets: metric::zip_buckets(hist.buckets, hist.counts),
-                            count: hist.count,
-                            sum: hist.sum,
-                        }
-                    }
-                    proto::MetricValue::AggregatedHistogram2(hist) => {
-                        MetricValue::AggregatedHistogram {
-                            buckets: hist.buckets.into_iter().map(Into::into).collect(),
-                            count: hist.count,
-                            sum: hist.sum,
-                        }
-                    }
-                    proto::MetricValue::AggregatedSummary1(summary) => {
-                        MetricValue::AggregatedSummary {
-                            quantiles: metric::zip_quantiles(summary.quantiles, summary.values),
-                            count: summary.count,
-                            sum: summary.sum,
-                        }
-                    }
-                    proto::MetricValue::AggregatedSummary2(summary) => {
-                        MetricValue::AggregatedSummary {
-                            quantiles: summary.quantiles.into_iter().map(Into::into).collect(),
-                            count: summary.count,
-                            sum: summary.sum,
-                        }
-                    }
-                };
-
-                Event::Metric(
-                    Metric::new(name, kind, value)
-                        .with_namespace(namespace)
-                        .with_tags(tags)
-                        .with_timestamp(timestamp),
-                )
-            }
-        }
-    }
-}
-
-fn encode_value(value: Value) -> proto::Value {
-    proto::Value {
-        kind: match value {
-            Value::Bytes(b) => Some(proto::value::Kind::RawBytes(b.to_vec())),
-            Value::Timestamp(ts) => Some(proto::value::Kind::Timestamp(prost_types::Timestamp {
-                seconds: ts.timestamp(),
-                nanos: ts.timestamp_subsec_nanos() as i32,
-            })),
-            Value::Integer(value) => Some(proto::value::Kind::Integer(value)),
-            Value::Float(value) => Some(proto::value::Kind::Float(value)),
-            Value::Boolean(value) => Some(proto::value::Kind::Boolean(value)),
-            Value::Map(fields) => Some(proto::value::Kind::Map(encode_map(fields))),
-            Value::Array(items) => Some(proto::value::Kind::Array(encode_array(items))),
-            Value::Null => Some(proto::value::Kind::Null(proto::ValueNull::NullValue as i32)),
-        },
-    }
-}
-
-fn encode_map(fields: BTreeMap<String, Value>) -> proto::ValueMap {
-    proto::ValueMap {
-        fields: fields
-            .into_iter()
-            .map(|(key, value)| (key, encode_value(value)))
-            .collect(),
-    }
-}
-
-fn encode_array(items: Vec<Value>) -> proto::ValueArray {
-    proto::ValueArray {
-        items: items.into_iter().map(encode_value).collect(),
-    }
-}
-
-impl From<LogEvent> for proto::Log {
-    fn from(log_event: LogEvent) -> Self {
-        let (fields, _metadata) = log_event.into_parts();
-        let fields = fields
-            .into_iter()
-            .map(|(k, v)| (k, encode_value(v)))
-            .collect::<BTreeMap<_, _>>();
-
-        Self { fields }
-    }
-}
-
-impl From<Metric> for proto::Metric {
-    fn from(metric: Metric) -> Self {
-        let name = metric.series.name.name;
-        let namespace = metric.series.name.namespace.unwrap_or_default();
-
-        let timestamp = metric.data.timestamp.map(|ts| prost_types::Timestamp {
-            seconds: ts.timestamp(),
-            nanos: ts.timestamp_subsec_nanos() as i32,
-        });
-
-        let tags = metric.series.tags.unwrap_or_default();
-
-        let kind = match metric.data.kind {
-            MetricKind::Incremental => proto::metric::Kind::Incremental,
-            MetricKind::Absolute => proto::metric::Kind::Absolute,
-        }
-        .into();
-
-        let metric = match metric.data.value {
-            MetricValue::Counter { value } => proto::MetricValue::Counter(proto::Counter { value }),
-            MetricValue::Gauge { value } => proto::MetricValue::Gauge(proto::Gauge { value }),
-            MetricValue::Set { values } => proto::MetricValue::Set(proto::Set {
-                values: values.into_iter().collect(),
-            }),
-            MetricValue::Distribution { samples, statistic } => {
-                proto::MetricValue::Distribution2(proto::Distribution2 {
-                    samples: samples.into_iter().map(Into::into).collect(),
-                    statistic: match statistic {
-                        StatisticKind::Histogram => proto::StatisticKind::Histogram,
-                        StatisticKind::Summary => proto::StatisticKind::Summary,
-                    }
-                    .into(),
-                })
-            }
-            MetricValue::AggregatedHistogram {
-                buckets,
-                count,
-                sum,
-            } => proto::MetricValue::AggregatedHistogram2(proto::AggregatedHistogram2 {
-                buckets: buckets.into_iter().map(Into::into).collect(),
-                count,
-                sum,
-            }),
-            MetricValue::AggregatedSummary {
-                quantiles,
-                count,
-                sum,
-            } => proto::MetricValue::AggregatedSummary2(proto::AggregatedSummary2 {
-                quantiles: quantiles.into_iter().map(Into::into).collect(),
-                count,
-                sum,
-            }),
-        };
-
-        Self {
-            name,
-            namespace,
-            timestamp,
-            tags,
-            kind,
-            value: Some(metric),
-        }
-    }
-}
-
-impl From<Event> for proto::Event {
-    fn from(event: Event) -> Self {
-        match event {
-            Event::Log(log_event) => proto::Log::from(log_event).into(),
-            Event::Metric(metric) => proto::Metric::from(metric).into(),
-        }
-    }
-}
-
-impl From<Event> for proto::EventWrapper {
-    fn from(event: Event) -> Self {
-        proto::Event::from(event).into()
     }
 }
 

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -1,0 +1,290 @@
+use crate::event::{self, BTreeMap};
+use chrono::TimeZone;
+
+include!(concat!(env!("OUT_DIR"), "/event.rs"));
+pub use event_wrapper::Event;
+pub use metric::Value as MetricValue;
+
+impl From<Event> for EventWrapper {
+    fn from(event: Event) -> Self {
+        Self { event: Some(event) }
+    }
+}
+
+impl From<Log> for Event {
+    fn from(log: Log) -> Self {
+        Self::Log(log)
+    }
+}
+
+impl From<Metric> for Event {
+    fn from(metric: Metric) -> Self {
+        Self::Metric(metric)
+    }
+}
+
+impl From<EventWrapper> for event::Event {
+    fn from(proto: EventWrapper) -> Self {
+        let event = proto.event.unwrap();
+
+        match event {
+            Event::Log(proto) => {
+                let fields = proto
+                    .fields
+                    .into_iter()
+                    .filter_map(|(k, v)| decode_value(v).map(|value| (k, value)))
+                    .collect::<BTreeMap<_, _>>();
+
+                Self::Log(event::LogEvent::from(fields))
+            }
+            Event::Metric(proto) => {
+                let kind = match proto.kind() {
+                    metric::Kind::Incremental => event::MetricKind::Incremental,
+                    metric::Kind::Absolute => event::MetricKind::Absolute,
+                };
+
+                let name = proto.name;
+
+                let namespace = if proto.namespace.is_empty() {
+                    None
+                } else {
+                    Some(proto.namespace)
+                };
+
+                let timestamp = proto
+                    .timestamp
+                    .map(|ts| chrono::Utc.timestamp(ts.seconds, ts.nanos as u32));
+
+                let tags = if proto.tags.is_empty() {
+                    None
+                } else {
+                    Some(proto.tags)
+                };
+
+                let value = match proto.value.unwrap() {
+                    MetricValue::Counter(counter) => event::MetricValue::Counter {
+                        value: counter.value,
+                    },
+                    MetricValue::Gauge(gauge) => event::MetricValue::Gauge { value: gauge.value },
+                    MetricValue::Set(set) => event::MetricValue::Set {
+                        values: set.values.into_iter().collect(),
+                    },
+                    MetricValue::Distribution1(dist) => event::MetricValue::Distribution {
+                        statistic: dist.statistic().into(),
+                        samples: event::metric::zip_samples(dist.values, dist.sample_rates),
+                    },
+                    MetricValue::Distribution2(dist) => event::MetricValue::Distribution {
+                        statistic: dist.statistic().into(),
+                        samples: dist.samples.into_iter().map(Into::into).collect(),
+                    },
+                    MetricValue::AggregatedHistogram1(hist) => {
+                        event::MetricValue::AggregatedHistogram {
+                            buckets: event::metric::zip_buckets(hist.buckets, hist.counts),
+                            count: hist.count,
+                            sum: hist.sum,
+                        }
+                    }
+                    MetricValue::AggregatedHistogram2(hist) => {
+                        event::MetricValue::AggregatedHistogram {
+                            buckets: hist.buckets.into_iter().map(Into::into).collect(),
+                            count: hist.count,
+                            sum: hist.sum,
+                        }
+                    }
+                    MetricValue::AggregatedSummary1(summary) => {
+                        event::MetricValue::AggregatedSummary {
+                            quantiles: event::metric::zip_quantiles(
+                                summary.quantiles,
+                                summary.values,
+                            ),
+                            count: summary.count,
+                            sum: summary.sum,
+                        }
+                    }
+                    MetricValue::AggregatedSummary2(summary) => {
+                        event::MetricValue::AggregatedSummary {
+                            quantiles: summary.quantiles.into_iter().map(Into::into).collect(),
+                            count: summary.count,
+                            sum: summary.sum,
+                        }
+                    }
+                };
+
+                Self::Metric(
+                    event::Metric::new(name, kind, value)
+                        .with_namespace(namespace)
+                        .with_tags(tags)
+                        .with_timestamp(timestamp),
+                )
+            }
+        }
+    }
+}
+
+impl From<event::LogEvent> for Log {
+    fn from(log_event: event::LogEvent) -> Self {
+        let (fields, _metadata) = log_event.into_parts();
+        let fields = fields
+            .into_iter()
+            .map(|(k, v)| (k, encode_value(v)))
+            .collect::<BTreeMap<_, _>>();
+
+        Self { fields }
+    }
+}
+
+impl From<event::Metric> for Metric {
+    fn from(metric: event::Metric) -> Self {
+        let name = metric.series.name.name;
+        let namespace = metric.series.name.namespace.unwrap_or_default();
+
+        let timestamp = metric.data.timestamp.map(|ts| prost_types::Timestamp {
+            seconds: ts.timestamp(),
+            nanos: ts.timestamp_subsec_nanos() as i32,
+        });
+
+        let tags = metric.series.tags.unwrap_or_default();
+
+        let kind = match metric.data.kind {
+            event::MetricKind::Incremental => metric::Kind::Incremental,
+            event::MetricKind::Absolute => metric::Kind::Absolute,
+        }
+        .into();
+
+        let metric = match metric.data.value {
+            event::MetricValue::Counter { value } => MetricValue::Counter(Counter { value }),
+            event::MetricValue::Gauge { value } => MetricValue::Gauge(Gauge { value }),
+            event::MetricValue::Set { values } => MetricValue::Set(Set {
+                values: values.into_iter().collect(),
+            }),
+            event::MetricValue::Distribution { samples, statistic } => {
+                MetricValue::Distribution2(Distribution2 {
+                    samples: samples.into_iter().map(Into::into).collect(),
+                    statistic: match statistic {
+                        event::StatisticKind::Histogram => StatisticKind::Histogram,
+                        event::StatisticKind::Summary => StatisticKind::Summary,
+                    }
+                    .into(),
+                })
+            }
+            event::MetricValue::AggregatedHistogram {
+                buckets,
+                count,
+                sum,
+            } => MetricValue::AggregatedHistogram2(AggregatedHistogram2 {
+                buckets: buckets.into_iter().map(Into::into).collect(),
+                count,
+                sum,
+            }),
+            event::MetricValue::AggregatedSummary {
+                quantiles,
+                count,
+                sum,
+            } => MetricValue::AggregatedSummary2(AggregatedSummary2 {
+                quantiles: quantiles.into_iter().map(Into::into).collect(),
+                count,
+                sum,
+            }),
+        };
+
+        Self {
+            name,
+            namespace,
+            timestamp,
+            tags,
+            kind,
+            value: Some(metric),
+        }
+    }
+}
+
+impl From<event::Event> for Event {
+    fn from(event: event::Event) -> Self {
+        match event {
+            event::Event::Log(log_event) => Log::from(log_event).into(),
+            event::Event::Metric(metric) => Metric::from(metric).into(),
+        }
+    }
+}
+
+impl From<event::Event> for EventWrapper {
+    fn from(event: event::Event) -> Self {
+        Event::from(event).into()
+    }
+}
+
+fn decode_value(input: Value) -> Option<event::Value> {
+    match input.kind {
+        Some(value::Kind::RawBytes(data)) => Some(event::Value::Bytes(data.into())),
+        Some(value::Kind::Timestamp(ts)) => Some(event::Value::Timestamp(
+            chrono::Utc.timestamp(ts.seconds, ts.nanos as u32),
+        )),
+        Some(value::Kind::Integer(value)) => Some(event::Value::Integer(value)),
+        Some(value::Kind::Float(value)) => Some(event::Value::Float(value)),
+        Some(value::Kind::Boolean(value)) => Some(event::Value::Boolean(value)),
+        Some(value::Kind::Map(map)) => decode_map(map.fields),
+        Some(value::Kind::Array(array)) => decode_array(array.items),
+        Some(value::Kind::Null(_)) => Some(event::Value::Null),
+        None => {
+            error!("Encoded event contains unknown value kind.");
+            None
+        }
+    }
+}
+
+fn decode_map(fields: BTreeMap<String, Value>) -> Option<event::Value> {
+    let mut accum: BTreeMap<String, event::Value> = BTreeMap::new();
+    for (key, value) in fields {
+        match decode_value(value) {
+            Some(value) => {
+                accum.insert(key, value);
+            }
+            None => return None,
+        }
+    }
+    Some(event::Value::Map(accum))
+}
+
+fn decode_array(items: Vec<Value>) -> Option<event::Value> {
+    let mut accum = Vec::with_capacity(items.len());
+    for value in items {
+        match decode_value(value) {
+            Some(value) => accum.push(value),
+            None => return None,
+        }
+    }
+    Some(event::Value::Array(accum))
+}
+
+fn encode_value(value: event::Value) -> Value {
+    Value {
+        kind: match value {
+            event::Value::Bytes(b) => Some(value::Kind::RawBytes(b.to_vec())),
+            event::Value::Timestamp(ts) => Some(value::Kind::Timestamp(prost_types::Timestamp {
+                seconds: ts.timestamp(),
+                nanos: ts.timestamp_subsec_nanos() as i32,
+            })),
+            event::Value::Integer(value) => Some(value::Kind::Integer(value)),
+            event::Value::Float(value) => Some(value::Kind::Float(value)),
+            event::Value::Boolean(value) => Some(value::Kind::Boolean(value)),
+            event::Value::Map(fields) => Some(value::Kind::Map(encode_map(fields))),
+            event::Value::Array(items) => Some(value::Kind::Array(encode_array(items))),
+            event::Value::Null => Some(value::Kind::Null(ValueNull::NullValue as i32)),
+        },
+    }
+}
+
+fn encode_map(fields: BTreeMap<String, event::Value>) -> ValueMap {
+    ValueMap {
+        fields: fields
+            .into_iter()
+            .map(|(key, value)| (key, encode_value(value)))
+            .collect(),
+    }
+}
+
+fn encode_array(items: Vec<event::Value>) -> ValueArray {
+    ValueArray {
+        items: items.into_iter().map(encode_value).collect(),
+    }
+}


### PR DESCRIPTION
This breaks out all the event proto related code into a separate module in `src/vector-core` and breaks up the `From` implementations into more primitive blocks. This introduces no new functionality other than the ability to convert to/from more parts of the event protocol.