### PR TITLE
chore: RFC for updating Vector configuration pattern

### DIFF
--- a/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
+++ b/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
@@ -75,8 +75,14 @@ templating in the future, reducing some long term burden (slight, and I can't im
 
 ## Drawbacks
 
-This change does make opting in or out to our default configurations slightly more difficult, since there would no longer be an "enabled" toggle. To opt out users
-would need to comment out or delete the default values, and to opt in (unless we move to have all the configurations active by default) uncomment our provided configuration.
+This change does make opting in or out to our default configurations slightly more difficult, since there would no longer be an "enabled" toggle. To opt in
+(unless we move to have all the configurations active by default) uncomment our provided configuration. To opt out the user would need to pass the following (based on example above):
+
+```yaml
+sources:
+  internal_metrics: null
+  host_metrics: null
+```
 
 ## Alternatives
 

--- a/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
+++ b/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
@@ -86,7 +86,8 @@ sources:
 
 ## Alternatives
 
-Do nothing - as noted it's not a _huge_ amount of burden but it does make our planned transition to configuring Vector with a YAML file more tricky.
+- Do nothing - as noted it's not a _huge_ amount of burden but it does make our planned transition to configuring Vector with a YAML file more tricky.
+- Change the component keys to arrays, which are not merged when providing overrides - but forces the user to replace all entries if they set custom values.
 
 ## Plan Of Attack
 

--- a/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
+++ b/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
@@ -23,9 +23,10 @@ vector-aggregator:
 
 ## Motivation
 
-We're duplicating the templating used to generate Vector's configuration file in Helm based deployments. While I was working on transitioning the
-currently TOML config to YAML realized the configuration building had several unexpected complications due to the separation between Vector's provided
-"default" configurations (listed in the Scope section) and a user provided configuration located under the `sources`, `transforms`, and `sinks` keys.
+Our current Helm chart for configuring Vector in Kubernetes provides shortcuts for configuring common
+sources and sinks, while also allowing users to specify their configuration in the more traditional "direct"
+fashion, similar to configuring Vector when running on a virtual machine. These two approaches being
+used simultaneously can lead to issues, and general confusion, about what the correct way to configure Vector is.
 
 ## Internal Proposal
 

--- a/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
+++ b/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
@@ -1,0 +1,90 @@
+# RFC 7709 - 2021-06-02 - Helm: Deprecate "custom" configuration keys
+
+Today the templates that user's leverage to generate their Vector config are separate from the ones used to generate the "default" Vector configuration.
+While these are not very complex in their functionality they do duplicate much of the same logic.
+
+## Scope
+
+This RFC will cover only the existing "default" `sinks` and `sources` defined in our Helm charts today.
+
+vector-agent:
+
+- `kubernetes_logs`
+- `vector`
+- `internal_metrics`
+- `host_metrics`
+- `prometheus_exporter`
+
+vector-aggregator:
+
+- `vector`
+- `internal_metrics`
+- `prometheus_exporter`
+
+## Motivation
+
+We're duplicating the templating used to generate Vector's configuration file in Helm based deployments. While I was working on transitioning the
+currently TOML config to YAML realized the configuration building had several unexpected complications due to the separation between Vector's provided
+"default" configurations (listed in the Scope section) and a user provided configuration located under the `sources`, `transforms`, and `sinks` keys.
+
+## Internal Proposal
+
+The "custom" `values.yaml` keys be deprecated and replaced with default values under the `sources`, `transforms`, and `sinks` keys that users configure
+for their provided Vector configuration. An example is below:
+
+```yaml
+-  internalMetricsSource:
+-    enabled: true
+-    sourceId: internal_metrics
+-    config: {}
+-  hostMetricsSource:
+-    enabled: true
+-    sourceId: host_metrics
+-    config:
+-      filesystem:
+-        devices:
+-          excludes: [binfmt_misc]
+-        filesystems:
+-          excludes: [binfmt_misc]
+-        mountpoints:
+-          excludes: ["*/proc/sys/fs/binfmt_misc"]
++  sources:
++    internal_metrics:
++      type: internal_metrics
++    host_metrics:
++      type: host_metrics
++      filesystem:
++        devices:
++          excludes: ["binfmt_misc"]
++        filesystems:
++          excludes: ["binfmt_misc"]
++        mountpoints:
++          excludes: ["*/proc/sys/fs/binfmt_misc"]
+```
+
+## Doc-level Proposal
+
+The only page we currently have with documentation around Helm is on the Kubernetes platform installation page, which today does not mention how to configure
+any of the default components.
+
+## Rationale
+
+This has us use the same configuration levers as our users do, and unifies _how_ Vector can be configured in Kubernetes. The default values can also be used
+as "in-line" documentation users can refer to as an example configuration. This also reduces the amount of changes needed if we need to adjust configuration
+templating in the future, reducing some long term burden (slight, and I can't imagine that will change much, or ever, once we stop converting the config into TOML).
+
+## Drawbacks
+
+This change does make opting in or out to our default configurations slightly more difficult, since there would no longer be an "enabled" toggle. To opt out users
+would need to comment out or delete the default values, and to opt in (unless we move to have all the configurations active by default) uncomment our provided configuration.
+
+## Alternatives
+
+Do nothing - as noted it's not a _huge_ amount of burden but it does make our planned transition to configuring Vector with a YAML file more tricky.
+
+## Plan Of Attack
+
+- [ ] Announce plan to deprecate the existing keys
+- [ ] Update Helm charts to have all of the "defaults" under the generic `sources`, `transforms`, and `sinks` keys (commented out to not interfere with existing configurations)
+- [ ] Phase our the "custom" keys in an upcoming release by defaulting to the generic keys and setting all "defaults" to have `enabled = false`
+- [ ] Remove the eight existing "custom" keys we use for configuration

--- a/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
+++ b/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md
@@ -1,66 +1,114 @@
 # RFC 7709 - 2021-06-02 - Helm: Deprecate "custom" configuration keys
 
-Today the templates that user's leverage to generate their Vector config are separate from the ones used to generate the "default" Vector configuration.
-While these are not very complex in their functionality they do duplicate much of the same logic.
+This RFC proposes an update for our current configuration to fully embrace our support of YAML configuration files.
 
 ## Scope
 
-This RFC will cover only the existing "default" `sinks` and `sources` defined in our Helm charts today.
+This RFC will cover the component configuration keys and the default `sinks` and `sources` defined under unique keys in 
+our Helm charts today. We provide defaults configurations for the following components:
 
 vector-agent:
 
-- `kubernetes_logs`
-- `vector`
-- `internal_metrics`
-- `host_metrics`
-- `prometheus_exporter`
+- `kubernetes_logs` source
+- `internal_metrics` source
+- `host_metrics` source
+- `vector` sink
+- `prometheus_exporter` sink
 
 vector-aggregator:
 
-- `vector`
-- `internal_metrics`
-- `prometheus_exporter`
+- `vector` source
+- `internal_metrics` source
+- `prometheus_exporter` sink
 
 ## Motivation
 
 Our current Helm chart for configuring Vector in Kubernetes provides shortcuts for configuring common
-sources and sinks, while also allowing users to specify their configuration in the more traditional "direct"
+`sources` and `sinks`, while also allowing users to specify their configuration in the more traditional "direct"
 fashion, similar to configuring Vector when running on a virtual machine. These two approaches being
 used simultaneously can lead to issues, and general confusion, about what the correct way to configure Vector is.
 
 ## Internal Proposal
 
-The "custom" `values.yaml` keys be deprecated and replaced with default values under the `sources`, `transforms`, and `sinks` keys that users configure
-for their provided Vector configuration. An example is below:
+...
+
+Ignoring backward compatibility with existing keys, the ConfigMap template would be replaced with the following:
 
 ```yaml
--  internalMetricsSource:
--    enabled: true
--    sourceId: internal_metrics
--    config: {}
--  hostMetricsSource:
--    enabled: true
--    sourceId: host_metrics
--    config:
--      filesystem:
--        devices:
--          excludes: [binfmt_misc]
--        filesystems:
--          excludes: [binfmt_misc]
--        mountpoints:
--          excludes: ["*/proc/sys/fs/binfmt_misc"]
-+  sources:
-+    internal_metrics:
-+      type: internal_metrics
-+    host_metrics:
-+      type: host_metrics
-+      filesystem:
-+        devices:
-+          excludes: ["binfmt_misc"]
-+        filesystems:
-+          excludes: ["binfmt_misc"]
-+        mountpoints:
-+          excludes: ["*/proc/sys/fs/binfmt_misc"]
+{{- if (empty .Values.existingConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "libvector.configMapName" . }}
+  labels:
+    {{- include "libvector.labels" . | nindent 4 }}
+data:
+  {{- if .Values.customConfig }}
+  vector.yaml: |
+{{ tpl (toYaml .Values.customConfig) . | indent 4 }}
+  {{- else }}
+  vector.yaml: |
+    # Docs: https://vector.dev/docs/
+    data_dir: "/vector-data-dir"
+    log_schema:
+      host_key: host
+      message_key: message
+      source_type_key: source_type
+      timestamp_key: timestamp
+    sources:
+      host_metrics:
+        type: host_metrics
+        filesystem:
+          devices:
+            excludes: ["binfmt_misc"]
+          filesystems:
+            excludes: ["binfmt_misc"]
+          mountpoints:
+            excludes: ["*/proc/sys/fs/binfmt_misc"]
+      internal_metrics:
+        type: internal_metrics
+      kubernetes_logs:
+        type: kubernetes_logs
+    sinks:
+      prometheus_sink:
+        type: prometheus_exporter
+        inputs: ["host_metrics", "internal_metrics"]
+        address: 0.0.0.0:9090
+  {{- end }}
+{{- end }}
+```
+
+To make it easier for users to make minor changes to our default configuration we would provide a copy of the
+default configuration (commented out). Users would uncomment the block and be able to make any required changes
+without having to rewrite the entire configuration.
+
+```yaml
+customConfig: {}
+  #  data_dir: "/vector-data-dir"
+  #  log_schema:
+  #    host_key: host
+  #    message_key: message
+  #    source_type_key: source_type
+  #    timestamp_key: timestamp
+  #  sources:
+  #    host_metrics:
+  #      type: host_metrics
+  #      filesystem:
+  #        devices:
+  #          excludes: ["binfmt_misc"]
+  #        filesystems:
+  #          excludes: ["binfmt_misc"]
+  #        mountpoints:
+  #          excludes: ["*/proc/sys/fs/binfmt_misc"]
+  #    internal_metrics:
+  #      type: internal_metrics
+  #    kubernetes_logs:
+  #      type: kubernetes_logs
+  #  sinks:
+  #    prometheus_sink:
+  #      type: prometheus_exporter
+  #      inputs: ["host_metrics", "internal_metrics"]
+  #      address: 0.0.0.0:9090
 ```
 
 ## Doc-level Proposal
@@ -70,29 +118,45 @@ any of the default components.
 
 ## Rationale
 
-This has us use the same configuration levers as our users do, and unifies _how_ Vector can be configured in Kubernetes. The default values can also be used
-as "in-line" documentation users can refer to as an example configuration. This also reduces the amount of changes needed if we need to adjust configuration
-templating in the future, reducing some long term burden (slight, and I can't imagine that will change much, or ever, once we stop converting the config into TOML).
+- Reduce template logic
+- Configuration files are more obvious/readable/apparent
+- More easily support #7902
+- More easily configure related Service and port options
+- Matches [Datadog Agent configuration](https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml#L1023-L1048)
+- ...
 
 ## Drawbacks
 
-This change does make opting in or out to our default configurations slightly more difficult, since there would no longer be an "enabled" toggle. To opt in
-(unless we move to have all the configurations active by default) uncomment our provided configuration. To opt out the user would need to pass the following (based on example above):
-
-```yaml
-sources:
-  internal_metrics: null
-  host_metrics: null
-```
+- Adjusting configuration for individual default components requires replacing the entire configuration
+- More user facing changes than the alternatives
+- ...
 
 ## Alternatives
 
-- Do nothing - as noted it's not a _huge_ amount of burden but it does make our planned transition to configuring Vector with a YAML file more tricky.
-- Change the component keys to arrays, which are not merged when providing overrides - but forces the user to replace all entries if they set custom values.
+### Do nothing
+
+- Maintains a separate and unique way of configuring specific components we consider "default" that does not align with user provided configuration.
+- Maintains extra code to handle the templating of our default configurations, new defaults would require new keys and templating.
+
+### Exclusively use generic `sources`, `transforms`, and `sinks` keys
+
+- Deprecate unique default components and move their configuration into the generic keys we include for user supplied configurations.
+- As we also convert from TOML to YAML based configuration files, we continue to maintain an unnecessary set of keys: `sources`, `transforms`, and `sinks`. We can simply `tpl` or `toYaml` YAML config from the `values.yaml` into our Vector configuration file(s).
+- Users would need to disable components, per component with a `null` value, example:
+
+```yaml
+sources:
+  kubernetes_logs: null
+  internal_metrics: null
+  host_metrics: null
+sinks:
+  vector_sink: null
+  prometheus_sink: null
+```
 
 ## Plan Of Attack
 
-- [ ] Announce plan to deprecate the existing keys
-- [ ] Update Helm charts to have all of the "defaults" under the generic `sources`, `transforms`, and `sinks` keys (commented out to not interfere with existing configurations)
-- [ ] Phase our the "custom" keys in an upcoming release by defaulting to the generic keys and setting all "defaults" to have `enabled = false`
-- [ ] Remove the eight existing "custom" keys we use for configuration
+- [ ] Announce plan to deprecate current keys with a highlight in the 0.15.0 release
+- [ ] TODO: Phase in ...
+- [ ] TODO: Phase out ...
+- [ ] Remove the `sources`, `transforms`, `sinks`, and "unique" default keys in future release


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

[Rendered markdown](https://github.com/spencergilbert/vector/blob/rfc-deprecate-custom-config-keys/rfcs/2021-06-02-7709-helm-deprecate-custom-config-keys.md)

Closes #7709

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->

