### PR TITLE
feat(elasticsearch sink): handle data stream mode

### DIFF
--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -153,7 +153,7 @@ components: sinks: elasticsearch: {
 		}
 		bulk_action: {
 			common:      false
-			description: "Action to use when making requests to the [Elasticsearch Bulk API](elasticsearch_bulk). Currently, Vector only supports `index` and `create`. `update` and `delete` actions are not supported."
+			description: "Action to use when making requests to the [Elasticsearch Bulk API](elasticsearch_bulk). Currently, Vector only supports `index` and `create` in the `regular` mode and `create` in `data_stream` mode. `update` and `delete` actions are not supported."
 			required:    false
 			warnings: []
 			type: string: {
@@ -201,6 +201,17 @@ components: sinks: elasticsearch: {
 				default: "vector-%F"
 				examples: ["application-{{ application_id }}-%Y-%m-%d", "vector-%Y-%m-%d"]
 				syntax: "template"
+			}
+		}
+		mode: {
+			common:      true
+			description: "The type of index mechanism. If `data_stream` mode is enabled, the `bulk_action` is set to `create`."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "regular"
+				examples: ["regular", "data_stream"]
+				syntax: "literal"
 			}
 		}
 		pipeline: {

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -162,6 +162,61 @@ components: sinks: elasticsearch: {
 				syntax: "template"
 			}
 		}
+		data_stream: {
+			common:      false
+			description: "Options for the data stream mode."
+			required:    false
+			warnings: []
+			type: object: {
+				examples: []
+				options: {
+					auto_routing: {
+						description: """
+							Automatically routes events by deriving the data stream name using specific event fields with the `data_stream.type-data_stream.dataset-data_stream.namespace` format.
+
+							If enabled, the data_stream.* event fields will take precedence over the data_stream.type, data_stream.dataset, and data_stream.namespace settings, but will fall back to them if any of the fields are missing from the event.
+						"""
+						required: false
+						warnings: []
+						type: string: {
+							default: "generic"
+							examples: ["generic", "nginx"]
+							syntax: "literal"
+						}
+					}
+					dataset: {
+						description: "The data stream dataset used to construct the data stream at index time."
+						required:    false
+						warnings: []
+						type: string: {
+							default: "generic"
+							examples: ["generic", "nginx"]
+							syntax: "literal"
+						}
+					}
+					namespace: {
+						description: "The data stream namespace used to construct the data stream at index time."
+						required:    false
+						warnings: []
+						type: string: {
+							default: "default"
+							examples: ["default"]
+							syntax: "literal"
+						}
+					}
+					type: {
+						description: "The data stream type used to construct the data stream at index time."
+						required:    false
+						warnings: []
+						type: string: {
+							default: "logs"
+							examples: ["logs", "metrics", "synthetics"]
+							syntax: "literal"
+						}
+					}
+				}
+			}
+		}
 		doc_type: {
 			common:      false
 			description: "The `doc_type` for your index data. This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to set this option since Elasticsearch has removed it."
@@ -257,9 +312,8 @@ components: sinks: elasticsearch: {
 		data_streams: {
 			title: "Data streams"
 			body: """
-				By default, Vector will use the `index` action with Elasticsearch's Bulk API.
-				To use [Data streams][urls.elasticsearch_data_streams], `bulk_action` must be configured
-				with the `create` option.
+				To use [Data streams][urls.elasticsearch_data_streams], set the `mode` to `data_stream`.
+				The `index` is not used but use the combination of `data_stream.type`, `data_stream.dataset` and `data_stream.namespace`.
 				"""
 		}
 

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -171,6 +171,7 @@ components: sinks: elasticsearch: {
 				examples: []
 				options: {
 					auto_routing: {
+						common: false
 						description: """
 							Automatically routes events by deriving the data stream name using specific event fields with the `data_stream.type-data_stream.dataset-data_stream.namespace` format.
 
@@ -178,13 +179,10 @@ components: sinks: elasticsearch: {
 						"""
 						required: false
 						warnings: []
-						type: string: {
-							default: "generic"
-							examples: ["generic", "nginx"]
-							syntax: "literal"
-						}
+						type: bool: default: true
 					}
 					dataset: {
+						common:      false
 						description: "The data stream dataset used to construct the data stream at index time."
 						required:    false
 						warnings: []
@@ -195,6 +193,7 @@ components: sinks: elasticsearch: {
 						}
 					}
 					namespace: {
+						common:      false
 						description: "The data stream namespace used to construct the data stream at index time."
 						required:    false
 						warnings: []
@@ -204,7 +203,15 @@ components: sinks: elasticsearch: {
 							syntax: "literal"
 						}
 					}
+					sync_fields: {
+						common:      false
+						description: "Automatically adds and syncs the data_stream.* event fields if they are missing from the event. This ensures that fields match the name of the data stream that is receiving events."
+						required:    false
+						warnings: []
+						type: bool: default: true
+					}
 					type: {
+						common:      false
 						description: "The data stream type used to construct the data stream at index time."
 						required:    false
 						warnings: []

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -271,8 +271,8 @@ components: sinks: elasticsearch: {
 			required:    false
 			warnings: []
 			type: string: {
-				default: "regular"
-				examples: ["regular", "data_stream"]
+				default: "normal"
+				examples: ["normal", "data_stream"]
 				syntax: "literal"
 			}
 		}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -188,8 +188,8 @@ components: sinks: elasticsearch: {
 						warnings: []
 						type: string: {
 							default: "generic"
-							examples: ["generic", "nginx"]
-							syntax: "literal"
+							examples: ["generic", "nginx", "{{ service }}"]
+							syntax: "template"
 						}
 					}
 					namespace: {
@@ -199,8 +199,8 @@ components: sinks: elasticsearch: {
 						warnings: []
 						type: string: {
 							default: "default"
-							examples: ["default"]
-							syntax: "literal"
+							examples: ["default", "{{ environment }}"]
+							syntax: "template"
 						}
 					}
 					sync_fields: {
@@ -217,8 +217,8 @@ components: sinks: elasticsearch: {
 						warnings: []
 						type: string: {
 							default: "logs"
-							examples: ["logs", "metrics", "synthetics"]
-							syntax: "literal"
+							examples: ["logs", "metrics", "synthetics", "{{ type }}"]
+							syntax: "template"
 						}
 					}
 				}

--- a/scripts/setup_integration/elasticsearch_integration_env.sh
+++ b/scripts/setup_integration/elasticsearch_integration_env.sh
@@ -23,13 +23,13 @@ start_podman () {
   podman run -d --pod=vector-test-integration-elasticsearch --name vector_localstack_es \
 	 -e SERVICES=elasticsearch:4571 localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
   podman run -d --pod=vector-test-integration-elasticsearch \
-	 --name vector_elasticsearch -e discovery.type=single-node -e ES_JAVA_OPTS="-Xms400m -Xmx400m" elasticsearch:6.6.2
+	 --name vector_elasticsearch -e discovery.type=single-node -e ES_JAVA_OPTS="-Xms400m -Xmx400m" elasticsearch:7.13.1
   podman run -d --pod=vector-test-integration-elasticsearch \
 	 --name vector_elasticsearch-tls -e discovery.type=single-node -e xpack.security.enabled=true \
 	 -e xpack.security.http.ssl.enabled=true -e xpack.security.transport.ssl.enabled=true \
 	 -e xpack.ssl.certificate=certs/localhost.crt -e xpack.ssl.key=certs/localhost.key \
 	 -e ES_JAVA_OPTS="-Xms400m -Xmx400m" \
-	 -v "$(pwd)"/tests/data:/usr/share/elasticsearch/config/certs:ro elasticsearch:6.6.2
+	 -v "$(pwd)"/tests/data:/usr/share/elasticsearch/config/certs:ro elasticsearch:7.13.1
 }
 
 start_docker () {
@@ -37,13 +37,13 @@ start_docker () {
   docker run -d --network=vector-test-integration-elasticsearch -p 4571:4571 --name vector_localstack_es \
 	 -e SERVICES=elasticsearch:4571 localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
   docker run -d --network=vector-test-integration-elasticsearch -p 9200:9200 -p 9300:9300 \
-	 --name vector_elasticsearch -e discovery.type=single-node -e ES_JAVA_OPTS="-Xms400m -Xmx400m" elasticsearch:6.6.2
+	 --name vector_elasticsearch -e discovery.type=single-node -e ES_JAVA_OPTS="-Xms400m -Xmx400m" elasticsearch:7.13.1
   docker run -d --network=vector-test-integration-elasticsearch -p 9201:9200 -p 9301:9300 \
 	 --name vector_elasticsearch-tls -e discovery.type=single-node -e xpack.security.enabled=true \
 	 -e xpack.security.http.ssl.enabled=true -e xpack.security.transport.ssl.enabled=true \
 	 -e xpack.ssl.certificate=certs/localhost.crt -e xpack.ssl.key=certs/localhost.key \
 	 -e ES_JAVA_OPTS="-Xms400m -Xmx400m" \
-	 -v "$(pwd)"/tests/data:/usr/share/elasticsearch/config/certs:ro elasticsearch:6.6.2
+	 -v "$(pwd)"/tests/data:/usr/share/elasticsearch/config/certs:ro elasticsearch:7.13.1
 }
 
 stop_podman () {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -413,7 +413,7 @@ impl ElasticSearchCommon {
     fn build_action(
         &self,
         index: &str,
-        bulk_action: &BulkAction,
+        bulk_action: BulkAction,
         event: &mut Event,
     ) -> serde_json::Value {
         let mut action = json!({
@@ -445,7 +445,7 @@ impl HttpSink for ElasticSearchCommon {
         }
 
         let bulk_action = self.mode.bulk_action(&event)?;
-        let action = self.build_action(&index, &bulk_action, &mut event);
+        let action = self.build_action(&index, bulk_action, &mut event);
 
         let mut body = serde_json::to_vec(&action).unwrap();
         body.push(b'\n');

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -283,15 +283,16 @@ pub enum BulkAction {
     Create,
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 impl BulkAction {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             BulkAction::Index => "index",
             BulkAction::Create => "create",
         }
     }
 
-    pub fn as_json_pointer(self) -> &'static str {
+    pub fn as_json_pointer(&self) -> &'static str {
         match self {
             BulkAction::Index => "/index",
             BulkAction::Create => "/create",

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -113,7 +113,7 @@ impl Default for ElasticSearchMode {
     }
 }
 
-#[derive(Derivative, Deserialize, Serialize, Clone, Debug)]
+#[derive(Derivative, Deserialize, Serialize, Clone, Copy, Debug)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum BulkAction {
     Index,
@@ -121,15 +121,15 @@ pub enum BulkAction {
 }
 
 impl BulkAction {
-    pub fn as_str(&self) -> &'static str {
-        match *self {
+    pub fn as_str(self) -> &'static str {
+        match self {
             BulkAction::Index => "index",
             BulkAction::Create => "create",
         }
     }
 
-    pub fn as_json_pointer(&self) -> &'static str {
-        match *self {
+    pub fn as_json_pointer(self) -> &'static str {
+        match self {
             BulkAction::Index => "/index",
             BulkAction::Create => "/create",
         }


### PR DESCRIPTION
This PR introduce the `data_stream` mode. The `bulk_action` is automatically set to `create` when using this mode.

## vector.toml example
``` toml
[sources.random]
type = "generator"
format = "json"

# if you want to specify the @timestamp field in vector, otherwise elasticsearch will set it itself
[transforms.random_clean]
type = "remap"
inputs = ["random"]
source = '''
.@timestamp = to_string(.timestamp) ?? to_string(now())
'''

[sinks.elastic]
type = "elasticsearch"
inputs = ["random_clean"]
endpoint = "http://localhost:9200"
index = "my-data-stream"
mode = "data_stream"
```

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>
