### PR TITLE
fix(dnstap source): eliminate warnings while building docker image for dnstap IT

### DIFF
--- a/tests/data/dnstap/Dockerfile
+++ b/tests/data/dnstap/Dockerfile
@@ -1,13 +1,14 @@
 FROM docker.io/library/debian:buster
 
 RUN apt-get update
-RUN apt-get -y install apt-transport-https lsb-release ca-certificates curl
-RUN apt-get -y install wget
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-utils
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-transport-https lsb-release ca-certificates curl
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install wget
 RUN wget -O /etc/apt/trusted.gpg.d/bind.gpg https://packages.sury.org/bind/apt.gpg
 RUN sh -c 'echo "deb https://packages.sury.org/bind/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/bind.list'
 RUN apt-get update
-RUN apt-get -y install bind9 bind9utils
-RUN apt-get -y install dnsutils
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install bind9 bind9utils
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install dnsutils
 
 ADD named.conf.local /etc/bind/
 ADD db.example.com /var/lib/bind/


### PR DESCRIPTION
Closes #8074 
* Install Debian package `apt-utils` first before installation of any other packages
* Set environmental variable `DEBIAN_FRONTEND` as `noninteractive` to eliminate warnings like `unable to initialize frontend`

Signed-off-by: James Bai <jbai@bluecatnetworks.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
