### PR TITLE
fix(ci): Run checks suite only for non-docs changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
         dependencies: ${{ steps.filter.outputs.dependencies }}
         internal_events: ${{ steps.filter.outputs.internal_events }}
         helm: ${{ steps.filter.outputs.helm }}
-        docs: ${{ steps.filter.outputs.docs }}
       steps:
       - uses: actions/checkout@v2.3.4
       - uses: dorny/paths-filter@v2
@@ -61,8 +60,6 @@ jobs:
               - "Cargo.toml"
               - "Makefile"
               - "rust-toolchain"
-            docs:
-              - 'docs/**'
             deny:
               - 'deny.toml'
             dependencies:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
         dependencies: ${{ steps.filter.outputs.dependencies }}
         internal_events: ${{ steps.filter.outputs.internal_events }}
         helm: ${{ steps.filter.outputs.helm }}
+        docs: ${{ steps.filter.outputs.docs }}
       steps:
       - uses: actions/checkout@v2.3.4
       - uses: dorny/paths-filter@v2
@@ -60,6 +61,8 @@ jobs:
               - "Cargo.toml"
               - "Makefile"
               - "rust-toolchain"
+            docs:
+              - 'docs/**'
             deny:
               - 'deny.toml'
             dependencies:
@@ -308,6 +311,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: timberio/ci_image
     needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
This PR changes our CI logic to run the main "Checks" suite only when there are changes to the `sources` outputs (i.e. `src/**`, `tests/**`, `rust-toolchain`, etc.). The desired effect is to not run this suite when changes are restricted to the `docs` directory, for the sake of cutting superfluous build time for docs/website-only changes. This is a somewhat imprecise way of doing this and I'm open to suggestion on a more precise method.