### PR TITLE
chore(ci): Add dummy job for cross matrix job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
   cross-linux-success:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Cross
+    name: Cross Linux
     needs: cross-linux
     steps:
       - name: Check cross matrix status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
   cross-linux-success:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Cross Linux
+    name: Cross - Linux
     needs: cross-linux
     steps:
       - name: Check cross matrix status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,8 +198,8 @@ jobs:
           name: "vector-debug-${{ matrix.target }}"
           path: "./target/${{ matrix.target }}/debug/vector"
 
-  cross-linux-success:
-    if: ${{ always() }}
+  cross-linux-check:
+    if: ${{ needs.changes.outputs.dependencies == 'true' }}
     runs-on: ubuntu-latest
     name: Cross - Linux
     needs: cross-linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,16 @@ jobs:
           name: "vector-debug-${{ matrix.target }}"
           path: "./target/${{ matrix.target }}/debug/vector"
 
+  cross-linux-success:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Cross
+    needs: cross-linux
+    steps:
+      - name: Check cross matrix status
+        if: ${{ needs.cross-linux.result != 'success' }}
+        run: exit 1
+
   test-mac:
     name: Unit - Mac
     # Full CI suites for this platform were only recently introduced.


### PR DESCRIPTION
This will allow us to require this for the PR status checks as requiring
the matrix job directly doesn't work as we discovered in https://github.com/timberio/vector/pull/6861#issuecomment-868822823

https://github.community/t/status-check-for-a-matrix-jobs/127354

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
