### PR TITLE
fix(sample transform)!: Accept remap conditions

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -9,7 +9,7 @@ pub mod remap;
 
 pub use check_fields::CheckFieldsConfig;
 
-use self::remap::RemapConfig;
+pub use self::remap::RemapConfig;
 
 pub trait Condition: Send + Sync + dyn_clone::DynClone {
     fn check(&self, e: &Event) -> bool;

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conditions::{CheckFieldsConfig, Condition, ConditionConfig},
+    conditions::{AnyCondition, Condition},
     config::{DataType, GenerateConfig, GlobalOptions, TransformConfig, TransformDescription},
     event::Event,
     internal_events::SampleEventDiscarded,
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct SampleConfig {
     pub rate: u64,
     pub key_field: Option<String>,
-    pub exclude: Option<CheckFieldsConfig>,
+    pub exclude: Option<AnyCondition>,
 }
 
 inventory::submit! {
@@ -28,7 +28,7 @@ impl GenerateConfig for SampleConfig {
         toml::Value::try_from(Self {
             rate: 10,
             key_field: None,
-            exclude: None,
+            exclude: None::<AnyCondition>,
         })
         .unwrap()
     }
@@ -142,24 +142,20 @@ impl FunctionTransform for Sample {
 mod tests {
     use super::*;
     use crate::{
-        conditions::check_fields::CheckFieldsPredicateArg, config::log_schema, event::Event,
-        test_util::random_lines, transforms::test::transform_one,
+        conditions::{ConditionConfig, RemapConfig},
+        config::log_schema,
+        event::Event,
+        test_util::random_lines,
+        transforms::test::transform_one,
     };
     use approx::assert_relative_eq;
-    use indexmap::IndexMap;
 
-    fn condition_contains(pre: &str) -> Box<dyn Condition> {
-        condition(log_schema().message_key(), "contains", pre)
-    }
-
-    fn condition(field: &str, condition: &str, value: &str) -> Box<dyn Condition> {
-        let mut preds: IndexMap<String, CheckFieldsPredicateArg> = IndexMap::new();
-        preds.insert(
-            format!("{}.{}", field, condition),
-            CheckFieldsPredicateArg::String(value.into()),
-        );
-
-        CheckFieldsConfig::new(preds).build().unwrap()
+    fn condition_contains(key: &str, needle: &str) -> Box<dyn Condition> {
+        RemapConfig {
+            source: format!(r#"contains!(."{}", "{}")"#, key, needle),
+        }
+        .build()
+        .unwrap()
     }
 
     #[test]
@@ -175,7 +171,7 @@ mod tests {
         let mut sampler = Sample::new(
             2,
             Some(log_schema().message_key().into()),
-            Some(condition_contains("na")),
+            Some(condition_contains(log_schema().message_key(), "na")),
         );
         let total_passed = events
             .into_iter()
@@ -193,7 +189,7 @@ mod tests {
         let mut sampler = Sample::new(
             25,
             Some(log_schema().message_key().into()),
-            Some(condition_contains("na")),
+            Some(condition_contains(log_schema().message_key(), "na")),
         );
         let total_passed = events
             .into_iter()
@@ -214,7 +210,7 @@ mod tests {
         let mut sampler = Sample::new(
             2,
             Some(log_schema().message_key().into()),
-            Some(condition_contains("na")),
+            Some(condition_contains(log_schema().message_key(), "na")),
         );
 
         let first_run = events
@@ -242,8 +238,11 @@ mod tests {
     fn always_passes_events_matching_pass_list() {
         for key_field in &[None, Some(log_schema().message_key().into())] {
             let event = Event::from("i am important");
-            let mut sampler =
-                Sample::new(0, key_field.clone(), Some(condition_contains("important")));
+            let mut sampler = Sample::new(
+                0,
+                key_field.clone(),
+                Some(condition_contains(log_schema().message_key(), "important")),
+            );
             let iterations = 0..1000;
             let total_passed = iterations
                 .filter_map(|_| {
@@ -257,12 +256,14 @@ mod tests {
 
     #[test]
     fn handles_key_field() {
-        for key_field in &[None, Some(log_schema().timestamp_key().into())] {
-            let event = Event::from("nananana");
+        for key_field in &[None, Some("other_field".into())] {
+            let mut event = Event::from("nananana");
+            let log = event.as_mut_log();
+            log.insert("other_field", "foo");
             let mut sampler = Sample::new(
                 0,
                 key_field.clone(),
-                Some(condition(log_schema().timestamp_key(), "contains", ":")),
+                Some(condition_contains("other_field".into(), "foo")),
             );
             let iterations = 0..1000;
             let total_passed = iterations
@@ -279,7 +280,11 @@ mod tests {
     fn sampler_adds_sampling_rate_to_event() {
         for key_field in &[None, Some(log_schema().message_key().into())] {
             let events = random_events(10000);
-            let mut sampler = Sample::new(10, key_field.clone(), Some(condition_contains("na")));
+            let mut sampler = Sample::new(
+                10,
+                key_field.clone(),
+                Some(condition_contains(log_schema().message_key(), "na")),
+            );
             let passing = events
                 .into_iter()
                 .filter(|s| {
@@ -292,7 +297,11 @@ mod tests {
             assert_eq!(passing.as_log()["sample_rate"], "10".into());
 
             let events = random_events(10000);
-            let mut sampler = Sample::new(25, key_field.clone(), Some(condition_contains("na")));
+            let mut sampler = Sample::new(
+                25,
+                key_field.clone(),
+                Some(condition_contains(log_schema().message_key(), "na")),
+            );
             let passing = events
                 .into_iter()
                 .filter(|s| {
@@ -305,7 +314,11 @@ mod tests {
             assert_eq!(passing.as_log()["sample_rate"], "25".into());
 
             // If the event passed the regex check, don't include the sampling rate
-            let mut sampler = Sample::new(25, key_field.clone(), Some(condition_contains("na")));
+            let mut sampler = Sample::new(
+                25,
+                key_field.clone(),
+                Some(condition_contains(log_schema().message_key(), "na")),
+            );
             let event = Event::from("nananana");
             let passing = transform_one(&mut sampler, event).unwrap();
             assert!(passing.as_log().get("sample_rate").is_none());

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -263,7 +263,7 @@ mod tests {
             let mut sampler = Sample::new(
                 0,
                 key_field.clone(),
-                Some(condition_contains("other_field".into(), "foo")),
+                Some(condition_contains("other_field", "foo")),
             );
             let iterations = 0..1000;
             let total_passed = iterations

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -40,7 +40,9 @@ async fn happy_path() {
         inputs = ["in"]
         rate = 10
         key_field = "message"
-        exclude."message.contains" = "error"
+        exclude = """
+            contains!(.message, "error")
+        """
 
         [sinks.out]
         type = "socket"
@@ -60,7 +62,7 @@ async fn happy_path() {
         in = {type = "socket", mode = "tcp", address = "127.0.0.1:1235"}
 
         [transforms]
-        sample = {type = "sample", inputs = ["in"], rate = 10, key_field = "message", exclude."message.contains" = "error"}
+        sample = {type = "sample", inputs = ["in"], rate = 10, key_field = "message", exclude = """ contains!(.message, "error") """ }
 
         [sinks]
         out = {type = "socket", mode = "tcp", inputs = ["sample"], encoding = "text", address = "127.0.0.1:9999"}
@@ -189,7 +191,9 @@ async fn nonexistant_input() {
         inputs = ["qwerty"]
         rate = 10
         key_field = "message"
-        exclude."message.contains" = "error"
+        exclude = """
+            contains!(.message, "error")
+        """
 
         [sinks.out]
         type = "socket"
@@ -273,6 +277,7 @@ async fn bad_regex() {
         inputs = ["in"]
         rate = 10
         key_field = "message"
+        exclude.type = "check_fields"
         exclude."message.regex" = "(["
 
         [sinks.out]
@@ -479,14 +484,18 @@ async fn warnings() {
         inputs = ["in1"]
         rate = 10
         key_field = "message"
-        exclude."message.contains" = "error"
+        exclude = """
+            contains!(.message, "error")
+        """
 
         [transforms.sample2]
         type = "sample"
         inputs = ["in1"]
         rate = 10
         key_field = "message"
-        exclude."message.contains" = "error"
+        exclude = """
+            contains!(.message, "error")
+        """
 
         [sinks.out]
         type = "socket"


### PR DESCRIPTION
The docs for the `sample` transform were updated to use an example remap
condition but the component itself only accepted `check_fields`-style
conditions. This updates the component to allow either condition style
(similar to the `filter` transform).

I updated the tests to just use the new remap style rather than check
both. I think it's fine to rely on the tests in `src/condition` to cover
the differences between conditions.

Fixes: #7863

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
