### PR TITLE
chore: Add scope section to RFC template

### DIFF
--- a/rfcs/_YYYY-MM-DD-issue#-title.md
+++ b/rfcs/_YYYY-MM-DD-issue#-title.md
@@ -2,11 +2,18 @@
 
 One paragraph description of the change.
 
+## Context
+
+- Link to any previous RFCs for additional context (do not repeat here).
+- Link to any ongoing or future changes that'll be affected by this change (cross cutting concerns).
+
 ## Scope
 
-- Address both *in* and *out* of scope.
-- Use out of scope to acknowledge future changes, cut scope, keep your change minimal, and keep the discussion focused.
-- Link to any previous RFCs for additional context.
+### In scope
+
+### Out of scope
+
+- Acknowledge future changes, cut scope, keep your change minimal, and keep the discussion focused.
 
 ## Pain
 


### PR DESCRIPTION
I've found that we're not addressing cross cutting concerns in our RFC. This is important since they can heavily affect our implementation. For example, the "resource" abstraction proposed in the [CSV enrichment RFC](https://github.com/timberio/vector/pull/8400) is largely supported by the need for admin to provision resources and provide them to the new pipelines concepts being proposed in the [Pipelines RFC](https://github.com/timberio/vector/pull/8378).