### PR TITLE
fix(buffers): Batch delete

### DIFF
--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
@@ -133,7 +133,7 @@ where
             max_uncompacted_size,
             uncompacted_size: 0,
             unacked_sizes: VecDeque::new(),
-            buffer: Vec::new(),
+            buffer: VecDeque::new(),
             last_compaction: Instant::now(),
             phantom: PhantomData,
         };

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
@@ -126,6 +126,7 @@ where
             blocked_write_tasks,
             read_offset: head,
             compacted_offset: 0,
+            acked: 0,
             delete_offset: head,
             current_size,
             ack_counter,

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -99,7 +99,7 @@ where
             // This will usually complete instantly, but in the case of a large
             // queue (or a fresh launch of the app), this will have to go to
             // disk.
-            let mut buffer = std::mem::replace(&mut self.buffer, VecDeque::default());
+            let mut buffer = std::mem::take(&mut self.buffer);
             tokio::task::block_in_place(|| {
                 buffer.extend(
                     self.db


### PR DESCRIPTION
Ref. #7425

Reduces performance impact of deletes. In worst case scenario when sink manages to stay up to date, every event would result in one delete operation which negatively impacted write/read performance. This PR batches deletes to reduce that.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
