### PR TITLE
chore: Speed up `LogEvent::contains`

### DIFF
--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -64,3 +64,7 @@ disk-buffer = ["buffers/disk-buffer"]
 [[bench]]
 name = "lookup"
 harness = false
+
+[[bench]]
+name = "event"
+harness = false

--- a/lib/vector-core/benches/event/common.rs
+++ b/lib/vector-core/benches/event/common.rs
@@ -1,0 +1,1 @@
+// nothing, intentionally

--- a/lib/vector-core/benches/event/log_event.rs
+++ b/lib/vector-core/benches/event/log_event.rs
@@ -1,0 +1,70 @@
+use criterion::BenchmarkId;
+use criterion::{
+    criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion, SamplingMode,
+};
+use vector_core::event::{LogEvent, Value};
+
+fn contains(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> =
+        c.benchmark_group("vector_core::event::LogEvent::contains");
+    group.sampling_mode(SamplingMode::Auto);
+
+    group.bench_function(BenchmarkId::new("contains", "does"), |b| {
+        b.iter_batched(
+            || {
+                let mut log = LogEvent::default();
+                log.insert_flat("a".to_string(), Value::Null);
+                let query = "a";
+                (log, query)
+            },
+            |(log, query)| {
+                log.contains(query);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(BenchmarkId::new("contains", "does_not"), |b| {
+        b.iter_batched(
+            || {
+                let log = LogEvent::default();
+                let query = "a";
+                (log, query)
+            },
+            |(log, query)| {
+                log.contains(query);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(BenchmarkId::new("contains", "deep_does_not"), |b| {
+        b.iter_batched(
+            || {
+                let log = LogEvent::default();
+                let query = "a.b.c.d.e";
+                (log, query)
+            },
+            |(log, query)| {
+                log.contains(query);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(100_000)
+        // total samples to collect within the set measurement time
+        .sample_size(200);
+    targets = contains
+);

--- a/lib/vector-core/benches/event/main.rs
+++ b/lib/vector-core/benches/event/main.rs
@@ -1,0 +1,6 @@
+use criterion::criterion_main;
+
+mod common;
+mod log_event;
+
+criterion_main!(log_event::benches);

--- a/lib/vector-core/benches/lookup.rs
+++ b/lib/vector-core/benches/lookup.rs
@@ -18,8 +18,8 @@ fn parse_artifact(path: impl AsRef<Path>) -> std::io::Result<String> {
     Ok(string)
 }
 
-// This test iterates over the `tests/data/fixtures/lookup` folder and ensures the lookup parsed,
-// then turned into a string again is the same.
+// This test iterates over the `tests/data/fixtures/lookup` folder and ensures
+// the lookup parsed, then turned into a string again is the same.
 fn lookup_to_string(c: &mut Criterion) {
     let mut fixtures = IndexMap::new();
 

--- a/lib/vector-core/src/event/util/log/contains.rs
+++ b/lib/vector-core/src/event/util/log/contains.rs
@@ -3,6 +3,20 @@ use std::collections::BTreeMap;
 
 /// Checks whether a field specified by a given path is present.
 pub fn contains(fields: &BTreeMap<String, Value>, path: &str) -> bool {
+    // Fast path
+    //
+    // In the event that we're able to find the `path` in the passed set of
+    // fields we have a fast bail-out opportunity: we don't need to go through
+    // the work of splitting up the path and iterating it.
+    if fields.contains_key(path) {
+        return true;
+    }
+
+    // Slow path
+    //
+    // If the passed `path` doesn't exist in the top-level of the fields we need
+    // to construct a `PathIter` and then search down through the -- potential
+    // -- tree to find our result.
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {


### PR DESCRIPTION
This function is hot-path for the work we're seeing over in #8263. Path
iteration remains expensive but we can cheat by avoiding path iteration if the
query key is present in the top-level tree.

This change is worth +2Mb/s of throughput. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
