### PR TITLE
fix(processing): Manage timeouts in multiline

### DIFF
--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -210,8 +210,7 @@ where
                         this.logic
                             .buffers
                             .drain()
-                            .map(|(src, (key, aggregate))| {
-                                timeouts.remove(&key);
+                            .map(|(src, (_, aggregate))| {
                                 let (line, context) = aggregate.merge();
                                 (src, line, context)
                             })

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -203,7 +203,6 @@ where
                     }
                 }
                 Poll::Ready(None) => {
-                    let timeouts = &mut this.logic.timeouts;
                     // We got `None`, this means the `inner` stream has ended.
                     // Start flushing all existing data, stop polling `inner`.
                     *this.draining = Some(

--- a/src/sources/util/multiline_config.rs
+++ b/src/sources/util/multiline_config.rs
@@ -30,13 +30,12 @@ impl TryFrom<&MultilineConfig> for line_agg::Config {
             .with_context(|| InvalidMultilineStartPattern { start_pattern })?;
         let condition_pattern = Regex::new(condition_pattern)
             .with_context(|| InvalidMultilineConditionPattern { condition_pattern })?;
-        let mode = mode.clone();
         let timeout = Duration::from_millis(*timeout_ms);
 
         Ok(Self {
             start_pattern,
             condition_pattern,
-            mode,
+            mode: *mode,
             timeout,
         })
     }


### PR DESCRIPTION
Closes #6486
Closes #6855

Timeouts were never reset or removed so they naturally timed out and broke merging for a random multiline.

It was also causing a memory leak for large `timeout_ms` so it's at least a partial cause of #7525.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
