### PR TITLE
chore(dev): Get `./scripts/skaffold.sh` working on OSX

### DIFF
--- a/scripts/skaffold.sh
+++ b/scripts/skaffold.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+triple="$(rustc --version --verbose | grep host | awk '{ print $2 }')"
+
 # Initial vector build to ensure we start at a valid state.
-cargo build
+if [[ "x86_64-unknown-linux-gnu" == "$triple" ]] ; then
+  cargo build
+  mkdir -p target/x86_64-unknown-linux-gnu/debug
+  cp target/debug/vector target/x86_64-unknown-linux-gnu/debug/vector
+else
+  PROFILE=debug make target/x86_64-unknown-linux-gnu/vector
+fi
 
 # Prepare .dockerignore so we don't send the whole dir to the docker as the
 # context.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,8 +8,8 @@ build:
     push: false
   artifacts:
     - image: timberio/vector
-      context: target/debug
+      context: target/x86_64-unknown-linux-gnu/debug
       docker:
-        dockerfile: ../../skaffold/docker/Dockerfile
+        dockerfile: ../../../skaffold/docker/Dockerfile
 deploy:
   kustomize: {}

--- a/skaffold/manifests/config.yaml
+++ b/skaffold/manifests/config.yaml
@@ -4,9 +4,6 @@ metadata:
   name: vector-agent-config
 data:
   vector.toml: |
-    [sources.internal_metrics]
-        type = "internal_metrics"
-
     [sinks.stdout]
         type = "console"
         inputs = ["kubernetes_logs", "internal_metrics"]


### PR DESCRIPTION
This modifies `skaffold.sh` to cross-build on OSX to create a Linux
binary (on Linux it will just do straight `cargo build` since it is more
efficient).

Also modifies the Helm config used to drop internal_metrics since that
is predefined.

Closes #8018

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
