### PR TITLE
chore(deps): Temporarily ignore prost warning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,4 +54,8 @@ ignore = [
     # Memory access due to code generation flaw in Cranelift module
     # https://github.com/timberio/vector/issues/7558
     "RUSTSEC-2021-0067",
+
+    # Conversion from prost_types::Timestamp to SystemTime can cause an overflow and panic
+    # https://github.com/timberio/vector/issues/8184
+    "RUSTSEC-2021-0073",
 ]


### PR DESCRIPTION
We don't seem to be affected since it only affects converting
`prost_types::Timestamp` to `SystemTime`.

Issue to resolve once dependencies are updated:

https://github.com/timberio/vector/issues/8184

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
