### PR TITLE
fix(kubernetes_logs source): change glob minimum value to 5000

### DIFF
--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -445,7 +445,7 @@ fn default_max_line_bytes() -> usize {
 }
 
 fn default_glob_minimum_cooldown_ms() -> usize {
-    1000
+    5000
 }
 
 /// This function construct the effective field selector to use, based on


### PR DESCRIPTION
Closes #7737 

It seems the recent change to 1000 was too small and wasn't giving the source enough time to be able to pick up the ip address of the associated pod. This changes it to 5000, which should hopefully be better.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
