### PR TITLE
fix(external docs): Remove Netlify ignore logic (for now)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,9 @@
 [build]
 base = "docs"
 publish = "public"
-ignore = "./scripts/build-ignore.sh"
+
+# Reinstate this when we figure out how to target this better
+#ignore = "./scripts/build-ignore.sh"
 
 [build.environment]
 HUGO_VERSION = "0.84.0"


### PR DESCRIPTION
This PR comments out the recently added build ignore script for Netlify, as that script appears to have been canceling builds that we don't want canceled (hashtag cancel culture!). I'm going to talk to their support and see if there's a way around this. At that point we can uncomment.