### PR TITLE
enhancement(aws_s3 source): improve performance of S3 source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1463,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch 0.9.3",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1510,7 +1510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "memoffset 0.6.3",
  "scopeguard",
@@ -1540,11 +1540,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -2999,7 +2998,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "basic-cookies",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "difference",
  "futures-util",
  "hyper",
@@ -3269,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e2bd04215e4e79c95af18dfc770e0210c734dc02027be1350f7c3fa00875953"
 dependencies = [
  "async-channel",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "curl",
  "curl-sys",
  "encoding_rs",
@@ -3998,7 +3997,7 @@ dependencies = [
  "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch 0.9.3",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "dashmap",
  "hashbrown",
  "indexmap",
@@ -5644,7 +5643,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
 ]
@@ -6124,7 +6123,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]

--- a/lib/vector-core/src/event/util/log/path_iter.rs
+++ b/lib/vector-core/src/event/util/log/path_iter.rs
@@ -1,10 +1,9 @@
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{mem, str::Chars};
 
-lazy_static! {
-    static ref FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
+thread_local! {
+    pub static FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -71,7 +70,7 @@ impl<'a> Iterator for PathIter<'a> {
             ClosingBracket, Dot, End, Fast, Index, Invalid, Key, KeyEscape, OpeningBracket, Start,
         };
 
-        if self.state.is_start() && FAST_RE.is_match(self.path) {
+        if self.state.is_start() && FAST_RE.with(|re| re.is_match(self.path)) {
             self.state = Fast(self.path.split('.'));
         }
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -430,6 +430,10 @@ impl IngestorProcess {
                     None => lines,
                 };
 
+                let bucket_name = Bytes::from(s3_event.s3.bucket.name.as_str().as_bytes().to_vec());
+                let object_key = Bytes::from(s3_event.s3.object.key.as_str().as_bytes().to_vec());
+                let aws_region = Bytes::from(s3_event.aws_region.as_str().as_bytes().to_vec());
+
                 let mut stream = lines.filter_map(|line| {
                     emit!(SqsS3EventReceived {
                         byte_size: line.len()
@@ -438,10 +442,10 @@ impl IngestorProcess {
                     let mut event = Event::from(line);
 
                     let log = event.as_mut_log();
-                    log.insert("bucket", s3_event.s3.bucket.name.clone());
-                    log.insert("object", s3_event.s3.object.key.clone());
-                    log.insert("region", s3_event.aws_region.clone());
-                    log.insert(log_schema().timestamp_key(), timestamp);
+                    log.insert_flat("bucket", bucket_name.clone());
+                    log.insert_flat("object", object_key.clone());
+                    log.insert_flat("region", aws_region.clone());
+                    log.insert_flat(log_schema().timestamp_key(), timestamp);
 
                     if let Some(metadata) = &metadata {
                         for (key, value) in metadata {


### PR DESCRIPTION
This PR does some minor tweaks to improve the performance of the S3 source, as well as some more generic tweaks.

We're approaching the performance shortcomings by focusing on the per-event overhead: a single S3 file itself may have hundreds of thousands of lines, or more, each of which could be turned into an event.  The overhead of creating that event can add up very quickly.

The biggest change here is switching from `LogEvent::insert` to `LogEvent::insert_flat` in the S3 source, which avoids a codepath that tries to parse the key as a JSONPath-esque value when it is otherwise not necessary.

At a higher level, for all the cases where we've yet to identify that `insert_flat` can be substituted in, we've updated `PathIter` to better utilize the pre-compiled regular expression it employs.  `PathIter` checks keys with a particular regular expression to see if it can utilize a fast path, avoiding full parsing of the string.  Unfortunately, the `regex` crate utilizes object pooling internally that is stashed within a `Mutex<T>`.  Under high concurrency, a shared `Regex` object can become a major source of contention overhead.

Instead of a single static `Regex` object, we've switched to using a thread-local version of it.  This allows the `Regex` object to avoid the slower synchronization code, which in turn lets `PathIter` correctly utilize this check for actually hitting a fast path. 

In a real-life workload simulating VPC Flow Logs dumped to an S3 bucket -- files at 4MB, ~25K lines per file -- we see an increased throughput of 20% with these changes alone.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>