### PR TITLE
fix(ci): Remove Netlify warning about Brewfile

### DIFF
--- a/docs/Brewfile.netlify
+++ b/docs/Brewfile.netlify
@@ -1,4 +1,4 @@
-tap "cuelang/tap"
+tap "cue-lang/tap"
 
-brew "cuelang/tap/cue"
+brew "cue-lang/tap/cue"
 brew "htmltest"

--- a/docs/Brewfile.netlify
+++ b/docs/Brewfile.netlify
@@ -1,2 +1,4 @@
+tap "cuelang/tap"
+
 brew "cuelang/tap/cue"
 brew "htmltest"


### PR DESCRIPTION
Just a bit of housekeeping. Netlify has been issuing a warning re: the vector.dev Brewfile (`docs/Brewfile.netlify`). The issue is basically that you're not supposed to run `brew` on taps without running `tap` first. I figured we might as well address that, as that warning will probably become a build-breaking error at some point.