### PR TITLE
chore: Warnings break build

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -37,7 +37,6 @@ env:
   AWS_SECRET_ACCESS_KEY: "dummy"
   CI: true
   AWS_REGION: us-east-1
-  RUSTFLAGS: "-D warnings"
 
 jobs:
   cancel-previous:

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -37,6 +37,7 @@ env:
   AWS_SECRET_ACCESS_KEY: "dummy"
   CI: true
   AWS_REGION: us-east-1
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   cancel-previous:

--- a/.github/workflows/cargo_flake.yml
+++ b/.github/workflows/cargo_flake.yml
@@ -14,6 +14,7 @@ env:
   VERBOSE: true
   CI: true
   DEBIAN_FRONTEND: noninteractive
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   hack:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ env:
   VERBOSE: true
   CI: true
   DEBIAN_FRONTEND: noninteractive
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   CI: true
   DEBIAN_FRONTEND: noninteractive
   CONTAINER_TOOL: docker
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   build-x86_64-unknown-linux-musl-packages:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ env:
   VERBOSE: true
   CI: true
   PROFILE: debug
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   cancel-previous:


### PR DESCRIPTION
This commit adds "-D warnings" to relevant Github Actions workflows, ensuring
that the build will fail if we leave any warnings present in the project.

Resolves #7733

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
