### PR TITLE
feat(remap): add string comparison capability

### DIFF
--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -162,6 +162,14 @@ impl Expression for Op {
             // ... != ...
             Eq | Ne => lhs_def.merge(rhs_def).boolean(),
 
+            // "b" >  "a"
+            // "a" >= "a"
+            // "a" <  "b"
+            // "b" <= "b"
+            Gt | Ge | Lt | Le if lhs_def.is_bytes() && rhs_def.is_bytes() => {
+                lhs_def.merge(rhs_def).boolean()
+            }
+
             // ... >  ...
             // ... >= ...
             // ... <  ...
@@ -570,6 +578,11 @@ mod tests {
             want: TypeDef::new().infallible().boolean(),
         }
 
+        greater_bytes {
+            expr: |_| op(Gt, "c", "b"),
+            want: TypeDef::new().infallible().boolean(),
+        }
+
         greater_other {
             expr: |_| op(Gt, 1, "foo"),
             want: TypeDef::new().fallible().boolean(),
@@ -587,6 +600,11 @@ mod tests {
 
         greater_or_equal_mixed {
             expr: |_| op(Ge, 1, 1.0),
+            want: TypeDef::new().infallible().boolean(),
+        }
+
+        greater_or_equal_bytes {
+            expr: |_| op(Ge, "foo", "foo"),
             want: TypeDef::new().infallible().boolean(),
         }
 
@@ -610,6 +628,11 @@ mod tests {
             want: TypeDef::new().infallible().boolean(),
         }
 
+        less_bytes {
+            expr: |_| op(Lt, "bar", "foo"),
+            want: TypeDef::new().infallible().boolean(),
+        }
+
         less_other {
             expr: |_| op(Lt, 1, "foo"),
             want: TypeDef::new().fallible().boolean(),
@@ -627,6 +650,11 @@ mod tests {
 
         less_or_equal_mixed {
             expr: |_| op(Le, 1, 1.0),
+            want: TypeDef::new().infallible().boolean(),
+        }
+
+        less_or_equal_bytes {
+            expr: |_| op(Le, "bar", "bar"),
             want: TypeDef::new().infallible().boolean(),
         }
 

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -136,6 +136,7 @@ impl Value {
             Value::Float(lhv) => {
                 (lhv.into_inner() > f64::try_from(&rhs).map_err(|_| err())?).into()
             }
+            Value::Bytes(lhv) => (lhv > rhs.try_bytes()?).into(),
             _ => return Err(err()),
         };
 
@@ -152,6 +153,7 @@ impl Value {
             Value::Float(lhv) => {
                 (lhv.into_inner() >= f64::try_from(&rhs).map_err(|_| err())?).into()
             }
+            Value::Bytes(lhv) => (lhv >= rhs.try_bytes()?).into(),
             _ => return Err(err()),
         };
 
@@ -168,6 +170,7 @@ impl Value {
             Value::Float(lhv) => {
                 (lhv.into_inner() < f64::try_from(&rhs).map_err(|_| err())?).into()
             }
+            Value::Bytes(lhv) => (lhv < rhs.try_bytes()?).into(),
             _ => return Err(err()),
         };
 
@@ -184,6 +187,7 @@ impl Value {
             Value::Float(lhv) => {
                 (lhv.into_inner() <= f64::try_from(&rhs).map_err(|_| err())?).into()
             }
+            Value::Bytes(lhv) => (lhv <= rhs.try_bytes()?).into(),
             _ => return Err(err()),
         };
 

--- a/lib/vrl/tests/tests/expressions/comparison/ge.vrl
+++ b/lib/vrl/tests/tests/expressions/comparison/ge.vrl
@@ -1,4 +1,4 @@
-# result: [false, true, true, false, true, true, false, true, true, false, true, true, "nope"]
+# result: [false, true, true, false, true, true, false, true, true, false, true, true, true, true, false, "nope", "nope", "nope", "nope", "nope"]
 
 [
     1 >= 2,
@@ -17,6 +17,14 @@
     2.0 >= 1.0,
     2.0 >= 2.0,
 
+    "foo" >= "bar",
+    "foo" >= "foo",
+    "bar" >= "foo",
+
     # fallible
     null >= 1 ?? "nope",
+    1 >= "bar" ?? "nope",
+    false >= "bar" ?? "nope",
+    null >= "bar" ?? "nope",
+    to_string([.foo]) >= "bar" ?? "nope",
 ]

--- a/lib/vrl/tests/tests/expressions/comparison/gt.vrl
+++ b/lib/vrl/tests/tests/expressions/comparison/gt.vrl
@@ -1,4 +1,4 @@
-# result: [false, true, false, true, false, true, false, true, "nope"]
+# result: [false, true, false, true, false, true, false, true, true, false, "nope", "nope", "nope", "nope", "nope"]
 
 [
     1 > 2,
@@ -13,6 +13,13 @@
     1.0 > 2.0,
     2.0 > 1.0,
 
+    "foo" > "bar",
+    "bar" > "foo",
+
     # fallible
     null > 1 ?? "nope",
+    1 > "foo" ?? "nope",
+    false > "foo" ?? "nope",
+    null > "foo" ?? "nope",
+    to_string([.foo]) > "bar" ?? "nope",
 ]

--- a/lib/vrl/tests/tests/expressions/comparison/le.vrl
+++ b/lib/vrl/tests/tests/expressions/comparison/le.vrl
@@ -1,4 +1,4 @@
-# result: [true, false, true, true, false, true, true, false, true, true, false, true, "nope"]
+# result: [true, false, true, true, false, true, true, false, true, true, false, true, false, true, true, "nope", "nope", "nope", "nope", "nope"]
 
 [
     1 <= 2,
@@ -17,7 +17,15 @@
     2.0 <= 1.0,
     2.0 <= 2.0,
 
+    "foo" <= "bar",
+    "foo" <= "foo",
+    "bar" <= "foo",
+
     # fallible
     null <= 1 ?? "nope",
+    1 <= "foo" ?? "nope",
+    false <= "bar" ?? "nope",
+    null <= "foo" ?? "nope",
+    to_string([.foo]) <= "bar" ?? "nope",
 ]
 

--- a/lib/vrl/tests/tests/expressions/comparison/lt.vrl
+++ b/lib/vrl/tests/tests/expressions/comparison/lt.vrl
@@ -1,4 +1,4 @@
-# result: [true, false, true, false, true, false, true, false, "nope"]
+# result: [true, false, true, false, true, false, true, false, false, true, "nope", "nope", "nope", "nope", "nope"]
 
 [
     1 < 2,
@@ -13,6 +13,13 @@
     1.0 < 2.0,
     2.0 < 1.0,
 
+    "foo" < "bar",
+    "bar" < "foo",
+
     # fallible
     null < 1 ?? "nope",
+    1 < "foo" ?? "nope",
+    false < "foo" ?? "nope",
+    null < "foo" ?? "nope",
+    to_string([.foo]) < "bar" ?? "nope",
 ]


### PR DESCRIPTION
Allow to compare strings

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
