### PR TITLE
chore: Move `Source` into core

### DIFF
--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod config;
 pub mod event;
 pub mod mapping;
 pub mod metrics;
+pub mod source;
 #[cfg(test)]
 mod test_util;
 pub mod transform;

--- a/lib/vector-core/src/source.rs
+++ b/lib/vector-core/src/source.rs
@@ -1,0 +1,3 @@
+use futures::future::BoxFuture;
+
+pub type Source = BoxFuture<'static, Result<(), ()>>;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,4 +1,3 @@
-use futures::future::BoxFuture;
 use snafu::Snafu;
 
 #[cfg(feature = "sources-apache_metrics")]
@@ -58,7 +57,7 @@ pub mod vector;
 
 mod util;
 
-pub type Source = BoxFuture<'static, Result<(), ()>>;
+pub use vector_core::source::Source;
 
 /// Common build errors
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
This commit moves the `Source` type alias down into core. There's
little else that needs to be done here, not like with `Sink` which is
coming shortly.

REF #7150

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
