### PR TITLE
chore: Apply suggestions from `cargo clippy --all-features`

### DIFF
--- a/src/internal_events/wasm/mod.rs
+++ b/src/internal_events/wasm/mod.rs
@@ -17,7 +17,7 @@ enum State {
 
 impl State {
     /// Cheaply turn into a `&'static str` so you don't need to format it for metrics.
-    pub fn as_const_str(&self) -> &'static str {
+    pub fn as_const_str(self) -> &'static str {
         match self {
             State::Beginning => BEGINNING,
             State::Completed => COMPLETED,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -120,7 +120,7 @@ impl WasmModule {
             .remove_embed_ctx::<Option<Registration>>()
             .and_then(|v| v);
 
-        if let None = registration {
+        if registration.is_none() {
             error!("Not registered! Please fill your `init` call with a `Registration::transform().register()`.");
         }
 


### PR DESCRIPTION
Just noticed some suggestions clippy has been giving when running `cargo clippy --all-features`.