### PR TITLE
chore(ci): add back error handling for grub commands

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -13,8 +13,14 @@ apt install --yes \
   apt-utils \
   apt-transport-https
 
+# We wrap these two commands such that we ignore errors in they fail.  Currently,
+# the commands work fine when run on a virtual machine, but not when run in a container.
+# Rather than explicitly try to figure out if we're in a container, which make itself
+# be a fragile check, we just ignore the errors because it's fine if it fails in that case.
+set +e
 apt-get install --yes grub-efi
 update-grub
+set -e
 
 apt upgrade --yes
 


### PR DESCRIPTION
Adds back the error handling that previously existed for running `update-grub` in a container.  Turns out, the area where this matters for us is when using the Ubuntu image from Docker Hub, which doesn't appear to have the same fixes as the previously referred to GH Actions Ubuntu image... thus we cannot yet avoid swallowing the errors.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>