### PR TITLE
docs(observability): Add missing HTTP metrics to internal_metrics docs

### DIFF
--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -161,13 +161,13 @@ components: sources: internal_metrics: {
 		// Metrics emitted by one or more components
 		// Reusable metric definitions
 		adaptive_concurrency_averaged_rtt: {
-			description:       "The average round-trip time (RTT) from the HTTP sink across the current window."
+			description:       "The average round-trip time (RTT) for the current window."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
 		adaptive_concurrency_in_flight: {
-			description:       "The number of outbound requests from the HTTP sink currently awaiting a response."
+			description:       "The number of outbound requests currently awaiting a response."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
@@ -179,7 +179,7 @@ components: sources: internal_metrics: {
 			tags:              _internal_metrics_tags
 		}
 		adaptive_concurrency_observed_rtt: {
-			description:       "The observed round-trip time (RTT) for requests from this HTTP sink."
+			description:       "The observed round-trip time (RTT) for requests."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
@@ -559,6 +559,28 @@ components: sources: internal_metrics: {
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
+		}
+		http_client_response_rtt_seconds: {
+			description:       "The round-trip time (RTT) of HTTP requests, tagged with the response code."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags & {
+				status: _status
+			}
+		}
+		http_client_responses_total: {
+			description:       "The total number of HTTP requests, tagged with the response code."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags & {
+				status: _status
+			}
+		}
+		http_client_rtt_seconds: {
+			description:       "The round-trip time (RTT) of HTTP requests."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags
 		}
 		http_error_response_total: {
 			description:       "The total number of HTTP error responses for this component."
@@ -966,6 +988,10 @@ components: sources: internal_metrics: {
 				tcp:  "Transmission Control Protocol"
 				unix: "Unix domain socket"
 			}
+		}
+		_status: {
+			description: "The HTTP status code of the request."
+			required:    false
 		}
 		_path: {
 			description: "The path that produced the error."


### PR DESCRIPTION
Also revise the adaptive concurrency metric descriptions to not be HTTP
specific since the controller could be used for non-HTTP requests in the
future.

I started to actually go through all of the sinks and add these metrics
where appropriate, but this turned into a bigger task than I expected so
I punted on it in-lieu of the upcoming work in #3900 . This change will
at least let users find these metrics.

This came up because a user in discord couldn't find descriptions for
them:
https://discord.com/channels/742820443487993987/746070604192415834/855217775983198228

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
