### PR TITLE
chore: Initial work on new transform benchmarks

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, benchmarks]
     strategy:
       matrix:
-        target: [bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics, bench-dnstap]
+        target: [bench, bench-remap-functions, bench-remap, bench-wasm, bench-languages, bench-metrics, bench-dnstap, bench-transform]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,12 +1352,8 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
-<<<<<<< HEAD
- "itertools 0.10.1",
-=======
  "futures 0.3.15",
- "itertools 0.10.0",
->>>>>>> 8807933ca (introduce reduce)
+ "itertools 0.10.1",
  "lazy_static",
  "num-traits",
  "oorandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,12 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+<<<<<<< HEAD
  "itertools 0.10.1",
+=======
+ "futures 0.3.15",
+ "itertools 0.10.0",
+>>>>>>> 8807933ca (introduce reduce)
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1364,6 +1369,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -700,7 +700,7 @@ language-benches = ["sinks-socket", "sources-socket", "transforms-add_fields", "
 statistic-benches = []
 metrics-benches = ["sinks-socket", "sources-socket"]
 remap-benches = ["transforms-add_fields", "transforms-coercer", "transforms-json_parser", "transforms-remap"]
-transform-benches = []
+transform-benches = ["transforms-filter"]
 wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-lua", "transforms-remap", "transforms-wasm"]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ tonic-build = { version = "0.4", default-features = false, features = ["transpor
 approx = "0.5.0"
 assert_cmd = "1.0.5"
 base64 = "0.13.0"
-criterion = { version = "0.3.4", features = ["html_reports"] }
+criterion = { version = "0.3.4", features = ["html_reports", "async_tokio"] }
 httpmock = { version = "0.5.8", default-features = false }
 libc = "0.2.97"
 libz-sys = "1.1.3"
@@ -700,7 +700,7 @@ language-benches = ["sinks-socket", "sources-socket", "transforms-add_fields", "
 statistic-benches = []
 metrics-benches = ["sinks-socket", "sources-socket"]
 remap-benches = ["transforms-add_fields", "transforms-coercer", "transforms-json_parser", "transforms-remap"]
-transform-benches = ["transforms-filter", "transforms-dedupe"]
+transform-benches = ["transforms-filter", "transforms-dedupe", "transforms-reduce"]
 wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-lua", "transforms-remap", "transforms-wasm"]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -700,7 +700,7 @@ language-benches = ["sinks-socket", "sources-socket", "transforms-add_fields", "
 statistic-benches = []
 metrics-benches = ["sinks-socket", "sources-socket"]
 remap-benches = ["transforms-add_fields", "transforms-coercer", "transforms-json_parser", "transforms-remap"]
-transform-benches = ["transforms-filter"]
+transform-benches = ["transforms-filter", "transforms-dedupe"]
 wasm-benches = ["transforms-add_fields", "transforms-field_filter", "transforms-lua", "transforms-remap", "transforms-wasm"]
 
 [[bench]]

--- a/benches/transform/common.rs
+++ b/benches/transform/common.rs
@@ -50,7 +50,7 @@ pub fn consume<T>(mut stream: Pin<Box<dyn Stream<Item = T>>>) {
 // ==== FixedLogStream ====
 
 /// A fixed size [`futures::stream::Stream`] of `Event::Log` instances.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FixedLogStream {
     events: Vec<Event>,
 }
@@ -78,6 +78,14 @@ impl FixedLogStream {
     /// measure you're trying to establish.
     pub fn new_from_vec(events: Vec<Event>) -> Self {
         FixedLogStream { events }
+    }
+
+    /// Return the length of the fixed stream
+    ///
+    /// This function will return the length of the items remaining in the
+    /// stream.
+    pub fn len(&self) -> usize {
+        self.events.len()
     }
 }
 

--- a/benches/transform/common.rs
+++ b/benches/transform/common.rs
@@ -1,0 +1,26 @@
+//! A common suite of structs, functions et al that are useful for the
+//! benchmarking of vector transforms.
+use vector::conditions::Condition;
+use vector::event::Event;
+
+#[derive(Debug, Clone)]
+/// A struct that will always pass its check `Event`s.
+pub struct AlwaysPass;
+
+impl Condition for AlwaysPass {
+    #[inline]
+    fn check(&self, _event: &Event) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A struct that will always fail its check `Event`s.
+pub struct AlwaysFail;
+
+impl Condition for AlwaysFail {
+    #[inline]
+    fn check(&self, _event: &Event) -> bool {
+        false
+    }
+}

--- a/benches/transform/common.rs
+++ b/benches/transform/common.rs
@@ -1,7 +1,16 @@
 //! A common suite of structs, functions et al that are useful for the
 //! benchmarking of vector transforms.
+use futures::task::noop_waker;
+use futures::Stream;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use vector::conditions::Condition;
 use vector::event::Event;
+
+// == Conditions ==
+
+// ==== AlwaysPass ====
 
 #[derive(Debug, Clone)]
 /// A struct that will always pass its check `Event`s.
@@ -14,6 +23,8 @@ impl Condition for AlwaysPass {
     }
 }
 
+// ==== AlwaysFail ====
+
 #[derive(Debug, Clone)]
 /// A struct that will always fail its check `Event`s.
 pub struct AlwaysFail;
@@ -22,5 +33,64 @@ impl Condition for AlwaysFail {
     #[inline]
     fn check(&self, _event: &Event) -> bool {
         false
+    }
+}
+
+// == Streams ==
+
+/// Consume a `Stream<T>` and do nothing with the received Items, runs to
+/// completion
+pub fn consume<T>(mut stream: Pin<Box<dyn Stream<Item = T>>>) {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+
+    while let Poll::Ready(Some(_)) = stream.as_mut().poll_next(&mut context) {}
+}
+
+// ==== FixedLogStream ====
+
+/// A fixed size [`futures::stream::Stream`] of `Event::Log` instances.
+#[derive(Debug)]
+pub struct FixedLogStream {
+    events: Vec<Event>,
+}
+
+impl FixedLogStream {
+    /// Create a new `FixedLogStream` with `total` unspecified `Event` instances
+    /// internal. `cycle_size` controls how often an `Event` will repeat.
+    ///
+    /// This constructor is useful for benchmarks where you do not care how the
+    /// `Event`s are shaped, only that they exist.
+    pub fn new(total: NonZeroUsize, cycle_size: NonZeroUsize) -> Self {
+        let mut events = Vec::with_capacity(total.get());
+        let mut cycle = 0;
+        for _ in 0..total.get() {
+            events.push(Event::from(format!("event{}", cycle)));
+            cycle = (cycle + 1) % cycle_size;
+        }
+        Self::new_from_vec(events)
+    }
+
+    /// Create a new `FixedLogStream` from an `Vec<Event>`
+    ///
+    /// This constructor is useful for benchmarks where you do care how the
+    /// `Event`s are shaped, that is, their specific details are relevant to the
+    /// measure you're trying to establish.
+    pub fn new_from_vec(events: Vec<Event>) -> Self {
+        FixedLogStream { events }
+    }
+}
+
+impl Stream for FixedLogStream {
+    type Item = Event;
+
+    fn poll_next(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        Poll::Ready(this.events.pop())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.events.len(), Some(self.events.len()))
     }
 }

--- a/benches/transform/dedupe.rs
+++ b/benches/transform/dedupe.rs
@@ -1,0 +1,130 @@
+use crate::common::{consume, FixedLogStream};
+use core::fmt;
+use criterion::BenchmarkId;
+use criterion::{
+    criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion, SamplingMode,
+    Throughput,
+};
+use std::num::NonZeroUsize;
+use std::time::Duration;
+use vector::transforms::dedupe::{CacheConfig, FieldMatchConfig};
+use vector::transforms::dedupe::{Dedupe, DedupeConfig};
+use vector_core::transform::Transform;
+
+#[derive(Debug)]
+struct Param {
+    slug: &'static str,
+    input_size: NonZeroUsize,
+    cycle_size: NonZeroUsize,
+    dedupe_config: DedupeConfig,
+}
+
+impl fmt::Display for Param {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}:({}, {})",
+            self.slug, self.input_size, self.cycle_size
+        )
+    }
+}
+
+fn dedupe(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> =
+        c.benchmark_group("vector::transforms::dedupe::Dedupe");
+    group.sampling_mode(SamplingMode::Auto);
+
+    for param in &[
+        // Measurement where field "message" is ignored. This field is
+        // automatically added by the LogEvent construction mechanism.
+        Param {
+            slug: "field_ignore_message",
+            input_size: NonZeroUsize::new(128).unwrap(),
+            cycle_size: NonZeroUsize::new(2).unwrap(),
+            dedupe_config: DedupeConfig {
+                fields: Some(FieldMatchConfig::IgnoreFields(vec![String::from(
+                    "message",
+                )])),
+                cache: CacheConfig { num_events: 4 },
+            },
+        },
+        // Modification of previous where field "message" is matched.
+        Param {
+            slug: "field_match_message",
+            input_size: NonZeroUsize::new(128).unwrap(),
+            cycle_size: NonZeroUsize::new(2).unwrap(),
+            dedupe_config: DedupeConfig {
+                fields: Some(FieldMatchConfig::MatchFields(vec![String::from("message")])),
+                cache: CacheConfig { num_events: 4 },
+            },
+        },
+        // Measurement where ignore fields do not exist in the event.
+        Param {
+            slug: "field_ignore_dne",
+            input_size: NonZeroUsize::new(128).unwrap(),
+            cycle_size: NonZeroUsize::new(2).unwrap(),
+            dedupe_config: DedupeConfig {
+                cache: CacheConfig { num_events: 4 },
+                fields: Some(FieldMatchConfig::IgnoreFields(vec![
+                    String::from("abcde"),
+                    String::from("eabcd"),
+                    String::from("deabc"),
+                    String::from("cdeab"),
+                    String::from("bcdea"),
+                ])),
+            },
+        },
+        // Modification of previous where match fields do not exist in the
+        // event.
+        Param {
+            slug: "field_match_dne",
+            input_size: NonZeroUsize::new(128).unwrap(),
+            cycle_size: NonZeroUsize::new(2).unwrap(),
+            dedupe_config: DedupeConfig {
+                cache: CacheConfig { num_events: 4 },
+                fields: Some(FieldMatchConfig::MatchFields(vec![
+                    String::from("abcde"),
+                    String::from("eabcd"),
+                    String::from("deabc"),
+                    String::from("cdeab"),
+                    String::from("bcdea"),
+                ])),
+            },
+        },
+    ] {
+        group.throughput(Throughput::Elements(param.input_size.get() as u64));
+        group.bench_with_input(BenchmarkId::new("transform", param), &param, |b, param| {
+            b.iter_batched(
+                || {
+                    let dedupe =
+                        Transform::task(Dedupe::new(param.dedupe_config.clone())).into_task();
+                    let input = FixedLogStream::new(param.input_size, param.cycle_size);
+                    (Box::new(dedupe), Box::pin(input))
+                },
+                |(dedupe, input)| {
+                    let output = dedupe.transform(input);
+                    consume(output)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(5))
+        .measurement_time(Duration::from_secs(120))
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(100_000)
+        // total samples to collect within the set measurement time
+        .sample_size(150);
+    targets = dedupe
+);

--- a/benches/transform/filter.rs
+++ b/benches/transform/filter.rs
@@ -1,0 +1,62 @@
+use crate::common::AlwaysFail;
+use crate::common::AlwaysPass;
+use criterion::{
+    criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion, SamplingMode,
+    Throughput,
+};
+use std::time::Duration;
+use vector::transforms::filter::Filter;
+use vector::transforms::FunctionTransform;
+use vector_core::event::{Event, LogEvent};
+
+///
+/// `Filter::transform` benchmarks
+///
+/// This benchmark examines the `transform` of `Filter`, demonstrating that its
+/// performance is bounded entirely by that of the `Condition`. The two cases
+/// below, `always_pass` and `always_fail` use `common::AlwaysPass` and
+/// `common::AlwaysFail` as the interior condition of the filter.
+///
+fn filter(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> =
+        c.benchmark_group("vector::transforms::filter::Filter");
+    group.sampling_mode(SamplingMode::Auto);
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("transform/always_fail", |b| {
+        b.iter_batched(
+            || {
+                let filter = Filter::new(Box::new(AlwaysFail));
+                let output = Vec::with_capacity(4); // arbitrary constant larger
+                                                    // than output
+                let event = Event::Log(LogEvent::default());
+                (filter, output, event)
+            },
+            |(mut filter, mut output, event)| filter.transform(&mut output, event),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("transform/always_pass", |b| {
+        b.iter_batched(
+            || {
+                let filter = Filter::new(Box::new(AlwaysPass));
+                let output = Vec::with_capacity(4); // arbitrary constant larger
+                                                    // than output
+                let event = Event::Log(LogEvent::default());
+                (filter, output, event)
+            },
+            |(mut filter, mut output, event)| filter.transform(&mut output, event),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(60))
+        .confidence_level(0.99)
+        .nresamples(250_000)
+        .sample_size(250);
+    targets = filter
+);

--- a/benches/transform/main.rs
+++ b/benches/transform/main.rs
@@ -3,5 +3,6 @@ use criterion::criterion_main;
 mod common;
 mod dedupe;
 mod filter;
+mod reduce;
 
-criterion_main!(dedupe::benches, filter::benches,);
+criterion_main!(reduce::benches, dedupe::benches, filter::benches,);

--- a/benches/transform/main.rs
+++ b/benches/transform/main.rs
@@ -5,4 +5,4 @@ mod dedupe;
 mod filter;
 mod reduce;
 
-criterion_main!(reduce::benches, dedupe::benches, filter::benches,);
+criterion_main!(dedupe::benches, filter::benches, reduce::benches,);

--- a/benches/transform/main.rs
+++ b/benches/transform/main.rs
@@ -1,1 +1,6 @@
-fn main() {}
+use criterion::criterion_main;
+
+mod common;
+mod filter;
+
+criterion_main!(filter::benches);

--- a/benches/transform/main.rs
+++ b/benches/transform/main.rs
@@ -1,6 +1,7 @@
 use criterion::criterion_main;
 
 mod common;
+mod dedupe;
 mod filter;
 
-criterion_main!(filter::benches);
+criterion_main!(dedupe::benches, filter::benches,);

--- a/benches/transform/reduce.rs
+++ b/benches/transform/reduce.rs
@@ -1,0 +1,90 @@
+use crate::common::{consume, FixedLogStream};
+use core::fmt;
+use criterion::BenchmarkId;
+use criterion::{
+    criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion, SamplingMode,
+    Throughput,
+};
+use indexmap::IndexMap;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+use vector::transforms::reduce::{Reduce, ReduceConfig};
+use vector_core::transform::Transform;
+
+#[derive(Debug)]
+struct Param {
+    slug: &'static str,
+    input: FixedLogStream,
+    reduce_config: ReduceConfig,
+}
+
+impl fmt::Display for Param {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.slug,)
+    }
+}
+
+fn reduce(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> =
+        c.benchmark_group("vector::transforms::reduce::Reduce");
+    group.sampling_mode(SamplingMode::Auto);
+
+    let fixed_stream = FixedLogStream::new(
+        NonZeroUsize::new(128).unwrap(),
+        NonZeroUsize::new(2).unwrap(),
+    );
+    for param in &[
+        // The `Reduce` transform has a high configuration surface. For now we
+        // only benchmark the "proof of concept" configuration, demonstrating
+        // that the benchmark does minimally work. Once we have soak tests with
+        // reduces in them we should extend this array to include those
+        // configuratoins.
+        Param {
+            slug: "proof_of_concept",
+            input: fixed_stream.clone(),
+            reduce_config: ReduceConfig {
+                expire_after_ms: None,
+                flush_period_ms: None,
+                group_by: vec![String::from("message")],
+                merge_strategies: IndexMap::default(),
+                ends_when: None,
+                starts_when: None,
+            },
+        },
+    ] {
+        group.throughput(Throughput::Elements(param.input.len() as u64));
+        group.bench_with_input(BenchmarkId::new("transform", param), &param, |b, param| {
+            b.to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter_batched(
+                    || {
+                        let reduce =
+                            Transform::task(Reduce::new(&param.reduce_config).unwrap()).into_task();
+                        (Box::new(reduce), Box::pin(param.input.clone()))
+                    },
+                    |(reduce, input)| async {
+                        let output = reduce.transform(input);
+                        consume(output)
+                    },
+                    BatchSize::SmallInput,
+                )
+        });
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(5))
+        .measurement_time(Duration::from_secs(120))
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(100_000)
+        // total samples to collect within the set measurement time
+        .sample_size(150);
+    targets = reduce
+);

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -41,8 +41,9 @@ fn default_cache_config() -> CacheConfig {
 }
 
 impl DedupeConfig {
-    /// We cannot rely on Serde to populate the default since we want it to be based on the user's
-    /// configured log_schema, which we only know about after we've already parsed the config.
+    /// We cannot rely on Serde to populate the default since we want it to be
+    /// based on the user's configured log_schema, which we only know about
+    /// after we've already parsed the config.
     pub fn fill_default_fields_match(&self) -> FieldMatchConfig {
         match &self.fields {
             Some(FieldMatchConfig::MatchFields(x)) => FieldMatchConfig::MatchFields(x.clone()),
@@ -99,23 +100,27 @@ type TypeId = u8;
 
 /// A CacheEntry comes in two forms, depending on the FieldMatchConfig in use.
 ///
-/// When matching fields, a CacheEntry contains a vector of optional 2-tuples.  Each element in the
-/// vector represents one field in the corresponding LogEvent.  Elements in the vector will
-/// correspond 1:1 (and in order) to the fields specified in "fields.match".  The tuples each store
-/// the TypeId for this field and the data as Bytes for the field.  There is no need to store the
-/// field name because the elements of the vector correspond 1:1 to "fields.match", so there is
-/// never any ambiguity about what field is being referred to.  If a field from "fields.match" does
-/// not show up in an incoming Event, the CacheEntry will have None in the correspond location in
-/// the vector.
+/// When matching fields, a CacheEntry contains a vector of optional 2-tuples.
+/// Each element in the vector represents one field in the corresponding
+/// LogEvent. Elements in the vector will correspond 1:1 (and in order) to the
+/// fields specified in "fields.match". The tuples each store the TypeId for
+/// this field and the data as Bytes for the field. There is no need to store
+/// the field name because the elements of the vector correspond 1:1 to
+/// "fields.match", so there is never any ambiguity about what field is being
+/// referred to. If a field from "fields.match" does not show up in an incoming
+/// Event, the CacheEntry will have None in the correspond location in the
+/// vector.
 ///
-/// When ignoring fields, a CacheEntry contains a vector of 3-tuples.  Each element in the vector
-/// represents one field in the corresponding LogEvent.  The tuples will each contain the field
-/// name, TypeId, and data as Bytes for the corresponding field (in that order).  Since the set of
-/// fields that might go into CacheEntries is not known at startup, we must store the field names
-/// as part of CacheEntries.  Since Event objects store their field in alphabetic order (as they
-/// are backed by a BTreeMap), and we build CacheEntries by iterating over the fields of the
-/// incoming Events, we know that the CacheEntries for 2 equivalent events will always contain the
-/// fields in the same order.
+/// When ignoring fields, a CacheEntry contains a vector of 3-tuples. Each
+/// element in the vector represents one field in the corresponding LogEvent.
+/// The tuples will each contain the field name, TypeId, and data as Bytes for
+/// the corresponding field (in that order). Since the set of fields that might
+/// go into CacheEntries is not known at startup, we must store the field names
+/// as part of CacheEntries. Since Event objects store their field in alphabetic
+/// order (as they are backed by a BTreeMap), and we build CacheEntries by
+/// iterating over the fields of the incoming Events, we know that the
+/// CacheEntries for 2 equivalent events will always contain the fields in the
+/// same order.
 #[derive(PartialEq, Eq, Hash)]
 enum CacheEntry {
     Match(Vec<Option<(TypeId, Bytes)>>),
@@ -157,9 +162,9 @@ impl Dedupe {
     }
 }
 
-/// Takes in an Event and returns a CacheEntry to place into the LRU cache containing
-/// all relevant information for the fields that need matching against according to the
-/// specified FieldMatchConfig.
+/// Takes in an Event and returns a CacheEntry to place into the LRU cache
+/// containing all relevant information for the fields that need matching
+/// against according to the specified FieldMatchConfig.
 fn build_cache_entry(event: &Event, fields: &FieldMatchConfig) -> CacheEntry {
     match &fields {
         FieldMatchConfig::MatchFields(fields) => {
@@ -293,8 +298,8 @@ mod tests {
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
 
-        // Second event has a different matched field name with the same value, so it should not be
-        // considered a dupe
+        // Second event has a different matched field name with the same value,
+        // so it should not be considered a dupe
         let new_event = transform.transform_one(event2.clone()).unwrap();
         assert_eq!(new_event, event2);
     }
@@ -311,8 +316,9 @@ mod tests {
         field_order_irrelevant(transform);
     }
 
-    /// Test that two Events that are considered duplicates get handled that way, even
-    /// if the order of the matched fields is different between the two.
+    /// Test that two Events that are considered duplicates get handled that
+    /// way, even if the order of the matched fields is different between the
+    /// two.
     fn field_order_irrelevant(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched1", "value1");
@@ -327,7 +333,8 @@ mod tests {
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
 
-        // Second event is the same just with different field order, so it shouldn't be outputted.
+        // Second event is the same just with different field order, so it
+        // shouldn't be outputted.
         assert_eq!(None, transform.transform_one(event2));
     }
 
@@ -362,8 +369,8 @@ mod tests {
         let new_event = transform.transform_one(event2.clone()).unwrap();
         assert_eq!(new_event, event2);
 
-        // Third event is a dupe but gets outputted anyway because the first event has aged
-        // out of the cache.
+        // Third event is a dupe but gets outputted anyway because the first
+        // event has aged out of the cache.
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
     }
@@ -380,8 +387,9 @@ mod tests {
         type_matching(transform);
     }
 
-    /// Test that two events with values for the matched fields that have different
-    /// types but the same string representation aren't considered duplicates.
+    /// Test that two events with values for the matched fields that have
+    /// different types but the same string representation aren't considered
+    /// duplicates.
     fn type_matching(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched", "123");
@@ -393,8 +401,8 @@ mod tests {
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
 
-        // Second event should also get passed through even though the string representations of
-        // "matched" are the same.
+        // Second event should also get passed through even though the string
+        // representations of "matched" are the same.
         let new_event = transform.transform_one(event2.clone()).unwrap();
         assert_eq!(new_event, event2);
     }
@@ -411,8 +419,9 @@ mod tests {
         type_matching_nested_objects(transform);
     }
 
-    /// Test that two events where the matched field is a sub object and that object contains values
-    /// that have different types but the same string representation aren't considered duplicates.
+    /// Test that two events where the matched field is a sub object and that
+    /// object contains values that have different types but the same string
+    /// representation aren't considered duplicates.
     fn type_matching_nested_objects(mut transform: Dedupe) {
         let mut map1: BTreeMap<String, Value> = BTreeMap::new();
         map1.insert("key".into(), "123".into());
@@ -428,8 +437,8 @@ mod tests {
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
 
-        // Second event should also get passed through even though the string representations of
-        // "matched" are the same.
+        // Second event should also get passed through even though the string
+        // representations of "matched" are the same.
         let new_event = transform.transform_one(event2.clone()).unwrap();
         assert_eq!(new_event, event2);
     }
@@ -457,7 +466,8 @@ mod tests {
         let new_event = transform.transform_one(event1.clone()).unwrap();
         assert_eq!(new_event, event1);
 
-        // Second event should also get passed through as null is different than missing
+        // Second event should also get passed through as null is different than
+        // missing
         let new_event = transform.transform_one(event2.clone()).unwrap();
         assert_eq!(new_event, event2);
     }

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -155,7 +155,7 @@ pub struct Reduce {
 }
 
 impl Reduce {
-    fn new(config: &ReduceConfig) -> crate::Result<Self> {
+    pub fn new(config: &ReduceConfig) -> crate::Result<Self> {
         if config.ends_when.is_some() && config.starts_when.is_some() {
             return Err("only one of `ends_when` and `starts_when` can be provided".into());
         }


### PR DESCRIPTION
This commit introduces new transform benchmarks, written to be the bottom-up peer of our soak testing work. That is, these benchmarks should stable per-transform and allow us to do "napkin math" on a vector config composed of benched transforms. If we measure that on such-and-such computer a topology of transforms can achieved X throughput but in soak testing find out that the config does Y and the two X and Y are not within some tolerance of one another we have a bug. 

In order to achieve that ultimate goal these benchmarks should eventually be rigged up to have transform configurations that are peered to a soak configuration. It's early days yet for soak testing in the vector project so the configs in this commit are guesses. The point here is to have something that works, is stable in CI and can be expanded. 

Resolves #7777

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
