### PR TITLE
chore(data model): Drop impl AtomInteger from status types

### DIFF
--- a/lib/vector-core/src/event/finalization.rs
+++ b/lib/vector-core/src/event/finalization.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-use atomig::{Atom, AtomInteger, Atomic, Ordering};
+use atomig::{Atom, Atomic, Ordering};
 use futures::future::FutureExt;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -263,10 +263,6 @@ impl BatchStatus {
     }
 }
 
-// Can be dropped when this issue is closed:
-// https://github.com/LukasKalbertodt/atomig/issues/3
-impl AtomInteger for BatchStatus {}
-
 /// The status of an individual event.
 #[derive(Atom, Copy, Clone, Debug, Derivative, Deserialize, Eq, PartialEq, Serialize)]
 #[derivative(Default)]
@@ -284,10 +280,6 @@ pub enum EventStatus {
     /// This status has been recorded and should not be updated.
     Recorded,
 }
-
-// Can be dropped when this issue is closed:
-// https://github.com/LukasKalbertodt/atomig/issues/3
-impl AtomInteger for EventStatus {}
 
 impl EventStatus {
     /// Update this status with another event's finalization status and return the result.


### PR DESCRIPTION
This is no longer needed with the update to atomig 0.3

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
