### PR TITLE
fix(dnstap source): Increase timeout for receiving events

### DIFF
--- a/tests/data/dnstap/configure_bind.sh
+++ b/tests/data/dnstap/configure_bind.sh
@@ -3,7 +3,8 @@
 # Set up folders and files needed for each bind instance
 mkdir -p /bind1/etc/bind /bind1/usr/share/dns /bind1/var/lib/bind \
          /bind2/etc/bind /bind2/usr/share/dns /bind2/var/lib/bind \
-         /bind3/etc/bind /bind3/usr/share/dns /bind3/var/lib/bind
+         /bind3/etc/bind /bind3/usr/share/dns /bind3/var/lib/bind \
+         /bind4/etc/bind /bind4/usr/share/dns /bind4/var/lib/bind
 cp -r /etc/bind/* /bind1/etc/bind/
 cp /usr/share/dns/root.hints /bind1/usr/share/dns/
 cp /var/lib/bind/db.example.com /bind1/var/lib/bind/
@@ -13,22 +14,24 @@ cp /var/lib/bind/db.example.com /bind2/var/lib/bind/
 cp -r /etc/bind/* /bind3/etc/bind/
 cp /usr/share/dns/root.hints /bind3/usr/share/dns/
 cp /var/lib/bind/db.example.com /bind3/var/lib/bind/
+cp -r /etc/bind/* /bind4/etc/bind/
+cp /usr/share/dns/root.hints /bind4/usr/share/dns/
+cp /var/lib/bind/db.example.com /bind4/var/lib/bind/
 
 # Apply named.conf.options.template to each bind instance
 mv /bind1/etc/bind/named.conf.options.template /bind1/etc/bind/named.conf.options
 mv /bind2/etc/bind/named.conf.options.template /bind2/etc/bind/named.conf.options
 mv /bind3/etc/bind/named.conf.options.template /bind3/etc/bind/named.conf.options
+mv /bind4/etc/bind/named.conf.options.template /bind4/etc/bind/named.conf.options
 file1="/bind1/etc/bind/named.conf.options"
 file2="/bind2/etc/bind/named.conf.options"
 file3="/bind3/etc/bind/named.conf.options"
+file4="/bind4/etc/bind/named.conf.options"
 sed -i "s/dnstap.sock#/dnstap.sock1/" $file1
-sed -i "s/port #/port 9001/" $file1
 sed -i "s/dnstap.sock#/dnstap.sock2/" $file2
-sed -i "s/port #/port 9002/" $file2
 sed -i "s/dnstap.sock#/dnstap.sock3/" $file3
-sed -i "s/port #/port 9003/" $file3
+sed -i "s/dnstap.sock#/dnstap.sock4/" $file4
 
-# Start bind instances
-/usr/sbin/named -p 8001 -t /bind1
-/usr/sbin/named -p 8002 -t /bind2
-/usr/sbin/named -g -p 8003 -t /bind3
+# Start bind4 instance to keep docker running
+# Will bring up actual bind instances for IT after starting vector
+/usr/sbin/named -g -p 8004 -t /bind4

--- a/tests/data/dnstap/named.conf.options.template
+++ b/tests/data/dnstap/named.conf.options.template
@@ -8,6 +8,6 @@ options {
 };
 
 controls {
-        inet 127.0.0.1 port #
+        inet 127.0.0.1
         allow { localhost; };
 };


### PR DESCRIPTION
Signed-off-by: Yunkun Zhu <yzhu@bluecatnetworks.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes #8240.
This changeset is to fix dnstap source flaky IT. It includes the following:
* change the timeout value for receiving second event to `1s`
* make sure start BIND after Vector gets started
* avoid sending extra queries
* remove `rndc reconfig`
* set `multithreaded` option to `false`
* add `println!` for error cases
