### PR TITLE
fix(tests): Fix flakey pulsar integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ test-integration-pulsar: ## Runs Pulsar integration tests
 ifeq ($(AUTOSPAWN), true)
 	@scripts/setup_integration_env.sh pulsar stop
 	@scripts/setup_integration_env.sh pulsar start
-	sleep 10 # Many services are very slow... Give them a sec..
+	sleep 15 # Many services are very slow... Give them a sec..
 endif
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features pulsar-integration-tests --lib ::pulsar::
 ifeq ($(AUTODESPAWN), true)

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -423,9 +423,14 @@ mod integration_tests {
             .with_consumer_name("VectorTestConsumer")
             .with_subscription_type(SubType::Shared)
             .with_subscription("VectorTestSub")
+            .with_options(pulsar::consumer::ConsumerOptions {
+                read_compacted: Some(false),
+                ..Default::default()
+            })
             .build::<String>()
             .await
             .unwrap();
+        dbg!("Pulsar.consumer");
 
         let (acker, ack_counter) = Acker::new_for_testing();
         let producer = cnf.create_pulsar_producer().await.unwrap();

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -430,7 +430,6 @@ mod integration_tests {
             .build::<String>()
             .await
             .unwrap();
-        dbg!("Pulsar.consumer");
 
         let (acker, ack_counter) = Acker::new_for_testing();
         let producer = cnf.create_pulsar_producer().await.unwrap();


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

Closes #7915

I found that:

 - Initially our test tried to connect before pulsar was ready setting up, 15s seems to always pass locally
 - When running against an already running pulsar container, we'd error with: `Field 'read_compacted' is not set`

I resolved this second one by explicitly setting that config on our test consumer, but I'm not sure why this wasn't an issue in the past or a consistent issue in testing...
We do appear to not be setting a specific tag so a change to the version we're testing against could have caused this.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
