### PR TITLE
chore(ci): Stop ignoring k8s e2e checkpointing test

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -1838,7 +1838,6 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-#[ignore] // https://github.com/timberio/vector/issues/8014
 async fn simple_checkpoint() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     let framework = make_framework();


### PR DESCRIPTION
Hopefully this works now after
https://github.com/timberio/vector/commit/7c648d5498d969ba314f9f9ccc5671b4cd515c37

Closes: #8014

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
