### PR TITLE
fix(journald source): Fix event metrics reporting

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -34,7 +34,6 @@ use tokio::{
     process::Command,
     time::sleep,
 };
-use tracing_futures::Instrument;
 
 const DEFAULT_BATCH_SIZE: usize = 16;
 
@@ -143,8 +142,7 @@ impl SourceConfig for JournaldConfig {
                 remap_priority: self.remap_priority,
                 out: cx.out,
             }
-            .run_shutdown(cx.shutdown, start)
-            .instrument(info_span!("journald-server")),
+            .run_shutdown(cx.shutdown, start),
         ))
     }
 


### PR DESCRIPTION
The `instrument()` call here was replacing the component span. I think we could
have made a nested span instead, and preserved the labels, but I don't
see a reason to have this span here since the component already has its
own span.

Fixes #8162 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
