### PR TITLE
chore: Upgrade metrics to latest releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       - run: make slim-builds
       - run: make test
         env:
-          CARGO_BUILD_JOBS: 6
+          CARGO_BUILD_JOBS: 5
       - name: Stop sccache
         run: sccache --stop-server
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
  "getrandom 0.2.2",
  "once_cell",
@@ -3952,13 +3952,13 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0a7fa53d812d26e59d2baf7a6f77442041454ab32908eb304447f00f0dd4de"
+checksum = "a00f42f354a2ed4894db863b3a4db47aef2d2e4435b937221749bd37a8a7aaa8"
 dependencies = [
+ "ahash",
  "metrics-macros",
  "proc-macro-hack",
- "t1ha",
 ]
 
 [[package]]
@@ -3977,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-tracing-context"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b0900f96236eaa964bb4b94d5cf300b1455ca3a9f28a5c9ba7dbc7deb633a3"
+checksum = "45770271d3b4f04a4b38b593e187d04d41f312694fff10ce1d60c356a082cc50"
 dependencies = [
  "itoa",
  "metrics",
@@ -3991,10 +3991,11 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2a095cccde5b79bf33556d987688db3d94cb1d75b1f9499a3de3291cb71ebd"
+checksum = "a58e622a425b7308e73e4390c68b8cb3df4443f2a57495e391b978412531638c"
 dependencies = [
+ "ahash",
  "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch 0.9.3",
@@ -4009,7 +4010,6 @@ dependencies = [
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
- "t1ha",
 ]
 
 [[package]]
@@ -7165,18 +7165,6 @@ checksum = "cb6ef7fbec50f39dab5b134b7997e822086429d39920e1bd7db9a17c85f06eeb"
 dependencies = [
  "chrono",
  "nom 6.1.2",
-]
-
-[[package]]
-name = "t1ha"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa44aa51ae1a544e2c35a38831ba54ae40591f21384816f531b84f3e984b9ccc"
-dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
- "num-traits",
- "rustc_version 0.2.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,9 +127,9 @@ opentelemetry = { version = "0.15.0", default-features = false, features = ["tra
 opentelemetry-datadog = { version = "0.3.1", default-features = false, features = ["reqwest-client"] }
 
 # Metrics
-metrics = { version = "0.16.0", default-features = false, features = ["std"] }
-metrics-tracing-context = { version = "0.6.0", default-features = false }
-metrics-util = { version = "0.9.1", default-features = false, features = ["std"] }
+metrics = { version = "0.17.0", default-features = false, features = ["std"] }
+metrics-tracing-context = { version = "0.7.0", default-features = false }
+metrics-util = { version = "0.10.0", default-features = false, features = ["std"] }
 
 # Aws
 rusoto_cloudwatch = { version = "0.47.0", optional = true }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -20,9 +20,9 @@ getset = { version = "0.1.1", default-features = false }
 indexmap = { version = "1.7.0", default-features = false, features = ["serde"] }
 lazy_static = { version = "1.4.0", default-features = false }
 lookup = { path = "../lookup", features = ["arbitrary"] }
-metrics = { version = "0.16.0", default-features = false, features = ["std"]}
-metrics-tracing-context = { version = "0.6.0", default-features = false }
-metrics-util = { version = "0.9.1", default-features = false, features = ["std"] }
+metrics = { version = "0.17.0", default-features = false, features = ["std"]}
+metrics-tracing-context = { version = "0.7.0", default-features = false }
+metrics-util = { version = "0.10.0", default-features = false, features = ["std"] }
 once_cell = { version = "1.8", default-features = false }
 pest = { version = "2.1.3", default-features = false }
 pest_derive = { version = "2.1.0", default-features = false }

--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -10,7 +10,7 @@ bytes = { version = "1.0.1", default-features = false }
 db-key = { version = "0.0.5", default-features = false, optional = true }
 futures = { version = "0.3.15", default-features = false, features = ["std"] }
 leveldb = { version = "0.8.6", default-features = false, optional = true }
-metrics = { version = "0.16.0", default-features = false, features = ["std"] }
+metrics = { version = "0.17.0", default-features = false, features = ["std"] }
 pin-project = { version = "1.0.7", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.10", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
This commit upgrades the metrics libraries to their most recent
releases. Performance has improved considerably upstream, as demonstrated in
issue #8263.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
