### PR TITLE
chore(releasing): Move where the `DEBUG` info is sensed during builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -141,6 +141,9 @@ fn main() {
     let target_arch = tracker
         .get_env_var("CARGO_CFG_TARGET_ARCH")
         .expect("Cargo-provided environment variables should always exist!");
+    let debug = tracker
+        .get_env_var("DEBUG")
+        .expect("Cargo-provided environment variables should always exist!");
     let build_desc = tracker.get_env_var("VECTOR_BUILD_DESC");
 
     // Gather up the constants and write them out to our build constants file.
@@ -166,6 +169,7 @@ fn main() {
         "The target architecture being compiled for. (e.g. x86_64)",
         target_arch,
     );
+    constants.add_required_constant("DEBUG", "Level of debug info for Vector.", debug);
     constants.add_optional_constant(
         "VECTOR_BUILD_DESC",
         "Special build description, related to versioned releases.",

--- a/scripts/set-build-description.sh
+++ b/scripts/set-build-description.sh
@@ -11,15 +11,6 @@ GIT_SHA=$(git rev-parse --short HEAD)
 CURRENT_DATE=$(date +%Y-%m-%d)
 BUILD_DESC="${GIT_SHA} ${CURRENT_DATE}"
 
-# We do not add 'debug' to the BUILD_DESC unless the caller has flagged on line
-# or full debug symbols. See the Cargo Book profiling section for value meaning:
-# https://doc.rust-lang.org/cargo/reference/profiles.html#debug
-if [ "$CARGO_PROFILE_RELEASE_DEBUG" == 1 ] ||
-       [ "$CARGO_PROFILE_RELEASE_DEBUG" == 2 ] ||
-       [ "$CARGO_PROFILE_RELEASE_DEBUG" == true ]; then
-    export BUILD_DESC="${BUILD_DESC} debug"
-fi
-
 # If we're in Github CI, set it in the special environment variables file. Otherwise,
 # export the variable.  This requires sourcing the file instead of simply running it.
 if [[ -f "${GITHUB_ENV}" ]]; then

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -10,6 +10,7 @@ impl InternalEvent for VectorStarted {
         info!(
             target: "vector",
             message = "Vector has started.",
+            debug = built_info::DEBUG,
             version = built_info::PKG_VERSION,
             arch = built_info::TARGET_ARCH,
             build_id = built_info::VECTOR_BUILD_DESC.unwrap_or("none"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,16 @@ pub fn get_version() -> String {
         Some(desc) => format!("{} {}", built_info::TARGET, desc),
         None => built_info::TARGET.into(),
     };
+
+    // We do not add 'debug' to the BUILD_DESC unless the caller has flagged on line
+    // or full debug symbols. See the Cargo Book profiling section for value meaning:
+    // https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+    let build_string = match built_info::DEBUG {
+        "1" => format!("{} debug=line", build_string),
+        "2" | "true" => format!("{} debug=full", build_string),
+        _ => build_string,
+    };
+
     format!("{} ({})", pkg_version, build_string)
 }
 


### PR DESCRIPTION
Spun off from https://github.com/timberio/vector/commit/d2ace8eaef15f8a8a6da5c5cbd1b2b67207a8d99#r52260627

Moves where we include how debug information is injected into the binary
to `build.rs` rather than CI. This feels a bit safer in that it will
check even outside of CI and augment the version string accordingly.

A release build of vector looks like:

```
vector 0.15.0 (x86_64-apple-darwin)
```

That is, no debug info. A debug build of vector looks like:

```
vector 0.15.0 (x86_64-apple-darwin debug=full)
```

We currently just have a binary `debug` or nothing, which we could
switch back to here. I'm not really sure how often `debug` is set to `1`
to only include line info and if that is substantially different in
meaning than including full debug info.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
