### PR TITLE
enhancement(vector source, vector sink): prepare for v2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
  "criterion-plot",
  "csv",
  "futures 0.3.16",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1464,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.1",
+ "itertools",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 name = "datadog-search-syntax"
 version = "0.1.0"
 dependencies = [
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "ordered-float",
  "pest",
@@ -3003,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -3147,6 +3147,18 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3344,15 +3356,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -3496,7 +3499,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.10.1",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -4451,6 +4454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.0.0-alpha1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd43cd1e53168596e629accc602ada1297f5125fed588d62cf8be81175b46002"
+dependencies = [
+ "memchr",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,7 +4768,7 @@ dependencies = [
  "async-trait",
  "http",
  "indexmap",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-http",
@@ -5154,7 +5167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e46ca79eb4e21e2ec14430340c71250ab69332abf85521c95d3a8bc336aa76"
 dependencies = [
  "difflib",
- "itertools 0.10.1",
+ "itertools",
  "predicates-core",
 ]
 
@@ -5332,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
  "prost-derive",
@@ -5342,13 +5355,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -5360,12 +5373,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn 1.0.72",
@@ -5373,9 +5386,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
  "prost",
@@ -5383,9 +5396,9 @@ dependencies = [
 
 [[package]]
 name = "pulsar"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b4422e82143ae595af7a6bb99cd64dcbc8d3dc5c386c61d543e46b4a0ec1ca"
+checksum = "647e253f7d1b1eedd9542951388f38099b92d2814ac37013976dea7d71d01959"
 dependencies = [
  "bit-vec 0.6.3",
  "bytes 1.0.1",
@@ -5396,7 +5409,7 @@ dependencies = [
  "futures-timer",
  "log",
  "native-tls",
- "nom 6.1.2",
+ "nom 7.0.0-alpha1",
  "pem",
  "prost",
  "prost-build",
@@ -7488,6 +7501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7620,9 +7643,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7634,6 +7657,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.8",
  "prost",
@@ -7643,6 +7667,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing 0.1.26",
  "tracing-futures 0.2.5",
@@ -7650,9 +7675,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
 dependencies = [
  "proc-macro2 1.0.26",
  "prost-build",
@@ -8289,7 +8314,7 @@ dependencies = [
  "indoc",
  "infer",
  "inventory",
- "itertools 0.10.1",
+ "itertools",
  "k8s-openapi",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,8 +165,8 @@ rmp-serde = { version = "0.15.5", default-features = false, optional = true }
 rmpv = { version = "0.4.7", default-features = false, features = ["with-serde"], optional = true }
 
 # Prost
-prost = { version = "0.7.0", default-features = false, features = ["std"]  }
-prost-types = { version = "0.7.0", default-features = false }
+prost = { version = "0.8", default-features = false, features = ["std"]  }
+prost-types = { version = "0.8", default-features = false }
 
 # GCP
 goauth = { version = "0.10.0", default-features = false, optional = true }
@@ -250,7 +250,7 @@ pest = { version = "2.1.3", default-features = false }
 pest_derive = { version = "2.1.0", default-features = false }
 pin-project = { version = "1.0.8", default-features = false }
 postgres-openssl = { version = "0.5.0", default-features = false, features = ["runtime"], optional = true }
-pulsar = { version = "3.0.1", default-features = false, features = ["tokio-runtime"], optional = true }
+pulsar = { version = "4.0", default-features = false, features = ["tokio-runtime"], optional = true }
 rand = { version = "0.8.4", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4.1", default-features = false }
 rdkafka = { version = "0.26.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
@@ -275,7 +275,7 @@ uuid = { version = "0.8.2", default-features = false, features = ["serde", "v4"]
 warp = { version = "0.3.1", default-features = false, optional = true }
 zstd = { version = "0.6", default-features = false }
 cfg-if = { version = "1.0.0", default-features = false }
-tonic = { version = "0.4", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls"] }
+tonic = { version = "0.5", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls"] }
 data-encoding = { version = "2.2", default-features = false, features = ["std"], optional = true }
 trust-dns-proto = { version = "0.20", features = ["dnssec"], optional = true }
 
@@ -298,8 +298,8 @@ atty = "0.2.14"
 nix = "0.22.0"
 
 [build-dependencies]
-prost-build = { version = "0.7.0", optional = true }
-tonic-build = { version = "0.4", default-features = false, features = ["transport", "prost"], optional = true }
+prost-build = { version = "0.8", optional = true }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.0"

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -12,10 +12,10 @@ license = "MPL-2.0"
 indexmap = "1.7.0"
 nom = "6.0.1"
 num_enum = "0.5.3"
-prost = "0.7.0"
-prost-types = "0.7.0"
+prost = "0.8"
+prost-types = "0.8"
 shared = { path = "../shared", features = ["btreemap"] }
 snafu = { version = "0.6" }
 
 [build-dependencies]
-prost-build = "0.7.0"
+prost-build = "0.8"

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -31,8 +31,8 @@ once_cell = { version = "1.8", default-features = false }
 pest = { version = "2.1.3", default-features = false }
 pest_derive = { version = "2.1.0", default-features = false }
 pin-project = { version = "1.0.8", default-features = false }
-prost = { version = "0.7.0", default-features = false }
-prost-types = { version = "0.7.0", default-features = false }
+prost = { version = "0.8", default-features = false }
+prost-types = { version = "0.8", default-features = false }
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.66", default-features = false }
@@ -50,7 +50,7 @@ twox-hash = { version = "1.6.1", default-features = false }
 vrl-core = { package = "vrl", path = "../vrl/core", optional = true }
 
 [build-dependencies]
-prost-build = "0.7.0"
+prost-build = "0.8"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -87,7 +87,7 @@ pub struct TcpSocketError {
 
 impl InternalEvent for TcpSocketError {
     fn emit_logs(&self) {
-        debug!(message = "TCP socket error.", error = %self.error);
+        warn!(message = "TCP socket error.", error = %self.error);
     }
 
     fn emit_metrics(&self) {

--- a/src/sinks/vector/v2.rs
+++ b/src/sinks/vector/v2.rs
@@ -80,7 +80,7 @@ fn new_client(
     let mut http = HttpConnector::new();
     http.enforce_http(false);
 
-    let tls = tls_connector_builder(&tls_settings)?;
+    let tls = tls_connector_builder(tls_settings)?;
     let mut https = HttpsConnector::with_connector(http, tls)?;
 
     let settings = tls_settings.tls().cloned();

--- a/src/sinks/vector/v2.rs
+++ b/src/sinks/vector/v2.rs
@@ -7,24 +7,22 @@ use crate::{
         EncodedLength, ServiceBuilderExt, TowerRequestConfig, VecBuffer,
     },
     sinks::{Healthcheck, VectorSink},
+    tls::{tls_connector_builder, MaybeTlsSettings, TlsConfig},
 };
 use futures::{future::BoxFuture, stream, SinkExt, StreamExt, TryFutureExt};
 use http::uri::Uri;
+use hyper::client::HttpConnector;
+use hyper_openssl::HttpsConnector;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-use std::path::PathBuf;
 use std::task::{Context, Poll};
-use tonic::{
-    transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity},
-    IntoRequest,
-};
+use tonic::{body::BoxBody, IntoRequest};
 use tower::ServiceBuilder;
 
-type Client = proto::Client<Channel>;
+type Client = proto::Client<HyperSvc>;
 type Response = Result<tonic::Response<proto::PushEventsResponse>, tonic::Status>;
 
-// TODO: rename
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfig {
@@ -34,15 +32,7 @@ pub struct VectorConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     #[serde(default)]
-    pub tls: Option<GrpcTlsConfig>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct GrpcTlsConfig {
-    ca_file: PathBuf,
-    crt_file: PathBuf,
-    key_file: PathBuf,
+    tls: Option<TlsConfig>,
 }
 
 impl GenerateConfig for VectorConfig {
@@ -84,38 +74,76 @@ fn default_http(address: &str) -> crate::Result<Uri> {
     }
 }
 
+fn new_client(
+    tls_settings: &MaybeTlsSettings,
+) -> crate::Result<hyper::Client<HttpsConnector<HttpConnector>, BoxBody>> {
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+
+    let tls = tls_connector_builder(&tls_settings)?;
+    let mut https = HttpsConnector::with_connector(http, tls)?;
+
+    let settings = tls_settings.tls().cloned();
+    https.set_callback(move |c, _uri| {
+        if let Some(settings) = &settings {
+            settings.apply_connect_configuration(c);
+        }
+
+        Ok(())
+    });
+
+    Ok(hyper::Client::builder().http2_only(true).build(https))
+}
+
+#[derive(Clone)]
+struct HyperSvc {
+    uri: Uri,
+    client: hyper::Client<HttpsConnector<HttpConnector>, BoxBody>,
+}
+
+impl tower::Service<hyper::Request<BoxBody>> for HyperSvc {
+    type Response = hyper::Response<hyper::Body>;
+    type Error = hyper::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, mut req: hyper::Request<BoxBody>) -> Self::Future {
+        let uri = Uri::builder()
+            .scheme(self.uri.scheme().unwrap().clone())
+            .authority(self.uri.authority().unwrap().clone())
+            .path_and_query(req.uri().path_and_query().unwrap().clone())
+            .build()
+            .unwrap();
+
+        *req.uri_mut() = uri;
+
+        Box::pin(self.client.request(req))
+    }
+}
+
 impl VectorConfig {
     pub(crate) async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let endpoint = Endpoint::from(default_http(&self.address)?);
-        let endpoint = match &self.tls {
-            Some(tls) => {
-                let host = get_authority(&self.address)?;
-                let ca = Certificate::from_pem(tokio::fs::read(&tls.ca_file).await?);
-                let crt = tokio::fs::read(&tls.crt_file).await?;
-                let key = tokio::fs::read(&tls.key_file).await?;
-                let identity = Identity::from_pem(crt, key);
+        let tls = MaybeTlsSettings::from_config(&self.tls, false)?;
+        let uri = default_http(&self.address)?;
 
-                let tls_config = ClientTlsConfig::new()
-                    .identity(identity)
-                    .ca_certificate(ca)
-                    .domain_name(host);
+        let client = new_client(&tls)?;
 
-                endpoint.tls_config(tls_config)?
-            }
-            None => endpoint,
-        };
-
-        let client = proto::Client::new(endpoint.connect_lazy()?);
-
-        let healthcheck_client = if let Some(uri) = cx.healthcheck.uri.clone() {
-            let endpoint = Endpoint::from(uri.uri);
-            proto::Client::new(endpoint.connect_lazy()?)
-        } else {
-            client.clone()
-        };
+        let healthcheck_uri = cx
+            .healthcheck
+            .uri
+            .clone()
+            .map(|uri| uri.uri)
+            .unwrap_or_else(|| uri.clone());
+        let healthcheck_client = proto::Client::new(HyperSvc {
+            uri: healthcheck_uri,
+            client: client.clone(),
+        });
 
         let healthcheck = healthcheck(healthcheck_client, cx.healthcheck.clone());
-
+        let client = proto::Client::new(HyperSvc { uri, client });
         let request = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch = BatchSettings::default()
             .events(1000)
@@ -164,13 +192,6 @@ async fn healthcheck(mut client: Client, options: SinkHealthcheckOptions) -> cra
     }
 
     Err(Box::new(Error::Health))
-}
-
-fn get_authority(url: &str) -> Result<String, Error> {
-    url.parse::<Uri>()
-        .ok()
-        .and_then(|uri| uri.authority().map(ToString::to_string))
-        .ok_or(Error::NoHost)
 }
 
 impl tower::Service<Vec<EventWrapper>> for Client {

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -176,7 +176,7 @@ impl Connected for MaybeTlsIncomingStream<TcpStream> {
                 .map(|s| {
                     s.into_iter()
                         .filter_map(|c| c.to_pem().ok())
-                        .map(|b| Certificate::from_pem(b))
+                        .map(Certificate::from_pem)
                         .collect()
                 }),
         }

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -4,16 +4,17 @@ use crate::{
     proto::vector as proto,
     shutdown::ShutdownSignalToken,
     sources::Source,
+    tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig},
     Pipeline,
 };
 
 use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::net::TcpStream;
 use tonic::{
-    transport::{Certificate, Identity, Server, ServerTlsConfig},
+    transport::{server::Connected, Certificate, Server},
     Request, Response, Status,
 };
 use vector_core::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event};
@@ -89,15 +90,7 @@ pub struct VectorConfig {
     #[serde(default = "default_shutdown_timeout_secs")]
     pub shutdown_timeout_secs: u64,
     #[serde(default)]
-    pub tls: Option<GrpcTlsConfig>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct GrpcTlsConfig {
-    ca_file: PathBuf,
-    crt_file: PathBuf,
-    key_file: PathBuf,
+    tls: Option<TlsConfig>,
 }
 
 fn default_shutdown_timeout_secs() -> u64 {
@@ -117,7 +110,9 @@ impl GenerateConfig for VectorConfig {
 
 impl VectorConfig {
     pub(super) async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
-        let source = run(self.address, self.tls.clone(), cx).map_err(|error| {
+        let tls_settings = MaybeTlsSettings::from_config(&self.tls, true)?;
+
+        let source = run(self.address, tls_settings, cx).map_err(|error| {
             error!(message = "Source future failed.", %error);
         });
 
@@ -139,7 +134,7 @@ impl VectorConfig {
 
 async fn run(
     address: SocketAddr,
-    tls: Option<GrpcTlsConfig>,
+    tls_settings: MaybeTlsSettings,
     cx: SourceContext,
 ) -> crate::Result<()> {
     let _span = crate::trace::current_span();
@@ -150,26 +145,32 @@ async fn run(
     });
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
 
-    let mut server = match tls {
-        Some(tls) => {
-            let ca = Certificate::from_pem(tokio::fs::read(&tls.ca_file).await?);
-            let crt = tokio::fs::read(&tls.crt_file).await?;
-            let key = tokio::fs::read(&tls.key_file).await?;
-            let identity = Identity::from_pem(crt, key);
+    let listener = tls_settings.bind(&address).await?;
+    let stream = listener.accept_stream();
 
-            let tls_config = ServerTlsConfig::new().identity(identity).client_ca_root(ca);
-
-            Server::builder().tls_config(tls_config)?
-        }
-        None => Server::builder(),
-    };
-
-    server
+    Server::builder()
         .add_service(service)
-        .serve_with_shutdown(address, cx.shutdown.map(|token| tx.send(token).unwrap()))
+        .serve_with_incoming_shutdown(stream, cx.shutdown.map(|token| tx.send(token).unwrap()))
         .await?;
 
     drop(rx.await);
 
     Ok(())
+}
+
+impl Connected for MaybeTlsIncomingStream<TcpStream> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        Some(self.peer_addr())
+    }
+
+    fn peer_certs(&self) -> Option<Vec<Certificate>> {
+        self.ssl_stream()
+            .and_then(|s| s.ssl().peer_cert_chain())
+            .map(|s| {
+                s.into_iter()
+                    .filter_map(|c| c.to_pem().ok())
+                    .map(|b| Certificate::from_pem(b))
+                    .collect()
+            })
+    }
 }

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -139,6 +139,18 @@ impl<S> MaybeTlsIncomingStream<S> {
         }
     }
 
+    pub fn ssl_stream(&self) -> Option<&SslStream<S>> {
+        use super::MaybeTls;
+
+        match &self.state {
+            StreamState::Accepted(stream) => match stream {
+                MaybeTls::Raw(_) => None,
+                MaybeTls::Tls(s) => Some(s),
+            },
+            StreamState::Accepting(_) | StreamState::AcceptError(_) | StreamState::Closed => None,
+        }
+    }
+
     #[cfg(all(
         test,
         feature = "sinks-socket",

--- a/src/tls/incoming.rs
+++ b/src/tls/incoming.rs
@@ -139,7 +139,8 @@ impl<S> MaybeTlsIncomingStream<S> {
         }
     }
 
-    pub fn ssl_stream(&self) -> Option<&SslStream<S>> {
+    #[cfg(feature = "sources-vector")]
+    pub(crate) fn ssl_stream(&self) -> Option<&SslStream<S>> {
         use super::MaybeTls;
 
         match &self.state {

--- a/tests/data/wasm/protobuf/Cargo.toml
+++ b/tests/data/wasm/protobuf/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-prost = "0.7"
+prost = "0.8"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 vector-wasm = { version = "0.1", path = "../../../../lib/vector-wasm"}
@@ -18,6 +18,6 @@ tracing = "0.1.15"
 anyhow = "1.0.28"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.8"
 
 [workspace]

--- a/website/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/website/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -1,8 +1,8 @@
 ---
-date: "2021-07-21"
+date: "2021-07-28"
 title: "0.16 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.16.0"
-authors: ["jszwedko"]
+authors: ["jszwedko", "JeanMertz"]
 pr_numbers: []
 release: "0.16.0"
 hide_on_release_notes: false
@@ -10,14 +10,18 @@ badges:
   type: breaking change
 ---
 
-Vector's 0.16.0 release includes one breaking change:
+Vector's 0.16.0 release includes two **breaking changes**:
 
 1. [Datadog Log sink encoding option removed](#encoding)
-1. [Renaming of `memory_use_bytes` internal metric](#memory_use_bytes)
+2. [Renaming of `memory_use_bytes` internal metric](#memory_use_bytes)
 
-We cover it below to help you upgrade quickly:
+And one **deprecation**:
 
-## Upgrade Guide
+1. [Vector source/sink version 2 released](#vector_source_sink)
+
+We cover them below to help you upgrade quickly:
+
+[##](##) Upgrade Guide
 
 ### Datadog Log sink encoding option removed {#encoding}
 
@@ -59,3 +63,100 @@ a measure of the `lua` runtime memory usage, you should update to refer to
 `lua_memory_use_bytes`.
 
 The documentation for this metric has also been updated.
+
+### Vector source/sink version 2 released {#vector_source_sink}
+
+We've released a new major version (`v2`) of our `vector` [source][]/[sink][]
+components. This release resolves several issues and limitations we experienced
+with our previous (`v1`) TCP-based implementation of these two components:
+
+- `vector` sink does not work in k8s with dynamic IP addresses ([#2070][])
+- Allow for HTTP in the vector source and sinks ([#5124][])
+- Allow Vector Source and Sink to Communicate over GRPC ([#6646][])
+- RFC 5843 - Encoding/Decoding for Vector to Vector Communication ([#6032][])
+
+The new version transitions to using gRPC over HTTP as its communication
+protocol, which resolves those limitations.
+
+To allow operators to transition at their leisure, this new release of Vector
+still defaults to `v1`. In the next release (`0.17.0`) we'll require operators
+to explicitly state which version they want to use, but continue to support
+`v1`. The release after that (`0.18.0`) we'll drop `v1` completely, and default
+to `v2`, we also no longer require you to explicitly set the version since there
+will only be one supported going forward.
+
+If you want to opt in to the new (stable!) `v2` version, you can do so as
+follows:
+
+```diff
+[sinks.vector]
+  type = "vector"
++ version = "v2"
+
+[sources.vector]
+  type = "vector"
++ version = "v2"
+```
+
+There are a couple of things to be aware of:
+
+#### Upgrade both the source _and_ sink
+
+You **have** to upgrade **both** the source and sink to `v2`, or none at all,
+you cannot update one without updating the other. Doing so will result in a loss
+of events.
+
+#### Zero-downtime deployment
+
+If you want to do a zero-downtime upgrade to `v2`, you'll have to introduce the
+new source/sink versions next to the existing versions, before removing the
+existing one.
+
+First, deploy the configuration that defines the source:
+
+```diff
+  [sources.vector]
+    address = "0.0.0.0:9000"
+    type = "vector"
++   version = "v1"
+
++ [sources.vector]
++   address = "0.0.0.0:5000"
++   type = "vector"
++   version = "v2"
+```
+
+Then, deploy the sink configuration, switching it over to the new version:
+
+```diff
+  [sinks.vector]
+-   address = "127.0.1.2:9000"
++   address = "127.0.1.2:5000"
+    type = "vector"
++   version = "v2"
+```
+
+Once the sink is deployed, you can do another deploy of the source, removing the
+old version:
+
+```diff
+- [sources.vector]
+-   address = "0.0.0.0:9000"
+-   type = "vector"
+-   version = "v1"
+-
+  [sources.vector]
+    address = "0.0.0.0:5000"
+    type = "vector"
+    version = "v2"
+```
+
+That's it! You are now using the new transport protocol for Vector-to-Vector
+communication.
+
+[source]: https://vector.dev/docs/reference/configuration/sources/vector/
+[sink]: https://vector.dev/docs/reference/configuration/sinks/vector/
+[#2070]: https://github.com/timberio/vector/issues/2070
+[#5124]: https://github.com/timberio/vector/issues/5124
+[#6646]: https://github.com/timberio/vector/issues/6646
+[#6032]: https://github.com/timberio/vector/pull/6032

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -1,7 +1,7 @@
 package metadata
 
 components: sinks: vector: {
-	_port: 9000
+	_port: 6000
 
 	title: "Vector"
 

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -1,8 +1,7 @@
 package metadata
 
 components: sinks: vector: {
-	_port_v1: 9000
-	_port_v2: 6000
+	_port: 9000
 
 	title: "Vector"
 
@@ -83,21 +82,10 @@ components: sinks: vector: {
 	configuration: {
 		address: {
 			description: "The downstream Vector address to connect to. The address _must_ include a port."
-			groups: ["v1"]
-			required: true
+			required:    true
 			warnings: []
 			type: string: {
-				examples: ["92.12.333.224:\(_port_v1)"]
-				syntax: "literal"
-			}
-		}
-		address: {
-			description: "The downstream Vector address to connect to. The address _must_ include a port."
-			groups: ["v2"]
-			required: true
-			warnings: []
-			type: string: {
-				examples: ["92.12.333.224:\(_port_v2)"]
+				examples: ["92.12.333.224:\(_port)"]
 				syntax: "literal"
 			}
 		}

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -1,6 +1,9 @@
 package metadata
 
 components: sinks: vector: {
+	_port_v1: 9000
+	_port_v2: 6000
+
 	title: "Vector"
 
 	description: """
@@ -21,8 +24,11 @@ components: sinks: vector: {
 		healthcheck: enabled: true
 		send: {
 			compression: enabled: false
-			encoding: enabled: false
-			send_buffer_bytes: enabled: true
+			encoding: {
+				enabled: true
+				codec: enabled: false
+			}
+			send_buffer_bytes: enabled: false
 			keepalive: enabled:         true
 			request: enabled:           false
 			tls: {
@@ -38,7 +44,7 @@ components: sinks: vector: {
 				interface: {
 					socket: {
 						direction: "outgoing"
-						protocols: ["tcp"]
+						protocols: ["http"]
 						ssl: "optional"
 					}
 				}
@@ -77,10 +83,21 @@ components: sinks: vector: {
 	configuration: {
 		address: {
 			description: "The downstream Vector address to connect to. The address _must_ include a port."
-			required:    true
+			groups: ["v1"]
+			required: true
 			warnings: []
 			type: string: {
-				examples: ["92.12.333.224:5000"]
+				examples: ["92.12.333.224:\(_port_v1)"]
+				syntax: "literal"
+			}
+		}
+		address: {
+			description: "The downstream Vector address to connect to. The address _must_ include a port."
+			groups: ["v2"]
+			required: true
+			warnings: []
+			type: string: {
+				examples: ["92.12.333.224:\(_port_v2)"]
 				syntax: "literal"
 			}
 		}

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -89,6 +89,20 @@ components: sinks: vector: {
 				syntax: "literal"
 			}
 		}
+		version: {
+			description: "Sink API version. Specifying this version ensures that Vector does not break backward compatibility."
+			common:      true
+			required:    false
+			warnings: ["Ensure you use the same version for both the sink and source."]
+			type: string: {
+				enum: {
+					"1": "Vector sink API version 1"
+					"2": "Vector sink API version 2"
+				}
+				default: "1"
+				syntax:  "literal"
+			}
+		}
 	}
 
 	how_it_works: components.sources.vector.how_it_works

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -1,12 +1,13 @@
 package metadata
 
 components: sources: vector: {
-	_port: 9000
+	_port_v1: 9000
+	_port_v2: 6000
 
 	title: "Vector"
 
 	description: """
-		Receives data from another upstream Vector instance	using the Vector sink.
+		Receives data from another upstream Vector instance using the Vector sink.
 		"""
 
 	classes: {
@@ -26,12 +27,12 @@ components: sources: vector: {
 
 				interface: socket: {
 					direction: "incoming"
-					port:      _port
-					protocols: ["tcp"]
+					port:      _port_v2
+					protocols: ["http"]
 					ssl: "optional"
 				}
 			}
-			receive_buffer_bytes: enabled: true
+			receive_buffer_bytes: enabled: false
 			keepalive: enabled:            true
 			tls: {
 				enabled:                true
@@ -66,20 +67,34 @@ components: sources: vector: {
 		acknowledgements: configuration._acknowledgements
 		address: {
 			description: """
-				The TCP address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd
-				socket activation. If an address is used it _must_ include a port.
+				The HTTP address to listen for connections on. It _must_ include a port.
 				"""
+			groups: ["v2"]
 			required: true
 			warnings: []
 			type: string: {
-				examples: ["0.0.0.0:\(_port)", "systemd", "systemd#1"]
+				examples: ["0.0.0.0:\(_port_v2)"]
+				syntax: "literal"
+			}
+		}
+		address: {
+			description: """
+				The TCP address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd
+				socket activation. If an address is used it _must_ include a port.
+				"""
+			groups: ["v1"]
+			required: true
+			warnings: []
+			type: string: {
+				examples: ["0.0.0.0:\(_port_v1)", "systemd", "systemd#1"]
 				syntax: "literal"
 			}
 		}
 		shutdown_timeout_secs: {
 			common:      false
 			description: "The timeout before a connection is forcefully closed during shutdown."
-			required:    false
+			groups: ["v1", "v2"]
+			required: false
 			warnings: []
 			type: uint: {
 				default: 30

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -1,8 +1,7 @@
 package metadata
 
 components: sources: vector: {
-	_port_v1: 9000
-	_port_v2: 6000
+	_port: 9000
 
 	title: "Vector"
 
@@ -27,7 +26,7 @@ components: sources: vector: {
 
 				interface: socket: {
 					direction: "incoming"
-					port:      _port_v2
+					port:      _port
 					protocols: ["http"]
 					ssl: "optional"
 				}
@@ -69,32 +68,17 @@ components: sources: vector: {
 			description: """
 				The HTTP address to listen for connections on. It _must_ include a port.
 				"""
-			groups: ["v2"]
 			required: true
 			warnings: []
 			type: string: {
-				examples: ["0.0.0.0:\(_port_v2)"]
-				syntax: "literal"
-			}
-		}
-		address: {
-			description: """
-				The TCP address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd
-				socket activation. If an address is used it _must_ include a port.
-				"""
-			groups: ["v1"]
-			required: true
-			warnings: []
-			type: string: {
-				examples: ["0.0.0.0:\(_port_v1)", "systemd", "systemd#1"]
+				examples: ["0.0.0.0:\(_port)"]
 				syntax: "literal"
 			}
 		}
 		shutdown_timeout_secs: {
 			common:      false
 			description: "The timeout before a connection is forcefully closed during shutdown."
-			groups: ["v1", "v2"]
-			required: false
+			required:    false
 			warnings: []
 			type: uint: {
 				default: 30

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -85,6 +85,20 @@ components: sources: vector: {
 				unit:    "seconds"
 			}
 		}
+		version: {
+			description: "Source API version. Specifying this version ensures that Vector does not break backward compatibility."
+			common:      true
+			required:    false
+			warnings: ["Ensure you use the same version for both the source and sink."]
+			type: string: {
+				enum: {
+					"1": "Vector source API version 1"
+					"2": "Vector source API version 2"
+				}
+				default: "1"
+				syntax:  "literal"
+			}
+		}
 	}
 
 	output: {


### PR DESCRIPTION
This PR makes a few changes to prepare for an official "v2" release of the vector source/sink combo.

- [x] Update Tonic gRPC library to the latest 0.5 release
- [x] Update documentation to mention v1/v2
- [x] Use default `TlsConfig` for `v2` to work similar to the `v1` config
- [x] Add upgrade guide