### PR TITLE
fix(file source): Handle legacy fingerprint checksums from < v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,6 +2253,7 @@ dependencies = [
  "glob 0.3.0",
  "indexmap",
  "libc",
+ "pretty_assertions",
  "quickcheck",
  "scan_fmt",
  "serde",

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -74,6 +74,7 @@ features = ["full"]
 criterion = "0.3"
 quickcheck = "1"
 tempfile = "3.1.0"
+pretty_assertions = "0.7.2"
 
 [[bench]]
 name = "buffer"

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -157,8 +157,15 @@ impl CheckpointsView {
         }
     }
 
-    fn maybe_upgrade(&self, path: &Path, fng: FileFingerprint, fingerprinter: &Fingerprinter) {
-        if let Ok(Some(old_checksum)) = fingerprinter.get_bytes_checksum(&path) {
+    fn maybe_upgrade(
+        &self,
+        path: &Path,
+        fng: FileFingerprint,
+        fingerprinter: &Fingerprinter,
+        fingerprint_buffer: &mut Vec<u8>,
+    ) {
+        if let Ok(Some(old_checksum)) = fingerprinter.get_bytes_checksum(&path, fingerprint_buffer)
+        {
             self.update_key(old_checksum, fng)
         }
 
@@ -170,7 +177,9 @@ impl CheckpointsView {
         }
 
         if self.checkpoints.get(&fng).is_none() {
-            if let Ok(Some(fingerprint)) = fingerprinter.get_legacy_checksum(&path) {
+            if let Ok(Some(fingerprint)) =
+                fingerprinter.get_legacy_checksum(&path, fingerprint_buffer)
+            {
                 if let Some((_, pos)) = self.checkpoints.remove(&fingerprint) {
                     self.update(fng, pos);
                 }
@@ -267,8 +276,10 @@ impl Checkpointer {
         path: &Path,
         fresh: FileFingerprint,
         fingerprinter: &Fingerprinter,
+        fingerprint_buffer: &mut Vec<u8>,
     ) {
-        self.checkpoints.maybe_upgrade(path, fresh, fingerprinter)
+        self.checkpoints
+            .maybe_upgrade(path, fresh, fingerprinter, fingerprint_buffer)
     }
 
     /// Persist the current checkpoints state to disk, making our best effort to
@@ -517,6 +528,8 @@ mod test {
             ignore_not_found: false,
         };
 
+        let mut buf = Vec::new();
+
         let data_dir = tempdir().unwrap();
         {
             let mut chkptr = Checkpointer::new(&data_dir.path());
@@ -529,7 +542,7 @@ mod test {
             chkptr.read_checkpoints(None);
             assert_eq!(chkptr.get_checkpoint(new_fingerprint), None);
 
-            chkptr.maybe_upgrade(&path, new_fingerprint, &fingerprinter);
+            chkptr.maybe_upgrade(&path, new_fingerprint, &fingerprinter, &mut buf);
 
             assert_eq!(chkptr.get_checkpoint(new_fingerprint), Some(position));
             assert_eq!(chkptr.get_checkpoint(old_fingerprint), None);
@@ -556,6 +569,8 @@ mod test {
             ignore_not_found: false,
         };
 
+        let mut buf = Vec::new();
+
         let data_dir = tempdir().unwrap();
         {
             let mut chkptr = Checkpointer::new(&data_dir.path());
@@ -568,7 +583,7 @@ mod test {
             chkptr.read_checkpoints(None);
             assert_eq!(chkptr.get_checkpoint(new_fingerprint), None);
 
-            chkptr.maybe_upgrade(&path, new_fingerprint, &fingerprinter);
+            chkptr.maybe_upgrade(&path, new_fingerprint, &fingerprinter, &mut buf);
 
             assert_eq!(chkptr.get_checkpoint(new_fingerprint), Some(position));
             assert_eq!(chkptr.get_checkpoint(old_fingerprint), None);
@@ -675,7 +690,7 @@ mod test {
 
         let mut buf = vec![0; 1024];
         let old = fingerprinter
-            .get_bytes_checksum(&log_path)
+            .get_bytes_checksum(&log_path, &mut buf)
             .expect("getting old checksum")
             .expect("still getting old checksum");
 
@@ -698,7 +713,7 @@ mod test {
 
         assert!(chkptr.checkpoints.contains_bytes_checksums());
 
-        chkptr.maybe_upgrade(&log_path, new, &fingerprinter);
+        chkptr.maybe_upgrade(&log_path, new, &fingerprinter, &mut buf);
 
         assert!(!chkptr.checkpoints.contains_bytes_checksums());
         assert_eq!(Some(1234), chkptr.get_checkpoint(new));

--- a/lib/file-source/src/checkpointer.rs
+++ b/lib/file-source/src/checkpointer.rs
@@ -502,7 +502,7 @@ mod test {
     }
 
     #[test]
-    fn test_checkpointer_fingerprint_upgrades() {
+    fn test_checkpointer_fingerprint_upgrades_unknown() {
         let log_dir = tempdir().unwrap();
         let path = log_dir.path().join("test.log");
         let data = "hello\n";
@@ -552,7 +552,7 @@ mod test {
                 ignored_header_bytes: 0,
                 lines: 1,
             },
-            max_line_length: 1000,
+            max_line_length: 102400,
             ignore_not_found: false,
         };
 

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -113,21 +113,15 @@ where
                 .unwrap_or_else(|_| Utc::now())
         });
 
-        checkpointer.maybe_upgrade(existing_files.iter().map(|(_, id)| id).cloned());
-
         let checkpoints = checkpointer.view();
 
-        let needs_checksum_upgrade = checkpoints.contains_bytes_checksums();
-
         for (path, file_id) in existing_files {
-            if needs_checksum_upgrade {
-                if let Ok(Some(old_checksum)) = self
-                    .fingerprinter
-                    .get_bytes_checksum(&path, &mut fingerprint_buffer)
-                {
-                    checkpoints.update_key(old_checksum, file_id)
-                }
-            }
+            checkpointer.maybe_upgrade(
+                &path,
+                file_id,
+                &self.fingerprinter,
+                &mut fingerprint_buffer,
+            );
 
             self.watch_new_file(path, file_id, &mut fp_map, &checkpoints, true);
         }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -116,7 +116,12 @@ where
         let checkpoints = checkpointer.view();
 
         for (path, file_id) in existing_files {
-            checkpointer.maybe_upgrade(&path, file_id, &self.fingerprinter);
+            checkpointer.maybe_upgrade(
+                &path,
+                file_id,
+                &self.fingerprinter,
+                &mut fingerprint_buffer,
+            );
 
             self.watch_new_file(path, file_id, &mut fp_map, &checkpoints, true);
         }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -116,12 +116,7 @@ where
         let checkpoints = checkpointer.view();
 
         for (path, file_id) in existing_files {
-            checkpointer.maybe_upgrade(
-                &path,
-                file_id,
-                &self.fingerprinter,
-                &mut fingerprint_buffer,
-            );
+            checkpointer.maybe_upgrade(&path, file_id, &self.fingerprinter);
 
             self.watch_new_file(path, file_id, &mut fp_map, &checkpoints, true);
         }

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -138,14 +138,17 @@ impl Fingerprinter {
             .flatten()
     }
 
-    pub fn get_bytes_checksum(&self, path: &Path) -> Result<Option<FileFingerprint>, io::Error> {
+    pub fn get_bytes_checksum(
+        &self,
+        path: &Path,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<FileFingerprint>, io::Error> {
         match self.strategy {
             FingerprintStrategy::Checksum {
                 bytes,
                 ignored_header_bytes,
                 lines: _,
             } => {
-                let mut buffer: Vec<u8> = Vec::with_capacity(bytes);
                 buffer.resize(bytes, 0u8);
                 let mut fp = fs::File::open(path)?;
                 fp.seek(io::SeekFrom::Start(ignored_header_bytes as u64))?;
@@ -159,7 +162,11 @@ impl Fingerprinter {
 
     /// Calculates checksums using strategy pre-0.14.0
     /// https://github.com/timberio/vector/issues/8182
-    pub fn get_legacy_checksum(&self, path: &Path) -> Result<Option<FileFingerprint>, io::Error> {
+    pub fn get_legacy_checksum(
+        &self,
+        path: &Path,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<FileFingerprint>, io::Error> {
         match self.strategy {
             FingerprintStrategy::Checksum {
                 ignored_header_bytes,
@@ -170,11 +177,10 @@ impl Fingerprinter {
                 ignored_header_bytes,
                 lines,
             } => {
-                let mut buffer: Vec<u8> = Vec::with_capacity(self.max_line_length);
                 buffer.resize(self.max_line_length, 0u8);
                 let mut fp = fs::File::open(path)?;
                 fp.seek(SeekFrom::Start(ignored_header_bytes as u64))?;
-                fingerprinter_read_until(fp, b'\n', lines, &mut buffer)?;
+                fingerprinter_read_until(fp, b'\n', lines, buffer)?;
                 let fingerprint = LEGACY_FINGERPRINT_CRC.checksum(&buffer[..]);
                 Ok(Some(FileFingerprint::FirstLinesChecksum(fingerprint)))
             }

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -10,15 +10,16 @@ use std::{
 use tracing::trace_span;
 
 const FINGERPRINT_CRC: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_ECMA_182);
+const LEGACY_FINGERPRINT_CRC: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_XZ);
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Fingerprinter {
     pub strategy: FingerprintStrategy,
     pub max_line_length: usize,
     pub ignore_not_found: bool,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum FingerprintStrategy {
     Checksum {
         bytes: usize,
@@ -37,6 +38,7 @@ pub enum FingerprintStrategy {
 pub enum FileFingerprint {
     #[serde(rename = "checksum")]
     BytesChecksum(u64),
+    #[serde(alias = "first_line_checksum")]
     FirstLinesChecksum(u64),
     DevInode(u64, u64),
     Unknown(u64),
@@ -153,6 +155,33 @@ impl Fingerprinter {
                 fp.read_exact(&mut buffer[..bytes])?;
                 let fingerprint = FINGERPRINT_CRC.checksum(&buffer[..]);
                 Ok(Some(FileFingerprint::BytesChecksum(fingerprint)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Calculates checksums using strategy pre-0.14.0
+    pub fn get_legacy_checksum(
+        &self,
+        path: &Path,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<FileFingerprint>, io::Error> {
+        match self.strategy {
+            FingerprintStrategy::Checksum {
+                ignored_header_bytes,
+                bytes: _,
+                lines,
+            }
+            | FingerprintStrategy::FirstLinesChecksum {
+                ignored_header_bytes,
+                lines,
+            } => {
+                buffer.resize(self.max_line_length, 0u8);
+                let mut fp = fs::File::open(path)?;
+                fp.seek(SeekFrom::Start(ignored_header_bytes as u64))?;
+                fingerprinter_read_until(fp, b'\n', lines, buffer)?;
+                let fingerprint = LEGACY_FINGERPRINT_CRC.checksum(&buffer[..]);
+                Ok(Some(FileFingerprint::FirstLinesChecksum(fingerprint)))
             }
             _ => Ok(None),
         }

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -158,6 +158,7 @@ impl Fingerprinter {
     }
 
     /// Calculates checksums using strategy pre-0.14.0
+    /// https://github.com/timberio/vector/issues/8182
     pub fn get_legacy_checksum(&self, path: &Path) -> Result<Option<FileFingerprint>, io::Error> {
         match self.strategy {
             FingerprintStrategy::Checksum {


### PR DESCRIPTION
Adds logic to convert from checkpoints written by Vector before version 0.14.0 to 0.14.0 checkpoints by seeing if any checkpoints, that don't match an existing file, match if the old checkpoint strategy is used.

Also adds alias for `first_line_checksum` strategy which would have broken checkpoints if released.

Ideally I'd like to include this in 0.15.0 to avoid needing to release a 0.15.1 with it.

This will be released as a 0.13.1.

Fixes: #8182

TODO:
- [x] Figure out why `test_checkpointer_fingerprint_upgrades_legacy_checksum` is failing. It seems to calculate a different checksum than I get when running 0.13.1 directly despite the upgrade working when I run this branch using 0.13.1 checkpoints.
- [x] Add tests to assert the literal value we are writing to the checkpoint file to avoid unexpected regressions

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
