### PR TITLE
enhancement(dnstap source): Make sure ITs are independent of container

### DIFF
--- a/tests/data/dnstap/configure_bind.sh
+++ b/tests/data/dnstap/configure_bind.sh
@@ -28,9 +28,13 @@ file2="/bind2/etc/bind/named.conf.options"
 file3="/bind3/etc/bind/named.conf.options"
 file4="/bind4/etc/bind/named.conf.options"
 sed -i "s/dnstap.sock#/dnstap.sock1/" $file1
+sed -i "s/port #/port 9001/" $file1
 sed -i "s/dnstap.sock#/dnstap.sock2/" $file2
+sed -i "s/port #/port 9002/" $file2
 sed -i "s/dnstap.sock#/dnstap.sock3/" $file3
+sed -i "s/port #/port 9003/" $file3
 sed -i "s/dnstap.sock#/dnstap.sock4/" $file4
+sed -i "s/port #/port 9004/" $file4
 
 # Start bind4 instance to keep docker running
 # Will bring up actual bind instances for IT after starting vector

--- a/tests/data/dnstap/named.conf.options.template
+++ b/tests/data/dnstap/named.conf.options.template
@@ -8,6 +8,6 @@ options {
 };
 
 controls {
-        inet 127.0.0.1
+        inet 127.0.0.1 port #
         allow { localhost; };
 };


### PR DESCRIPTION
Signed-off-by: Yunkun Zhu <yzhu@bluecatnetworks.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This enhancement is based on the comment https://github.com/timberio/vector/pull/8302#issuecomment-880894919. It makes sure to do proper cleanup in the end of each IT test case and let IT test cases not dependent on the container.