### PR TITLE
fix(file source): fix regression in fingerprint calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1374,15 @@ dependencies = [
  "log",
  "thiserror",
  "wasmparser 0.58.0",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -2245,7 +2260,7 @@ dependencies = [
  "bstr",
  "bytes 1.0.1",
  "chrono",
- "crc",
+ "crc 1.8.1",
  "criterion",
  "dashmap",
  "flate2",
@@ -5274,7 +5289,7 @@ dependencies = [
  "bit-vec 0.6.3",
  "bytes 1.0.1",
  "chrono",
- "crc",
+ "crc 2.0.0",
  "futures 0.3.15",
  "futures-io",
  "futures-timer",

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2"
 winapi = { version = "0.3", features = ["winioctl"] }
 
 [dependencies]
-crc = "2.0.0"
+crc = "1.8.1"
 glob = "0.3.0"
 scan_fmt = "0.2.6"
 


### PR DESCRIPTION
0.14.0 included an upgrade to the `crc` crate, with associated updates
to use the new API, however it appears to calculate different checksums.

I put a comment here asking about how to calculate an equivalent
checksum using the new API:
https://github.com/mrhooray/crc-rs/issues/62#issuecomment-876720733

This also adds an alias to ensure that checkpoints written by 0.14.0
will be able to be read by 0.15.0 when it is released.

Fixes: #8182

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
