### PR TITLE
fix(external docs): Fix typos on main page plus some small wording changes

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -10,22 +10,22 @@ what:
 # Items listed in the "Why Vector?" section. Markdown is supported in the descriptions.
 why:
 - title: "Ultra fast and reliable"
-  description: "Built in [Rust](https://rust-lang.org), Vector is blistering fast, memory efficient, and designed to handle the most demanding environments."
+  description: "Built in [Rust](https://rust-lang.org), Vector is blistering fast, memory efficient, and designed to handle the most demanding workloads."
   icon: "clock.svg"
 - title: "End to end"
-  description: "Vector strives to be the only tool you need to get observability data from A to B, [deploying](/docs/setup/deployment) as an [daemon](/docs/setup/deployment/roles/#daemon)), [sidecar](/docs/setup/deployment/roles/#sidecar), or [aggregator](/docs/setup/deployment/roles/#aggregator)."
+  description: "Vector strives to be the only tool you need to get observability data from A to B, [deploying](/docs/setup/deployment) as a [daemon](/docs/setup/deployment/roles/#daemon), [sidecar](/docs/setup/deployment/roles/#sidecar), or [aggregator](/docs/setup/deployment/roles/#aggregator)."
   icon: "chart.svg"
 -  title: "Unified"
    description: "Vector supports [logs](/docs/about/under-the-hood/architecture/data-model/log) and [metrics](/docs/about/under-the-hood/architecture/data-model/metric), making it easy to collect and process all your observability data."
    icon: "hex.svg"
 - title: "Vendor neutral"
-  description: "Vector doesn't favor any storage and fosters a fair, open ecosystem with your best interest in mind. Lock-in free and future proof."
+  description: "Vector doesn't favor any specific vendor platforms and fosters a fair, open ecosystem with your best interests in mind. Lock-in free and future proof."
   icon: "lock.svg"
 - title: "Programmable transforms"
-  description: "[Programmable transforms](/docs/reference/configuration/transforms) give you the full power of programmable runtimes. Handle complex use cases without limitation."
+  description: "Vector's highly configurable [transforms](/docs/reference/configuration/transforms) give you the full power of programmable runtimes. Handle complex use cases without limitation."
   icon: "code.svg"
 - title: "Clear guarantees"
-  description: "Guarantees matter, and Vector is [clear on its guarantees](/docs/about/under-the-hood/guarantees), helping you to make the appropriate trade offs for your use case."
+  description: "Guarantees matter, and Vector is clear on [which guarantees](/docs/about/under-the-hood/guarantees) it provides, helping you make the appropriate trade-offs for your use case."
   icon: "laptop.svg"
 
 # Platform section


### PR DESCRIPTION
This PR fixes a small but jarring typo on the main page and also changes the wording in a few other sentences.
