### PR TITLE
enhancement(tests): run k8s-e2e tests on multinode kubernetes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,12 +3230,12 @@ dependencies = [
  "indoc",
  "k8s-openapi",
  "k8s-test-framework",
- "log",
  "rand 0.8.3",
  "regex",
  "reqwest",
  "serde_json",
  "tokio",
+ "tracing 0.1.26",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,10 +3225,13 @@ dependencies = [
 name = "k8s-e2e-tests"
 version = "0.1.0"
 dependencies = [
+ "env_logger 0.8.3",
  "futures 0.3.15",
  "indoc",
  "k8s-openapi",
  "k8s-test-framework",
+ "log",
+ "rand 0.8.3",
  "regex",
  "reqwest",
  "serde_json",
@@ -3257,6 +3260,7 @@ name = "k8s-test-framework"
 version = "0.1.0"
 dependencies = [
  "k8s-openapi",
+ "log",
  "once_cell",
  "serde_json",
  "tempfile",

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -16,6 +16,8 @@ reqwest = { version = "0.11.3", features = ["json"] }
 serde_json = "1"
 tokio = { version = "1.5.0", features = ["full"] }
 indoc = "1.0.3"
+env_logger = "0.8"
+log = "0.4"
 
 [features]
 e2e-tests = []

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 tokio = { version = "1.5.0", features = ["full"] }
 indoc = "1.0.3"
 env_logger = "0.8"
-log = "0.4"
+tracing = { version = "0.1", features = ["log"] }
 rand = "0.8"
 
 [features]

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.5.0", features = ["full"] }
 indoc = "1.0.3"
 env_logger = "0.8"
 log = "0.4"
+rand = "0.8"
 
 [features]
 e2e-tests = []

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use k8s_openapi::{
     api::core::v1::{Container, Pod, PodSpec},
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
@@ -26,7 +27,15 @@ pub fn get_override_name(suffix: &str) -> String {
 /// Adds a fullnameOverride entry to the given config. This allows multiple tests
 /// to be run against the same cluster without the role anmes clashing.
 pub fn config_override_name(config: &str, name: &str) -> String {
-    format!("fullnameOverride: \"{}\"\n{}", name, config)
+    format!(
+        indoc! {r#"
+            fullnameOverride: "{}"
+            dataVolume:
+              hostPath:
+                path: /var/lib/{}-vector/
+            {}"#},
+        name, name, config
+    )
 }
 
 pub fn make_framework() -> Framework {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -6,28 +6,27 @@ use k8s_openapi::{
 use k8s_test_framework::{
     test_pod, wait_for_resource::WaitFor, CommandBuilder, Framework, Interface, Manager, Reader,
 };
-use log::{debug, error, info};
 use std::collections::BTreeMap;
+use tracing::{debug, error, info};
 
 pub mod metrics;
 
 pub const BUSYBOX_IMAGE: &str = "busybox:1.28";
 
 pub fn init() {
-    let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::max())
-        .is_test(true)
-        .try_init();
+    let _ = env_logger::builder().is_test(true).try_init();
 }
 
 pub fn get_namespace() -> String {
-    //env::var("NAMESPACE").unwrap_or_else(|_| "test-vector".to_string())
     use rand::Rng;
 
+    // Generate a random alphanumeric (lowercase) string to ensure each test is run with unique
+    // names.
+    // There is a 36 ^ 5 chance of a name collision, which is likely to be an acceptable risk.
     let id: String = rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
         .take(5)
-        .map(|num| num as char)
+        .map(|num| (num as char).to_ascii_lowercase())
         .collect();
 
     format!("test-vector-{}", id.to_string())

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -29,7 +29,7 @@ pub fn get_namespace() -> String {
         .map(|num| (num as char).to_ascii_lowercase())
         .collect();
 
-    format!("test-vector-{}", id.to_string())
+    format!("test-vector-{}", id)
 }
 
 pub fn get_namespace_appended(namespace: &str, suffix: &str) -> String {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -7,6 +7,7 @@ use k8s_test_framework::{
     test_pod, wait_for_resource::WaitFor, CommandBuilder, Framework, Interface, Manager, Reader,
 };
 use std::collections::BTreeMap;
+use std::env;
 use tracing::{debug, error, info};
 
 pub mod metrics;
@@ -45,15 +46,24 @@ pub fn get_override_name(namespace: &str, suffix: &str) -> String {
 /// Adds a fullnameOverride entry to the given config. This allows multiple tests
 /// to be run against the same cluster without the role anmes clashing.
 pub fn config_override_name(config: &str, name: &str) -> String {
-    format!(
-        indoc! {r#"
+    if env::var("multinode".to_string()) == Ok("yes".to_string()) {
+        format!(
+            indoc! {r#"
             fullnameOverride: "{}"
             dataVolume:
               hostPath:
                 path: /var/lib/{}-vector/
             {}"#},
-        name, name, config
-    )
+            name, name, config
+        )
+    } else {
+        format!(
+            indoc! {r#"
+            fullnameOverride: "{}"
+            {}"#},
+            name, config
+        )
+    }
 }
 
 pub fn make_framework() -> Framework {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -7,7 +7,7 @@ use k8s_test_framework::{
     test_pod, wait_for_resource::WaitFor, CommandBuilder, Framework, Interface, Manager, Reader,
 };
 use log::{debug, error, info};
-use std::{collections::BTreeMap, env};
+use std::collections::BTreeMap;
 
 pub mod metrics;
 
@@ -21,17 +21,26 @@ pub fn init() {
 }
 
 pub fn get_namespace() -> String {
-    env::var("NAMESPACE").unwrap_or_else(|_| "test-vector".to_string())
+    //env::var("NAMESPACE").unwrap_or_else(|_| "test-vector".to_string())
+    use rand::Rng;
+
+    let id: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(5)
+        .map(|num| num as char)
+        .collect();
+
+    format!("test-vector-{}", id.to_string())
 }
 
-pub fn get_namespace_appended(suffix: &str) -> String {
-    format!("{}-{}", get_namespace(), suffix)
+pub fn get_namespace_appended(namespace: &str, suffix: &str) -> String {
+    format!("{}-{}", namespace, suffix)
 }
 
 /// Gets a name we can use for roles to prevent them conflicting with other tests.
 /// Uses the provided namespace as the root.
-pub fn get_override_name(suffix: &str) -> String {
-    format!("{}-{}", get_namespace(), suffix)
+pub fn get_override_name(namespace: &str, suffix: &str) -> String {
+    format!("{}-{}", namespace, suffix)
 }
 
 /// Adds a fullnameOverride entry to the given config. This allows multiple tests

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -99,7 +99,19 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, &format!("daemonset/{}", override_name))?;
+    let node = framework
+        .get_node_for_pod(&pod_namespace, "test-pod")
+        .await
+        .expect("need the node name");
+
+    let vector_pod = framework
+        .get_pod_on_node(&namespace, &node, &override_name)
+        .await
+        .expect("cant get the vector pod running on the test node");
+
+    println!("node {} pod {}", node, vector_pod);
+
+    let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -11,9 +11,6 @@ use tracing::{debug, info};
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
 const HELM_VALUES_STDOUT_SINK: &str = indoc! {r#"
-    kubernetesLogsSource:
-      rawConfig: |
-        glob_minimum_cooldown_ms = 5000
     sinks:
       stdout:
         type: "console"

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -4,9 +4,9 @@ use k8s_e2e_tests::*;
 use k8s_test_framework::{
     lock, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
-use log::{debug, info};
 use std::collections::HashSet;
 use std::str::FromStr;
+use tracing::{debug, info};
 
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
@@ -1003,7 +1003,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        info!("Got line: {:?}", line);
+        debug!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1161,7 +1161,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        info!("Got line: {:?}", line);
+        debug!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1334,7 +1334,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        info!("Got line: {:?}", line);
+        debug!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -103,15 +103,9 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -206,15 +200,9 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -305,15 +293,9 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -406,15 +388,9 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -506,15 +482,9 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -605,15 +575,9 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -771,15 +735,14 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod-control")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(
+            &pod_namespace,
+            "test-pod-control",
+            &namespace,
+            &override_name,
+        )
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -971,15 +934,14 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod-control")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(
+            &pod_namespace,
+            "test-pod-control",
+            &namespace,
+            &override_name,
+        )
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -1129,15 +1091,9 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -1302,15 +1258,9 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -1476,15 +1426,9 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "affinity-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "affinity-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -1584,15 +1528,9 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;
@@ -1716,15 +1654,9 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Make sure we read the correct nodes logs.
-    let node = framework
-        .get_node_for_pod(&pod_namespace, "test-pod")
-        .await
-        .expect("need the node name");
-
     let vector_pod = framework
-        .get_pod_on_node(&namespace, &node, &override_name)
-        .await
-        .expect("cant get the vector pod running on the test node");
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
 
     let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
     smoke_check_first_line(&mut log_reader).await;

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -58,9 +58,9 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -160,9 +160,9 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -261,9 +261,9 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -361,8 +361,9 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
 
     let framework = make_framework();
 
-    let pod_namespace = get_namespace_appended("test-pod");
-    let override_name = get_override_name("vector-agent");
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
+    let override_name = get_override_name(&namespace, "vector-agent");
     let test_namespace = framework.namespace(&pod_namespace).await?;
 
     let test_pod = framework
@@ -385,8 +386,6 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
 
     // Wait for some extra time to ensure pod completes.
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-
-    let namespace = get_namespace();
 
     let vector = framework
         .vector(
@@ -462,8 +461,8 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
-    let override_name = get_override_name("vector-agent");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let framework = make_framework();
 
@@ -563,8 +562,8 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
-    let override_name = get_override_name("vector-agent");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
+    let override_name = get_override_name(&namespace, "vector-agent");
     let framework = make_framework();
 
     let vector = framework
@@ -701,10 +700,10 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let affinity_label = format!("{}-affinity", pod_namespace);
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -883,9 +882,9 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     const CONFIG: &str = indoc! {r#"
         kubernetesLogsSource:
@@ -1083,9 +1082,9 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -1244,9 +1243,9 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let config: &str = &format!(
         indoc! {r#"
@@ -1415,10 +1414,10 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let affinity_label = format!("{}-affinity", pod_namespace);
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -1539,9 +1538,9 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -1640,9 +1639,9 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(
@@ -1791,7 +1790,7 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
 
     let namespace = get_namespace();
     let framework = make_framework();
-    let override_name = get_override_name("vector-agent");
+    let override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -4,6 +4,7 @@ use k8s_e2e_tests::*;
 use k8s_test_framework::{
     lock, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
+use log::{debug, info};
 use std::collections::HashSet;
 use std::str::FromStr;
 
@@ -54,6 +55,8 @@ const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = indoc! {r#"
 #[tokio::test]
 async fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -154,6 +157,8 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -253,6 +258,8 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -350,6 +357,8 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let framework = make_framework();
 
     let pod_namespace = get_namespace_appended("test-pod");
@@ -450,6 +459,8 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let override_name = get_override_name("vector-agent");
@@ -549,6 +560,8 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let override_name = get_override_name("vector-agent");
@@ -685,6 +698,8 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let affinity_label = format!("{}-affinity", pod_namespace);
@@ -789,11 +804,11 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        println!("Got line: {:?}", line);
+        debug!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
-            println!("Giving up");
+            info!("Giving up");
             log_reader.kill().await?;
             break;
         }
@@ -840,9 +855,9 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
             let duration = std::time::Duration::from_secs(120);
-            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            info!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::sleep(duration).await;
-            println!("Stop timer complete");
+            info!("Stop timer complete");
             stop_tx.send(()).await.unwrap();
         });
     }
@@ -865,6 +880,8 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -987,11 +1004,11 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        println!("Got line: {:?}", line);
+        info!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
-            println!("Giving up");
+            info!("Giving up");
             log_reader.kill().await?;
             break;
         }
@@ -1038,9 +1055,9 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
             let duration = std::time::Duration::from_secs(120);
-            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            info!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::sleep(duration).await;
-            println!("Stop timer complete");
+            info!("Stop timer complete");
             stop_tx.send(()).await.unwrap();
         });
     }
@@ -1063,6 +1080,8 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -1143,11 +1162,11 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        println!("Got line: {:?}", line);
+        info!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
-            println!("Giving up");
+            info!("Giving up");
             log_reader.kill().await?;
             break;
         }
@@ -1198,9 +1217,9 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
             let duration = std::time::Duration::from_secs(30);
-            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            info!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::sleep(duration).await;
-            println!("Stop timer complete");
+            info!("Stop timer complete");
             stop_tx.send(()).await.unwrap();
         });
     }
@@ -1222,6 +1241,8 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -1314,11 +1335,11 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        println!("Got line: {:?}", line);
+        info!("Got line: {:?}", line);
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
-            println!("Giving up");
+            info!("Giving up");
             log_reader.kill().await?;
             break;
         }
@@ -1368,9 +1389,9 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             // logs to appear to have high confidence that Vector has enough
             // time to pick them up and spit them out.
             let duration = std::time::Duration::from_secs(30);
-            println!("Starting stop timer, due in {} seconds", duration.as_secs());
+            info!("Starting stop timer, due in {} seconds", duration.as_secs());
             tokio::time::sleep(duration).await;
-            println!("Stop timer complete");
+            info!("Stop timer complete");
             stop_tx.send(()).await.unwrap();
         });
     }
@@ -1391,6 +1412,8 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let affinity_label = format!("{}-affinity", pod_namespace);
@@ -1430,7 +1453,7 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut test_pods = vec![];
     for ns in &expected_namespaces {
-        println!("creating {}", ns);
+        debug!("creating {}", ns);
         let test_pod = framework
             .test_pod(test_pod::Config::from_pod(&make_test_pod_with_affinity(
                 ns,
@@ -1513,6 +1536,8 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -1612,6 +1637,8 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();
@@ -1662,9 +1689,9 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     // the `processed_events` is even defined.
     // We give Vector some reasonable time to perform this initial bootstrap,
     // and capture the `processed_events` value afterwards.
-    println!("Waiting for Vector bootstrap");
+    debug!("Waiting for Vector bootstrap");
     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-    println!("Done waiting for Vector bootstrap");
+    debug!("Done waiting for Vector bootstrap");
 
     // Capture events processed before deploying the test pod.
     let processed_events_before = metrics::get_processed_events(&vector_metrics_url).await?;
@@ -1733,9 +1760,9 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
 
     // Due to how `internal_metrics` are implemented, we have to wait for it's
     // scraping period to pass before we can observe the updates.
-    println!("Waiting for `internal_metrics` to update");
+    debug!("Waiting for `internal_metrics` to update");
     tokio::time::sleep(std::time::Duration::from_secs(6)).await;
-    println!("Done waiting for `internal_metrics` to update");
+    debug!("Done waiting for `internal_metrics` to update");
 
     // Capture events processed after the test pod has finished.
     let processed_events_after = metrics::get_processed_events(&vector_metrics_url).await?;
@@ -1760,6 +1787,8 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let framework = make_framework();
     let override_name = get_override_name("vector-agent");
@@ -1805,9 +1834,9 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
     // We want to capture the value for the host metrics, but the pipeline for
     // collecting them takes some time to boot (15s roughly).
     // We wait twice as much, so the bootstrap is guaranteed.
-    println!("Waiting for Vector bootstrap");
+    debug!("Waiting for Vector bootstrap");
     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-    println!("Done waiting for Vector bootstrap");
+    debug!("Done waiting for Vector bootstrap");
 
     // Ensure the host metrics are exposed in the Prometheus endpoint.
     metrics::assert_host_metrics_present(&vector_metrics_url).await?;

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -11,6 +11,9 @@ use tracing::{debug, info};
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
 const HELM_VALUES_STDOUT_SINK: &str = indoc! {r#"
+    kubernetesLogsSource:
+      rawConfig: |
+        glob_minimum_cooldown_ms = 5000
     sinks:
       stdout:
         type: "console"

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -29,7 +29,7 @@ async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
     let framework = make_framework();
-    let override_name = get_override_name("vector-aggregator");
+    let override_name = get_override_name(&namespace, "vector-aggregator");
 
     let vector = framework
         .vector(
@@ -65,7 +65,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
     let framework = make_framework();
-    let override_name = get_override_name("vector-aggregator");
+    let override_name = get_override_name(&namespace, "vector-aggregator");
 
     let vector = framework
         .vector(

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -24,6 +24,8 @@ const HELM_VALUES_DUMMY_TOPOLOGY: &str = indoc! {r#"
 /// settings and a dummy topology.
 #[tokio::test]
 async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
+    init();
+
     let _guard = lock();
     let namespace = get_namespace();
     let framework = make_framework();
@@ -58,6 +60,8 @@ async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
 /// a Prometheus scraping format ot of the box.
 #[tokio::test]
 async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
+    init();
+
     let _guard = lock();
     let namespace = get_namespace();
     let framework = make_framework();

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -32,11 +32,11 @@ const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
 async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
-    let override_name = get_override_name("vector-aggregator");
+    let override_name = get_override_name(&namespace, "vector-aggregator");
     let vector_endpoint = &format!("{}.{}.svc.cluster.local", override_name, namespace);
-    let datadog_namespace = get_namespace_appended("datadog-agent");
-    let datadog_override_name = get_override_name("datadog-agent");
-    let pod_namespace = get_namespace_appended("test-pod");
+    let datadog_namespace = get_namespace_appended(&namespace, "datadog-agent");
+    let datadog_override_name = get_override_name(&namespace, "datadog-agent");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
 
     // Value.yaml for datadog offical chart

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -30,7 +30,7 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
           encoding: "json"
 "# },
         agent_override_name,
-        aggregator_override_name
+        aggregator_override_name,
         agent_override_name,
         aggregator_override_name
     )

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -41,6 +41,8 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
 #[tokio::test]
 async fn logs() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
+    init();
+
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended("test-pod");
     let framework = make_framework();

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -1,16 +1,15 @@
-use indoc::indoc;
+use indoc::formatdoc;
 use k8s_e2e_tests::*;
 use k8s_test_framework::{
     lock, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
-use std::env;
 
 const HELM_CHART_VECTOR: &str = "vector";
 
 fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: &str) -> String {
-    if env::var("multinode".to_string()) == Ok("yes".to_string()) {
-        format!(
-            indoc! {r#"
+    if is_multinode() {
+        formatdoc!(
+            r#"
     vector-agent:
       fullnameOverride: "{}"
       vectorSink:
@@ -30,15 +29,15 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
           inputs: ["vector"]
           target: "stdout"
           encoding: "json"
-"# },
+    "#,
             agent_override_name,
             aggregator_override_name,
             agent_override_name,
             aggregator_override_name
         )
     } else {
-        format!(
-            indoc! {r#"
+        formatdoc!(
+            r#"
     vector-agent:
       fullnameOverride: "{}"
       vectorSink:
@@ -55,8 +54,10 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
           inputs: ["vector"]
           target: "stdout"
           encoding: "json"
-"# },
-            agent_override_name, aggregator_override_name, aggregator_override_name
+    "#,
+            agent_override_name,
+            aggregator_override_name,
+            aggregator_override_name
         )
     }
 }

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -44,10 +44,10 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
     init();
 
     let namespace = get_namespace();
-    let pod_namespace = get_namespace_appended("test-pod");
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
-    let aggregator_override_name = get_override_name("vector-aggregator");
-    let agent_override_name = get_override_name("vector-agent");
+    let aggregator_override_name = get_override_name(&namespace, "vector-aggregator");
+    let agent_override_name = get_override_name(&namespace, "vector-agent");
 
     let vector = framework
         .vector(

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -13,3 +13,4 @@ once_cell = "1"
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1.5.0", features = ["full"] }
+log = "0.4"

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -1,8 +1,8 @@
 //! The test framework main entry point.
 
 use super::{
-    exec_tail, kubernetes_version, log_lookup, namespace, port_forward, test_pod, up_down, vector,
-    wait_for_resource, wait_for_rollout, Interface, PortForwarder, Reader, Result,
+    exec_tail, kubernetes_version, log_lookup, namespace, pod, port_forward, test_pod, up_down,
+    vector, wait_for_resource, wait_for_rollout, Interface, PortForwarder, Reader, Result,
 };
 
 /// Framework wraps the interface to the system with an easy-to-use rust API
@@ -160,5 +160,20 @@ impl Framework {
         extra: impl IntoIterator<Item = &'a str>,
     ) -> Result<()> {
         wait_for_rollout::run(&self.interface.kubectl_command, namespace, resource, extra).await
+    }
+
+    /// Gets the node for a given pod.
+    pub async fn get_node_for_pod(&self, namespace: &str, pod: &str) -> Result<String> {
+        pod::get_node(&self.interface.kubectl_command, namespace, pod).await
+    }
+
+    /// Gets the name of the pod implementing the service on the given node.
+    pub async fn get_pod_on_node(
+        &self,
+        namespace: &str,
+        node: &str,
+        service: &str,
+    ) -> Result<String> {
+        pod::get_pod_on_node(&self.interface.kubectl_command, namespace, node, service).await
     }
 }

--- a/lib/k8s-test-framework/src/helm_values_file.rs
+++ b/lib/k8s-test-framework/src/helm_values_file.rs
@@ -1,12 +1,14 @@
 use std::path::Path;
 
 use crate::temp_file::TempFile;
+use log::info;
 
 #[derive(Debug)]
 pub struct HelmValuesFile(TempFile);
 
 impl HelmValuesFile {
     pub fn new(data: &str) -> std::io::Result<Self> {
+        info!("Using values \n {}", data);
         Ok(Self(TempFile::new("values.yml", data)?))
     }
 

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -23,6 +23,7 @@ pub mod kubernetes_version;
 mod lock;
 mod log_lookup;
 pub mod namespace;
+mod pod;
 mod port_forward;
 mod reader;
 mod resource_file;

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -45,5 +45,7 @@ use log_lookup::log_lookup;
 use port_forward::port_forward;
 pub use port_forward::PortForwarder;
 pub use reader::Reader;
+pub use test_pod::CommandBuilder;
+pub use up_down::Manager;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/lib/k8s-test-framework/src/pod.rs
+++ b/lib/k8s-test-framework/src/pod.rs
@@ -1,0 +1,98 @@
+use super::Result;
+use crate::util::run_command_output;
+use std::{ffi::OsStr, process::Stdio};
+use tokio::process::Command;
+
+#[derive(Debug)]
+pub struct Config {
+    pod_name: String,
+}
+
+#[derive(Debug)]
+pub struct CommandBuilder {
+    kubctl_command: String,
+    config: Config,
+}
+
+fn prepare_base_command<Cmd, NS, Pod>(
+    kubectl_command: Cmd,
+    namespace: NS,
+    pod: Option<Pod>,
+) -> Command
+where
+    Cmd: AsRef<OsStr>,
+    NS: AsRef<OsStr>,
+    Pod: AsRef<OsStr>,
+{
+    let mut command = Command::new(&kubectl_command);
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    command.arg("get").arg("pod");
+
+    if let Some(pod) = pod {
+        command.arg(pod);
+    }
+
+    command.arg("-n").arg(namespace).arg("-o").arg("json");
+
+    command
+}
+
+/// Returns the node the given pod is on
+pub async fn get_node<Cmd, NS, Pod>(kubectl_command: Cmd, namespace: NS, pod: Pod) -> Result<String>
+where
+    Pod: AsRef<OsStr>,
+    Cmd: AsRef<OsStr>,
+    NS: AsRef<OsStr>,
+{
+    let command = prepare_base_command(kubectl_command, namespace, Some(pod));
+    let pod = run_command_output(command).await?;
+    let pod: serde_json::Value = serde_json::from_str(&pod)?;
+
+    let node = pod["spec"]["nodeName"]
+        .as_str()
+        .ok_or("nodename must be a string")?;
+
+    Ok(node.to_string())
+}
+
+pub async fn get_pod_on_node<Cmd, NS>(
+    kubectl_command: Cmd,
+    namespace: NS,
+    node: &str,
+    service: &str,
+) -> Result<String>
+where
+    Cmd: AsRef<OsStr>,
+    NS: AsRef<OsStr>,
+{
+    let nopod: Option<&str> = None;
+    let command = prepare_base_command(kubectl_command, namespace, nopod);
+    let pods = run_command_output(command).await?;
+    let pods: serde_json::Value = serde_json::from_str(&pods)?;
+
+    let pods = pods["items"].as_array().ok_or("items should be an array")?;
+
+    for pod in pods {
+        if pod["spec"]["nodeName"]
+            .as_str()
+            .ok_or("nodeName must be a string")?
+            == node
+            && pod["spec"]["serviceAccount"]
+                .as_str()
+                .ok_or("serviceAccount must be a string")?
+                == service
+        {
+            return Ok(pod["metadata"]["name"]
+                .as_str()
+                .ok_or("name must be a string")?
+                .to_string());
+        }
+    }
+
+    Err("No pod on this node".into())
+}

--- a/lib/k8s-test-framework/src/up_down.rs
+++ b/lib/k8s-test-framework/src/up_down.rs
@@ -12,6 +12,7 @@ pub trait CommandBuilder {
     fn build(&self, command_to_build: CommandToBuild) -> Command;
 }
 
+/// Manages commands for bringing up and shutting down resources on the cluster.
 #[derive(Debug)]
 pub struct Manager<B>
 where
@@ -25,6 +26,7 @@ impl<B> Manager<B>
 where
     B: CommandBuilder,
 {
+    /// Create a new Manager.
     pub fn new(command_builder: B) -> Self {
         Self {
             command_builder,
@@ -32,21 +34,25 @@ where
         }
     }
 
+    /// Bring up the resource.
     pub async fn up(&mut self) -> Result<()> {
         self.needs_drop = true;
         self.exec(CommandToBuild::Up).await
     }
 
+    /// Shut down the resource.
     pub async fn down(&mut self) -> Result<()> {
         self.needs_drop = false;
         self.exec(CommandToBuild::Down).await
     }
 
+    /// Bring up the resource, blocking execution.
     pub fn up_blocking(&mut self) -> Result<()> {
         self.needs_drop = true;
         self.exec_blocking(CommandToBuild::Up)
     }
 
+    /// Shut down the resource, blocking execution.
     pub fn down_blocking(&mut self) -> Result<()> {
         self.needs_drop = false;
         self.exec_blocking(CommandToBuild::Down)

--- a/lib/k8s-test-framework/src/util.rs
+++ b/lib/k8s-test-framework/src/util.rs
@@ -15,3 +15,13 @@ pub fn run_command_blocking(mut command: std::process::Command) -> Result<()> {
     }
     Ok(())
 }
+
+pub async fn run_command_output(mut command: tokio::process::Command) -> Result<String> {
+    let output = command.spawn()?.wait_with_output().await?;
+    if !output.status.success() {
+        return Err(format!("exec failed: {:?}", command).into());
+    }
+
+    let output = String::from_utf8(output.stdout)?;
+    Ok(output)
+}

--- a/lib/k8s-test-framework/src/util.rs
+++ b/lib/k8s-test-framework/src/util.rs
@@ -1,6 +1,8 @@
 use crate::Result;
+use log::info;
 
 pub async fn run_command(mut command: tokio::process::Command) -> Result<()> {
+    info!("Running command `{:?}`", command);
     let exit_status = command.spawn()?.wait().await?;
     if !exit_status.success() {
         return Err(format!("exec failed: {:?}", command).into());
@@ -9,6 +11,7 @@ pub async fn run_command(mut command: tokio::process::Command) -> Result<()> {
 }
 
 pub fn run_command_blocking(mut command: std::process::Command) -> Result<()> {
+    info!("Running command blocking `{:?}`", command);
     let exit_status = command.spawn()?.wait()?;
     if !exit_status.success() {
         return Err(format!("exec failed: {:?}", command).into());
@@ -17,6 +20,7 @@ pub fn run_command_blocking(mut command: std::process::Command) -> Result<()> {
 }
 
 pub async fn run_command_output(mut command: tokio::process::Command) -> Result<String> {
+    info!("Fetching command `{:?}`", command);
     let output = command.spawn()?.wait_with_output().await?;
     if !output.status.success() {
         return Err(format!("exec failed: {:?}", command).into());

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -23,6 +23,12 @@ is_kubectl_context_minikube() {
   [[ "$(kubectl config current-context || true)" == "minikube" ]]
 }
 
+# Detect if current kubectl context is `kind`.
+is_kubectl_context_kind() {
+  [[ "$(kubectl config current-context || true)" == "kind-kind" ]]
+}
+
+
 # Whether to use `minikube cache` to pass image to the k8s cluster.
 # After we build vector docker image, instead of pushing to the remote repo,
 # we'll be using `minikube cache` to make image available to the cluster.

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -151,6 +151,7 @@ fi
 
 # Run the tests.
 cd lib/k8s-e2e-tests
+export RUST_LOG=debug
 cargo test \
   --no-fail-fast \
   --no-default-features \


### PR DESCRIPTION
Closes #7541 
Closes #7542

This PR makes three changes to our test suite to enable it to run on multinode kubernetes clusters.

1. It determines which node a given test pod is installed on and queries the logs from the Vector pod installed on that node. Before it would query a random pod in the daemonset.
2. It sets up Pod affinity to ensure that all test pods are installed on the same node so only a single Vector instance needs to be queried for that test.
3.  Customises the directory Vector is mounted to so that multiple Vector agents can be running on a node at any one time.

I have tested on Minikube and multinode Kind so far. Will test on AWS shortly..