### PR TITLE
enhancement(vrl): support standalone key encoding in `encode_key_value`

### DIFF
--- a/docs/reference/remap/functions/encode_key_value.cue
+++ b/docs/reference/remap/functions/encode_key_value.cue
@@ -39,6 +39,13 @@ remap: functions: encode_key_value: {
 			default:     " "
 			type: ["string"]
 		},
+		{
+			name:        "flatten_boolean"
+			description: "Whether to encode key/value with a boolean value as a standalone key if `true` and nothing if `false`."
+			required:    false
+			type: ["boolean"]
+			default: false
+		},
 	]
 	internal_failure_reasons: [
 		"`fields_ordering` contains a non-string element",
@@ -84,6 +91,18 @@ remap: functions: encode_key_value: {
 				)
 				"""
 			return: #"lvl:info,msg:"This is a message",ts:2021-06-05T17:20:00Z"#
+		},
+		{
+			title: "Encode with custom delimiters and flatten boolean"
+			source: """
+				encode_key_value(
+					{"ts": "2021-06-05T17:20:00Z", "msg": "This is a message", "lvl": "info", "beta": true, "dropped": false},
+					field_delimiter: ",",
+					key_value_delimiter: ":",
+					flatten_boolean: true
+				)
+				"""
+			return: #"beta,lvl:info,msg:"This is a message",ts:2021-06-05T17:20:00Z"#
 		},
 	]
 }

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::result::Result;
 use vrl::prelude::*;
-use Value::{Array, Object};
+use Value::{Array, Boolean, Object};
 
 #[derive(Clone, Copy, Debug)]
 pub struct EncodeKeyValue;
@@ -34,6 +34,11 @@ impl Function for EncodeKeyValue {
                 kind: kind::BYTES,
                 required: false,
             },
+            Parameter {
+                keyword: "flatten_boolean",
+                kind: kind::BOOLEAN,
+                required: false,
+            },
         ]
     }
 
@@ -49,11 +54,16 @@ impl Function for EncodeKeyValue {
             .optional("field_delimiter")
             .unwrap_or_else(|| expr!(" "));
 
+        let flatten_boolean = arguments
+            .optional("flatten_boolean")
+            .unwrap_or_else(|| expr!(false));
+
         Ok(Box::new(EncodeKeyValueFn {
             value,
             fields,
             key_value_delimiter,
             field_delimiter,
+            flatten_boolean,
         }))
     }
 
@@ -84,6 +94,7 @@ pub(crate) struct EncodeKeyValueFn {
     pub(crate) fields: Option<Box<dyn Expression>>,
     pub(crate) key_value_delimiter: Box<dyn Expression>,
     pub(crate) field_delimiter: Box<dyn Expression>,
+    pub(crate) flatten_boolean: Box<dyn Expression>,
 }
 
 fn resolve_fields(fields: Value) -> Result<Vec<String>, ExpressionError> {
@@ -116,8 +127,16 @@ impl Expression for EncodeKeyValueFn {
 
         let value = self.field_delimiter.resolve(ctx)?;
         let field_delimiter = value.try_bytes_utf8_lossy()?;
+        let flatten_boolean = self.flatten_boolean.resolve(ctx)?.try_boolean()?;
 
-        Ok(encode(object, &fields[..], &key_value_delimiter, &field_delimiter).into())
+        Ok(encode(
+            object,
+            &fields[..],
+            &key_value_delimiter,
+            &field_delimiter,
+            flatten_boolean,
+        )
+        .into())
     }
 
     fn type_def(&self, _state: &state::Compiler) -> TypeDef {
@@ -200,20 +219,31 @@ pub fn encode<'a>(
     fields: &[String],
     key_value_delimiter: &'a str,
     field_delimiter: &'a str,
+    flatten_boolean: bool,
 ) -> String {
     let mut output = String::new();
 
     let mut input: BTreeMap<_, _> = flatten(input, String::from(""), '.', 0).collect();
 
     for field in fields.iter() {
-        if let Some(val) = input.remove(field) {
-            encode_field(&mut output, field, &val, key_value_delimiter);
-            output.write_str(field_delimiter).unwrap();
-        }
+        match (input.remove(field), flatten_boolean) {
+            (Some(Boolean(true)), true) => {
+                encode_string(&mut output, field);
+                output.write_str(field_delimiter).unwrap();
+            }
+            (Some(val), _) => {
+                encode_field(&mut output, field, &val, key_value_delimiter);
+                output.write_str(field_delimiter).unwrap();
+            }
+            (None, _) => (),
+        };
     }
 
     for (key, value) in input.iter() {
-        encode_field(&mut output, key, value, key_value_delimiter);
+        match (value, flatten_boolean) {
+            (Boolean(true), true) => encode_string(&mut output, key),
+            (_, _) => encode_field(&mut output, key, value, key_value_delimiter),
+        };
         output.write_str(field_delimiter).unwrap();
     }
 
@@ -263,6 +293,34 @@ mod tests {
             tdef: TypeDef::new().bytes().infallible(),
         }
 
+        flatten_boolean {
+            args: func_args![value:
+                btreemap! {
+                    "beta" => true,
+                    "lvl" => "info",
+                    "msg" => "This is a log message",
+                },
+                flatten_boolean: value!(true)
+            ],
+            want: Ok(r#"beta lvl=info msg="This is a log message""#),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
+
+
+        flatten_boolean_with_custom_delimiters {
+            args: func_args![value:
+                btreemap! {
+                    "tag_a" => "val_a",
+                    "tag_b" => "val_b",
+                    "tag_c" => true,
+                },
+                key_value_delimiter: value!(":"),
+                field_delimiter: value!(","),
+                flatten_boolean: value!(true)
+            ],
+            want: Ok(r#"tag_a:val_a,tag_b:val_b,tag_c"#),
+            tdef: TypeDef::new().bytes().infallible(),
+        }
         string_with_characters_to_escape {
             args: func_args![value:
                 btreemap! {

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -29,6 +29,7 @@ impl Function for EncodeLogfmt {
         // parameters for the delimiters.
         let key_value_delimiter = expr!("=");
         let field_delimiter = expr!(" ");
+        let flatten_boolean = expr!(true);
 
         let value = arguments.required("value");
         let fields = arguments.optional("fields_ordering");
@@ -38,6 +39,7 @@ impl Function for EncodeLogfmt {
             fields,
             key_value_delimiter,
             field_delimiter,
+            flatten_boolean,
         }))
     }
 


### PR DESCRIPTION
Allow :
```json
{
"k1": "v1",
"k2": true,
"k3": false
}
```

to be serialised as:
`k1=v1 k2` 

See [here](https://github.com/kr/logfmt/blob/64c009c7f6482dbcd6fb94b6c1f9a7eda47c02d3/decode.go#L1-L20) for this logfmt "extension"