### PR TITLE
chore(ci): add tracking of workflow metrics for common workflows

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,32 @@
+name: Workflow Metrics
+on:
+  workflow_run:
+    workflows:
+      - 'Benchmark Suite'
+      - 'K8S E2E Suite'
+      - 'Test Suite'
+      - 'Integration Test Suite'
+      - 'Nightly'
+    types:
+      - completed
+
+permissions:
+  actions: read
+
+jobs:
+  report:
+    name: Report 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v2
+        with:
+          repository: timberio/gh-actions-workflow-metrics
+          ref: master
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          path: .github/actions/gh-actions-workflow-metrics
+      - name: Run Action
+        uses: ./.github/actions/gh-actions-workflow-metrics
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: nightly
+name: Nightly
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR adds a new workflow -- `metrics.yml` -- which is triggered by the completion of some of our other more common workflows, such as benchmarking and test suites.  When these workflows complete, this new workflow will extract metrics from them -- how long it was queued, how long it ran, success vs failure, etc -- and emit those metrics to our internal Datadog.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>