### PR TITLE
enhancement(releasing): Refine Vector user for debian

### DIFF
--- a/distribution/debian/scripts/preinst
+++ b/distribution/debian/scripts/preinst
@@ -2,7 +2,9 @@
 set -e
 
 # Add vector:vector user & group
-id --user vector >/dev/null 2>&1 || useradd -M --system --user-group vector
+id --user vector >/dev/null 2>&1 || \
+  useradd --system --shell /sbin/nologin --home-dir /var/lib/vector --user-group \
+    --comment "Vector observability data router" vector
 
 # Create default Vector data directory
 mkdir -p /var/lib/vector

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -63,8 +63,8 @@ cp -a %{_builddir}/systemd/vector.default %{buildroot}%{_sysconfdir}/default/vec
 %post
 getent group %{_username} > /dev/null || groupadd -r %{_username}
 getent passwd %{_username} > /dev/null || \
-  useradd -r -d %{_sharedstatedir}/%{_name} -g %{_username} -s /sbin/nologin \
-  -c "Vector observability data router" %{_username}
+  useradd --shell /sbin/nologin --system --home-dir %{_sharedstatedir}/%{_name} --user-group \
+    --comment "Vector observability data router" %{_username}
 chown %{_username} %{_sharedstatedir}/%{_name}
 usermod -aG systemd-journal %{_username}  || true
 


### PR DESCRIPTION
This refines the `vector` user created by the deb packages to create
with no login shell and with the home directory set to
`/var/lib/vector`. This brings it in-line with the user created by the
rpm package.

I also updated the rpm user creation to use long flags and in the same
order as the deb to make it easier to spot differences.

Closes #7945

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
