### PR TITLE
chore(metrics): Rework metrics batch buffer

### DIFF
--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -444,22 +444,24 @@ impl MetricData {
     }
 
     /// Update this `MetricData` by adding the value from another.
-    pub fn update(&mut self, other: &Self) {
-        self.value.add(&other.value);
-        // Update the timestamp to the latest one
-        self.timestamp = match (self.timestamp, other.timestamp) {
-            (None, None) => None,
-            (Some(t), None) | (None, Some(t)) => Some(t),
-            (Some(t1), Some(t2)) => Some(t1.max(t2)),
-        };
+    #[must_use]
+    pub fn update(&mut self, other: &Self) -> bool {
+        self.value.add(&other.value) && {
+            // Update the timestamp to the latest one
+            self.timestamp = match (self.timestamp, other.timestamp) {
+                (None, None) => None,
+                (Some(t), None) | (None, Some(t)) => Some(t),
+                (Some(t1), Some(t2)) => Some(t1.max(t2)),
+            };
+            true
+        }
     }
 
     /// Add the data from the other metric to this one. The `other` must
-    /// be relative and contain the same value type as this one.
-    pub fn add(&mut self, other: &Self) {
-        if other.kind == MetricKind::Incremental {
-            self.update(other);
-        }
+    /// be incremental and contain the same value type as this one.
+    #[must_use]
+    pub fn add(&mut self, other: &Self) -> bool {
+        other.kind == MetricKind::Incremental && self.update(other)
     }
 
     /// Create a new metric data from this with a zero value.
@@ -514,14 +516,17 @@ impl MetricValue {
     }
 
     /// Add another same value to this.
-    pub fn add(&mut self, other: &Self) {
+    #[must_use]
+    pub fn add(&mut self, other: &Self) -> bool {
         match (self, other) {
             (Self::Counter { ref mut value }, Self::Counter { value: value2 })
             | (Self::Gauge { ref mut value }, Self::Gauge { value: value2 }) => {
                 *value += value2;
+                true
             }
             (Self::Set { ref mut values }, Self::Set { values: values2 }) => {
                 values.extend(values2.iter().map(Into::into));
+                true
             }
             (
                 Self::Distribution {
@@ -534,6 +539,7 @@ impl MetricValue {
                 },
             ) if statistic_a == statistic_b => {
                 samples.extend_from_slice(&samples2);
+                true
             }
             (
                 Self::AggregatedHistogram {
@@ -546,20 +552,20 @@ impl MetricValue {
                     count: count2,
                     sum: sum2,
                 },
-            ) => {
-                if buckets.len() == buckets2.len()
-                    && buckets
-                        .iter()
-                        .zip(buckets2.iter())
-                        .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
-                {
-                    for (b1, b2) in buckets.iter_mut().zip(buckets2) {
-                        b1.count += b2.count;
-                    }
-                    *count += count2;
-                    *sum += sum2;
+            ) if buckets.len() == buckets2.len()
+                && buckets
+                    .iter()
+                    .zip(buckets2.iter())
+                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
+            {
+                for (b1, b2) in buckets.iter_mut().zip(buckets2) {
+                    b1.count += b2.count;
                 }
+                *count += count2;
+                *sum += sum2;
+                true
             }
+
             (
                 Self::AggregatedSummary {
                     ref mut quantiles,
@@ -571,35 +577,38 @@ impl MetricValue {
                     count: count2,
                     sum: sum2,
                 },
-            ) => {
-                if quantiles.len() == quantiles2.len()
-                    && quantiles
-                        .iter()
-                        .zip(quantiles2.iter())
-                        .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
-                {
-                    for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
-                        b1.value += b2.value;
-                    }
-                    *count += count2;
-                    *sum += sum2;
+            ) if quantiles.len() == quantiles2.len()
+                && quantiles
+                    .iter()
+                    .zip(quantiles2.iter())
+                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
+            {
+                for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
+                    b1.value += b2.value;
                 }
+                *count += count2;
+                *sum += sum2;
+                true
             }
-            _ => {}
+
+            _ => false,
         }
     }
 
     /// Subtract another (same type) value from this.
-    pub fn subtract(&mut self, other: &Self) {
+    #[must_use]
+    pub fn subtract(&mut self, other: &Self) -> bool {
         match (self, other) {
             (Self::Counter { ref mut value }, Self::Counter { value: value2 })
             | (Self::Gauge { ref mut value }, Self::Gauge { value: value2 }) => {
                 *value -= value2;
+                true
             }
             (Self::Set { ref mut values }, Self::Set { values: values2 }) => {
                 for item in values2 {
                     values.remove(item);
                 }
+                true
             }
             (
                 Self::Distribution {
@@ -619,6 +628,7 @@ impl MetricValue {
                     .copied()
                     .filter(|sample| samples2.iter().all(|sample2| sample != sample2))
                     .collect();
+                true
             }
             (
                 Self::AggregatedHistogram {
@@ -631,19 +641,18 @@ impl MetricValue {
                     count: count2,
                     sum: sum2,
                 },
-            ) => {
-                if buckets.len() == buckets2.len()
-                    && buckets
-                        .iter()
-                        .zip(buckets2.iter())
-                        .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
-                {
-                    for (b1, b2) in buckets.iter_mut().zip(buckets2) {
-                        b1.count -= b2.count;
-                    }
-                    *count -= count2;
-                    *sum -= sum2;
+            ) if buckets.len() == buckets2.len()
+                && buckets
+                    .iter()
+                    .zip(buckets2.iter())
+                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
+            {
+                for (b1, b2) in buckets.iter_mut().zip(buckets2) {
+                    b1.count -= b2.count;
                 }
+                *count -= count2;
+                *sum -= sum2;
+                true
             }
             (
                 Self::AggregatedSummary {
@@ -656,21 +665,20 @@ impl MetricValue {
                     count: count2,
                     sum: sum2,
                 },
-            ) => {
-                if quantiles.len() == quantiles2.len()
-                    && quantiles
-                        .iter()
-                        .zip(quantiles2.iter())
-                        .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
-                {
-                    for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
-                        b1.value -= b2.value;
-                    }
-                    *count -= count2;
-                    *sum -= sum2;
+            ) if quantiles.len() == quantiles2.len()
+                && quantiles
+                    .iter()
+                    .zip(quantiles2.iter())
+                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
+            {
+                for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
+                    b1.value -= b2.value;
                 }
+                *count -= count2;
+                *sum -= sum2;
+                true
             }
-            _ => {}
+            _ => false,
         }
     }
 }
@@ -841,7 +849,7 @@ mod test {
             .with_value(MetricValue::Counter { value: 3.0 })
             .with_timestamp(Some(ts()));
 
-        counter.data.add(&delta.data);
+        assert!(counter.data.add(&delta.data));
         assert_eq!(counter, expected);
     }
 
@@ -867,7 +875,7 @@ mod test {
             .with_value(MetricValue::Gauge { value: -1.0 })
             .with_timestamp(Some(ts()));
 
-        gauge.data.add(&delta.data);
+        assert!(gauge.data.add(&delta.data));
         assert_eq!(gauge, expected);
     }
 
@@ -899,7 +907,7 @@ mod test {
             })
             .with_timestamp(Some(ts()));
 
-        set.data.add(&delta.data);
+        assert!(set.data.add(&delta.data));
         assert_eq!(set, expected);
     }
 
@@ -934,7 +942,7 @@ mod test {
             })
             .with_timestamp(Some(ts()));
 
-        dist.data.add(&delta.data);
+        assert!(dist.data.add(&delta.data));
         assert_eq!(dist, expected);
     }
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -1,11 +1,11 @@
 use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, Resource, SinkConfig, SinkContext, SinkDescription},
-    event::metric::{MetricKind, MetricValue},
+    event::metric::{Metric, MetricKind, MetricValue},
     event::Event,
     internal_events::PrometheusServerRequestComplete,
     sinks::{
-        util::{statistic::validate_quantiles, MetricEntry, StreamSink},
+        util::{statistic::validate_quantiles, StreamSink},
         Healthcheck, VectorSink,
     },
     tls::{MaybeTlsSettings, TlsConfig},
@@ -23,7 +23,10 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::{
     convert::Infallible,
+    hash::{Hash, Hasher},
+    mem::discriminant,
     net::SocketAddr,
+    ops::{Deref, DerefMut},
     sync::{Arc, RwLock},
 };
 use stream_cancel::{Trigger, Tripwire};
@@ -330,6 +333,90 @@ impl StreamSink for PrometheusExporter {
             self.acker.ack(1);
         }
         Ok(())
+    }
+}
+
+struct MetricEntry(Metric);
+
+impl Deref for MetricEntry {
+    type Target = Metric;
+    fn deref(&self) -> &Metric {
+        &self.0
+    }
+}
+
+impl DerefMut for MetricEntry {
+    fn deref_mut(&mut self) -> &mut Metric {
+        &mut self.0
+    }
+}
+
+impl Eq for MetricEntry {}
+
+impl Hash for MetricEntry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let metric = &self.0;
+        metric.series.hash(state);
+        metric.data.kind.hash(state);
+        discriminant(&metric.data.value).hash(state);
+
+        match &metric.data.value {
+            MetricValue::AggregatedHistogram { buckets, .. } => {
+                for bucket in buckets {
+                    bucket.upper_limit.to_bits().hash(state);
+                }
+            }
+            MetricValue::AggregatedSummary { quantiles, .. } => {
+                for quantile in quantiles {
+                    quantile.upper_limit.to_bits().hash(state);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl PartialEq for MetricEntry {
+    fn eq(&self, other: &Self) -> bool {
+        // This differs from a straightforward implementation of `eq` by
+        // comparing only the "shape" bits (name, tags, and type) while
+        // allowing the contained values to be different.
+        self.series == other.series
+            && self.data.kind == other.data.kind
+            && discriminant(&self.data.value) == discriminant(&other.data.value)
+            && match (&self.data.value, &other.data.value) {
+                (
+                    MetricValue::AggregatedHistogram {
+                        buckets: buckets1, ..
+                    },
+                    MetricValue::AggregatedHistogram {
+                        buckets: buckets2, ..
+                    },
+                ) => {
+                    buckets1.len() == buckets2.len()
+                        && buckets1
+                            .iter()
+                            .zip(buckets2.iter())
+                            .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
+                }
+                (
+                    MetricValue::AggregatedSummary {
+                        quantiles: quantiles1,
+                        ..
+                    },
+                    MetricValue::AggregatedSummary {
+                        quantiles: quantiles2,
+                        ..
+                    },
+                ) => {
+                    quantiles1.len() == quantiles2.len()
+                        && quantiles1
+                            .iter()
+                            .zip(quantiles2.iter())
+                            .all(|(q1, q2)| q1.upper_limit == q2.upper_limit)
+                }
+                _ => true,
+            }
     }
 }
 

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -1,103 +1,11 @@
-use crate::{
-    event::{
-        metric::{Metric, MetricKind, MetricValue, Sample},
-        Event,
-    },
-    sinks::util::batch::{Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult},
+use crate::sinks::util::batch::{
+    Batch, BatchConfig, BatchError, BatchSettings, BatchSize, PushResult,
 };
-use std::{
-    cmp::Ordering,
-    collections::HashSet,
-    hash::{Hash, Hasher},
-    marker::PhantomData,
-    mem::discriminant,
-    ops::{Deref, DerefMut},
+use std::{cmp::Ordering, collections::HashMap, marker::PhantomData};
+use vector_core::event::{
+    metric::{Metric, MetricData, MetricKind, MetricSeries, MetricValue, Sample},
+    Event, EventMetadata,
 };
-
-#[derive(Clone, Debug)]
-pub struct MetricEntry(pub Metric);
-
-impl Eq for MetricEntry {}
-
-impl Hash for MetricEntry {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let metric = &self.0;
-        metric.series.hash(state);
-        metric.data.kind.hash(state);
-        discriminant(&metric.data.value).hash(state);
-
-        match &metric.data.value {
-            MetricValue::AggregatedHistogram { buckets, .. } => {
-                for bucket in buckets {
-                    bucket.upper_limit.to_bits().hash(state);
-                }
-            }
-            MetricValue::AggregatedSummary { quantiles, .. } => {
-                for quantile in quantiles {
-                    quantile.upper_limit.to_bits().hash(state);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-impl PartialEq for MetricEntry {
-    fn eq(&self, other: &Self) -> bool {
-        // This differs from a straightforward implementation of `eq` by
-        // comparing only the "shape" bits (name, tags, and type) while
-        // allowing the contained values to be different.
-        self.series == other.series
-            && self.data.kind == other.data.kind
-            && discriminant(&self.data.value) == discriminant(&other.data.value)
-            && match (&self.data.value, &other.data.value) {
-                (
-                    MetricValue::AggregatedHistogram {
-                        buckets: buckets1, ..
-                    },
-                    MetricValue::AggregatedHistogram {
-                        buckets: buckets2, ..
-                    },
-                ) => {
-                    buckets1.len() == buckets2.len()
-                        && buckets1
-                            .iter()
-                            .zip(buckets2.iter())
-                            .all(|(b1, b2)| b1.upper_limit == b2.upper_limit)
-                }
-                (
-                    MetricValue::AggregatedSummary {
-                        quantiles: quantiles1,
-                        ..
-                    },
-                    MetricValue::AggregatedSummary {
-                        quantiles: quantiles2,
-                        ..
-                    },
-                ) => {
-                    quantiles1.len() == quantiles2.len()
-                        && quantiles1
-                            .iter()
-                            .zip(quantiles2.iter())
-                            .all(|(q1, q2)| q1.upper_limit == q2.upper_limit)
-                }
-                _ => true,
-            }
-    }
-}
-
-impl Deref for MetricEntry {
-    type Target = Metric;
-    fn deref(&self) -> &Metric {
-        &self.0
-    }
-}
-
-impl DerefMut for MetricEntry {
-    fn deref_mut(&mut self) -> &mut Metric {
-        &mut self.0
-    }
-}
 
 /// The metrics buffer is a data structure for collecting a flow of data
 /// points into a batch.
@@ -147,24 +55,9 @@ impl Batch for MetricsBuffer {
             PushResult::Overflow(item)
         } else {
             let max_events = self.max_events;
-            let metrics = self
-                .metrics
-                .get_or_insert_with(|| MetricSet::with_capacity(max_events));
-            let new_entry = match item.data.kind {
-                MetricKind::Absolute => MetricEntry(item),
-                MetricKind::Incremental => {
-                    // Incremental metrics update existing entries, if present
-                    let entry = MetricEntry(item);
-                    metrics
-                        .take(&entry)
-                        .map(|mut existing| {
-                            existing.data.update(&entry.data);
-                            existing
-                        })
-                        .unwrap_or(entry)
-                }
-            };
-            metrics.replace(new_entry);
+            self.metrics
+                .get_or_insert_with(|| MetricSet::with_capacity(max_events))
+                .insert_update(item);
             PushResult::Ok(self.num_items() >= self.max_events)
         }
     }
@@ -239,27 +132,16 @@ pub trait MetricNormalize {
     fn apply_state(state: &mut MetricSet, metric: Metric) -> Option<Metric>;
 }
 
-/// This is a convenience newtype wrapper for HashSet<MetricEntry> that
-/// provides some extra functionality.
+type MetricEntry = (MetricData, EventMetadata);
+
+/// This is a convenience wrapper for HashMap<MetricSeries, MetricData>
+/// that provides some extra functionality.
 #[derive(Clone, Default)]
-pub struct MetricSet(HashSet<MetricEntry>);
-
-impl Deref for MetricSet {
-    type Target = HashSet<MetricEntry>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for MetricSet {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+pub struct MetricSet(HashMap<MetricSeries, MetricEntry>);
 
 impl MetricSet {
     fn with_capacity(capacity: usize) -> Self {
-        Self(HashSet::with_capacity(capacity))
+        Self(HashMap::with_capacity(capacity))
     }
 
     /// Either pass the metric through as-is if absolute, or convert it
@@ -283,47 +165,71 @@ impl MetricSet {
     /// Convert the incremental metric into an absolute one, using the
     /// state buffer to keep track of the value throughout the entire
     /// application uptime.
-    fn incremental_to_absolute(&mut self, metric: Metric) -> Metric {
-        let mut entry = MetricEntry(metric.into_absolute());
-        let mut existing = self.0.take(&entry).unwrap_or_else(|| {
-            // Start from zero value if the entry is not found.
-            MetricEntry(entry.zero())
-        });
-        existing.data.value.add(&entry.data.value);
-        entry.data.value = existing.data.value.clone();
-        self.0.insert(existing);
-        entry.0
+    fn incremental_to_absolute(&mut self, mut metric: Metric) -> Metric {
+        match self.0.get_mut(&metric.series) {
+            Some(existing) => {
+                existing.0.value.add(&metric.data.value);
+                metric.data.value = existing.0.value.clone();
+            }
+            None => {
+                self.0.insert(
+                    metric.series.clone(),
+                    (metric.data.clone(), EventMetadata::default()),
+                );
+            }
+        }
+        metric.into_absolute()
     }
 
     /// Convert the absolute metric into an incremental by calculating
     /// the increment from the last saved absolute state.
-    fn absolute_to_incremental(&mut self, metric: Metric) -> Option<Metric> {
-        let mut entry = MetricEntry(metric);
-        match self.0.take(&entry) {
-            Some(mut reference) => {
-                let new_value = entry.data.value.clone();
+    fn absolute_to_incremental(&mut self, mut metric: Metric) -> Option<Metric> {
+        match self.0.get_mut(&metric.series) {
+            Some(reference) => {
+                let new_value = metric.data.value.clone();
                 // From the stored reference value, emit an increment
-                entry.data.value.subtract(&reference.data.value);
-                reference.data.value = new_value;
-                self.0.insert(reference);
-                Some(entry.0.into_incremental())
+                metric.data.value.subtract(&reference.0.value);
+                reference.0.value = new_value;
+                Some(metric.into_incremental())
             }
             None => {
                 // No reference so store this and emit nothing
-                self.0.insert(entry);
+                self.insert(metric);
                 None
+            }
+        }
+    }
+
+    fn insert(&mut self, metric: Metric) {
+        let (series, data, metadata) = metric.into_parts();
+        self.0.insert(series, (data, metadata));
+    }
+
+    fn insert_update(&mut self, metric: Metric) {
+        match metric.data.kind {
+            MetricKind::Absolute => self.insert(metric),
+            MetricKind::Incremental => {
+                // Incremental metrics update existing entries, if present
+                match self.0.get_mut(&metric.series) {
+                    Some(existing) => {
+                        let (_series, data, metadata) = metric.into_parts();
+                        existing.0.update(&data);
+                        existing.1.merge(metadata);
+                    }
+                    None => self.insert(metric),
+                }
             }
         }
     }
 }
 
-fn finish_metric(metric: MetricEntry) -> Metric {
-    let mut metric = metric.0;
-    if let MetricValue::Distribution { samples, statistic } = metric.data.value {
+fn finish_metric(item: (MetricSeries, MetricEntry)) -> Metric {
+    let (series, (mut data, metadata)) = item;
+    if let MetricValue::Distribution { samples, statistic } = data.value {
         let samples = compress_distribution(samples);
-        metric.data.value = MetricValue::Distribution { samples, statistic };
+        data.value = MetricValue::Distribution { samples, statistic };
     }
-    metric
+    Metric::from_parts(series, data, metadata)
 }
 
 fn compress_distribution(mut samples: Vec<Sample>) -> Vec<Sample> {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -25,7 +25,6 @@ use std::borrow::Cow;
 
 pub use batch::{Batch, BatchConfig, BatchSettings, BatchSize, PushResult};
 pub use buffer::json::{BoxedRawValue, JsonArrayBuffer};
-pub use buffer::metrics::MetricEntry;
 pub use buffer::partition::Partition;
 pub use buffer::vec::{EncodedLength, VecBuffer};
 pub use buffer::{Buffer, Compression, PartitionBuffer, PartitionInnerBuffer};


### PR DESCRIPTION
Closes #6045

**Note:** This changes the behavior of vector when an incoming metric stream changes type within a batch, including where histogram buckets are divided. This should effectively never happen in normal circumstances. We discussed documenting it, but I am unsure where would be appropriate.