### PR TITLE
chore(ci): Avoid updating "bundled with" in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,8 +221,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -10,7 +10,6 @@ rustup run stable cargo install cargo-deb --version 1.29.2
 rustup run stable cargo install cross --version 0.2.1
 
 cd scripts
-gem install bundler
 bundle install
 cd ..
 

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -10,7 +10,7 @@ rustup run stable cargo install cargo-deb --version 1.29.2
 rustup run stable cargo install cross --version 0.2.1
 
 cd scripts
-bundle update --bundler
+gem install bundler
 bundle install
 cd ..
 


### PR DESCRIPTION
Otherwise fails on MacOS in Github Actions with:

```
Traceback (most recent call last):
        1: from /usr/local/lib/ruby/gems/2.7.0/bin/bundle:23:in `<main>'
        /usr/local/lib/ruby/gems/2.7.0/bin/bundle:23:in `load': cannot load such file -- /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.2.21/exe/bundle (LoadError)
```

When `bundle install` is run.

I'm not quite sure why, but also this step seems unnecessary.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
