### PR TITLE
enhancement(helm platform): metricRelabelings for Prometheus PodMonitor

### DIFF
--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -258,6 +258,8 @@ prometheusSink:
     additionalLabels: {}
     # Additional relabelings to include in the `PodMonitor`.
     extraRelabelings: []
+    # metricRelabelings to include in the `PodMonitor`.
+    metricRelabelings: []
 
 # Sources to add to the generated `vector` config (besides "built-in" kubernetes
 # logs source).

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -275,6 +275,8 @@ prometheusSink:
     additionalLabels: {}
     # Additional relabelings to include in the `PodMonitor`.
     extraRelabelings: []
+    # metricRelabelings to include in the `PodMonitor`.
+    metricRelabelings: []
 
 # Sources to add to the generated `vector` config
 sources: {}

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -109,5 +109,9 @@ spec:
         {{- with .Values.prometheusSink.podMonitor.extraRelabelings }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      metricRelabelings:
+        {{- with .Values.prometheusSink.podMonitor.metricRelabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Similar to the existing `extraRelabelings` option, and can be used in conjunction with it.

See also [Prometheus API docs](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint): 
> MetricRelabelConfigs to apply to samples before ingestion.