### PR TITLE
fix(buffers): Min uncompact size

### DIFF
--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -186,7 +186,10 @@ where
                 && self.uncompacted_size > unread_size;
 
             // Basic requirement to avoid leaving ldb files behind.
-            // See https://github.com/timberio/vector/issues/7425#issuecomment-849522738
+            // See:
+            // Vector  https://github.com/timberio/vector/issues/7425#issuecomment-849522738
+            // leveldb https://github.com/google/leveldb/issues/783
+            //         https://github.com/syndtr/goleveldb/issues/166
             let min_size = self.uncompacted_size >= MIN_UNCOMPACTED_SIZE;
 
             if min_size && (max_trigger || timed_trigger) {

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 const MIN_TIME_UNCOMPACTED: Duration = Duration::from_secs(60);
 
 /// Minimal size of uncompacted for which a compaction can be triggered.
-const MIN_UNCOMPACTED_SIZE: usize = 2 * 1024 * 1024;
+const MIN_UNCOMPACTED_SIZE: usize = 4 * 1024 * 1024;
 
 /// The reader side of N to 1 channel through leveldb.
 ///

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -23,6 +23,9 @@ use std::time::{Duration, Instant};
 /// How much time needs to pass between compaction to trigger new one.
 const MIN_TIME_UNCOMPACTED: Duration = Duration::from_secs(60);
 
+/// Minimal size of uncompacted for which a compaction can be triggered.
+const MIN_UNCOMPACTED_SIZE: usize = 2 * 1024 * 1024;
+
 /// The reader side of N to 1 channel through leveldb.
 ///
 /// Reader maintains/manages events thorugh several stages.
@@ -182,7 +185,11 @@ where
             let timed_trigger = self.last_compaction.elapsed() >= MIN_TIME_UNCOMPACTED
                 && self.uncompacted_size > unread_size;
 
-            if max_trigger || timed_trigger {
+            // Basic requirement to avoid leaving ldb files behind.
+            // See https://github.com/timberio/vector/issues/7425#issuecomment-849522738
+            let min_size = self.uncompacted_size >= MIN_UNCOMPACTED_SIZE;
+
+            if min_size && (max_trigger || timed_trigger) {
                 self.compact();
             }
         }


### PR DESCRIPTION
Ref. #7425

Fixes issue with residual ldb files by requiring minimal size of uncompacted bytes. https://github.com/timberio/vector/issues/7425#issuecomment-849522738



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
