### PR TITLE
docs: Remove the banner

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -38,7 +38,7 @@
   </head>
   <body class="dark:bg-dark font-sans antialiased flex flex-col min-h-full{{ if $hasBottomNav }} pb-16 lg:pb-0{{ end }}" onload="showBody()" style="visibility: hidden;">
     <div class="flex-1 z-1">
-      {{ partial "banner.html" . }}
+      {#{{ partial "banner.html" . }}#}
       {{ partial "navbar.html" . }}
 
       {{ block "main" . }}

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -38,7 +38,7 @@
   </head>
   <body class="dark:bg-dark font-sans antialiased flex flex-col min-h-full{{ if $hasBottomNav }} pb-16 lg:pb-0{{ end }}" onload="showBody()" style="visibility: hidden;">
     <div class="flex-1 z-1">
-      {#{{ partial "banner.html" . }}#}
+      {{ /* {{ partial "banner.html" . }} */}}
       {{ partial "navbar.html" . }}
 
       {{ block "main" . }}

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -38,7 +38,7 @@
   </head>
   <body class="dark:bg-dark font-sans antialiased flex flex-col min-h-full{{ if $hasBottomNav }} pb-16 lg:pb-0{{ end }}" onload="showBody()" style="visibility: hidden;">
     <div class="flex-1 z-1">
-      {{ /* {{ partial "banner.html" . }} */}}
+      {{/* {{ partial "banner.html" . }} */}}
       {{ partial "navbar.html" . }}
 
       {{ block "main" . }}


### PR DESCRIPTION
I think since it's been several months and we have "By Datadog" in the
logo now the banner is no longer needed.

I left the partial there so it is easy to bring back with a new announcement if we need to.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
