### PR TITLE
docs(kubernetes_logs source): Add missing ingestion_timestamp_field and fix descriptions

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -153,6 +153,15 @@ components: sources: kubernetes_logs: {
 			required:    false
 			type: bool: default: true
 		}
+		ingestion_timestamp_field: {
+			common:      false
+			description: "The exact time the event was ingested into Vector."
+			required:    false
+			type: string: {
+				default: null
+				syntax:  "literal"
+			}
+		}
 		kube_config_file: {
 			common:      false
 			description: "Optional path to a kubeconfig file readable by Vector. If not set, Vector will try to connect to Kubernetes using in-cluster configuration."
@@ -284,7 +293,7 @@ components: sources: kubernetes_logs: {
 				}
 			}
 			"kubernetes.pod_labels": {
-				description: "Pod labels name."
+				description: "Set of labels attached to the Pod."
 				required:    false
 				common:      true
 				type: object: {
@@ -356,7 +365,9 @@ components: sources: kubernetes_logs: {
 					syntax: "literal"
 				}
 			}
-			timestamp: fields._current_timestamp
+			timestamp: fields._current_timestamp & {
+				description: "The exact time the event was processed by Kubernetes."
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #7691

I also noticed `pod_labels` isn't rendering the examples properly, but couldn't figure out why.
Not sure how much we care given the replacement of the current site.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
