### PR TITLE
chore: Convert cargo-flake run to matrix format

### DIFF
--- a/.github/workflows/cargo_flake.yml
+++ b/.github/workflows/cargo_flake.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     strategy:
       matrix:
-        target: [bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics]
+        target: [default, bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6

--- a/.github/workflows/cargo_flake.yml
+++ b/.github/workflows/cargo_flake.yml
@@ -17,8 +17,11 @@ env:
 
 jobs:
   hack:
-    runs-on: [self-hosted, linux, x64, general]
     name: Cargo Flake
+    runs-on: [self-hosted, linux, x64, general]
+    strategy:
+      matrix:
+        target: [default, benches, metrics-benches, remap-benches]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6
@@ -33,4 +36,4 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: cargo install cargo-flake
       - run: make slim-builds
-      - run: cargo flake --features 'default benches metrics-benches remap-benches'
+      - run: cargo flake --features $${ matrix.target }}

--- a/.github/workflows/cargo_flake.yml
+++ b/.github/workflows/cargo_flake.yml
@@ -5,6 +5,7 @@
 name: cargo_flake
 
 on:
+  pull_request: # temporary
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -21,7 +22,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     strategy:
       matrix:
-        target: [default, benches, metrics-benches, remap-benches]
+        target: [bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6
@@ -36,4 +37,4 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: cargo install cargo-flake
       - run: make slim-builds
-      - run: cargo flake --features $${ matrix.target }}
+      - run: cargo flake --features "$${ matrix.target }}"


### PR DESCRIPTION
Our nightly cargo-flake runs have been timing out at the 6 hour limit. This
means we don't actually get a read on whether or not the build's tests are
flakey. This commit spreads each feature out in parallel as there's no purpose
to running them in serial as we do now.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
