### PR TITLE
chore(remap): define type def object and array inner type

### DIFF
--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -93,16 +93,30 @@ impl Expression for ParseJsonFn {
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
-        TypeDef::new()
-            .fallible()
-            .bytes()
-            .add_boolean()
-            .add_integer()
-            .add_float()
-            .add_null()
-            .add_array_mapped::<(), Kind>(map! { (): Kind::all() })
-            .add_object::<(), Kind>(map! { (): Kind::all() })
+        type_def()
     }
+}
+
+fn inner_kind() -> Kind {
+    Kind::Null
+        | Kind::Bytes
+        | Kind::Integer
+        | Kind::Float
+        | Kind::Boolean
+        | Kind::Array
+        | Kind::Object
+}
+
+fn type_def() -> TypeDef {
+    TypeDef::new()
+        .fallible()
+        .bytes()
+        .add_boolean()
+        .add_integer()
+        .add_float()
+        .add_null()
+        .add_array_mapped::<(), Kind>(map! { (): inner_kind() })
+        .add_object::<(), Kind>(map! { (): inner_kind() })
 }
 
 #[cfg(test)]
@@ -115,15 +129,13 @@ mod tests {
         parses {
             args: func_args![ value: r#"{"field": "value"}"# ],
             want: Ok(value!({ field: "value" })),
-            tdef: TypeDef::new()
-                .fallible()
-                .bytes()
-                .add_boolean()
-                .add_integer()
-                .add_float()
-                .add_null()
-                .add_array_mapped::<(), Kind>(map! { (): Kind::all() })
-                .add_object::<(), Kind>(map! { (): Kind::all() }),
+            tdef: type_def(),
+        }
+
+        complex_json {
+            args: func_args![ value: r#"{"object": {"string":"value","number":42,"array":["hello","world"],"boolean":false}}"# ],
+            want: Ok(value!({ object: {string: "value", number: 42, array: ["hello", "world"], boolean: false} })),
+            tdef: type_def(),
         }
 
         invalid_json_errors {
@@ -136,8 +148,8 @@ mod tests {
                 .add_integer()
                 .add_float()
                 .add_null()
-                .add_array_mapped::<(), Kind>(map! { (): Kind::all() })
-                .add_object::<(), Kind>(map! { (): Kind::all() }),
+                .add_array_mapped::<(), Kind>(map! { (): inner_kind() })
+                .add_object::<(), Kind>(map! { (): inner_kind() }),
         }
     ];
 }


### PR DESCRIPTION
Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

refactor typedef:
- avoid duplication
- limit the kind of object in Array and Object.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
