### PR TITLE
feat(cli): Add support for --config-dir

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use cfg_if::cfg_if;
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use tokio::{
     runtime::{self, Runtime},
     sync::mpsc,
@@ -151,7 +151,7 @@ impl Application {
 
                 info!(
                     message = "Loading configs.",
-                    path = ?config_paths
+                    paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
                 );
 
                 config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use cfg_if::cfg_if;
 use futures::StreamExt;
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 use tokio::{
     runtime::{self, Runtime},
     sync::mpsc,
@@ -32,7 +32,7 @@ use crate::internal_events::{
 };
 
 pub struct ApplicationConfig {
-    pub config_paths: Vec<(PathBuf, config::FormatHint)>,
+    pub config_paths: Vec<config::ConfigPath>,
     pub topology: RunningTopology,
     pub graceful_crash: mpsc::UnboundedReceiver<()>,
     #[cfg(feature = "api")]
@@ -142,7 +142,7 @@ impl Application {
 
                 if watch_config {
                     // Start listening for config changes immediately.
-                    config::watcher::spawn_thread(config_paths.iter().map(|(path, _)| path), None)
+                    config::watcher::spawn_thread(config_paths.iter().map(Into::into), None)
                         .map_err(|error| {
                             error!(message = "Unable to start config watcher.", %error);
                             exitcode::CONFIG

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,19 @@ pub struct RootOpts {
     )]
     pub config_paths: Vec<PathBuf>,
 
+    /// Read configuration from files in one or more directories.
+    /// File format is detected from the file name.
+    ///
+    /// Files not ending in .toml, .json, .yaml, or .yml will be ignored.
+    #[structopt(
+        name = "config-dir",
+        short = "C",
+        long,
+        env = "VECTOR_CONFIG_DIR",
+        use_delimiter(true)
+    )]
+    pub config_dirs: Vec<PathBuf>,
+
     /// Read configuration from one or more files. Wildcard paths are supported.
     /// TOML file format is expected.
     #[structopt(
@@ -140,13 +153,20 @@ pub struct RootOpts {
 
 impl RootOpts {
     /// Return a list of config paths with the associated formats.
-    pub fn config_paths_with_formats(&self) -> Vec<(PathBuf, config::FormatHint)> {
+    pub fn config_paths_with_formats(&self) -> Vec<config::ConfigPath> {
         config::merge_path_lists(vec![
             (&self.config_paths, None),
             (&self.config_paths_toml, Some(config::Format::Toml)),
             (&self.config_paths_json, Some(config::Format::Json)),
             (&self.config_paths_yaml, Some(config::Format::Yaml)),
         ])
+        .map(|(path, hint)| config::ConfigPath::File(path, hint))
+        .chain(
+            self.config_dirs
+                .iter()
+                .map(|dir| config::ConfigPath::Dir(dir.to_path_buf())),
+        )
+        .collect()
     }
 }
 

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 pub type FormatHint = Option<Format>;
 
 /// The format used to represent the configuration data.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Format {
     /// TOML format is used.
     Toml,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,10 +47,7 @@ pub use vector_core::config::{log_schema, LogSchema};
 /// Once this is done, configurations can be correctly loaded using
 /// configured log schema defaults.
 /// If deny is set, will panic if schema has already been set.
-pub fn init_log_schema(
-    config_paths: &[(PathBuf, FormatHint)],
-    deny_if_set: bool,
-) -> Result<(), Vec<String>> {
+pub fn init_log_schema(config_paths: &[ConfigPath], deny_if_set: bool) -> Result<(), Vec<String>> {
     vector_core::config::init_log_schema(
         || {
             let (builder, _) = load_builder_from_paths(config_paths)?;
@@ -58,6 +55,21 @@ pub fn init_log_schema(
         },
         deny_if_set,
     )
+}
+
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum ConfigPath {
+    File(PathBuf, FormatHint),
+    Dir(PathBuf),
+}
+
+impl<'a> From<&'a ConfigPath> for &'a PathBuf {
+    fn from(config_path: &'a ConfigPath) -> &'a PathBuf {
+        match config_path {
+            ConfigPath::File(path, _) => path,
+            ConfigPath::Dir(path) => path,
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -1,16 +1,14 @@
 use super::{Config, ConfigBuilder, TestDefinition, TestInput, TestInputValue};
-use crate::config::{self, GlobalOptions, TransformConfig};
+use crate::config::{self, ConfigPath, GlobalOptions, TransformConfig};
 use crate::{
     conditions::Condition,
     event::{Event, Value},
     transforms::Transform,
 };
 use indexmap::IndexMap;
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
-pub async fn build_unit_tests_main(
-    paths: &[(PathBuf, config::FormatHint)],
-) -> Result<Vec<UnitTest>, Vec<String>> {
+pub async fn build_unit_tests_main(paths: &[ConfigPath]) -> Result<Vec<UnitTest>, Vec<String>> {
     config::init_log_schema(paths, false)?;
 
     let (config, _) = super::loading::load_builder_from_paths(paths)?;

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -135,6 +135,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_directory_update() {
+        trace_init();
+
+        let delay = Duration::from_secs(3);
+        let file_path = temp_file();
+        let mut file = File::create(&file_path).unwrap();
+
+        let _ = spawn_thread(&[file_path.parent().unwrap().to_path_buf()], delay).unwrap();
+
+        if !test(&mut file, delay * 5).await {
+            panic!("Test timed out");
+        }
+    }
+
+    #[tokio::test]
     async fn file_update() {
         trace_init();
 

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -1,7 +1,6 @@
 use super::InternalEvent;
 use crate::{built_info, config};
 use metrics::counter;
-use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct VectorStarted;
@@ -24,7 +23,7 @@ impl InternalEvent for VectorStarted {
 
 #[derive(Debug)]
 pub struct VectorReloaded<'a> {
-    pub config_paths: &'a [(PathBuf, config::FormatHint)],
+    pub config_paths: &'a [config::ConfigPath],
 }
 
 impl InternalEvent for VectorReloaded<'_> {

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, CONFIG_PATHS},
+    config::{self, DataType, CONFIG_PATHS},
     event::Event,
     internal_events::{LuaBuildError, LuaGcTriggered},
     transforms::Transform,
@@ -55,9 +55,12 @@ fn default_config_paths() -> Vec<PathBuf> {
         Some(config_paths) => config_paths
             .clone()
             .into_iter()
-            .map(|(mut path_buf, _format)| {
-                path_buf.pop();
-                path_buf
+            .map(|config_path| match config_path {
+                config::ConfigPath::File(mut path, _format) => {
+                    path.pop();
+                    path
+                }
+                config::ConfigPath::Dir(path) => path,
             })
             .collect(),
         None => vec![],

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -22,16 +22,36 @@ pub struct Opts {
     /// default config path `/etc/vector/vector.toml` will be targeted.
     #[structopt(use_delimiter(true))]
     paths: Vec<PathBuf>,
+
+    /// Read configuration from files in one or more directories.
+    /// File format is detected from the file name.
+    ///
+    /// Files not ending in .toml, .json, .yaml, or .yml will be ignored.
+    #[structopt(
+        name = "config-dir",
+        short = "C",
+        long,
+        env = "VECTOR_CONFIG_DIR",
+        use_delimiter(true)
+    )]
+    pub config_dirs: Vec<PathBuf>,
 }
 
 impl Opts {
-    fn paths_with_formats(&self) -> Vec<(PathBuf, config::FormatHint)> {
+    fn paths_with_formats(&self) -> Vec<config::ConfigPath> {
         config::merge_path_lists(vec![
             (&self.paths, None),
             (&self.paths_toml, Some(config::Format::Toml)),
             (&self.paths_json, Some(config::Format::Json)),
             (&self.paths_yaml, Some(config::Format::Yaml)),
         ])
+        .map(|(path, hint)| config::ConfigPath::File(path, hint))
+        .chain(
+            self.config_dirs
+                .iter()
+                .map(|dir| config::ConfigPath::Dir(dir.to_path_buf())),
+        )
+        .collect()
     }
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -40,16 +40,36 @@ pub struct Opts {
     /// will be targeted.
     #[structopt(use_delimiter(true))]
     paths: Vec<PathBuf>,
+
+    /// Read configuration from files in one or more directories.
+    /// File format is detected from the file name.
+    ///
+    /// Files not ending in .toml, .json, .yaml, or .yml will be ignored.
+    #[structopt(
+        name = "config-dir",
+        short = "C",
+        long,
+        env = "VECTOR_CONFIG_DIR",
+        use_delimiter(true)
+    )]
+    pub config_dirs: Vec<PathBuf>,
 }
 
 impl Opts {
-    fn paths_with_formats(&self) -> Vec<(PathBuf, config::FormatHint)> {
+    fn paths_with_formats(&self) -> Vec<config::ConfigPath> {
         config::merge_path_lists(vec![
             (&self.paths, None),
             (&self.paths_toml, Some(config::Format::Toml)),
             (&self.paths_json, Some(config::Format::Json)),
             (&self.paths_yaml, Some(config::Format::Yaml)),
         ])
+        .map(|(path, hint)| config::ConfigPath::File(path, hint))
+        .chain(
+            self.config_dirs
+                .iter()
+                .map(|dir| config::ConfigPath::Dir(dir.to_path_buf())),
+        )
+        .collect()
     }
 }
 
@@ -92,9 +112,8 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
     };
 
     // Load
-    let paths_list: Vec<_> = paths.iter().map(|(path, _)| path).collect();
     let mut report_error = |errors| {
-        fmt.title(format!("Failed to load {:?}", &paths_list));
+        fmt.title(format!("Failed to load {:?}", &paths));
         fmt.sub_error(errors);
     };
     config::init_log_schema(&paths, true)
@@ -121,10 +140,10 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
             return None;
         }
 
-        fmt.title(format!("Loaded with warnings {:?}", &paths_list));
+        fmt.title(format!("Loaded with warnings {:?}", &paths));
         fmt.sub_warning(warnings);
     } else {
-        fmt.success(format!("Loaded {:?}", &paths_list));
+        fmt.success(format!("Loaded {:?}", &paths));
     }
 
     Some(config)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -112,8 +112,10 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
     };
 
     // Load
+    let paths_list: Vec<_> = paths.iter().map(<&PathBuf>::from).collect();
+
     let mut report_error = |errors| {
-        fmt.title(format!("Failed to load {:?}", &paths));
+        fmt.title(format!("Failed to load {:?}", &paths_list));
         fmt.sub_error(errors);
     };
     config::init_log_schema(&paths, true)
@@ -140,10 +142,10 @@ fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
             return None;
         }
 
-        fmt.title(format!("Loaded with warnings {:?}", &paths));
+        fmt.title(format!("Loaded with warnings {:?}", &paths_list));
         fmt.sub_warning(warnings);
     } else {
-        fmt.success(format!("Loaded {:?}", &paths));
+        fmt.success(format!("Loaded {:?}", &paths_list));
     }
 
     Some(config)


### PR DESCRIPTION
This adds support for passing a configuration directory to look for
configuartion files to supplement the existing support for specifying
individual files. Vector will ignore any files in this directory that
are not one of its known formats (yaml, json, toml).

The motivation for this change is primarily to support a future change
to the way we manage helm charts to, instead of trying to build one
configuration file, instead write a separate file for managed sources
(`managed.yaml`) rather than translating it everything to TOML and
writing `vector.toml`; however it should also more easily enable users
to use a set of configuration files. We do currently support globbing,
but that has the disadvantage of causing a failure on start-up if the
glob doesn't match any files (which I think is correct behavior).

Inspiration for this feature was taken from
[`consul`](https://www.consul.io/docs/agent/options#commandline_options).

TODOs:

- [x] Better rendering of config file paths in log output. It currently
  renders things like `File("/tmp/vector/vector.toml", None)`
- [x] Fix tests

Open questions:

- Do we want to change the default to look for anything in `/etc/vector`
  by default rather than specifically `/etc/vector/vector.toml`? This
  would be a backwards incompatible change, but seemingly unlikely to
  be hit by users.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
