### PR TITLE
chore(tests): Resolve example.com instead of vector.dev for tests

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -87,8 +87,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_vector() {
-        assert!(resolve("vector.dev").await);
+    async fn resolve_example() {
+        assert!(resolve("example.com").await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I don't see a lot of value in specifically resolving vector.dev and it
is currently causing CI failures due to failed lookups. I was going to
`#[ignore]` it but figured I'd just update it to resolve a domain that
should always be there.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
