### PR TITLE
chore(external docs): Document `disk` buffer behavior

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -93,7 +93,7 @@ components: sinks: [Name=string]: {
 								default: "memory"
 								enum: {
 									memory: "Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully."
-									disk:   """
+									disk: """
 									Stores the sink's buffer on disk. This is less performant, but durable.
 									Data will not be lost between restarts.
 									Will also hold data in memory to enhance performance.

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -93,7 +93,13 @@ components: sinks: [Name=string]: {
 								default: "memory"
 								enum: {
 									memory: "Stores the sink's buffer in memory. This is more performant, but less durable. Data will be lost if Vector is restarted forcefully."
-									disk:   "Stores the sink's buffer on disk. This is less performant, but durable. Data will not be lost between restarts."
+									disk:   """
+									Stores the sink's buffer on disk. This is less performant, but durable.
+									Data will not be lost between restarts.
+									Will also hold data in memory to enhance performance.
+									WARNING: This may stall the sink if disk performance isn't on par with the throughput.
+									For comparison, AWS gp2 volumes are usually too slow for common cases.
+									"""
 								}
 								syntax: "literal"
 							}


### PR DESCRIPTION
Ref.  #7425

Not sure if the warning is visible enough, maybe it should be moved.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
