### PR TITLE
fix(releasing): Remove creation of vector group from rpm

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -286,10 +286,12 @@ jobs:
           path: target/artifacts
       - name: First install of DEB package.
         run: |
-          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb && vector --version
+          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb
+          ./scripts/verify-install.sh
       - name: Second install of DEB package.
         run: |
-          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb && vector --version
+          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb
+          ./scripts/verify-install.sh
 
   rpm-verify:
     needs:
@@ -319,10 +321,12 @@ jobs:
           path: target/artifacts
       - name: First install of RPM package.
         run: |
-          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
+          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh
       - name: Second install of RPM package.
         run: |
-          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
+          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh
 
   osx-verify:
     runs-on: macos-10.15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,10 +265,12 @@ jobs:
           path: target/artifacts
       - name: First install of DEB package.
         run: |
-          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb && vector --version
+          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb
+          ./scripts/verify-install.sh
       - name: Second install of DEB package.
         run: |
-          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb && vector --version
+          dpkg -i target/artifacts/vector-${{ env.VECTOR_VERSION }}-amd64.deb
+          ./scripts/verify-install.sh
 
   rpm-verify:
     needs:
@@ -298,10 +300,12 @@ jobs:
           path: target/artifacts
       - name: First install of RPM package.
         run: |
-          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
+          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh
       - name: Second install of RPM package.
         run: |
-          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm && vector --version
+          rpm -i --replacepkgs target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh
 
   osx-verify:
     runs-on: macos-10.15

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -61,7 +61,6 @@ cp -a %{_builddir}/systemd/vector.service %{buildroot}%{_unitdir}/vector.service
 cp -a %{_builddir}/systemd/vector.default %{buildroot}%{_sysconfdir}/default/vector
 
 %post
-getent group %{_username} > /dev/null || groupadd -r %{_username}
 getent passwd %{_username} > /dev/null || \
   useradd --shell /sbin/nologin --system --home-dir %{_sharedstatedir}/%{_name} --user-group \
     --comment "Vector observability data router" %{_username}

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-install.sh
+#
+# SUMMARY
+#
+#   Verifies vector packages have been installed correctly
+
+getent passwd vector || (echo "vector user missing" && exit 1)
+getent group vector || (echo "vector group  missing" && exit 1)
+vector --version || (echo "vector --version failed" && exit 1)


### PR DESCRIPTION
This happens now automatically as part of useradd as per https://github.com/timberio/vector/pull/8064

Also updates release scripts to have additional verification as `rpm -i`
doesn't exit non-zero whenever parts of the install script fail.

Fixes: #8361

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
