### PR TITLE
chore: Teach `Event` what its size is

### DIFF
--- a/lib/vector-core/src/byte_size_of.rs
+++ b/lib/vector-core/src/byte_size_of.rs
@@ -1,0 +1,70 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    mem,
+};
+
+pub trait ByteSizeOf {
+    /// Returns the in-memory size of this type
+    ///
+    /// This function returns the total number of bytes that
+    /// [`std::mem::size_of`] does in addition to any interior allocated
+    /// bytes. It default implementation is `std::mem::size_of` +
+    /// `ByteSizeOf::allocated_bytes`.
+    fn size_of(&self) -> usize {
+        mem::size_of_val(self) + self.allocated_bytes()
+    }
+
+    /// Returns the allocated bytes of this type
+    ///
+    /// This function returns the total number of bytes that have been allocated
+    /// interior to this type instance. It does not include any bytes that are
+    /// captured by [`std::mem::size_of`] except for any bytes that are iterior
+    /// to this type. For instance, `BTreeMap<String, Vec<u8>>` would count all
+    /// bytes for `String` and `Vec<u8>` instances but not the exterior bytes
+    /// for `BTreeMap`.
+    fn allocated_bytes(&self) -> usize;
+}
+
+impl ByteSizeOf for String {
+    fn allocated_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<K, V> ByteSizeOf for BTreeMap<K, V>
+where
+    K: ByteSizeOf,
+    V: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.iter()
+            .fold(0, |acc, (k, v)| acc + k.size_of() + v.size_of())
+    }
+}
+
+impl<T> ByteSizeOf for BTreeSet<T>
+where
+    T: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.iter().fold(0, |acc, v| acc + v.size_of())
+    }
+}
+
+impl<T> ByteSizeOf for Vec<T>
+where
+    T: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.iter().fold(0, |acc, v| acc + v.size_of())
+    }
+}
+
+impl<T> ByteSizeOf for Option<T>
+where
+    T: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.as_ref().map_or(0, |x| x.allocated_bytes())
+    }
+}

--- a/lib/vector-core/src/event/finalization.rs
+++ b/lib/vector-core/src/event/finalization.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 
+use crate::ByteSizeOf;
 use atomig::{Atom, Atomic, Ordering};
 use futures::future::FutureExt;
 use serde::{Deserialize, Serialize};
@@ -35,6 +36,12 @@ impl PartialOrd for EventFinalizers {
         // `Arc`s. Therefore, partial ordering of `EventFinalizers` is defined
         // only on the length of the finalizers.
         self.0.len().partial_cmp(&other.0.len())
+    }
+}
+
+impl ByteSizeOf for EventFinalizers {
+    fn allocated_bytes(&self) -> usize {
+        self.0.iter().fold(0, |acc, arc| acc + arc.size_of())
     }
 }
 
@@ -110,6 +117,12 @@ impl EventFinalizers {
 pub struct EventFinalizer {
     status: Atomic<EventStatus>,
     batch: Arc<BatchNotifier>,
+}
+
+impl ByteSizeOf for EventFinalizer {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
 }
 
 impl EventFinalizer {

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -4,7 +4,7 @@ use super::{
     metadata::EventMetadata,
     util, Lookup, PathComponent, Value,
 };
-use crate::config::log_schema;
+use crate::{config::log_schema, ByteSizeOf};
 use bytes::Bytes;
 use chrono::Utc;
 use derivative::Derivative;
@@ -37,6 +37,12 @@ impl Default for LogEvent {
             fields: Value::Map(BTreeMap::new()),
             metadata: EventMetadata::default(),
         }
+    }
+}
+
+impl ByteSizeOf for LogEvent {
+    fn allocated_bytes(&self) -> usize {
+        self.fields.allocated_bytes() + self.metadata.allocated_bytes()
     }
 }
 

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 
 use super::{BatchNotifier, EventFinalizer, EventFinalizers, EventStatus};
+use crate::ByteSizeOf;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 use shared::EventDataEq;
@@ -18,6 +19,15 @@ pub struct EventMetadata {
     datadog_api_key: Option<Arc<str>>,
     #[serde(default, skip)]
     finalizers: EventFinalizers,
+}
+
+impl ByteSizeOf for EventMetadata {
+    fn allocated_bytes(&self) -> usize {
+        // NOTE we don't count the `str` here because it's allocated somewhere
+        // else. We're just moving around the pointer, which is already captured
+        // by `ByteSizeOf::size_of`.
+        self.finalizers.allocated_bytes()
+    }
 }
 
 impl EventMetadata {

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1,5 +1,6 @@
 use super::{BatchNotifier, EventFinalizer, EventMetadata};
 use crate::metrics::Handle;
+use crate::ByteSizeOf;
 use chrono::{DateTime, Utc};
 use getset::{Getters, MutGetters};
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,14 @@ pub struct Metric {
     metadata: EventMetadata,
 }
 
+impl ByteSizeOf for Metric {
+    fn allocated_bytes(&self) -> usize {
+        self.series.allocated_bytes()
+            + self.data.allocated_bytes()
+            + self.metadata.allocated_bytes()
+    }
+}
+
 impl AsRef<MetricData> for Metric {
     fn as_ref(&self) -> &MetricData {
         &self.data
@@ -50,11 +59,23 @@ pub struct MetricSeries {
 
 pub type MetricTags = BTreeMap<String, String>;
 
+impl ByteSizeOf for MetricSeries {
+    fn allocated_bytes(&self) -> usize {
+        self.name.allocated_bytes() + self.tags.allocated_bytes()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize)]
 pub struct MetricName {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+}
+
+impl ByteSizeOf for MetricName {
+    fn allocated_bytes(&self) -> usize {
+        self.name.allocated_bytes() + self.namespace.allocated_bytes()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
@@ -66,6 +87,12 @@ pub struct MetricData {
 
     #[serde(flatten)]
     pub value: MetricValue,
+}
+
+impl ByteSizeOf for MetricData {
+    fn allocated_bytes(&self) -> usize {
+        self.value.allocated_bytes()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize)]
@@ -141,12 +168,30 @@ pub enum MetricValue {
     },
 }
 
+impl ByteSizeOf for MetricValue {
+    fn allocated_bytes(&self) -> usize {
+        match self {
+            Self::Counter { .. } | Self::Gauge { .. } => 0,
+            Self::Set { values } => values.allocated_bytes(),
+            Self::Distribution { samples, .. } => samples.allocated_bytes(),
+            Self::AggregatedHistogram { buckets, .. } => buckets.allocated_bytes(),
+            Self::AggregatedSummary { quantiles, .. } => quantiles.allocated_bytes(),
+        }
+    }
+}
+
 /// A single sample from a `MetricValue::Distribution`, containing the
 /// sampled value paired with the rate at which it was observed.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct Sample {
     pub value: f64,
     pub rate: u32,
+}
+
+impl ByteSizeOf for Sample {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
 }
 
 /// A single value from a `MetricValue::AggregatedHistogram`. The value
@@ -159,11 +204,23 @@ pub struct Bucket {
     pub count: u32,
 }
 
+impl ByteSizeOf for Bucket {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
+}
+
 /// A single value from a `MetricValue::AggregatedSummary`.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct Quantile {
     pub upper_limit: f64,
     pub value: f64,
+}
+
+impl ByteSizeOf for Quantile {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
 }
 
 // Constructor helper macros

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -1,3 +1,4 @@
+use crate::ByteSizeOf;
 use buffers::bytes::{DecodeBytes, EncodeBytes};
 use bytes::{Buf, BufMut, Bytes};
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -45,6 +46,15 @@ pub const PARTIAL: &str = "_partial";
 pub enum Event {
     Log(LogEvent),
     Metric(Metric),
+}
+
+impl ByteSizeOf for Event {
+    fn allocated_bytes(&self) -> usize {
+        match self {
+            Event::Log(log_event) => log_event.allocated_bytes(),
+            Event::Metric(metric_event) => metric_event.allocated_bytes(),
+        }
+    }
 }
 
 impl Event {

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -8,6 +8,7 @@ use quickcheck::{empty_shrinker, Arbitrary, Gen};
 use std::collections::{BTreeMap, BTreeSet};
 
 const MAX_F64_SIZE: f64 = 1_000_000.0;
+const MAX_ARRAY_SIZE: usize = 4;
 const MAX_MAP_SIZE: usize = 4;
 const MAX_STR_SIZE: usize = 16;
 const ALPHABET: [&str; 27] = [
@@ -16,7 +17,7 @@ const ALPHABET: [&str; 27] = [
 ];
 
 #[derive(Debug, Clone)]
-struct Name {
+pub struct Name {
     inner: String,
 }
 
@@ -554,7 +555,10 @@ impl Arbitrary for Value {
                 let mut gen = Gen::new(MAX_MAP_SIZE);
                 Value::Map(BTreeMap::arbitrary(&mut gen))
             }
-            6 => Value::Array(Vec::arbitrary(g)),
+            6 => {
+                let mut gen = Gen::new(MAX_ARRAY_SIZE);
+                Value::Array(Vec::arbitrary(&mut gen))
+            }
             7 => Value::Null,
             _ => unreachable!(),
         }

--- a/lib/vector-core/src/event/test/mod.rs
+++ b/lib/vector-core/src/event/test/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 mod serialization;
+mod size_of;
 
 use super::*;
 use std::collections::HashSet;

--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -1,0 +1,140 @@
+use super::*;
+use crate::event::test::common::Name;
+use crate::ByteSizeOf;
+use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
+use std::mem;
+
+#[test]
+fn at_least_wrapper_size() {
+    // The byte size of an `Event` should always be at least as big as the
+    // mem::size_of of the `Event`.
+    fn inner(event: Event) -> TestResult {
+        let baseline = mem::size_of::<Event>();
+        assert!(baseline <= event.size_of());
+        TestResult::passed()
+    }
+
+    QuickCheck::new()
+        .tests(1_000)
+        .max_tests(10_000)
+        .quickcheck(inner as fn(Event) -> TestResult);
+}
+
+#[test]
+fn exactly_equal_if_no_allocated_bytes() {
+    // The byte size of an `Event` should always be exactly equal to its
+    // `mem::size_of` if there are no reported allocated bytes.
+    fn inner(event: Event) -> TestResult {
+        let allocated_sz = event.allocated_bytes();
+        if allocated_sz == 0 {
+            let baseline = mem::size_of::<Event>();
+            assert_eq!(baseline, event.size_of());
+            return TestResult::passed();
+        }
+        TestResult::discard()
+    }
+
+    QuickCheck::new()
+        .tests(1_000)
+        .max_tests(10_000)
+        .quickcheck(inner as fn(Event) -> TestResult);
+}
+
+#[test]
+fn size_greater_than_allocated_size() {
+    // The total byte size of an `Event` should always be strictly greater than
+    // the allocated bytes of the `Event`.
+    fn inner(event: Event) -> TestResult {
+        let total_sz = event.size_of();
+        let allocated_sz = event.allocated_bytes();
+
+        assert!(total_sz > allocated_sz);
+        TestResult::passed()
+    }
+
+    QuickCheck::new()
+        .tests(1_000)
+        .max_tests(10_000)
+        .quickcheck(inner as fn(Event) -> TestResult);
+}
+
+//
+// Log Events
+//
+
+/// The action that our model interpreter loop will take.
+#[derive(Debug, Clone)]
+pub enum Action {
+    Contains {
+        key: String,
+    },
+    SizeOf,
+    /// Insert a key/value pair into the [`LogEvent`]
+    InsertFlat {
+        key: String,
+        value: Value,
+    },
+    Remove {
+        key: String,
+    },
+}
+
+impl Arbitrary for Action {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match u8::arbitrary(g) % 3 {
+            0 => Action::InsertFlat {
+                key: String::from(Name::arbitrary(g)),
+                value: Value::arbitrary(g),
+            },
+            1 => Action::SizeOf,
+            2 => Action::Contains {
+                key: String::from(Name::arbitrary(g)),
+            },
+            3 => Action::Remove {
+                key: String::from(Name::arbitrary(g)),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn log_operation_maintains_size() {
+    // Asserts that the stated size of a LogEvent only changes by the amount
+    // that we insert / remove from it and that read-only operations do not
+    // change the size.
+    fn inner(actions: Vec<Action>, mut log_event: LogEvent) -> TestResult {
+        let mut current_size = log_event.size_of();
+
+        for action in actions {
+            match action {
+                Action::InsertFlat { key, value } => {
+                    let new_value_sz = value.size_of();
+                    let old_value_sz = log_event.get_flat(&key).map(|x| x.size_of()).unwrap_or(0);
+                    log_event.insert_flat(&key, value);
+                    current_size += key.len();
+                    current_size -= old_value_sz;
+                    current_size += new_value_sz;
+                }
+                Action::SizeOf => {
+                    assert_eq!(current_size, log_event.size_of())
+                }
+                Action::Contains { key } => {
+                    log_event.contains(key);
+                }
+                Action::Remove { key } => {
+                    let value_sz = log_event.remove(&key).size_of();
+                    current_size -= value_sz;
+                    current_size -= key.size_of();
+                }
+            }
+        }
+
+        TestResult::passed()
+    }
+
+    QuickCheck::new()
+        .tests(1_000)
+        .max_tests(10_000)
+        .quickcheck(inner as fn(Vec<Action>, LogEvent) -> TestResult);
+}

--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -8,6 +8,7 @@ use std::mem;
 fn at_least_wrapper_size() {
     // The byte size of an `Event` should always be at least as big as the
     // mem::size_of of the `Event`.
+    #[allow(clippy::needless_pass_by_value)]
     fn inner(event: Event) -> TestResult {
         let baseline = mem::size_of::<Event>();
         assert!(baseline <= event.size_of());
@@ -24,6 +25,7 @@ fn at_least_wrapper_size() {
 fn exactly_equal_if_no_allocated_bytes() {
     // The byte size of an `Event` should always be exactly equal to its
     // `mem::size_of` if there are no reported allocated bytes.
+    #[allow(clippy::needless_pass_by_value)]
     fn inner(event: Event) -> TestResult {
         let allocated_sz = event.allocated_bytes();
         if allocated_sz == 0 {
@@ -44,6 +46,7 @@ fn exactly_equal_if_no_allocated_bytes() {
 fn size_greater_than_allocated_size() {
     // The total byte size of an `Event` should always be strictly greater than
     // the allocated bytes of the `Event`.
+    #[allow(clippy::needless_pass_by_value)]
     fn inner(event: Event) -> TestResult {
         let total_sz = event.size_of();
         let allocated_sz = event.allocated_bytes();
@@ -110,7 +113,7 @@ fn log_operation_maintains_size() {
             match action {
                 Action::InsertFlat { key, value } => {
                     let new_value_sz = value.size_of();
-                    let old_value_sz = log_event.get_flat(&key).map(|x| x.size_of()).unwrap_or(0);
+                    let old_value_sz = log_event.get_flat(&key).map_or(0, |x| x.size_of());
                     log_event.insert_flat(&key, value);
                     current_size += key.len();
                     current_size -= old_value_sz;

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -1,3 +1,4 @@
+use crate::ByteSizeOf;
 use crate::{event::error::EventError, event::timestamp_to_string, Result};
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
@@ -19,6 +20,19 @@ pub enum Value {
     Map(BTreeMap<String, Value>),
     Array(Vec<Value>),
     Null,
+}
+
+impl ByteSizeOf for Value {
+    fn allocated_bytes(&self) -> usize {
+        match self {
+            Value::Bytes(bytes) => bytes.len(),
+            Value::Map(map) => map
+                .iter()
+                .fold(0, |acc, (k, v)| acc + k.len() + v.size_of()),
+            Value::Array(arr) => arr.iter().fold(0, |acc, v| acc + v.size_of()),
+            _ => 0,
+        }
+    }
 }
 
 impl Serialize for Value {

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -33,6 +33,9 @@ pub mod source;
 mod test_util;
 pub mod transform;
 pub use buffers;
+mod byte_size_of;
+
+pub use byte_size_of::ByteSizeOf;
 
 #[macro_use]
 extern crate derivative;


### PR DESCRIPTION
This commit introduces the `ByteSizeOf` trait into vector-core and implements
this for the `Event` type, focused specifically on the `LogEvent` side of that
structure in testing. This allows us to determine how big `Event` is in memory
without necessarily serializing it. The current implementation for `Event`
trawls through any collections to get the size of the structure but there's no
reason if we need constant time access why this can't be a continually
maintained value.

This has bearing on issue #8263, both in the recognition that the blackhole sink
is slow because of serialization to get byte size and in a similar constraint on
the datadog logs sink for similar reasons. 

Resolves #8272

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
