### PR TITLE
fix(releasing): Replace SystemD service file with previous

### DIFF
--- a/distribution/systemd/hardened-vector.service
+++ b/distribution/systemd/hardened-vector.service
@@ -1,0 +1,56 @@
+# Experimental service configuration for a hardened Vector
+#
+# This has not been widely tested on all OSes and with all Vector
+# configuartions, but can be used as a basis for limiting the Vector service
+# capabilities
+
+[Unit]
+Description=Vector
+Documentation=https://vector.dev
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/vector
+User=vector
+Group=vector
+ExecStartPre=/usr/bin/vector validate
+ExecStart=/usr/bin/vector
+ExecReload=/usr/bin/vector validate
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=no
+
+# capabilities
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+# sandboxing
+ProtectHostname=yes
+ProtectClock=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectSystem=strict
+ProtectHome=yes
+StateDirectory=vector
+ProtectControlGroups=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+NoNewPrivileges=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+
+# syscall filtering
+SystemCallFilter=@system-service @debug
+SystemCallArchitectures=native
+
+# process properties
+UMask=077
+
+[Install]
+WantedBy=multi-user.target

--- a/distribution/systemd/vector.service
+++ b/distribution/systemd/vector.service
@@ -5,7 +5,6 @@ After=network-online.target
 Requires=network-online.target
 
 [Service]
-EnvironmentFile=-/etc/default/vector
 User=vector
 Group=vector
 ExecStartPre=/usr/bin/vector validate
@@ -13,38 +12,8 @@ ExecStart=/usr/bin/vector
 ExecReload=/usr/bin/vector validate
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=no
-
-# capabilities
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-
-# sandboxing
-ProtectHostname=yes
-ProtectClock=yes
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
-ProtectKernelLogs=yes
-ProtectSystem=strict
-ProtectHome=yes
-StateDirectory=vector
-ProtectControlGroups=yes
-PrivateTmp=yes
-PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-LockPersonality=yes
-MemoryDenyWriteExecute=yes
-RestrictRealtime=yes
-RestrictSUIDSGID=yes
-NoNewPrivileges=yes
-RemoveIPC=yes
-RestrictNamespaces=yes
-
-# syscall filtering
-SystemCallFilter=@system-service @debug
-SystemCallArchitectures=native
-
-# process properties
-UMask=077
+EnvironmentFile=-/etc/default/vector
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This replaces the previous vector.service file since a user reported
that the new file does not work on CentOS 7.

I think we'll want to do broader testing before making this the default.
For now, just include as an optional reference.

Closes: #8336

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
