### PR TITLE
enhancement(internal_metrics source): Add pid as tag

### DIFF
--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -149,6 +149,9 @@ impl_valuekind_from_integer!(i64);
 impl_valuekind_from_integer!(i32);
 impl_valuekind_from_integer!(i16);
 impl_valuekind_from_integer!(i8);
+impl_valuekind_from_integer!(u32);
+impl_valuekind_from_integer!(u16);
+impl_valuekind_from_integer!(u8);
 impl_valuekind_from_integer!(isize);
 
 impl From<bool> for Value {

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, SourceConfig, SourceContext, SourceDescription},
+    config::{log_schema, DataType, SourceConfig, SourceContext, SourceDescription},
     metrics::Controller,
     metrics::{capture_metrics, get_controller},
     shutdown::ShutdownSignal,
@@ -68,8 +68,9 @@ async fn run(
 
         out.send_all(&mut stream::iter(metrics.map(|mut metric| {
             if let Ok(hostname) = &hostname {
-                metric.insert_tag("host".into(), hostname.into());
+                metric.insert_tag(log_schema().host_key().to_owned(), hostname.to_owned());
             }
+            metric.insert_tag(String::from("pid"), std::process::id().to_string());
             Ok(metric.into())
         })))
         .await?;

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -66,13 +66,13 @@ async fn run(
 
         let metrics = capture_metrics(controller);
 
-        out.send_all(&mut stream::iter(metrics.map(|mut metric| {
+        out.send_all(&mut stream::iter(metrics).map(|mut metric| {
             if let Ok(hostname) = &hostname {
                 metric.insert_tag(log_schema().host_key().to_owned(), hostname.to_owned());
             }
             metric.insert_tag(String::from("pid"), std::process::id().to_string());
             Ok(metric.into())
-        })))
+        }))
         .await?;
     }
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -63,6 +63,7 @@ async fn run(
     let mut interval = IntervalStream::new(time::interval(interval)).take_until(shutdown);
     while interval.next().await.is_some() {
         let hostname = crate::get_hostname();
+        let pid = std::process::id().to_string();
 
         let metrics = capture_metrics(controller);
 
@@ -70,7 +71,7 @@ async fn run(
             if let Ok(hostname) = &hostname {
                 metric.insert_tag(log_schema().host_key().to_owned(), hostname.to_owned());
             }
-            metric.insert_tag(String::from("pid"), std::process::id().to_string());
+            metric.insert_tag(String::from("pid"), std::process::id().clone());
             Ok(metric.into())
         }))
         .await?;

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -71,7 +71,7 @@ async fn run(
             if let Ok(hostname) = &hostname {
                 metric.insert_tag(log_schema().host_key().to_owned(), hostname.to_owned());
             }
-            metric.insert_tag(String::from("pid"), std::process::id().clone());
+            metric.insert_tag(String::from("pid"), pid.clone());
             Ok(metric.into())
         }))
         .await?;


### PR DESCRIPTION
I realized today that `host` may not be enough to differentiate two vectors running on the same host so I added the process id too.