### PR TITLE
feat(elasticsearch sink): bulk action template

### DIFF
--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -158,7 +158,7 @@ components: sinks: elasticsearch: {
 			warnings: []
 			type: string: {
 				default: "index"
-				examples: ["{{ action }}"]
+				examples: ["index", "create", "{{ action }}"]
 				syntax: "template"
 			}
 		}

--- a/docs/reference/components/sinks/elasticsearch.cue
+++ b/docs/reference/components/sinks/elasticsearch.cue
@@ -158,8 +158,8 @@ components: sinks: elasticsearch: {
 			warnings: []
 			type: string: {
 				default: "index"
-				examples: ["index", "create"]
-				syntax: "literal"
+				examples: ["{{ action }}"]
+				syntax: "template"
 			}
 		}
 		doc_type: {

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -70,8 +70,7 @@ pub struct ElasticSearchConfig {
 impl ElasticSearchConfig {
     fn bulk_action(&self) -> crate::Result<Template> {
         let value = self.bulk_action.as_deref().unwrap_or("index");
-        let value = Template::try_from(value).context(BatchActionTemplate)?;
-        Ok(value)
+        Ok(Template::try_from(value).context(BatchActionTemplate)?)
     }
 }
 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -64,8 +64,15 @@ pub struct ElasticSearchConfig {
 
     pub aws: Option<RegionOrEndpoint>,
     pub tls: Option<TlsOptions>,
-    #[serde(default)]
-    pub bulk_action: BulkAction,
+    pub bulk_action: Option<String>,
+}
+
+impl ElasticSearchConfig {
+    fn bulk_action(&self) -> crate::Result<Template> {
+        let value = self.bulk_action.as_deref().unwrap_or("index");
+        let value = Template::try_from(value).context(BatchActionTemplate)?;
+        Ok(value)
+    }
 }
 
 lazy_static! {
@@ -110,6 +117,18 @@ impl BulkAction {
         match *self {
             BulkAction::Index => "/index",
             BulkAction::Create => "/create",
+        }
+    }
+}
+
+impl TryFrom<&str> for BulkAction {
+    type Error = String;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        match input {
+            "index" => Ok(BulkAction::Index),
+            "create" => Ok(BulkAction::Create),
+            _ => Err(format!("Invalid bulk action: {}", input)),
         }
     }
 }
@@ -176,7 +195,7 @@ pub struct ElasticSearchCommon {
     compression: Compression,
     region: Region,
     query_params: HashMap<String, String>,
-    bulk_action: BulkAction,
+    bulk_action: Template,
 }
 
 #[derive(Debug, Snafu)]
@@ -189,6 +208,38 @@ enum ParseError {
     AwsCredentialsGenerateFailed { source: CredentialsError },
     #[snafu(display("Index template parse error: {}", source))]
     IndexTemplate { source: TemplateParseError },
+    #[snafu(display("Batch action template parse error: {}", source))]
+    BatchActionTemplate { source: TemplateParseError },
+}
+
+impl ElasticSearchCommon {
+    fn index(&self, event: &Event) -> Option<String> {
+        self.index
+            .render_string(event)
+            .map_err(|error| {
+                emit!(TemplateRenderingFailed {
+                    error,
+                    field: Some("index"),
+                    drop_event: true,
+                });
+            })
+            .ok()
+    }
+
+    fn bulk_action(&self, event: &Event) -> Option<BulkAction> {
+        let value = self
+            .bulk_action
+            .render_string(event)
+            .map_err(|error| {
+                emit!(TemplateRenderingFailed {
+                    error,
+                    field: Some("bulk_action"),
+                    drop_event: true,
+                });
+            })
+            .ok()?;
+        BulkAction::try_from(value.as_str()).ok()
+    }
 }
 
 #[async_trait::async_trait]
@@ -197,29 +248,18 @@ impl HttpSink for ElasticSearchCommon {
     type Output = Vec<u8>;
 
     fn encode_event(&self, mut event: Event) -> Option<EncodedEvent<Self::Input>> {
-        let index = self
-            .index
-            .render_string(&event)
-            .map_err(|error| {
-                emit!(TemplateRenderingFailed {
-                    error,
-                    field: Some("index"),
-                    drop_event: true,
-                });
-            })
-            .ok()?;
+        let index = self.index(&event)?;
+        let bulk_action = self.bulk_action(&event)?;
 
         let mut action = json!({
-            self.bulk_action.as_str(): {
+            bulk_action.as_str(): {
                 "_index": index,
                 "_type": self.doc_type,
             }
         });
         maybe_set_id(
             self.config.id_key.as_ref(),
-            action
-                .pointer_mut(self.bulk_action.as_json_pointer())
-                .unwrap(),
+            action.pointer_mut(bulk_action.as_json_pointer()).unwrap(),
             &mut event,
         );
 
@@ -415,7 +455,7 @@ impl ElasticSearchCommon {
         let index = Template::try_from(index).context(IndexTemplate)?;
 
         let doc_type = config.doc_type.clone().unwrap_or_else(|| "_doc".into());
-        let bulk_action = config.bulk_action.clone();
+        let bulk_action = config.bulk_action()?;
 
         let request = config.request.tower.unwrap_with(&REQUEST_DEFAULTS);
 
@@ -601,7 +641,7 @@ mod tests {
         use chrono::{TimeZone, Utc};
 
         let config = ElasticSearchConfig {
-            bulk_action: BulkAction::Create,
+            bulk_action: Some(String::from("create")),
             index: Some(String::from("vector")),
             endpoint: String::from("https://example.com"),
             ..Default::default()
@@ -618,6 +658,38 @@ mod tests {
 {"message":"hello there","timestamp":"2020-12-01T01:02:03Z"}
 "#;
         assert_eq!(std::str::from_utf8(&encoded).unwrap(), expected);
+    }
+
+    #[test]
+    fn decode_bulk_action_error() {
+        let config = ElasticSearchConfig {
+            bulk_action: Some(String::from("{{ action }}")),
+            index: Some(String::from("vector")),
+            endpoint: String::from("https://example.com"),
+            ..Default::default()
+        };
+        let es = ElasticSearchCommon::parse_config(&config).unwrap();
+
+        let mut event = Event::from("hello world");
+        event.as_mut_log().insert("foo", "bar");
+        event.as_mut_log().insert("idx", "purple");
+        let action = es.bulk_action(&event);
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn decode_bulk_action() {
+        let config = ElasticSearchConfig {
+            bulk_action: Some(String::from("create")),
+            index: Some(String::from("vector")),
+            endpoint: String::from("https://example.com"),
+            ..Default::default()
+        };
+        let es = ElasticSearchCommon::parse_config(&config).unwrap();
+
+        let event = Event::from("hello there");
+        let action = es.bulk_action(&event).unwrap();
+        assert!(matches!(action, BulkAction::Create));
     }
 
     #[test]


### PR DESCRIPTION
Just adds the ability to use templating for the bulk action.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
