### PR TITLE
fix(vrl): `to_int` truncates floats

### DIFF
--- a/docs/reference/remap/functions/to_int.cue
+++ b/docs/reference/remap/functions/to_int.cue
@@ -23,6 +23,8 @@ remap: functions: to_int: {
 	return: {
 		types: ["integer"]
 		rules: [
+			"If `value` is an integer, it will be returned as-is.",
+			"If `value` is a float, it will be truncated to its integer portion.",
 			"If `value` is a string, it must be the string representation of an integer or else an error is raised.",
 			"If `value` is a boolean, `0` is returned for `false` and `1` is returned for `true`.",
 			"If `value` is a timestamp, a [Unix timestamp](\(urls.unix_timestamp)) (in seconds) is returned.",

--- a/lib/vrl/stdlib/src/to_int.rs
+++ b/lib/vrl/stdlib/src/to_int.rs
@@ -27,7 +27,7 @@ impl Function for ToInt {
             Example {
                 title: "float",
                 source: "to_int(5.6)",
-                result: Ok("6"),
+                result: Ok("5"),
             },
             Example {
                 title: "true",
@@ -105,7 +105,7 @@ impl Expression for ToIntFn {
 
         match value {
             Integer(_) => Ok(value),
-            Float(v) => Ok(Integer(v.into_inner().round() as i64)),
+            Float(v) => Ok(Integer(v.into_inner() as i64)),
             Boolean(v) => Ok(Integer(if v { 1 } else { 0 })),
             Null => Ok(0.into()),
             Bytes(v) => Conversion::Integer
@@ -143,7 +143,7 @@ mod tests {
 
         float {
              args: func_args![value: 20.5],
-             want: Ok(21),
+             want: Ok(20),
              tdef: TypeDef::new().infallible().integer(),
         }
 


### PR DESCRIPTION
It seems like we explicitly decided to round, but I agree with the user
that filed #8135 that truncation is a more common behavior for integer
coercion of floats.

Fixes: #8135

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
