### PR TITLE
enhancement(helm platform): Option to add additional ports to the service in vector-agent helm chart

### DIFF
--- a/distribution/helm/vector-agent/templates/service.yaml
+++ b/distribution/helm/vector-agent/templates/service.yaml
@@ -8,11 +8,10 @@ metadata:
     {{- include "libvector.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ports }}
   ports:
-  - name: api
-    targetPort: api
-    port: {{ .Values.service.port }}
-    protocol: TCP
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "libvector.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.topologyKeys }}

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -35,16 +35,17 @@ service:
   # Whether to create service resource or not.
   enabled: false
   type: ClusterIP
-  topologyKeys:
-    - "kubernetes.io/hostname"
-    - "topology.kubernetes.io/zone"
-    - "topology.kubernetes.io/region"
-    - "*"
+  topologyKeys: {}
+  # List of valid topologyKeys values.
+  #   - "kubernetes.io/hostname"
+  #   - "topology.kubernetes.io/zone"
+  #   - "topology.kubernetes.io/region"
+  #   - "*"
   ports:
     - name: api
-      port: 80
+      port: 8686
       protocol: TCP
-      targetPort: 80
+      targetPort: 8686
     # Additional ports (Vector sources, etc.)
     # - name: another_port
     #   port: 8081

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -30,16 +30,26 @@ fullnameOverride: ""
 
 updateStrategy: RollingUpdate
 
-# Deploy service to use Topology-aware traffic routing with topology keys.
+# Deploy a service to use Topology-aware traffic routing with topology keys.
 service:
-  enabled: false
-  # type: ClusterIP
-  # port: 80
-  # topologyKeys:
-  #   - "kubernetes.io/hostname"
-  #   - "topology.kubernetes.io/zone"
-  #   - "topology.kubernetes.io/region"
-  #   - "*"
+  # Whether to create service resource or not.
+  enabled: true
+  type: ClusterIP
+  topologyKeys:
+    - "kubernetes.io/hostname"
+    - "topology.kubernetes.io/zone"
+    - "topology.kubernetes.io/region"
+    - "*"
+  ports:
+    - name: api
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    # Additional ports (Vector sources, etc.)
+    # - name: another_port
+    #   port: 8081
+    #   protocol: TCP
+    #   targetPort: 8081
 
 serviceAccount:
   # Specifies whether a service account should be created.

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -30,10 +30,10 @@ fullnameOverride: ""
 
 updateStrategy: RollingUpdate
 
-# Deploy a service to use Topology-aware traffic routing with topology keys.
+# Deploy a service resource to use Topology-aware traffic routing with topology keys.
 service:
   # Whether to create service resource or not.
-  enabled: true
+  enabled: false
   type: ClusterIP
   topologyKeys:
     - "kubernetes.io/hostname"


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
This PR is adding an option to the vector-agent helm chart to add extra ports to the service resource used for [Topology-aware traffic routing](https://kubernetes.io/docs/concepts/services-networking/service-topology/). So now also the traffic from the sources can be routed based on the topology of the cluster.