### PR TITLE
enhancement(search website): Add page tags to search index

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,3 +15,6 @@ tmp/
 
 # Yarn errors
 yarn-error.log
+
+# Local env vars
+.env

--- a/docs/algolia.json
+++ b/docs/algolia.json
@@ -6,6 +6,7 @@
   "searchableAttributes": [
     "title",
     "content",
+    "unordered(hierarchy)",
     "unordered(tags)"
   ],
   "numericAttributesToIndex": null,

--- a/docs/assets/js/search.tsx
+++ b/docs/assets/js/search.tsx
@@ -44,7 +44,7 @@ const Chevron: React.FC = () => {
 }
 
 const Result = ({ hit, components }) => {
-  const isRootPage = hit.tags.length < 1
+  const isRootPage = hit.hierarchy.length < 1
   return (
     <a href={hit.itemUrl}>
       <div className="border-r border-gray-300 py-4 pl-2 h-full leading-relaxed">
@@ -53,12 +53,12 @@ const Result = ({ hit, components }) => {
       <div className="p-2 block">
         <div className="text-gray-800 text-md mb-1 font-medium leading-relaxed ">
           {!isRootPage &&
-            hit.tags.map((t, i) => (
+            hit.hierarchy.map((t, i) => (
               <span key={`${hit.itemUrl}-${t}`}>
                 <span className="w-2 h-2 inline" key={`${t.itemUrl}`}>
                   {t}
                 </span>
-                {i < hit.tags.length - 1 && (
+                {i < hit.hierarchy.length - 1 && (
                   <span className="inline ml-1 mr-1">
                     <Chevron />
                   </span>

--- a/docs/layouts/partials/meta.html
+++ b/docs/layouts/partials/meta.html
@@ -37,3 +37,6 @@
 
 {{/* For Algolia search */}}
 <meta name="algolia:title" content="{{ .Title }}">
+{{ with .Params.tags }}
+<meta name="algolia:tags" content="{{ delimit . "," }}">
+{{ end }}

--- a/docs/layouts/partials/meta.html
+++ b/docs/layouts/partials/meta.html
@@ -38,5 +38,5 @@
 {{/* For Algolia search */}}
 <meta name="algolia:title" content="{{ .Title }}">
 {{ with .Params.tags }}
-<meta name="algolia:tags" content="{{ delimit . "," }}">
+<meta name="keywords" content="{{ delimit . "," }}">
 {{ end }}

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -76,7 +76,8 @@ async function indexHTMLFiles(
     const containers = $("#page-content");
     const pageTitle = $('meta[name="algolia:title"]').attr('content') || "";
 
-    const pageTags = $('meta[name="keywords"]').attr('content')?.split(",") || [];
+    const tags = $('meta[name="keywords"]').attr('content');
+    const pageTags: string[] = tags?.split(",") || [];
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -33,7 +33,7 @@ type AlgoliaRecord = {
 // Constants
 const targetFile = "./public/search.json";
 
-const DEBUG = process.env.DEBUG === "true" || false;
+const DEBUG = process.env.DEBUG === "true" ?? false;
 const publicPath = path.resolve(__dirname, "..", "public");
 const tagHierarchy = {
   h1: 6,
@@ -74,10 +74,9 @@ async function indexHTMLFiles(
     const html = fs.readFileSync(file, "utf-8");
     const $ = cheerio.load(html);
     const containers = $("#page-content");
-    const pageTitle = $('meta[name="algolia:title"]').attr('content') || "";
+    const pageTitle = $('meta[name="algolia:title"]').attr('content') ?? "";
 
-    const tags = $('meta[name="keywords"]').attr('content');
-    const pageTags: string[] = tags?.split(",") || [];
+    const pageTags = $('meta[name="keywords"]').attr('content')?.split(",") ?? [];
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());
@@ -214,9 +213,6 @@ async function indexHTMLFiles(
 
 async function buildIndex() {
   var allRecords: AlgoliaRecord[] = [];
-
-  const appId = process.env.ALGOLIA_APP_ID || "";
-  const adminPublicKey = process.env.ALGOLIA_ADMIN_KEY || "";
 
   console.log(`Building Vector search index`);
 

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -74,9 +74,9 @@ async function indexHTMLFiles(
     const html = fs.readFileSync(file, "utf-8");
     const $ = cheerio.load(html);
     const containers = $("#page-content");
-    const pageTitle = $('meta[name="algolia:title"]').attr('content') ?? "";
+    const pageTitle = $('meta[name="algolia:title"]').attr('content') || "";
 
-    const pageTags = $('meta[name="keywords"]').attr('content')?.split(",") ?? [];
+    const pageTags = $('meta[name="keywords"]').attr('content')?.split(",") || [];
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -33,7 +33,7 @@ type AlgoliaRecord = {
 // Constants
 const targetFile = "./public/search.json";
 
-const DEBUG = process.env.DEBUG === "true" ?? false;
+const DEBUG = process.env.DEBUG === "true" || false;
 const publicPath = path.resolve(__dirname, "..", "public");
 const tagHierarchy = {
   h1: 6,

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -76,7 +76,7 @@ async function indexHTMLFiles(
     const containers = $("#page-content");
     const pageTitle = $('meta[name="algolia:title"]').attr('content') || "";
 
-    const pageTags = $('meta[name="algolia:tags"]').attr('content')?.split(",") || [];
+    const pageTags = $('meta[name="keywords"]').attr('content')?.split(",") || [];
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());


### PR DESCRIPTION
This PR updates the search indexing logic for the new vector.dev to include per-page tags. It also performs some basic input sanitation by ensuring that there's no extraneous whitespace in section titles. Including tags should improve the search sensitivity and give us more per-page levers that we can use to influence result sets.

Please note that this renames what was previously the `tags` field to `hierarchy` to make room for what I feel is a more intuitively named `tags` field.
