### PR TITLE
enhancement(vrl): accept standalone key in `parse_logfmt` + minor related fix

### DIFF
--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -293,9 +293,9 @@ fn parse_key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
                     many_m_n(
                         !standalone_key as usize,
                         1,
-                        preceded(space0, tag(key_value_delimiter)),
+                        delimited(space0, tag(key_value_delimiter), space0),
                     ),
-                    preceded(space0, parse_value(field_delimiter)),
+                    parse_value(field_delimiter),
                 ))(input),
             },
             |(field, sep, value): (&str, Vec<&str>, Value)| {
@@ -455,6 +455,33 @@ mod test {
                 ("foobar".to_string(), value!(true))
             ]),
             parse("foo:bar ,   foobar   ", ":", ",", Whitespace::Lenient, true)
+        );
+    }
+
+    #[test]
+    fn test_multiple_standalone_key() {
+        assert_eq!(
+            Ok(vec![
+                ("foo".to_string(), "bar".into()),
+                ("foobar".to_string(), value!(true)),
+                ("bar".to_string(), "baz".into()),
+                ("barfoo".to_string(), value!(true)),
+            ]),
+            parse("foo=bar foobar bar=baz barfoo","=", " ", Whitespace::Lenient, true)
+        );
+    }
+
+    #[test]
+    fn test_only_standalone_key() {
+        assert_eq!(
+            Ok(vec![
+                ("foo".to_string(), value!(true)),
+                ("bar".to_string(), value!(true)),
+                ("foobar".to_string(), value!(true)),
+                ("baz".to_string(), value!(true)),
+                ("barfoo".to_string(), value!(true)),
+            ]),
+            parse("foo bar foobar baz barfoo","=", " ", Whitespace::Lenient, true)
         );
     }
 

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -467,7 +467,13 @@ mod test {
                 ("bar".to_string(), "baz".into()),
                 ("barfoo".to_string(), value!(true)),
             ]),
-            parse("foo=bar foobar bar=baz barfoo","=", " ", Whitespace::Lenient, true)
+            parse(
+                "foo=bar foobar bar=baz barfoo",
+                "=",
+                " ",
+                Whitespace::Lenient,
+                true
+            )
         );
     }
 
@@ -481,7 +487,13 @@ mod test {
                 ("baz".to_string(), value!(true)),
                 ("barfoo".to_string(), value!(true)),
             ]),
-            parse("foo bar foobar baz barfoo","=", " ", Whitespace::Lenient, true)
+            parse(
+                "foo bar foobar baz barfoo",
+                "=",
+                " ",
+                Whitespace::Lenient,
+                true
+            )
         );
     }
 

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -18,11 +18,18 @@ impl Function for ParseLogFmt {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "simple log",
-            source: r#"parse_logfmt!("zork=zook zonk=nork")"#,
-            result: Ok(r#"{"zork": "zook", "zonk": "nork"}"#),
-        }]
+        &[
+            Example {
+                title: "simple log",
+                source: r#"parse_logfmt!("zork=zook zonk=nork")"#,
+                result: Ok(r#"{"zork": "zook", "zonk": "nork"}"#),
+            },
+            Example {
+                title: "standalone key",
+                source: r#"parse_logfmt!("zork=zook plonk zonk=nork")"#,
+                result: Ok(r#"{"plonk": true, "zork": "zook", "zonk": "nork"}"#),
+            },
+        ]
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Compiled {
@@ -33,7 +40,7 @@ impl Function for ParseLogFmt {
         let key_value_delimiter = expr!("=");
         let field_delimiter = expr!(" ");
         let whitespace = Whitespace::Lenient;
-        let standalone_key = expr!(false);
+        let standalone_key = expr!(true);
 
         Ok(Box::new(ParseKeyValueFn {
             value,


### PR DESCRIPTION
The fix addresses the following situation: when using space as a field
delimiter and `whitespace:lenient` along with `accept_standalone_key:true`
the field following a standalone key was dropped:

Before:
```
$ parse_key_value!("foo=bar foobarbaz bar=baz", key_value_delimiter: "=", field_delimiter: " ", whitespace: "lenient", accept_standalone_key: true)
{ "foo": "bar", "foobarbaz": true }
```
After:
```
$ parse_key_value!("foo=bar foobarbaz bar=baz", key_value_delimiter: "=", field_delimiter: " ", whitespace: "lenient", accept_standalone_key: true)
{ "bar": "baz", "foo": "bar", "foobarbaz": true }
```

In #7907 it was agreed to enable standalone key by default, but `parse_logfmt` was left with the setting deactivated (but the doc was updated) this fixes it. 


