### PR TITLE
chore(file source): Write checkpoints only if they changed

### DIFF
--- a/docs/cue/reference/components/sources/file.cue
+++ b/docs/cue/reference/components/sources/file.cue
@@ -129,8 +129,8 @@ components: sources: file: {
 			common:      false
 			description: """
 				Delay between file discovery calls. This controls the interval at which Vector searches for files.
-				The higher the value the greater the chance of some short living files to be missed between
-				searches, but the lower the value the greater of performance impact file discovery will have.
+				Higher value result in greater chances of some short living files being missed between
+				searches, but lower value increases the performance impact of file discovery.
 				"""
 			required:    false
 			type: uint: {

--- a/docs/cue/reference/components/sources/file.cue
+++ b/docs/cue/reference/components/sources/file.cue
@@ -127,7 +127,11 @@ components: sources: file: {
 		}
 		glob_minimum_cooldown_ms: {
 			common:      false
-			description: "Delay between file discovery calls. This controls the interval at which Vector searches for files."
+			description: """
+				Delay between file discovery calls. This controls the interval at which Vector searches for files.
+				The higher the value the greater the chance of some short living files to be missed between
+				searches, but the lower the value the greater of performance impact file discovery will have.
+				"""
 			required:    false
 			type: uint: {
 				default: 1_000

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -4,7 +4,7 @@ use dashmap::DashMap;
 use glob::glob;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeSet,
     fs, io,
     path::{Path, PathBuf},
     sync::Arc,
@@ -19,41 +19,16 @@ const STABLE_FILE_NAME: &str = "checkpoints.json";
 /// now there is only one variant, but any incompatible changes will require and
 /// additional variant to be added here and handled anywhere that we transit
 /// this format.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "version", rename_all = "snake_case")]
 enum State {
     #[serde(rename = "1")]
-    V1 { checkpoints: Vec<Checkpoint> },
-}
-
-impl Eq for State {}
-
-impl PartialEq for State {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (State::V1 { checkpoints: a }, State::V1 { checkpoints: b }) if a.len() == b.len() => {
-                let map: HashMap<_, _> = a.iter().map(|c| (c.fingerprint, c)).collect();
-
-                for c in b {
-                    if let Some(entry) = map.get(&c.fingerprint) {
-                        if entry != &c {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                }
-
-                true
-            }
-            (State::V1 { .. }, State::V1 { .. }) => false,
-        }
-    }
+    V1 { checkpoints: BTreeSet<Checkpoint> },
 }
 
 /// A simple JSON-friendly struct of the fingerprint/position pair, since
 /// fingerprints as objects cannot be keys in a plain JSON map.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 struct Checkpoint {
     fingerprint: FileFingerprint,
@@ -296,14 +271,7 @@ impl Checkpointer {
         let current = self.checkpoints.get_state();
 
         // Fetch last written state.
-        let mut last = match self.last.lock() {
-            Ok(guard) => guard,
-            Err(mut poisoned) => {
-                // Remove possibly invalid state.
-                **poisoned.get_mut() = None;
-                poisoned.into_inner()
-            }
-        };
+        let mut last = self.last.lock().expect("Data poisoned.");
         if last.as_ref() != Some(&current) {
             // Write the new checkpoints to a tmp file and flush it fully to
             // disk. If vector dies anywhere during this section, the existing

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -32,7 +32,7 @@ pub enum FingerprintStrategy {
     DevInode,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum FileFingerprint {
     #[serde(rename = "checksum")]


### PR DESCRIPTION
Closes #7948

This PR addresses two of three improvements that can be done regarding performance impact of opening/closing files in file source. 
* Checkpoints are now only written if the state has changed.
* Document performance consideration for `glob_minimum_cooldown_ms`.

While the last improvement, the impact of globing, is being tackled in #7840.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
