### PR TITLE
enhancement(kubernetes_logs source): Changed default for glob_minimum_cooldown_ms

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -220,13 +220,13 @@ components: sources: kubernetes_logs: {
 				unit:    "bytes"
 			}
 		}
-		glob_minimum_cooldown_ms {
-			common: 	false
+		glob_minimum_cooldown_ms: {
+			common:      false
 			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files within a single pod."
-			required: 	false
+			required:    false
 			type: uint: {
 				default: 1_000
-				unit: "milliseconds"
+				unit:    "milliseconds"
 			}
 		}
 		timezone: configuration._timezone

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -220,6 +220,15 @@ components: sources: kubernetes_logs: {
 				unit:    "bytes"
 			}
 		}
+		glob_minimum_cooldown_ms {
+			common: 	false
+			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files within a single pod."
+			required: 	false
+			type: uint: {
+				default: 1_000
+				unit: "milliseconds"
+			}
+		}
 		timezone: configuration._timezone
 	}
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -445,7 +445,7 @@ fn default_max_line_bytes() -> usize {
 }
 
 fn default_glob_minimum_cooldown_ms() -> usize {
-    60000
+    1000
 }
 
 /// This function construct the effective field selector to use, based on


### PR DESCRIPTION
Closes #6771 

This updates the glob_minimum_cooldown_ms default to be 1000 ms.  It also adds documentation for the field.

This field is only the time it scans for new files within a pod, presumably for logs being rotated. It doesn't affect the time we are scanning for new pods. I am currently wondering if this needs to be documented too..

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
