### PR TITLE
fix(releasing): Remove filters from changelog generation

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -15,6 +15,7 @@ types:
   - enhancement         # Any user observable enhancement to an existing feature.
   - feat                # Any user observable new feature, such as a new platform, source, transform, or sink.
   - fix                 # Any user observable bug fix.
+  - docs                # Documentation changes
 
 scopes:
   - new source

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -15,7 +15,6 @@ types:
   - enhancement         # Any user observable enhancement to an existing feature.
   - feat                # Any user observable new feature, such as a new platform, source, transform, or sink.
   - fix                 # Any user observable bug fix.
-  - docs                # Documentation changes
 
 scopes:
   - new source

--- a/scripts/release-prepare.rb
+++ b/scripts/release-prepare.rb
@@ -181,12 +181,7 @@ def create_release_file!(new_version)
 end
 
 def get_commits_since(last_version)
-  Vector::Commit.fetch_since(last_version).select do |commit|
-      commit.type != "chore" &&
-        commit.type != "docs" &&
-        !commit.scopes.include?("external docs") &&
-        !commit.scopes.include?("docs")
-    end
+  Vector::Commit.fetch_since(last_version)
 end
 
 # Grabs all existing commits that are included in the `.meta/releases/*.toml`


### PR DESCRIPTION
Currently docs and task types are filtered however:

* docs is not actually a type though it appears as a toggle on the
  release notes page (see https://vector.dev/releases/0.13.0/#changelog
  for example)
* chore is a togglable type on the release notes page (it defaults to
  unchecked)

Given this, I think it is appropriate to include all commits and let
users filter them. I would like to add additional filter capabilities to
the changelog in the future to, for example, filter out internal only
changes.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
