### PR TITLE
chore: Parse Datadog Log agent payloads faster

### DIFF
--- a/src/sources/datadog/agent.rs
+++ b/src/sources/datadog/agent.rs
@@ -1,20 +1,21 @@
+use crate::sources::util::{ErrorMessage, HttpSource, HttpSourceAuthConfig};
 use crate::{
     config::{
         log_schema, DataType, GenerateConfig, Resource, SourceConfig, SourceContext,
         SourceDescription,
     },
     event::Event,
-    sources::{
-        self,
-        util::{decode_body, Encoding, ErrorMessage, HttpSource, HttpSourceAuthConfig},
-    },
+    sources,
     tls::TlsConfig,
 };
 use bytes::Bytes;
+use chrono::Utc;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use vector_core::event::LogEvent;
+use warp::http::StatusCode;
 
 use warp::http::HeaderMap;
 
@@ -77,6 +78,12 @@ struct DatadogAgentSource {
     store_api_key: bool,
 }
 
+#[derive(Deserialize)]
+struct LogMsg {
+    pub message: String,
+    pub timestamp: i64,
+}
+
 impl HttpSource for DatadogAgentSource {
     fn build_events(
         &self,
@@ -86,7 +93,7 @@ impl HttpSource for DatadogAgentSource {
         request_path: &str,
     ) -> Result<Vec<Event>, ErrorMessage> {
         if body.is_empty() {
-            // The datadog agent may sent empty payload as keep alive
+            // The datadog agent may send an empty payload as a keep alive
             debug!(
                 message = "Empty payload ignored.",
                 internal_log_rate_secs = 30
@@ -100,18 +107,28 @@ impl HttpSource for DatadogAgentSource {
         }
         .map(Arc::from);
 
-        decode_body(body, Encoding::Json).map(|mut events| {
-            // Datadog API key in metadata & source type field
-            let key = log_schema().source_type_key();
-            for event in &mut events {
-                let log = event.as_mut_log();
+        let messages: Vec<LogMsg> = serde_json::from_slice(&body).map_err(|error| {
+            ErrorMessage::new(
+                StatusCode::BAD_REQUEST,
+                format!("Error parsing JSON: {:?}", error),
+            )
+        })?;
+        messages
+            .into_iter()
+            .map(|msg| {
+                let mut log = LogEvent::default();
+                log.insert(log_schema().timestamp_key(), Utc::now()); // Add timestamp
+                log.insert_flat("message".to_string(), msg.message);
+                log.insert_flat("timestamp".to_string(), msg.timestamp);
+                let key = log_schema().source_type_key();
                 log.try_insert(key, Bytes::from("datadog_agent"));
                 if let Some(k) = &api_key {
                     log.metadata_mut().set_datadog_api_key(Some(Arc::clone(k)));
                 }
-            }
-            events
-        })
+                log
+            })
+            .map(|log| Ok(log.into()))
+            .collect()
     }
 }
 

--- a/src/sources/util/body_decoding.rs
+++ b/src/sources/util/body_decoding.rs
@@ -22,7 +22,6 @@ pub enum Encoding {
     Binary,
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 fn body_to_lines(buf: Bytes) -> impl Iterator<Item = Result<Bytes, ErrorMessage>> {
     let mut body = BytesMut::new();
     body.extend_from_slice(&buf);
@@ -45,7 +44,6 @@ fn body_to_lines(buf: Bytes) -> impl Iterator<Item = Result<Bytes, ErrorMessage>
     })
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 pub fn decode_body(body: Bytes, enc: Encoding) -> Result<Vec<Event>, ErrorMessage> {
     match enc {
         Encoding::Text => body_to_lines(body)
@@ -67,7 +65,6 @@ pub fn decode_body(body: Bytes, enc: Encoding) -> Result<Vec<Event>, ErrorMessag
     }
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 fn json_parse_object(value: JsonValue) -> Result<LogEvent, ErrorMessage> {
     match value {
         JsonValue::Object(map) => {
@@ -85,7 +82,6 @@ fn json_parse_object(value: JsonValue) -> Result<LogEvent, ErrorMessage> {
     }
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 fn json_parse_array_of_object(value: JsonValue) -> Result<Vec<Event>, ErrorMessage> {
     match value {
         JsonValue::Array(v) => v
@@ -103,12 +99,10 @@ fn json_parse_array_of_object(value: JsonValue) -> Result<Vec<Event>, ErrorMessa
     }
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 fn json_error(s: String) -> ErrorMessage {
     ErrorMessage::new(StatusCode::BAD_REQUEST, format!("Bad JSON: {}", s))
 }
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 fn json_value_to_type_string(value: &JsonValue) -> &'static str {
     match value {
         JsonValue::Object(_) => "Object",

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
+#[cfg(any(feature = "sources-http"))]
 mod body_decoding;
 mod encoding_config;
 #[cfg(any(feature = "sources-file", feature = "sources-kafka"))]
@@ -15,7 +15,7 @@ mod unix_datagram;
 #[cfg(all(unix, feature = "sources-utils-unix"))]
 mod unix_stream;
 
-#[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
+#[cfg(any(feature = "sources-http"))]
 pub(crate) use self::body_decoding::{decode_body, Encoding};
 #[cfg(any(feature = "sources-http", feature = "sources-heroku_logs"))]
 pub(crate) use self::http::add_query_parameters;


### PR DESCRIPTION
This commit adjusts the way the datadog agent log payloads are parsed, avoiding
the generic `decode_body` and relying on our knowledge of the payload's
structure to avoid the branch misses etc etc inherent in that function. We gain
20Mb/s of parse speed per investigation done in #8263. This commit passes
tests (locally) but I don't have documentation on hand to assert that this
payload is, in fact, what the datadog agent is meant to send.

Resolves #8286

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
