### PR TITLE
fix(tests): Fix k8s e2e line assertion

### DIFF
--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -235,7 +235,8 @@ pub async fn smoke_check_first_line(log_reader: &mut Reader) {
         .read_line()
         .await
         .expect("unable to read first line");
-    let expected_pat = "INFO vector::app: Log level is enabled. level=\"info\"\n";
+    let expected_pat =
+        "INFO vector::app: Log level is enabled. level=\"info\" enable_datadog_tracing=false\n";
     assert!(
         first_line.ends_with(expected_pat),
         "Expected a line ending with {:?} but got {:?}; vector might be malfunctioning",


### PR DESCRIPTION
Was changed with #7929

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
