### PR TITLE
chore(external docs): clarify ElasticSearch bulk actions #7616

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1010,11 +1010,9 @@ Highlights are not blog posts. They are short one, maybe two, paragraph
 announcements. Highlights should allude to, or link to, a blog post if
 relevant.
 
-For example, [this performance increase announcement][urls.performance_highlight]
+For example, [this adaptive concurrency announcement][urls.adaptive_concurrency]
 is noteworthy, but also deserves an in-depth blog post covering the work that
-resulted in the performance benefit. Notice that the highlight alludes to an
-upcoming blog post. This allows us to communicate a high-value performance
-improvement without being blocked by an in-depth blog post.
+resulted in the performance and reliability benefit.
 
 ## Security
 
@@ -1086,7 +1084,7 @@ contact us at vector@timber.io.
 [urls.github_sign_commits]: https://help.github.com/en/github/authenticating-to-github/signing-commits
 [urls.new_issue]: https://github.com/timberio/vector/issues/new
 [urls.push_it_to_the_limit]: https://www.youtube.com/watch?v=ueRzA9GUj9c
-[urls.performance_highlight]: https://vector.dev/highlights/2020-04-11-overall-performance-increase
+[urls.adaptive_concurrency]: https://vector.dev/highlights/2020-09-18-adaptive-concurrency
 [urls.submit_pr]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
 [urls.vector_test_harness]: https://github.com/timberio/vector-test-harness/
 [urls.watchexec]: https://github.com/watchexec/watchexec

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -176,7 +176,7 @@ components: sinks: [Name=string]: {
 
 						only_fields: {
 							common:      false
-							description: "Prevent the sink from encoding the specified fields."
+							description: "Makes the sink encode only the specified fields."
 							required:    false
 							type: array: {
 								default: null

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -153,7 +153,7 @@ components: sinks: elasticsearch: {
 		}
 		bulk_action: {
 			common:      false
-			description: "Action to use when making requests to the [Elasticsearch Bulk API](elasticsearch_bulk). Supports `index` and `create`."
+			description: "Action to use when making requests to the [Elasticsearch Bulk API](elasticsearch_bulk). Currently, Vector only supports `index` and `create`. `update` and `delete` actions are not supported."
 			required:    false
 			warnings: []
 			type: string: {
@@ -237,7 +237,7 @@ components: sinks: elasticsearch: {
 			body: """
 				Vector [batches](#buffers--batches) data flushes it to Elasticsearch's
 				[`_bulk` API endpoint][urls.elasticsearch_bulk]. By default, all events are
-				inserted via the `index` action which will update documents if an existing
+				inserted via the `index` action which will replace documents if an existing
 				one has the same `id`. If `bulk_action` is configured with `create`, Elasticsearch
 				will _not_ replace an existing document and instead return a conflict error.
 				"""


### PR DESCRIPTION
In [sinks.cue](https://github.com/timberio/vector/blob/9b5d3b6efcf88c8dbe5901bee8ecb91149474096/docs/reference/components/sinks.cue#L164-L188), the `only_fields` and `except_fields` have the same description. This change fixes the description to show the correct function.

In [elasticsearch.cue](https://github.com/timberio/vector/blob/9b5d3b6efcf88c8dbe5901bee8ecb91149474096/docs/reference/components/sinks/elasticsearch.cue#L240), i've added a clarification that the operation will not update the document, but replace it. Usually updates will "patch" a partial document, but the `index` action replaces the full document, so if a partial document is sent, it will overwrite the existing one.

Fix a broken link in CONTRIBUTING.md