### PR TITLE
fix(css website): Remove extra scrollbar

### DIFF
--- a/docs/assets/sass/toc.sass
+++ b/docs/assets/sass/toc.sass
@@ -5,7 +5,6 @@
 
 .dark, .light
   #toc
-    overflow-y: scroll
     padding-top: $y-padding
     padding-bottom: $y-padding
     line-height: 110%


### PR DESCRIPTION
This removes an extra scrollbar caused by a superfluous `overflow-y: scroll` setting (already covered by the containing div).