### PR TITLE
enhancement(internal_logs source): Allow host_key and pid_key to be configured

### DIFF
--- a/docs/cue/reference/components/sources/internal_logs.cue
+++ b/docs/cue/reference/components/sources/internal_logs.cue
@@ -47,6 +47,37 @@ components: sources: internal_logs: {
 	}
 
 	configuration: {
+		host_key: {
+			category:    "Context"
+			common:      false
+			description: """
+				The key name added to each event representing the current host. This can also be globally set via the
+				[global `host_key` option](\(urls.vector_configuration)/global-options#log_schema.host_key).
+
+				Set to "" to suppress this key.
+				"""
+			required:    false
+			warnings: []
+			type: string: {
+				default: "host"
+				syntax:  "literal"
+			}
+		}
+		pid_key: {
+			category: "Context"
+			common:   false
+			description: """
+				The key name added to each event representing the current process ID.
+
+				Set to "" to suppress this key.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: "host"
+				syntax:  "literal"
+			}
+		}
 	}
 
 	output: logs: line: {

--- a/docs/cue/reference/components/sources/internal_logs.cue
+++ b/docs/cue/reference/components/sources/internal_logs.cue
@@ -74,7 +74,7 @@ components: sources: internal_logs: {
 			required: false
 			warnings: []
 			type: string: {
-				default: "host"
+				default: "pid"
 				syntax:  "literal"
 			}
 		}

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -30,7 +30,7 @@ impl SourceConfig for InternalLogsConfig {
             .as_deref()
             .unwrap_or_else(|| log_schema().host_key())
             .to_owned();
-        let pid_key = self.pid_key.as_deref().unwrap_or_else(|| "pid").to_owned();
+        let pid_key = self.pid_key.as_deref().unwrap_or(|| "pid").to_owned();
 
         Ok(Box::pin(run(host_key, pid_key, cx.out, cx.shutdown)))
     }

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -30,7 +30,7 @@ impl SourceConfig for InternalLogsConfig {
             .as_deref()
             .unwrap_or_else(|| log_schema().host_key())
             .to_owned();
-        let pid_key = self.pid_key.as_deref().unwrap_or(|| "pid").to_owned();
+        let pid_key = self.pid_key.as_deref().unwrap_or("pid").to_owned();
 
         Ok(Box::pin(run(host_key, pid_key, cx.out, cx.shutdown)))
     }

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -139,7 +139,7 @@ mod tests {
     async fn start_source() -> mpsc::Receiver<Event> {
         let (tx, rx) = Pipeline::new_test();
 
-        let source = InternalLogsConfig {}
+        let source = InternalLogsConfig::default()
             .build(SourceContext::new_test(tx))
             .await
             .unwrap();

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -10,7 +10,10 @@ use tokio::sync::broadcast::error::RecvError;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct InternalLogsConfig {}
+pub struct InternalLogsConfig {
+    host_key: Option<String>,
+    pid_key: Option<String>,
+}
 
 inventory::submit! {
     SourceDescription::new::<InternalLogsConfig>("internal_logs")
@@ -22,7 +25,14 @@ impl_generate_config_from_default!(InternalLogsConfig);
 #[typetag::serde(name = "internal_logs")]
 impl SourceConfig for InternalLogsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        Ok(Box::pin(run(cx.out, cx.shutdown)))
+        let host_key = self
+            .host_key
+            .as_deref()
+            .unwrap_or_else(|| log_schema().host_key())
+            .to_owned();
+        let pid_key = self.pid_key.as_deref().unwrap_or_else(|| "pid").to_owned();
+
+        Ok(Box::pin(run(host_key, pid_key, cx.out, cx.shutdown)))
     }
 
     fn output_type(&self) -> DataType {
@@ -34,7 +44,12 @@ impl SourceConfig for InternalLogsConfig {
     }
 }
 
-async fn run(out: Pipeline, mut shutdown: ShutdownSignal) -> Result<(), ()> {
+async fn run(
+    host_key: String,
+    pid_key: String,
+    out: Pipeline,
+    mut shutdown: ShutdownSignal,
+) -> Result<(), ()> {
     let mut out = out.sink_map_err(|error| error!(message = "Error sending log.", %error));
     let subscription = trace::subscribe();
     let mut rx = subscription.receiver;
@@ -44,9 +59,9 @@ async fn run(out: Pipeline, mut shutdown: ShutdownSignal) -> Result<(), ()> {
 
     out.send_all(&mut stream::iter(subscription.buffer).map(|mut log| {
         if let Ok(hostname) = &hostname {
-            log.insert(log_schema().host_key().to_owned(), hostname.to_owned());
+            log.insert(host_key.clone(), hostname.to_owned());
         }
-        log.insert(String::from("pid"), pid);
+        log.insert(pid_key.clone(), pid);
         Ok(Event::from(log))
     }))
     .await?;


### PR DESCRIPTION
Also allows for disabling via setting the key to `""`.

I'm still not crazy about these keys, but we don't have a better way to
handle it yet.

Partially addresses https://github.com/timberio/vector/issues/8407

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
