### PR TITLE
fix(observability): missing tracing context on HTTP client metrics

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -68,10 +68,7 @@ where
         let user_agent = HeaderValue::from_str(&format!("Vector/{}", version))
             .expect("Invalid header value for version!");
 
-        Ok(HttpClient {
-            client,
-            user_agent,
-        })
+        Ok(HttpClient { client, user_agent })
     }
 
     pub fn send(

--- a/src/http.rs
+++ b/src/http.rs
@@ -20,7 +20,6 @@ use std::{
     task::{Context, Poll},
 };
 use tower::Service;
-use tracing::Span;
 use tracing_futures::Instrument;
 
 #[derive(Debug, Snafu)]
@@ -37,7 +36,6 @@ pub type HttpClientFuture = <HttpClient as Service<http::Request<Body>>>::Future
 
 pub struct HttpClient<B = Body> {
     client: Client<HttpsConnector<HttpConnector>, B>,
-    span: Span,
     user_agent: HeaderValue,
 }
 
@@ -70,11 +68,8 @@ where
         let user_agent = HeaderValue::from_str(&format!("Vector/{}", version))
             .expect("Invalid header value for version!");
 
-        let span = tracing::info_span!("http");
-
         Ok(HttpClient {
             client,
-            span,
             user_agent,
         })
     }
@@ -83,7 +78,8 @@ where
         &self,
         mut request: Request<B>,
     ) -> BoxFuture<'static, Result<http::Response<Body>, HttpError>> {
-        let _enter = self.span.enter();
+        let span = tracing::info_span!("http");
+        let _enter = span.enter();
 
         default_request_headers(&mut request, &self.user_agent);
 
@@ -122,7 +118,7 @@ where
             });
             Ok(response)
         }
-        .instrument(self.span.clone());
+        .instrument(span.clone());
 
         Box::pin(fut)
     }
@@ -167,7 +163,6 @@ impl<B> Clone for HttpClient<B> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
-            span: self.span.clone(),
             user_agent: self.user_agent.clone(),
         }
     }


### PR DESCRIPTION
Currently, we create a dedicated `http` span when building an instance of `HttpClient<B>` that gets wrapped around subsequent usages of the client, such as when sending a request.  However, based on where we create this span -- when building `HttpClient<B>` itself -- and how we use it -- instrumenting request futures directly -- we never capture the current span context at the time of when the request is made, which leads to all internal metrics that happen in that request lacking labels.

This PR simply eschews the at-creation-time span and instead generates the `http` span when the request is being constructed.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>