### PR TITLE
chore: Fix the using `customConfig` section

### DIFF
--- a/docs/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/docs/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -189,13 +189,14 @@ extraContainerPorts:
 
 ## Using `customConfig`
 
-We've configured the `ConfigMap` template to fail if the deprecated keys are enabled at the same time
-as the new YAML based configurations. The following values can be used to disable the old deprecated
-keys and use the new YAML based configuration with default values.
+The `customConfig` key is mututally exclusive with the now deprecated configuration
+keys, if any values are provided to `customConfig` any pre-generated config we provide
+by default will not be templated. Please review the sections above to see example
+converstions between the deprecated keys and the new `customConfig` based options.
 
-With the deprecated keys disabled, a custom Vector configuration can be provided in raw YAML and is passed
-through a `tpl` function to allow for the evaluation of Helm templates contained within. Below is an example
-of values using `customConfig` and templating.
+With `customConfig` a Vector configuration can be provided in raw YAML and is passed
+through a `tpl` function to allow for the evaluation of Helm templates contained within.
+Below is an example of values using `customConfig` and templating.
 
 ```yaml title="cusomConfig.yaml"
 customConfig:
@@ -248,23 +249,4 @@ service:
     port: 8000
     protocol: TCP
     targetPort: 8000
-# Disable deprecated keys
-globalOptions:
-  enabled: false
-logSchema:
-  enabled: false
-vectorApi:
-  enabled: false
-kubernetesLogsSource:
-  enabled: false
-vectorSource:
-  enabled: false
-vectorSink:
-  enabled: false
-internalMetricsSource:
-  enabled: false
-hostMetricsSource:
-  enabled: false
-prometheusSink:
-  enabled: false
 ```


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

@binarylogic pointed out that I didn't update the "using" section of the highlight after our decision to make the options mutually exclusive and preferring `customConfig` over the deprecated keys.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
