### PR TITLE
chore(helm platform): Add deprecation notice for rawConfig

### DIFF
--- a/distribution/helm/vector-agent/templates/NOTES.txt
+++ b/distribution/helm/vector-agent/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{ .Chart.Name }} has been installed. Check it's status by running:
+  $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+
+Visit https://vector.dev/ for documentation and guides.

--- a/distribution/helm/vector-agent/templates/NOTES.txt
+++ b/distribution/helm/vector-agent/templates/NOTES.txt
@@ -2,5 +2,6 @@
   $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
 
 WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+See https://vector.dev/highlights/2021-06-01-removing-helm-rawconfig for more information.
 
 Visit https://vector.dev/ for documentation and guides.

--- a/distribution/helm/vector-aggregator/templates/NOTES.txt
+++ b/distribution/helm/vector-aggregator/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{ .Chart.Name }} has been installed. Check it's status by running:
+  $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+
+Visit https://vector.dev/ for documentation and guides.

--- a/distribution/helm/vector-aggregator/templates/NOTES.txt
+++ b/distribution/helm/vector-aggregator/templates/NOTES.txt
@@ -2,5 +2,6 @@
   $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
 
 WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+See https://vector.dev/highlights/2021-06-01-removing-helm-rawconfig for more information.
 
 Visit https://vector.dev/ for documentation and guides.

--- a/distribution/helm/vector/templates/NOTES.txt
+++ b/distribution/helm/vector/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{ .Chart.Name }} has been installed. Check it's status by running:
+  $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+
+Visit https://vector.dev/ for documentation and guides.

--- a/distribution/helm/vector/templates/NOTES.txt
+++ b/distribution/helm/vector/templates/NOTES.txt
@@ -2,5 +2,6 @@
   $ kubectl --namespace {{ .Release.Namespace}} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
 
 WARNING: The `rawConfig` key has been deprecated and will be removed in an upcoming release.
+See https://vector.dev/highlights/2021-06-01-removing-helm-rawconfig for more information.
 
 Visit https://vector.dev/ for documentation and guides.

--- a/docs/highlights/2021-06-01-removing-helm-rawconfig.md
+++ b/docs/highlights/2021-06-01-removing-helm-rawconfig.md
@@ -16,6 +16,8 @@ using configuration provided in the `values.yaml` without converting them for th
 
 ## Upgrade Guide
 
+The values that were in `rawConfig` in TOML format now need to be moved up a level and written as YAML.
+
 Below is an example of how to transition your `values.yaml` file:
 
 ```diff title="values.yaml"

--- a/docs/highlights/2021-06-01-removing-helm-rawconfig.md
+++ b/docs/highlights/2021-06-01-removing-helm-rawconfig.md
@@ -17,6 +17,7 @@ using configuration provided in the `values.yaml` without converting them for th
 ## Upgrade Guide
 
 The values that were in `rawConfig` in TOML format now need to be moved up a level and written as YAML.
+Please refer to the `vector.yaml` on each component's documentation page for specific configuration examples.
 
 Below is an example of how to transition your `values.yaml` file:
 

--- a/docs/highlights/2021-06-01-removing-helm-rawconfig.md
+++ b/docs/highlights/2021-06-01-removing-helm-rawconfig.md
@@ -1,0 +1,42 @@
+---
+last_modified_on: "2021-06-01"
+$schema: ".schema.json"
+title: "Deprecating Helm `rawConfig` option"
+description: "The `rawConfig` option in the Vector Helm charts will be fully deprecated in an upcoming release"
+author_github: "https://github.com/spencergilbert"
+pr_numbers: []
+release: "0.14.0"
+hide_on_release_notes: false
+tags: ["type: announcement", "platform: kubernetes", "domain: config"]
+---
+
+With the release of Vector 0.14.0, we are announcing the planned deprecation of the `rawConfig` option
+in our Helm charts. This will remove a source of complexity in our chart logic, and is a step towards
+using configuration provided in the `values.yaml` without converting them for the `managed.toml` config file.
+
+## Upgrade Guide
+
+Below is an example of how to transition your `values.yaml` file:
+
+```diff title="values.yaml"
+   sources:
+     dummy:
+       type: "generator"
+-      rawConfig: |
+-        format = "shuffle"
+-        lines = ["Hello world"]
+-        interval = 60 # once a minute
++      format: "shuffle"
++      lines: ["Hello world"]
++      interval: 60 # once a minute
+
+   sinks:
+     stdout:
+       type: "console"
+       inputs: ["dummy"]
+-      rawConfig: |
+-        target = "stdout"
+-        encoding = "json"
++      target: "stdout"
++      encoding: "json"
+```


### PR DESCRIPTION
As far as I can tell, the only notice of deprecation before was the comments in `values.yaml`.

This will provide a more official notice and let us remove `rawConfig` with the 0.15 release.

Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
