### PR TITLE
chore: Build a fat release binary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,23 @@ jobs:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl.tar.gz"
 
+  build-x86_64-unknown-linux-gnu-debug-tarball:
+    runs-on: [self-hosted, linux, x64, general]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
+      - run: bash scripts/set-build-description.sh
+      - env:
+          PASS_FEATURES: "default"
+          CARGO_PROFILE_RELEASE_DEBUG: 2 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+        run: make package-x86_64-unknown-linux-gnu
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu-debug.tar.gz
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu.tar.gz"
+
   build-x86_64-unknown-linux-gnu-packages:
     runs-on: [self-hosted, linux, x64, general]
     steps:
@@ -376,6 +393,7 @@ jobs:
   release-s3:
     runs-on: ubuntu-18.04
     needs:
+      - build-x86_64-unknown-linux-gnu-debug-tarball
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-musl-packages
@@ -390,6 +408,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
+      - uses: actions/download-artifact@v2
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu-debug.tar.gz
+          path: target/artifacts
       - uses: actions/download-artifact@v2
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -611,6 +611,7 @@ jobs:
     name: nightly-failure
     if: failure() && github.ref == 'refs/heads/master'
     needs:
+      - build-x86_64-unknown-linux-gnu-debug-tarball
       - build-x86_64-unknown-linux-gnu-packages
       - build-x86_64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-musl-packages

--- a/scripts/set-build-description.sh
+++ b/scripts/set-build-description.sh
@@ -1,5 +1,8 @@
-#! /usr/bin/env bash
-set -e -o verbose
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o verbose
 
 # Set VECTOR_BUILD_DESC to add in pertinent build information.  We typically only
 # enable this when generating binaries that will be in the hands of users so that
@@ -7,6 +10,15 @@ set -e -o verbose
 GIT_SHA=$(git rev-parse --short HEAD)
 CURRENT_DATE=$(date +%Y-%m-%d)
 BUILD_DESC="${GIT_SHA} ${CURRENT_DATE}"
+
+# We do not add 'debug' to the BUILD_DESC unless the caller has flagged on line
+# or full debug symbols. See the Cargo Book profiling section for value meaning:
+# https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+if [ "$CARGO_PROFILE_RELEASE_DEBUG" == 1 ] ||
+       [ "$CARGO_PROFILE_RELEASE_DEBUG" == 2 ] ||
+       [ "$CARGO_PROFILE_RELEASE_DEBUG" == true ]; then
+    export BUILD_DESC="${BUILD_DESC} debug"
+fi
 
 # If we're in Github CI, set it in the special environment variables file. Otherwise,
 # export the variable.  This requires sourcing the file instead of simply running it.


### PR DESCRIPTION
This commit builds a release binary with debuginfo included. We build only a
tarball to avoid the situation where a user might install our CD-sized binary
accidentally. I have not made any changes to release-s3.sh as it didn't seem
like most other artifacts were explicitly mentioned there.

Resolves #7892

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
