### PR TITLE
fix(search website): Display title in all search result hierarchies

### DIFF
--- a/docs/assets/js/search.tsx
+++ b/docs/assets/js/search.tsx
@@ -44,7 +44,9 @@ const Chevron: React.FC = () => {
 }
 
 const Result = ({ hit, components }) => {
-  const isRootPage = hit.hierarchy.length < 1
+  const hierarchy = hit.hierarchy.concat(hit.title)
+  const isRootPage = hierarchy.length < 1
+
   return (
     <a href={hit.itemUrl}>
       <div className="border-r border-gray-300 py-4 pl-2 h-full leading-relaxed">
@@ -53,12 +55,12 @@ const Result = ({ hit, components }) => {
       <div className="p-2 block">
         <div className="text-gray-800 text-md mb-1 font-medium leading-relaxed ">
           {!isRootPage &&
-            hit.hierarchy.map((t, i) => (
+            hierarchy.map((t, i) => (
               <span key={`${hit.itemUrl}-${t}`}>
                 <span className="w-2 h-2 inline" key={`${t.itemUrl}`}>
                   {t}
                 </span>
-                {i < hit.hierarchy.length - 1 && (
+                {i < hierarchy.length - 1 && (
                   <span className="inline ml-1 mr-1">
                     <Chevron />
                   </span>

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -38,21 +38,9 @@ type Section = {
 };
 
 function sanitizeRecord(record: AlgoliaRecord): AlgoliaRecord {
-  const sanitizedRecord: AlgoliaRecord = {
-    title: record.title.trim(),
-    hierarchy: record.hierarchy.map((item) => item.trim()),
-    objectID: record.objectID,
-    pageTitle: record.pageTitle,
-    pageUrl: record.pageUrl,
-    itemUrl: record.itemUrl,
-    level: record.level,
-    tags: record.tags,
-    ranking: record.ranking,
-    section: record.section,
-    content: record.content,
-  };
-
-  return sanitizedRecord;
+  record.title = record.title.trim();
+  record.hierarchy = record.hierarchy.map((item) => item.trim());
+  return record;
 }
 
 // Constants

--- a/docs/scripts/algolia-index.ts
+++ b/docs/scripts/algolia-index.ts
@@ -37,6 +37,24 @@ type Section = {
   ranking: number;
 };
 
+function sanitizeRecord(record: AlgoliaRecord): AlgoliaRecord {
+  const sanitizedRecord: AlgoliaRecord = {
+    title: record.title.trim(),
+    hierarchy: record.hierarchy.map((item) => item.trim()),
+    objectID: record.objectID,
+    pageTitle: record.pageTitle,
+    pageUrl: record.pageUrl,
+    itemUrl: record.itemUrl,
+    level: record.level,
+    tags: record.tags,
+    ranking: record.ranking,
+    section: record.section,
+    content: record.content,
+  };
+
+  return sanitizedRecord;
+}
+
 // Constants
 const DEBUG = process.env.DEBUG === "true" || false;
 const targetFile = "./public/search.json";
@@ -144,7 +162,8 @@ async function indexHTMLFiles(
 
         activeRecord.content += item.content;
       } else if (item.level < activeRecord.level) {
-        algoliaRecords.push({ ...activeRecord });
+        const sanitizedRecord = sanitizeRecord(activeRecord);
+        algoliaRecords.push({ ...sanitizedRecord });
 
         activeRecord = {
           objectID: itemUrl,
@@ -160,10 +179,10 @@ async function indexHTMLFiles(
           content: "",
         };
       } else { // h2-h6 logic
-        algoliaRecords.push({ ...activeRecord });
+        const sanitizedRecord = sanitizeRecord(activeRecord);
+        algoliaRecords.push({ ...sanitizedRecord });
 
-        const levelDiff = item.level - activeRecord.level;
-        const lastIndex = activeRecord.hierarchy.length - levelDiff;
+        const lastIndex = activeRecord.hierarchy.length - 1;
 
         activeRecord = {
           objectID: itemUrl,
@@ -181,9 +200,8 @@ async function indexHTMLFiles(
       }
 
       if (activeRecord) {
-        activeRecord.title = activeRecord.title.trim();
-        activeRecord.hierarchy.map((item) => item.trim());
-        algoliaRecords.push({ ...activeRecord });
+        const sanitizedRecord = sanitizeRecord(activeRecord);
+        algoliaRecords.push({ ...sanitizedRecord });
       }
 
       for (const rec of algoliaRecords) {


### PR DESCRIPTION
Current vector.dev:

<img width="629" alt="Screen Shot 2021-07-26 at 5 29 16 PM" src="https://user-images.githubusercontent.com/1523104/127076347-ba7819da-570b-4547-b458-192d3c0c963b.png">

With this PR:

<img width="570" alt="Screen Shot 2021-07-26 at 5 29 49 PM" src="https://user-images.githubusercontent.com/1523104/127076360-0f100836-fb83-489a-a27c-6102574a4110.png">

I originally tried to fix this via the indexing script (which we still *could* do) but instead I opted to alter the view layer, which I think is more "correct."