### PR TITLE
docs: add Datadog agent config info in source/datadog_logs.cue

### DIFF
--- a/docs/cue/reference/components/sources/datadog_logs.cue
+++ b/docs/cue/reference/components/sources/datadog_logs.cue
@@ -7,7 +7,7 @@ components: sources: datadog_logs: {
 
 	description: """
 		Receives logs from a Datadog Agent over HTTP or HTTPS. To sent logs from a Datadog Agent to this source,
-		the [Datadog Agent](\(datadog_agent_doc)) configuration must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`,
+		the [Datadog Agent](\(urls.datadog_agent_doc)) configuration must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`,
 		`logs_config.use_http` should be set to `true` as this source only supports HTTP/HTTPS and `logs_config.logs_no_ssl`
 		must be set to `true` or `false` in accordance to the source SSL configuration.
 		"""

--- a/docs/cue/reference/components/sources/datadog_logs.cue
+++ b/docs/cue/reference/components/sources/datadog_logs.cue
@@ -6,7 +6,10 @@ components: sources: datadog_logs: {
 	title: "Datadog Logs"
 
 	description: """
-		Receives logs from a Datadog Agent over HTTP or HTTPS.
+		Receives logs from a Datadog Agent over HTTP or HTTPS. To sent logs from a Datadog Agent to this source,
+		the [Datadog Agent](\(datadog_agent_doc)) configuration must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`,
+		`logs_config.use_http` should be set to `true` as this source only supports HTTP/HTTPS and `logs_config.logs_no_ssl`
+		must be set to `true` or `false` in accordance to the source SSL configuration.
 		"""
 
 	classes: {

--- a/docs/cue/reference/urls.cue
+++ b/docs/cue/reference/urls.cue
@@ -109,6 +109,7 @@ urls: {
 	dag:                                                      "\(wikipedia)/wiki/Directed_acyclic_graph"
 	datadog:                                                  "https://www.datadoghq.com"
 	datadog_agent:                                            "https://github.com/DataDog/datadog-agent"
+	datadog_agent_doc:                                        "\(datadog_docs)/agent/""
 	datadog_distribution:                                     "\(datadog_docs)/developers/metrics/types/?tab=distribution#definition"
 	datadog_docs:                                             "https://docs.datadoghq.com"
 	datadog_events:                                           "\(datadog_docs)/events/"

--- a/docs/cue/reference/urls.cue
+++ b/docs/cue/reference/urls.cue
@@ -109,7 +109,7 @@ urls: {
 	dag:                                                      "\(wikipedia)/wiki/Directed_acyclic_graph"
 	datadog:                                                  "https://www.datadoghq.com"
 	datadog_agent:                                            "https://github.com/DataDog/datadog-agent"
-	datadog_agent_doc:                                        "\(datadog_docs)/agent/""
+	datadog_agent_doc:                                        "\(datadog_docs)/agent/vector_aggregation/"
 	datadog_distribution:                                     "\(datadog_docs)/developers/metrics/types/?tab=distribution#definition"
 	datadog_docs:                                             "https://docs.datadoghq.com"
 	datadog_events:                                           "\(datadog_docs)/events/"


### PR DESCRIPTION
Minor doc update to highlight datadog agent config settings that should be updated to divert logs to a local Vector deployment.
Link to DataDog/documentation#10790, so this PR should be kept un-merged until DataDog/documentation#10790 has been merged.