### PR TITLE
enhancement(config): Allow wildcards anywhere in identifiers

### DIFF
--- a/docs/reference/configuration.cue
+++ b/docs/reference/configuration.cue
@@ -216,8 +216,9 @@ configuration: {
 		wildcards: {
 			title: "Wildcards in identifiers"
 			body: """
-				Vector supports wildcards (`*`) in component identifiers when building your topology, but only supports
-				them as the last character. For example:
+				Vector supports wildcard characters (`*`) in component identifiers when building your topology.
+
+				For example:
 
 				```toml
 				[sources.app1_logs]
@@ -238,7 +239,7 @@ configuration: {
 
 				[sinks.archive]
 				type = "aws_s3"
-				inputs = ["app*", "system_logs"]
+				inputs = ["*_logs"]
 				```
 				"""
 		}

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -4,9 +4,9 @@ use indexmap::IndexMap;
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
 
-    expand_globs(&mut builder);
-
     let expansions = expand_macros(&mut builder)?;
+
+    expand_globs(&mut builder);
 
     let warnings = validation::warnings(&builder);
 

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -110,7 +110,7 @@ enum InputMatcher {
 
 impl InputMatcher {
     fn matches(&self, candidate: &str) -> bool {
-        use Matcher::*;
+        use InputMatcher::*;
 
         match self {
             Pattern(pattern) => pattern.matches(candidate),

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
 
-    expand_wildcards(&mut builder);
+    expand_globs(&mut builder);
 
     let expansions = expand_macros(&mut builder)?;
 
@@ -85,8 +85,8 @@ pub(super) fn expand_macros(
     }
 }
 
-/// Expand trailing `*` wildcards in input lists
-fn expand_wildcards(config: &mut ConfigBuilder) {
+/// Expand globs in input lists
+fn expand_globs(config: &mut ConfigBuilder) {
     let candidates = config
         .sources
         .keys()
@@ -95,26 +95,29 @@ fn expand_wildcards(config: &mut ConfigBuilder) {
         .collect::<Vec<String>>();
 
     for (name, transform) in config.transforms.iter_mut() {
-        expand_wildcards_inner(&mut transform.inputs, name, &candidates);
+        expand_globs_inner(&mut transform.inputs, name, &candidates);
     }
 
     for (name, sink) in config.sinks.iter_mut() {
-        expand_wildcards_inner(&mut sink.inputs, name, &candidates);
+        expand_globs_inner(&mut sink.inputs, name, &candidates);
     }
 }
 
-fn expand_wildcards_inner(inputs: &mut Vec<String>, name: &str, candidates: &[String]) {
+fn expand_globs_inner(inputs: &mut Vec<String>, name: &str, candidates: &[String]) {
     let raw_inputs = std::mem::take(inputs);
     for raw_input in raw_inputs {
-        if raw_input.ends_with('*') {
-            let prefix = &raw_input[0..raw_input.len() - 1];
-            for input in candidates {
-                if input.starts_with(prefix) && input != name {
-                    inputs.push(input.clone())
+        match glob::Pattern::new(&raw_input) {
+            Ok(pattern) => {
+                for input in candidates {
+                    if pattern.matches(input) && input != name {
+                        inputs.push(input.clone())
+                    }
                 }
             }
-        } else {
-            inputs.push(raw_input);
+            Err(error) => {
+                error!(message = "Invalid glob pattern for input.", component_name = name, %error);
+                continue;
+            }
         }
     }
 }
@@ -196,13 +199,14 @@ mod test {
     }
 
     #[test]
-    fn wildcard_expansion() {
+    fn glob_expansion() {
         let mut builder = ConfigBuilder::default();
         builder.add_source("foo1", MockSourceConfig);
         builder.add_source("foo2", MockSourceConfig);
         builder.add_source("bar", MockSourceConfig);
         builder.add_transform("foos", &["foo*"], MockTransformConfig);
         builder.add_sink("baz", &["foos*", "b*"], MockSinkConfig);
+        builder.add_sink("quix", &["*oo*"], MockSinkConfig);
         builder.add_sink("quux", &["*"], MockSinkConfig);
 
         let config = builder.build().expect("build should succeed");
@@ -213,5 +217,6 @@ mod test {
             config.sinks["quux"].inputs,
             vec!["foo1", "foo2", "bar", "foos"]
         );
+        assert_eq!(config.sinks["quix"].inputs, vec!["foo1", "foo2", "foos"]);
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -206,8 +206,8 @@ async fn nonexistant_input() {
     assert_eq!(
         err,
         vec![
-            "Input \"asdf\" for sink \"out\" doesn't exist.",
-            "Input \"qwerty\" for transform \"sample\" doesn't exist.",
+            "Input \"asdf\" for sink \"out\" doesn\'t exist.",
+            "Input \"qwerty\" for transform \"sample\" doesn\'t exist."
         ]
     );
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -206,8 +206,8 @@ async fn nonexistant_input() {
     assert_eq!(
         err,
         vec![
-            "Input \"asdf\" for sink \"out\" doesn\'t exist.",
-            "Input \"qwerty\" for transform \"sample\" doesn\'t exist."
+            "Sink \"out\" has no inputs",
+            "Transform \"sample\" has no inputs"
         ]
     );
 }


### PR DESCRIPTION
https://github.com/timberio/vector/pull/6170 had added support for
wildcards in identifiers in vector configs, but only as the last
character. This PR expands support to allow glob matching in the same
way that `vector tap` does which allows for `*` to appear anywhere in
the input name.

Closes #6786

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
