### PR TITLE
chore(kubernetes_logs source): Glob uncompressed rotated log files

### DIFF
--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -187,7 +187,7 @@ components: sources: kubernetes_logs: {
 				"""
 			required: false
 			type: array: {
-				default: []
+				default: ["**/*.gz", "**/*.tmp"]
 				items: type: string: {
 					examples: ["**/exclude/**"]
 					syntax: "literal"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -434,6 +434,20 @@ components: sources: kubernetes_logs: {
 				"""
 		}
 
+		globbing: {
+			title: "Globbing"
+			body:  """
+				By default, the [`kubernetes_logs` source](\(urls.vector_kubernetes_logs_source))
+				ignores compressed and temporary files. This behavior can be configured with the
+				[`exclude_paths_glob_patterns`](\(urls.vector_kubernetes_logs_source)#configuration) option.
+
+				[Globbing](\(urls.globbing)) is used to continually discover `Pod`s log files
+				at a rate defined by the `glob_minimum_cooldown` option. In environments when files are
+				rotated rapidly, we recommend lowering the `glob_minimum_cooldown` to catch files
+				before they are compressed.
+				"""
+		}
+
 		pod_exclusion: {
 			title: "Pod exclusion"
 			body:  """

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -149,7 +149,7 @@ where
                 &[dir, "*/*.log*"].join("/"),
             );
 
-            // Extract the containers to exclude, then build patters from them
+            // Extract the containers to exclude, then build patterns from them
             // and cache the results into a Vec.
             let excluded_containers = extract_excluded_containers_for_pod(pod);
             let exclusion_patterns: Vec<_> =
@@ -377,7 +377,7 @@ mod tests {
                 // Calls to the glob mock.
                 vec![(
                     // The pattern to expect at the mock.
-                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/*/*.log",
+                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/*/*.log*",
                     // The paths to return from the mock.
                     vec![
                         "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/container1/qwe.log",
@@ -408,7 +408,7 @@ mod tests {
                     ..Pod::default()
                 },
                 vec![(
-                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/*/*.log",
+                    "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/*/*.log*",
                     vec![],
                 )],
                 vec![],

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -146,7 +146,7 @@ where
                 // architecture.
                 // In some setups, there will also be paths like
                 // `<pod_logs_dir>/<hash>.log` - those we want to skip.
-                &[dir, "*/*.log"].join("/"),
+                &[dir, "*/*.log*"].join("/"),
             );
 
             // Extract the containers to exclude, then build patters from them
@@ -438,9 +438,19 @@ mod tests {
         let cases = vec![
             // No exclusion pattern allows everything.
             (
-                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log.foo",
+                    "/var/log/pods/d.logbar",
+                ],
                 vec![],
-                vec!["/var/log/pods/a.log", "/var/log/pods/b.log"],
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log.foo",
+                    "/var/log/pods/d.logbar",
+                ],
             ),
             // Test a filter that doesn't apply to anything.
             (

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -451,6 +451,8 @@ fn default_glob_minimum_cooldown_ms() -> usize {
     60000
 }
 
+// This function constructs the patterns we exclude from file watching, created
+// from the defaults or user provided configuration.
 fn prepare_exclude_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
     let exclude_paths = config
         .exclude_paths_glob_patterns
@@ -465,14 +467,17 @@ fn prepare_exclude_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
 
     info!(
         message = "Excluding matching files.",
-        exclude_paths = format!("[{}]", exclude_paths.iter().join(","))
+        exclude_paths = ?exclude_paths
+            .iter()
+            .map(glob::Pattern::as_str)
+            .collect::<Vec<_>>()
     );
 
     Ok(exclude_paths)
 }
 
-/// This function constructs the effective field selector to use, based on
-/// the specified configuration.
+// This function constructs the effective field selector to use, based on
+// the specified configuration.
 fn prepare_field_selector(config: &Config) -> crate::Result<String> {
     let self_node_name = if config.self_node_name.is_empty()
         || config.self_node_name == default_self_node_name_env_template()
@@ -503,8 +508,8 @@ fn prepare_field_selector(config: &Config) -> crate::Result<String> {
     ))
 }
 
-/// This function constructs the effective label selector to use, based on
-/// the specified configuration.
+// This function constructs the effective label selector to use, based on
+// the specified configuration.
 fn prepare_label_selector(config: &Config) -> String {
     const BUILT_IN: &str = "vector.dev/exclude!=true";
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -460,7 +460,7 @@ fn default_glob_minimum_cooldown_ms() -> usize {
     60000
 }
 
-/// This function construct the effective field selector to use, based on
+/// This function constructs the effective field selector to use, based on
 /// the specified configuration.
 fn prepare_field_selector(config: &Config) -> crate::Result<String> {
     let self_node_name = if config.self_node_name.is_empty()
@@ -492,7 +492,7 @@ fn prepare_field_selector(config: &Config) -> crate::Result<String> {
     ))
 }
 
-/// This function construct the effective label selector to use, based on
+/// This function constructs the effective label selector to use, based on
 /// the specified configuration.
 fn prepare_label_selector(config: &Config) -> String {
     const BUILT_IN: &str = "vector.dev/exclude!=true";

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -80,6 +80,7 @@ pub struct Config {
     annotation_fields: pod_metadata_annotator::FieldsSpec,
 
     /// A list of glob patterns to exclude from reading the files.
+    #[serde(default = "default_path_exclusion")]
     exclude_paths_glob_patterns: Vec<PathBuf>,
 
     /// Max amount of bytes to read from a single file before switching over
@@ -432,6 +433,10 @@ fn create_event(line: Bytes, file: &str, ingestion_timestamp_field: Option<&str>
 /// as it should be at the generated config file.
 fn default_self_node_name_env_template() -> String {
     format!("${{{}}}", SELF_NODE_NAME_ENV_KEY.to_owned())
+}
+
+fn default_path_exclusion() -> Vec<PathBuf> {
+    vec![PathBuf::from("**/*.tmp"), PathBuf::from("**/*.gz")]
 }
 
 fn default_max_read_bytes() -> usize {

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -579,11 +579,9 @@ mod tests {
 
         for (input, mut expected) in cases {
             let mut output = super::prepare_exclude_paths(&input).unwrap();
-            assert_eq!(
-                expected.sort(),
-                output.sort(),
-                "expected left, actual right"
-            );
+            expected.sort();
+            output.sort();
+            assert_eq!(expected, output, "expected left, actual right");
         }
     }
 


### PR DESCRIPTION
Relates #7934

This updates our `kubernetes_logs` source to watch for log files that have been rotated, ex: `0.log.20210618-133041`.

We exclude the following patterns by default:

- `"**/*.gz"` - See: https://github.com/timberio/vector/issues/7990
- `"**/*.tmp"` - These are related to the compression steps

When combined with a lower `glob_minimum_cooldown_ms` this should help with high throughput logging situations.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
