### PR TITLE
docs(remap): Fix 'Modify metric tags' example

### DIFF
--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -162,9 +162,9 @@ remap: #Remap & {
 				}
 			}
 			source: #"""
-				.environment = get_env_var!("ENV") # add
-				.hostname = del(.host) # rename
-				del(.email)
+				.tags.environment = get_env_var!("ENV") # add
+				.tags.hostname = del(.tags.host) # rename
+				del(.tags.email)
 				"""#
 			output: metric: {
 				kind: "incremental"

--- a/docs/reference/remap.cue
+++ b/docs/reference/remap.cue
@@ -270,9 +270,9 @@ remap: #Remap & {
 			title: "Event Data Model"
 			body:  """
 				You can use the `remap` transform with both log and metric events. Log events in the `remap` transform
-				correspond directly to Vector's [log schem](\(urls.vector_log)), which means that the transform has
-				access to the whole event. With metric events, however, the remap transform only has access to the
-				event's tags.
+				correspond directly to Vector's [log schema](\(urls.vector_log)), which means that the transform has
+				access to the whole event. With metric events the remap transform has read access to the event's`.type`,
+				and read/write access to the `.name`, `.namespace`, `.timestamp`, `.kind`, and `.tags`.
 				"""
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #7881 (partially)

There is a snippet of text referencing how remap interacts with metric events, but it's not rendered on today's website.
Do we want to edit the existing website and correct the snippet, or have an issue to ensure we document the interactions on the new website?

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
