### PR TITLE
chore: Correct clippy ding in master

### DIFF
--- a/src/sources/fluent.rs
+++ b/src/sources/fluent.rs
@@ -162,7 +162,7 @@ impl FluentDecoder {
             FluentMessage::Message(tag, timestamp, record)
             | FluentMessage::MessageWithOptions(tag, timestamp, record, ..) => {
                 self.unread_frames.push_back(FluentFrame {
-                    tag: tag.clone(),
+                    tag,
                     timestamp,
                     record,
                 });


### PR DESCRIPTION
This commit corrects a clippy ding regard the needless clone of tag in
sources/fluent.rs. Looks like clippy got smarter. Noticed this as a part of my
work on #7783 which does not interact.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
