### PR TITLE
enhancement(helm platform)!: Deprecate rawConfig and use YAML configs directly

### DIFF
--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -8,31 +8,23 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     {{- include "libvector.vectorConfigHeader" . | nindent 4 -}}
+    {{- if or .Values.sources .Values.kubernetesLogsSource.enabled .Values.internalMetricsSource.enabled .Values.hostMetricsSource.enabled }}
+    sources:
+    {{- if .Values.sources }}
+    {{- toYaml .Values.sources | nindent 6 }}
+    {{- end }}
+    {{- end }}
 
     {{- with .Values.kubernetesLogsSource }}
     {{- if .enabled }}
     # Ingest logs from Kubernetes.
     {{- $value := merge (dict) .config -}}
     {{- $_ := set $value "type" "kubernetes_logs" -}}
-    {{- $_ := set $value "rawConfig" .rawConfig -}}
     {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
     {{- end }}
     {{- end }}
-
-    {{- with .Values.vectorSink -}}
-    {{- if .enabled }}
-    # Send logs to the aggregator.
-    {{- $value := merge (dict) .config -}}
-    {{- $_ := set $value "type" "vector" -}}
-    {{- $_ := set $value "inputs" (required "You must specify the `inputs` for the built-in vector sink" .inputs) -}}
-    {{- $_ := set $value "address" (include "vector-agent.vectorSinkAddress" $) -}}
-    {{- $_ := set $value "rawConfig" .rawConfig -}}
-    {{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 4 -}}
-    {{- end }}
-    {{- end }}
-
     {{- $prometheusInputs := (list) -}}
     {{- with .Values.hostMetricsSource -}}
     {{- if .enabled }}
@@ -40,13 +32,40 @@ data:
     # Capture the metrics from the host.
     {{- $value := merge (dict) .config -}}
     {{- $_ := set $value "type" "host_metrics" -}}
-    {{- $_ := set $value "rawConfig" .rawConfig -}}
     {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
     {{- end -}}
     {{- end -}}
+    {{- $values := .Values -}}
+    {{- with $values.internalMetricsSource }}
+    {{- if .enabled }}
+    # Emit internal Vector metrics.
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "internal_metrics" -}}
+    {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.transforms }}
+    transforms:
+    {{- toYaml .Values.transforms | nindent 6 }} 
+    {{- end }}
+
+    {{- if or .Values.sinks .Values.vectorSink.enabled .Values.prometheusSink.enabled }}
+    sinks:
+    {{- if .Values.sinks }}
+    {{- toYaml .Values.sinks | nindent 6 }} 
+    {{- end }}
+    {{- with .Values.vectorSink -}}
+    {{- if .enabled }}
+    # Send logs to the aggregator.
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "vector" -}}
+    {{- $_ := set $value "inputs" (required "You must specify the `inputs` for the built-in vector sink" .inputs) -}}
+    {{- $_ := set $value "address" (include "vector-agent.vectorSinkAddress" $) -}}
+    {{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 4 -}}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 
     {{- merge . (dict "prometheusInputs" $prometheusInputs) | include "libvector.metricsConfigPartial" | nindent 4 -}}
-
-    {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
-
 {{- end }}

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -47,13 +47,13 @@ data:
 
     {{- if .Values.transforms }}
     transforms:
-    {{- toYaml .Values.transforms | nindent 6 }} 
+    {{- toYaml .Values.transforms | nindent 6 }}
     {{- end }}
 
     {{- if or .Values.sinks .Values.vectorSink.enabled .Values.prometheusSink.enabled }}
     sinks:
     {{- if .Values.sinks }}
-    {{- toYaml .Values.sinks | nindent 6 }} 
+    {{- toYaml .Values.sinks | nindent 6 }}
     {{- end }}
     {{- with .Values.vectorSink -}}
     {{- if .enabled }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
             {{- toYaml .Values.command | nindent 12 }}
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -153,8 +153,6 @@ kubernetesLogsSource:
   # Additional config to embed at the kubernetes logs source.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the kubernetes logs source (deprecated).
-  rawConfig: null
 
 # The "built-in" vector sink, to send the logs to the vector aggregator.
 # Disabled by default when using `vector-agent` chart.
@@ -173,8 +171,6 @@ vectorSink:
   # Additional config to embed at the vector sink.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the vector sink (deprecated).
-  rawConfig: null
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
 # metrics.
@@ -186,8 +182,6 @@ internalMetricsSource:
   # Additional config to embed at the internal metrics source.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the internal metrics source (deprecated).
-  rawConfig: null
 
 # The "built-in" host metrics source emitting the metrics gathered from the node
 # that Vector is executing on.
@@ -206,8 +200,6 @@ hostMetricsSource:
       mountpoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     # option: "value"
-  # Raw TOML config to embed at the host metrics source (deprecated).
-  rawConfig: null
 
 # The "built-in" prometheus sink exposing metrics in the Prometheus scraping
 # format.
@@ -235,8 +227,6 @@ prometheusSink:
   # Additional config to embed at the prometheus sink.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the prometheus sink (deprecated).
-  rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
   # To be used in clusters that rely on Pod annotations in the form of
   # `prometheus.io/scrape` to discover scrape targets.
@@ -259,8 +249,6 @@ sources: {}
   # source_name:
   #   type: "source_type"
   #   option: "value"
-  #   rawConfig: |
-  #     option = "value"
 
 # Transforms to add to the generated `vector` config.
 transforms: {}
@@ -268,8 +256,6 @@ transforms: {}
   #   type: "transform_type"
   #   inputs: ["input1", "input2"]
   #   option: "value"
-  #   rawConfig: |
-  #     option = "value"
 
 # Sinks to add to the generated `vector` config.
 sinks: {}
@@ -277,5 +263,3 @@ sinks: {}
   #   type: "sink_type"
   #   inputs: ["input1", "input2"]
   #   option: "value"
-  #   rawConfig: |
-  #     option = "value"

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -8,8 +8,14 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     {{- include "libvector.vectorConfigHeader" . | nindent 4 -}}
+    {{- if or .Values.sources .Values.vectorSource.enabled .Values.internalMetricsSource.enabled }}
+    sources:
+    {{- if .Values.sources }}
+    {{- toYaml .Values.sources | nindent 6 }}
+    {{- end }}
+    {{- end }}
 
     {{- with .Values.vectorSource }}
     {{- if .enabled }}
@@ -17,13 +23,29 @@ data:
     {{- $value := merge (dict) .config -}}
     {{- $_ := set $value "type" "vector" -}}
     {{- $_ := set $value "address" (printf "%v:%v" .listenAddress .listenPort) -}}
-    {{- $_ := set $value "rawConfig" .rawConfig -}}
+    {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
+    {{- end }}
+    {{- end }}
+    {{- $values := .Values -}}
+    {{- with $values.internalMetricsSource }}
+    {{- if .enabled }}
+    # Emit internal Vector metrics.
+    {{- $value := merge (dict) .config -}}
+    {{- $_ := set $value "type" "internal_metrics" -}}
     {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
     {{- end }}
     {{- end }}
 
+    {{- if .Values.transforms }}
+    transforms:
+    {{- toYaml .Values.transforms | nindent 6 }} 
+    {{- end }}
+
+    {{- if or .Values.sinks .Values.prometheusSink.enabled }}
+    sinks:
+    {{- if .Values.sinks }}
+    {{- toYaml .Values.sinks | nindent 6 }} 
+    {{- end }}
+    {{- end }}
     {{- include "libvector.metricsConfigPartial" . | nindent 4  }}
-
-    {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
-
 {{- end }}

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -38,13 +38,13 @@ data:
 
     {{- if .Values.transforms }}
     transforms:
-    {{- toYaml .Values.transforms | nindent 6 }} 
+    {{- toYaml .Values.transforms | nindent 6 }}
     {{- end }}
 
     {{- if or .Values.sinks .Values.prometheusSink.enabled }}
     sinks:
     {{- if .Values.sinks }}
-    {{- toYaml .Values.sinks | nindent 6 }} 
+    {{- toYaml .Values.sinks | nindent 6 }}
     {{- end }}
     {{- end }}
     {{- include "libvector.metricsConfigPartial" . | nindent 4  }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -210,8 +210,6 @@ vectorSource:
     # option: "value"
   # Specific node port to bind (useful if `service.type` is set to `NodePort`).
   nodePort: null  # 9090 (must be a number)
-  # Raw TOML config to embed at the vector source (deprecated).
-  rawConfig: null
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
 # metrics.
@@ -223,8 +221,6 @@ internalMetricsSource:
   # Additional config to embed at the internal metrics source.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the internal metrics source (deprecated).
-  rawConfig: null
 
 # The "built-in" prometheus sink exposing metrics in the Prometheus scraping
 # format.
@@ -252,8 +248,6 @@ prometheusSink:
   # Additional config to embed at the prometheus sink.
   config: {}
     # option: "value"
-  # Raw TOML config to embed at the prometheus sink (deprecated).
-  rawConfig: null
   # Add Prometheus annotations to Pod to opt-in for Prometheus scraping.
   # To be used in clusters that rely on Pod annotations in the form of
   # `prometheus.io/scrape` to discover scrape targets.
@@ -274,21 +268,15 @@ prometheusSink:
 sources: {}
   # source_name:
   #   type: "source_type"
-  #   rawConfig: |
-  #     option = "value"
 
 # Transforms to add to the generated `vector` config.
 transforms: {}
   # transform_name:
   #   type: "transform_type"
   #   inputs: ["input1", "input2"]
-  #   rawConfig: |
-  #     option = "value"
 
 # Sinks to add to the generated `vector` config.
 sinks: {}
   # sink_name:
   #   type: "sink_type"
   #   inputs: ["input1", "input2"]
-  #   rawConfig: |
-  #     option = "value"

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -9,16 +9,6 @@ Internal metrics are common, so we share and reuse the definition.
 {{- $values := .Values -}}
 
 {{- $prometheusInputs := .prometheusInputs -}}
-{{- with $values.internalMetricsSource }}
-{{- if .enabled }}
-# Emit internal Vector metrics.
-{{- $value := merge (dict) .config -}}
-{{- $_ := set $value "type" "internal_metrics" -}}
-{{- $_ := set $value "rawConfig" .rawConfig -}}
-{{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 0 -}}
-{{- end }}
-{{- end }}
-
 {{- with $values.prometheusSink }}
 {{- if .enabled }}
 
@@ -34,7 +24,6 @@ Internal metrics are common, so we share and reuse the definition.
 {{- $_ := set $value "type" "prometheus" -}}
 {{- $_ := set $value "inputs" $inputs -}}
 {{- $_ := set $value "address" (printf "%v:%v" .listenAddress .listenPort) -}}
-{{- $_ := set $value "rawConfig" .rawConfig -}}
 {{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 0 -}}
 {{- end }}
 {{- end }}

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -1,46 +1,27 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Serialize the passed Vector component configuration bits as TOML.
+Serialize the passed Vector component configuration bits as YAML.
 */}}
 {{- define "libvector.vectorComponentConfig" -}}
 {{- $componentGroup := index . 0 -}}
 {{- $componentId := index . 1 -}}
 {{- $value := index . 2 -}}
 
-{{- $rawConfig := $value.rawConfig -}}
-{{- $value = unset $value "rawConfig" -}}
-
-{{- $header := printf "[%s.%s]" $componentGroup $componentId -}}
-
-{{- /* Build the right hierarchy and evaluate the TOML. */ -}}
-{{- $toml := toToml (dict $componentGroup (dict $componentId $value)) -}}
-{{- /* Cut the root-level key containing the component kind name (i.e. `[sinks]`). */ -}}
-{{- $toml = $toml | trimPrefix (printf "[%s]\n" $componentGroup) -}}
-{{- /* Remove one level of indentation. */ -}}
-{{- $toml = regexReplaceAllLiteral "(?m)^  " $toml "" -}}
+{{- /* Build the right hierarchy and evaluate the YAML. */ -}}
+{{- $yaml := toYaml (dict $componentGroup (dict $componentId $value)) -}}
+{{- /* Cut the root-level key containing the component kind name (i.e. `sinks`). */ -}}
+{{- $yaml = $yaml | trimPrefix (printf "%s:\n" $componentGroup) -}}
 {{- /* Cut tailing newline. */ -}}
-{{- $toml = $toml | trimSuffix "\n" -}}
+{{- $yaml = $yaml | trimSuffix "\n" -}}
 {{- /* Print the value. */ -}}
-{{- $toml -}}
-
-{{- with $rawConfig -}}
-{{- /* Here is a poor attempt to ensure raw config section is put under the */ -}}
-{{- /* component-level section. What we're trying to do here is prohibited */ -}}
-{{- /* in the TOML spec, but it may work in the simple case - and this is */ -}}
-{{- /* what we have to support for the backward compatibility. */ -}}
-{{- if contains (printf "[%s.%s." $componentGroup $componentId) $toml -}}
-{{- $header| nindent 0 -}}
-{{- end -}}
-{{- /* Print the raw config. */ -}}
-  {{- $rawConfig | nindent 2 -}}
-{{- end }}
+{{- $yaml -}}
 
 {{- printf "\n" -}}
 {{- end }}
 
 {{/*
-Serialize the passed Vector source configuration bits as TOML.
+Serialize the passed Vector source configuration bits as YAML.
 */}}
 {{- define "libvector.vectorSourceConfig" -}}
 {{- $componentId := index . 0 -}}
@@ -49,7 +30,7 @@ Serialize the passed Vector source configuration bits as TOML.
 {{- end }}
 
 {{/*
-Serialize the passed Vector transform configuration bits as TOML.
+Serialize the passed Vector transform configuration bits as YAML.
 */}}
 {{- define "libvector.vectorTransformConfig" -}}
 {{- $componentId := index . 0 -}}
@@ -58,7 +39,7 @@ Serialize the passed Vector transform configuration bits as TOML.
 {{- end }}
 
 {{/*
-Serialize the passed Vector sink configuration bits as TOML.
+Serialize the passed Vector sink configuration bits as YAML.
 */}}
 {{- define "libvector.vectorSinkConfig" -}}
 {{- $componentId := index . 0 -}}
@@ -67,7 +48,7 @@ Serialize the passed Vector sink configuration bits as TOML.
 {{- end }}
 
 {{/*
-Serialize the passed Vector topology configuration bits as TOML.
+Serialize the passed Vector topology configuration bits as YAML.
 */}}
 {{- define "libvector.vectorTopology" -}}
 {{- range $componentId, $value := .sources }}
@@ -90,20 +71,20 @@ The common header for Vector ConfigMaps.
 # Configuration for vector.
 # Docs: https://vector.dev/docs/
 
-data_dir = "{{ .Values.globalOptions.dataDir }}"
+data_dir: "{{ .Values.globalOptions.dataDir }}"
 
-[api]
-  enabled = {{ .Values.vectorApi.enabled }}
-  address = {{ .Values.vectorApi.address | quote }}
-  playground = {{ .Values.vectorApi.playground }}
+api:
+  enabled: {{ .Values.vectorApi.enabled }}
+  address: {{ .Values.vectorApi.address | quote }}
+  playground: {{ .Values.vectorApi.playground }}
 {{- printf "\n" -}}
 
 {{- with .Values.logSchema }}
-[log_schema]
-  host_key = "{{ .hostKey }}"
-  message_key = "{{ .messageKey }}"
-  source_type_key = "{{ .sourceTypeKey }}"
-  timestamp_key = "{{ .timestampKey }}"
+log_schema:
+  host_key: "{{ .hostKey }}"
+  message_key: "{{ .messageKey }}"
+  source_type_key: "{{ .sourceTypeKey }}"
+  timestamp_key: "{{ .timestampKey }}"
   {{- printf "\n" -}}
 {{- end }}
 {{- end }}

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -33,48 +33,55 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Ingest logs from Kubernetes.
-    [sources.kubernetes_logs]
-      type = "kubernetes_logs"
+      kubernetes_logs:
+        type: kubernetes_logs
     
     # Capture the metrics from the host.
-    [sources.host_metrics]
-      type = "host_metrics"
-      [sources.host_metrics.filesystem]
-        [sources.host_metrics.filesystem.devices]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.filesystems]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.mountpoints]
-          excludes = ["*/proc/sys/fs/binfmt_misc"]
-    
+      host_metrics:
+        filesystem:
+          devices:
+            excludes:
+            - binfmt_misc
+          filesystems:
+            excludes:
+            - binfmt_misc
+          mountpoints:
+            excludes:
+            - '*/proc/sys/fs/binfmt_misc'
+        type: host_metrics
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    sinks:
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics", "host_metrics"]
-      type = "prometheus"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        - host_metrics
+        type: prometheus
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -161,7 +161,7 @@ spec:
             []
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -153,7 +153,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             
             - name: LOG

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -33,38 +33,41 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Accept logs from Vector agents.
-    [sources.vector]
-      address = "0.0.0.0:9000"
-      type = "vector"
-    
+      vector:
+        address: 0.0.0.0:9000
+        type: vector
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    sinks:
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics"]
-      type = "prometheus"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        type: prometheus
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -274,7 +274,7 @@ spec:
             []
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
@@ -404,7 +404,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             
             - name: "LOG"

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -46,54 +46,62 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Ingest logs from Kubernetes.
-    [sources.kubernetes_logs]
-      type = "kubernetes_logs"
-    
-    # Send logs to the aggregator.
-    [sinks.vector_sink]
-      address = "vector-aggregator:9000"
-      inputs = ["kubernetes_logs"]
-      type = "vector"
+      kubernetes_logs:
+        type: kubernetes_logs
     
     # Capture the metrics from the host.
-    [sources.host_metrics]
-      type = "host_metrics"
-      [sources.host_metrics.filesystem]
-        [sources.host_metrics.filesystem.devices]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.filesystems]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.mountpoints]
-          excludes = ["*/proc/sys/fs/binfmt_misc"]
-    
+      host_metrics:
+        filesystem:
+          devices:
+            excludes:
+            - binfmt_misc
+          filesystems:
+            excludes:
+            - binfmt_misc
+          mountpoints:
+            excludes:
+            - '*/proc/sys/fs/binfmt_misc'
+        type: host_metrics
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    sinks:
+    # Send logs to the aggregator.
+      vector_sink:
+        address: vector-aggregator:9000
+        inputs:
+        - kubernetes_logs
+        type: vector
+    
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics", "host_metrics"]
-      type = "prometheus"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        - host_metrics
+        type: prometheus
 ---
 # Source: vector/charts/vector-aggregator/templates/configmap.yaml
 apiVersion: v1
@@ -109,38 +117,41 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Accept logs from Vector agents.
-    [sources.vector]
-      address = "0.0.0.0:9000"
-      type = "vector"
-    
+      vector:
+        address: 0.0.0.0:9000
+        type: vector
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    sinks:
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics"]
-      type = "prometheus"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        type: prometheus
 ---
 # Source: vector/charts/vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/docs/highlights/2021-06-01-remove-helm-rawconfig.md
+++ b/docs/highlights/2021-06-01-remove-helm-rawconfig.md
@@ -1,0 +1,42 @@
+---
+last_modified_on: "2021-06-01"
+$schema: ".schema.json"
+title: "Helm `rawConfig` removal"
+description: "The `rawConfig` option in the Vector Helm charts has been fully deprecated"
+author_github: "https://github.com/spencergilbert"
+pr_numbers: [7608]
+release: "0.14.0"
+hide_on_release_notes: false
+tags: ["type: breaking change"]
+---
+
+In the Vector 0.14.0 Helm charts, we no longer support the `rawConfig` key for component configuration.
+This reduces complexity and improves maintainability for our charts, as well as eliminating bugs
+related to the templating of `rawConfigs`.
+
+## Upgrade Guide
+
+Below is an example of how to make the required changes in your `values.yaml` file:
+
+```diff title="values.yaml"
+   sources:
+     dummy:
+       type: "generator"
+-      rawConfig: |
+-        format = "shuffle"
+-        lines = ["Hello world"]
+-        interval = 60 # once a minute
++      format: "shuffle"
++      lines: ["Hello world"]
++      interval: 60 # once a minute
+
+   sinks:
+     stdout:
+       type: "console"
+       inputs: ["dummy"]
+-      rawConfig: |
+-        target = "stdout"
+-        encoding = "json"
++      target: "stdout"
++      encoding: "json"
+```

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -30,12 +30,13 @@ const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = indoc! {r#"
     metadata:
       name: vector-agent-config
     data:
-      vector.toml: |
-        [sinks.stdout]
-            type = "console"
-            inputs = ["kubernetes_logs"]
-            target = "stdout"
-            encoding = "json"
+      vector.yaml: |
+        sinks:
+          stdout:
+            type: "console"
+            inputs: ["kubernetes_logs"]
+            target: "stdout"
+            encoding: "json"
 "#};
 
 /// This test validates that vector-agent picks up logs at the simplest case

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -177,7 +177,7 @@ spec:
             []
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -31,70 +31,73 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Ingest logs from Kubernetes.
-    [sources.kubernetes_logs]
-      option1 = "value1"
-      option2 = "value2"
-      type = "kubernetes_logs"
-      arbitrary text 1
-    
-    # Send logs to the aggregator.
-    [sinks.vector_sink]
-      address = "vector.internal:9000"
-      inputs = ["my_input_1", "my_input_2"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "vector"
-      arbitrary text 1
+      kubernetes_logs:
+        option1: value1
+        option2: value2
+        type: kubernetes_logs
     
     # Capture the metrics from the host.
-    [sources.host_metrics]
-      option1 = "value1"
-      option2 = "value2"
-      type = "host_metrics"
-      [sources.host_metrics.filesystem]
-        [sources.host_metrics.filesystem.devices]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.filesystems]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.mountpoints]
-          excludes = ["*/proc/sys/fs/binfmt_misc"]
-    [sources.host_metrics]
-      arbitrary text 1
-    
+      host_metrics:
+        filesystem:
+          devices:
+            excludes:
+            - binfmt_misc
+          filesystems:
+            excludes:
+            - binfmt_misc
+          mountpoints:
+            excludes:
+            - '*/proc/sys/fs/binfmt_misc'
+        option1: value1
+        option2: value2
+        type: host_metrics
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      option1 = "value1"
-      option2 = "value2"
-      type = "internal_metrics"
-      arbitrary text 1
+      internal_metrics:
+        option1: value1
+        option2: value2
+        type: internal_metrics
+    
+    sinks:
+    # Send logs to the aggregator.
+      vector_sink:
+        address: vector.internal:9000
+        inputs:
+        - my_input_1
+        - my_input_2
+        option1: value1
+        option2: value2
+        type: vector
+    
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics", "host_metrics"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "prometheus"
-      arbitrary text 1
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        - host_metrics
+        option1: value1
+        option2: value2
+        type: prometheus
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/tests/helm-snapshots/builtin_configs/vector-agent/values.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/values.yaml
@@ -2,8 +2,6 @@ kubernetesLogsSource:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 vectorSink:
   enabled: true
@@ -13,26 +11,18 @@ vectorSink:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 internalMetricsSource:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 hostMetricsSource:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 prometheusSink:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -157,7 +157,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             
           ports:

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -31,47 +31,47 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
     # Accept logs from Vector agents.
-    [sources.vector]
-      address = "0.0.0.0:9000"
-      option1 = "value1"
-      option2 = "value2"
-      type = "vector"
-      arbitrary text 1
-    
+      vector:
+        address: 0.0.0.0:9000
+        option1: value1
+        option2: value2
+        type: vector
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      option1 = "value1"
-      option2 = "value2"
-      type = "internal_metrics"
-      arbitrary text 1
+      internal_metrics:
+        option1: value1
+        option2: value2
+        type: internal_metrics
+    
+    sinks:
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "prometheus"
-      arbitrary text 1
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        option1: value1
+        option2: value2
+        type: prometheus
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/values.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/values.yaml
@@ -2,19 +2,13 @@ vectorSource:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 internalMetricsSource:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1
 
 prometheusSink:
   config:
     option1: value1
     option2: value2
-  rawConfig: |-
-    arbitrary text 1

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -207,7 +207,7 @@ spec:
             []
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -52,15 +52,11 @@ data:
       source1:
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       source2:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       source3:
         type: type3
@@ -93,9 +89,6 @@ data:
         - input2
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       transform2:
         inputs:
@@ -104,7 +97,6 @@ data:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       transform3:
         inputs: []
@@ -116,9 +108,6 @@ data:
         - input2
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       sink2:
         inputs:
@@ -127,7 +116,6 @@ data:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       sink3:
         inputs: []

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -31,109 +31,115 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
+      source1:
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      source2:
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      source3:
+        type: type3
     # Ingest logs from Kubernetes.
-    [sources.kubernetes_logs]
-      type = "kubernetes_logs"
+      kubernetes_logs:
+        type: kubernetes_logs
     
     # Capture the metrics from the host.
-    [sources.host_metrics]
-      type = "host_metrics"
-      [sources.host_metrics.filesystem]
-        [sources.host_metrics.filesystem.devices]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.filesystems]
-          excludes = ["binfmt_misc"]
-        [sources.host_metrics.filesystem.mountpoints]
-          excludes = ["*/proc/sys/fs/binfmt_misc"]
-    
+      host_metrics:
+        filesystem:
+          devices:
+            excludes:
+            - binfmt_misc
+          filesystems:
+            excludes:
+            - binfmt_misc
+          mountpoints:
+            excludes:
+            - '*/proc/sys/fs/binfmt_misc'
+        type: host_metrics
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    transforms:
+      transform1:
+        inputs:
+        - input1
+        - input2
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      transform2:
+        inputs:
+        - input2
+        - input1
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      transform3:
+        inputs: []
+        type: type3
+    sinks:
+      sink1:
+        inputs:
+        - input1
+        - input2
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      sink2:
+        inputs:
+        - input2
+        - input1
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      sink3:
+        inputs: []
+        type: type3
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics", "host_metrics"]
-      type = "prometheus"
-    
-    
-    [sources.source1]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [sources.source2]
-      optionA = "valueA"
-      type = "type2"
-      [sources.source2.optionB]
-        suboption = "valueB"
-    [sources.source2]
-      arbitrary text 2
-    
-    [sources.source3]
-      type = "type3"
-    
-    [transforms.transform1]
-      inputs = ["input1", "input2"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [transforms.transform2]
-      inputs = ["input2", "input1"]
-      optionA = "valueA"
-      type = "type2"
-      [transforms.transform2.optionB]
-        suboption = "valueB"
-    [transforms.transform2]
-      arbitrary text 2
-    
-    [transforms.transform3]
-      inputs = []
-      type = "type3"
-    
-    [sinks.sink1]
-      inputs = ["input1", "input2"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [sinks.sink2]
-      inputs = ["input2", "input1"]
-      optionA = "valueA"
-      type = "type2"
-      [sinks.sink2.optionB]
-        suboption = "valueB"
-    [sinks.sink2]
-      arbitrary text 2
-    
-    [sinks.sink3]
-      inputs = []
-      type = "type3"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        - host_metrics
+        type: prometheus
 ---
 # Source: vector-agent/templates/rbac.yaml
 # Permissions to use Kubernetes API.

--- a/tests/helm-snapshots/topology_config/vector-agent/values.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/values.yaml
@@ -3,16 +3,11 @@ sources:
     type: "type1"
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   source2:
     type: "type2"
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   source3:
     type: "type3"
 
@@ -22,17 +17,12 @@ transforms:
     inputs: ["input1", "input2"]
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   transform2:
     type: "type2"
     inputs: ["input2", "input1"]
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   transform3:
     type: "type3"
     inputs: []
@@ -43,17 +33,12 @@ sinks:
     inputs: ["input1", "input2"]
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   sink2:
     type: "type2"
     inputs: ["input2", "input1"]
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   sink3:
     type: "type3"
     inputs: []

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -52,15 +52,11 @@ data:
       source1:
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       source2:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       source3:
         type: type3
@@ -80,9 +76,6 @@ data:
         - input2
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       transform2:
         inputs:
@@ -91,7 +84,6 @@ data:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       transform3:
         inputs: []
@@ -103,9 +95,6 @@ data:
         - input2
         option1: value1
         option2: value2
-        rawConfig: |-
-          option = "value"
-          arbitrary text
         type: type1
       sink2:
         inputs:
@@ -114,7 +103,6 @@ data:
         optionA: valueA
         optionB:
           suboption: valueB
-        rawConfig: arbitrary text 2
         type: type2
       sink3:
         inputs: []

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -199,7 +199,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --config
-            - /etc/vector/*.toml
+            - /etc/vector/*.yaml
           env:
             
           ports:

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -31,99 +31,101 @@ metadata:
 data:
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
-  managed.toml: |
+  managed.yaml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
     
-    data_dir = "/vector-data-dir"
+    data_dir: "/vector-data-dir"
     
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
+    api:
+      enabled: false
+      address: "0.0.0.0:8686"
+      playground: true
     
-    [log_schema]
-      host_key = "host"
-      message_key = "message"
-      source_type_key = "source_type"
-      timestamp_key = "timestamp"
+    log_schema:
+      host_key: "host"
+      message_key: "message"
+      source_type_key: "source_type"
+      timestamp_key: "timestamp"
     
+    sources:
+      source1:
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      source2:
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      source3:
+        type: type3
     # Accept logs from Vector agents.
-    [sources.vector]
-      address = "0.0.0.0:9000"
-      type = "vector"
-    
+      vector:
+        address: 0.0.0.0:9000
+        type: vector
     
     # Emit internal Vector metrics.
-    [sources.internal_metrics]
-      type = "internal_metrics"
+      internal_metrics:
+        type: internal_metrics
+    
+    transforms:
+      transform1:
+        inputs:
+        - input1
+        - input2
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      transform2:
+        inputs:
+        - input2
+        - input1
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      transform3:
+        inputs: []
+        type: type3
+    sinks:
+      sink1:
+        inputs:
+        - input1
+        - input2
+        option1: value1
+        option2: value2
+        rawConfig: |-
+          option = "value"
+          arbitrary text
+        type: type1
+      sink2:
+        inputs:
+        - input2
+        - input1
+        optionA: valueA
+        optionB:
+          suboption: valueB
+        rawConfig: arbitrary text 2
+        type: type2
+      sink3:
+        inputs: []
+        type: type3
     
     # Expose metrics for scraping in the Prometheus format.
-    [sinks.prometheus_sink]
-      address = "0.0.0.0:9090"
-      inputs = ["internal_metrics"]
-      type = "prometheus"
-    
-    
-    [sources.source1]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [sources.source2]
-      optionA = "valueA"
-      type = "type2"
-      [sources.source2.optionB]
-        suboption = "valueB"
-    [sources.source2]
-      arbitrary text 2
-    
-    [sources.source3]
-      type = "type3"
-    
-    [transforms.transform1]
-      inputs = ["input1", "input2"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [transforms.transform2]
-      inputs = ["input2", "input1"]
-      optionA = "valueA"
-      type = "type2"
-      [transforms.transform2.optionB]
-        suboption = "valueB"
-    [transforms.transform2]
-      arbitrary text 2
-    
-    [transforms.transform3]
-      inputs = []
-      type = "type3"
-    
-    [sinks.sink1]
-      inputs = ["input1", "input2"]
-      option1 = "value1"
-      option2 = "value2"
-      type = "type1"
-      option = "value"
-      arbitrary text
-    
-    [sinks.sink2]
-      inputs = ["input2", "input1"]
-      optionA = "valueA"
-      type = "type2"
-      [sinks.sink2.optionB]
-        suboption = "valueB"
-    [sinks.sink2]
-      arbitrary text 2
-    
-    [sinks.sink3]
-      inputs = []
-      type = "type3"
+      prometheus_sink:
+        address: 0.0.0.0:9090
+        inputs:
+        - internal_metrics
+        type: prometheus
 ---
 # Source: vector-aggregator/templates/service-headless.yaml
 apiVersion: v1

--- a/tests/helm-snapshots/topology_config/vector-aggregator/values.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/values.yaml
@@ -3,16 +3,11 @@ sources:
     type: "type1"
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   source2:
     type: "type2"
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   source3:
     type: "type3"
 
@@ -22,17 +17,12 @@ transforms:
     inputs: ["input1", "input2"]
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   transform2:
     type: "type2"
     inputs: ["input2", "input1"]
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   transform3:
     type: "type3"
     inputs: []
@@ -43,17 +33,12 @@ sinks:
     inputs: ["input1", "input2"]
     option1: "value1"
     option2: "value2"
-    rawConfig: |-
-      option = "value"
-      arbitrary text
   sink2:
     type: "type2"
     inputs: ["input2", "input1"]
     optionA: "valueA"
     optionB:
       suboption: "valueB"
-    rawConfig: |-
-      arbitrary text 2
   sink3:
     type: "type3"
     inputs: []


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #6042, resolves #7453

This is a bit of a messy deprecation, but it currently looks to be a drop in replacement. I'm opening an RFC to clean up the templating further and reducing complexity, as well as seeing how I can improve the state of the code from this PR.

This PR still needs to add to the highlights section, as well as documentation updates

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
