### PR TITLE
fix(external docs): Remove redundant title header in highlights

### DIFF
--- a/docs/layouts/highlights/single.html
+++ b/docs/layouts/highlights/single.html
@@ -5,10 +5,6 @@
 {{ define "main" }}
 <div class="relative max-w-3xl md:max-w-5xl mx-auto px-6 lg:px-8 lg:grid lg:grid-cols-5 lg:gap-8  my-16">
   <main aria-label="Main highlight content" class="lg:col-span-4 md:px-0">
-    <div class="pb-8 md:pb-10 lg:pb-12">
-      {{ partial "hero.html" . }}
-    </div>
-
     <div class="pb-32">
       {{ partial "content.html" . }}
     </div>


### PR DESCRIPTION
Some recent templating changes caused pages under /highlights to have a doubled title header. This PR removes that.
