### PR TITLE
docs: Move highlights up on release page

### DIFF
--- a/docs/layouts/releases/single.html
+++ b/docs/layouts/releases/single.html
@@ -32,6 +32,20 @@
       </div>
       {{ end }}
 
+      {{ with $highlights }}
+      <div class="mt-8">
+        <div class="prose dark:prose-dark">
+          {{ partial "heading.html" (dict "text" "Highlights" "level" 2) }}
+        </div>
+
+        <div class="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {{ range . }}
+          {{ .Render "li" }}
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
       {{ with $release.whats_next }}
       <div class="mt-8 prose dark:prose-dark">
         {{ partial "heading.html" (dict "text" "What's next" "level" 2) }}
@@ -47,20 +61,6 @@
               {{ .description | markdownify }}
             </div>
           </div>
-          {{ end }}
-        </div>
-      </div>
-      {{ end }}
-
-      {{ with $highlights }}
-      <div class="mt-8">
-        <div class="prose dark:prose-dark">
-          {{ partial "heading.html" (dict "text" "Highlights" "level" 2) }}
-        </div>
-
-        <div class="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-          {{ range . }}
-          {{ .Render "li" }}
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
I think these are more important for users to see than what's coming
next for a given release.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
