### PR TITLE
enhancement(reload): Enable component internal reload

### DIFF
--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -1,4 +1,5 @@
 use super::InternalEvent;
+use crate::Error;
 use metrics::counter;
 
 #[derive(Debug)]
@@ -34,5 +35,20 @@ impl InternalEvent for EventOut {
             // jank.
             counter!("events_out_total", self.count as u64);
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct InternalReloadFailed {
+    pub error: Error,
+}
+
+impl InternalEvent for InternalReloadFailed {
+    fn emit_logs(&self) {
+        warn!(message = "Failed reloading component internal data.", error = %self.error);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("reload_errors_total", 1);
     }
 }

--- a/src/topology/generation.rs
+++ b/src/topology/generation.rs
@@ -110,15 +110,19 @@ mod tests {
     use super::*;
     use std::cell::Cell;
 
-    #[test]
-    fn reload() {
+    fn counter() -> Aged<usize> {
         let cell = Cell::new(0);
-        let mut aged = Aged::new(move || {
+        Aged::new(move || {
             let new = cell.get() + 1;
             cell.set(new);
             Ok(new)
         })
-        .unwrap();
+        .unwrap()
+    }
+
+    #[test]
+    fn reload() {
+        let mut aged = counter();
 
         let start = *aged.as_ref();
         inc_generation();
@@ -129,22 +133,18 @@ mod tests {
 
     #[test]
     fn reuse() {
-        let cell = Cell::new(0);
-        let mut aged = Aged::new(move || {
-            let new = cell.get() + 1;
-            cell.set(new);
-            Ok(new)
-        })
-        .unwrap();
+        let mut aged = counter();
 
         let mut gen = aged.age.gen;
         loop {
             let first = *aged.as_ref();
             let second = *aged.as_ref();
+
             if aged.age.gen == gen {
                 assert_eq!(first, second);
                 break;
             }
+
             gen = aged.age.gen;
         }
     }

--- a/src/topology/generation.rs
+++ b/src/topology/generation.rs
@@ -33,7 +33,7 @@ pub struct Age {
 
 impl Age {
     /// Creates new Age with current generation.
-    pub fn new() -> Self {
+    pub fn current() -> Self {
         Age {
             gen: GENERATION.load(Ordering::Relaxed),
         }
@@ -42,7 +42,7 @@ impl Age {
     /// Returns new age to be seted after the data
     /// has been reloaded.
     pub fn is_old(&self) -> Option<Age> {
-        let current = Self::new();
+        let current = Self::current();
         if current != *self {
             Some(current)
         } else {
@@ -87,7 +87,7 @@ pub struct Aged<T> {
 
 impl<T> Aged<T> {
     pub fn new(create: impl Fn() -> crate::Result<T> + Send + 'static) -> crate::Result<Self> {
-        let age = Age::new();
+        let age = Age::current();
         let data = create()?;
         Ok(Self {
             create: Box::new(create) as Box<_>,

--- a/src/topology/generation.rs
+++ b/src/topology/generation.rs
@@ -1,0 +1,44 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Generation counter incremented for each reload.
+static RELOAD_GENERATION: AtomicUsize = AtomicUsize::new(0);
+
+/// Increments generation causing all Ages to report that they
+/// are old.
+pub(super) fn inc_generation() {
+    RELOAD_GENERATION.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Age to be paired with some relodable data.
+/// Age::new() -> is_old() -> set_age()
+#[derive(Debug, PartialEq, Eq)]
+pub struct Age {
+    gen: usize,
+}
+
+impl Age {
+    /// Creates new Age with current generation.
+    pub fn new() -> Self {
+        Age {
+            gen: RELOAD_GENERATION.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Returns new age to be seted after the data
+    /// has been reloaded.
+    pub fn is_old(&self) -> Option<Age> {
+        let current = Self::new();
+        if current != *self {
+            Some(current)
+        } else {
+            None
+        }
+    }
+
+    /// Sets age to new value and checks wheter this new
+    /// age is old in which case it returns even newer age.
+    pub fn set_age(&mut self, new: Age) -> Option<Age> {
+        *self = new;
+        self.is_old()
+    }
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod builder;
 pub mod fanout;
+pub mod generation;
 mod task;
 
 use crate::{
@@ -237,6 +238,10 @@ impl RunningTopology {
             // This value is guess work.
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
+
+        /// Increment generation to trigger inner reloads in remaining
+        /// components and for the new pieces to have new age.
+        self::generation::inc_generation();
 
         // Now let's actually build the new pieces.
         if let Some(mut new_pieces) = build_or_log_errors(&new_config, &diff, buffers.clone()).await

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -239,8 +239,8 @@ impl RunningTopology {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        /// Increment generation to trigger inner reloads in remaining
-        /// components and for the new pieces to have new age.
+        // Increment generation to trigger inner reloads in remaining
+        // components and for the new pieces to have new age.
         self::generation::inc_generation();
 
         // Now let's actually build the new pieces.


### PR DESCRIPTION
Closes #7013

This PR has two parts:
* Initial procedure for triggering component internal reload. The idea is to have global atomic counter of reload generations which is incremented on reload. Then when accessing a reloadable data the stored generation would be compared with current generation and reload the data if they differ.
* Example usage of this procedure on reloading AWS credentials.

### Open questions

- [ ] Should component internal reload happen only on SIGHUP or always when reloading?
- [ ] Is the default of using old data on failure to reload it ok?

cc. @jszwedko @lukesteensen 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
