### PR TITLE
chore(tests): Fix aws_s3 source integration tests

### DIFF
--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -265,7 +265,9 @@ mod integration_tests {
         line_agg,
         rusoto::RegionOrEndpoint,
         sources::util::MultilineConfig,
-        test_util::{collect_n, lines_from_gzip_file, lines_from_zst_file, random_lines},
+        test_util::{
+            collect_n, lines_from_gzip_file, lines_from_zst_file, random_lines, trace_init,
+        },
         Pipeline,
     };
     use pretty_assertions::assert_eq;
@@ -275,6 +277,8 @@ mod integration_tests {
 
     #[tokio::test]
     async fn s3_process_message() {
+        trace_init();
+
         let key = uuid::Uuid::new_v4().to_string();
         let logs: Vec<String> = random_lines(100).take(10).collect();
 
@@ -283,6 +287,8 @@ mod integration_tests {
 
     #[tokio::test]
     async fn s3_process_message_special_characters() {
+        trace_init();
+
         let key = format!("special:{}", uuid::Uuid::new_v4().to_string());
         let logs: Vec<String> = random_lines(100).take(10).collect();
 
@@ -292,6 +298,8 @@ mod integration_tests {
     #[tokio::test]
     async fn s3_process_message_gzip() {
         use std::io::Read;
+
+        trace_init();
 
         let key = uuid::Uuid::new_v4().to_string();
         let logs: Vec<String> = random_lines(100).take(10).collect();
@@ -309,6 +317,8 @@ mod integration_tests {
     #[tokio::test]
     async fn s3_process_message_multipart_gzip() {
         use std::io::Read;
+
+        trace_init();
 
         let key = uuid::Uuid::new_v4().to_string();
         let logs = lines_from_gzip_file("tests/data/multipart-gzip.log.gz");
@@ -328,6 +338,8 @@ mod integration_tests {
     async fn s3_process_message_multipart_zstd() {
         use std::io::Read;
 
+        trace_init();
+
         let key = uuid::Uuid::new_v4().to_string();
         let logs = lines_from_zst_file("tests/data/multipart-zst.log.zst");
 
@@ -344,6 +356,8 @@ mod integration_tests {
 
     #[tokio::test]
     async fn s3_process_message_multiline() {
+        trace_init();
+
         let key = uuid::Uuid::new_v4().to_string();
         let logs: Vec<String> = vec!["abc", "def", "geh"]
             .into_iter()

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -32,7 +32,8 @@ lazy_static! {
         semver::VersionReq::parse("~2").unwrap();
 }
 
-#[derive(Derivative, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Derivative, Clone, Debug, Deserialize, Serialize)]
+#[derivative(Default)]
 #[serde(deny_unknown_fields)]
 pub(super) struct Config {
     pub(super) queue_url: String,


### PR DESCRIPTION
The new `client_concurrency` was not being correctly defaulted as we
were deriving `Default` rather than letting `Derivative` do it to call
our custom functions. The result was that it would default to 0 and the
source would immediately shut down.

I also added in `trace_init` calls to these tests to help with
debugging them.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
