### PR TITLE
chore: Avoid double-counting keys in `log_operation_maintains_size`

### DIFF
--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -114,8 +114,10 @@ fn log_operation_maintains_size() {
                 Action::InsertFlat { key, value } => {
                     let new_value_sz = value.size_of();
                     let old_value_sz = log_event.get_flat(&key).map_or(0, |x| x.size_of());
+                    if !log_event.contains(&key) {
+                        current_size += key.len();
+                    }
                     log_event.insert_flat(&key, value);
-                    current_size += key.len();
                     current_size -= old_value_sz;
                     current_size += new_value_sz;
                 }


### PR DESCRIPTION
This commit avoids double (or more) counting the keys that we insert into the
`LogEvent`. Previously we would always add the key size to the expected size of
the `LogEvent` even if the key already existed in the `LogEvent`.

Resolves #8413

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
