### PR TITLE
enhancement(kafka sink): disable sending key when no `key_field` configured

### DIFF
--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -54,11 +54,11 @@ components: sinks: kafka: {
 	configuration: {
 		bootstrap_servers: components._kafka.configuration.bootstrap_servers
 		key_field: {
-			description: "The log field name or tags key to use for the topic key. If unspecified, the key will be randomly generated. If the field does not exist on the log or in tags, a blank value will be used."
+			description: "The log field name or tags key to use for the topic key. If unspecified, the key will be randomly generated. If the field does not exist on the log or in tags, a blank value will be used. Setting to 'none' will results to not sending key, which disables sending blank or other value"
 			required:    true
 			warnings: []
 			type: string: {
-				examples: ["user_id"]
+				examples: ["user_id", "none"]
 				syntax: "literal"
 			}
 		}

--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -54,10 +54,12 @@ components: sinks: kafka: {
 	configuration: {
 		bootstrap_servers: components._kafka.configuration.bootstrap_servers
 		key_field: {
+			common:      true
 			description: "The log field name or tags key to use for the topic key. If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent. Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key."
 			required:    false
 			warnings: []
 			type: string: {
+				default: null
 				examples: ["user_id"]
 				syntax: "literal"
 			}

--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -54,7 +54,7 @@ components: sinks: kafka: {
 	configuration: {
 		bootstrap_servers: components._kafka.configuration.bootstrap_servers
 		key_field: {
-			description: "The log field name or tags key to use for the topic key. If the field does not exist on the log or in tags, a blank value will be used. If key_field is not set, the key is not send. Kafka uses a hash of the key to choose the partition or uses a round-robin if the record has no key."
+			description: "The log field name or tags key to use for the topic key. If the field does not exist on the log or in tags, a blank value will be used. If unspecified, the key is not send. Kafka uses a hash of the key to choose the partition or uses a round-robin if the record has no key."
 			required:    false
 			warnings: []
 			type: string: {

--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -54,11 +54,11 @@ components: sinks: kafka: {
 	configuration: {
 		bootstrap_servers: components._kafka.configuration.bootstrap_servers
 		key_field: {
-			description: "The log field name or tags key to use for the topic key. If unspecified, the key will be randomly generated. If the field does not exist on the log or in tags, a blank value will be used. Setting to 'none' will results to not sending key, which disables sending blank or other value"
-			required:    true
+			description: "The log field name or tags key to use for the topic key. If the field does not exist on the log or in tags, a blank value will be used. If key_field is not set, the key is not send. Kafka uses a hash of the key to choose the partition or uses a round-robin if the record has no key."
+			required:    false
 			warnings: []
 			type: string: {
-				examples: ["user_id", "none"]
+				examples: ["user_id"]
 				syntax: "literal"
 			}
 		}

--- a/docs/reference/components/sinks/kafka.cue
+++ b/docs/reference/components/sinks/kafka.cue
@@ -54,7 +54,7 @@ components: sinks: kafka: {
 	configuration: {
 		bootstrap_servers: components._kafka.configuration.bootstrap_servers
 		key_field: {
-			description: "The log field name or tags key to use for the topic key. If the field does not exist on the log or in tags, a blank value will be used. If unspecified, the key is not send. Kafka uses a hash of the key to choose the partition or uses a round-robin if the record has no key."
+			description: "The log field name or tags key to use for the topic key. If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent. Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key."
 			required:    false
 			warnings: []
 			type: string: {

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -303,12 +303,12 @@ impl Sink<Event> for KafkaSink {
         self.seq_head += 1;
 
         let producer = Arc::clone(&self.producer);
-        let kf = self.key_field.clone();
+        let kf = self.key_field.is_some();
         self.delivery_fut.push(Box::pin(async move {
-            let mut record = if kf == None {
-                FutureRecord::to(&topic).payload(&body[..])
-            } else {
+            let mut record = if kf {
                 FutureRecord::to(&topic).key(&key).payload(&body[..])
+            } else {
+                FutureRecord::to(&topic).payload(&body[..])
             };
             if let Some(timestamp) = timestamp_ms {
                 record = record.timestamp(timestamp);

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -303,9 +303,9 @@ impl Sink<Event> for KafkaSink {
         self.seq_head += 1;
 
         let producer = Arc::clone(&self.producer);
-        let kf = self.key_field.as_ref().unwrap_or(&String::new()).clone();
+        let kf = self.key_field.clone();
         self.delivery_fut.push(Box::pin(async move {
-            let mut record = if kf.eq("none") {
+            let mut record = if kf == None {
                 FutureRecord::to(&topic).payload(&body[..])
             } else {
                 FutureRecord::to(&topic).key(&key).payload(&body[..])

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -303,8 +303,13 @@ impl Sink<Event> for KafkaSink {
         self.seq_head += 1;
 
         let producer = Arc::clone(&self.producer);
+        let kf = self.key_field.as_ref().unwrap_or(&String::new()).clone();
         self.delivery_fut.push(Box::pin(async move {
-            let mut record = FutureRecord::to(&topic).key(&key).payload(&body[..]);
+            let mut record = if kf.eq("none") {
+                FutureRecord::to(&topic).payload(&body[..])
+            } else {
+                FutureRecord::to(&topic).key(&key).payload(&body[..])
+            };
             if let Some(timestamp) = timestamp_ms {
                 record = record.timestamp(timestamp);
             }


### PR DESCRIPTION
Hi, this PR allows to disable sending kafka message key. The key is optional and vector is now always setting it, even as an empty value. Some kafka consumers excepts that key has the same encoding as the message (https://github.com/confluentinc/confluent-kafka-python/issues/428). Empty key breaks our consumer as we are sending AVRO messages through vector. So there is new option "none" which prevents sending the key to kafka.
Related PR https://github.com/timberio/vector/pull/7859, these two PR allows vector to work with AVRO and other binary protocols, at least from http source through kafka sink.

example config snippet
```
[sinks.out_kafka]
  type = "kafka"  
  inputs = ["http_in"]  
  bootstrap_servers = "192.168.0.67:9092"  
  compression = "none"  
  key_field = "none"  
  topic = "some-topic"  
  encoding.codec = "text"  
  encoding.only_fields = ["message"]  
  buffer.type = "disk"  
  buffer.max_size = 10000000000  
```