### PR TITLE
enhancement(tests): delete resources without waiting in k8s tests

### DIFF
--- a/lib/k8s-test-framework/src/namespace.rs
+++ b/lib/k8s-test-framework/src/namespace.rs
@@ -19,8 +19,17 @@ impl up_down::CommandBuilder for CommandBuilder {
                 up_down::CommandToBuild::Down => "delete",
             })
             .arg("namespace")
-            .arg(&self.namespace)
-            .stdin(Stdio::null());
+            .arg(&self.namespace);
+
+        if matches!(command_to_build, up_down::CommandToBuild::Down) {
+            // We don't need a graceful shutdown
+            command.arg("--force=true");
+            command.arg("--grace-period=0");
+            command.arg("--wait=false");
+        }
+
+        command.stdin(Stdio::null());
+
         command
     }
 }

--- a/lib/k8s-test-framework/src/test_pod.rs
+++ b/lib/k8s-test-framework/src/test_pod.rs
@@ -42,8 +42,16 @@ impl up_down::CommandBuilder for CommandBuilder {
                 up_down::CommandToBuild::Down => "delete",
             })
             .arg("-f")
-            .arg(self.config.test_pod_resource_file.path())
-            .stdin(Stdio::null());
+            .arg(self.config.test_pod_resource_file.path());
+
+        if matches!(command_to_build, up_down::CommandToBuild::Down) {
+            // We don't need a graceful shutdown
+            command.arg("--force=true");
+            command.arg("--grace-period=0");
+            command.arg("--wait=false");
+        }
+
+        command.stdin(Stdio::null());
         command
     }
 }

--- a/scripts/deploy-kubernetes-test.sh
+++ b/scripts/deploy-kubernetes-test.sh
@@ -102,7 +102,7 @@ down() {
     $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "vector"
   fi
 
-  $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"
+  $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE" --force=true --grace-period=0 --wait=false
 }
 
 case "$COMMAND" in

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -151,7 +151,6 @@ fi
 
 # Run the tests.
 cd lib/k8s-e2e-tests
-export RUST_LOG=debug
 cargo test \
   --no-fail-fast \
   --no-default-features \


### PR DESCRIPTION
Ref #7540 

This makes the k8s tests pass `--force=true --wait-period=0 --wait=false` when deleting pods and namespaces to prevent the tests from waiting around whilst clearing up. This shaves several minutes from the test time.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
