### PR TITLE
enhancement(kubernetes_logs source): Expose `lines` option

### DIFF
--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -395,7 +395,7 @@ components: sources: file: {
 			title: "Fingerprint"
 			body: """
 				By default, Vector identifies files by creating a
-				[cyclic redundancy check](urls.crc) (CRC) on the first N lines of
+				[cyclic redundancy check](urls.crc) (CRC) on the first line of
 				the file. This serves as a fingerprint to uniquely identify the file.
 				The amount of lines read can be controlled via the `fingerprint.lines`
 				and `fingerprint.ignored_header_bytes` options.

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -229,6 +229,22 @@ components: sources: kubernetes_logs: {
 				unit:    "bytes"
 			}
 		}
+		fingerprint_lines: {
+			common: false
+			description: """
+				The number of lines to read when generating a unique fingerprint of a log file.
+				This is helpful when some containers share common first log lines.
+				WARNING: If the file has less than this amount of lines then it won't be read at all. 
+				This is important since container logs are broken up into several files, so the greater 
+			    `lines` value is, the greater the chance of it not reading the last file/logs of 
+				the container.
+				"""
+			required:      false
+			type: uint: {
+				default: 1
+				unit:    "lines"
+			}
+		}
 		glob_minimum_cooldown_ms: {
 			common:      false
 			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files within a single pod."

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -239,7 +239,7 @@ components: sources: kubernetes_logs: {
 			    `lines` value is, the greater the chance of it not reading the last file/logs of 
 				the container.
 				"""
-			required:      false
+			required: false
 			type: uint: {
 				default: 1
 				unit:    "lines"

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -234,9 +234,9 @@ components: sources: kubernetes_logs: {
 			description: """
 				The number of lines to read when generating a unique fingerprint of a log file.
 				This is helpful when some containers share common first log lines.
-				WARNING: If the file has less than this amount of lines then it won't be read at all. 
-				This is important since container logs are broken up into several files, so the greater 
-			    `lines` value is, the greater the chance of it not reading the last file/logs of 
+				WARNING: If the file has less than this amount of lines then it won't be read at all.
+				This is important since container logs are broken up into several files, so the greater
+				`lines` value is, the greater the chance of it not reading the last file/logs of
 				the container.
 				"""
 			required: false

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -91,7 +91,6 @@ pub struct Config {
     max_line_bytes: usize,
 
     /// How many first lines in a file are used for fingerprinting.
-    #[serde(default = "default_fingerprint_lines")]
     fingerprint_lines: usize,
 
     /// This value specifies not exactly the globbing, but interval
@@ -143,6 +142,7 @@ impl Default for Config {
             exclude_paths_glob_patterns: default_path_exclusion(),
             max_read_bytes: default_max_read_bytes(),
             max_line_bytes: default_max_line_bytes(),
+            fingerprint_lines: default_fingerprint_lines(),
             glob_minimum_cooldown_ms: default_glob_minimum_cooldown_ms(),
             ingestion_timestamp_field: None,
             timezone: None,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -94,6 +94,10 @@ pub struct Config {
     #[serde(default = "default_max_line_bytes")]
     max_line_bytes: usize,
 
+    /// How many first lines in a file are used for fingerprinting.
+    #[serde(default = "default_fingerprint_lines")]
+    fingerprint_lines: usize,
+
     /// This value specifies not exactly the globbing, but interval
     /// between the polling the files to watch from the `paths_provider`.
     /// This is quite efficient, yet might still create some load of the
@@ -166,6 +170,7 @@ struct Source {
     exclude_paths: Vec<glob::Pattern>,
     max_read_bytes: usize,
     max_line_bytes: usize,
+    fingerprint_lines: usize,
     glob_minimum_cooldown: Duration,
     ingestion_timestamp_field: Option<String>,
     timezone: TimeZone,
@@ -211,6 +216,7 @@ impl Source {
             exclude_paths,
             max_read_bytes: config.max_read_bytes,
             max_line_bytes: config.max_line_bytes,
+            fingerprint_lines: config.fingerprint_lines,
             glob_minimum_cooldown,
             ingestion_timestamp_field: config.ingestion_timestamp_field.clone(),
             timezone,
@@ -232,6 +238,7 @@ impl Source {
             exclude_paths,
             max_read_bytes,
             max_line_bytes,
+            fingerprint_lines,
             glob_minimum_cooldown,
             ingestion_timestamp_field,
             timezone,
@@ -298,7 +305,7 @@ impl Source {
                     // Max line length to expect during fingerprinting, see the
                     // explanation above.
                     ignored_header_bytes: 0,
-                    lines: 1,
+                    lines: fingerprint_lines,
                 },
                 max_line_length: max_line_bytes,
                 ignore_not_found: true,
@@ -453,6 +460,10 @@ fn default_max_line_bytes() -> usize {
 
 fn default_glob_minimum_cooldown_ms() -> usize {
     60000
+}
+
+fn default_fingerprint_lines() -> usize {
+    1
 }
 
 /// This function construct the effective field selector to use, based on


### PR DESCRIPTION
Closes #8070

I'm kinda reluctant to expose this for two reasons:
1. It exposes internal implementation.
2. It kinda isn't straightforward because of this sentence:
    `If the file has less than this amount of lines then it won't be read at all.` 
    Without knowing how the collection of logs from Kubernetes works users can shot them self in the foot by setting that value too high. That's because the logs are broken into several files, so the larger `lines` is the greater the chance is for the last logs of a container to be lost. So the way how collection works needs to be explained in the documentation. 

This should be fine as a quick fix, but considering how the problem of identifying files is difficult, it will probably be permanent. 

---
Ideally, we should only apply `lines` for the start of container logs. Which can be aproximated as the first logs we encounter for that container but this would require expanding `files` "source" with a concept of a group of files belonging to a same stream.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
