### PR TITLE
chore: Move `VectorSink`, `StreamSink` into core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -1951,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -1963,8 +1963,11 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
+ "atty",
+ "humantime 2.1.0",
  "log",
  "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -2907,6 +2910,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error 1.2.3",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -7997,6 +8006,7 @@ name = "vector_core"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
+ "async-trait",
  "atomig",
  "buffers",
  "bytes 1.0.1",

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = { version = "0.1", default-features = false }
 async-graphql = { version = "=2.6.4", default-features = false, optional = true }
 atomig = { version = "0.2.0", features = ["derive", "serde"] }
 buffers = { path = "buffers", default-features = false }

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -27,11 +27,11 @@ pub mod config;
 pub mod event;
 pub mod mapping;
 pub mod metrics;
+pub mod sink;
 pub mod source;
 #[cfg(test)]
 mod test_util;
 pub mod transform;
-
 pub use buffers;
 
 #[macro_use]

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -10,6 +10,11 @@ pub enum VectorSink {
 }
 
 impl VectorSink {
+    /// Run the `VectorSink`
+    ///
+    /// # Errors
+    ///
+    /// It is unclear under what conditions this function will error.
     pub async fn run<S>(mut self, input: S) -> Result<(), ()>
     where
         S: Stream<Item = Event> + Send,
@@ -20,6 +25,11 @@ impl VectorSink {
         }
     }
 
+    /// Converts `VectorSink` into a `futures::Sink`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the self instance is not `VectorSink::Sink`.
     pub fn into_sink(self) -> Box<dyn Sink<Event, Error = ()> + Send + Unpin> {
         match self {
             Self::Sink(sink) => sink,

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -1,0 +1,42 @@
+use crate::event::Event;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::{Sink, Stream, StreamExt};
+use std::fmt;
+
+pub enum VectorSink {
+    Sink(Box<dyn Sink<Event, Error = ()> + Send + Unpin>),
+    Stream(Box<dyn StreamSink + Send>),
+}
+
+impl VectorSink {
+    pub async fn run<S>(mut self, input: S) -> Result<(), ()>
+    where
+        S: Stream<Item = Event> + Send,
+    {
+        match self {
+            Self::Sink(sink) => input.map(Ok).forward(sink).await,
+            Self::Stream(ref mut s) => s.run(Box::pin(input)).await,
+        }
+    }
+
+    pub fn into_sink(self) -> Box<dyn Sink<Event, Error = ()> + Send + Unpin> {
+        match self {
+            Self::Sink(sink) => sink,
+            _ => panic!("Failed type coercion, {:?} is not a Sink", self),
+        }
+    }
+}
+
+impl fmt::Debug for VectorSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VectorSink").finish()
+    }
+}
+
+// === StreamSink ===
+
+#[async_trait]
+pub trait StreamSink {
+    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()>;
+}

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -39,14 +39,10 @@ use super::{
 };
 use crate::{
     buffers::Acker,
-    event::{Event, EventMetadata, EventStatus},
+    event::{EventMetadata, EventStatus},
 };
-use async_trait::async_trait;
 use futures::{
-    future::BoxFuture,
-    ready,
-    stream::{BoxStream, FuturesUnordered},
-    FutureExt, Sink, Stream, TryFutureExt,
+    future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, Sink, Stream, TryFutureExt,
 };
 use pin_project::pin_project;
 use std::{
@@ -66,10 +62,7 @@ use tracing_futures::Instrument;
 
 // === StreamSink ===
 
-#[async_trait]
-pub trait StreamSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()>;
-}
+pub use vector_core::sink::StreamSink;
 
 // === BatchSink ===
 


### PR DESCRIPTION
This commit moves `VectorSink` and `StreamSink` into core, leaving behind a fair
bit extra of the sink traits. Sink is our most complicated notion in vector by
far and fairly self-referential in its implementation. Getting it teased into
core will take some doing and will, very likely, need to be driven by need.

Future work in this area will be done one piece at a time. There's simply too
much code to move in bulk.

REF #7150

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
