### PR TITLE
enhancement(vrl): Add `format_int` and `parse_int` functions

### DIFF
--- a/docs/reference/remap/functions/format_int.cue
+++ b/docs/reference/remap/functions/format_int.cue
@@ -1,0 +1,45 @@
+package metadata
+
+remap: functions: format_int: {
+	category: "Number"
+	description: #"""
+		Formats the integer `value` into a string representation using the given base/radix.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The number to format as a string."
+			required:    true
+			type: ["integer"]
+		},
+		{
+			name:        "base"
+			description: "The base to format the number in. Must be between 2 and 36 (inclusive)."
+			required:    false
+			type: ["integer"]
+			default: 10
+		},
+	]
+	internal_failure_reasons: [
+		"base is not between 2 and 36",
+	]
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Format as a hexidecimal integer"
+			source: #"""
+				format_int!(42, 16)
+				"""#
+			return: "2a"
+		},
+		{
+			title: "Format as a negative hexidecimal integer"
+			source: #"""
+				format_int!(-42, 16)
+				"""#
+			return: "-2a"
+		},
+	]
+}

--- a/docs/reference/remap/functions/format_int.cue
+++ b/docs/reference/remap/functions/format_int.cue
@@ -9,7 +9,7 @@ remap: functions: format_int: {
 	arguments: [
 		{
 			name:        "value"
-			description: "The number to format as a string."
+			description: "The number to format."
 			required:    true
 			type: ["integer"]
 		},

--- a/docs/reference/remap/functions/parse_int.cue
+++ b/docs/reference/remap/functions/parse_int.cue
@@ -9,7 +9,7 @@ remap: functions: parse_int: {
 	arguments: [
 		{
 			name:        "value"
-			description: "The number to format as a string."
+			description: "The string to parse."
 			required:    true
 			type: ["string"]
 		},

--- a/docs/reference/remap/functions/parse_int.cue
+++ b/docs/reference/remap/functions/parse_int.cue
@@ -1,0 +1,72 @@
+package metadata
+
+remap: functions: parse_int: {
+	category: "Parse"
+	description: #"""
+		Parses the string `value` representing a number in an optional base/radix to an integer.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The number to format as a string."
+			required:    true
+			type: ["string"]
+		},
+		{
+			name: "base"
+			description: """
+					The base the number is in. Must be between 2 and 36 (inclusive).
+
+					If unspecified, will use the string prefix to try to
+					determine the base: "0b", 8 for "0" or "0o", 16 for "0x",
+					and 10 otherwise
+				"""
+			required: false
+			type: ["integer"]
+		},
+	]
+	internal_failure_reasons: [
+		"base is not between 2 and 36",
+		"number cannot be parsed in the base",
+	]
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Parse decimal"
+			source: #"""
+				parse_int!("-42")
+				"""#
+			return: -42
+		},
+		{
+			title: "Parse binary"
+			source: #"""
+				parse_int!("0b1001")
+				"""#
+			return: 9
+		},
+		{
+			title: "Parse octal"
+			source: #"""
+				parse_int!("0o42")
+				"""#
+			return: 34
+		},
+		{
+			title: "Parse hexdecimal"
+			source: #"""
+				parse_int!("0x2a")
+				"""#
+			return: 42
+		},
+		{
+			title: "Parse explicit base"
+			source: #"""
+				parse_int!("2a", 17)
+				"""#
+			return: 44
+		},
+	]
+}

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -64,6 +64,7 @@ default = [
     "flatten",
     "float",
     "floor",
+    "format_int",
     "format_number",
     "format_timestamp",
     "get_env_var",
@@ -105,6 +106,7 @@ default = [
     "parse_duration",
     "parse_glog",
     "parse_grok",
+    "parse_int",
     "parse_json",
     "parse_key_value",
     "parse_klog",
@@ -172,6 +174,7 @@ exists = []
 flatten = []
 float = []
 floor = []
+format_int = []
 format_number = ["rust_decimal"]
 format_timestamp = ["chrono"]
 get_env_var = []
@@ -213,6 +216,7 @@ parse_csv = ["csv"]
 parse_duration = ["rust_decimal"]
 parse_glog = ["chrono"]
 parse_grok = ["grok"]
+parse_int = []
 parse_json = ["serde_json"]
 parse_key_value = ["nom"]
 parse_klog = ["chrono"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -29,6 +29,7 @@ criterion_group!(
               //exists
               flatten,
               floor,
+              format_int,
               format_number,
               format_timestamp,
               get_env_var,
@@ -71,6 +72,7 @@ criterion_group!(
               parse_grok,
               parse_key_value,
               parse_klog,
+              parse_int,
               parse_json,
               parse_nginx_log,
               parse_query_string,
@@ -366,6 +368,20 @@ bench_function! {
     literal {
         args: func_args![value: 1234.56725, precision: 4],
         want: Ok(1234.5672),
+    }
+}
+
+bench_function! {
+    format_int => vrl_stdlib::FormatInt;
+
+    decimal {
+        args: func_args![value: 42],
+        want: Ok("42"),
+    }
+
+    hexidecimal {
+        args: func_args![value: 42, base: 16],
+        want: Ok(value!("2a")),
     }
 }
 
@@ -1065,6 +1081,25 @@ bench_function! {
             "level": "info",
             "message": "Hello world",
         })),
+    }
+}
+
+bench_function! {
+    parse_int => vrl_stdlib::ParseInt;
+
+    decimal {
+        args: func_args![value: "-42"],
+        want: Ok(-42),
+    }
+
+    hexidecimal {
+        args: func_args![value: "0x2a"],
+        want: Ok(42),
+    }
+
+    explicit_hexidecimal {
+        args: func_args![value: "2a", base: 16],
+        want: Ok(42),
     }
 }
 

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -1,0 +1,147 @@
+use std::collections::VecDeque;
+
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct FormatInt;
+
+impl Function for FormatInt {
+    fn identifier(&self) -> &'static str {
+        "format_int"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::INTEGER,
+                required: true,
+            },
+            Parameter {
+                keyword: "base",
+                kind: kind::INTEGER,
+                required: false,
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let base = arguments.optional("base");
+
+        Ok(Box::new(FormatIntFn { value, base }))
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "format decimal integer",
+                source: r#"format_int!(42)"#,
+                result: Ok("42"),
+            },
+            Example {
+                title: "format hexidecimal integer",
+                source: r#"format_int!(42, 16)"#,
+                result: Ok("2a"),
+            },
+            Example {
+                title: "format negative hexidecimal integer",
+                source: r#"format_int!(-42, 16)"#,
+                result: Ok("-2a"),
+            },
+        ]
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FormatIntFn {
+    value: Box<dyn Expression>,
+    base: Option<Box<dyn Expression>>,
+}
+
+impl Expression for FormatIntFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?.try_integer()?;
+        let base = match &self.base {
+            Some(base) => base
+                .resolve(ctx)
+                .and_then(|value| value.try_integer().map_err(Into::into))
+                .and_then(|value| {
+                    if !(2..=36).contains(&value) {
+                        return Err(format!(
+                            "invalid base {}: must be be between 2 and 36 (inclusive)",
+                            value
+                        )
+                        .into());
+                    }
+
+                    Ok(value as u32)
+                }),
+            None => Ok(10u32),
+        }?;
+
+        let converted = format_radix(value, base as u32);
+
+        Ok(converted.into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().fallible().integer()
+    }
+}
+
+// Formats x in the provided radix
+//
+// Panics if radix is < 2 or > 36
+fn format_radix(x: i64, radix: u32) -> String {
+    let mut result: VecDeque<char> = VecDeque::new();
+
+    let (mut x, negative) = if x < 0 {
+        (-x as u64, true)
+    } else {
+        (x as u64, false)
+    };
+
+    loop {
+        let m = (x % radix as u64) as u32; // max of 35
+        x /= radix as u64;
+
+        result.push_front(std::char::from_digit(m, radix).unwrap());
+        if x == 0 {
+            break;
+        }
+    }
+
+    if negative {
+        result.push_front('-');
+    }
+
+    result.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        format_int => FormatInt;
+
+        decimal {
+            args: func_args![value: 42],
+            want: Ok(value!("42")),
+            tdef: TypeDef::new().fallible().integer(),
+        }
+
+        hexidecimal {
+            args: func_args![value: 42, base: 16],
+            want: Ok(value!("2a")),
+            tdef: TypeDef::new().fallible().integer(),
+        }
+
+        negative_hexidecimal {
+            args: func_args![value: -42, base: 16],
+            want: Ok(value!("-2a")),
+            tdef: TypeDef::new().fallible().integer(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -37,7 +37,8 @@ impl Function for FormatInt {
             Example {
                 title: "format decimal integer",
                 source: r#"format_int!(42)"#,
-                result: Ok("42"),
+                // extra "s are needed to avoid being read as an integer by tests
+                result: Ok("\"42\""),
             },
             Example {
                 title: "format hexidecimal integer",

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -44,6 +44,8 @@ mod flatten;
 mod float;
 #[cfg(feature = "floor")]
 mod floor;
+#[cfg(feature = "format_int")]
+mod format_int;
 #[cfg(feature = "format_number")]
 mod format_number;
 #[cfg(feature = "format_timestamp")]
@@ -134,6 +136,8 @@ mod parse_duration;
 mod parse_glog;
 #[cfg(feature = "parse_grok")]
 mod parse_grok;
+#[cfg(feature = "parse_int")]
+mod parse_int;
 #[cfg(feature = "parse_json")]
 mod parse_json;
 #[cfg(feature = "parse_key_value")]
@@ -271,6 +275,8 @@ pub use flatten::Flatten;
 pub use float::Float;
 #[cfg(feature = "floor")]
 pub use floor::Floor;
+#[cfg(feature = "format_int")]
+pub use format_int::FormatInt;
 #[cfg(feature = "format_number")]
 pub use format_number::FormatNumber;
 #[cfg(feature = "format_timestamp")]
@@ -351,6 +357,8 @@ pub use parse_duration::ParseDuration;
 pub use parse_glog::ParseGlog;
 #[cfg(feature = "parse_grok")]
 pub use parse_grok::ParseGrok;
+#[cfg(feature = "parse_int")]
+pub use parse_int::ParseInt;
 #[cfg(feature = "parse_json")]
 pub use parse_json::ParseJson;
 #[cfg(feature = "parse_key_value")]
@@ -484,6 +492,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Float),
         #[cfg(feature = "floor")]
         Box::new(Floor),
+        #[cfg(feature = "format_int")]
+        Box::new(FormatInt),
         #[cfg(feature = "format_number")]
         Box::new(FormatNumber),
         #[cfg(feature = "format_timestamp")]
@@ -564,6 +574,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ParseGlog),
         #[cfg(feature = "parse_grok")]
         Box::new(ParseGrok),
+        #[cfg(feature = "parse_int")]
+        Box::new(ParseInt),
         #[cfg(feature = "parse_json")]
         Box::new(ParseJson),
         #[cfg(feature = "parse_apache_log")]

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -1,0 +1,140 @@
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ParseInt;
+
+impl Function for ParseInt {
+    fn identifier(&self) -> &'static str {
+        "parse_int"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "base",
+                kind: kind::INTEGER,
+                required: false,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "integer",
+                source: r#"parse_int!("-42")"#,
+                result: Ok("-42"),
+            },
+            Example {
+                title: "hexidecimal",
+                source: r#"parse_int!("0x2a")"#,
+                result: Ok("42"),
+            },
+            Example {
+                title: "hexidecimal explicit",
+                source: r#"parse_int!("2a", base: 16)"#,
+                result: Ok("42"),
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let base = arguments.optional("base");
+
+        Ok(Box::new(ParseIntFn { value, base }))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseIntFn {
+    value: Box<dyn Expression>,
+    base: Option<Box<dyn Expression>>,
+}
+
+impl Expression for ParseIntFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let string = value.try_bytes_utf8_lossy()?;
+
+        let (base, index) = match &self.base {
+            Some(base) => base
+                .resolve(ctx)
+                .and_then(|value| value.try_integer().map_err(Into::into))
+                .and_then(|value| {
+                    if !(2..=36).contains(&value) {
+                        return Err(format!(
+                            "invalid base {}: must be be between 2 and 36 (inclusive)",
+                            value
+                        )
+                        .into());
+                    }
+
+                    Ok((value as u32, 0))
+                }),
+            None => match string.chars().next() {
+                Some('0') => match string.chars().nth(1) {
+                    Some('b') => Ok((2, 2)),
+                    Some('o') => Ok((8, 2)),
+                    Some('x') => Ok((16, 2)),
+                    _ => Ok((8, 1)),
+                },
+                Some(_) => Ok((10u32, 0)),
+                None => Err("value is empty".into()),
+            },
+        }?;
+
+        let converted = i64::from_str_radix(&string[index..], base)
+            .map_err(|err| format!("could not parse integer: {}", err))?;
+
+        Ok(converted.into())
+    }
+
+    fn type_def(&self, _state: &state::Compiler) -> TypeDef {
+        TypeDef::new().fallible().integer()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        parse_int => ParseInt;
+
+        decimal {
+             args: func_args![value: "-42"],
+             want: Ok(-42),
+             tdef: TypeDef::new().fallible().integer(),
+        }
+
+        binary {
+             args: func_args![value: "0b1001"],
+             want: Ok(9),
+             tdef: TypeDef::new().fallible().integer(),
+        }
+
+        octal {
+             args: func_args![value: "042"],
+             want: Ok(34),
+             tdef: TypeDef::new().fallible().integer(),
+        }
+
+        hexidecimal {
+             args: func_args![value: "0x2a"],
+             want: Ok(42),
+             tdef: TypeDef::new().fallible().integer(),
+        }
+
+        explicit_hexidecimal {
+             args: func_args![value: "2a", base: 16],
+             want: Ok(42),
+             tdef: TypeDef::new().fallible().integer(),
+        }
+    ];
+}


### PR DESCRIPTION
For converting integers to/from strings.

We currently have `to_int` which is equivalent to `parse_int(foo, 10)`,
but the added `parse_int` is able to:

* Parse in a specified base
* Determine the base of the number by looking at its prefix (e.g. 0x ->
  16)

I added an analogous `format_int` for going the other way.

Closes: https://github.com/timberio/vector/issues/7228

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
