### PR TITLE
enhancement(vrl): standalone key support for `parse_key_value`

### DIFF
--- a/docs/reference/remap/functions/parse_key_value.cue
+++ b/docs/reference/remap/functions/parse_key_value.cue
@@ -104,7 +104,7 @@ remap: functions: parse_key_value: {
 					"env:prod,service:backend,region:eu-east1,beta",
 					field_delimiter: ",",
 					key_value_delimiter: ":",
-					standalone_key: true
+					accept_standalone_key: true
 				)
 				"""#
 			return: {

--- a/docs/reference/remap/functions/parse_key_value.cue
+++ b/docs/reference/remap/functions/parse_key_value.cue
@@ -51,7 +51,7 @@ remap: functions: parse_key_value: {
 			description: "Whether a standalone key should be accepted, the resulting object will associate such keys with boolean value `true`"
 			required:    false
 			type: ["boolean"]
-			default: false
+			default: true
 		},
 	]
 	internal_failure_reasons: [
@@ -104,7 +104,6 @@ remap: functions: parse_key_value: {
 					"env:prod,service:backend,region:eu-east1,beta",
 					field_delimiter: ",",
 					key_value_delimiter: ":",
-					accept_standalone_key: true
 				)
 				"""#
 			return: {

--- a/docs/reference/remap/functions/parse_key_value.cue
+++ b/docs/reference/remap/functions/parse_key_value.cue
@@ -46,6 +46,13 @@ remap: functions: parse_key_value: {
 			default: "lenient"
 			type: ["string"]
 		},
+		{
+			name:        "accept_standalone_key"
+			description: "Whether a standalone key should be accepted, the resulting object will associate such keys with boolean value `true`"
+			required:    false
+			type: ["boolean"]
+			default: false
+		},
 	]
 	internal_failure_reasons: [
 		"`value` isn't a properly formatted key/value string",
@@ -88,6 +95,23 @@ remap: functions: parse_key_value: {
 				status:   "304"
 				bytes:    "632"
 				protocol: "https"
+			}
+		},
+		{
+			title: "Parse comma delimited log with standalone keys"
+			source: #"""
+				parse_key_value!(
+					"env:prod,service:backend,region:eu-east1,beta",
+					field_delimiter: ",",
+					key_value_delimiter: ":",
+					standalone_key: true
+				)
+				"""#
+			return: {
+				env:     "prod"
+				service: "backend"
+				region:  "eu-east1"
+				beta:    true
 			}
 		},
 	]

--- a/docs/reference/remap/functions/parse_logfmt.cue
+++ b/docs/reference/remap/functions/parse_logfmt.cue
@@ -7,6 +7,7 @@ remap: functions: parse_logfmt: {
 
 		* Keys and values can be wrapped with `"`.
 		* `"` characters can be escaped by `\`.
+		* As per this [logfmt specification](\#(urls.logfmt_specs)) standlone key are accepted and will be associated with the boolean value `true`.
 		"""#
 	notices: [
 		"""

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -265,6 +265,7 @@ urls: {
 	linux_capability:                                         "https://man7.org/linux/man-pages/man7/capabilities.7.html"
 	logdna:                                                   "https://logdna.com/"
 	logfmt:                                                   "https://brandur.org/logfmt"
+	logfmt_specs:                                             "https://pkg.go.dev/github.com/kr/logfmt#section-documentation"
 	logstash:                                                 "https://www.elastic.co/logstash"
 	logstash_protocol:                                        "https://github.com/elastic/logstash-forwarder/blob/master/PROTOCOL.md"
 	loki:                                                     "https://grafana.com/oss/loki/"

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -993,6 +993,20 @@ bench_function! {
             module: "kafka.consumer.ConsumerFetcherManager"
         }))
     }
+
+    standalone_key_disabled {
+        args: func_args! [
+            value: r#"level=info msg="Stopping all fetchers" tag=stopping_fetchers id=ConsumerFetcherManager-1382721708341 module=kafka.consumer.ConsumerFetcherManager"#,
+            accept_standalone_key: false
+        ],
+        want: Ok(value!({
+            level: "info",
+            msg: "Stopping all fetchers",
+            tag: "stopping_fetchers",
+            id: "ConsumerFetcherManager-1382721708341",
+            module: "kafka.consumer.ConsumerFetcherManager"
+        }))
+    }
 }
 
 bench_function! {

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -71,7 +71,7 @@ impl Function for ParseKeyValue {
             },
             Example {
                 title: "standalone key",
-                source: r#"parse_key_value!(s'foo=bar foobar', whitespace: "strict", accept_standalone_key: true)"#,
+                source: r#"parse_key_value!(s'foo=bar foobar', whitespace: "strict")"#,
                 result: Ok(r#"{"foo": "bar", "foobar": true}"#),
             },
         ]
@@ -98,7 +98,7 @@ impl Function for ParseKeyValue {
 
         let standalone_key = arguments
             .optional("accept_standalone_key")
-            .unwrap_or_else(|| expr!(false));
+            .unwrap_or_else(|| expr!(true));
 
         Ok(Box::new(ParseKeyValueFn {
             value,
@@ -668,6 +668,7 @@ mod test {
                 value: r#"I am not a valid line."#,
                 key_value_delimiter: "--",
                 field_delimiter: "||",
+                accept_standalone_key: false,
             ],
             want: Err("0: at line 1, in Tag:\nI am not a valid line.\n                      ^\n\n1: at line 1, in ManyMN:\nI am not a valid line.\n                      ^\n\n"),
             tdef: TypeDef::new().fallible().object::<(), Kind>(map! {

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -69,6 +69,11 @@ impl Function for ParseKeyValue {
                     r#"{"app": "my-app", "ip": "1.2.3.4", "user": "", "msg": "hello-world"}"#,
                 ),
             },
+            Example {
+                title: "standalone key",
+                source: r#"parse_key_value!(s'foo=bar foobar', whitespace: "strict", accept_standalone_key: true)"#,
+                result: Ok(r#"{"foo": "bar", "foobar": true}"#),
+            },
         ]
     }
 

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -33,12 +33,14 @@ impl Function for ParseLogFmt {
         let key_value_delimiter = expr!("=");
         let field_delimiter = expr!(" ");
         let whitespace = Whitespace::Lenient;
+        let standalone_key = expr!(false);
 
         Ok(Box::new(ParseKeyValueFn {
             value,
             key_value_delimiter,
             field_delimiter,
             whitespace,
+            standalone_key,
         }))
     }
 }


### PR DESCRIPTION
Add an option to support parsing `foo:bar,foobaar`.
```
parse_key_value!(
	"foo:bar,foobaar",
	field_delimiter: ",",
	key_value_delimiter: ":",
	standalone_key: true
)
```
returns
```json
{
  foo: "bar",
  foobaar: true
}
```