### PR TITLE
chore: Adjust datadog logs sink defaults

### DIFF
--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -104,7 +104,7 @@ impl DatadogLogsConfig {
         BatchSettings::default()
             .bytes(bytesize::mib(5_u32))
             .events(1_000)
-            .timeout(15)
+            .timeout(1)
             .parse_config(self.batch)
     }
 

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -7,6 +7,7 @@ use crate::{
     sinks::{
         util::{
             batch::{Batch, BatchError},
+            buffer::GZIP_FAST,
             encode_event,
             encoding::{EncodingConfig, EncodingConfiguration},
             http::{HttpSink, PartitionHttpSink},
@@ -101,9 +102,9 @@ impl DatadogLogsConfig {
 
     fn batch_settings<T: Batch>(&self) -> Result<BatchSettings<T>, BatchError> {
         BatchSettings::default()
-            .bytes(bytesize::kib(100u64))
-            .events(20)
-            .timeout(1)
+            .bytes(bytesize::mib(5_u32))
+            .events(1_000)
+            .timeout(15)
             .parse_config(self.batch)
     }
 
@@ -171,9 +172,7 @@ impl DatadogLogsConfig {
         let (request, body) = match compression {
             Compression::None => (request, body),
             Compression::Gzip(level) => {
-                // Default the compression level to 6, which is similar to datadog agent.
-                // https://docs.datadoghq.com/agent/logs/log_transport/?tab=https#log-compression
-                let level = level.unwrap_or(6);
+                let level = level.unwrap_or(GZIP_FAST);
                 let mut encoder =
                     GzEncoder::new(Vec::new(), flate2::Compression::new(level as u32));
 


### PR DESCRIPTION
This commit adjusts the datadog logs sink defaults to the maximum payload byte
size, 5Mb, and total array events, 1000. See
https://docs.datadoghq.com/api/latest/logs/#send-logs I have also adjusted the
gzip compression ratio to `GZIP_FAST`, with consideration that in
https://github.com/timberio/vector/issues/8263#issuecomment-885152529 we found
vector spent 30% of its time in compression activity.

This does not appreciably change throughput but does address conversation around
adjusting sink defaults as a way of improving throughput.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
