### PR TITLE
enhancement(helm platform): Add maxUnavailable for updateStrategy in vector-agent helm chart

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -11,6 +11,10 @@ spec:
   minReadySeconds: 1
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+    {{- if eq .Values.updateStrategy "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       annotations:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -29,6 +29,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 updateStrategy: RollingUpdate
+# Only used when updateStrategy is set to "RollingUpdate".
+maxUnavailable: 1
 
 # Deploy service to use Topology-aware traffic routing with topology keys.
 service:
@@ -298,4 +300,3 @@ sinks: {}
   #   option: "value"
   #   rawConfig: |
   #     option = "value"
-

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -134,6 +134,8 @@ spec:
   minReadySeconds: 1
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -251,6 +251,8 @@ spec:
   minReadySeconds: 1
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -154,6 +154,8 @@ spec:
   minReadySeconds: 1
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -193,6 +193,8 @@ spec:
   minReadySeconds: 1
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Signed-off-by: Michal Muransky <michal.muransky@lablabs.io>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
Hi there, this PR is extending the `updateStrategy` of vector-agent DaemonSet. If the strategy is set to "RollingUpdate" user has an option to change the value of `maxUnavailable`.