### PR TITLE
chore: Replace `lua` example with `remap`

### DIFF
--- a/docs/content/en/docs/reference/configuration/template-syntax.md
+++ b/docs/content/en/docs/reference/configuration/template-syntax.md
@@ -85,17 +85,17 @@ option = "{{ parent.child[0] }}"
 
 ### Fallback values
 
-Vector doesn't currently support fallback values. [Issue 1692][1692] is open to add this functionality. In the interim, you can use the [`lua` transform][lua] to set a default value:
+Vector doesn't currently support fallback values. [Issue 1692][1692] is open to add this functionality. In the interim, you can use the [`remap` transform][remap] to set a default value:
 
 ```toml
 [transforms.set_defaults]
   # REQUIRED
-  type = "lua"
+  type = "remap"
   inputs = ["my-source-id"]
   source = '''
-    if event["my_field"] == nil then
-      event["my_field"] = "default"
-    end
+    if !exists(.my_field) {
+      .my_field = "default"
+    }
   '''
 ```
 
@@ -117,6 +117,7 @@ option = "{{ parent.child[0] }}"
 [fields]: /docs/reference/configuration/field-path-notation
 [log]: /docs/about/under-the-hood/architecture/data-model/log
 [paths]: /docs/reference/configuration/field-path-notation
+[remap]: /docs/reference/configuration/transforms/remap
 [strftime]: https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html#specifiers
 [timestamp]: /docs/about/under-the-hood/architecture/data-model/log/#timestamps
 [timestamp_key]: /docs/reference/configuration/global-options/#log_schema.timestamp_key


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
