### PR TITLE
chore: Trim unused public functions

### DIFF
--- a/lib/lookup/src/lookup_buf/mod.rs
+++ b/lib/lookup/src/lookup_buf/mod.rs
@@ -138,10 +138,6 @@ impl LookupBuf {
         self.segments.iter()
     }
 
-    pub fn to_lookup(&self) -> Lookup {
-        Lookup::from(self)
-    }
-
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
     }
@@ -155,11 +151,6 @@ impl LookupBuf {
     /// Return a borrow of the SegmentBuf set.
     pub fn as_segments(&self) -> &VecDeque<SegmentBuf> {
         &self.segments
-    }
-
-    /// Return the SegmentBuf set.
-    pub fn into_segments(self) -> VecDeque<SegmentBuf> {
-        self.segments
     }
 
     /// Create the possible fields that can be followed by this lookup.

--- a/lib/lookup/src/lookup_buf/mod.rs
+++ b/lib/lookup/src/lookup_buf/mod.rs
@@ -138,6 +138,10 @@ impl LookupBuf {
         self.segments.iter()
     }
 
+    pub fn to_lookup(&self) -> Lookup {
+        Lookup::from(self)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
     }

--- a/lib/lookup/src/lookup_buf/segmentbuf.rs
+++ b/lib/lookup/src/lookup_buf/segmentbuf.rs
@@ -92,18 +92,6 @@ pub enum SegmentBuf {
     Coalesce(Vec<FieldBuf>),
 }
 
-impl SegmentBuf {
-    pub fn as_segment(&self) -> Segment {
-        match self {
-            SegmentBuf::Field(field) => Segment::field(field.into()),
-            SegmentBuf::Index(i) => Segment::index(*i),
-            SegmentBuf::Coalesce(v) => {
-                Segment::coalesce(v.iter().map(|field| field.into()).collect())
-            }
-        }
-    }
-}
-
 #[cfg(any(test, feature = "arbitrary"))]
 impl Arbitrary for SegmentBuf {
     fn arbitrary(g: &mut Gen) -> Self {

--- a/lib/lookup/src/lookup_view/mod.rs
+++ b/lib/lookup/src/lookup_view/mod.rs
@@ -105,7 +105,6 @@ impl<'a> Display for Lookup<'a> {
 }
 
 impl<'a> Lookup<'a> {
-    #[cfg(test)]
     /// Creates a lookup to the root
     pub fn root() -> Self {
         Self {

--- a/lib/lookup/src/lookup_view/mod.rs
+++ b/lib/lookup/src/lookup_view/mod.rs
@@ -105,13 +105,6 @@ impl<'a> Display for Lookup<'a> {
 }
 
 impl<'a> Lookup<'a> {
-    /// Creates a lookup to the root
-    pub fn root() -> Self {
-        Self {
-            segments: VecDeque::new(),
-        }
-    }
-
     pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, Segment<'a>> {
         self.segments.iter()
     }
@@ -119,16 +112,6 @@ impl<'a> Lookup<'a> {
     /// Become a `LookupBuf` (by allocating).
     pub fn into_buf(self) -> LookupBuf {
         LookupBuf::from(self)
-    }
-
-    /// Return a borrow of the Segment set.
-    pub fn as_segments(&self) -> &VecDeque<Segment<'_>> {
-        &self.segments
-    }
-
-    /// Return the Segment set.
-    pub fn into_segments(self) -> VecDeque<Segment<'a>> {
-        self.segments
     }
 }
 

--- a/lib/lookup/src/lookup_view/mod.rs
+++ b/lib/lookup/src/lookup_view/mod.rs
@@ -105,6 +105,14 @@ impl<'a> Display for Lookup<'a> {
 }
 
 impl<'a> Lookup<'a> {
+    #[cfg(test)]
+    /// Creates a lookup to the root
+    pub fn root() -> Self {
+        Self {
+            segments: VecDeque::new(),
+        }
+    }
+
     pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, Segment<'a>> {
         self.segments.iter()
     }

--- a/lib/vector-core/buffers/src/variant/disk_and_memory.rs
+++ b/lib/vector-core/buffers/src/variant/disk_and_memory.rs
@@ -25,6 +25,7 @@ pub enum Variant {
     },
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 struct Name {
     inner: String,

--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -6,7 +6,7 @@ use std::{
 
 // TODO: if we had `Value` implement `Eq` and `Hash`, the implementation here
 // would be much easier. The issue is with `f64` type. We should consider using
-// a newtype for `f64` there that'd implement `Eq` and `Hash` is it's safe, for
+// a newtype for `f64` there that'd implement `Eq` and `Hash` if it's safe, for
 // example `NormalF64`, and guard the values with `val.is_normal() == true`
 // invariant.
 // See also: https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436/32

--- a/lib/vector-core/src/event/legacy_lookup/mod.rs
+++ b/lib/vector-core/src/event/legacy_lookup/mod.rs
@@ -108,35 +108,6 @@ impl Lookup {
     }
 
     #[instrument(level = "trace")]
-    pub fn from_indexmap(
-        values: IndexMap<String, TomlValue>,
-    ) -> crate::Result<IndexMap<Lookup, Value>> {
-        let mut discoveries = IndexMap::new();
-        for (key, value) in values {
-            Self::recursive_step(Lookup::try_from(key)?, value, &mut discoveries)?;
-        }
-        Ok(discoveries)
-    }
-
-    #[instrument(level = "trace")]
-    pub fn from_toml_table(value: TomlValue) -> crate::Result<IndexMap<Lookup, Value>> {
-        let mut discoveries = IndexMap::new();
-        match value {
-            TomlValue::Table(map) => {
-                for (key, value) in map {
-                    Self::recursive_step(Lookup::try_from(key)?, value, &mut discoveries)?;
-                }
-                Ok(discoveries)
-            }
-            _ => Err(format!(
-                "A TOML table must be passed to the `from_toml_table` function. Passed: {:?}",
-                value
-            )
-            .into()),
-        }
-    }
-
-    #[instrument(level = "trace")]
     fn recursive_step(
         lookup: Lookup,
         value: TomlValue,

--- a/lib/vector-core/src/event/legacy_lookup/segment.rs
+++ b/lib/vector-core/src/event/legacy_lookup/segment.rs
@@ -23,10 +23,6 @@ impl Segment {
         Segment::Index(v)
     }
 
-    pub fn is_value(&self) -> bool {
-        matches!(self, Segment::Index(_))
-    }
-
     #[tracing::instrument(skip(segment))]
     pub(crate) fn from_lookup(segment: Pair<'_, Rule>) -> crate::Result<Vec<Segment>> {
         let rule = segment.as_rule();

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -357,44 +357,6 @@ impl Value {
         }
     }
 
-    /// Lookup API methods
-    /// Return if the node is a leaf (meaning it has no children) or not.
-    ///
-    /// This is notably useful for things like influxdb logs where we list only leaves.
-    ///
-    /// ```rust
-    /// use vector_core::event::Value;
-    /// use std::collections::BTreeMap;
-    ///
-    /// let val = Value::from(1);
-    /// assert_eq!(val.is_leaf(), true);
-    ///
-    /// let mut val = Value::from(Vec::<Value>::default());
-    /// assert_eq!(val.is_leaf(), true);
-    /// val.insert(0, 1);
-    /// assert_eq!(val.is_leaf(), false);
-    /// val.insert(3, 1);
-    /// assert_eq!(val.is_leaf(), false);
-    ///
-    /// let mut val = Value::from(BTreeMap::default());
-    /// assert_eq!(val.is_leaf(), true);
-    /// val.insert("foo", 1);
-    /// assert_eq!(val.is_leaf(), false);
-    /// val.insert("bar", 2);
-    /// assert_eq!(val.is_leaf(), false);
-    /// ```
-    pub fn is_leaf(&self) -> bool {
-        match &self {
-            Value::Boolean(_)
-            | Value::Bytes(_)
-            | Value::Timestamp(_)
-            | Value::Float(_)
-            | Value::Integer(_)
-            | Value::Null => true,
-            Value::Map(_) | Value::Array(_) => self.is_empty(),
-        }
-    }
-
     /// Return if the node is empty, that is, it is an array or map with no items.
     ///
     /// ```rust
@@ -428,42 +390,6 @@ impl Value {
             Value::Null => true,
             Value::Map(v) => v.is_empty(),
             Value::Array(v) => v.is_empty(),
-        }
-    }
-
-    /// Return the number of subvalues the value has.
-    ///
-    /// ```rust
-    /// use vector_core::event::Value;
-    /// use std::collections::BTreeMap;
-    ///
-    /// let val = Value::from(1);
-    /// assert_eq!(val.len(), None);
-    ///
-    /// let mut val = Value::from(Vec::<Value>::default());
-    /// assert_eq!(val.len(), Some(0));
-    /// val.insert(0, 1);
-    /// assert_eq!(val.len(), Some(1));
-    /// val.insert(3, 1);
-    /// assert_eq!(val.len(), Some(4));
-    ///
-    /// let mut val = Value::from(BTreeMap::default());
-    /// assert_eq!(val.len(), Some(0));
-    /// val.insert("foo", 1);
-    /// assert_eq!(val.len(), Some(1));
-    /// val.insert("bar", 2);
-    /// assert_eq!(val.len(), Some(2));
-    /// ```
-    pub fn len(&self) -> Option<usize> {
-        match &self {
-            Value::Boolean(_)
-            | Value::Bytes(_)
-            | Value::Timestamp(_)
-            | Value::Float(_)
-            | Value::Integer(_)
-            | Value::Null => None,
-            Value::Map(v) => Some(v.len()),
-            Value::Array(v) => Some(v.len()),
         }
     }
 

--- a/lib/vector-core/src/mapping/mod.rs
+++ b/lib/vector-core/src/mapping/mod.rs
@@ -150,20 +150,6 @@ impl Mapping {
     pub(self) fn new(assignments: Vec<Box<dyn Function>>) -> Self {
         Mapping { assignments }
     }
-
-    /// Execute the mapping with a given `Event`
-    ///
-    /// # Errors
-    ///
-    /// This function will fail if the underlying mapping could not be applied.
-    pub fn execute(&self, event: &mut Event) -> Result<()> {
-        for (i, assignment) in self.assignments.iter().enumerate() {
-            if let Err(err) = assignment.apply(event) {
-                return Err(format!("failed to apply mapping {}: {}", i, err));
-            }
-        }
-        Ok(())
-    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This commit trims public but otherwise unused functions from the codebase. I
used [warnalyzer](https://github.com/est31/warnalyzer) to find possible
public-but-dead candidates and manually tested each one. `warnalyzer` doesn't
have insight into tests, macros so it's possible I've deleted something needed
here and haven't quite got the right feature flags to light it up.

Neat tool, warnalyzer.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
