### PR TITLE
feat(clickhouse sink): Allow enabling `input_format_skip_unknown_fields`

### DIFF
--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -120,12 +120,12 @@ components: sinks: clickhouse: {
 				examples: ["mytable"]
 				syntax: "literal"
 			}
-			skip_unknown_fields: {
-				common:      true
-				description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
-				required:    false
-				type: bool: default: false
-			}
+		}
+		skip_unknown_fields: {
+			common:      true
+			description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
+			required:    false
+			type: bool: default: false
 		}
 	}
 

--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -120,6 +120,12 @@ components: sinks: clickhouse: {
 				examples: ["mytable"]
 				syntax: "literal"
 			}
+		skip_unknown_fields: {
+			common:      true
+			description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
+			required:    false
+			type: bool: default: false
+		}
 		}
 	}
 

--- a/docs/reference/components/sinks/clickhouse.cue
+++ b/docs/reference/components/sinks/clickhouse.cue
@@ -120,12 +120,12 @@ components: sinks: clickhouse: {
 				examples: ["mytable"]
 				syntax: "literal"
 			}
-		skip_unknown_fields: {
-			common:      true
-			description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
-			required:    false
-			type: bool: default: false
-		}
+			skip_unknown_fields: {
+				common:      true
+				description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
+				required:    false
+				type: bool: default: false
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #6891

Defaults to false to maintain existing behavior. Integration test added to verify `true` allows unknown fields, existing integration tests cover the `false` path.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
