### PR TITLE
fix(aws_s3 source): labels missing for s3 source metrics

### DIFF
--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -23,6 +23,7 @@ use rusoto_sqs::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use snafu::{ResultExt, Snafu};
+use tracing::Instrument;
 use std::{cmp, future::ready, panic, sync::Arc};
 use tokio::{pin, select};
 use tokio_util::codec::FramedRead;
@@ -182,7 +183,8 @@ impl Ingestor {
         for _ in 0..self.state.client_concurrency {
             let process =
                 IngestorProcess::new(Arc::clone(&self.state), out.clone(), shutdown.clone());
-            let handle = tokio::spawn(async move { process.run().await });
+            let fut = async move { process.run().await };
+            let handle = tokio::spawn(fut.in_current_span());
             handles.push(handle);
         }
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -23,10 +23,10 @@ use rusoto_sqs::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use snafu::{ResultExt, Snafu};
-use tracing::Instrument;
 use std::{cmp, future::ready, panic, sync::Arc};
 use tokio::{pin, select};
 use tokio_util::codec::FramedRead;
+use tracing::Instrument;
 
 lazy_static! {
     static ref SUPPORTED_S3S_EVENT_VERSION: semver::VersionReq =


### PR DESCRIPTION
This fixes an issue introduced by 1ccb214 where the tracing span the S3 source was created within was not propagated when spawning the ingestor tasks, leading to internal metrics that lacked the necessary labels for proper filtering and for correctly driving `vector top`.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>