### PR TITLE
fix(setup): Fix config dir in install script output

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -177,7 +177,7 @@ install_from_archive() {
     printf "%s Install succeeded! 🚀\n" "$_prompt"
     printf "%s To start Vector:\n" "$_prompt"
     printf "\n"
-    printf "%s vector --config ~/.vector/vector.toml\n" "$_indent"
+    printf "%s vector --config ~/.vector/config/vector.toml\n" "$_indent"
     printf "\n"
     printf "%s More information at https://vector.dev/docs/\n" "$_prompt"
 


### PR DESCRIPTION
This PR updates the text output of the EZ install script, which tells you to look for the placeholder Vector config in $HOME/.vector/vector.toml, while the location is actually $HOME/.vector/config/vector.toml.
