### PR TITLE
enhancement(observability): add flag to send tracing spans to Datadog APM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4534,6 +4534,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492848ff47f11b7f9de0443b404e2c5775f695e1af6b7076ca25f999581d547a"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel 0.5.1",
+ "futures 0.3.15",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project 1.0.7",
+ "rand 0.8.4",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-datadog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8794eb897decce87294f264182580c0615a6df1c8bfd1db03de6eda39903e87d"
+dependencies = [
+ "async-trait",
+ "http",
+ "indexmap",
+ "itertools 0.10.1",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-http",
+ "reqwest",
+ "rmp",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b752610d59706ff7cae48003552b3d0bf19bcce532629c8a49095894f21c319"
+dependencies = [
+ "async-trait",
+ "bytes 1.0.1",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7496,6 +7547,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f4cb277b92a8ba1170b3b911056428ce2ef9993351baf5965bb0359a2e5963"
+dependencies = [
+ "opentelemetry",
+ "tracing 0.1.26",
+ "tracing-core 0.1.18",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7978,6 +8041,8 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-probe",
+ "opentelemetry",
+ "opentelemetry-datadog",
  "percent-encoding",
  "pest",
  "pest_derive",
@@ -8046,6 +8111,7 @@ dependencies = [
  "tracing-futures 0.2.5",
  "tracing-limit",
  "tracing-log",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-tower",
  "trust-dns-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,9 @@ tracing-futures = { version = "0.2.5", default-features = false, features = ["fu
 tracing-log = { version = "0.1.2", default-features = false }
 tracing-subscriber = { version = "0.2.18", default-features = false }
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", default-features = false, rev = "f470db1b0354b368f62f9ee4d763595d16373231" }
+tracing-opentelemetry = { version = "0.13.0", default-features = false }
+opentelemetry = { version = "0.14.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-datadog = { version = "0.2.0", default-features = false, features = ["reqwest-client"] }
 
 # Metrics
 metrics = { version = "0.16.0", default-features = false, features = ["std"] }

--- a/benches/metrics_bench_util/mod.rs
+++ b/benches/metrics_bench_util/mod.rs
@@ -35,7 +35,7 @@ fn disable_metrics_tracing_integration() {
 
 #[inline]
 fn boot() {
-    vector::trace::init(false, false, "warn");
+    vector::trace::init(false, false, "warn", false);
     vector::metrics::init().expect("metrics initialization failed");
 }
 

--- a/docs/reference/cli.cue
+++ b/docs/reference/cli.cue
@@ -103,6 +103,13 @@ cli: {
 			description: "Watch for changes in the configuration file, and reload accordingly"
 			env_var:     "VECTOR_WATCH_CONFIG"
 		}
+		"enable-datadog-tracing": {
+			description: """
+				  [experimental] Send internal tracing spans to a local APM-enabled
+				  Datadog agent with a granularity matching the current log level.
+				"""
+			env_var: "VECTOR_ENABLE_DATADOG_TRACING"
+		}
 	}
 
 	options: {

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -7,6 +7,7 @@ use std::{
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
+use tracing::trace_span;
 
 const FINGERPRINT_CRC: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_ECMA_182);
 
@@ -102,6 +103,7 @@ impl Fingerprinter {
         known_small_files: &mut HashSet<PathBuf>,
         emitter: &impl FileSourceInternalEvents,
     ) -> Option<FileFingerprint> {
+        let _span = trace_span!("fingerprinting", ?path).entered();
         metadata(path)
             .and_then(|metadata| {
                 if metadata.is_dir() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,8 @@ impl Application {
             LogFormat::Json => true,
         };
 
+        let enable_datadog_tracing = root_opts.enable_datadog_tracing;
+
         metrics::init().expect("metrics initialization failed");
 
         if let Some(threads) = root_opts.threads {
@@ -107,8 +109,12 @@ impl Application {
 
         // We need a runtime to initiate the datadog tracing exporter
         rt.block_on(async move {
-            trace::init(color, json, &level);
-            info!(message = "Log level is enabled.", level = ?level);
+            trace::init(color, json, &level, enable_datadog_tracing);
+            info!(
+                message = "Log level is enabled.",
+                ?level,
+                ?enable_datadog_tracing
+            );
         });
 
         let config = {

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,7 +91,9 @@ impl Application {
 
         if let Some(threads) = root_opts.threads {
             if threads < 1 {
-                error!("The `threads` argument must be greater or equal to 1.");
+                // Unforunately we can't `error!` here because we haven't yet called `trace::init`,
+                // and we can't call that without a runtime available.
+                println!("Config error: The `threads` argument must be greater or equal to 1.");
                 return Err(exitcode::CONFIG);
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,11 @@ pub struct RootOpts {
     /// Watch for changes in configuration file, and reload accordingly.
     #[structopt(short, long, env = "VECTOR_WATCH_CONFIG")]
     pub watch_config: bool,
+
+    /// [experimental] Send internal tracing spans to a local APM-enabled Datadog agent with
+    /// a granularity matching the current log level.
+    #[structopt(long, env = "VECTOR_ENABLE_DATADOG_TRACING")]
+    pub enable_datadog_tracing: bool,
 }
 
 impl RootOpts {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,7 +152,7 @@ pub struct RootOpts {
 
     /// [experimental] Send internal tracing spans to a local APM-enabled Datadog agent with
     /// a granularity matching the current log level.
-    #[structopt(long, env = "VECTOR_ENABLE_DATADOG_TRACING")]
+    #[structopt(long, env = "VECTOR_ENABLE_DATADOG_TRACING", takes_value(false))]
     pub enable_datadog_tracing: bool,
 }
 

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -75,7 +75,7 @@ mod tests {
     #[tokio::test]
     async fn receives_logs() {
         let start = chrono::Utc::now();
-        trace::init(false, false, "debug");
+        trace::init(false, false, "debug", false);
         trace::reset_early_buffer();
         error!(message = "Before source started.");
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -112,7 +112,7 @@ pub fn trace_init() {
 
     let levels = std::env::var("TEST_LOG").unwrap_or_else(|_| "error".to_string());
 
-    trace::init(color, false, &levels);
+    trace::init(color, false, &levels, false);
 }
 
 pub async fn send_lines(

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -60,6 +60,20 @@ pub fn init(color: bool, json: bool, levels: &str) {
 
         let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
 
+        let tracer = opentelemetry_datadog::new_pipeline()
+            .with_service_name("vector")
+            .with_version(opentelemetry_datadog::ApiVersion::Version05)
+            .with_trace_config(
+                opentelemetry::sdk::trace::config()
+                    .with_sampler(opentelemetry::sdk::trace::Sampler::AlwaysOn),
+            )
+            .install_batch(opentelemetry::runtime::Tokio)
+            .expect("building tracer");
+
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        let subscriber = subscriber.with(telemetry);
+
         if metrics_layer_enabled {
             let subscriber = subscriber.with(MetricsLayer::new());
             Dispatch::new(BroadcastSubscriber { subscriber })
@@ -76,6 +90,20 @@ pub fn init(color: bool, json: bool, levels: &str) {
             .with_test_writer(); // ensures output is captured
 
         let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
+
+        let tracer = opentelemetry_datadog::new_pipeline()
+            .with_service_name("vector")
+            .with_version(opentelemetry_datadog::ApiVersion::Version05)
+            .with_trace_config(
+                opentelemetry::sdk::trace::config()
+                    .with_sampler(opentelemetry::sdk::trace::Sampler::AlwaysOn),
+            )
+            .install_batch(opentelemetry::runtime::Tokio)
+            .expect("building tracer");
+
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        let subscriber = subscriber.with(telemetry);
 
         if metrics_layer_enabled {
             let subscriber = subscriber.with(MetricsLayer::new());

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -87,13 +87,11 @@ pub fn init(color: bool, json: bool, levels: &str, enable_datadog_tracing: bool)
             } else {
                 Dispatch::new(BroadcastSubscriber { subscriber })
             }
+        } else if enable_datadog_tracing {
+            send_to_dd!(subscriber);
+            Dispatch::new(BroadcastSubscriber { subscriber })
         } else {
-            if enable_datadog_tracing {
-                send_to_dd!(subscriber);
-                Dispatch::new(BroadcastSubscriber { subscriber })
-            } else {
-                Dispatch::new(BroadcastSubscriber { subscriber })
-            }
+            Dispatch::new(BroadcastSubscriber { subscriber })
         }
     } else {
         #[cfg(not(test))]
@@ -114,13 +112,11 @@ pub fn init(color: bool, json: bool, levels: &str, enable_datadog_tracing: bool)
             } else {
                 Dispatch::new(BroadcastSubscriber { subscriber })
             }
+        } else if enable_datadog_tracing {
+            send_to_dd!(subscriber);
+            Dispatch::new(BroadcastSubscriber { subscriber })
         } else {
-            if enable_datadog_tracing {
-                send_to_dd!(subscriber);
-                Dispatch::new(BroadcastSubscriber { subscriber })
-            } else {
-                Dispatch::new(BroadcastSubscriber { subscriber })
-            }
+            Dispatch::new(BroadcastSubscriber { subscriber })
         }
     };
 


### PR DESCRIPTION
Closes #7641 

This adds an option for sending tracing spans to a local Datadog agent (with APM enabled, which is not the default, see [docs](https://docs.datadoghq.com/agent/docker/apm/?tab=linux)). There is still some work to do to make the tracing data interesting, but I've added some new spans to the file source that would have come in very handy in previous investigations.

An important thing to note is that these spans respect the current log level, so if you want to see the new tracing spans from the file source you'll need to run with something like `LOG=info,file_source=trace`. This obviously makes the logs noisy as well, so we may want to do some thinking about how to choose levels. If the performance impact is low enough many of these could be bumped to debug or even info.