### PR TITLE
enhancement(external docs): Add color scheme for highlights

### DIFF
--- a/docs/layouts/highlights/li.html
+++ b/docs/layouts/highlights/li.html
@@ -1,62 +1,70 @@
 {{ $title := .Title | markdownify }}
 {{ $date := .Date | dateFormat "January 2, 2006" }}
 {{ $badges := .Params.badges }}
+{{ $colors := dict "deprecation" "red" "enhancement" "green" "new feature" "blue"
+  "breaking change" "yellow" "featured" "violet" "performance" "orange"
+  "announcement" "fuchsia" }}
+{{ $type := $badges.type | default "enhancement" }}
+{{ $color := index $colors $type }}
 <div>
   <a href="{{ .RelPermalink }}">
-    <div class="flex flex-col justify-between p-6 border rounded-md shadow dark:border-gray-700 hover:border-secondary dark:hover:border-primary">
-      <span class="text-lg leading-tight font-semibold tracking-tight text-dark dark:text-gray-300">
-        {{ $title }}
-      </span>
+    <div class="border-t-6 border-{{ $color }}-500 bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-900 rounded-md shadow">
+      <div class="flex flex-col justify-between p-6">
+        <span class="text-lg leading-tight font-semibold tracking-tight text-dark dark:text-gray-300">
+          {{ $title }}
+        </span>
 
-      <p class="mt-3 mb-4 text-sm text-dark dark:text-gray-200 font-light">
-        <time datetime="{{ $date }}">
-          {{ $date }}
-        </time>
-      </p>
+        <p class="mt-3 mb-4 text-sm text-dark dark:text-gray-200 font-light">
+          <time datetime="{{ $date }}">
+            {{ $date }}
+          </time>
+        </p>
 
-      <div class="my-4 flex items-center">
-        <div class="flex-shrink-0">
-          <div class="flex space-x-1 relative z-0 overflow-hidden">
+        <div class="my-4 flex items-center">
+          <div class="flex-shrink-0">
+            <div class="flex space-x-1 relative z-0 overflow-hidden">
+              {{ range .Params.authors }}
+              {{ $img := printf "https://github.com/%s.png" . }}
+              {{ $name := (index (where site.Data.docs.authors ".handle" "eq" .) 0).name }}
+              <img class="relative z-30 inline-block h-8 w-8 rounded-full ring-1 ring-white dark:ring-dark" src="{{ $img }}" alt="Author photo for {{ $name }}">
+              {{ end }}
+            </div>
+          </div>
+
+
+          <div class="ml-4 flex flex-col space-y-1">
             {{ range .Params.authors }}
-            {{ $img := printf "https://github.com/%s.png" . }}
             {{ $name := (index (where site.Data.docs.authors ".handle" "eq" .) 0).name }}
-            <img class="relative z-30 inline-block h-8 w-8 rounded-full ring-1 ring-white dark:ring-dark" src="{{ $img }}" alt="Author photo for {{ $name }}">
+            {{ $link := printf "https://github.com/%s" . }}
+            <a href="{{ $link }}" class="text-md font-bold tracking-tight text-gray-700 hover:text-secondary dark:text-gray-200 dark:hover:text-primary" target="_blank">
+              {{ $name }}
+            </a>
             {{ end }}
           </div>
         </div>
 
+        <div class="block space-y-1.5">
+          {{ with $badges.type }}
+          {{ $color := cond (eq . "deprecation") "red" "blue" }}
+          {{ partial "badge.html" (dict "prefix" "type" "word" . "color" $color "inline" true) }}
+          {{ end }}
 
-        <div class="ml-4 flex flex-col space-y-1">
-          {{ range .Params.authors }}
-          {{ $name := (index (where site.Data.docs.authors ".handle" "eq" .) 0).name }}
-          {{ $link := printf "https://github.com/%s" . }}
-          <a href="{{ $link }}" class="text-md font-bold tracking-tight text-gray-700 hover:text-secondary dark:text-gray-200 dark:hover:text-primary" target="_blank">
-            {{ $name }}
-          </a>
+          {{ range $badges.domains }}
+          {{ partial "badge.html" (dict "prefix" "domain" "word" . "color" "indigo" "inline" true) }}
+          {{ end }}
+
+          {{ range $badges.sources }}
+          {{ partial "badge.html" (dict "prefix" "source" "word" . "color" "violet" "inline" true) }}
+          {{ end }}
+
+          {{ range $badges.transforms }}
+          {{ partial "badge.html" (dict "prefix" "transform" "word" . "color" "violet" "inline" true) }}
+          {{ end }}
+
+          {{ range $badges.sinks }}
+          {{ partial "badge.html" (dict "prefix" "sink" "word" . "color" "violet" "inline" true) }}
           {{ end }}
         </div>
-      </div>
-
-      <div class="block space-y-1.5">
-        {{ with $badges.type }}
-        {{ partial "badge.html" (dict "prefix" "type" "word" . "color" "blue" "inline" true) }}
-        {{ end }}
-
-        {{ range $badges.domains }}
-        {{ partial "badge.html" (dict "prefix" "domain" "word" . "color" "indigo" "inline" true) }}
-        {{ end }}
-
-        {{ range $badges.sources }}
-        {{ partial "badge.html" (dict "prefix" "source" "word" . "color" "violet" "inline" true) }}
-        {{ end }}
-
-        {{ range $badges.transforms }}
-        {{ partial "badge.html" (dict "prefix" "transform" "word" . "color" "violet" "inline" true) }}
-        {{ end }}
-
-        {{ range $badges.sinks }}
-        {{ partial "badge.html" (dict "prefix" "sink" "word" . "color" "violet" "inline" true) }}
-        {{ end }}
       </div>
     </div>
   </a>

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -264,6 +264,7 @@ module.exports = {
       '2.5': '2.5px',
       3: '3px',
       4: '4px',
+      6: '6px',
       8: '8px',
     },
     boxShadow: {


### PR DESCRIPTION
This PR adds a highlight color scheme for, well, highlights 😄 The scheme in this PR is totally provisional and I'm open to suggestion on which highlight types correspond to which colors.

You can see the scheme on display here:

https://deploy-preview-8394--vector-project.netlify.app/highlights/