### PR TITLE
docs(http sink, clickhouse sink): Correct default max_bytes

### DIFF
--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -19,7 +19,7 @@ components: sinks: clickhouse: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    1049000
+				max_bytes:    10485760
 				timeout_secs: 1
 			}
 			compression: {

--- a/docs/reference/components/sinks/http.cue
+++ b/docs/reference/components/sinks/http.cue
@@ -19,7 +19,7 @@ components: sinks: http: {
 			batch: {
 				enabled:      true
 				common:       true
-				max_bytes:    1049000
+				max_bytes:    10485760
 				timeout_secs: 1
 			}
 			compression: {


### PR DESCRIPTION
It is actually defaulting to 10 MiB

Discovered by discord user:
https://discord.com/channels/742820443487993987/746070591097798688/852944913187864606

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
