### PR TITLE
chore(kubernetes_logs source): Revert glob minimum cooldown to 60s

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -234,7 +234,7 @@ components: sources: kubernetes_logs: {
 			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files within a single pod."
 			required:    false
 			type: uint: {
-				default: 1_000
+				default: 60_000
 				unit:    "milliseconds"
 			}
 		}

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -451,7 +451,7 @@ fn default_max_line_bytes() -> usize {
 }
 
 fn default_glob_minimum_cooldown_ms() -> usize {
-    5000
+    60000
 }
 
 /// This function construct the effective field selector to use, based on


### PR DESCRIPTION
Pending investigation in
https://github.com/timberio/vector/issues/7840

This is just to make sure we don't accidentally release the new default
of 5s before we are confident in it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
