### PR TITLE
chore(datadog_logs sink)!: Strike text encoding from Datadog logs sink

### DIFF
--- a/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -1,0 +1,47 @@
+---
+date: "2021-07-21"
+title: "0.16 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.16.0"
+authors: ["jszwedko"]
+pr_numbers: []
+release: "0.16.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.16.0 release includes one breaking change:
+
+1. [Datadog Log sink encoding option removed](#encoding)
+1. [Component name field renamed to ID](#first)
+
+We cover it below to help you upgrade quickly:
+
+[##](##) Upgrade Guide
+
+### Datadog Log sink encoding option removed {#encoding}
+
+In previous versions of vector it was possible to configure the Datadog logs
+sink to send in 'text' or 'json' encoding. While the logs ingest API does accept
+text format the native format for that API is json. Sending text comes with
+limitations and is only useful for backward compatability with older clients.
+
+We no longer allow you to set the encoding of the payloads in the Datadog logs
+sink. For instance, if your configuration looks like so:
+
+```toml
+[sinks.dd_logs_egress]
+type = "datadog_logs"
+inputs = ["datadog_agent"]
+encoding.codec = "json"
+```
+
+You should remove `encoding.codec` entirely, leaving you with:
+
+```toml
+[sinks.dd_logs_egress]
+type = "datadog_logs"
+inputs = ["datadog_agent"]
+```
+
+Encoding fields other than `codec` are still valid.

--- a/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -13,7 +13,6 @@ badges:
 Vector's 0.16.0 release includes one breaking change:
 
 1. [Datadog Log sink encoding option removed](#encoding)
-1. [Component name field renamed to ID](#first)
 
 We cover it below to help you upgrade quickly:
 

--- a/docs/cue/reference/components/sinks/datadog_logs.cue
+++ b/docs/cue/reference/components/sinks/datadog_logs.cue
@@ -23,11 +23,7 @@ components: sinks: datadog_logs: {
 			}
 			encoding: {
 				enabled: true
-				codec: {
-					enabled: true
-					default: null
-					enum: ["json", "text"]
-				}
+				codec: enabled: false
 			}
 			request: enabled: false
 			tls: {

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -4,6 +4,7 @@ use crate::sinks::datadog::logs::healthcheck::healthcheck;
 use crate::sinks::datadog::logs::service::DatadogLogsJsonService;
 use crate::sinks::datadog::ApiKey;
 use crate::sinks::datadog::Region;
+use crate::sinks::util::encoding::EncodingConfigWithDefault;
 use crate::sinks::util::{
     batch::{Batch, BatchError},
     buffer::GZIP_FAST,
@@ -30,6 +31,11 @@ pub struct DatadogLogsConfig {
     // Deprecated name
     #[serde(alias = "api_key")]
     default_api_key: String,
+    #[serde(
+        skip_serializing_if = "crate::serde::skip_serializing_if_default",
+        default
+    )]
+    pub(crate) encoding: EncodingConfigWithDefault<Encoding>,
     tls: Option<TlsConfig>,
 
     #[serde(default)]
@@ -40,6 +46,14 @@ pub struct DatadogLogsConfig {
 
     #[serde(default)]
     request: TowerRequestConfig,
+}
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
+#[serde(rename_all = "snake_case")]
+#[derivative(Default)]
+pub enum Encoding {
+    #[derivative(Default)]
+    Json,
 }
 
 impl GenerateConfig for DatadogLogsConfig {

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -1,10 +1,8 @@
 use super::ApiKey;
 use crate::sinks::datadog::logs::DatadogLogsConfig;
-use crate::sinks::util::encoding::EncodingConfiguration;
 use crate::sinks::util::http::HttpSink;
-use crate::sinks::util::{encode_event, BoxedRawValue, EncodedEvent, PartitionInnerBuffer};
+use crate::sinks::util::{BoxedRawValue, EncodedEvent, PartitionInnerBuffer};
 use crate::{config::log_schema, internal_events::DatadogLogEventProcessed};
-use bytes::Bytes;
 use http::Request;
 use serde_json::json;
 use std::sync::Arc;
@@ -38,8 +36,6 @@ impl HttpSink for DatadogLogsJsonService {
             log.insert("host", host);
         }
 
-        self.config.encoding.apply_rules(&mut event);
-
         let (fields, metadata) = event.into_log().into_parts();
         let json_event = json!(fields);
         let api_key = metadata
@@ -66,50 +62,5 @@ impl HttpSink for DatadogLogsJsonService {
         }
         self.config
             .build_request(self.uri.as_str(), &api_key[..], "application/json", body)
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DatadogLogsTextService {
-    pub(crate) config: DatadogLogsConfig,
-    // Used to store the complete URI and avoid calling `get_uri` for each
-    // request
-    pub(crate) uri: String,
-    pub(crate) default_api_key: ApiKey,
-}
-
-#[async_trait::async_trait]
-impl HttpSink for DatadogLogsTextService {
-    type Input = PartitionInnerBuffer<Bytes, ApiKey>;
-    type Output = PartitionInnerBuffer<Vec<Bytes>, ApiKey>;
-
-    fn encode_event(&self, event: Event) -> Option<EncodedEvent<Self::Input>> {
-        let api_key = Arc::clone(
-            event
-                .metadata()
-                .datadog_api_key()
-                .as_ref()
-                .unwrap_or(&self.default_api_key),
-        );
-
-        encode_event(event, &self.config.encoding).map(|e| {
-            emit!(DatadogLogEventProcessed {
-                byte_size: e.item.len(),
-                count: 1,
-            });
-
-            EncodedEvent {
-                item: PartitionInnerBuffer::new(e.item, api_key),
-                metadata: e.metadata,
-            }
-        })
-    }
-
-    async fn build_request(&self, events: Self::Output) -> crate::Result<Request<Vec<u8>>> {
-        let (events, api_key) = events.into_parts();
-        let body: Vec<u8> = events.into_iter().flat_map(Bytes::into_iter).collect();
-
-        self.config
-            .build_request(self.uri.as_str(), &api_key[..], "text/plain", body)
     }
 }

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -1,5 +1,6 @@
-use super::ApiKey;
 use crate::sinks::datadog::logs::DatadogLogsConfig;
+use crate::sinks::datadog::ApiKey;
+use crate::sinks::util::encoding::EncodingConfiguration;
 use crate::sinks::util::http::HttpSink;
 use crate::sinks::util::{BoxedRawValue, EncodedEvent, PartitionInnerBuffer};
 use crate::{config::log_schema, internal_events::DatadogLogEventProcessed};
@@ -35,6 +36,8 @@ impl HttpSink for DatadogLogsJsonService {
         if let Some(host) = log.remove(log_schema().host_key()) {
             log.insert("host", host);
         }
+
+        self.config.encoding.apply_rules(&mut event);
 
         let (fields, metadata) = event.into_log().into_parts();
         let json_event = json!(fields);

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -26,18 +26,8 @@ fn event_with_api_key(msg: &str, key: &str) -> Event {
 }
 
 #[tokio::test]
-async fn smoke_text() {
-    let (expected, output) = smoke_test("text").await;
-
-    for (i, val) in output.iter().enumerate() {
-        assert_eq!(val.0.headers.get("Content-Type").unwrap(), "text/plain");
-        assert_eq!(val.1, format!("{}\n", expected[i]));
-    }
-}
-
-#[tokio::test]
 async fn smoke_json() {
-    let (expected, output) = smoke_test("json").await;
+    let (expected, output) = smoke_test().await;
 
     for (i, val) in output.iter().enumerate() {
         assert_eq!(
@@ -65,8 +55,8 @@ async fn smoke_json() {
     }
 }
 
-async fn smoke_test(encoding: &str) -> (Vec<String>, Vec<(http::request::Parts, Bytes)>) {
-    let (expected, rx) = start_test(encoding, StatusCode::OK, BatchStatus::Delivered).await;
+async fn smoke_test() -> (Vec<String>, Vec<(http::request::Parts, Bytes)>) {
+    let (expected, rx) = start_test(StatusCode::OK, BatchStatus::Delivered).await;
 
     let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
@@ -74,36 +64,25 @@ async fn smoke_test(encoding: &str) -> (Vec<String>, Vec<(http::request::Parts, 
 }
 
 #[tokio::test]
-async fn handles_failure_text() {
-    handles_failure("text").await;
-}
-
-#[tokio::test]
 async fn handles_failure_json() {
-    handles_failure("json").await;
+    handles_failure().await;
 }
 
-async fn handles_failure(encoding: &str) {
-    let (_expected, mut rx) =
-        start_test(encoding, StatusCode::FORBIDDEN, BatchStatus::Failed).await;
+async fn handles_failure() {
+    let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Failed).await;
 
     assert!(matches!(rx.try_next(), Err(TryRecvError { .. })));
 }
 
 async fn start_test(
-    encoding: &str,
     http_status: StatusCode,
     batch_status: BatchStatus,
 ) -> (Vec<String>, Receiver<(http::request::Parts, Bytes)>) {
-    let config = format!(
-        indoc! {r#"
+    let config = format!(indoc! {r#"
             default_api_key = "atoken"
-            encoding = "{}"
             compression = "none"
             batch.max_events = 1
-        "#},
-        encoding
-    );
+        "#},);
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(&config).unwrap();
 
     let addr = next_addr();
@@ -131,7 +110,6 @@ async fn start_test(
 async fn api_key_in_metadata() {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
-            encoding = "json"
             compression = "none"
             batch.max_events = 1
         "#})
@@ -192,7 +170,6 @@ async fn api_key_in_metadata() {
 async fn multiple_api_keys() {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
-            encoding = "json"
             compression = "none"
             batch.max_events = 1
         "#})

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -78,11 +78,11 @@ async fn start_test(
     http_status: StatusCode,
     batch_status: BatchStatus,
 ) -> (Vec<String>, Receiver<(http::request::Parts, Bytes)>) {
-    let config = format!(indoc! {r#"
+    let config = indoc! {r#"
             default_api_key = "atoken"
             compression = "none"
             batch.max_events = 1
-        "#},);
+        "#};
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(&config).unwrap();
 
     let addr = next_addr();


### PR DESCRIPTION
There are two acceptable encodings for datadog logs ingest: JSON and 'text'. The
text encoding is the more limited of the two and does not make sense for end
users to have as a configuration option, considering that JSON ingest is the
more accepted format for ingest.

This commit strikes the 'encoding' option from the sink entirely. This does
simplify the internal logic of the sink -- good -- but removes other features
inherent in the encoding configuration like field exclusion which may or may not
be a problem.

I have not updated the documentation yet but intend to with @spencergilbert's help.

REF #8263

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
