### PR TITLE
docs(new_relic_logs sink): Move region documentation to correct file

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -167,21 +167,6 @@ components: sinks: [Name=string]: {
 							}
 						}
 
-						region: {
-							common:      true
-							description: "The region to send data to."
-							required:    false
-							warnings: []
-							type: string: {
-								default: "us"
-								enum: {
-									us: "United States"
-									eu: "Europe"
-								}
-								syntax: "literal"
-							}
-						}
-
 						except_fields: {
 							common:      false
 							description: "Prevent the sink from encoding the specified fields."

--- a/docs/reference/components/sinks/new_relic_logs.cue
+++ b/docs/reference/components/sinks/new_relic_logs.cue
@@ -100,6 +100,21 @@ components: sinks: new_relic_logs: {
 				syntax: "literal"
 			}
 		}
+		region: {
+			common:      true
+			description: "The region to send data to."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "us"
+				enum: {
+					us: "United States"
+					eu: "Europe"
+				}
+				syntax: "literal"
+			}
+		}
+
 	}
 
 	input: {


### PR DESCRIPTION
Accidentally added this to `sinks.cue` in #7870 but it should be in
new_relic_logs.cue

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
