### PR TITLE
fix(vrl): ensure parse_syslog handles non structured messages

### DIFF
--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -236,5 +236,18 @@ mod tests {
             }),
             tdef: TypeDef::new().fallible().object(type_def()),
         }
+
+        non_structured_data_in_message {
+            args: func_args![value: "<131>Jun 8 11:54:08 master apache_error [Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message"],
+            want: Ok(btreemap!{
+                "appname" => "apache_error",
+                "facility" => "local0",
+                "hostname" => "master",
+                "severity" => "err",
+                "timestamp" => DateTime::<Utc>::from(chrono::Local.ymd(2021, 6, 8).and_hms_milli(11, 54, 8, 0)),
+                "message" => "[Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
     ];
 }


### PR DESCRIPTION
closes #7796
fixed by [this PR](https://github.com/StephenWakely/syslog-loose/pull/12)

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
