### PR TITLE
fix(vrl): update type_def after del

### DIFF
--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
 parser = { package = "vrl-parser", path = "../parser" }
-shared = { path = "../../shared", default-features = false }
+shared = { path = "../../shared", default-features = false, features = ["conversion"] }
 lookup = { path = "../../lookup" }
 
 bitflags = "1"

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -67,6 +67,10 @@ pub trait Expression: Send + Sync + fmt::Debug + DynClone {
     /// This method is executed at compile-time.
     fn type_def(&self, state: &crate::State) -> TypeDef;
 
+    /// Updates the state if necessary.
+    /// By default it does nothing.
+    fn update_state(&self, _state: &mut crate::State) {}
+
     /// Format the expression into a consistent style.
     ///
     /// This defaults to not formatting, so that function implementations don't

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -34,7 +34,7 @@ impl FunctionCall {
         abort_on_error: bool,
         arguments: Vec<Node<FunctionArgument>>,
         funcs: &[Box<dyn Function>],
-        state: &State,
+        state: &mut State,
     ) -> Result<Self, Error> {
         let (ident_span, ident) = ident.take();
 
@@ -175,6 +175,9 @@ impl FunctionCall {
                 abort_span: Span::new(ident_span.end(), ident_span.end() + 1),
             });
         }
+
+        // Update the state if necessary.
+        expr.update_state(state);
 
         Ok(Self {
             abort_on_error,

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -1,4 +1,4 @@
-use crate::expression::{Container, FunctionCall, Resolved, Variable};
+use crate::expression::{assignment, Container, FunctionCall, Resolved, Variable};
 use crate::parser::ast::Ident;
 use crate::{Context, Expression, State, TypeDef, Value};
 use lookup::LookupBuf;
@@ -43,6 +43,20 @@ impl Query {
             Target::FunctionCall(expr) => Some(expr),
             Target::Container(expr) => Some(expr),
             _ => None,
+        }
+    }
+
+    pub fn delete_type_def(&self, state: &mut State) {
+        if self.is_external() {
+            match state.target().as_mut() {
+                Some(ref mut target) => {
+                    let value = target.value.clone();
+                    let type_def = target.type_def.remove_path(&self.path);
+
+                    state.update_target(assignment::Details { type_def, value })
+                }
+                None => (),
+            }
         }
     }
 }

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -48,14 +48,11 @@ impl Query {
 
     pub fn delete_type_def(&self, state: &mut State) {
         if self.is_external() {
-            match state.target().as_mut() {
-                Some(ref mut target) => {
-                    let value = target.value.clone();
-                    let type_def = target.type_def.remove_path(&self.path);
+            if let Some(ref mut target) = state.target().as_mut() {
+                let value = target.value.clone();
+                let type_def = target.type_def.remove_path(&self.path);
 
-                    state.update_target(assignment::Details { type_def, value })
-                }
-                None => (),
+                state.update_target(assignment::Details { type_def, value })
             }
         }
     }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -1172,6 +1172,139 @@ impl TypeDef {
             kind: newkind,
         }
     }
+
+    fn remove_segment<'a, I>(kind: &KindInfo, mut path: std::iter::Peekable<I>) -> KindInfo
+    where
+        I: std::iter::Iterator<Item = &'a SegmentBuf> + Clone,
+    {
+        match kind {
+            KindInfo::Unknown => {
+                // The kind is unknown and thus there is nothing to remove.
+                kind.clone()
+            }
+            KindInfo::Known(kinds) => KindInfo::Known(
+                kinds
+                    .into_iter()
+                    .map(|kind| match (kind, path.next(), path.peek()) {
+                        (
+                            TypeKind::Object(object),
+                            Some(SegmentBuf::Field(_fieldname)),
+                            Some(_),
+                        ) => TypeKind::Object(
+                            object
+                                .into_iter()
+                                .map(|(field, kindinfo)| {
+                                    (field.clone(), Self::remove_segment(kindinfo, path.clone()))
+                                })
+                                .collect(),
+                        ),
+
+                        (TypeKind::Object(object), Some(SegmentBuf::Field(fieldname)), None) => {
+                            TypeKind::Object(
+                                object
+                                    .into_iter()
+                                    .filter_map(|(field, kindinfo)| match field {
+                                        Field::Field(name) if name == fieldname.as_str() => None,
+                                        _ => Some((field.clone(), kindinfo.clone())),
+                                    })
+                                    .collect(),
+                            )
+                        }
+
+                        (
+                            TypeKind::Object(object),
+                            Some(SegmentBuf::Coalesce(_fieldnames)),
+                            Some(_),
+                        ) => TypeKind::Object(
+                            object
+                                .into_iter()
+                                .map(|(field, kindinfo)| {
+                                    (field.clone(), Self::remove_segment(kindinfo, path.clone()))
+                                })
+                                .collect(),
+                        ),
+
+                        (
+                            TypeKind::Object(object),
+                            Some(SegmentBuf::Coalesce(fieldnames)),
+                            None,
+                        ) => TypeKind::Object(
+                            object
+                                .into_iter()
+                                .filter_map(|(field, kindinfo)| match field {
+                                    Field::Field(name)
+                                        if fieldnames
+                                            .iter()
+                                            .any(|fieldname| fieldname.as_str() == name) =>
+                                    {
+                                        // With coalesced paths we need to remove all fields within
+                                        // the coalesce.
+                                        None
+                                    }
+                                    _ => Some((field.clone(), kindinfo.clone())),
+                                })
+                                .collect(),
+                        ),
+
+                        (TypeKind::Array(array), Some(SegmentBuf::Index(_index)), Some(_)) => {
+                            TypeKind::Array(
+                                array
+                                    .into_iter()
+                                    .map(|(idx, kindinfo)| {
+                                        (idx.clone(), Self::remove_segment(kindinfo, path.clone()))
+                                    })
+                                    .collect(),
+                            )
+                        }
+
+                        (TypeKind::Array(array), Some(SegmentBuf::Index(index)), None) => {
+                            TypeKind::Array(
+                                array
+                                    .into_iter()
+                                    .filter_map(|(idx, kindinfo)| match idx {
+                                        Index::Index(idx)
+                                            if *index >= 0 && *idx == *index as usize =>
+                                        {
+                                            None
+                                        }
+                                        Index::Index(idx)
+                                            if *index >= 0 && *idx > *index as usize =>
+                                        {
+                                            // Elements after the removed index need the index
+                                            // shifting down one.
+                                            Some((Index::Index(idx - 1), kindinfo.clone()))
+                                        }
+                                        Index::Index(_) if *index < 0 => {
+                                            // After attempting to delete an element in an array
+                                            // with a negative index we can no longer maintain the
+                                            // type definition of any specific element in the array
+                                            // as we don't know which precise index is deleted
+                                            // until runtime.
+                                            None
+                                        }
+                                        _ => Some((idx.clone(), kindinfo.clone())),
+                                    })
+                                    .collect(),
+                            )
+                        }
+
+                        (kind, _, _) => kind.clone(),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Removes the given path from the typedef
+    pub fn remove_path(&self, path: &LookupBuf) -> Self {
+        let segments = path.as_segments();
+        let peekable = segments.into_iter().peekable();
+
+        TypeDef {
+            fallible: self.fallible,
+            kind: Self::remove_segment(&self.kind, peekable),
+        }
+    }
 }
 
 impl Default for TypeDef {
@@ -1379,6 +1512,108 @@ mod tests {
             let path = LookupBuf::from_str(case.path).unwrap();
             let new = case.old.update_path(&path, &newkind);
             assert_eq!(case.new, new, "{}", path);
+        }
+    }
+
+    #[test]
+    fn remove_path() {
+        struct TestCase {
+            old: TypeDef,
+            path: &'static str,
+            new: TypeDef,
+        }
+
+        let cases = vec![
+            // A field is removed.
+            TestCase {
+                old: type_def! { object {
+                    "nonk" => type_def! { array [
+                        type_def! { object {
+                            "noog" => type_def! { bytes },
+                            "nork" => type_def! { bytes },
+                        } },
+                    ] },
+                } },
+                path: "nonk[0].noog",
+                new: type_def! { object {
+                    "nonk" => type_def! { array [
+                        type_def! { object {
+                            "nork" => type_def! { bytes },
+                        } },
+                    ] },
+                } },
+            },
+            // Coalesced field
+            TestCase {
+                old: type_def! { object {
+                    "nonk" => type_def! { object {
+                        "nork" => type_def! { bytes },
+                        "noog" => type_def! { bytes },
+                        "nonk" => type_def! { bytes },
+                    } },
+                } },
+                path: "nonk.(noog | nonk)",
+                new: type_def! { object {
+                    "nonk" => type_def! { object {
+                        "nork" => type_def! { bytes },
+                    } },
+                } },
+            },
+            // A single array element when the typedef is for any index.
+            TestCase {
+                old: type_def! { object {
+                    "nonk" => type_def! { array [
+                        type_def! { object {
+                            "noog" => type_def! { bytes },
+                            "nork" => type_def! { bytes },
+                        } },
+                    ] },
+                } },
+                path: "nonk[0]",
+                new: type_def! { object {
+                    "nonk" => type_def! { array [
+                        type_def! { object {
+                            "noog" => type_def! { bytes },
+                            "nork" => type_def! { bytes },
+                        } },
+                    ] },
+                } },
+            },
+            // A single array element when the typedef is for that index.
+            TestCase {
+                old: type_def! { object {
+                    "nonk" => type_def! { array {
+                        0 => type_def! { object {
+                            "noog" => type_def! { bytes },
+                            "nork" => type_def! { bytes },
+                        } },
+                    } },
+                } },
+                path: "nonk[0]",
+                new: type_def! { object {
+                    "nonk" => type_def! { array },
+                } },
+            },
+            // A single array element with a negative index has to remove all typedefs.
+            TestCase {
+                old: type_def! { object {
+                    "nonk" => type_def! { array {
+                        0 => type_def! { object {
+                            "noog" => type_def! { bytes },
+                            "nork" => type_def! { bytes },
+                        } },
+                    } },
+                } },
+                path: "nonk[-1]",
+                new: type_def! { object {
+                    "nonk" => type_def! { array },
+                } },
+            },
+        ];
+
+        for case in cases {
+            let path = LookupBuf::from_str(case.path).unwrap();
+            assert_eq!(case.new, case.old.remove_path(&path));
         }
     }
 

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -1186,18 +1186,19 @@ impl TypeDef {
                 kinds
                     .into_iter()
                     .map(|kind| match (kind, path.next(), path.peek()) {
-                        (
-                            TypeKind::Object(object),
-                            Some(SegmentBuf::Field(_fieldname)),
-                            Some(_),
-                        ) => TypeKind::Object(
-                            object
-                                .into_iter()
-                                .map(|(field, kindinfo)| {
-                                    (field.clone(), Self::remove_segment(kindinfo, path.clone()))
-                                })
-                                .collect(),
-                        ),
+                        (TypeKind::Object(object), Some(SegmentBuf::Field(_)), Some(_)) => {
+                            TypeKind::Object(
+                                object
+                                    .into_iter()
+                                    .map(|(field, kindinfo)| {
+                                        (
+                                            field.clone(),
+                                            Self::remove_segment(kindinfo, path.clone()),
+                                        )
+                                    })
+                                    .collect(),
+                            )
+                        }
 
                         (TypeKind::Object(object), Some(SegmentBuf::Field(fieldname)), None) => {
                             TypeKind::Object(
@@ -1211,18 +1212,19 @@ impl TypeDef {
                             )
                         }
 
-                        (
-                            TypeKind::Object(object),
-                            Some(SegmentBuf::Coalesce(_fieldnames)),
-                            Some(_),
-                        ) => TypeKind::Object(
-                            object
-                                .into_iter()
-                                .map(|(field, kindinfo)| {
-                                    (field.clone(), Self::remove_segment(kindinfo, path.clone()))
-                                })
-                                .collect(),
-                        ),
+                        (TypeKind::Object(object), Some(SegmentBuf::Coalesce(_)), Some(_)) => {
+                            TypeKind::Object(
+                                object
+                                    .into_iter()
+                                    .map(|(field, kindinfo)| {
+                                        (
+                                            field.clone(),
+                                            Self::remove_segment(kindinfo, path.clone()),
+                                        )
+                                    })
+                                    .collect(),
+                            )
+                        }
 
                         (
                             TypeKind::Object(object),
@@ -1246,7 +1248,7 @@ impl TypeDef {
                                 .collect(),
                         ),
 
-                        (TypeKind::Array(array), Some(SegmentBuf::Index(_index)), Some(_)) => {
+                        (TypeKind::Array(array), Some(SegmentBuf::Index(_)), Some(_)) => {
                             TypeKind::Array(
                                 array
                                     .into_iter()

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -1184,12 +1184,12 @@ impl TypeDef {
             }
             KindInfo::Known(kinds) => KindInfo::Known(
                 kinds
-                    .into_iter()
+                    .iter()
                     .map(|kind| match (kind, path.next(), path.peek()) {
                         (TypeKind::Object(object), Some(SegmentBuf::Field(_)), Some(_)) => {
                             TypeKind::Object(
                                 object
-                                    .into_iter()
+                                    .iter()
                                     .map(|(field, kindinfo)| {
                                         (
                                             field.clone(),
@@ -1203,7 +1203,7 @@ impl TypeDef {
                         (TypeKind::Object(object), Some(SegmentBuf::Field(fieldname)), None) => {
                             TypeKind::Object(
                                 object
-                                    .into_iter()
+                                    .iter()
                                     .filter_map(|(field, kindinfo)| match field {
                                         Field::Field(name) if name == fieldname.as_str() => None,
                                         _ => Some((field.clone(), kindinfo.clone())),
@@ -1215,7 +1215,7 @@ impl TypeDef {
                         (TypeKind::Object(object), Some(SegmentBuf::Coalesce(_)), Some(_)) => {
                             TypeKind::Object(
                                 object
-                                    .into_iter()
+                                    .iter()
                                     .map(|(field, kindinfo)| {
                                         (
                                             field.clone(),
@@ -1232,7 +1232,7 @@ impl TypeDef {
                             None,
                         ) => TypeKind::Object(
                             object
-                                .into_iter()
+                                .iter()
                                 .filter_map(|(field, kindinfo)| match field {
                                     Field::Field(name)
                                         if fieldnames
@@ -1251,9 +1251,9 @@ impl TypeDef {
                         (TypeKind::Array(array), Some(SegmentBuf::Index(_)), Some(_)) => {
                             TypeKind::Array(
                                 array
-                                    .into_iter()
+                                    .iter()
                                     .map(|(idx, kindinfo)| {
-                                        (idx.clone(), Self::remove_segment(kindinfo, path.clone()))
+                                        (*idx, Self::remove_segment(kindinfo, path.clone()))
                                     })
                                     .collect(),
                             )
@@ -1262,7 +1262,7 @@ impl TypeDef {
                         (TypeKind::Array(array), Some(SegmentBuf::Index(index)), None) => {
                             TypeKind::Array(
                                 array
-                                    .into_iter()
+                                    .iter()
                                     .filter_map(|(idx, kindinfo)| match idx {
                                         Index::Index(idx)
                                             if *index >= 0 && *idx == *index as usize =>
@@ -1284,7 +1284,7 @@ impl TypeDef {
                                             // until runtime.
                                             None
                                         }
-                                        _ => Some((idx.clone(), kindinfo.clone())),
+                                        _ => Some((*idx, kindinfo.clone())),
                                     })
                                     .collect(),
                             )
@@ -1300,7 +1300,7 @@ impl TypeDef {
     /// Removes the given path from the typedef
     pub fn remove_path(&self, path: &LookupBuf) -> Self {
         let segments = path.as_segments();
-        let peekable = segments.into_iter().peekable();
+        let peekable = segments.iter().peekable();
 
         TypeDef {
             fallible: self.fallible,

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -125,6 +125,10 @@ impl Expression for DelFn {
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef::new().unknown()
     }
+
+    fn update_state(&self, state: &mut state::Compiler) {
+        self.query.delete_type_def(state);
+    }
 }
 
 impl fmt::Display for DelFn {

--- a/lib/vrl/tests/tests/issues/8068_del_type_def.vrl
+++ b/lib/vrl/tests/tests/issues/8068_del_type_def.vrl
@@ -1,0 +1,19 @@
+# https://github.com/timberio/vector/issues/8068
+# result:
+# error[E100]: unhandled error
+#   ┌─ :5:1
+#   │
+# 5 │ .onk[1] + "nork"
+#   │ ^^^^^^^^^^^^^^^^
+#   │ │
+#   │ expression can result in runtime error
+#   │ handle the error case to ensure runtime success
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = learn more about error code 100 at https://errors.vrl.dev/100
+#   = see language documentation at https://vrl.dev
+
+.onk = ["nork", "spork"]
+del(.onk[0])
+
+.onk[1] + "nork"


### PR DESCRIPTION
Closes #8068 

This ensures the type def for any paths are removed after they are removed using `del`.

To enable this fix I have had to add a new function, `update_state` to the `Expression` trait. This gives an expressions the option to mutate the state during the compilation stage. Note, I am only invoking this function whilst compiling a function call. For any other expressions, even if they implement this function it will currently have no effect. Technically, this may not be completely correct, but in the interests of not doing work when it isn't really necessary I have not pursued it further.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

