### PR TITLE
chore(releasing): Fix commit listing when generating release notes

### DIFF
--- a/scripts/util/git_log_commit.rb
+++ b/scripts/util/git_log_commit.rb
@@ -3,7 +3,7 @@ module Vector
     class << self
       def fetch_since!(last_version)
         range = "v#{last_version}..."
-        commit_log = `git log #{range} --cherry --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
+        commit_log = `git log #{range} --cherry-pick --right-only --no-merges --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
         commit_lines = commit_log.split("\n").reverse
 
         commit_lines.collect do |commit_line|

--- a/scripts/util/git_log_commit.rb
+++ b/scripts/util/git_log_commit.rb
@@ -3,7 +3,7 @@ module Vector
     class << self
       def fetch_since!(last_version)
         range = "v#{last_version}..."
-        commit_log = `git log #{range} --no-merges --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
+        commit_log = `git log #{range} --cherry --pretty=format:'%H\t%s\t%aN\t%ad'`.chomp
         commit_lines = commit_log.split("\n").reverse
 
         commit_lines.collect do |commit_line|


### PR DESCRIPTION
Currently, when listing commits from the last release during release
note generation, we end up:

* missing commits that appear in master before the last patch release
* listing commits that were released in the last patch release that were
  cherry-picked from master and thus should not be included in the next
  release changelog

Here we add `--right-only --cherry-pick`. `--right-only` limits to
commits that appear in master and excludes commits that are in the patch
release. `--cherry-pick` ensures we supress commits that were
cherry-picked and appear in the last patch release.

For example, generating the notes for v0.14.0 which looks at the log from v0.13.1, with this change, yields this diff from what it was previously:

```
 0240ae601 - (fix-discord-action-versio) enhancement: created new lookup library (#7087) (5 weeks ago) <Stephen Wakely>
 ffaa9e4e9 - feat(new source): Initial `exec` source (#6876) (5 weeks ago) <moogstuart>
 b11ac642e - chore(releasing): Update install script to 0.13.1 (#7275) (5 weeks ago) <Jesse Szwedko>
-f0749f61d - (tag: v0.13.1) Prepare 0.13.1 (5 weeks ago) <Jesse Szwedko>
-420a74fe5 - fix(kafka source): Fix runaway memory usage of kafka source (#7266) (5 weeks ago) <Jesse Szwedko>
 29736f341 - chore(deps): bump pulsar from 2.0.0 to 2.0.1 (#7271) (5 weeks ago) <dependabot[bot]>
 c9cd09d5b - chore(deps): bump openssl from 0.10.33 to 0.10.34 (#7270) (5 weeks ago) <dependabot[bot]>
 fb34ddc36 - fix(external docs): typo (#7268) (5 weeks ago) <Frank Murphy>
-38f9b78aa - fix(kafka source): Fix runaway memory usage of kafka source (#7266) (5 weeks ago) <Jesse Szwedko>
 1102e5e84 - chore(deps): bump syn from 1.0.70 to 1.0.71 (#7261) (5 weeks ago) <dependabot[bot]>
 4792effed - chore(deps): bump tower from 0.4.6 to 0.4.7 (#7260) (5 weeks ago) <dependabot[bot]>
 45a209101 - enhancement(kubernetes_logs source): Allow configuration of max_line_bytes (#7226) (5 weeks ago) <Jesse Szwedko>
@@ -205,7 +202,6 @@
 990ee46ac - chore(buffers): Upgrade DiskBuffer to futures 0.3 (#7165) (5 weeks ago) <Kruno Tomola Fabro>
 a6125ba9e - chore: Run cargo-hack on self-hosted machines (#7227) (6 weeks ago) <Brian L. Troutwine>
 2b434b73f - chore(deps): bump async-nats from 0.9.12 to 0.9.14 (#7234) (6 weeks ago) <dependabot[bot]>
-5d891b8d2 - chore(external docs): Correct highlight dates for 0.13.0 (6 weeks ago) <Jesse Szwedko>
 ddfcbdb35 - chore(deps): bump regex from 1.4.5 to 1.4.6 (#7233) (6 weeks ago) <dependabot[bot]>
 f49662a89 - chore(deps): bump hyper from 0.14.6 to 0.14.7 (#7232) (6 weeks ago) <dependabot[bot]>
 5a384382b - chore: Adjust import of `crate::Event` to `crate::event::Event` (#7200) (6 weeks ago) <Brian L. Troutwine>
@@ -218,17 +214,8 @@
 2429b0b85 - chore(deps): bump hyper from 0.14.5 to 0.14.6 (#7212) (6 weeks ago) <dependabot[bot]>
 507e2c386 - chore(deps): bump syn from 1.0.69 to 1.0.70 (#7210) (6 weeks ago) <dependabot[bot]>
 2a5e6a2b0 - chore(deps): bump async-stream from 0.3.0 to 0.3.1 (#7209) (6 weeks ago) <dependabot[bot]>
-fe0a3a106 - chore(external docs): Correct highlight dates for 0.13.0 (6 weeks ago) <Jesse Szwedko>
 345088a14 - chore(deps): bump cidr-utils from 0.5.1 to 0.5.3 (#7211) (6 weeks ago) <dependabot[bot]>
 1af0551ce - fix(remap): Escape quotes and backslashes when printing VRL strings (#6739) (6 weeks ago) <Pablo Sichert>
 69d64f58c - chore(dev): Bump to 0.14.0 (#7205) (6 weeks ago) <Jesse Szwedko>
 07e63a9a4 - chore(releasing): Merge down of 0.13.0 release (#7194) (6 weeks ago) <Jesse Szwedko>
-d0e31c249 - chore(external docs): Fix typos in 0.13.0 release (6 weeks ago) <Jesse Szwedko>
-2d0af78c7 - chore(external docs): Fix missing ) for link (6 weeks ago) <Jesse Szwedko>
-99bf2171c - (tag: v0.13.0) chore(releasing): Only delete old files for 0.X and 0.13.X artifacts (6 weeks ago) <Jesse Szwedko>
-5d996733f - chore(releasing): avoid deleting just uploaded latest artifacts (6 weeks ago) <Jesse Szwedko>
-4aa1db42e - chore: Prep v0.12.2 release (9 weeks ago) <Jesse Szwedko>
-2267b11cc - chore(external docs): Fix typo of tags in highlight (6 weeks ago) <Jesse Szwedko>
-c931e844c - Rename `core` to `vector-core` (#7195) (6 weeks ago) <Brian L. Troutwine>
-95245a61d - chore(external docs): Fix markdown (6 weeks ago) <Jesse Szwedko>
-863a4f588 - chore(releasing): Prep 0.13.0 release (6 weeks ago) <Jesse Szwedko>
+c931e844c - Rename `core` to `vector-core` (#7195) (6 weeks ago) <Brian L. Troutwine>
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
