### PR TITLE
chore(tests): Pin kafka version due to missing zstd support in latest

### DIFF
--- a/scripts/setup_integration/kafka_integration_env.sh
+++ b/scripts/setup_integration/kafka_integration_env.sh
@@ -21,6 +21,7 @@ ACTION=$1
 start_podman () {
   podman pod create --replace --name vector-test-integration-kafka -p 2181:2181 -p 9091-9093:9091-9093
   podman run -d --pod=vector-test-integration-kafka --name vector_zookeeper wurstmeister/zookeeper
+   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
   podman run -d --pod=vector-test-integration-kafka -e KAFKA_BROKER_ID=1 \
 	 -e KAFKA_ZOOKEEPER_CONNECT=vector_zookeeper:2181 -e KAFKA_LISTENERS=PLAINTEXT://:9091,SSL://:9092,SASL_PLAINTEXT://:9093 \
 	 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9091,SSL://localhost:9092,SASL_PLAINTEXT://localhost:9093 \
@@ -30,13 +31,13 @@ start_podman () {
 	 -e KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf" \
 	 -e KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT -e KAFKA_SASL_ENABLED_MECHANISMS=PLAIN \
 	 -e KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN -v "$(pwd)"/tests/data/localhost.p12:/certs/localhost.p12:ro \
-   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
 	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka:2.13-2.6.0
 }
 
 start_docker () {
   docker network create vector-test-integration-kafka
   docker run -d --network=vector-test-integration-kafka -p 2181:2181 --name vector_zookeeper wurstmeister/zookeeper
+   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
   docker run -d --network=vector-test-integration-kafka -p 9091-9093:9091-9093 -e KAFKA_BROKER_ID=1 \
 	 -e KAFKA_ZOOKEEPER_CONNECT=vector_zookeeper:2181 -e KAFKA_LISTENERS=PLAINTEXT://:9091,SSL://:9092,SASL_PLAINTEXT://:9093 \
 	 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9091,SSL://localhost:9092,SASL_PLAINTEXT://localhost:9093 \
@@ -46,7 +47,6 @@ start_docker () {
 	 -e KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf" \
 	 -e KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT -e KAFKA_SASL_ENABLED_MECHANISMS=PLAIN \
 	 -e KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN -v "$(pwd)"/tests/data/localhost.p12:/certs/localhost.p12:ro \
-   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
 	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka:2.13-2.6.0
 }
 

--- a/scripts/setup_integration/kafka_integration_env.sh
+++ b/scripts/setup_integration/kafka_integration_env.sh
@@ -30,7 +30,8 @@ start_podman () {
 	 -e KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf" \
 	 -e KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT -e KAFKA_SASL_ENABLED_MECHANISMS=PLAIN \
 	 -e KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN -v "$(pwd)"/tests/data/localhost.p12:/certs/localhost.p12:ro \
-	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka
+   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
+	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka:2.13-2.6.0
 }
 
 start_docker () {
@@ -45,7 +46,8 @@ start_docker () {
 	 -e KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf" \
 	 -e KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT -e KAFKA_SASL_ENABLED_MECHANISMS=PLAIN \
 	 -e KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN -v "$(pwd)"/tests/data/localhost.p12:/certs/localhost.p12:ro \
-	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka
+   # pinned to 2.6.0 due to https://github.com/wurstmeister/kafka-docker/issues/669
+	 -v "$(pwd)"/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf --name vector_kafka wurstmeister/kafka:2.13-2.6.0
 }
 
 stop_podman () {


### PR DESCRIPTION
Ref: https://github.com/wurstmeister/kafka-docker/issues/669

Fixes broken integration tests:
https://github.com/timberio/vector/runs/2766357722?check_suite_focus=true

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
