### PR TITLE
fix(ci): Install rustup when creating docker environment

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,8 +1,10 @@
 name: Environment Suite
 
 on:
+  pull_request: {}
   push:
-    branches: master
+    branches:
+      - master
   workflow_dispatch:
 
 env:
@@ -29,5 +31,5 @@ jobs:
         with:
           context: .
           file: ./scripts/environment/Dockerfile
-          push: true
+          push: github.ref == 'refs/heads/master'
           tags: timberio/ci_image:latest

--- a/scripts/environment/Dockerfile
+++ b/scripts/environment/Dockerfile
@@ -19,6 +19,7 @@ RUN ./git/timberio/vector/scripts/environment/bootstrap-ubuntu-20.04.sh
 WORKDIR /git/timberio/vector
 ADD scripts/environment/prepare.sh /git/timberio/vector/scripts/environment/
 ADD scripts/environment/setup-helm.sh /git/timberio/vector/scripts/environment/
+ADD scripts/environment/release-flags.sh /git/timberio/vector/scripts/environment/
 ADD scripts/Gemfile scripts/Gemfile.lock \
     /git/timberio/vector/scripts/
 ADD rust-toolchain \

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -70,6 +70,12 @@ cp "${TEMP}/grease/bin/grease" /usr/bin/grease
 locale-gen en_US.UTF-8
 dpkg-reconfigure locales
 
+if ! command -v rustup ; then
+  # Rust/Cargo should already be installed on both GH Actions-provided Ubuntu 20.04 images _and_
+  # by our own Ubuntu 20.04 images
+  curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+fi
+
 # Rust/Cargo should already be installed on both GH Actions-provided Ubuntu 20.04 images _and_
 # by our own Ubuntu 20.04 images, so this is really just make sure the path is configured.
 if [ -n "${CI-}" ] ; then


### PR DESCRIPTION
This was removed in e147113ba as our CI runners already have this
installed, but the bootstrap script is also shared with the `Dockerfile`
used to create the image used by `make environment`.

This is related to https://github.com/timberio/vector/issues/7862 which
should hopefully improve the bootstrapping situation.

Failure: https://github.com/timberio/vector/runs/2833564450#step:6:8338

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
