### PR TITLE
fix(observability): Fix span labels for http-based sources

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -110,7 +110,8 @@ impl SourceConfig for SplunkConfig {
 
         let shutdown = cx.shutdown;
         Ok(Box::pin(async move {
-            warp::serve(services)
+            let span = crate::trace::current_span();
+            warp::serve(services.with(warp::trace(move |_info| span.clone())))
                 .serve_incoming_with_graceful_shutdown(
                     listener.accept_stream(),
                     shutdown.map(|_| ()),

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -14,7 +14,6 @@ use snap::raw::Decoder as SnappyDecoder;
 use std::{
     collections::HashMap, convert::TryFrom, error::Error, fmt, io::Read, net::SocketAddr, sync::Arc,
 };
-use tracing_futures::Instrument;
 use vector_core::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event};
 use warp::{
     filters::{path::FullPath, path::Tail, BoxedFilter},

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -233,7 +233,6 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                           headers: HeaderMap,
                           body: Bytes,
                           query_parameters: HashMap<String, String>| {
-                        let _guard = span.enter();
                         debug!(message = "Handling HTTP request.", headers = ?headers);
 
                         let events = auth
@@ -246,9 +245,9 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                             });
 
                         handle_request(events, acknowledgements, out.clone())
-                            .instrument(span.clone())
                     },
-                );
+                )
+                .with(warp::trace(move |_info| span.clone()));
 
             let ping = warp::get().and(warp::path("ping")).map(|| "pong");
             let routes = svc.or(ping).recover(|r: Rejection| async move {


### PR DESCRIPTION
This ensures requests are correctly tagged with their span labels.

The `http` source was already correctly labeling, but I refactored it to
use the same mechanism for attaching the spans to the requests for
consistency.

Fixes: #8257
Ref: #7970

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
