### PR TITLE
enhancement(helm platform): Introduce customConfig key

### DIFF
--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -36,8 +36,7 @@ data:
         type: prometheus_exporter
         inputs: ["host_metrics", "internal_metrics"]
         address: 0.0.0.0:9090
-  {{- end }}
-  {{- if $deprecatedConfig }}
+  {{- else }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
   {{- if .Values.customConfig }}
-  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use deprecated keys with customConfig" }}{{- end }}
+  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use the following deprecated keys with customConfig: logSchema, vectorApi, kubernetesLogsSource, vectorSink, internalMetricsSource, hostMetricsSource, prometheusSink, sources, transforms, sinks" }}{{- end }}
   vector.yaml: |
 {{ tpl (toYaml .Values.customConfig) . | indent 4 }}
   {{- else if (not $deprecatedConfig) }}

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- $deprecatedConfig := or .Values.logSchema .Values.vectorApi.enabled .Values.kubernetesLogsSource.enabled .Values.vectorSink.enabled .Values.internalMetricsSource.enabled .Values.hostMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
+
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -6,6 +8,35 @@ metadata:
   labels:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
+  {{- if .Values.customConfig }}
+  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use deprecated keys with customConfig" }}{{- end }}
+  vector.yaml: |
+{{ tpl (toYaml .Values.customConfig) . | indent 4 }}
+  {{- else if (not $deprecatedConfig) }}
+  vector.yaml: |
+    # Configuration for Vector.
+    # Docs: https://vector.dev/docs/
+    data_dir: "/vector-data-dir"
+    sources:
+      host_metrics:
+        type: host_metrics
+        filesystem:
+          devices:
+            excludes: ["binfmt_misc"]
+          filesystems:
+            excludes: ["binfmt_misc"]
+          mountpoints:
+            excludes: ["*/proc/sys/fs/binfmt_misc"]
+      internal_metrics:
+        type: internal_metrics
+      kubernetes_logs:
+        type: kubernetes_logs
+    sinks:
+      prometheus_sink:
+        type: prometheus_exporter
+        inputs: ["host_metrics", "internal_metrics"]
+        address: 0.0.0.0:9090
+  {{- end }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $deprecatedConfig := or .Values.logSchema .Values.vectorApi.enabled .Values.kubernetesLogsSource.enabled .Values.vectorSink.enabled .Values.internalMetricsSource.enabled .Values.hostMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
+{{- $deprecatedConfig := or .Values.logSchema.enabled .Values.vectorApi.enabled .Values.kubernetesLogsSource.enabled .Values.vectorSink.enabled .Values.internalMetricsSource.enabled .Values.hostMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
 
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
@@ -37,11 +37,15 @@ data:
         inputs: ["host_metrics", "internal_metrics"]
         address: 0.0.0.0:9090
   {{- end }}
+  {{- if $deprecatedConfig }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |
+    {{- if .Values.vectorApi }}
     {{- include "libvector.vectorConfigHeader" . | nindent 4 -}}
+    {{- end }}
 
+    {{- if .Values.kubernetesLogsSource }}
     {{- with .Values.kubernetesLogsSource }}
     {{- if .enabled }}
     # Ingest logs from Kubernetes.
@@ -51,7 +55,9 @@ data:
     {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
     {{- end }}
     {{- end }}
+    {{- end }}
 
+    {{- if .Values.vectorSink -}}
     {{- with .Values.vectorSink -}}
     {{- if .enabled }}
     # Send logs to the aggregator.
@@ -63,8 +69,10 @@ data:
     {{- tuple .sinkId $value | include "libvector.vectorSinkConfig" | nindent 4 -}}
     {{- end }}
     {{- end }}
+    {{- end }}
 
     {{- $prometheusInputs := (list) -}}
+    {{- if .Values.hostMetricsSource -}}
     {{- with .Values.hostMetricsSource -}}
     {{- if .enabled }}
     {{- $prometheusInputs = prepend $prometheusInputs .sourceId }}
@@ -75,9 +83,11 @@ data:
     {{- tuple .sourceId $value | include "libvector.vectorSourceConfig" | nindent 4 -}}
     {{- end -}}
     {{- end -}}
+    {{- end -}}
 
     {{- merge . (dict "prometheusInputs" $prometheusInputs) | include "libvector.metricsConfigPartial" | nindent 4 -}}
 
     {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
 
+  {{- end }}
 {{- end }}

--- a/distribution/helm/vector-agent/templates/configmap.yaml
+++ b/distribution/helm/vector-agent/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- $deprecatedConfig := or .Values.logSchema.enabled .Values.vectorApi.enabled .Values.kubernetesLogsSource.enabled .Values.vectorSink.enabled .Values.internalMetricsSource.enabled .Values.hostMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
-
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -9,33 +7,8 @@ metadata:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
   {{- if .Values.customConfig }}
-  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use the following deprecated keys with customConfig: logSchema, vectorApi, kubernetesLogsSource, vectorSink, internalMetricsSource, hostMetricsSource, prometheusSink, sources, transforms, sinks" }}{{- end }}
   vector.yaml: |
 {{ tpl (toYaml .Values.customConfig) . | indent 4 }}
-  {{- else if (not $deprecatedConfig) }}
-  vector.yaml: |
-    # Configuration for Vector.
-    # Docs: https://vector.dev/docs/
-    data_dir: "/vector-data-dir"
-    sources:
-      host_metrics:
-        type: host_metrics
-        filesystem:
-          devices:
-            excludes: ["binfmt_misc"]
-          filesystems:
-            excludes: ["binfmt_misc"]
-          mountpoints:
-            excludes: ["*/proc/sys/fs/binfmt_misc"]
-      internal_metrics:
-        type: internal_metrics
-      kubernetes_logs:
-        type: kubernetes_logs
-    sinks:
-      prometheus_sink:
-        type: prometheus_exporter
-        inputs: ["host_metrics", "internal_metrics"]
-        address: 0.0.0.0:9090
   {{- else }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.hostMetricsSource.enabled }}
+            {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
             - name: PROCFS_ROOT
               value: /host/proc
             - name: SYSFS_ROOT
@@ -93,12 +93,16 @@ spec:
               readOnly: true
             # Vector data dir mount.
             - name: data-dir
+            {{- if .Values.globalOptions.enabled }}
               mountPath: "{{ .Values.globalOptions.dataDir }}"
+            {{- else }}
+              mountPath: "{{ .Values.customConfig.data_dir | default "/vector-data-dir" }}"
+            {{- end }}
             # Vector config dir mount.
             - name: config-dir
               mountPath: /etc/vector
               readOnly: true
-            {{- if .Values.hostMetricsSource.enabled }}
+            {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
             # Host procsfs mount.
             - name: procfs
               mountPath: /host/proc
@@ -146,7 +150,7 @@ spec:
               {{- with .Values.extraConfigDirSources }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
-        {{- if .Values.hostMetricsSource.enabled }}
+        {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
         # Host procsfs.
         - name: procfs
           hostPath:

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -61,12 +61,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
             - name: PROCFS_ROOT
               value: /host/proc
             - name: SYSFS_ROOT
               value: /host/sys
-            {{- end }}
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -102,7 +100,6 @@ spec:
             - name: config-dir
               mountPath: /etc/vector
               readOnly: true
-            {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
             # Host procsfs mount.
             - name: procfs
               mountPath: /host/proc
@@ -111,7 +108,6 @@ spec:
             - name: sysfs
               mountPath: /host/sys
               readOnly: true
-            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             # Extra volumes.
             {{- toYaml . | nindent 12 }}
@@ -150,7 +146,6 @@ spec:
               {{- with .Values.extraConfigDirSources }}
               {{- toYaml . | nindent 14 }}
               {{- end }}
-        {{- if or .Values.hostMetricsSource.enabled (not .Values.customConfig) }}
         # Host procsfs.
         - name: procfs
           hostPath:
@@ -159,7 +154,6 @@ spec:
         - name: sysfs
           hostPath:
             path: /sys
-        {{- end }}
         {{- with .Values.extraVolumes }}
         # Extra volumes.
         {{- toYaml . | nindent 8 }}

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -91,10 +91,10 @@ spec:
               readOnly: true
             # Vector data dir mount.
             - name: data-dir
-            {{- if .Values.globalOptions.enabled }}
-              mountPath: "{{ .Values.globalOptions.dataDir }}"
-            {{- else }}
+            {{- if .Values.customConfig }}
               mountPath: "{{ .Values.customConfig.data_dir | default "/vector-data-dir" }}"
+            {{- else }}
+              mountPath: "{{ .Values.globalOptions.dataDir }}"
             {{- end }}
             # Vector config dir mount.
             - name: config-dir

--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -46,8 +46,8 @@ spec:
           command:
             {{- toYaml .Values.command | nindent 12 }}
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -149,10 +149,10 @@ psp:
 existingConfigMap: ""
 
 # Specify custom contents for the Vector config
-## ref: https://vector.dev/docs/reference/configuration/
-## Note a complete and valid configuration is required. If used, the deprecated
-## configuration keys will be ignored. More information can be found at:
-## https://vector.dev/highlights/2021-07-13-helm-customconfig
+# ref: https://vector.dev/docs/reference/configuration/
+# Note a complete and valid configuration is required. If used, the deprecated
+# configuration keys will be ignored. More information can be found at:
+# https://vector.dev/highlights/2021-07-13-helm-customconfig
 customConfig: {}
   #  data_dir: "/vector-data-dir"
   #  sources:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -174,7 +174,7 @@ customConfig: {}
   #      address: 0.0.0.0:9090
 
 # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
-# To be used in clusters that rely on prometheus-operator to gether metrics.
+# To be used in clusters that rely on prometheus-operator to gather metrics.
 # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
 # using prometheus-operator Helm chart to allow `PodMonitor` resources
 # dicovery in all namespaces.
@@ -321,7 +321,7 @@ prometheusSink:
   # `prometheus.io/scrape` to discover scrape targets.
   addPodAnnotations: false
   # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
-  # To be used in clusters that rely on prometheus-operator to gether metrics.
+  # To be used in clusters that rely on prometheus-operator to gather metrics.
   # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
   # using prometheus-operator Helm chart to allow `PodMonitor` resources
   # dicovery in all namespaces.

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -148,12 +148,38 @@ psp:
 # of using a generated one.
 existingConfigMap: ""
 
+# Specify custom contents for the Vector config
+## ref: https://vector.dev/docs/reference/configuration/
+## Note a complete and valid configuration is required
+customConfig: {}
+  #  data_dir: "/vector-data-dir"
+  #  sources:
+  #    host_metrics:
+  #      type: host_metrics
+  #      filesystem:
+  #        devices:
+  #          excludes: ["binfmt_misc"]
+  #        filesystems:
+  #          excludes: ["binfmt_misc"]
+  #        mountpoints:
+  #          excludes: ["*/proc/sys/fs/binfmt_misc"]
+  #    internal_metrics:
+  #      type: internal_metrics
+  #    kubernetes_logs:
+  #      type: kubernetes_logs
+  #  sinks:
+  #    prometheus_sink:
+  #      type: prometheus_exporter
+  #      inputs: ["host_metrics", "internal_metrics"]
+  #      address: 0.0.0.0:9090
+
 # Global parts of the generated `vector` config.
 globalOptions:
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 logSchema:
   hostKey: "host"
   messageKey: "message"
@@ -162,6 +188,7 @@ logSchema:
 
 # The Vector API.
 # Will be disabled by default.
+# DEPRECATED. Use customConfig instead
 vectorApi:
   # Turn the Vector API on or off.
   enabled: false
@@ -173,6 +200,7 @@ vectorApi:
 # The "built-in" kubernetes logs source to collect logs from the `Pod`s running
 # on the `Node`.
 # Will be added by default, unless explicitly disabled.
+# DEPRECATED. Use customConfig instead
 kubernetesLogsSource:
   # Disable to omit the kubernetes logs source from being added.
   enabled: true
@@ -187,6 +215,7 @@ kubernetesLogsSource:
 # The "built-in" vector sink, to send the logs to the vector aggregator.
 # Disabled by default when using `vector-agent` chart.
 # Enabled by default when using `vector` chart, and automatically configured.
+# DEPRECATED. Use customConfig instead
 vectorSink:
   # Disable to omit the vector sink from being added.
   enabled: false
@@ -206,6 +235,7 @@ vectorSink:
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
 # metrics.
+# DEPRECATED. Use customConfig instead
 internalMetricsSource:
   # Disable to omit the internal metrics source from being added.
   enabled: true
@@ -219,6 +249,7 @@ internalMetricsSource:
 
 # The "built-in" host metrics source emitting the metrics gathered from the node
 # that Vector is executing on.
+# DEPRECATED. Use customConfig instead
 hostMetricsSource:
   # Disable to omit the host metrics source from being added.
   enabled: true
@@ -242,6 +273,7 @@ hostMetricsSource:
 # When using this "built-in" sink, we automatically configure container ports,
 # and ensure things are ready for discovery and scraping via Prometheus'
 # `kubernetes_sd_configs` jobs.
+# DEPRECATED. Use customConfig instead
 prometheusSink:
   # Disable to omit the prometheus sink from being added.
   enabled: true
@@ -287,6 +319,7 @@ prometheusSink:
 
 # Sources to add to the generated `vector` config (besides "built-in" kubernetes
 # logs source).
+# DEPRECATED. Use customConfig instead
 sources: {}
   # source_name:
   #   type: "source_type"
@@ -295,6 +328,7 @@ sources: {}
   #     option = "value"
 
 # Transforms to add to the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 transforms: {}
   # transform_name:
   #   type: "transform_type"
@@ -304,6 +338,7 @@ transforms: {}
   #     option = "value"
 
 # Sinks to add to the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 sinks: {}
   # sink_name:
   #   type: "sink_type"

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -173,14 +173,33 @@ customConfig: {}
   #      inputs: ["host_metrics", "internal_metrics"]
   #      address: 0.0.0.0:9090
 
+# Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
+# To be used in clusters that rely on prometheus-operator to gether metrics.
+# You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
+# using prometheus-operator Helm chart to allow `PodMonitor` resources
+# dicovery in all namespaces.
+podMonitor:
+  # Whether to add the `PodMonitor` resource or not.
+  # `prometheus-operator` CRDs are necessary, otherwise you'll get an error.
+  enabled: false
+  # Additional labels for PodMonitor
+  additionalLabels: {}
+  # Additional relabelings to include in the `PodMonitor`.
+  extraRelabelings: []
+  # metricRelabelings to include in the `PodMonitor`.
+  metricRelabelings: []
+
 # Global parts of the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 globalOptions:
+  enabled: true
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 logSchema:
+  enabled: true
   hostKey: "host"
   messageKey: "message"
   sourceTypeKey: "source_type"

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -150,7 +150,9 @@ existingConfigMap: ""
 
 # Specify custom contents for the Vector config
 ## ref: https://vector.dev/docs/reference/configuration/
-## Note a complete and valid configuration is required
+## Note a complete and valid configuration is required. If used, the deprecated
+## configuration keys will be ignored. More information can be found at:
+## https://vector.dev/highlights/2021-07-13-helm-customconfig
 customConfig: {}
   #  data_dir: "/vector-data-dir"
   #  sources:
@@ -192,14 +194,12 @@ podMonitor:
 # Global parts of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 globalOptions:
-  enabled: true
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 logSchema:
-  enabled: true
   hostKey: "host"
   messageKey: "message"
   sourceTypeKey: "source_type"

--- a/distribution/helm/vector-aggregator/templates/_helpers.tpl
+++ b/distribution/helm/vector-aggregator/templates/_helpers.tpl
@@ -39,5 +39,5 @@ Generate effective service ports for headless service definition.
 Determines whether there are any ports present.
 */}}
 {{- define "vector-aggregator.servicePortsPresent" -}}
-{{- (not (empty .Values.service.ports)) }}
+{{- or (and .Values.vectorSource.enabled (not .Values.customConfig)) (not (empty .Values.service.ports)) }}
 {{- end }}

--- a/distribution/helm/vector-aggregator/templates/_helpers.tpl
+++ b/distribution/helm/vector-aggregator/templates/_helpers.tpl
@@ -7,7 +7,7 @@ either 'vector-aggregator.servicePorts' or 'vector-aggregator.headlessServicePor
 {{- define "vector-aggregator.internalServicePorts" -}}
 {{- $headless := index . 0 -}}
 {{- $values := index . 1 -}}
-{{- if $values.vectorSource.enabled }}
+{{- if and $values.vectorSource.enabled (not $values.customConfig) }}
 {{- $servicePort := dict -}}
 {{- $_ := set $servicePort "name" "vector" -}}
 {{- $_ := set $servicePort "port" $values.vectorSource.listenPort -}}
@@ -39,5 +39,5 @@ Generate effective service ports for headless service definition.
 Determines whether there are any ports present.
 */}}
 {{- define "vector-aggregator.servicePortsPresent" -}}
-{{- or .Values.vectorSource.enabled (not (empty .Values.service.ports)) }}
+{{- (not (empty .Values.service.ports)) }}
 {{- end }}

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- $deprecatedConfig := or .Values.logSchema.enabled .Values.vectorApi.enabled .Values.vectorSource.enabled .Values.internalMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
-
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -9,26 +7,8 @@ metadata:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
   {{- if .Values.customConfig }}
-  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use the following deprecated keys with customConfig: logSchema, vectorApi,  vectorSource, internalMetricsSource, prometheusSink, sources, transforms, sinks" }}{{- end }}
   vector.yaml: |
 {{ tpl (toYaml .Values.customConfig) . | indent 4 }}
-  {{- else if (not $deprecatedConfig) }}
-  vector.yaml: |
-    # Configuration for Vector.
-    # Docs: https://vector.dev/docs/
-    data_dir: "/vector-data-dir"
-    sources:
-      internal_metrics:
-        type: internal_metrics
-      vector:
-        type: vector
-        address: 0.0.0.0:9000
-        version: "2"
-    sinks:
-      prometheus_sink:
-        type: prometheus_exporter
-        inputs: ["internal_metrics"]
-        address: 0.0.0.0:9090
   {{- else }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- $deprecatedConfig := or .Values.logSchema .Values.vectorApi.enabled .Values.vectorSource.enabled .Values.internalMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
+
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -6,6 +8,28 @@ metadata:
   labels:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
+  {{- if .Values.customConfig }}
+  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use deprecated keys with customConfig" }}{{- end }}
+  vector.yaml: |
+{{ tpl (toYaml .Values.customConfig) . | indent 4 }}
+  {{- else if (not $deprecatedConfig) }}
+  vector.yaml: |
+    # Configuration for Vector.
+    # Docs: https://vector.dev/docs/
+    data_dir: "/vector-data-dir"
+    sources:
+      internal_metrics:
+        type: internal_metrics
+      vector:
+        type: vector
+        address: 0.0.0.0:9000
+        version: "2"
+    sinks:
+      prometheus_sink:
+        type: prometheus_exporter
+        inputs: ["internal_metrics"]
+        address: 0.0.0.0:9090
+  {{- end }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -29,8 +29,7 @@ data:
         type: prometheus_exporter
         inputs: ["internal_metrics"]
         address: 0.0.0.0:9090
-  {{- end }}
-  {{- if $deprecatedConfig }}
+  {{- else }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $deprecatedConfig := or .Values.logSchema .Values.vectorApi.enabled .Values.vectorSource.enabled .Values.internalMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
+{{- $deprecatedConfig := or .Values.logSchema.enabled .Values.vectorApi.enabled .Values.vectorSource.enabled .Values.internalMetricsSource.enabled .Values.prometheusSink.enabled .Values.sources .Values.transforms .Values.sinks -}}
 
 {{- if (empty .Values.existingConfigMap) -}}
 apiVersion: v1
@@ -30,6 +30,7 @@ data:
         inputs: ["internal_metrics"]
         address: 0.0.0.0:9090
   {{- end }}
+  {{- if $deprecatedConfig }}
   # We leave `vector.toml` file name available to let externally managed config
   # maps to provide it.
   managed.toml: |
@@ -50,4 +51,5 @@ data:
 
     {{- include "libvector.vectorTopology" .Values | nindent 4 -}}
 
+  {{- end }}
 {{- end }}

--- a/distribution/helm/vector-aggregator/templates/configmap.yaml
+++ b/distribution/helm/vector-aggregator/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "libvector.labels" . | nindent 4 }}
 data:
   {{- if .Values.customConfig }}
-  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use deprecated keys with customConfig" }}{{- end }}
+  {{- if and .Values.customConfig $deprecatedConfig }}{{ fail "Can't use the following deprecated keys with customConfig: logSchema, vectorApi,  vectorSource, internalMetricsSource, prometheusSink, sources, transforms, sinks" }}{{- end }}
   vector.yaml: |
 {{ tpl (toYaml .Values.customConfig) . | indent 4 }}
   {{- else if (not $deprecatedConfig) }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -42,8 +42,8 @@ spec:
           image: {{ include "libvector.image" . | quote }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -59,7 +59,11 @@ spec:
           volumeMounts:
             # Vector data dir mount.
             - name: data-dir
+            {{- if .Values.globalOptions.enabled }}
               mountPath: "{{ .Values.globalOptions.dataDir }}"
+            {{- else }}
+              mountPath: "{{ .Values.customConfig.data_dir | default "/vector-data-dir" }}"
+            {{- end }}
             # Vector config dir mount.
             - name: config-dir
               mountPath: /etc/vector

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -180,10 +180,10 @@ service:
 existingConfigMap: ""
 
 # Specify custom contents for the Vector config
-## ref: https://vector.dev/docs/reference/configuration/
-## Note a complete and valid configuration is required. If used, the deprecated
-## configuration keys will be ignored. More information can be found at:
-## https://vector.dev/highlights/2021-07-13-helm-customconfig
+# ref: https://vector.dev/docs/reference/configuration/
+# Note a complete and valid configuration is required. If used, the deprecated
+# configuration keys will be ignored. More information can be found at:
+# https://vector.dev/highlights/2021-07-13-helm-customconfig
 customConfig: {}
   #  data_dir: "/vector-data-dir"
   #  sources:

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -181,7 +181,9 @@ existingConfigMap: ""
 
 # Specify custom contents for the Vector config
 ## ref: https://vector.dev/docs/reference/configuration/
-## Note a complete and valid configuration is required
+## Note a complete and valid configuration is required. If used, the deprecated
+## configuration keys will be ignored. More information can be found at:
+## https://vector.dev/highlights/2021-07-13-helm-customconfig
 customConfig: {}
   #  data_dir: "/vector-data-dir"
   #  sources:
@@ -217,14 +219,12 @@ podMonitor:
 # Global parts of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 globalOptions:
-  enabled: true
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 logSchema:
-  enabled: true
   hostKey: "host"
   messageKey: "message"
   sourceTypeKey: "source_type"

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -179,12 +179,32 @@ service:
 # of using a generated one.
 existingConfigMap: ""
 
+# Specify custom contents for the Vector config
+## ref: https://vector.dev/docs/reference/configuration/
+## Note a complete and valid configuration is required
+customConfig: {}
+  #  data_dir: "/vector-data-dir"
+  #  sources:
+  #    host_metrics:
+  #    internal_metrics:
+  #      type: internal_metrics
+  #   vector:
+  #     type: vector
+  #     address: 0.0.0.0:9000
+  #     version: "2"
+  #  sinks:
+  #    prometheus_sink:
+  #      type: prometheus_exporter
+  #      inputs: ["internal_metrics"]
+  #      address: 0.0.0.0:9090
+
 # Global parts of the generated `vector` config.
 globalOptions:
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 logSchema:
   hostKey: "host"
   messageKey: "message"
@@ -193,6 +213,7 @@ logSchema:
 
 # The Vector API.
 # Will be disabled by default.
+# DEPRECATED. Use customConfig instead
 vectorApi:
   # Turn the Vector API on or off.
   enabled: false
@@ -203,6 +224,7 @@ vectorApi:
 
 # The "built-in" vector source, for accepting logs from the vector agents.
 # Will be added by default, unless explicitly disabled.
+# DEPRECATED. Use customConfig instead
 vectorSource:
   # Disable to omit the vector source from being added.
   enabled: true
@@ -222,6 +244,7 @@ vectorSource:
 
 # The "built-in" internal metrics source emitting Vector's internal opertaional
 # metrics.
+# DEPRECATED. Use customConfig instead
 internalMetricsSource:
   # Disable to omit the internal metrics source from being added.
   enabled: true
@@ -238,6 +261,7 @@ internalMetricsSource:
 # When using this "built-in" sink, we automatically configure container ports,
 # and ensure things are ready for discovery and scraping via Prometheus'
 # `kubernetes_sd_configs` jobs.
+# DEPRECATED. Use customConfig instead
 prometheusSink:
   # Disable to omit the prometheus sink from being added.
   enabled: true
@@ -282,6 +306,7 @@ prometheusSink:
     metricRelabelings: []
 
 # Sources to add to the generated `vector` config
+# DEPRECATED. Use customConfig instead
 sources: {}
   # source_name:
   #   type: "source_type"
@@ -289,6 +314,7 @@ sources: {}
   #     option = "value"
 
 # Transforms to add to the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 transforms: {}
   # transform_name:
   #   type: "transform_type"
@@ -297,6 +323,7 @@ transforms: {}
   #     option = "value"
 
 # Sinks to add to the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 sinks: {}
   # sink_name:
   #   type: "sink_type"

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -198,14 +198,33 @@ customConfig: {}
   #      inputs: ["internal_metrics"]
   #      address: 0.0.0.0:9090
 
+# Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
+# To be used in clusters that rely on prometheus-operator to gether metrics.
+# You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
+# using prometheus-operator Helm chart to allow `PodMonitor` resources
+# dicovery in all namespaces.
+podMonitor:
+  # Whether to add the `PodMonitor` resource or not.
+  # `prometheus-operator` CRDs are necessary, otherwise you'll get an error.
+  enabled: false
+  # Additional labels for PodMonitor
+  additionalLabels: {}
+  # Additional relabelings to include in the `PodMonitor`.
+  extraRelabelings: []
+  # metricRelabelings to include in the `PodMonitor`.
+  metricRelabelings: []
+
 # Global parts of the generated `vector` config.
+# DEPRECATED. Use customConfig instead
 globalOptions:
+  enabled: true
   # Specifies the (in-container) data dir used by `vector`.
   dataDir: "/vector-data-dir"
 
 # Schema part of the generated `vector` config.
 # DEPRECATED. Use customConfig instead
 logSchema:
+  enabled: true
   hostKey: "host"
   messageKey: "message"
   sourceTypeKey: "source_type"

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -199,7 +199,7 @@ customConfig: {}
   #      address: 0.0.0.0:9090
 
 # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
-# To be used in clusters that rely on prometheus-operator to gether metrics.
+# To be used in clusters that rely on prometheus-operator to gather metrics.
 # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
 # using prometheus-operator Helm chart to allow `PodMonitor` resources
 # dicovery in all namespaces.
@@ -309,7 +309,7 @@ prometheusSink:
   # `prometheus.io/scrape` to discover scrape targets.
   addPodAnnotations: false
   # Use prometheus-operator `PodMonitor` to opt-in for Prometheus scraping.
-  # To be used in clusters that rely on prometheus-operator to gether metrics.
+  # To be used in clusters that rely on prometheus-operator to gather metrics.
   # You might want to set `podMonitorSelectorNilUsesHelmValues=false` if you're
   # using prometheus-operator Helm chart to allow `PodMonitor` resources
   # dicovery in all namespaces.

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -48,12 +48,12 @@ Common Vector container ports used by the built-in metrics pipeline.
 Internal metrics are common, so we share and reuse the definition.
 */}}
 {{- define "libvector.metricsContainerPorts" -}}
-{{- if .Values.prometheusSink -}}
-{{- if .Values.prometheusSink.enabled -}}
+{{- with .Values.prometheusSink }}
+{{- if .enabled -}}
 - name: metrics
-  containerPort: {{ .Values.prometheusSink.listenPort }}
+  containerPort: {{ .listenPort }}
   protocol: TCP
-{{- else if not .Values.customConfig -}}
+{{- else if not $.Values.customConfig -}}
 - name: metrics
   containerPort: 9090
   protocol: TCP

--- a/distribution/helm/vector-shared/templates/_metrics.tpl
+++ b/distribution/helm/vector-shared/templates/_metrics.tpl
@@ -49,13 +49,9 @@ Internal metrics are common, so we share and reuse the definition.
 */}}
 {{- define "libvector.metricsContainerPorts" -}}
 {{- with .Values.prometheusSink }}
-{{- if .enabled -}}
+{{- if and .enabled (not $.Values.customConfig) -}}
 - name: metrics
   containerPort: {{ .listenPort }}
-  protocol: TCP
-{{- else if not $.Values.customConfig -}}
-- name: metrics
-  containerPort: 9090
   protocol: TCP
 {{- end }}
 {{- end }}

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -90,14 +90,18 @@ The common header for Vector ConfigMaps.
 # Configuration for vector.
 # Docs: https://vector.dev/docs/
 
+{{- if .Values.globalOptions.enabled }}
 data_dir = "{{ .Values.globalOptions.dataDir }}"
-
+{{- end }}
+{{ if .Values.vectorApi.enabled }}
 [api]
   enabled = {{ .Values.vectorApi.enabled }}
   address = {{ .Values.vectorApi.address | quote }}
   playground = {{ .Values.vectorApi.playground }}
 {{- printf "\n" -}}
+{{- end }}
 
+{{- if .Values.logSchema.enabled }}
 {{- with .Values.logSchema }}
 [log_schema]
   host_key = "{{ .hostKey }}"
@@ -105,5 +109,6 @@ data_dir = "{{ .Values.globalOptions.dataDir }}"
   source_type_key = "{{ .sourceTypeKey }}"
   timestamp_key = "{{ .timestampKey }}"
   {{- printf "\n" -}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/distribution/helm/vector-shared/templates/_vector_config.tpl
+++ b/distribution/helm/vector-shared/templates/_vector_config.tpl
@@ -90,18 +90,14 @@ The common header for Vector ConfigMaps.
 # Configuration for vector.
 # Docs: https://vector.dev/docs/
 
-{{- if .Values.globalOptions.enabled }}
 data_dir = "{{ .Values.globalOptions.dataDir }}"
-{{- end }}
-{{ if .Values.vectorApi.enabled }}
+
 [api]
   enabled = {{ .Values.vectorApi.enabled }}
   address = {{ .Values.vectorApi.address | quote }}
   playground = {{ .Values.vectorApi.playground }}
 {{- printf "\n" -}}
-{{- end }}
 
-{{- if .Values.logSchema.enabled }}
 {{- with .Values.logSchema }}
 [log_schema]
   host_key = "{{ .hostKey }}"
@@ -109,6 +105,5 @@ data_dir = "{{ .Values.globalOptions.dataDir }}"
   source_type_key = "{{ .sourceTypeKey }}"
   timestamp_key = "{{ .timestampKey }}"
   {{- printf "\n" -}}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -38,7 +38,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"

--- a/distribution/kubernetes/vector-agent/resources.yaml
+++ b/distribution/kubernetes/vector-agent/resources.yaml
@@ -38,13 +38,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -158,8 +152,8 @@ spec:
           command:
             []
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -38,13 +38,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -158,8 +152,8 @@ spec:
           image: "timberio/vector:latest-debian"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             
             - name: LOG

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -38,7 +38,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"
@@ -62,53 +68,6 @@ data:
       address = "0.0.0.0:9090"
       inputs = ["internal_metrics"]
       type = "prometheus"
----
-# Source: vector-aggregator/templates/service-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator-headless
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  clusterIP: None
-  ports:
-  - port: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
----
-# Source: vector-aggregator/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  type: ClusterIP
-  ports:
-  - port: 9000
-    targetPort: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
 ---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1

--- a/distribution/kubernetes/vector-aggregator/resources.yaml
+++ b/distribution/kubernetes/vector-aggregator/resources.yaml
@@ -69,6 +69,53 @@ data:
       inputs = ["internal_metrics"]
       type = "prometheus"
 ---
+# Source: vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  clusterIP: None
+  ports:
+  - port: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
+# Source: vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -52,13 +52,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -117,13 +111,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -275,8 +263,8 @@ spec:
           command:
             []
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
@@ -407,8 +395,8 @@ spec:
           image: "timberio/vector:latest-debian"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             
             - name: "LOG"

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -52,7 +52,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"
@@ -111,7 +117,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"
@@ -171,53 +183,6 @@ subjects:
   - kind: ServiceAccount
     name: vector-agent
     namespace: vector
----
-# Source: vector/charts/vector-aggregator/templates/service-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator-headless
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  clusterIP: None
-  ports:
-  - port: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
----
-# Source: vector/charts/vector-aggregator/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  type: ClusterIP
-  ports:
-  - port: 9000
-    targetPort: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
 ---
 # Source: vector/charts/vector-agent/templates/daemonset.yaml
 apiVersion: apps/v1

--- a/distribution/kubernetes/vector-all/resources.yaml
+++ b/distribution/kubernetes/vector-all/resources.yaml
@@ -184,6 +184,53 @@ subjects:
     name: vector-agent
     namespace: vector
 ---
+# Source: vector/charts/vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  clusterIP: None
+  ports:
+  - port: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
+# Source: vector/charts/vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
 # Source: vector/charts/vector-agent/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -17,6 +17,9 @@ With the release of Vector 0.15.0, we have introduced a new method of configurin
 This new method uses YAML configuration files, and in a coming release will become the default configuration
 method.
 
+The new `customConfig` key will take precedence over the existing configuration options, if `customConfig` is
+set then no default configurations will be rendered.
+
 **You do not need to upgrade immediately. The deprecated keys will not be removed before Vector hits 1.0**
 
 ## Upgrade Guide
@@ -34,23 +37,17 @@ into a separate directory or into a sub-directory of "etc/vector".
 Any [global options](/docs/reference/configuration/global-options/) can be moved directly
 into the `customConfig` key and converted into snake-case.
 
-```diff title="values.yaml"
-   globalOptions:
-     dataDir: "/vector-data-dir"
-   logSchema:
-     hostKey: "host"
-     messageKey: "message"
-     sourceTypeKey: "source_type"
-     timestampKey: "timestamp"
-   ...
-+  customConfig:
-+    data_dir: "/vector-data-dir"
-+    log_schema:
-+      host_key: host
-+      message_key: message
-+      source_type_key: source_type
-+      timestamp_key: timestamp
-+  ...
+If you had 
+
+```yaml title="values.yaml"
+customConfig:
+  data_dir: "/vector-data-dir"
+  log_schema:
+    host_key: host
+    message_key: message
+    source_type_key: source_type
+    timestamp_key: timestamp
+  ...
 ```
 
 ### vectorApi
@@ -58,169 +55,136 @@ into the `customConfig` key and converted into snake-case.
 [Vector API](/docs/reference/api/) options can be moved as is under a `customConfig.api` key.
 The `extraContainerPorts` or `service` key should be used to expose the port configured in `customConfig`.
 
-```diff title="values.yaml"
-   vectorApi:
-     enabled: true
-     address: "0.0.0.0:8686"
-     playground: true
-   ...
-+  customConfig:
-+    ...
-+    api:
-+      enabled: true
-+      address: 0.0.0.0:8686
-+      playground: true
-+    ...
+If you had `vectorApi` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  api:
+    enabled: true
+    address: 0.0.0.0:8686
+    playground: true
+  ...
 ```
 
 ### kubernetesLogsSource
 
 The vector-agent chart will continue to mount the hostPaths required to access Pod logs.
 
-```diff title="values.yaml"
-   kubernetesLogsSource:
-     enabled: true
-     sourceId: kubernetes_logs
-     config: {}
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sources:
-+      ...
-+      kubernetes_logs:
-+        type: kubernetes_logs
-+    ...
+If you had `kubernetesLogsSource` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sources:
+  ...
+    kubernetes_logs:
+      type: kubernetes_logs
+  ...
 ```
 
 ### vectorSource
 
-The `extraContainerPorts` or `service` key should be used to expose the port configured in `customConfig`.
+The `service` key should be used to expose the port configured in `customConfig`.
 
-```diff title="values.yaml"
-   vectorSource:
-     enabled: true
-     sourceId: vector
-     listenAddress: "0.0.0.0"
-     listenPort: "9000"
-     config: {}
-     nodePort: null
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sources:
-+      ...
-+      vector:
-+        type: vector
-+        address: 0.0.0.0:9000
-+    ...
+If you had `vectorSource` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sources:
+  ...
+    vector:
+      type: vector
+      address: 0.0.0.0:9000
+  ...
+service:
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
 ```
 
 ### vectorSink
 
-```diff title="values.yaml"
-   vectorSink:
-     enabled: true
-     sinkId: vector_sink
-     inputs: ["kubernetes_logs"]
-     host: vector
-     port: "9000"
-     config: {}
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sinks:
-+      ...
-+      vector_sink:
-+        type: vector
-+        inputs: ["kubernetes_logs"]
-+        address: vector:9000
-+    ...
+If you had `vectorSink` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sinks:
+  ...
+    vector_sink:
+      type: vector
+      inputs: ["kubernetes_logs"]
+      address: vector:9000
+  ...
 ```
 
 ### internalMetricsSource
 
-```diff title="values.yaml"
-   internalMetricsSource:
-     enabled: true
-     sourceId: internal_metrics
-     config: {}
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sources:
-+      ...
-+      internal_metrics:
-+        type: internal_metrics
-+    ...
+If you had `internalMetricsSource` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sources:
+    ...
+    internal_metrics:
+      type: internal_metrics
+  ...
 ```
 
 ### hostMetricsSource
 
-The `vector-agent` chart will automatically set the `PROCFS_ROOT` and `SYSFS_ROOT` environment variables,
-as well as mounting the required hostPaths.
+The `vector-agent` chart will continue to set the `PROCFS_ROOT` and `SYSFS_ROOT` environment variables,
+as well as mount the required hostPaths.
 
-```diff title="values.yaml"
-   hostMetricsSource:
-     enabled: true
-     sourceId: host_metrics
-     config:
-       filesystem:
-         devices:
-           excludes: [binfmt_misc]
-         filesystems:
-           excludes: [binfmt_misc]
-         mountpoints:
-           excludes: ["*/proc/sys/fs/binfmt_misc"]
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sources:
-+      ...
-+      host_metrics:
-+        type: host_metrics
-+        filesystem:
-+          devices:
-+            excludes: ["binfmt_misc"]
-+          filesystems:
-+            excludes: ["binfmt_misc"]
-+          mountPoints:
-+            excludes: ["*/proc/sys/fs/binfmt_misc"]
-+    ...
+If you had `hostMetricsSource` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sources:
+    ...
+    host_metrics:
+      type: host_metrics
+      filesystem:
+        devices:
+          excludes: ["binfmt_misc"]
+        filesystems:
+          excludes: ["binfmt_misc"]
+        mountPoints:
+          excludes: ["*/proc/sys/fs/binfmt_misc"]
+  ...
 ```
 
 ### prometheusSink
 
-The `extraContainerPorts` or `service` key should be used to expose the port configured in `customConfig`.
+The `extraContainerPorts` key should be used to expose the port configured in `customConfig`.
 
 The `prometheusSink.podMonitor` key has been moved to a top level key and can be accessed directly at
 `podMonitor`. The `addPodAnnotations` option has been removed in favor setting the required annotations
 with the `podAnnotations` key.
 
-```diff title="values.yaml"
-   prometheusSink:
-     enabled: true
-     sinkId: prometheus_sink
-     inputs: []
-     excludeInternalMetrics: false
-     listenAddress: "0.0.0.0"
-     listenPort: "9090"
-     config: {}
-     rawConfig: null
-   ...
-+  customConfig:
-+    ...
-+    sinks:
-+      ...
-+      prometheus_sink:
-+        type: prometheus_exporter
-+        inputs: ["host_metrics", "internal_metrics"]
-+        address: 0.0.0.0:9090
-+    ...
+If you had `prometheusSink` enabled, include:
+
+```yaml title="values.yaml"
+customConfig:
+  ...
+  sinks:
+    ...
+    prometheus_sink:
+      type: prometheus_exporter
+      inputs: ["host_metrics", "internal_metrics"]
+      address: 0.0.0.0:9090
+  ...
+extraContainerPorts:
+  - name: http
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
 ```
 
 ## Using `customConfig`

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -1,0 +1,120 @@
+---
+date: "2021-07-13"
+title: "Introduction of `customConfig` and deprecation notice for TOML based config keys"
+description: "Configure Vector directly through your `values.yaml` without having to converting to TOML"
+authors: ["spencergilbert"]
+pr_numbers: [8079]
+release: "0.15.0"
+hide_on_release_notes: false
+badges:
+  type: "deprecation"
+  platforms: ["helm"]
+  domains: ["config"]
+---
+
+...
+
+## Upgrade Guide
+
+We've configured the ConfigMap template to `fail` if the deprecated keys are
+enabled at the same time as the new YAML based configurations. The following
+values can be used to disable the old deprecated keys and use the new YAML
+based configuration with default values.
+
+```yaml title="disable-deprecated.yaml"
+globalOptions:
+  enabled: false
+logSchema:
+  enabled: false
+vectorApi:
+  enabled: false
+kubernetesLogsSource:
+  enabled: false
+vectorSource:
+  enabled: false
+vectorSink:
+  enabled: false
+internalMetricsSource:
+  enabled: false
+hostMetricsSource:
+  enabled: false
+prometheusSink:
+  enabled: false
+```
+
+With the deprecated keys disabled, custom Vector configuration can be provided
+in raw YAML and is passed through the `tpl` function to allow templating.
+
+Below is an example of values using `customConfig` and templating.
+
+```yaml title="cusomConfig.yaml"
+customConfig:
+  data_dir: "/custom-data-dir"
+  healthchecks:
+    enabled: true
+    require_healthy: false
+  api:
+    enabled: true
+    address: "127.0.0.1:{{ with index .Values.service.ports 0 }}{{ .port }}{{ end }}"
+    playground: false
+  sources:
+    internal_logs:
+      type: internal_logs
+    internal_metrics:
+      type: internal_metrics
+    kubernetes_logs:
+      type: kubernetes_logs
+      glob_minimum_cooldown_ms: 1000
+      ingestion_timestamp_field: ingestion_timestamp
+    statsd_metrics:
+      type: statsd
+      address: "0.0.0.0:{{ with index .Values.service.ports 1 }}{{ .port }}{{ end }}"
+      mode: tcp
+  transforms:
+    sample:
+      type: sample
+      inputs: ["*_logs"]
+      rate: 20
+  sinks:
+    datadog_logs:
+      type: datadog_logs
+      inputs: ["sample"]
+      compression: gzip
+      default_api_key: "${DATADOG_API_KEY}"
+      encoding:
+        codec: json
+    datadog_metrics:
+      type: datadog_metrics
+      inputs: ["*_metrics"]
+      api_key: "${DATADOG_API_KEY}"
+service:
+  enabled: true
+  ports:
+  - name: api
+    port: 8686
+    protocol: TCP
+    targetPort: 8686
+  - name: statsd
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+# Disable deprecated keys
+globalOptions:
+  enabled: false
+logSchema:
+  enabled: false
+vectorApi:
+  enabled: false
+kubernetesLogsSource:
+  enabled: false
+vectorSource:
+  enabled: false
+vectorSink:
+  enabled: false
+internalMetricsSource:
+  enabled: false
+hostMetricsSource:
+  enabled: false
+prometheusSink:
+  enabled: false
+```

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -62,7 +62,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 +    ...
 +    api:
 +      enabled: true
-+      address: 127.0.0.1:8686
++      address: 0.0.0.0:8686
 +      playground: true
 +    ...
 ```
@@ -251,7 +251,7 @@ customConfig:
   data_dir: "/custom-data-dir"
   healthchecks:
     enabled: true
-    require_healthy: false
+    require_healthy: true
   api:
     enabled: true
     address: "0.0.0.0:{{ with index .Values.service.ports 0 }}{{ .port }}{{ end }}"

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -1,8 +1,8 @@
 ---
 date: "2021-07-13"
-title: "Introduction of `customConfig` and deprecation notice for TOML based config keys"
-short: "Introduction of `customConfig`"
-description: "Configure Vector directly through your `values.yaml` without having to converting to TOML"
+title: "Introduction of `customConfig` Helm option and deprecation notice for TOML based config keys"
+short: "Introduction of `customConfig` in Helm charts"
+description: "Configure Vector directly through your Helm `values.yaml` without having to converting to TOML"
 authors: ["spencergilbert"]
 pr_numbers: [8079]
 release: "0.15.0"
@@ -26,9 +26,12 @@ method.
 The argument passed to Vector has been changed to `--config-dir` which will load any TOML, YAML, or JSON
 files added to the "/etc/vector" directory.
 
+If you have been including files that should not be loaded by Vector as configuration you should move them
+into a separate directory or into a sub-directory of "etc/vector".
+
 ### globalOptions and logSchema
 
-Any [global options](https://vector.dev/docs/reference/configuration/global-options/) can be moved directly
+Any [global options](/docs/reference/configuration/global-options/) can be moved directly
 into the `customConfig` key and converted into snake-case.
 
 ```diff title="values.yaml"
@@ -54,7 +57,7 @@ into the `customConfig` key and converted into snake-case.
 
 ### vectorApi
 
-[Vector API](https://vector.dev/docs/reference/api/) options can be moved as is under a `customConfig.api` key.
+[Vector API](/docs/reference/api/) options can be moved as is under a `customConfig.api` key.
 The `extraContainerPorts` or `service` key should be used to expose the port configured in `customConfig`.
 
 ```diff title="values.yaml"
@@ -159,7 +162,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ### hostMetricsSource
 
-Users should set the PROCFS_ROOT and SYSFS_ROOT environment variables, as well as mounting the
+Users should set the `PROCFS_ROOT` and `SYSFS_ROOT` environment variables, as well as mounting the
 required hostPaths.
 
 ```diff title="values.yaml"
@@ -243,7 +246,7 @@ with the `podAnnotations` key.
 
 ## Using `customConfig`
 
-We've configured the ConfigMap template to `fail` if the deprecated keys are enabled at the same time
+We've configured the `ConfigMap` template to fail if the deprecated keys are enabled at the same time
 as the new YAML based configurations. The following values can be used to disable the old deprecated
 keys and use the new YAML based configuration with default values.
 

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -21,6 +21,11 @@ method.
 
 ## Upgrade Guide
 
+### Breaking: updated container args
+
+The argument passed to Vector has been changed to `--config-dir` which will load any TOML, YAML, or JSON
+files added to the "/etc/vector" directory.
+
 ### globalOptions and logSchema
 
 Any [global options](https://vector.dev/docs/reference/configuration/global-options/) can be moved directly

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -1,6 +1,7 @@
 ---
 date: "2021-07-13"
 title: "Introduction of `customConfig` and deprecation notice for TOML based config keys"
+short: "Introduction of `customConfig`"
 description: "Configure Vector directly through your `values.yaml` without having to converting to TOML"
 authors: ["spencergilbert"]
 pr_numbers: [8079]
@@ -12,14 +13,20 @@ badges:
   domains: ["config"]
 ---
 
-...
+With the release of Vector 0.15.0, we have introduced a new method of configuring Vector through Helm.
+This new method uses YAML configuration files, and in a coming release will become the default configuration
+method.
 
 ## Upgrade Guide
 
-We've configured the ConfigMap template to `fail` if the deprecated keys are
-enabled at the same time as the new YAML based configurations. The following
-values can be used to disable the old deprecated keys and use the new YAML
-based configuration with default values.
+Those using the `sources`, `transforms`, and `sinks` keys are already YAML (excluding any usage of `rawConfig`)
+and only need to be moved under the new `customConfig` and properly indented. For configurations taking advantage
+of the named keys (`kubernetesLogsSource`, `vectorSink`, etc), users can reference the the YAML configuration
+provided in the `values.yaml`.
+
+We've configured the ConfigMap template to `fail` if the deprecated keys are enabled at the same time
+as the new YAML based configurations. The following values can be used to disable the old deprecated
+keys and use the new YAML based configuration with default values.
 
 ```yaml title="disable-deprecated.yaml"
 globalOptions:
@@ -42,10 +49,9 @@ prometheusSink:
   enabled: false
 ```
 
-With the deprecated keys disabled, custom Vector configuration can be provided
-in raw YAML and is passed through the `tpl` function to allow templating.
-
-Below is an example of values using `customConfig` and templating.
+With the deprecated keys disabled, a custom Vector configuration can be provided in raw YAML and is passed
+through a `tpl` function to allow for the evaluation of Helm templates contained within. Below is an example
+of values using `customConfig` and templating.
 
 ```yaml title="cusomConfig.yaml"
 customConfig:

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -36,10 +36,8 @@ into the `customConfig` key and converted into snake-case.
 
 ```diff title="values.yaml"
    globalOptions:
-+    enabled: false
      dataDir: "/vector-data-dir"
    logSchema:
-+    enabled: false
      hostKey: "host"
      messageKey: "message"
      sourceTypeKey: "source_type"
@@ -62,7 +60,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ```diff title="values.yaml"
    vectorApi:
-+    enabled: false
+     enabled: true
      address: "0.0.0.0:8686"
      playground: true
    ...
@@ -81,7 +79,7 @@ The vector-agent chart will continue to mount the hostPaths required to access P
 
 ```diff title="values.yaml"
    kubernetesLogsSource:
-+    enabled: false
+     enabled: true
      sourceId: kubernetes_logs
      config: {}
      rawConfig: null
@@ -101,7 +99,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ```diff title="values.yaml"
    vectorSource:
-+    enabled: false
+     enabled: true
      sourceId: vector
      listenAddress: "0.0.0.0"
      listenPort: "9000"
@@ -123,7 +121,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ```diff title="values.yaml"
    vectorSink:
-+    enabled: false
+     enabled: true
      sinkId: vector_sink
      inputs: ["kubernetes_logs"]
      host: vector
@@ -146,7 +144,7 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ```diff title="values.yaml"
    internalMetricsSource:
-+    enabled: false
+     enabled: true
      sourceId: internal_metrics
      config: {}
      rawConfig: null
@@ -162,12 +160,12 @@ The `extraContainerPorts` or `service` key should be used to expose the port con
 
 ### hostMetricsSource
 
-Users should set the `PROCFS_ROOT` and `SYSFS_ROOT` environment variables, as well as mounting the
-required hostPaths.
+The `vector-agent` chart will automatically set the `PROCFS_ROOT` and `SYSFS_ROOT` environment variables,
+as well as mounting the required hostPaths.
 
 ```diff title="values.yaml"
    hostMetricsSource:
-+    enabled: false
+     enabled: true
      sourceId: host_metrics
      config:
        filesystem:
@@ -192,25 +190,6 @@ required hostPaths.
 +            excludes: ["binfmt_misc"]
 +          mountPoints:
 +            excludes: ["*/proc/sys/fs/binfmt_misc"]
-+  env:
-+    - name: PROCFS_ROOT
-+      value: /host/proc
-+    - name: SYSFS_ROOT
-+      value: /host/sys
-+  extraVolumeMounts:
-+    - name: procfs
-+      mountPath: /host/proc
-+      readOnly: true
-+    - name: sysfs
-+      mountPath: /host/sys
-+      readOnly: true
-+  extraVolumes:
-+    - name: procfs
-+      hostPath:
-+        path: /proc
-+    - name: sysfs
-+      hostPath:
-+        path: /sys
 +    ...
 ```
 
@@ -224,7 +203,7 @@ with the `podAnnotations` key.
 
 ```diff title="values.yaml"
    prometheusSink:
-+    enabled: false
+     enabled: true
      sinkId: prometheus_sink
      inputs: []
      excludeInternalMetrics: false

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -54,7 +54,7 @@ into the `customConfig` key and converted into snake-case.
 
 ### vectorApi
 
-[Vector API](https://vector.dev/docs/reference/api/) configuration can be moved as is under a `customConfig.api` key.
+[Vector API](https://vector.dev/docs/reference/api/) options can be moved as is under a `customConfig.api` key.
 The `extraContainerPorts` or `service` key should be used to expose the port configured in `customConfig`.
 
 ```diff title="values.yaml"

--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -37,7 +37,7 @@ into a separate directory or into a sub-directory of "etc/vector".
 Any [global options](/docs/reference/configuration/global-options/) can be moved directly
 into the `customConfig` key and converted into snake-case.
 
-If you had 
+If you had the default `dataDir` and `logSchema` values, include:
 
 ```yaml title="values.yaml"
 customConfig:

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -10,10 +10,60 @@ use tracing::{debug, info};
 
 const HELM_CHART_VECTOR_AGENT: &str = "vector-agent";
 
+const HELM_VALUES_DISABLE_DEPRECATED: &str = indoc! {r#"
+    globalOptions:
+      enabled: false
+    logSchema:
+      enabled: false
+    vectorApi:
+      enabled: false
+    kubernetesLogsSource:
+      enabled: false
+    vectorSource:
+      enabled: false
+    vectorSink:
+      enabled: false
+    internalMetricsSource:
+      enabled: false
+    hostMetricsSource:
+      enabled: false
+    prometheusSink:
+      enabled: false
+"#};
+
 const HELM_VALUES_LOWER_GLOB: &str = indoc! {r#"
     kubernetesLogsSource:
       rawConfig: |
         glob_minimum_cooldown_ms = 5000
+"#};
+
+const HELM_VALUES_CUSTOM_CONFIG: &str = indoc! {r#"
+    customConfig:
+      data_dir: "/vector-data-dir"
+      sources:
+        host_metrics:
+          type: host_metrics
+          filesystem:
+            devices:
+              excludes: ["binfmt_misc"]
+            filesystems:
+              excludes: ["binfmt_misc"]
+            mountpoints:
+              excludes: ["*/proc/sys/fs/binfmt_misc"]
+        internal_metrics:
+          type: internal_metrics
+        kubernetes_logs:
+          type: kubernetes_logs
+          glob_minimum_cooldown_ms: 5000
+      sinks:
+        prometheus_sink:
+          type: prometheus_exporter
+          inputs: ["host_metrics", "internal_metrics"]
+          address: 0.0.0.0:9090
+        stdout:
+          type: console
+          inputs: ["kubernetes_logs"]
+          encoding: json
 "#};
 
 const HELM_VALUES_STDOUT_SINK: &str = indoc! {r#"
@@ -103,6 +153,104 @@ async fn simple() -> Result<(), Box<dyn std::error::Error>> {
         ))?)
         .await?;
 
+    framework
+        .wait(
+            &pod_namespace,
+            vec!["pods/test-pod"],
+            WaitFor::Condition("initialized"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Make sure we read the correct nodes logs.
+    let vector_pod = framework
+        .get_vector_pod_with_pod(&pod_namespace, "test-pod", &namespace, &override_name)
+        .await?;
+
+    let mut log_reader = framework.logs(&namespace, &format!("pod/{}", vector_pod))?;
+    smoke_check_first_line(&mut log_reader).await;
+
+    // Read the rest of the log lines.
+    let mut got_marker = false;
+    look_for_log_line(&mut log_reader, |val| {
+        if val["kubernetes"]["pod_namespace"] != pod_namespace.as_str() {
+            // A log from something other than our test pod, pretend we don't
+            // see it.
+            return FlowControlCommand::GoOn;
+        }
+
+        // Ensure we got the marker.
+        assert_eq!(val["message"], "MARKER");
+
+        if got_marker {
+            // We've already seen one marker! This is not good, we only emitted
+            // one.
+            panic!("Marker seen more than once");
+        }
+
+        // If we did, remember it.
+        got_marker = true;
+
+        // Request to stop the flow.
+        FlowControlCommand::Terminate
+    })
+    .await?;
+
+    assert!(got_marker);
+
+    drop(test_pod);
+    drop(test_namespace);
+    drop(vector);
+    Ok(())
+}
+
+/// This test validates that vector-agent picks up logs at the simplest case
+/// possible - a new pod is deployed and prints to stdout, and we assert that
+/// vector picks that up - but with the new `customConfig` way of passing the
+/// sink configuration.
+#[tokio::test]
+async fn simple_custom_config() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector-agent");
+
+    let vector = framework
+        .vector(
+            &namespace,
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: vec![
+                    &config_override_name(&override_name, true),
+                    HELM_VALUES_CUSTOM_CONFIG,
+                    HELM_VALUES_DISABLE_DEPRECATED,
+                ],
+                ..Default::default()
+            },
+        )
+        .await?;
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{}", override_name),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    let test_namespace = framework.namespace(&pod_namespace).await?;
+
+    let test_pod = framework
+        .test_pod(test_pod::Config::from_pod(&make_test_pod(
+            &pod_namespace,
+            "test-pod",
+            "echo MARKER",
+            vec![],
+            vec![],
+        ))?)
+        .await?;
     framework
         .wait(
             &pod_namespace,
@@ -1960,5 +2108,41 @@ async fn simple_checkpoint() -> Result<(), Box<dyn std::error::Error>> {
     drop(test_pod);
     drop(test_namespace);
     drop(vector);
+    Ok(())
+}
+
+/// This test validates that vector-agent picks up logs at the simplest case
+#[tokio::test]
+async fn test_template_fail() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let pod_namespace = get_namespace_appended(&namespace, "test-pod");
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector-agent");
+
+    let mut failed = false;
+    let vector = framework
+        .vector(
+            &namespace,
+            HELM_CHART_VECTOR_AGENT,
+            VectorConfig {
+                custom_helm_values: vec![
+                    &config_override_name(&override_name, true),
+                    HELM_VALUES_CUSTOM_CONFIG,
+                ],
+                ..Default::default()
+            },
+        )
+        .await;
+    if vector.is_err() {
+        failed = true;
+    } else {
+        drop(pod_namespace);
+        drop(vector);
+    }
+
+    assert!(failed);
     Ok(())
 }

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -204,7 +204,7 @@ async fn simple_custom_config() -> Result<(), Box<dyn std::error::Error>> {
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
-                    HELM_VALUES_CUSTOM_CONFIG
+                    HELM_VALUES_CUSTOM_CONFIG,
                 ],
                 ..Default::default()
             },

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -36,13 +36,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -178,8 +172,8 @@ spec:
           command:
             []
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-agent/snapshot.yaml
@@ -36,7 +36,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -36,7 +36,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"
@@ -69,53 +75,6 @@ data:
       option2 = "value2"
       type = "prometheus"
       arbitrary text 1
----
-# Source: vector-aggregator/templates/service-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator-headless
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  clusterIP: None
-  ports:
-  - port: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
----
-# Source: vector-aggregator/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  type: ClusterIP
-  ports:
-  - port: 9000
-    targetPort: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
 ---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -76,6 +76,53 @@ data:
       type = "prometheus"
       arbitrary text 1
 ---
+# Source: vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  clusterIP: None
+  ports:
+  - port: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
+# Source: vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/builtin_configs/vector-aggregator/snapshot.yaml
@@ -36,13 +36,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -165,8 +159,8 @@ spec:
           image: "timberio/vector:0.0.0-debian"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             
           ports:

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -36,13 +36,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -217,8 +211,8 @@ spec:
           command:
             []
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-agent/snapshot.yaml
@@ -36,7 +36,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -36,13 +36,7 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
-    
     data_dir = "/vector-data-dir"
-    
-    [api]
-      enabled = false
-      address = "0.0.0.0:8686"
-      playground = true
     
     [log_schema]
       host_key = "host"
@@ -217,8 +211,8 @@ spec:
           image: "timberio/vector:0.0.0-debian"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --config
-            - /etc/vector/*.toml
+            - --config-dir
+            - /etc/vector/
           env:
             
           ports:

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -128,6 +128,53 @@ data:
       inputs = []
       type = "type3"
 ---
+# Source: vector-aggregator/templates/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator-headless
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  clusterIP: None
+  ports:
+  - port: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
+# Source: vector-aggregator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-aggregator
+  labels:
+    helm.sh/chart: vector-aggregator-0.0.0
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: vector-aggregator
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9000
+    targetPort: 9000
+    name: vector
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: vector-aggregator
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: aggregator
+---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
+++ b/tests/helm-snapshots/topology_config/vector-aggregator/snapshot.yaml
@@ -36,7 +36,13 @@ data:
   managed.toml: |
     # Configuration for vector.
     # Docs: https://vector.dev/docs/
+    
     data_dir = "/vector-data-dir"
+    
+    [api]
+      enabled = false
+      address = "0.0.0.0:8686"
+      playground = true
     
     [log_schema]
       host_key = "host"
@@ -121,53 +127,6 @@ data:
     [sinks.sink3]
       inputs = []
       type = "type3"
----
-# Source: vector-aggregator/templates/service-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator-headless
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  clusterIP: None
-  ports:
-  - port: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
----
-# Source: vector-aggregator/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vector-aggregator
-  labels:
-    helm.sh/chart: vector-aggregator-0.0.0
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/version: "0.0.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: vector-aggregator
-spec:
-  type: ClusterIP
-  ports:
-  - port: 9000
-    targetPort: 9000
-    name: vector
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: vector-aggregator
-    app.kubernetes.io/instance: vector
-    app.kubernetes.io/component: aggregator
 ---
 # Source: vector-aggregator/templates/statefulset.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Rendered: https://deploy-preview-8168--vector-dot-dev.netlify.app/highlights/2021-07-13-helm-customconfig/

Related #7709
Close #7453

This PR introduces the `customConfig` key to rework how we configure Vector with Helm. It completes the first two steps from [the RFC's Plan of Attack](https://github.com/timberio/vector/blob/master/rfcs/2021-06-29-7709-helm-update-vector-config-pattern.md#plan-of-attack):

- Announce plan to deprecate current keys with a highlight in the 0.15.0 release, and mark the values as deprecated in the values.yaml
- If any deprecated key is used or set as enabled, block usage of new configuration and customConfig pattern

This also moves the `podMonitor` key out from under the now deprecated `prometheusSink` key to a separate top level key. I've additionally removed the `addPodAnnotations` key which can be replicated through the existing `podAnnotations` key. I'm open to reverting that change but it would require either strict naming of sources or ports.

The current implementation should allow us to keep support for the deprecated keys in place until our 1.0 release without too much trouble.

Todo:

- [x] Finish writing highlight and transition docs
- [x] Add/update tests