### PR TITLE
chore: Remove `transform_one` warning ding

### DIFF
--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -85,6 +85,11 @@ mod test {
     ///
     /// If `ft` attempts to emit more than one `Event` on transform this
     /// function will panic.
+    // We allow dead_code here to avoid unused warnings when we compile our
+    // benchmarks as tests. It's a valid warning -- the benchmarks don't use
+    // this function -- but flagging this function off for bench flags will
+    // issue a unused warnings about the import above.
+    #[allow(dead_code)]
     pub(crate) fn transform_one(ft: &mut dyn FunctionTransform, event: Event) -> Option<Event> {
         let mut buf = Vec::with_capacity(1);
         ft.transform(&mut buf, event);


### PR DESCRIPTION
The `transform_one` function was added in #7701 but is unused by benchmarks,
which causes a warning when we compile them as test instances. This commit
allows `transform_one` to be dead to avoid the warning in that context.

Resolves #7728
REF #7733 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
