### PR TITLE
chore: Adjust blackhole sink to use ByteSizeOf trait

### DIFF
--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -2,7 +2,6 @@ use crate::{
     buffers::Acker,
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     emit,
-    event::Event,
     internal_events::BlackholeEventReceived,
     sinks::util::StreamSink,
 };
@@ -11,6 +10,8 @@ use futures::{future, stream::BoxStream, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use tokio::time::sleep_until;
+use vector_core::event::Event;
+use vector_core::ByteSizeOf;
 
 pub struct BlackholeSink {
     total_events: usize,
@@ -80,8 +81,9 @@ impl BlackholeSink {
 
 #[async_trait]
 impl StreamSink for BlackholeSink {
-    async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        while let Some(event) = input.next().await {
+    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let mut chunks = input.chunks(128);
+        while let Some(events) = chunks.next().await {
             if let Some(rate) = self.config.rate {
                 let until = self.last.unwrap_or_else(Instant::now)
                     + Duration::from_secs_f32(1.0 / rate as f32);
@@ -89,14 +91,9 @@ impl StreamSink for BlackholeSink {
                 self.last = Some(until);
             }
 
-            let message_len = match event {
-                Event::Log(log) => serde_json::to_string(&log),
-                Event::Metric(metric) => serde_json::to_string(&metric),
-            }
-            .map(|v| v.len())
-            .unwrap_or(0);
+            let message_len = events.size_of();
 
-            self.total_events += 1;
+            self.total_events += events.len();
             self.total_raw_bytes += message_len;
 
             emit!(BlackholeEventReceived {


### PR DESCRIPTION
This commit adjusts the blackhole sink in two important ways. First, it
processes incoming events in a chunk using the `StreamExt::chunk` method,
reducing per-event overhead in this sink to 128th of previous, considering the
chunk size. This does imply that blackhole sink will not remove an event from
the stream until there are 127 of its compatriots waiting, but that seems
acceptable for what blackhole sink is. Second, the sink now uses ByteSizeOf
trait methods to calculate the size of the Event chunk, removing json
serialization cost discussed in #4705.

Blackhole sink is now as fast as it's severely mangled form discussed in #8263.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
