### PR TITLE
chore(tests): Ensure that tracing output is captured

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -47,9 +47,16 @@ pub fn init(color: bool, json: bool, levels: &str) {
     // bit of duplication as we started to create a generic struct to wrap the formatters that also
     // implemented `Layer`
     let dispatch = if json {
+        #[cfg(not(test))]
         let formatter = tracing_subscriber::fmt::Layer::default()
             .json()
             .flatten_event(true);
+
+        #[cfg(test)]
+        let formatter = tracing_subscriber::fmt::Layer::default()
+            .json()
+            .flatten_event(true)
+            .with_test_writer(); // ensures output is captured
 
         let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
 
@@ -60,7 +67,13 @@ pub fn init(color: bool, json: bool, levels: &str) {
             Dispatch::new(BroadcastSubscriber { subscriber })
         }
     } else {
+        #[cfg(not(test))]
         let formatter = tracing_subscriber::fmt::Layer::default().with_ansi(color);
+
+        #[cfg(test)]
+        let formatter = tracing_subscriber::fmt::Layer::default()
+            .with_ansi(color)
+            .with_test_writer(); // ensures output is captured
 
         let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
 


### PR DESCRIPTION
Currently tracing output always appears in tests because it side-steps
the print macros that `libtest` hijacks to capture output. Calling
`with_test_writer` swaps to using `print!` and so is captured
appropriately. It will now be output only if the test fails.

I attempted to refactor this a bit but struggled again to make this more
composable due to the fact that Subscribers and Layers are generic over
much of their configuration. I welcome thoughts here though.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
