### PR TITLE
fix(external docs): Fix broken links in getting started guide

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -224,3 +224,4 @@ scopes:
   - javascript website # Anything related to the JavaScript functionality on vector.dev
   - search website # Anything related to the website's Algolia search indexing/config
   - template website # Anything related to website HTML and other templates
+  - links website # Reserved for PRs devoted only to link fixes

--- a/docs/content/en/guides/getting-started/getting-started.md
+++ b/docs/content/en/guides/getting-started/getting-started.md
@@ -175,15 +175,15 @@ check out:
 * Finally, [deploying Vector][docs.deployment] to launch Vector in your production environment.
 
 [docs.deployment]: /docs/setup/deployment/
-[docs.installation]: /docs/manual/installation/
+[docs.installation]: /docs/setup/installation/
 [docs.setup.configuration]: /docs/setup/configuration/
-[docs.sinks]: /docs/reference/components/sinks/
-[docs.sinks.console]: /docs/reference/components/sinks/console/
-[docs.sources]: /docs/reference/components/sources/
-[docs.sources.generator]: /docs/reference/components/sources/generator/
-[docs.sources.stdin]: /docs/reference/components/sources/stdin/
-[docs.transforms.remap]: /docs/reference/components/transforms/remap/
-[docs.transforms]: /docs/reference/components/transforms/
+[docs.sinks]: /docs/reference/configuration/sinks/
+[docs.sinks.console]: /docs/reference/configuration/sinks/console/
+[docs.sources]: /docs/reference/configuration/sources/
+[docs.sources.generator]: /docs/reference/configuration/sources/generator/
+[docs.sources.stdin]: /docs/reference/configuration/sources/stdin/
+[docs.transforms.remap]: /docs/reference/configuration/transforms/remap/
+[docs.transforms]: /docs/reference/configuration/transforms/
 [docs.vrl]: /docs/reference/vrl/
 [docs.vrl.parse_syslog]: /docs/reference/vrl/functions/#parse_syslog
 [pages.components]: /components/


### PR DESCRIPTION
Given the Netlify build failures for most of today, I merged some PRs without ensuring that they pass CI. A few broken links managed to sneak in that way. This PR corrects that and adds a new Semantic PR category for link fixes.
