### PR TITLE
enhancement(tests): e2e logs ingestion from Datadog agent to Vector

### DIFF
--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -29,5 +29,9 @@ name = "vector-aggregator"
 required-features = ["e2e-tests"]
 
 [[test]]
+name = "vector-dd-agent-aggregator"
+required-features = ["e2e-tests"]
+
+[[test]]
 name = "vector"
 required-features = ["e2e-tests"]

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -3,13 +3,19 @@ use k8s_e2e_tests::*;
 use k8s_test_framework::{lock, test_pod, vector::Config as VectorConfig};
 use serde_json::Value;
 
-
 const HELM_CHART_VECTOR_AGGREGATOR: &str = "vector-aggregator";
 
 const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
+    service:
+      type: "ClusterIP"
+      ports:
+        - name: datadog
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
     sources:
-      ddog-agg:
-        type: "datadog-agent"
+      datadog-agent:
+        type: "datadog_logs"
         rawConfig: |
           address = "0.0.0.0:8080"
 
@@ -21,37 +27,53 @@ const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
         encoding: "json"
 "#};
 
-// Value.yaml for datadog offical chart
-const DATADOG_AGENT_CHART_CONFIG: &str = indoc! {r#"
-    datadog:
-      apiKey: 0123456789ABCDEF0123456789ABCDEF
-      logs:
-        enabled: true
-    agents:
-      customAgentConfig:
-        kubelet_tls_verify: false
-        logs_config.use_http: true
-        logs_config.logs_no_ssl: true
-        logs_config.logs_dd_url: vector-aggregator:8080
-        listeners:
-          - name: kubelet
-        config_providers:
-          - name: kubelet
-            polling: true
-          - name: docker
-            polling: true
-"#};
-
-
 /// This test validates that vector-aggregator can deploy with the default
 /// settings and a dummy topology.
 #[tokio::test]
 async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let namespace = get_namespace();
-    let framework = make_framework();
-    let pod_namespace = get_namespace_appended("test-pod");
     let override_name = get_override_name("vector-aggregator");
+    let vector_endpoint = &format!("{}.{}.svc.cluster.local", override_name, namespace);
+    let datadog_namespace = get_namespace_appended("datadog-agent");
+    let datadog_override_name = get_override_name("datadog-agent");
+    let pod_namespace = get_namespace_appended("test-pod");
+    let framework = make_framework();
+
+    // Value.yaml for datadog offical chart
+    let datadog_chart_values = &format!(
+        indoc! {r#"
+        datadog:
+          apiKey: 0123456789ABCDEF0123456789ABCDEF
+          logs:
+            enabled: true
+          processAgent:
+            enabled: false
+          clusterAgent:
+            enabled: false
+          kubeStateMetricsEnabled: false
+        agents:
+          containers:
+            agent:
+              readinessProbe:
+                exec:
+                  command: ["/bin/true"]
+          useConfigMap: true
+          customAgentConfig:
+            kubelet_tls_verify: false
+            logs_config.use_http: true
+            logs_config.logs_no_ssl: true
+            logs_config.logs_dd_url: {}:8080
+            listeners:
+              - name: kubelet
+            config_providers:
+              - name: kubelet
+                polling: true
+              - name: docker
+                polling: true
+"#},
+        vector_endpoint
+    );
 
     let vector = framework
         .vector(
@@ -76,39 +98,43 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
 
     let datadog_agent = framework
         .external_chart(
-            &namespace,
+            &datadog_namespace,
             "datadog",
             "https://helm.datadoghq.com",
-            // Vector is a generic config container
+            // VectorConfig is a generic config container
             VectorConfig {
-                custom_helm_values: DATADOG_AGENT_CHART_CONFIG,
+                custom_helm_values: &config_override_name(
+                    datadog_chart_values,
+                    &datadog_override_name,
+                ),
                 ..Default::default()
-            }
+            },
         )
         .await?;
-
     framework
         .wait_for_rollout(
-            &namespace,
-            &format!("daemonset/datadog-agent", ),
+            &datadog_namespace,
+            &format!("daemonset/{}", datadog_override_name),
             vec!["--timeout=60s"],
         )
         .await?;
 
-        let test_namespace = framework.namespace(&pod_namespace).await?;
-
+    let test_namespace = framework.namespace(&pod_namespace).await?;
     let test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
             &pod_namespace,
             "test-pod",
             "echo MARKER",
-            vec![("ad.datadoghq.com/test-pod.logs", "[{\"source\":\"test_source\",\"service\":\"test_service\"}]")],
             vec![],
+            // Annotation to enable log collection by the Datadog agent
+            vec![(
+                "ad.datadoghq.com/test-pod.logs",
+                "[{\"source\":\"test_source\",\"service\":\"test_service\"}]",
+            )],
         ))?)
         .await?;
 
-    let mut log_reader =
-        framework.logs(&namespace, &format!("statefulset/{}", "vector-aggregator"))?;
+    let mut log_reader = framework.logs(&namespace, &format!("statefulset/{}", override_name))?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -122,6 +148,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
 
         // Ensure we got the marker.
         assert_eq!(val["message"], "MARKER");
+        assert_eq!(val["source_type"], "datadog_logs");
 
         if got_marker {
             // We've already seen one marker! This is not good, we only emitted

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -7,7 +7,7 @@ const HELM_CHART_VECTOR_AGGREGATOR: &str = "vector-aggregator";
 
 const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
     service:
-      type: "ClusterIP"
+      type: ClusterIP
       ports:
         - name: datadog
           port: 8080
@@ -15,16 +15,15 @@ const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
           targetPort: 8080
     sources:
       datadog-agent:
-        type: "datadog_logs"
-        rawConfig: |
-          address = "0.0.0.0:8080"
+        type: datadog_logs
+        address: 0.0.0.0:8080
 
     sinks:
       stdout:
-        type: "console"
+        type: console
         inputs: ["datadog-agent"]
-        target: "stdout"
-        encoding: "json"
+        target: stdout
+        encoding: json
 "#};
 
 /// This test validates that vector-aggregator can deploy with the default

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -74,7 +74,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
         vector_endpoint
     );
 
-    let vector = framework
+    let _vector = framework
         .vector(
             &namespace,
             HELM_CHART_VECTOR_AGGREGATOR,
@@ -95,7 +95,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let datadog_agent = framework
+    let _datadog_agent = framework
         .external_chart(
             &datadog_namespace,
             "datadog",
@@ -118,8 +118,8 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let test_namespace = framework.namespace(&pod_namespace).await?;
-    let test_pod = framework
+    let _test_namespace = framework.namespace(&pod_namespace).await?;
+    let _test_pod = framework
         .test_pod(test_pod::Config::from_pod(&make_test_pod(
             &pod_namespace,
             "test-pod",
@@ -165,9 +165,5 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(got_marker);
 
-    drop(test_pod);
-    drop(test_namespace);
-    drop(datadog_agent);
-    drop(vector);
     Ok(())
 }

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -1,0 +1,149 @@
+use indoc::indoc;
+use k8s_e2e_tests::*;
+use k8s_test_framework::{lock, test_pod, vector::Config as VectorConfig};
+
+
+const HELM_CHART_VECTOR_AGGREGATOR: &str = "vector-aggregator";
+
+const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
+    sources:
+      ddog-agg:
+        type: "datadog-agent"
+        rawConfig: |
+          address = "0.0.0.0:8080"
+
+    sinks:
+      stdout:
+        type: "console"
+        inputs: ["datadog-agent"]
+        target: "stdout"
+        encoding: "json"
+"#};
+
+// Value.yaml for datadog offical chart
+const DATADOG_AGENT_CHART_CONFIG: &str = indoc! {r#"
+    datadog:
+      apiKey: 0123456789ABCDEF0123456789ABCDEF
+      logs:
+        enabled: true
+    agents:
+      customAgentConfig:
+        kubelet_tls_verify: false
+        logs_config.use_http: true
+        logs_config.logs_no_ssl: true
+        logs_config.logs_dd_url: vector-aggregator:8080
+        listeners:
+          - name: kubelet
+        config_providers:
+          - name: kubelet
+            polling: true
+          - name: docker
+            polling: true
+"#};
+
+
+/// This test validates that vector-aggregator can deploy with the default
+/// settings and a dummy topology.
+#[tokio::test]
+async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let pod_namespace = get_namespace_appended("test-pod");
+    let override_name = get_override_name("vector-aggregator");
+
+    let vector = framework
+        .vector(
+            &namespace,
+            HELM_CHART_VECTOR_AGGREGATOR,
+            VectorConfig {
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_DDOG_AGG_TOPOLOGY,
+                    &override_name,
+                ),
+                ..Default::default()
+            },
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("statefulset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let datadog_agent = framework
+        .external_chart(
+            &namespace,
+            "datadog",
+            "https://helm.datadoghq.com",
+            // Vector is a generic config container
+            VectorConfig {
+                custom_helm_values: DATADOG_AGENT_CHART_CONFIG,
+                ..Default::default()
+            }
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/datadog-agent", ),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+        let test_namespace = framework.namespace(&pod_namespace).await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod(
+            &pod_namespace,
+            "test-pod",
+            "echo MARKER",
+            vec![("ad.datadoghq.com/test-pod.logs", "[{\"source\":\"test_source\",\"service\":\"test_service\"}]")],
+            vec![],
+        ))?)
+        .await?;
+
+    let mut log_reader =
+        framework.logs(&namespace, &format!("statefulset/{}", "vector-aggregator"))?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the rest of the log lines.
+    let mut got_marker = false;
+    look_for_log_line(&mut log_reader, |val| {
+        if let Some(service) = val.get("service") {
+            if service != json!("test_service") {
+                fewfew
+            }
+        }
+        else {
+            return FlowControlCommand::GoOn;
+        }
+
+        // Ensure we got the marker.
+        assert_eq!(val["message"], "MARKER");
+
+        if got_marker {
+            // We've already seen one marker! This is not good, we only emitted
+            // one.
+            panic!("Marker seen more than once");
+        }
+
+        // If we did, remember it.
+        got_marker = true;
+
+        // Request to stop the flow.
+        FlowControlCommand::Terminate
+    })
+    .await?;
+
+    assert!(got_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(datadog_agent);
+    drop(vector);
+    Ok(())
+}

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -1,6 +1,7 @@
 use indoc::indoc;
 use k8s_e2e_tests::*;
 use k8s_test_framework::{lock, test_pod, vector::Config as VectorConfig};
+use serde_json::Value;
 
 
 const HELM_CHART_VECTOR_AGGREGATOR: &str = "vector-aggregator";
@@ -113,12 +114,9 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
     // Read the rest of the log lines.
     let mut got_marker = false;
     look_for_log_line(&mut log_reader, |val| {
-        if let Some(service) = val.get("service") {
-            if service != json!("test_service") {
-                fewfew
-            }
-        }
-        else {
+        if val["service"] != Value::Null && val["service"] != "test_service" {
+            panic!("Unexpected logs");
+        } else if val["service"] == Value::Null {
             return FlowControlCommand::GoOn;
         }
 

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -43,13 +43,13 @@ impl Framework {
         helm_repo: &str,
         config: vector::Config<'_>,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
-        let env = vec![("HELM_REPO".to_owned(), helm_repo.to_owned())];
+        let env = vec![("CHART_REPO".to_owned(), helm_repo.to_owned())];
         let mut manager = vector::manager_with_env(
             self.interface.deploy_generic_chart_command.as_str(),
             namespace,
             helm_chart,
             config,
-            Some(env)
+            Some(env),
         )?;
         manager.up().await?;
         Ok(manager)

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -30,6 +30,7 @@ impl Framework {
             namespace,
             helm_chart,
             config,
+            None,
         )?;
         manager.up().await?;
         Ok(manager)
@@ -44,7 +45,7 @@ impl Framework {
         config: vector::Config<'_>,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
         let env = vec![("CHART_REPO".to_owned(), helm_repo.to_owned())];
-        let mut manager = vector::manager_with_env(
+        let mut manager = vector::manager(
             self.interface.deploy_generic_chart_command.as_str(),
             namespace,
             helm_chart,

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -35,6 +35,26 @@ impl Framework {
         Ok(manager)
     }
 
+    /// Deploy an external chart into a cluster.
+    pub async fn external_chart(
+        &self,
+        namespace: &str,
+        helm_chart: &str,
+        helm_repo: &str,
+        config: vector::Config<'_>,
+    ) -> Result<up_down::Manager<vector::CommandBuilder>> {
+        let env = vec![("HELM_REPO".to_owned(), helm_repo.to_owned())];
+        let mut manager = vector::manager_with_env(
+            self.interface.deploy_generic_chart_command.as_str(),
+            namespace,
+            helm_chart,
+            config,
+            Some(env)
+        )?;
+        manager.up().await?;
+        Ok(manager)
+    }
+
     /// Create a new namespace.
     pub async fn namespace(
         &self,

--- a/lib/k8s-test-framework/src/interface.rs
+++ b/lib/k8s-test-framework/src/interface.rs
@@ -10,6 +10,10 @@ pub struct Interface {
     /// delete if from there.
     pub deploy_vector_command: String,
 
+    /// A command used to deploy a generic chart into the kubernetes cluster and
+    /// delete if from there.
+    pub deploy_generic_chart_command: String,
+
     /// A `kubectl` command used for generic cluster interaction.
     pub kubectl_command: String,
 }
@@ -20,6 +24,7 @@ impl Interface {
     pub fn from_env() -> Option<Self> {
         Some(Self {
             deploy_vector_command: env::var("KUBE_TEST_DEPLOY_COMMAND").ok()?,
+            deploy_generic_chart_command: env::var("KUBE_TEST_DEPLOY_GENERIC_COMMAND").ok()?,
             kubectl_command: env::var("VECTOR_TEST_KUBECTL")
                 .unwrap_or_else(|_| "kubectl".to_owned()),
         })

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -58,20 +58,8 @@ pub struct Config<'a> {
 
 /// Takes care of deploying Vector into the Kubernetes cluster.
 ///
-/// Manages the config file secret accordingly.
-pub fn manager(
-    interface_command: &str,
-    namespace: &str,
-    helm_chart: &str,
-    config: Config<'_>,
-) -> Result<up_down::Manager<CommandBuilder>> {
-    manager_with_env(interface_command, namespace, helm_chart, config, None)
-}
-
-/// Takes care of deploying Vector into the Kubernetes cluster.
-///
 /// Manages the config file secret accordingly, accept additional env var
-pub fn manager_with_env(
+pub fn manager(
     interface_command: &str,
     namespace: &str,
     helm_chart: &str,

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -3,7 +3,7 @@
 use crate::{helm_values_file::HelmValuesFile, resource_file::ResourceFile, up_down, Result};
 use std::process::{Command, Stdio};
 
-/// Parameters required to build a `kubectl` command to manage Vector in the
+/// Parameters required to build `kubectl` & `helm` commands to manage charts deployments in the
 /// Kubernetes cluster.
 #[derive(Debug)]
 pub struct CommandBuilder {
@@ -65,15 +65,8 @@ pub fn manager(
     helm_chart: &str,
     config: Config<'_>,
 ) -> Result<up_down::Manager<CommandBuilder>> {
-    manager_with_env(
-        interface_command,
-        namespace,
-        helm_chart,
-        config,
-        None,
-    )
+    manager_with_env(interface_command, namespace, helm_chart, config, None)
 }
-
 
 /// Takes care of deploying Vector into the Kubernetes cluster.
 ///

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -35,8 +35,7 @@ impl up_down::CommandBuilder for CommandBuilder {
             command.env("CUSTOM_RESOURCE_CONFIGS_FILE", custom_resource_file.path());
         }
         if let Some(env) = &self.custom_env {
-            let iter = env.iter();
-            for envvar in iter {
+            for envvar in env {
                 command.env(envvar.0.clone(), envvar.1.clone());
             }
         }

--- a/scripts/deploy-public-chart-test.sh
+++ b/scripts/deploy-public-chart-test.sh
@@ -30,10 +30,8 @@ COMMAND="${1:?"Specify the command (up/down) as the first argument"}"
 # A Kubernetes namespace to deploy to.
 NAMESPACE="${2:?"Specify the namespace as the second argument"}"
 
-if [[ "$COMMAND" == "up" ]]; then
-  # The helm chart to deploy.
-  HELM_CHART="${3:?"Specify the helm chart name as the third argument"}"
-fi
+# The helm chart to manage
+HELM_CHART="${3:?"Specify the helm chart name as the third argument"}"
 
 # Allow overriding kubectl with something like `minikube kubectl --`.
 VECTOR_TEST_KUBECTL="${VECTOR_TEST_KUBECTL:-"kubectl"}"
@@ -50,11 +48,8 @@ CUSTOM_HELM_VALUES_FILE="${CUSTOM_HELM_VALUES_FILE:-""}"
 # Allow overriding the local repo name, useful to use multiple external repo
 CUSTOM_HELM_REPO_LOCAL_NAME="${CUSTOM_HELM_REPO_LOCAL_NAME:-"local_repo"}"
 
-# Allow overriding the deployment name, the default value is the chart name
-CUSTOM_HELM_DEPLOYMENT_NAME="${HELM_CHART}"
-
 up() {
-  $VECTOR_TEST_HELM repo add $CUSTOM_HELM_REPO_LOCAL_NAME $CHART_REPO
+  $VECTOR_TEST_HELM repo add "$CUSTOM_HELM_REPO_LOCAL_NAME" "$CHART_REPO" || true
   $VECTOR_TEST_HELM repo update
 
   $VECTOR_TEST_KUBECTL create namespace "$NAMESPACE"
@@ -64,17 +59,17 @@ up() {
   fi
 
 
-  HELM_VALUES=""
+  HELM_VALUES=()
   if [[ -n "$CUSTOM_HELM_VALUES_FILE" ]]; then
-    HELM_VALUES="--values $CUSTOM_HELM_VALUES_FILE"
+    HELM_VALUES=(--values "$CUSTOM_HELM_VALUES_FILE")
   fi
 
   set -x
   $VECTOR_TEST_HELM install \
     --atomic \
     --namespace "$NAMESPACE" \
-    $HELM_VALUES \
-    "$CUSTOM_HELM_DEPLOYMENT_NAME" \
+    "${HELM_VALUES[@]}" \
+    "$HELM_CHART" \
     "$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART"
   { set +x; } &>/dev/null
 }
@@ -84,8 +79,8 @@ down() {
     $VECTOR_TEST_KUBECTL delete --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
   fi
 
-  if $VECTOR_TEST_HELM status --namespace "$NAMESPACE" "$CUSTOM_HELM_DEPLOYMENT_NAME" &>/dev/null; then
-    $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "$CUSTOM_HELM_DEPLOYMENT_NAME"
+  if $VECTOR_TEST_HELM status --namespace "$NAMESPACE" "$HELM_CHART" &>/dev/null; then
+    $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "$HELM_CHART"
   fi
 
   $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"

--- a/scripts/deploy-public-chart-test.sh
+++ b/scripts/deploy-public-chart-test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# deploy-public-chart-test.sh
+#
+# SUMMARY
+#
+#   Deploys a public chart into Kubernetes for testing purposes.
+#   Uses the same installation method our users would use.
+#
+#   This script implements cli interface required by the kubernetes E2E
+#   tests.
+#
+# USAGE
+#
+#   Deploy:
+#
+#   $ CHART_REPO=https://helm.testmaterial.tld scripts/deploy-public-chart-test.sh up test-namespace-qwerty chart
+#
+#   Teardown:
+#
+#   $ scripts/deploy-public-chart-test.sh down test-namespace-qwerty chart
+#
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Command to perform.
+COMMAND="${1:?"Specify the command (up/down) as the first argument"}"
+
+# A Kubernetes namespace to deploy to.
+NAMESPACE="${2:?"Specify the namespace as the second argument"}"
+
+if [[ "$COMMAND" == "up" ]]; then
+  # The helm chart to deploy.
+  HELM_CHART="${3:?"Specify the helm chart name as the third argument"}"
+fi
+
+# Allow overriding kubectl with something like `minikube kubectl --`.
+VECTOR_TEST_KUBECTL="${VECTOR_TEST_KUBECTL:-"kubectl"}"
+
+# Allow overriding helm with a custom command.
+VECTOR_TEST_HELM="${VECTOR_TEST_HELM:-"helm"}"
+
+# Allow optionally installing custom resource configs.
+CUSTOM_RESOURCE_CONFIGS_FILE="${CUSTOM_RESOURCE_CONFIGS_FILE:-""}"
+
+# Allow optionally passing custom Helm values.
+CUSTOM_HELM_VALUES_FILE="${CUSTOM_HELM_VALUES_FILE:-""}"
+
+# Allow overriding the local repo name, useful to use multiple external repo
+CUSTOM_HELM_REPO_LOCAL_NAME="${CUSTOM_HELM_REPO_LOCAL_NAME:-"local_repo"}"
+
+# Allow overriding the deployment name, the default value is the chart name
+CUSTOM_HELM_DEPLOYMENT_NAME="${HELM_CHART}"
+
+up() {
+  $VECTOR_TEST_HELM repo add $CUSTOM_HELM_REPO_LOCAL_NAME $CHART_REPO
+  $VECTOR_TEST_HELM repo update
+
+  $VECTOR_TEST_KUBECTL create namespace "$NAMESPACE"
+
+  if [[ -n "$CUSTOM_RESOURCE_CONFIGS_FILE" ]]; then
+    $VECTOR_TEST_KUBECTL create --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
+  fi
+
+
+  HELM_VALUES=""
+  if [[ -n "$CUSTOM_HELM_VALUES_FILE" ]]; then
+    HELM_VALUES="--values $CUSTOM_HELM_VALUES_FILE"
+  fi
+
+  set -x
+  $VECTOR_TEST_HELM install \
+    --atomic \
+    --namespace "$NAMESPACE" \
+    $HELM_VALUES \
+    "$CUSTOM_HELM_DEPLOYMENT_NAME" \
+    "$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART"
+  { set +x; } &>/dev/null
+}
+
+down() {
+  if [[ -n "$CUSTOM_RESOURCE_CONFIGS_FILE" ]]; then
+    $VECTOR_TEST_KUBECTL delete --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
+  fi
+
+  if $VECTOR_TEST_HELM status --namespace "$NAMESPACE" "$CUSTOM_HELM_DEPLOYMENT_NAME" &>/dev/null; then
+    $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "$CUSTOM_HELM_DEPLOYMENT_NAME"
+  fi
+
+  $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"
+}
+
+case "$COMMAND" in
+  up|down)
+    "$COMMAND" "$@"
+    ;;
+  *)
+    echo "Invalid command: $COMMAND" >&2
+    exit 1
+esac

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -125,9 +125,11 @@ fi
 # Export the container image to be accessible from the deployment command.
 export CONTAINER_IMAGE
 
-# Set the deployment command for integration tests.
+# Set the deployment commands for integration tests.
 KUBE_TEST_DEPLOY_COMMAND="$(pwd)/scripts/deploy-kubernetes-test.sh"
 export KUBE_TEST_DEPLOY_COMMAND
+KUBE_TEST_DEPLOY_GENERIC_COMMAND="$(pwd)/scripts/deploy-public-chart-test.sh"
+export KUBE_TEST_DEPLOY_GENERIC_COMMAND
 
 # Prepare args.
 CARGO_TEST_ARGS_CARGO=()


### PR DESCRIPTION
Quick summary:
* Add the ability to spawn a generic chart into the k8s e2e tests framework
* Spawn a datadog agent, a vector aggregator and a dummy pod, the datadog agent read container log, ship those to vector where delivery is asserted in a simple test

Side note:
./lib/k8s-test-framework/src/vector.rs may be rename `chart.rs` as it now manage charts on a general basis on not only vector.