### PR TITLE
fix(aws_cloudwatch_logs sink): Fix healthcheck to allow for log group creation at runtime

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -529,7 +529,14 @@ async fn healthcheck(
                     Err(HealthcheckError::GroupNameError.into())
                 }
             }
-            None => Err(HealthcheckError::NoLogGroup.into()),
+            None => {
+                if config.create_missing_group.unwrap() == true {
+                    info!("Cloudwatch group_name will be created at runtime");
+                    return Ok(());
+                } else {
+                    Err(HealthcheckError::NoLogGroup.into())
+                }
+            }
         },
         Err(source) => Err(HealthcheckError::DescribeLogGroupsFailed { source }.into()),
     }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -530,7 +530,7 @@ async fn healthcheck(
                 }
             }
             None => {
-                if config.create_missing_group.unwrap() == true {
+                if config.create_missing_group.unwrap_or(true) {
                     info!("Cloudwatch group_name will be created at runtime");
                     return Ok(());
                 } else {

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -526,10 +526,10 @@ async fn healthcheck(
             }
             None => {
                 if config.group_name.is_dynamic() {
-                    info!("Cloudwatch group_name is dynamic");
+                    info!("Cloudwatch group_name is dynamic.");
                     return Ok(());
                 } else if config.create_missing_group.unwrap_or(true) {
-                    info!("Cloudwatch group_name will be created if missing");
+                    info!("Cloudwatch group_name will be created if missing.");
                     return Ok(());
                 } else {
                     Err(HealthcheckError::NoLogGroup.into())

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -501,6 +501,11 @@ async fn healthcheck(
         return Ok(());
     }
 
+    if config.create_missing_group.unwrap_or(true) {
+        info!("Cloudwatch group_name will be created if missing; skipping healthcheck.");
+        return Ok(());
+    }
+
     let group_name = config.group_name.get_ref().to_owned();
     let expected_group_name = group_name.clone();
 
@@ -529,14 +534,7 @@ async fn healthcheck(
                     Err(HealthcheckError::GroupNameError.into())
                 }
             }
-            None => {
-                if config.create_missing_group.unwrap_or(true) {
-                    info!("Cloudwatch group_name will be created at runtime");
-                    return Ok(());
-                } else {
-                    Err(HealthcheckError::NoLogGroup.into())
-                }
-            }
+            None => Err(HealthcheckError::NoLogGroup.into()),
         },
         Err(source) => Err(HealthcheckError::DescribeLogGroupsFailed { source }.into()),
     }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -496,16 +496,6 @@ async fn healthcheck(
     config: CloudwatchLogsSinkConfig,
     client: CloudWatchLogsClient,
 ) -> crate::Result<()> {
-    if config.group_name.is_dynamic() {
-        info!("Cloudwatch group_name is dynamic; skipping healthcheck.");
-        return Ok(());
-    }
-
-    if config.create_missing_group.unwrap_or(true) {
-        info!("Cloudwatch group_name will be created if missing; skipping healthcheck.");
-        return Ok(());
-    }
-
     let group_name = config.group_name.get_ref().to_owned();
     let expected_group_name = group_name.clone();
 
@@ -534,7 +524,17 @@ async fn healthcheck(
                     Err(HealthcheckError::GroupNameError.into())
                 }
             }
-            None => Err(HealthcheckError::NoLogGroup.into()),
+            None => {
+                if config.group_name.is_dynamic() {
+                    info!("Cloudwatch group_name is dynamic");
+                    return Ok(());
+                } else if config.create_missing_group.unwrap_or(true) {
+                    info!("Cloudwatch group_name will be created if missing");
+                    return Ok(());
+                } else {
+                    Err(HealthcheckError::NoLogGroup.into())
+                }
+            }
         },
         Err(source) => Err(HealthcheckError::DescribeLogGroupsFailed { source }.into()),
     }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -526,10 +526,10 @@ async fn healthcheck(
             }
             None => {
                 if config.group_name.is_dynamic() {
-                    info!("Cloudwatch group_name is dynamic.");
+                    info!("Skipping healthcheck log group check: `group_name` is dynamic.");
                     return Ok(());
                 } else if config.create_missing_group.unwrap_or(true) {
-                    info!("Cloudwatch group_name will be created if missing.");
+                    info!("Skipping healthcheck log group check: `group_name` will be created if missing.");
                     return Ok(());
                 } else {
                     Err(HealthcheckError::NoLogGroup.into())


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #7592

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
