### PR TITLE
enhancement(tests): cleanup vector dir post k8s test

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -74,6 +74,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             # Host log directory mount.
             - name: var-log

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -50,28 +50,60 @@ pub fn is_multinode() -> bool {
 
 /// Adds a fullnameOverride entry to the given config. This allows multiple tests
 /// to be run against the same cluster without the role anmes clashing.
-pub fn config_override_name(config: &str, name: &str) -> String {
-    if is_multinode() {
+pub fn config_override_name(config: &str, name: &str, cleanup: bool) -> String {
+    let vectordir = if is_multinode() {
+        format!("{}-vector", name)
+    } else {
+        "vector".to_string()
+    };
+
+    let volumeconfig = if is_multinode() {
         formatdoc!(
             r#"
-            fullnameOverride: "{}"
             dataVolume:
               hostPath:
-                path: /var/lib/{}-vector/
-            {}"#,
-            name,
-            name,
-            config
+                path: /var/lib/{}/
+            "#,
+            vectordir,
         )
     } else {
+        String::new()
+    };
+
+    let cleanupconfig = if cleanup {
         formatdoc!(
             r#"
-            fullnameOverride: "{}"
-            {}"#,
-            name,
-            config
+        extraVolumeMounts:
+          - name: var-lib
+            mountPath: /var/writablelib
+            readOnly: false
+         
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - sh
+                - -c
+                - rm -rf /var/writablelib/{}
+                "#,
+            vectordir,
         )
-    }
+    } else {
+        String::new()
+    };
+
+    formatdoc!(
+        r#"
+        fullnameOverride: "{}"
+        {}
+        {}
+        {}
+        "#,
+        name,
+        volumeconfig,
+        cleanupconfig,
+        config
+    )
 }
 
 pub fn make_framework() -> Framework {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -77,7 +77,7 @@ pub fn config_override_name(config: &str, name: &str, cleanup: bool) -> String {
           - name: var-lib
             mountPath: /var/writablelib
             readOnly: false
-         
+
         lifecycle:
           preStop:
             exec:

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -67,7 +67,11 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -166,6 +170,7 @@ async fn simple_raw_config() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     HELM_VALUES_STDOUT_SINK_RAW_CONFIG,
                     &override_name,
+                    true,
                 ),
                 ..Default::default()
             },
@@ -258,7 +263,11 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -374,7 +383,11 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -447,7 +460,11 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -541,7 +558,11 @@ async fn pod_metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -674,7 +695,11 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -864,6 +889,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     &format!("{}\n{}", CONFIG, HELM_VALUES_STDOUT_SINK),
                     &override_name,
+                    true,
                 ),
                 ..Default::default()
             },
@@ -1053,7 +1079,11 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -1220,6 +1250,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     &format!("{}\n{}", config, HELM_VALUES_STDOUT_SINK),
                     &override_name,
+                    true,
                 ),
                 ..Default::default()
             },
@@ -1374,7 +1405,11 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -1494,6 +1529,7 @@ async fn additional_config_file() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     HELM_VALUES_ADDITIONAL_CONFIGMAP,
                     &override_name,
+                    true,
                 ),
                 custom_resource: CUSTOM_RESOURCE_VECTOR_CONFIG,
             },
@@ -1586,7 +1622,11 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name(HELM_VALUES_STDOUT_SINK, &override_name),
+                custom_helm_values: &config_override_name(
+                    HELM_VALUES_STDOUT_SINK,
+                    &override_name,
+                    true,
+                ),
                 ..Default::default()
             },
         )
@@ -1729,7 +1769,7 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGENT,
             VectorConfig {
-                custom_helm_values: &config_override_name("", &override_name),
+                custom_helm_values: &config_override_name("", &override_name, true),
                 ..Default::default()
             },
         )

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -39,6 +39,7 @@ async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     HELM_VALUES_DUMMY_TOPOLOGY,
                     &override_name,
+                    false,
                 ),
                 ..Default::default()
             },
@@ -72,7 +73,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             HELM_CHART_VECTOR_AGGREGATOR,
             VectorConfig {
-                custom_helm_values: &config_override_name("", &override_name),
+                custom_helm_values: &config_override_name("", &override_name, false),
                 ..Default::default()
             },
         )

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -82,6 +82,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     HELM_VALUES_DDOG_AGG_TOPOLOGY,
                     &override_name,
+                    false,
                 ),
                 ..Default::default()
             },
@@ -105,6 +106,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
                 custom_helm_values: &config_override_name(
                     datadog_chart_values,
                     &datadog_override_name,
+                    false,
                 ),
                 ..Default::default()
             },

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -22,7 +22,7 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
         - name: var-lib
           mountPath: /var/writablelib
           readOnly: false
-     
+
       lifecycle:
         preStop:
           exec:
@@ -30,7 +30,7 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
               - sh
               - -c
               - rm -rf /var/writablelib/{}-vector
-            
+
     vector-aggregator:
       fullnameOverride: "{}"
       vectorSource:

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -18,6 +18,19 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
         hostPath:
           path: /var/lib/{}-vector/
 
+      extraVolumeMounts:
+        - name: var-lib
+          mountPath: /var/writablelib
+          readOnly: false
+     
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - sh
+              - -c
+              - rm -rf /var/writablelib/{}-vector
+            
     vector-aggregator:
       fullnameOverride: "{}"
       vectorSource:
@@ -32,6 +45,7 @@ fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: 
     "#,
             agent_override_name,
             aggregator_override_name,
+            agent_override_name,
             agent_override_name,
             aggregator_override_name
         )


### PR DESCRIPTION
Closes #7544

As suggested [here](https://github.com/timberio/vector/pull/7810#issuecomment-857902297), this PR introduces lifecycle hooks into our Helm chart which the tests can use to cleanup the Vector data directory on deletion.

As this is my first actual work with the Helm charts, I would especially appreciate advice on whether I have implemented the changes there correctly.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

