### PR TITLE
chore: Rebuild vrl-parser only if parser.lalrpop has changed

### DIFF
--- a/lib/vrl/parser/build.rs
+++ b/lib/vrl/parser/build.rs
@@ -1,10 +1,9 @@
 extern crate lalrpop;
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/parser.lalrpop");
     lalrpop::Configuration::new()
         .always_use_colors()
         .process_current_dir()
         .unwrap();
-
-    println!("cargo:rerun-if-changed=src/parser.lalrpop");
 }


### PR DESCRIPTION
The build.rs for vrl-parser placed its rerun-if-changed at the bottom of the
build.rs file, meaning cargo would not know to check if the grammer had changed
until after it had already rebuilt. This commit should save a minute of cycle
time, noticed as I was working on #7783.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
