### PR TITLE
chore: Ignore flakey file-source tests

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -953,11 +953,13 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn file_start_position_server_restart_acknowledged() {
         file_start_position_server_restart(Acks).await
     }
 
+    #[ignore]
     #[tokio::test]
     async fn file_start_position_server_restart_nonacknowledged() {
         file_start_position_server_restart(NoAcks).await

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -953,18 +953,19 @@ mod tests {
         }
     }
 
-    #[ignore]
+    #[cfg(target_os = "linux")] // see #7988
     #[tokio::test]
     async fn file_start_position_server_restart_acknowledged() {
         file_start_position_server_restart(Acks).await
     }
 
-    #[ignore]
+    #[cfg(target_os = "linux")] // see #7988
     #[tokio::test]
     async fn file_start_position_server_restart_nonacknowledged() {
         file_start_position_server_restart(NoAcks).await
     }
 
+    #[cfg(target_os = "linux")] // see #7988
     async fn file_start_position_server_restart(acking: AckingMode) {
         let dir = tempdir().unwrap();
         let config = file::FileConfig {


### PR DESCRIPTION
This commit marks two tests in the file-source as ignore. Both deal with
restarts. We've fiddled with this mechanism quite a bit lately. My argument is
that file-source needs a fundamental rethink -- I did the basic work in
[cernan](https://github.com/postmates/cernan) before `Future` existed -- and
tinkering with restart isn't working.

The test appears to be flakey only on Mac and Windows, our slowest CI machines,
which drives out CI turn-around time. Consider that #8421 has failed CI in two
runs because of one or other of these tests.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
