### PR TITLE
fix(external docs): Reinstate route transform doc

### DIFF
--- a/docs/content/en/docs/reference/configuration/transforms/route.md
+++ b/docs/content/en/docs/reference/configuration/transforms/route.md
@@ -1,7 +1,7 @@
 ---
 title: Route
 description: Split a stream of events into multiple sub-streams based on user-supplied conditions
-kind: transforms
+kind: transform
 layout: component
 tags: ["route", "swimlanes", "split", "component", "transform"]
 ---


### PR DESCRIPTION
Due to a typo, the route transform doc was excluded from the public-facing docs. This PR fixes that error.
