### PR TITLE
chore(datadog service)!: Rename `datadog_logs` source to `datadog_agent`

### DIFF
--- a/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
+++ b/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
@@ -3,7 +3,7 @@ date: "2021-07-16"
 title: "The `datadog_logs` source has been renamed to `datadog_agent`"
 description: "To make the intention of the `datadog_logs` source clearer it has been renamed to `datadog_agent`"
 authors: ["jszweko"]
-pr_numbers: [TODO]
+pr_numbers: [8350]
 release: "0.16.0"
 hide_on_release_notes: false
 badges:

--- a/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
+++ b/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
@@ -39,3 +39,6 @@ Rename an `datadog_logs` source components in your configuration to `datadog_age
 address = "0.0.0.0:8080"
 store_api_key = true
 ```
+
+[datadog_agent]: https://docs.datadoghq.com/agent/
+[datadog_logs_api]: https://docs.datadoghq.com/api/latest/logs/#send-logs

--- a/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
+++ b/docs/content/en/highlights/2021-07-16-rename-datadog-logs-source.md
@@ -1,0 +1,41 @@
+---
+date: "2021-07-16"
+title: "The `datadog_logs` source has been renamed to `datadog_agent`"
+description: "To make the intention of the `datadog_logs` source clearer it has been renamed to `datadog_agent`"
+authors: ["jszweko"]
+pr_numbers: [TODO]
+release: "0.16.0"
+hide_on_release_notes: false
+badges:
+  type: "breaking"
+  providers: ["datadog"]
+  domains: ["config"]
+---
+
+With the release of Vector 0.16.0, we've renamed the `datadog_logs` source to `datadog_agent`.
+
+The naming of the `datadog_logs` source was somewhat ambiguous as it could be construed to indicate it is compatible
+with the `datadog_logs` sink and that it mimics the [Datadog Logs API][datadog_logs_api]. However, the intention of this
+source is to collect data specifically from running [Datadog Agents][datadog_agent] and this release contains some more
+baked in assumptions that the data is specifically coming from agent.
+
+For now, this source only collects logs forwarded by the agent, but in the future it will be expanded to collect metrics
+and traces.
+
+It is possible that we will re-add a `datadog_logs` source in the future that mimics the Datadog API for use with other
+Datadog clients aside from the agent. Let us know if this would be useful to you!
+
+We decided to make this a breaking change, instead of aliasing `datadog_logs`, as the released changes are not backwords
+compatible and the name change reflects this.
+
+## Upgrade Guide
+
+Rename an `datadog_logs` source components in your configuration to `datadog_agent`:
+
+```diff
+[sources.datadog]
+-type = "datadog_logs"
++type = "datadog_agent"
+address = "0.0.0.0:8080"
+store_api_key = true
+```

--- a/docs/cue/reference/components/sources/datadog_logs.cue
+++ b/docs/cue/reference/components/sources/datadog_logs.cue
@@ -1,15 +1,18 @@
 package metadata
 
-components: sources: datadog_logs: {
+components: sources: datadog_agent: {
 	_port: 8080
 
-	title: "Datadog Logs"
+	title: "Datadog Agent"
 
 	description: """
-		Receives logs from a Datadog Agent over HTTP or HTTPS. To sent logs from a Datadog Agent to this source,
-		the [Datadog Agent](\(urls.datadog_agent_doc)) configuration must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`,
-		`logs_config.use_http` should be set to `true` as this source only supports HTTP/HTTPS and `logs_config.logs_no_ssl`
-		must be set to `true` or `false` in accordance to the source SSL configuration.
+		Receives observability data from a Datadog Agent over HTTP or HTTPS. For now, this is limited to logs, but will
+		be expanded in the future to cover metrics and traces.
+
+		To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
+		must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`, `logs_config.use_http` should be set
+		to `true` as this source only supports HTTP/HTTPS and `logs_config.logs_no_ssl` must be set to `true` or `false`
+		in accordance to the source SSL configuration.
 		"""
 
 	classes: {
@@ -25,7 +28,7 @@ components: sources: datadog_logs: {
 		multiline: enabled: false
 		receive: {
 			from: {
-				service: services.datadog_logs
+				service: services.datadog_agent
 
 				interface: socket: {
 					direction: "incoming"

--- a/docs/cue/reference/examples.cue
+++ b/docs/cue/reference/examples.cue
@@ -1,16 +1,16 @@
 package metadata
 
 #ConfigExample: {
-	title: !=""
+	title:   !=""
 	example: !=""
 }
 
 config_examples: [#ConfigExample, ...#ConfigExample] & [
-	{
+			{
 		title: "Redacted Datadog Agent logs to Datadog"
 		example: #"""
 			[sources.datadog_agent]
-			type = "datadog_logs"
+			type = "datadog_agent"
 			address = "0.0.0.0:80"
 
 			[transforms.remove_sensitive_user_info]
@@ -81,5 +81,5 @@ config_examples: [#ConfigExample, ...#ConfigExample] & [
 			inputs = ["splunk_hec_in"]
 			default_api_key = "${DATADOG_API_KEY}"
 			"""#
-	}
+	},
 ]

--- a/docs/cue/reference/services/datadog_agent.cue
+++ b/docs/cue/reference/services/datadog_agent.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: datadog_agent: {
+	name:     "Datadog Agent"
+	thing:    "a \(name)"
+	url:      urls.datadog_agent
+	versions: null
+
+	description: "The [Datadog agent](\(urls.datadog_agent)) is a daemon that collects eventst and metrics from hosts to forward to Datadog, but can also be sent to Vector."
+}

--- a/docs/cue/reference/urls.cue
+++ b/docs/cue/reference/urls.cue
@@ -109,7 +109,7 @@ urls: {
 	cue:                                                      "https://cuelang.org/"
 	dag:                                                      "\(wikipedia)/wiki/Directed_acyclic_graph"
 	datadog:                                                  "https://www.datadoghq.com"
-	datadog_agent:                                            "https://github.com/DataDog/datadog-agent"
+	datadog_agent:                                            "https://docs.datadoghq.com/agent/"
 	datadog_agent_doc:                                        "\(datadog_docs)/agent/vector_aggregation/"
 	datadog_distribution:                                     "\(datadog_docs)/developers/metrics/types/?tab=distribution#definition"
 	datadog_docs:                                             "https://docs.datadoghq.com"

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -15,7 +15,7 @@ const HELM_VALUES_DDOG_AGG_TOPOLOGY: &str = indoc! {r#"
           targetPort: 8080
     sources:
       datadog-agent:
-        type: datadog_logs
+        type: datadog_agent
         address: 0.0.0.0:8080
 
     sinks:
@@ -147,7 +147,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
 
         // Ensure we got the marker.
         assert_eq!(val["message"], "MARKER");
-        assert_eq!(val["source_type"], "datadog_logs");
+        assert_eq!(val["source_type"], "datadog_agent");
 
         if got_marker {
             // We've already seen one marker! This is not good, we only emitted

--- a/src/sources/datadog/mod.rs
+++ b/src/sources/datadog/mod.rs
@@ -1,1 +1,1 @@
-pub mod logs;
+pub mod agent;


### PR DESCRIPTION
We've decided to make this source specific to the agent as-per
https://github.com/timberio/vector/pull/8297#discussion_r670788059

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
