### PR TITLE
chore: update to latest version of metrics-tracing-context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8166fbddef141acbea89cf3425ed97d4c22d14a68161977fc01c301175a4fb89"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,13 +3983,15 @@ dependencies = [
 
 [[package]]
 name = "metrics-tracing-context"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45770271d3b4f04a4b38b593e187d04d41f312694fff10ce1d60c356a082cc50"
+checksum = "5ae4119c3866149edb3289413cdec4728420a0245f318457ec85029172c81d8b"
 dependencies = [
  "itoa",
+ "lockfree-object-pool",
  "metrics",
  "metrics-util",
+ "once_cell",
  "tracing 0.1.26",
  "tracing-core 0.1.18",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ opentelemetry-datadog = { version = "0.3.1", default-features = false, features 
 
 # Metrics
 metrics = { version = "0.17.0", default-features = false, features = ["std"] }
-metrics-tracing-context = { version = "0.7.0", default-features = false }
+metrics-tracing-context = { version = "0.8.0", default-features = false }
 metrics-util = { version = "0.10.0", default-features = false, features = ["std"] }
 
 # Aws

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "1.7.0", default-features = false, features = ["serde"] }
 lazy_static = { version = "1.4.0", default-features = false }
 lookup = { path = "../lookup", features = ["arbitrary"] }
 metrics = { version = "0.17.0", default-features = false, features = ["std"]}
-metrics-tracing-context = { version = "0.7.0", default-features = false }
+metrics-tracing-context = { version = "0.8.0", default-features = false }
 metrics-util = { version = "0.10.0", default-features = false, features = ["std"] }
 once_cell = { version = "1.8", default-features = false }
 pest = { version = "2.1.3", default-features = false }


### PR DESCRIPTION
Updates to `metrics-tracing-context@v0.8.0` which contains significant performance improvements, specifically with components that emit metrics on a per-event basis.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>