### PR TITLE
fix(kafka source): add tokio feature to rdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5632,6 +5632,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slab",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,7 @@ postgres-openssl = { version = "0.5.0", default-features = false, features = ["r
 pulsar = { version = "3.0.1", default-features = false, features = ["tokio-runtime"], optional = true }
 rand = { version = "0.8.4", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4.1", default-features = false }
-rdkafka = { version = "0.26.0", default-features = false, features = ["libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.26.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 # make sure to update the external docs when the Lua version changes
 rlua = { version = "0.17.0", default-features = true, optional = true }


### PR DESCRIPTION
Found as part of investigating #7842.

Between an upgrade of the crate and our move to turn off default features on deps, we lost `rdkafka`'s [direct integration](https://github.com/fede1024/rust-rdkafka/blob/b4ec50e72e9b6d0199519092c4db4835315d91ba/src/util.rs#L395-L418) with tokio and began using its [`NaiveRuntime`](https://github.com/fede1024/rust-rdkafka/blob/b4ec50e72e9b6d0199519092c4db4835315d91ba/src/util.rs#L375-L393).

It's not clear how much of a performance impact this actually has for us (my test setup didn't show much, but might be too artificial to do so), but it's definitely something to fix either way.