### PR TITLE
enhancement(vrl): Add ip_aton and ip_ntoa functions

### DIFF
--- a/docs/reference/remap/functions/ip_aton.cue
+++ b/docs/reference/remap/functions/ip_aton.cue
@@ -20,10 +20,7 @@ remap: functions: ip_aton: {
 	internal_failure_reasons: [
 		"`value` isn't a valid IPv4 address",
 	]
-	return: {
-		types: ["integer"]
-		rules: []
-	}
+	return: types: ["integer"]
 
 	examples: [
 		{

--- a/docs/reference/remap/functions/ip_aton.cue
+++ b/docs/reference/remap/functions/ip_aton.cue
@@ -1,0 +1,37 @@
+package metadata
+
+remap: functions: ip_aton: {
+	category:    "IP"
+	description: """
+		Converts IPv4 address in numbers-and-dots notation into network-order
+		bytes represented as an integer.
+
+		This behavior mimics [inet_aton](\(urls.ip_aton)).
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The IP address to convert to binary."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` isn't a valid IPv4 address",
+	]
+	return: {
+		types: ["integer"]
+		rules: []
+	}
+
+	examples: [
+		{
+			title: "IPv4 to integer"
+			source: #"""
+				ip_ntoa!("1.2.3.4")
+				"""#
+			return: 67305985
+		},
+	]
+}

--- a/docs/reference/remap/functions/ip_aton.cue
+++ b/docs/reference/remap/functions/ip_aton.cue
@@ -26,7 +26,7 @@ remap: functions: ip_aton: {
 		{
 			title: "IPv4 to integer"
 			source: #"""
-				ip_ntoa!("1.2.3.4")
+				ip_aton!("1.2.3.4")
 				"""#
 			return: 67305985
 		},

--- a/docs/reference/remap/functions/ip_ntoa.cue
+++ b/docs/reference/remap/functions/ip_ntoa.cue
@@ -20,10 +20,7 @@ remap: functions: ip_ntoa: {
 	internal_failure_reasons: [
 		"`value` cannot fit in u32",
 	]
-	return: {
-		types: ["string"]
-		rules: []
-	}
+	return: types: ["string"]
 
 	examples: [
 		{

--- a/docs/reference/remap/functions/ip_ntoa.cue
+++ b/docs/reference/remap/functions/ip_ntoa.cue
@@ -26,7 +26,7 @@ remap: functions: ip_ntoa: {
 		{
 			title: "Integer to IPv4"
 			source: #"""
-				ip_aton!(67305985)
+				ip_ntoa!(67305985)
 				"""#
 			return: "1.2.3.4"
 		},

--- a/docs/reference/remap/functions/ip_ntoa.cue
+++ b/docs/reference/remap/functions/ip_ntoa.cue
@@ -1,0 +1,37 @@
+package metadata
+
+remap: functions: ip_ntoa: {
+	category:    "IP"
+	description: """
+		Converts numeric representation of IPv4 address in network-order bytes
+		to numbers-and-dots notation..
+
+		This behavior mimics [inet_ntoa](\(urls.ip_ntoa)).
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The integer representation of an IPv4 address."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` cannot fit in u32",
+	]
+	return: {
+		types: ["string"]
+		rules: []
+	}
+
+	examples: [
+		{
+			title: "Integer to IPv4"
+			source: #"""
+				ip_aton!(67305985)
+				"""#
+			return: "1.2.3.4"
+		},
+	]
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -234,7 +234,7 @@ urls: {
 	influxdb_line_protocol:                                   "https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/"
 	inode:                                                    "\(wikipedia)/wiki/Inode"
 	ip_aton:                                                  "https://linux.die.net/man/3/inet_aton"
-	ip_nota:                                                  "https://linux.die.net/man/3/inet_ntoa"
+	ip_ntoa:                                                  "https://linux.die.net/man/3/inet_ntoa"
 	iso_8601:                                                 "\(wikipedia)/wiki/ISO_8601"
 	iso3166_2:                                                "\(wikipedia)/wiki/ISO_3166-2"
 	issue_1694:                                               "\(vector_repo)/issues/1694"

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -233,6 +233,8 @@ urls: {
 	influxdb_authentication_token:                            "https://v2.docs.influxdata.com/v2.0/security/tokens/"
 	influxdb_line_protocol:                                   "https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/"
 	inode:                                                    "\(wikipedia)/wiki/Inode"
+	ip_aton:                                                  "https://linux.die.net/man/3/inet_aton"
+	ip_nota:                                                  "https://linux.die.net/man/3/inet_ntoa"
 	iso_8601:                                                 "\(wikipedia)/wiki/ISO_8601"
 	iso3166_2:                                                "\(wikipedia)/wiki/ISO_3166-2"
 	issue_1694:                                               "\(vector_repo)/issues/1694"

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -69,8 +69,10 @@ default = [
     "get_hostname",
     "includes",
     "integer",
+    "ip_aton",
     "ip_cidr_contains",
     "ip_subnet",
+    "ip_ntoa",
     "ip_to_ipv6",
     "ipv6_to_ipv4",
     "is_array",
@@ -174,7 +176,9 @@ get_env_var = []
 get_hostname = ["hostname"]
 includes = []
 integer = []
+ip_aton = []
 ip_cidr_contains = ["cidr-utils"]
+ip_ntoa = []
 ip_subnet = ["lazy_static", "regex"]
 ip_to_ipv6 = []
 ipv6_to_ipv4 = []

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -34,7 +34,9 @@ criterion_group!(
               get_env_var,
               get_hostname,
               includes,
+              ip_aton,
               ip_cidr_contains,
+              ip_ntoa,
               ip_subnet,
               ip_to_ipv6,
               ipv6_to_ipv4,
@@ -415,7 +417,15 @@ bench_function! {
         args: func_args![value: value!(["foo", 1, true, [1,2,3]]), item: value!("foo")],
         want: Ok(value!(true)),
     }
+}
 
+bench_function! {
+    ip_aton => vrl_stdlib::IpAton;
+
+    valid {
+        args: func_args![value: "1.2.3.4"],
+        want: Ok(value!(67305985)),
+    }
 }
 
 bench_function! {
@@ -429,6 +439,15 @@ bench_function! {
     ipv6 {
         args: func_args![cidr: "2001:4f8:3:ba::/64", value: "2001:4f8:3:ba:2e0:81ff:fe22:d1f1"],
         want: Ok(true),
+    }
+}
+
+bench_function! {
+    ip_ntoa => vrl_stdlib::IpNtoa;
+
+    valid {
+        args: func_args![value: 67305985],
+        want: Ok(value!("1.2.3.4")),
     }
 }
 

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -47,9 +47,9 @@ impl Expression for IpAtonFn {
             .parse()
             .map_err(|err| format!("unable to parse IPv4 address: {}", err))?;
 
-        let mut octets = ip.octets();
-        octets.reverse();
-        Ok(u32::from_be_bytes(octets).into())
+        let i = u32::from(ip); // host-order
+
+        Ok(i.to_be().into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -1,0 +1,79 @@
+use std::net::Ipv4Addr;
+
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct IpAton;
+
+impl Function for IpAton {
+    fn identifier(&self) -> &'static str {
+        "ip_aton"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "Example",
+            source: r#"ip_aton!("1.2.3.4")"#,
+            result: Ok("67305985"),
+        }]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(IpAtonFn { value }))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IpAtonFn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for IpAtonFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let ip: Ipv4Addr = self
+            .value
+            .resolve(ctx)?
+            .try_bytes_utf8_lossy()?
+            .parse()
+            .map_err(|err| format!("unable to parse IPv4 address: {}", err))?;
+
+        let mut octets = ip.octets();
+        octets.reverse();
+        Ok(u32::from_be_bytes(octets).into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().fallible().integer()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        ip_aton => IpAton;
+
+        invalid {
+            args: func_args![value: "i am not an ipaddress"],
+            want: Err("unable to parse IPv4 address: invalid IP address syntax"),
+            tdef: TypeDef::new().fallible().integer(),
+        }
+
+        valid {
+            args: func_args![value: "1.2.3.4"],
+            want: Ok(value!(67305985)),
+            tdef: TypeDef::new().fallible().integer(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -1,0 +1,81 @@
+use std::{convert::TryInto, net::Ipv4Addr};
+
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct IpNtoa;
+
+impl Function for IpNtoa {
+    fn identifier(&self) -> &'static str {
+        "ip_ntoa"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "Example",
+            source: r#"ip_ntoa!(67305985)"#,
+            result: Ok("1.2.3.4"),
+        }]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(IpNtoaFn { value }))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IpNtoaFn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for IpNtoaFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let i: u32 = self
+            .value
+            .resolve(ctx)?
+            .try_integer()?
+            .try_into()
+            .map_err(|_| format!("cannot convert to bytes: integer does not fit in u32"))?;
+
+        let mut bytes = i.to_be_bytes();
+        bytes.reverse();
+        let ip = Ipv4Addr::from(bytes);
+
+        Ok(ip.to_string().into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().fallible().bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        ip_ntoa => IpNtoa;
+
+        invalid {
+            args: func_args![value: u32::MAX as i64 + 1],
+            want: Err("cannot convert to bytes: integer does not fit in u32"),
+            tdef: TypeDef::new().fallible().bytes(),
+        }
+
+        valid {
+            args: func_args![value: 67305985],
+            want: Ok(value!("1.2.3.4")),
+            tdef: TypeDef::new().fallible().bytes(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -13,7 +13,7 @@ impl Function for IpNtoa {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            kind: kind::BYTES,
+            kind: kind::INTEGER,
             required: true,
         }]
     }

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -45,7 +45,7 @@ impl Expression for IpNtoaFn {
             .resolve(ctx)?
             .try_integer()?
             .try_into()
-            .map_err(|_| format!("cannot convert to bytes: integer does not fit in u32"))?;
+            .map_err(|_| String::from("cannot convert to bytes: integer does not fit in u32"))?;
 
         let ip = Ipv4Addr::from(u32::from_be(i));
 

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -47,9 +47,7 @@ impl Expression for IpNtoaFn {
             .try_into()
             .map_err(|_| format!("cannot convert to bytes: integer does not fit in u32"))?;
 
-        let mut bytes = i.to_be_bytes();
-        bytes.reverse();
-        let ip = Ipv4Addr::from(bytes);
+        let ip = Ipv4Addr::from(i.to_ne_bytes());
 
         Ok(ip.to_string().into())
     }

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -47,7 +47,7 @@ impl Expression for IpNtoaFn {
             .try_into()
             .map_err(|_| format!("cannot convert to bytes: integer does not fit in u32"))?;
 
-        let ip = Ipv4Addr::from(i.to_ne_bytes());
+        let ip = Ipv4Addr::from(u32::from_be(i));
 
         Ok(ip.to_string().into())
     }

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -56,8 +56,12 @@ mod get_hostname;
 mod includes;
 #[cfg(feature = "integer")]
 mod integer;
+#[cfg(feature = "ip_aton")]
+mod ip_aton;
 #[cfg(feature = "ip_cidr_contains")]
 mod ip_cidr_contains;
+#[cfg(feature = "ip_ntoa")]
+mod ip_ntoa;
 #[cfg(feature = "ip_subnet")]
 mod ip_subnet;
 #[cfg(feature = "ip_to_ipv6")]
@@ -277,8 +281,12 @@ pub use get_hostname::GetHostname;
 pub use includes::Includes;
 #[cfg(feature = "integer")]
 pub use integer::Integer;
+#[cfg(feature = "ip_aton")]
+pub use ip_aton::IpAton;
 #[cfg(feature = "ip_cidr_contains")]
 pub use ip_cidr_contains::IpCidrContains;
+#[cfg(feature = "ip_ntoa")]
+pub use ip_ntoa::IpNtoa;
 #[cfg(feature = "ip_subnet")]
 pub use ip_subnet::IpSubnet;
 #[cfg(feature = "ip_to_ipv6")]
@@ -484,8 +492,12 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Includes),
         #[cfg(feature = "integer")]
         Box::new(Integer),
+        #[cfg(feature = "ip_aton")]
+        Box::new(IpAton),
         #[cfg(feature = "ip_cidr_contains")]
         Box::new(IpCidrContains),
+        #[cfg(feature = "ip_ntoa")]
+        Box::new(IpNtoa),
         #[cfg(feature = "ip_subnet")]
         Box::new(IpSubnet),
         #[cfg(feature = "ip_to_ipv6")]


### PR DESCRIPTION
This PR adds two new functions that convert IPv4 addresses to and from
their numbers-and-dots notation and numeric represenattion. These mimic
the C standard library inet_aton and inet_ntoa functions.

Rust's `Ipv4Addr` is directly convertable to/from `u32` via defined
`From` implementations; however these seem to use host-byte order rather
than network-byte order. I chose to maintain the C library behavior of
network-byte order.

We could opt to extend these functions to work with IPv6 addresses but
they'd require an internal integer representation capable of storing an
u128 whereas our current `integer` representation is i64.

Closes #7188

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
