### PR TITLE
fix(vrl): apache error parser without thread id

### DIFF
--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -64,8 +64,8 @@ lazy_static! {
         (-|\[(-|(?P<timestamp>[^\[]*))\])\s+        # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
         (-|\[(-|(?P<module>[^:]*):                  # Match `-` or `[` followed by `-` or any character except `:`.
         (?P<severity>[^\[]*))\])\s+                 # Match ary character except `]`, `]` and at least one whitespace.
-        (-|\[\s*pid\s*(-|(?P<pid>[^:]*):            # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
-        \s*tid\s*(?P<thread>[^\[]*))\])\s           # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
+        (-|\[\s*pid\s*(-|(?P<pid>[^:]*)             # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
+        (:\s*tid\s*(?P<thread>[^\[]*))?)\])\s       # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
         (-|\[\s*client\s*(-|(?P<client>[^:]*):      # Match `-` or `[` followed by `client`, `-` or any character except `:`.
         (?P<port>[^\[]*))\])\s                      # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
         (-|(?P<message>.*))                         # Match `-` or any character.

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -248,6 +248,25 @@ mod tests {
             tdef: TypeDef::new().fallible().object(type_def_error()),
         }
 
+        error_line_thread_id {
+            args: func_args![
+                value: r#"[2021-06-04 15:40:27.138633] [php7:emerg] [pid 4803] [client 95.223.77.60:35106] PHP Parse error:  syntax error, unexpected \'->\' (T_OBJECT_OPERATOR) in /var/www/prod/releases/master-c7225365fd9faa26262cffeeb57b31bd7448c94a/source/index.php on line 14"#,
+                timestamp_format: "%Y-%m-%d %H:%M:%S.%f",
+                format: "error",
+            ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-06-04T15:40:27.000138633Z").unwrap().into()),
+                "message" => "PHP Parse error:  syntax error, unexpected \\\'->\\\' (T_OBJECT_OPERATOR) in /var/www/prod/releases/master-c7225365fd9faa26262cffeeb57b31bd7448c94a/source/index.php on line 14",
+                "module" => "php7",
+                "severity" => "emerg",
+                "pid" => 4803,
+                "client" => "95.223.77.60",
+                "port" => 35106
+
+            }),
+            tdef: TypeDef::new().fallible().object(type_def_error()),
+        }
+
         log_line_valid_empty {
             args: func_args![value: "- - - - - - -",
                              format: "common",


### PR DESCRIPTION
fixes #7827

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
