### PR TITLE
enhancement(dev): k8s e2e tests script minor improvements

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -95,7 +95,7 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.15.1",
+              "v1.21.0",
             ]
             const kubernetes_version = [
               { version: "v1.19.2", is_essential: true },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -826,15 +826,16 @@ Vector release artifacts are prepared for E2E tests, so the ability to do that
 is required too, see Vector [docs](https://vector.dev) for more details.
 
 Notes:
+
 > - `minikube` had a bug in the versions `1.12.x` that affected our test
-> process - see https://github.com/kubernetes/minikube/issues/8799.
-> Use version `1.13.0+` that has this bug fixed.
+>   process - see https://github.com/kubernetes/minikube/issues/8799.
+>   Use version `1.13.0+` that has this bug fixed.
 > - `minikube` has troubles running on ZFS systems. If you're using ZFS, we
-> suggest using a cloud cluster or [`minik8s`](https://microk8s.io/) with local
-> registry.
+>   suggest using a cloud cluster or [`minik8s`](https://microk8s.io/) with local
+>   registry.
 > - E2E tests expect to have enough resources to perform a full Vector build,
-> usually 8GB of RAM with 2CPUs are sufficient to succesfully complete E2E tests
-> locally.
+>   usually 8GB of RAM with 2CPUs are sufficient to succesfully complete E2E tests
+>   locally.
 
 ##### Running the E2E tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -825,15 +825,16 @@ E2E (end-to-end) tests.
 Vector release artifacts are prepared for E2E tests, so the ability to do that
 is required too, see Vector [docs](https://vector.dev) for more details.
 
-> Note: `minikube` had a bug in the versions `1.12.x` that affected our test
+Notes:
+> - `minikube` had a bug in the versions `1.12.x` that affected our test
 > process - see https://github.com/kubernetes/minikube/issues/8799.
 > Use version `1.13.0+` that has this bug fixed.
-
-Also:
-
-> Note: `minikube` has troubles running on ZFS systems. If you're using ZFS, we
+> - `minikube` has troubles running on ZFS systems. If you're using ZFS, we
 > suggest using a cloud cluster or [`minik8s`](https://microk8s.io/) with local
 > registry.
+> - E2E tests expect to have enough resources to perform a full Vector build,
+> usually 8GB of RAM with 2CPUs are sufficient to succesfully complete E2E tests
+> locally.
 
 ##### Running the E2E tests
 

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -20,12 +20,18 @@ random-string() {
 
 # Detect if current kubectl context match the one from `minikube`.
 is_kubectl_context_minikube() {
-  [[ "$(kubectl config current-context || true)" == "$(minikube profile)" ]]
+  MINIKUBE_CLUSTER=$(minikube profile || true)
+  [[ "$(kubectl config current-context || true)" == "${MINIKUBE_CLUSTER:-"minikube"}" ]]
 }
 
 # Detect if current kubectl context is `kind`.
 is_kubectl_context_kind() {
-  [[ "$(kubectl config current-context || true)" == "kind-kind" ]]
+  for KIND_CLUSTER in $(kind get clusters || true); do
+    if [[ "$(kubectl config current-context || true)" == "kind-${KIND_CLUSTER}" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -18,9 +18,9 @@ random-string() {
   echo
 }
 
-# Detect if current kubectl context is `minikube`.
+# Detect if current kubectl context match the one from `minikube`.
 is_kubectl_context_minikube() {
-  [[ "$(kubectl config current-context || true)" == "minikube" ]]
+  [[ "$(kubectl config current-context || true)" == "$(minikube profile)" ]]
 }
 
 # Detect if current kubectl context is `kind`.
@@ -121,8 +121,8 @@ fi
 if [[ -z "${SKIP_CONTAINER_IMAGE_PUBLISHING:-}" ]]; then
   # Make the container image accessible to the k8s cluster.
   if is_minikube_cache_enabled; then
-    minikube cache add "$CONTAINER_IMAGE"
-    trap 'minikube cache delete "$CONTAINER_IMAGE"' EXIT
+    minikube image load "$CONTAINER_IMAGE"
+    trap 'minikube image rm "$CONTAINER_IMAGE"' EXIT
   else
     docker push "$CONTAINER_IMAGE"
   fi

--- a/scripts/test-e2e-kubernetes.sh
+++ b/scripts/test-e2e-kubernetes.sh
@@ -18,13 +18,13 @@ random-string() {
   echo
 }
 
-# Detect if current kubectl context match the one from `minikube`.
+# Detect if current kubectl context matches the one from `minikube`.
 is_kubectl_context_minikube() {
   MINIKUBE_CLUSTER=$(minikube profile || true)
   [[ "$(kubectl config current-context || true)" == "${MINIKUBE_CLUSTER:-"minikube"}" ]]
 }
 
-# Detect if current kubectl context is `kind`.
+# Detect if current kubectl context matches a `kind` cluster.
 is_kubectl_context_kind() {
   for KIND_CLUSTER in $(kind get clusters || true); do
     if [[ "$(kubectl config current-context || true)" == "kind-${KIND_CLUSTER}" ]]; then


### PR DESCRIPTION
closes #7545

Account for minikube/kind non-default cluster name and
switch from `minikube cache` to `minikube image` as
the former is scheduled for deprecation.