### PR TITLE
chore(tests): Revert glob faster in checkpoint test

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -10,13 +10,7 @@ use tracing::{debug, info};
 
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
-// Lower cooldown to avoid breaking simple_checkpoint test
-// This is added as rawConfig due to the following bug:
-// https://github.com/timberio/vector/issues/7453
 const HELM_VALUES_STDOUT_SINK: &str = indoc! {r#"
-    kubernetesLogsSource:
-      rawConfig: |
-        glob_minimum_cooldown_ms = 5000
     sinks:
       stdout:
         type: "console"


### PR DESCRIPTION
Reverts timberio/vector#8006

This breaks any test setting config under kubernetesLogsSource because we concat the values files together rather than passing them both in with the `-f` flag