### PR TITLE
chore: Correctly upload -debug artifact

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,15 +37,21 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV
-      - run: bash scripts/set-build-description.sh
+      - env:
+          CARGO_PROFILE_RELEASE_DEBUG: 2 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+        run: bash scripts/set-build-description.sh
       - env:
           PASS_FEATURES: "default"
           CARGO_PROFILE_RELEASE_DEBUG: 2 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
         run: make package-x86_64-unknown-linux-gnu
+      - name: rename gnu tarball to gnu-debug tarball
+        run: |
+          mv "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu.tar.gz" \
+             "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu-debug.tar.gz"
       - uses: actions/upload-artifact@v1
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu-debug.tar.gz
-          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu.tar.gz"
+          path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu-debug.tar.gz"
 
   build-x86_64-unknown-linux-gnu-packages:
     runs-on: [self-hosted, linux, x64, general]

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -77,6 +77,9 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   verify_artifact \
     "https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-gnu.tar.gz" \
     "$td_nightly/vector-nightly-x86_64-unknown-linux-gnu.tar.gz"
+  verify_artifact \
+    "https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-gnu-debug.tar.gz" \
+    "$td_nightly/vector-nightly-x86_64-unknown-linux-gnu-debug.tar.gz"
 elif [[ "$CHANNEL" == "latest" ]]; then
   VERSION_EXACT="$VERSION"
   # shellcheck disable=SC2001
@@ -124,6 +127,9 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+  verify_artifact \
+    "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu-debug.tar.gz" \
+    "$td/vector-$VERSION-x86_64-unknown-linux-gnu-debug.tar.gz"
 fi
 
 #


### PR DESCRIPTION
This commit corrects the -debug artifact upload to be to `gnu-debug`. We
previously were overwriting the `gnu` artifact, which will be a rude surprise to
users. This we'll correct by triggering the nightly run manually.

This commit also adds a verify_artifact in the s3 upload for the debug tarball
to break the build if it's missing.

REF #7900 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
