### PR TITLE
fix(new_relic_logs sink): Default encoding field to json

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -167,6 +167,21 @@ components: sinks: [Name=string]: {
 							}
 						}
 
+						region: {
+							common:      true
+							description: "The region to send data to."
+							required:    false
+							warnings: []
+							type: string: {
+								default: "us"
+								enum: {
+									us: "United States"
+									eu: "Europe"
+								}
+								syntax: "literal"
+							}
+						}
+
 						except_fields: {
 							common:      false
 							description: "Prevent the sink from encoding the specified fields."

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -3,8 +3,9 @@ use crate::{
     sinks::{
         http::{HttpMethod, HttpSinkConfig},
         util::{
-            encoding::EncodingConfig, http::RequestConfig, BatchConfig, Compression, Concurrency,
-            TowerRequestConfig,
+            encoding::{EncodingConfig, EncodingConfigWithDefault},
+            http::RequestConfig,
+            BatchConfig, Compression, Concurrency, TowerRequestConfig,
         },
     },
 };
@@ -38,12 +39,17 @@ pub enum NewRelicLogsRegion {
     Eu,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Derivative, Clone)]
+#[derivative(Default)]
 pub struct NewRelicLogsConfig {
     pub license_key: Option<String>,
     pub insert_key: Option<String>,
     pub region: Option<NewRelicLogsRegion>,
-    pub encoding: EncodingConfig<Encoding>,
+    #[serde(
+        skip_serializing_if = "crate::serde::skip_serializing_if_default",
+        default
+    )]
+    pub encoding: EncodingConfigWithDefault<Encoding>,
     #[serde(default)]
     pub compression: Compression,
     #[serde(default)]
@@ -63,9 +69,11 @@ impl GenerateConfig for NewRelicLogsConfig {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]
+#[derivative(Default)]
 pub enum Encoding {
+    #[derivative(Default)]
     Json,
 }
 
@@ -153,8 +161,7 @@ impl NewRelicLogsConfig {
             auth: None,
             headers: None,
             compression: self.compression,
-            encoding: self.encoding.clone().into_encoding(),
-
+            encoding: EncodingConfig::<Encoding>::from(self.encoding.clone()).into_encoding(),
             batch,
             request,
 


### PR DESCRIPTION
This is the only supported encoding for the New Relic sink.

There was some discussion about this in
https://github.com/timberio/vector/pull/5281 when the default was
dropped. It was dropped as we thought `text` was also a valid encoding,
that we would be adding shortly, in which case it would make sense to
make the user choose; however, I found that `text` is not a valid
encoding for the New Relic logs API
(https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/).

Also document the undocumented region field.

Fixes #7872 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
