### PR TITLE
chore(ci): allow VECTOR_BUILD_DESC to be passed thru during packaging

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -3,6 +3,7 @@ passthrough = [
     "BUILD_DIR",
     "RUST_BACKTRACE",
     "RUST_LOG",
+    "VECTOR_BUILD_DESC",
 ]
 
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
By default, `cross` won't pass through environment variables to the build container unless explicitly added to the `passthrough` setting in `Cross.toml`.  We need to do this for `VECTOR_BUILD_DESC` so that we can properly add back the `<git sha> <build time>` portion of the `vector --version` output. 

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>