### PR TITLE
chore(config)!: Rename `remap` to `vrl` for condition types

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -5,11 +5,11 @@ use serde::{Deserialize, Serialize};
 pub mod check_fields;
 pub mod is_log;
 pub mod is_metric;
-pub mod remap;
+pub mod vrl;
 
 pub use check_fields::CheckFieldsConfig;
 
-pub use self::remap::RemapConfig;
+pub use self::vrl::VrlConfig;
 
 pub trait Condition: Send + Sync + dyn_clone::DynClone {
     fn check(&self, e: &Event) -> bool;
@@ -40,7 +40,7 @@ inventory::collect!(ConditionDescription);
 
 /// A condition can either be a raw string such as
 /// `condition = '.message == "hooray"'`.
-/// In this case it is turned into a Remap condition.
+/// In this case it is turned into a Vrl condition.
 /// Otherwise it is a condition such as:
 ///
 /// condition.type = 'check_fields'
@@ -67,7 +67,7 @@ pub enum AnyCondition {
 impl AnyCondition {
     pub fn build(&self) -> crate::Result<Box<dyn Condition>> {
         match self {
-            AnyCondition::String(s) => RemapConfig { source: s.clone() }.build(),
+            AnyCondition::String(s) => VrlConfig { source: s.clone() }.build(),
             AnyCondition::Map(m) => m.build(),
         }
     }
@@ -107,15 +107,15 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_anycondition_remap() {
+    fn deserialize_anycondition_vrl() {
         let conf: Test = toml::from_str(indoc! {r#"
-            condition.type = "remap"
+            condition.type = "vrl"
             condition.source = '.nork == true'
         "#})
         .unwrap();
 
         assert_eq!(
-            r#"Map(RemapConfig { source: ".nork == true" })"#,
+            r#"Map(VrlConfig { source: ".nork == true" })"#,
             format!("{:?}", conf.condition)
         )
     }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -40,7 +40,7 @@ inventory::collect!(ConditionDescription);
 
 /// A condition can either be a raw string such as
 /// `condition = '.message == "hooray"'`.
-/// In this case it is turned into a Vrl condition.
+/// In this case it is turned into a VRL condition.
 /// Otherwise it is a condition such as:
 ///
 /// condition.type = 'check_fields'

--- a/src/internal_events/conditions.rs
+++ b/src/internal_events/conditions.rs
@@ -1,0 +1,18 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug, Copy, Clone)]
+pub struct VrlConditionExecutionError;
+
+impl InternalEvent for VrlConditionExecutionError {
+    fn emit_logs(&self) {
+        warn!(
+            message = "VRL condition execution failed.",
+            internal_log_rate_secs = 120
+        )
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processing_errors_total", 1);
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -27,6 +27,7 @@ mod blackhole;
 mod coercer;
 #[cfg(feature = "transforms-concat")]
 mod concat;
+mod conditions;
 #[cfg(feature = "sinks-console")]
 mod console;
 #[cfg(feature = "sinks-datadog")]
@@ -154,6 +155,7 @@ pub use self::blackhole::*;
 pub(crate) use self::coercer::*;
 #[cfg(feature = "transforms-concat")]
 pub use self::concat::*;
+pub use self::conditions::*;
 #[cfg(feature = "sinks-console")]
 pub use self::console::*;
 #[cfg(feature = "sinks-datadog")]

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -30,22 +30,6 @@ impl InternalEvent for RemapMappingError {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct RemapConditionExecutionError;
-
-impl InternalEvent for RemapConditionExecutionError {
-    fn emit_logs(&self) {
-        warn!(
-            message = "Remap condition execution failed.",
-            internal_log_rate_secs = 120
-        )
-    }
-
-    fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1);
-    }
-}
-
 #[derive(Debug)]
 pub struct RemapMappingAbort {
     /// If set to true, the remap transform has dropped the event after an abort

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -142,7 +142,7 @@ impl FunctionTransform for Sample {
 mod tests {
     use super::*;
     use crate::{
-        conditions::{ConditionConfig, RemapConfig},
+        conditions::{ConditionConfig, VrlConfig},
         config::log_schema,
         event::Event,
         test_util::random_lines,
@@ -151,7 +151,7 @@ mod tests {
     use approx::assert_relative_eq;
 
     fn condition_contains(key: &str, needle: &str) -> Box<dyn Condition> {
-        RemapConfig {
+        VrlConfig {
             source: format!(r#"contains!(."{}", "{}")"#, key, needle),
         }
         .build()

--- a/tests/behavior/formats/simple.json
+++ b/tests/behavior/formats/simple.json
@@ -25,7 +25,7 @@
           "extract_from": "add_fields_nested_json",
           "conditions": [
             {
-              "type": "remap",
+              "type": "vrl",
               "source": ".a.b == 123 && .x.y == 456 && .x.z == 789"
             }
           ]

--- a/tests/behavior/formats/simple.toml
+++ b/tests/behavior/formats/simple.toml
@@ -15,5 +15,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested_toml"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/formats/simple.yaml
+++ b/tests/behavior/formats/simple.yaml
@@ -17,5 +17,5 @@ tests:
     outputs:
       - extract_from: add_fields_nested_yaml
         conditions:
-           - type: remap
+           - type: vrl
              source: ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/formats/simple.yml
+++ b/tests/behavior/formats/simple.yml
@@ -17,5 +17,5 @@ tests:
     outputs:
       - extract_from: add_fields_nested_yml
         conditions:
-           - type: remap
+           - type: vrl
              source: ".a.b == 123 && .x.y == 456 && .x.z == 789"

--- a/tests/behavior/transforms/add_fields.toml
+++ b/tests/behavior/transforms/add_fields.toml
@@ -14,7 +14,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested"
     [[tests.outputs.conditions]]
-        type = "remap"
+        type = "vrl"
         source = '''
             .a.b == 123
             .x.y == 456
@@ -40,7 +40,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_array"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == [0, "1", 2.0] &&
         .b == [0, null, "two"]
@@ -65,7 +65,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_nested_2"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a.b == "new value"'
 
 [transforms.add_fields_nested_then_scalar_1]
@@ -87,7 +87,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_nested_then_scalar_2"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a == "new value"'
 
 [transforms.add_fields_scalar_then_scalar_1]
@@ -109,7 +109,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_scalar_then_scalar_2"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a == "new value"'
 
 [transforms.add_fields_templated_1]
@@ -131,7 +131,7 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_2"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.b == "a was: initial value"'
 
 [transforms.add_fields_templated_nested_1]
@@ -153,5 +153,5 @@
   [[tests.outputs]]
     extract_from = "add_fields_templated_nested_2"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.b.c == "a.b was: initial value"'

--- a/tests/behavior/transforms/ansi_stripper.toml
+++ b/tests/behavior/transforms/ansi_stripper.toml
@@ -11,7 +11,7 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "hello123"'
 
 [transforms.ansi_stripper_nested]
@@ -28,5 +28,5 @@
   [[tests.outputs]]
     extract_from = "ansi_stripper_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a.b == "hello123"'

--- a/tests/behavior/transforms/coercer.toml
+++ b/tests/behavior/transforms/coercer.toml
@@ -23,7 +23,7 @@
   [[tests.outputs]]
     extract_from = "coercer_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .integer_field == 123 &&
         .boolean_field == true &&
@@ -48,5 +48,5 @@
   [[tests.outputs]]
     extract_from = "coercer_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".nested.field == 1234"

--- a/tests/behavior/transforms/concat.toml
+++ b/tests/behavior/transforms/concat.toml
@@ -15,7 +15,7 @@
   [[tests.outputs]]
     extract_from = "concat_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.concatenated == "on wo re"'
 
 [transforms.concat_nested]
@@ -35,5 +35,5 @@
   [[tests.outputs]]
     extract_from = "concat_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.nested.concatenated.field == "ababab cdcdcd efe"'

--- a/tests/behavior/transforms/dedupe.toml
+++ b/tests/behavior/transforms/dedupe.toml
@@ -26,12 +26,12 @@
   [[tests.outputs]]
     extract_from = "dedupe_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".a == 1 && .b == 2"
   [[tests.outputs]]
     extract_from = "dedupe_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".a == 2 && .b == 4"
 
 [transforms.dedupe_field_order]
@@ -65,14 +65,14 @@
   [[tests.outputs]]
     extract_from = "dedupe_field_order"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == 1 && .b == 2 && .c == 3
       '''
   [[tests.outputs]]
     extract_from = "dedupe_field_order"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == 1 && .b == 3 && .c == 3
       '''
@@ -105,10 +105,10 @@
   [[tests.outputs]]
     extract_from = "dedupe_nested_fields"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a.b.c == "d" && .b == 2'
   [[tests.outputs]]
     extract_from = "dedupe_nested_fields"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.a.b == "c.d" && .b == 4'

--- a/tests/behavior/transforms/filter.toml
+++ b/tests/behavior/transforms/filter.toml
@@ -2,7 +2,7 @@
   inputs = ["ignored"]
   type = "filter"
   [transforms.filter_a.condition]
-    type = "remap"
+    type = "vrl"
     source = '''
       message = if exists(.tags) { .tags.message } else { .message }
       message == "test filter 1"
@@ -11,7 +11,7 @@
   inputs = ["ignored"]
   type = "filter"
   [transforms.filter_b.condition]
-    type = "remap"
+    type = "vrl"
     source = '''
       message = if exists(.tags) { string!(.tags.message) } else { string!(.message) }
       contains(message, "test filter") &&
@@ -32,7 +32,7 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "test filter 1"'
 
 [[tests]]
@@ -65,7 +65,7 @@
   [[tests.outputs]]
     extract_from = "filter_b"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "test filter 2"'
 
 [[tests]]
@@ -87,5 +87,5 @@
   [[tests.outputs]]
     extract_from = "filter_a"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.tags.message == "test filter 1"'

--- a/tests/behavior/transforms/grok_parser.toml
+++ b/tests/behavior/transforms/grok_parser.toml
@@ -11,7 +11,7 @@
   [[tests.outputs]]
     extract_from = "grok_parser_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .timestamp == "12/Dec/2015:18:32:56 +0100" &&
         .message == "hello"
@@ -30,7 +30,7 @@
   [[tests.outputs]]
     extract_from = "grok_parser_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.timestamp == "12/Dec/2015:18:32:56 +0100" &&
         .doubly.nested.message == "hello"

--- a/tests/behavior/transforms/json_parser.toml
+++ b/tests/behavior/transforms/json_parser.toml
@@ -10,7 +10,7 @@
   [[tests.outputs]]
     extract_from = "json_parser_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == 3 &&
         .b.c == 4
@@ -29,7 +29,7 @@
   [[tests.outputs]]
     extract_from = "json_parser_target_field"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .target_field.a == 3
         .target_field.b.c == 4
@@ -47,7 +47,7 @@
   [[tests.outputs]]
     extract_from = "json_parser_null_value"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == 3 &&
         .b == null

--- a/tests/behavior/transforms/key_value_parser.toml
+++ b/tests/behavior/transforms/key_value_parser.toml
@@ -19,7 +19,7 @@
     [[tests.outputs]]
       extract_from = "key_value_parser"
       [[tests.outputs.conditions]]
-        type = "remap"
+        type = "vrl"
         source = '''
           .data.action == "Accept"
           .data.ifdir == "inbound"
@@ -39,7 +39,7 @@
     [[tests.outputs]]
       extract_from = "key_value_parser_defaults"
       [[tests.outputs.conditions]]
-        type = "remap"
+        type = "vrl"
         source = '''
           .action == "\"Accept\""
           .ifdir == "\"inbound\""

--- a/tests/behavior/transforms/logfmt_parser.toml
+++ b/tests/behavior/transforms/logfmt_parser.toml
@@ -15,7 +15,7 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .code == 1234 &&
         .flag == true &&
@@ -40,7 +40,7 @@
   [[tests.outputs]]
     extract_from = "logfmt_parser_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.code == 1234 &&
         .nested.flag == true &&

--- a/tests/behavior/transforms/lua_v1.toml
+++ b/tests/behavior/transforms/lua_v1.toml
@@ -14,7 +14,7 @@
   [[tests.outputs]]
     extract_from = "lua_unversioned"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         !exists(.a) &&
         .b == "example value"
@@ -37,7 +37,7 @@
   [[tests.outputs]]
     extract_from = "lua_v1"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         !exists(.a) &&
         .b == "example value"

--- a/tests/behavior/transforms/lua_v2.toml
+++ b/tests/behavior/transforms/lua_v2.toml
@@ -18,7 +18,7 @@
   [[tests.outputs]]
     extract_from = "lua_v2_log"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         !exists(.a) &&
         .b == "example value"
@@ -45,7 +45,7 @@
   [[tests.outputs]]
     extract_from = "lua_v2_source"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .some_field == "some value" &&
         .inserted_field == "inserted value"
@@ -128,7 +128,7 @@
   [[tests.outputs]]
     extract_from = "lua_v2_metric_to_log"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .field == "example value"
       '''

--- a/tests/behavior/transforms/merge.toml
+++ b/tests/behavior/transforms/merge.toml
@@ -17,7 +17,7 @@
   [[tests.outputs]]
     extract_from = "merge"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "hello world" &&
         !exists(."_partial")
@@ -43,7 +43,7 @@
   [[tests.outputs]]
     extract_from = "merge_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.message == "hello world" &&
         !exists(."_partial")
@@ -70,7 +70,7 @@
   [[tests.outputs]]
     extract_from = "merge_nested_marker"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.message == "hello world" &&
         !exists(.nested.is_partial)

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -281,43 +281,43 @@
 
 ##------------------------------------------------------------------------------
 
-[transforms.ends_when_remap]
+[transforms.ends_when_vrl]
   inputs = []
   type = "reduce"
   group_by = ["request_id"]
 
-  [transforms.ends_when_remap.ends_when]
+  [transforms.ends_when_vrl.ends_when]
     type = "vrl"
     source = """
         .test_end_message == true
     """
 
 [[tests]]
-  name = "reduce_ends_when_remap"
+  name = "reduce_ends_when_vrl"
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "1"
       counter = 1
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "1"
       counter = 3
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "2"
       counter = 5
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "1"
@@ -325,14 +325,14 @@
       test_end_message = true
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "1"
       counter = 7
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "2"
@@ -340,7 +340,7 @@
       test_end_message = true
 
   [[tests.inputs]]
-    insert_at = "ends_when_remap"
+    insert_at = "ends_when_vrl"
     type = "log"
     [tests.inputs.log_fields]
       request_id = "3"
@@ -348,7 +348,7 @@
       test_end_message = true
 
   [[tests.outputs]]
-    extract_from = "ends_when_remap"
+    extract_from = "ends_when_vrl"
     [[tests.outputs.conditions]]
       type = "vrl"
       source = '''
@@ -377,7 +377,7 @@
     inputs = []
     type = "reduce"
     merge_strategies.message = "concat_newline"
-    starts_when.type = "remap"
+    starts_when.type = "vrl"
     starts_when.source = "match(string!(.message), r'^\\w.*')"
 
 [[tests]]
@@ -436,7 +436,7 @@
     inputs = []
     type = "reduce"
     merge_strategies.message = "concat"
-    ends_when.type = "remap"
+    ends_when.type = "vrl"
     ends_when.source = """!ends_with(strip_whitespace(string!(.message)), "\\\\")"""
 
 [[tests]]
@@ -490,7 +490,7 @@
   inputs = []
   type = "reduce"
   merge_strategies.message = "concat"
-  ends_when.type = "remap"
+  ends_when.type = "vrl"
   ends_when.source = """ends_with(strip_whitespace(string!(.message)), ";")"""
 
 [[tests]]
@@ -544,7 +544,7 @@
     inputs = []
     type = "reduce"
     merge_strategies.message = "concat"
-    starts_when.type = "remap"
+    starts_when.type = "vrl"
     starts_when.source = "match(string!(.message), r'^<\\d\\d> ')"
 
 [[tests]]
@@ -598,7 +598,7 @@
     inputs = []
     type = "reduce"
     merge_strategies.message = "concat_newline"
-    starts_when.type = "remap"
+    starts_when.type = "vrl"
     starts_when.source = "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2} .+')"
 
 [[tests]]

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -3,7 +3,7 @@
   type = "reduce"
   group_by = [ "request_id" ]
   [transforms.reduce.ends_when]
-    type = "remap"
+    type = "vrl"
     source = "exists(.test_end_message)"
 
 [[tests]]
@@ -68,7 +68,7 @@
   [[tests.outputs]]
     extract_from = "reduce"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "first message value" &&
         .host == "host1" &&
@@ -77,7 +77,7 @@
         exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "other reduce one" &&
         .host == "host3" &&
@@ -100,7 +100,7 @@
     "concat_array" = "concat"
 
   [transforms.reduce_strats.ends_when]
-    type = "remap"
+    type = "vrl"
     source = 'exists(.test_end_message)'
 
 [[tests]]
@@ -175,7 +175,7 @@
   [[tests.outputs]]
     extract_from = "reduce_strats"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "first message value second message value third message value" &&
         .another == "foo\nbar baz\nqux\nquux" &&
@@ -185,7 +185,7 @@
         exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "other reduce one other reduce two other reduce three" &&
         .concat_array == ["foo", "bar", "baz"] &&
@@ -206,7 +206,7 @@
     "maxs" = "max"
 
   [transforms.reduce_numbers.ends_when]
-    type = "remap"
+    type = "vrl"
     source = "exists(.test_end_message)"
 
 [[tests]]
@@ -237,7 +237,7 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .mins == 5.1 &&
         .maxs == 7.2 &&
@@ -272,7 +272,7 @@
   [[tests.outputs]]
     extract_from = "reduce_numbers"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .mins == 5 &&
         .maxs == 7 &&
@@ -287,7 +287,7 @@
   group_by = ["request_id"]
 
   [transforms.ends_when_remap.ends_when]
-    type = "remap"
+    type = "vrl"
     source = """
         .test_end_message == true
     """
@@ -350,21 +350,21 @@
   [[tests.outputs]]
     extract_from = "ends_when_remap"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .request_id == "1" &&
         .counter == 6 &&
         exists(.timestamp_end)
       '''
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .request_id == "2" &&
         .counter == 7 &&
         exists(.test_end_message)
       '''
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .request_id == "3" &&
         .counter == 5 &&
@@ -422,10 +422,10 @@
   [[tests.outputs]]
     extract_from = "ruby_exception"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
       '''
@@ -475,13 +475,13 @@
   [[tests.outputs]]
     extract_from = "line_continuation"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "First-line"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "Second line\\ more second line\\      end of second line"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "third line"'
 
 ##------------------------------------------------------------------------------
@@ -529,13 +529,13 @@
   [[tests.outputs]]
     extract_from = "line_termination"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "first line;"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "second line more of the second line end of second line;         "'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "third line;"'
 
 ##------------------------------------------------------------------------------
@@ -583,13 +583,13 @@
   [[tests.outputs]]
     extract_from = "log_stream"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "<12> first line   more of the first line"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "<22> second line"'
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '.message == "<17> third line"'
 
 ##------------------------------------------------------------------------------
@@ -667,7 +667,7 @@
   [[tests.outputs]]
     extract_from = "java_exception"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         message = string!(.message)
         starts_with(message, "2020-10-19 04:34:15,389") &&

--- a/tests/behavior/transforms/regex_parser.toml
+++ b/tests/behavior/transforms/regex_parser.toml
@@ -11,7 +11,7 @@
   [[tests.outputs]]
     extract_from = "regex_parser_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .timestamp == "2020-01-01T12:34:56Z" &&
         .level == "INFO" &&
@@ -32,7 +32,7 @@
   [[tests.outputs]]
     extract_from = "regex_parser_target"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .something.timestamp == "2020-01-01T12:34:56Z" &&
         .something.level == "INFO" &&

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -14,7 +14,7 @@
   [[tests.outputs]]
     extract_from = "remap_emit_multiple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       # unit test will only catch the first one output
       source = ".message == \"hello\""
 
@@ -34,7 +34,7 @@
   [[tests.outputs]]
     extract_from = "remap_mapped_scalars"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".message == 5"
 
 [transforms.remap_abort]
@@ -57,7 +57,7 @@
   [[tests.outputs]]
     extract_from = "remap_abort"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".foo == true && .bar == true"
 
 [transforms.remap_abort_drop_on_abort]
@@ -96,7 +96,7 @@
   [[tests.outputs]]
     extract_from = "remap_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a.b == 123 &&
         .x.y == 456 &&
@@ -122,7 +122,7 @@
   [[tests.outputs]]
     extract_from = "remap_array"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == [0, "1", 2.0] &&
         .b == [0, null, "two"]
@@ -152,7 +152,7 @@
   [[tests.outputs]]
     extract_from = "remap_arithmetic"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .result_a == 27 &&
         .result_b == 51 &&
@@ -179,7 +179,7 @@
   [[tests.outputs]]
     extract_from = "remap_arithmetic_error"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = ".a == 0.0"
 
 [transforms.remap_boolean_arithmetic]
@@ -204,7 +204,7 @@
   [[tests.outputs]]
     extract_from = "remap_boolean_arithmetic"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .result_a == true &&
         .result_b == false &&
@@ -237,7 +237,7 @@
   [[tests.outputs]]
     extract_from = "remap_coercion"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .foo == "10" &&
         .bar == 20 &&
@@ -263,7 +263,7 @@
   [[tests.outputs]]
     extract_from = "remap_quoted_path"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a."b.c" == "baz"
       '''
@@ -284,7 +284,7 @@
   [[tests.outputs]]
     extract_from = "remap_infallible_assignment"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nope == null &&
         .err1 == "function call error for \"parse_json\" at (19:44): unable to parse json: key must be a string at line 1 column 3" &&
@@ -308,7 +308,7 @@
   [[tests.outputs]]
     extract_from = "remap_error_coalesce_operator"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .val1 == "nope"
         .val2 == true
@@ -329,7 +329,7 @@
   [[tests.outputs]]
     extract_from = "remap_bang_function"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = "!exists(.val)"
 
 [transforms.remap_function_arguments]
@@ -354,7 +354,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_arguments"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "10" &&
         .b == "10" &&
@@ -389,7 +389,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_upcase"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "A" &&
         .b == "BBB BB" &&
@@ -441,7 +441,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_downcase"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "a" &&
         .b == "bbb bb" &&
@@ -487,7 +487,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_uuid_v4"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         match(string!(.a), r'(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') &&
         .b == "bar"
@@ -514,7 +514,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_sha1"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" &&
         .b == "6f74c252bb7f19f553115af5e49a733b9ff17138"
@@ -559,7 +559,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_md5"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "acbd18db4cc2f85cedef654fccc4a4d8" &&
         .b == "223cfa6567e4c0599c9a23628bf7a234"
@@ -598,7 +598,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_now"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         ends_with(to_string!(.a), "Z")
       '''
@@ -619,7 +619,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_format_timestamp"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == "1970-01-01T00:00:10+00:00"
       '''
@@ -648,7 +648,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_contains"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == false &&
         .b == true &&
@@ -680,7 +680,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_starts_with"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a == true &&
         .b == true &&
@@ -710,7 +710,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ends_with"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == true &&
 #         .b == true &&
@@ -739,7 +739,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_slice"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "oobar" &&
 #         .b == "f" &&
@@ -765,7 +765,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_tokens"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == ["217.250.207.207",
 #                null,
@@ -797,7 +797,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_sha2"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d" &&
 #         .b == "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
@@ -824,7 +824,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_sha3"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7" &&
 #         .b == "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"
@@ -848,7 +848,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_duration"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == 2000 &&
 #         .b == 0.1
@@ -870,7 +870,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_glog"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .glog.level == "info" &&
 #         .glog.timestamp == to_timestamp!("2021-01-31T14:48:54.411655Z") &&
@@ -896,7 +896,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_format_number"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "1.234,56"
 #       '''
@@ -917,7 +917,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_url"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .parts == { "scheme": "https",
 #                     "username": "",
@@ -948,7 +948,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ceil"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == 93 &&
 #         .b == 92.5 &&
@@ -973,7 +973,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_floor"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == 92 &&
 #         .b == 92.4 &&
@@ -998,7 +998,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_round"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == 92 &&
 #         .b == 92.5 &&
@@ -1021,7 +1021,7 @@
 #   [[tests.outputs]]
 #   extract_from = "remap_function_parse_syslog"
 #   [[tests.outputs.conditions]]
-#     type = "remap"
+#     type = "vrl"
 #     source = '''
 #       .a.facility == "daemon" &&
 #       .a.severity == "warning" &&
@@ -1048,7 +1048,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_split_regex"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo[0] == "bar" &&
 #         .foo[1] == "bat" &&
@@ -1071,7 +1071,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_split_string"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo[0] == "bar" &&
 #         .foo[1] == "bat" &&
@@ -1093,7 +1093,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_timestamp"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo == to_timestamp!("1970-01-01T00:00:10Z")
 #       '''
@@ -1114,7 +1114,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_truncate"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo == "foo" &&
 #         .bar == "foob..."
@@ -1143,7 +1143,7 @@
   [[tests.outputs]]
     extract_from = "remap_function_tag_types_externally"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .string == { "string": "foo" } &&
         .integer == { "integer": 123 } &&
@@ -1171,7 +1171,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_strip_whitespace"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo == "foobar"
 #       '''
@@ -1193,7 +1193,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_grok"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .grokked.timestamp == "2020-10-02T23:22:12.223222Z" &&
 #         .grokked.level == "info" &&
@@ -1222,7 +1222,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_common_log"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .common_log.host == "127.0.0.1" &&
 #         .common_log.identity == "bob" &&
@@ -1264,7 +1264,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ip_subnet"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "192.168.0.0" &&
 #         .b == "192.0.0.0" &&
@@ -1290,7 +1290,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ip_cidr_contains"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == true &&
 #         .b == false &&
@@ -1313,7 +1313,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ip_to_ipv6"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "::ffff:192.168.10.2"
 #       '''
@@ -1333,7 +1333,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_ipv6_to_ipv4"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "192.168.10.2"
 #       '''
@@ -1363,7 +1363,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_exists"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a  && !.b  && .c && !.d  && .e && !.f ?? false
 #       '''
@@ -1399,7 +1399,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_compact"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == false &&
 #         .b == true &&
@@ -1427,7 +1427,7 @@
 #   [[tests.outputs]]
 #   extract_from = "remap_function_assert_pass"
 #   [[tests.outputs.conditions]]
-#     type = "remap"
+#     type = "vrl"
 #     source = '''
 #       .check == "checked"
 #     '''
@@ -1464,7 +1464,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_log"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .foo == "this should be unchanged"
 #       '''
@@ -1492,7 +1492,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_merge"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .bar.field1 == "ook" &&
 #         .bar.field2 == "ook ook"
@@ -1520,7 +1520,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_flatten"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .arr[0] == 1 &&
 #         .arr[1] == 2 &&
@@ -1552,7 +1552,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_redact"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "**** world, **** universe" &&
 #         .b == "**** ****ld, **** universe" &&
@@ -1578,7 +1578,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_replace"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "fbaro" &&
 #         .b == "fbarbar"
@@ -1600,7 +1600,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_aws_alb_log"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .parts.type == "http" &&
 #         .parts.timestamp == "2018-11-30T22:23:00.186641Z" &&
@@ -1651,7 +1651,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_aws_vpc_flow_log"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a.version == 2 &&
 #         .a.account_id == 123456789010 &&
@@ -1697,7 +1697,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_metrics"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .tags.name == "example counter" &&
 #         .tags.namespace == "zork" &&
@@ -1723,7 +1723,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_encode_json"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "[1,2,3]" &&
 #         .b == "{\"field1\":{\"field2\":1,\"field3\":null}}"
@@ -1748,7 +1748,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_regex"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .bytes_in == 5667 &&
 #         .host == "5.86.210.12" &&
@@ -1777,7 +1777,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_regex_all"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result[0].fruit == "apples" &&
 #         .result[0].veg == "carrots" &&
@@ -1803,7 +1803,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_aws_cloudwatch_log_subscription_message"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result.owner == "CloudwatchLogs" &&
 #         .result.message_type == "CONTROL_MESSAGE" &&
@@ -1833,7 +1833,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_parse_key_value"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .path == "/cart_link" &&
 #         .host == "lumberjack-store.herokuapp.com" &&
@@ -1875,7 +1875,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_is_nullish"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == true &&
 #         .b == true &&
@@ -1906,7 +1906,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_to_syslog_facility"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == "daemon" &&
 #         .b == "ftp" &&
@@ -1931,7 +1931,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_to_unix_timestamp"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .secs == 1600077224 &&
 #         .millis == 1600077224000 &&
@@ -1955,7 +1955,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_push_to_array"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result[0] == "apple" &&
 #         .result[1] == "orange" &&
@@ -1980,7 +1980,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_append_to_array"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result[0] == "apple" &&
 #         .result[1] == "orange" &&
@@ -2003,7 +2003,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_encode_base64"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result == "QnJvbi1ZLUF1ciBTdG9tcA=="
 #       '''
@@ -2023,7 +2023,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_decode_base64"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .result == "Bron-Y-Aur Stomp"
 #       '''
@@ -2051,7 +2051,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_comments"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a == 1
 #         .b == true
@@ -2075,7 +2075,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_multiline"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '.a == "A long multiline string"'
 
 # [transforms.remap_function_length]
@@ -2098,7 +2098,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_length"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '[.a, .b, .c] == [3, 2, 3]'
 
 # [transforms.remap_function_get_hostname]
@@ -2116,7 +2116,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_get_hostname"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .a != ""
 #       '''
@@ -2140,7 +2140,7 @@
 #   [[tests.outputs]]
 #     extract_from = "remap_function_join"
 #     [[tests.outputs.conditions]]
-#       type = "remap"
+#       type = "vrl"
 #       source = '''
 #         .comma == "foo, bar, baz" &&
 #         .space == "foo bar baz" &&

--- a/tests/behavior/transforms/remove_fields.toml
+++ b/tests/behavior/transforms/remove_fields.toml
@@ -13,7 +13,7 @@
   [[tests.outputs]]
     extract_from = "remove_fields_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         !exists(.a) &&
         .b == 4
@@ -34,7 +34,7 @@
   [[tests.outputs]]
     extract_from = "remove_fields_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a.b == 3 &&
         !exists(.a.c)
@@ -58,7 +58,7 @@
   [[tests.outputs]]
     extract_from = "remove_fields_empty_objects"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         !exists(.a.b) &&
         !exists(.a.c) &&

--- a/tests/behavior/transforms/rename_fields.toml
+++ b/tests/behavior/transforms/rename_fields.toml
@@ -21,7 +21,7 @@
   [[tests.outputs]]
     extract_from = "rename_fields_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         # Plain
         !exists(.a) &&
@@ -58,7 +58,7 @@
   [[tests.outputs]]
     extract_from = "rename_fields_empty_objects"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .a.b == 1 &&
         exists(.a) &&

--- a/tests/behavior/transforms/route.toml
+++ b/tests/behavior/transforms/route.toml
@@ -2,12 +2,12 @@
   inputs = ["ignored"]
   type = "route"
   [transforms.foo.route.first]
-    type = "remap"
+    type = "vrl"
     source = '''
       .message == "test swimlane 1"
     '''
   [transforms.foo.route.second]
-    type = "remap"
+    type = "vrl"
     source = '''
       .message == "test swimlane 2"
     '''
@@ -31,7 +31,7 @@
   [[tests.outputs]]
     extract_from = "foo.first"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "test swimlane 1"
       '''
@@ -39,7 +39,7 @@
   [[tests.outputs]]
     extract_from = "bar"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "test swimlane 1"
         .new_field == "new field added"
@@ -48,7 +48,7 @@
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "test swimlane 1"
       '''
@@ -64,7 +64,7 @@
   [[tests.outputs]]
     extract_from = "foo.second"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "test swimlane 2"
       '''
@@ -72,7 +72,7 @@
   [[tests.outputs]]
     extract_from = "foo.third"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .message == "test swimlane 2"
       '''

--- a/tests/behavior/transforms/split.toml
+++ b/tests/behavior/transforms/split.toml
@@ -11,7 +11,7 @@
   [[tests.outputs]]
     extract_from = "split_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .timestamp == "2020-01-01T12:34:56Z" &&
         .level == "INFO" &&
@@ -32,7 +32,7 @@
   [[tests.outputs]]
     extract_from = "split_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.timestamp == "2020-01-01T12:34:56Z" &&
         .nested.level == "INFO" &&

--- a/tests/behavior/transforms/tokenizer.toml
+++ b/tests/behavior/transforms/tokenizer.toml
@@ -11,7 +11,7 @@
   [[tests.outputs]]
     extract_from = "tokenizer_simple"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .timestamp == "2020-01-01T12:34:56Z" &&
         .level == "INFO" &&
@@ -32,7 +32,7 @@
   [[tests.outputs]]
     extract_from = "tokenizer_nested"
     [[tests.outputs.conditions]]
-      type = "remap"
+      type = "vrl"
       source = '''
         .nested.timestamp == "2020-01-01T12:34:56Z" &&
         .nested.level == "INFO" &&


### PR DESCRIPTION
Part of
https://github.com/timberio/vector/issues/6261 and suggested by
https://github.com/timberio/vector/issues/6964#issuecomment-863119403

I was hoping alias `remap` as `vrl` but it doesn't look like the
`typetag` crate supports this. I think the breakages will be limited as
we generally encourage users to just do:

`condition = "<some VRL program>"`

Rather than

```toml
type = "remap"
source = "<some VRL program>"
```

I think the change is worthwhile as `remap` is kinda a confusing name
for the condition type.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
