### PR TITLE
chore(ci): force stop sccache before attempting to start it

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -66,15 +66,17 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make slim-builds
-
       # First, we run the benchmarks against master to establish our baseline numbers. Our benchmark
       # runners are configured to isolate CPU 0 from OS scheduling so that benchmarks aren't subject
       # to scheduling noise.  We make sure to utilize all CPUs for compiling the benchmark binaries,

--- a/.github/workflows/cargo_flake.yml
+++ b/.github/workflows/cargo_flake.yml
@@ -31,11 +31,14 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: cargo install cargo-flake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,9 +243,7 @@ jobs:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          Invoke-Expression 'sccache --stop-server; exit 0'
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          Invoke-Expression 'sccache --stop-server;  sccache --start-server; echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV'
       - run: make test
       - name: Stop sccache
         run: sccache --stop-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,11 +103,14 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make slim-builds
@@ -137,11 +140,14 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make slim-builds
@@ -230,11 +236,14 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - run: choco install llvm
       - run: .\scripts\environment\bootstrap-windows-2019.ps1
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test
@@ -251,11 +260,14 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test-vrl
@@ -272,11 +284,14 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
       - name: Start sccache
         env:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: cargo install cargo-hack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,9 +243,10 @@ jobs:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          sccache --stop-server -or true
+          sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        shell: bash
       - run: make test
       - name: Stop sccache
         run: sccache --stop-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          sccache --stop-server || true
+          Invoke-Expression 'sccache --stop-server; exit 0'
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,9 @@ jobs:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          Invoke-Expression 'sccache --stop-server;  sccache --start-server; echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV'
+          sccache --stop-server
+          sccache --start-server
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test
       - name: Stop sccache
         run: sccache --stop-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,6 @@ jobs:
           Invoke-Expression 'sccache --stop-server; exit 0'
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-        shell: bash
       - run: make test
       - name: Stop sccache
         run: sccache --stop-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
           SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
-          sccache --stop-server || true
+          sccache --stop-server -or true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test


### PR DESCRIPTION
If a CI workflow fails, sometimes it won't make it to the step that stops the `sccache` process.  This causes issues on subsequent runs using the same runner, as `sccache` is still running, and `sccache --start-server` exits with a non-zero code if it's already running.... which then kills _that_ run.  No bueno.

We forcefully stop the `sccache` process before attempting to start it.  We still stop it after the run, or try, if we make it there... but this is a stopgap until there's a better/single action that can more cleanly provide the `try { start } finally { stop }` logic.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>