### PR TITLE
fix(aws service): Allow zero size compressed messages

### DIFF
--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -108,6 +108,10 @@ fn decode_record(
 ) -> Result<Bytes, RecordDecodeError> {
     let buf = base64::decode(record.data.as_bytes()).context(Base64 {})?;
 
+    if buf.is_empty() {
+        return Ok(Bytes::default());
+    }
+
     match compression {
         Compression::None => Ok(Bytes::from(buf)),
         Compression::Gzip => decode_gzip(&buf[..]).with_context(|| Decompression {

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -296,8 +296,8 @@ mod tests {
                 Compression::Gzip,
                 Compression::Gzip,
                 true,
-                String::new(),
-                String::new(),
+                Vec::new(),
+                Vec::new(),
             ),
         ];
 

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -204,9 +204,10 @@ mod tests {
             Compression::Auto => panic!("cannot encode records as Auto"),
             Compression::Gzip => {
                 let mut buffer = Vec::new();
-
-                let mut gz = GzEncoder::new(record, flate2::Compression::fast());
-                gz.read_to_end(&mut buffer)?;
+                if !record.is_empty() {
+                    let mut gz = GzEncoder::new(record, flate2::Compression::fast());
+                    gz.read_to_end(&mut buffer)?;
+                }
                 buffer
             }
             Compression::None => record.to_vec(),

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -292,6 +292,13 @@ mod tests {
                 record.to_owned(),
                 record.to_owned(),
             ),
+            (
+                Compression::Gzip,
+                Compression::Gzip,
+                true,
+                String::new(),
+                String::new(),
+            ),
         ];
 
         for (source_record_compression, record_compression, success, record, expected) in cases {

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -394,11 +394,6 @@ impl IngestorProcess {
                 )
                 .await;
 
-                let object_reader = match object_reader {
-                    Some(reader) => reader,
-                    None => return Ok(()),
-                };
-
                 // Record the read error seen to propagate up later so we avoid ack'ing the SQS
                 // message
                 //

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -391,7 +391,13 @@ impl IngestorProcess {
                     object.content_encoding.as_deref(),
                     object.content_type.as_deref(),
                     body,
-                );
+                )
+                .await;
+
+                let object_reader = match object_reader {
+                    Some(reader) => reader,
+                    None => return Ok(()),
+                };
 
                 // Record the read error seen to propagate up later so we avoid ack'ing the SQS
                 // message


### PR DESCRIPTION
Closes  #7710

Enable for individually compressed messages to be empty for sources:
* `aws_kinesis_firehose`
* `aws_s3`

Other sources either don't have sub messages or they can't be individually compressed. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
