### PR TITLE
chore(dev): Flag src/service.rs as Windows-only

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod providers;
 #[cfg(feature = "rusoto_core")]
 pub mod rusoto;
 pub mod serde;
+#[cfg(windows)]
 pub mod service;
 pub mod shutdown;
 pub mod signal;

--- a/src/service.rs
+++ b/src/service.rs
@@ -181,7 +181,6 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
     }
 }
 
-#[cfg(windows)]
 fn control_service(service: &ServiceInfo, action: ControlAction) -> exitcode::ExitCode {
     use crate::vector_windows;
 
@@ -223,12 +222,6 @@ fn control_service(service: &ServiceInfo, action: ControlAction) -> exitcode::Ex
             exitcode::SOFTWARE
         }
     }
-}
-
-#[cfg(unix)]
-fn control_service(_service: &ServiceInfo, _action: ControlAction) -> exitcode::ExitCode {
-    error!("Service commands are currently not supported on this platform.");
-    exitcode::UNAVAILABLE
 }
 
 fn create_service_arguments(config_paths: &[config::ConfigPath]) -> Option<Vec<OsString>> {


### PR DESCRIPTION
This file is only used by `vector_windows.rs` which is flagged for
Windows.

```
cargo 1.54.0-nightly (44456677b 2021-06-12)
```

correctly picked up that there is dead code there when compiling on
non-Windows.

Discovered by @tshepang in https://github.com/timberio/vector/pull/7931

This PR supersedes https://github.com/timberio/vector/pull/7931

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
