### PR TITLE
chore(sinks): Rework the ARC test harness to avoid the polling loop

### DIFF
--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use core::task::Context;
 use futures::{
+    channel::oneshot,
     future::{self, BoxFuture},
     stream, FutureExt, SinkExt,
 };
@@ -126,7 +127,7 @@ fn default_concurrency() -> Concurrency {
     Concurrency::Adaptive
 }
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 struct TestConfig {
     request: TowerRequestConfig,
     params: TestParams,
@@ -135,7 +136,7 @@ struct TestConfig {
     // test and retained past the completion of the topology. So, they
     // are created by `Default` and may be cloned to retain a handle.
     #[serde(skip)]
-    stats: Arc<Mutex<Statistics>>,
+    control: Arc<Mutex<TestController>>,
     // Oh, the horror!
     #[serde(skip)]
     controller_stats: Arc<Mutex<Arc<Mutex<ControllerStatistics>>>>,
@@ -191,14 +192,14 @@ impl SinkConfig for TestConfig {
 
 #[derive(Clone, Debug)]
 struct TestSink {
-    stats: Arc<Mutex<Statistics>>,
+    control: Arc<Mutex<TestController>>,
     params: TestParams,
 }
 
 impl TestSink {
     fn new(config: &TestConfig) -> Self {
         Self {
-            stats: Arc::clone(&config.stats),
+            control: Arc::clone(&config.control),
             params: config.params,
         }
     }
@@ -233,7 +234,8 @@ impl Service<Vec<Event>> for TestSink {
 
     fn call(&mut self, _request: Vec<Event>) -> Self::Future {
         let now = Instant::now();
-        let mut stats = self.stats.lock().expect("Poisoned stats lock");
+        let mut control = self.control.lock().expect("Poisoned control lock");
+        let stats = &mut control.stats;
         stats.start_request(now);
         let in_flight = stats.in_flight.level();
         let rate = stats.requests.len();
@@ -246,14 +248,14 @@ impl Service<Vec<Event>> for TestSink {
         match action {
             None => {
                 let delay = self.delay_at(in_flight, rate);
-                respond_after(Ok(Response::Ok), delay, Arc::clone(&self.stats))
+                respond_after(Ok(Response::Ok), delay, Arc::clone(&self.control))
             }
             Some(Action::Defer) => {
                 let delay = self.delay_at(1, 1);
-                respond_after(Err(Error::Deferred), delay, Arc::clone(&self.stats))
+                respond_after(Err(Error::Deferred), delay, Arc::clone(&self.control))
             }
             Some(Action::Drop) => {
-                stats.end_request(now, false);
+                control.end_request(now, false);
                 Box::pin(pending())
             }
         }
@@ -263,12 +265,12 @@ impl Service<Vec<Event>> for TestSink {
 fn respond_after(
     response: Result<Response, Error>,
     delay: f64,
-    stats: Arc<Mutex<Statistics>>,
+    control: Arc<Mutex<TestController>>,
 ) -> BoxFuture<'static, Result<Response, Error>> {
     Box::pin(async move {
         sleep(Duration::from_secs_f64(delay)).await;
-        let mut stats = stats.lock().expect("Poisoned stats lock");
-        stats.end_request(Instant::now(), matches!(response, Ok(Response::Ok)));
+        let mut control = control.lock().expect("Poisoned control lock");
+        control.end_request(Instant::now(), matches!(response, Ok(Response::Ok)));
         response
     })
 }
@@ -296,6 +298,13 @@ impl RetryLogic for TestRetryLogic {
     }
 }
 
+#[derive(Debug)]
+struct TestController {
+    todo: usize,
+    send_done: Option<oneshot::Sender<()>>,
+    stats: Statistics,
+}
+
 #[derive(Default)]
 struct Statistics {
     completed: usize,
@@ -306,12 +315,31 @@ struct Statistics {
 
 impl fmt::Debug for Statistics {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt.debug_struct("Statistics")
+        fmt.debug_struct("SharedData")
             .field("completed", &self.completed)
             .field("in_flight", &self.in_flight)
             .field("rate", &self.rate.stats())
             .field("requests", &self.requests.len())
             .finish()
+    }
+}
+
+impl TestController {
+    fn new(todo: usize, send_done: oneshot::Sender<()>) -> Self {
+        Self {
+            todo,
+            send_done: Some(send_done),
+            stats: Default::default(),
+        }
+    }
+
+    fn end_request(&mut self, now: Instant, completed: bool) {
+        self.stats.end_request(now, completed);
+        if self.stats.completed >= self.todo {
+            if let Some(done) = self.send_done.take() {
+                done.send(()).expect("Could not send done signal");
+            }
+        }
     }
 }
 
@@ -357,6 +385,7 @@ struct TestResults {
 
 async fn run_test(params: TestParams) -> TestResults {
     let _ = metrics::init();
+    let (send_done, is_done) = oneshot::channel();
 
     let test_config = TestConfig {
         request: TowerRequestConfig {
@@ -366,10 +395,11 @@ async fn run_test(params: TestParams) -> TestResults {
             ..Default::default()
         },
         params,
-        ..Default::default()
+        control: Arc::new(Mutex::new(TestController::new(params.requests, send_done))),
+        controller_stats: Default::default(),
     };
 
-    let stats = Arc::clone(&test_config.stats);
+    let control = Arc::clone(&test_config.control);
     let cstats = Arc::clone(&test_config.controller_stats);
 
     let mut config = config::Config::builder();
@@ -382,17 +412,14 @@ async fn run_test(params: TestParams) -> TestResults {
 
     let controller = get_controller().unwrap();
 
-    // This is crude and dumb, but it works, and the tests run fast and
-    // the results are highly repeatable.
-    while stats.lock().expect("Poisoned stats lock").completed < params.requests {
-        time::sleep(Duration::from_millis(1)).await;
-    }
+    is_done.await.expect("Test failed to complete");
     topology.stop().await;
 
-    let stats = Arc::try_unwrap(stats)
-        .expect("Failed to unwrap stats Arc")
+    let control = Arc::try_unwrap(control)
+        .expect("Failed to unwrap control Arc")
         .into_inner()
-        .expect("Failed to unwrap stats Mutex");
+        .expect("Failed to unwrap control Mutex");
+    let stats = control.stats;
 
     let cstats = Arc::try_unwrap(cstats)
         .expect("Failed to unwrap controller_stats Arc")


### PR DESCRIPTION
This was part of my work on the ARC testing for #8325 but I decided to break it out for separate review.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>