### PR TITLE
enhancement(docker_logs source): Re-add named pipe support on Windows

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -25,10 +25,7 @@ pub fn docker(host: Option<String>, tls: Option<DockerTlsConfig>) -> crate::Resu
     let host = host.or_else(|| env::var("DOCKER_HOST").ok());
 
     match host {
-        None => {
-                Docker::connect_with_local_defaults().map_err(Into::into)
-            }
-        }
+        None => Docker::connect_with_local_defaults().map_err(Into::into),
         Some(host) => {
             let scheme = host
                 .parse::<Uri>()

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -26,14 +26,6 @@ pub fn docker(host: Option<String>, tls: Option<DockerTlsConfig>) -> crate::Resu
 
     match host {
         None => {
-            // TODO: Use `connect_with_local_defaults` on all platforms.
-            //
-            // Using `connect_with_local_defaults` defers to `connect_with_named_pipe_defaults` on Windows. However,
-            // named pipes are currently disabled in Tokio. Tracking issue:
-            // https://github.com/fussybeaver/bollard/pull/138
-            if cfg!(windows) {
-                Docker::connect_with_http_defaults().map_err(Into::into)
-            } else {
                 Docker::connect_with_local_defaults().map_err(Into::into)
             }
         }


### PR DESCRIPTION
This is supported in Tokio again as of 1.7 and bollard as of 0.11.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
