### PR TITLE
chore(ci)!: Update tested Kubernetes versions

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -95,15 +95,16 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.15.1",
+              "v1.20.0",
             ]
             const kubernetes_version = [
-              { version: "v1.19.2", is_essential: true },
-              { version: "v1.18.9" },
-              { version: "v1.17.12" },
-              { version: "v1.16.15" }, // v1.16.13 is broken, see https://github.com/kubernetes/kubernetes/issues/93194
+              { version: "v1.21.2", is_essential: true },
+              { version: "v1.20.8" },
+              { version: "v1.19.12" },
+              { version: "v1.18.19" },
+              { version: "v1.17.17" },
+              { version: "v1.16.15" },
               { version: "v1.15.12" },
-              { version: "v1.14.10" },
             ]
             const container_runtime = [
               "docker",

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -95,14 +95,12 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.20.0",
+              "v1.15.1",
             ]
             const kubernetes_version = [
-              { version: "v1.21.1", is_essential: true }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
-              { version: "v1.20.7" }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
-              { version: "v1.19.11" },
-              { version: "v1.18.19" },
-              { version: "v1.17.17" },
+              { version: "v1.19.2", is_essential: true },
+              { version: "v1.18.9" },
+              { version: "v1.17.12" },
               { version: "v1.16.15" },
               { version: "v1.15.12" },
             ]

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -100,10 +100,10 @@ jobs:
             const kubernetes_version = [
               { version: "v1.21.1", is_essential: true }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
               { version: "v1.20.7" }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
-              { version: "v1.19.10" },
+              { version: "v1.19.11" },
               { version: "v1.18.19" },
               { version: "v1.17.17" },
-              { version: "v1.16.14" },
+              { version: "v1.16.15" },
               { version: "v1.15.12" },
             ]
             const container_runtime = [

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -100,10 +100,10 @@ jobs:
             const kubernetes_version = [
               { version: "v1.21.1", is_essential: true }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
               { version: "v1.20.7" }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
-              { version: "v1.19.11" },
+              { version: "v1.19.10" },
               { version: "v1.18.19" },
               { version: "v1.17.17" },
-              { version: "v1.16.15" },
+              { version: "v1.16.14" },
               { version: "v1.15.12" },
             ]
             const container_runtime = [

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -98,9 +98,9 @@ jobs:
               "v1.20.0",
             ]
             const kubernetes_version = [
-              { version: "v1.21.2", is_essential: true },
-              { version: "v1.20.8" },
-              { version: "v1.19.12" },
+              { version: "v1.21.1", is_essential: true }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
+              { version: "v1.20.7" }, // Has a known performance issue on cluster startup. It might take 2 to 3 minutes for a cluster to start.
+              { version: "v1.19.11" },
               { version: "v1.18.19" },
               { version: "v1.17.17" },
               { version: "v1.16.15" },

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -540,7 +540,7 @@ components: sources: kubernetes_logs: {
 				Vector is tested extensively against Kubernetes. In addition to Kubernetes
 				being Vector's most popular installation method, Vector implements a
 				comprehensive end-to-end test suite for all minor Kubernetes versions starting
-				with `1.14.
+				with `1.15`.
 				"""
 		}
 

--- a/docs/reference/installation/platforms/kubernetes.cue
+++ b/docs/reference/installation/platforms/kubernetes.cue
@@ -7,7 +7,7 @@ installation: platforms: kubernetes: {
 		open-source container-orchestration system for automating
 		application deployment, scaling, and management.
 		"""
-	minimum_supported_version: "1.14"
+	minimum_supported_version: "1.15"
 
 	how_it_works: {
 		components.sources.kubernetes_logs.how_it_works

--- a/docs/reference/services/kubernetes.cue
+++ b/docs/reference/services/kubernetes.cue
@@ -4,5 +4,5 @@ services: kubernetes: {
 	name:     "Kubernetes"
 	thing:    "a \(name) cluster"
 	url:      urls.kubernetes
-	versions: ">= 1.14"
+	versions: ">= 1.15"
 }


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

While Vector still _runs_ on kubernetes 1.14.x, as far as I can tell it's no longer offered/supported
by any major cloud provider. Right now #6564 is failing CI as we try to use a kubectl command that isn't
supported in 1.14.x (`rollout restart`).

This PR does the following:

- Drops 1.14.10

I'd also suggest consider adjusting our documentation around required/supported kubernetes versions. We'll also need to update and include more versions in a followup

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
