### PR TITLE
chore(tests): Sleep longer for k8s checkpointing test

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1903,7 +1903,7 @@ async fn simple_checkpoint() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sleep to ensure checkpoints are written
     // https://github.com/timberio/vector/issues/7898
-    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(61)).await;
 
     framework
         .restart_rollout("test-vector", "daemonset/vector-agent", vec![])


### PR DESCRIPTION
Needs to sleep longer than glob cooldown. I think the better fix here is
to lower the glob cooldown for the k8s e2e tests, but I didn't see an
easy way to do that so I figured I'd leave it for someone more familiar
:)

Failure: https://github.com/timberio/vector/runs/2890300521

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
