### PR TITLE
chore: Rate limit defaults reconsidered

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use chrono::{Duration, Utc};
 use futures::{future::BoxFuture, ready, stream, FutureExt, SinkExt, StreamExt, TryFutureExt};
-use lazy_static::lazy_static;
 use rusoto_core::{request::BufferedHttpResponse, RusotoError};
 use rusoto_logs::{
     CloudWatchLogs, CloudWatchLogsClient, CreateLogGroupError, CreateLogStreamError,
@@ -106,12 +105,6 @@ fn default_config(e: Encoding) -> CloudwatchLogsSinkConfig {
     }
 }
 
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig<Option<usize>> = TowerRequestConfig {
-        ..Default::default()
-    };
-}
-
 pub struct CloudwatchLogsSvc {
     client: CloudWatchLogsClient,
     stream_name: String,
@@ -183,7 +176,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             .events(10_000)
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig::default());
 
         let log_group = self.group_name.clone();
         let log_stream = self.stream_name.clone();
@@ -220,7 +213,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 
 impl CloudwatchLogsPartitionSvc {
     pub fn new(config: CloudwatchLogsSinkConfig, client: CloudWatchLogsClient) -> Self {
-        let request_settings = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request_settings = config.request.unwrap_with(&TowerRequestConfig::default());
 
         Self {
             config,

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use chrono::{DateTime, SecondsFormat, Utc};
 use futures::{future, future::BoxFuture, stream, FutureExt, SinkExt};
-use lazy_static::lazy_static;
 use rusoto_cloudwatch::{
     CloudWatch, CloudWatchClient, Dimension, MetricDatum, PutMetricDataError, PutMetricDataInput,
 };
@@ -51,14 +50,6 @@ pub struct CloudWatchMetricsSinkConfig {
     assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        timeout_secs: Some(30),
-        rate_limit_num: Some(150),
-        ..Default::default()
-    };
 }
 
 inventory::submit! {
@@ -138,7 +129,11 @@ impl CloudWatchMetricsSvc {
             .events(20)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.unwrap_with(&TowerRequestConfig {
+            timeout_secs: Some(30),
+            rate_limit_num: Some(150),
+            ..Default::default()
+        });
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, FutureExt, Sink, SinkExt, StreamExt};
-use lazy_static::lazy_static;
 use rusoto_core::RusotoError;
 use rusoto_firehose::{
     DescribeDeliveryStreamError, DescribeDeliveryStreamInput, KinesisFirehose,
@@ -51,13 +50,6 @@ pub struct KinesisFirehoseSinkConfig {
     assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        timeout_secs: Some(30),
-        ..Default::default()
-    };
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
@@ -149,7 +141,11 @@ impl KinesisFirehoseService {
             .events(500)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.unwrap_with(&TowerRequestConfig {
+            timeout_secs: Some(30),
+            ..Default::default()
+        });
+
         let encoding = config.encoding.clone();
 
         let kinesis = KinesisFirehoseService { client, config };

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, FutureExt, Sink, SinkExt, StreamExt, TryFutureExt};
-use lazy_static::lazy_static;
 use rand::random;
 use rusoto_core::RusotoError;
 use rusoto_kinesis::{
@@ -54,13 +53,6 @@ pub struct KinesisSinkConfig {
     assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        timeout_secs: Some(30),
-        ..Default::default()
-    };
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -152,7 +144,11 @@ impl KinesisService {
             .events(500)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.unwrap_with(&TowerRequestConfig {
+            timeout_secs: Some(30),
+            ..Default::default()
+        });
+
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();
 

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -59,9 +59,6 @@ pub enum Encoding {
 }
 
 lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        ..Default::default()
-    };
     static ref LOG_TYPE_REGEX: Regex = Regex::new(r"^\w+$").unwrap();
     static ref LOG_TYPE_HEADER: HeaderName = HeaderName::from_static("log-type");
     static ref X_MS_DATE_HEADER: HeaderName = HeaderName::from_static(X_MS_DATE);
@@ -114,7 +111,7 @@ impl SinkConfig for AzureMonitorLogsConfig {
         let client = HttpClient::new(Some(tls_settings))?;
 
         let sink = AzureMonitorLogsSink::new(self)?;
-        let request_settings = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
 
         let healthcheck = healthcheck(sink.clone(), client.clone()).boxed();
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -15,7 +15,6 @@ use bytes::Bytes;
 use futures::{FutureExt, SinkExt};
 use http::{Request, StatusCode, Uri};
 use hyper::Body;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
@@ -44,12 +43,6 @@ pub struct ClickhouseConfig {
     pub tls: Option<TlsOptions>,
 }
 
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        ..Default::default()
-    };
-}
-
 inventory::submit! {
     SinkDescription::new::<ClickhouseConfig>("clickhouse")
 }
@@ -75,7 +68,7 @@ impl SinkConfig for ClickhouseConfig {
             .bytes(bytesize::mib(10u64))
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig::default());
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(tls_settings)?;
 

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -19,7 +19,6 @@ use crate::{
 use chrono::{DateTime, Utc};
 use futures::{stream, FutureExt, SinkExt};
 use http::{uri::InvalidUri, Request, Uri};
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{
@@ -62,13 +61,6 @@ struct DatadogSink {
     config: DatadogConfig,
     /// Endpoint -> (uri_path, last_sent_timestamp)
     endpoint_data: HashMap<DatadogEndpoint, (Uri, AtomicI64)>,
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        retry_attempts: Some(5),
-        ..Default::default()
-    };
 }
 
 // https://docs.datadoghq.com/api/?lang=bash#post-timeseries-points
@@ -194,7 +186,10 @@ impl SinkConfig for DatadogConfig {
             .events(20)
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig {
+            retry_attempts: Some(5),
+            ..Default::default()
+        });
 
         let uri = DatadogEndpoint::build_uri(&self.get_endpoint())?;
         let timestamp = Utc::now().timestamp();

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -25,7 +25,6 @@ use http::{
 };
 use hyper::Body;
 use indexmap::IndexMap;
-use lazy_static::lazy_static;
 use rusoto_core::Region;
 use rusoto_credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_signature::{SignedRequest, SignedRequestPayload};
@@ -287,12 +286,6 @@ impl DataStreamConfig {
     }
 }
 
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        ..Default::default()
-    };
-}
-
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
@@ -381,7 +374,10 @@ impl SinkConfig for ElasticSearchConfig {
             .bytes(bytesize::mib(10u64))
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.tower.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self
+            .request
+            .tower
+            .unwrap_with(&TowerRequestConfig::default());
 
         let sink = BatchedHttpSink::with_logic(
             common,
@@ -640,7 +636,10 @@ impl ElasticSearchCommon {
 
         let doc_type = config.doc_type.clone().unwrap_or_else(|| "_doc".into());
 
-        let tower_request = config.request.tower.unwrap_with(&REQUEST_DEFAULTS);
+        let tower_request = config
+            .request
+            .tower
+            .unwrap_with(&TowerRequestConfig::default());
 
         let mut query_params = config.query.clone().unwrap_or_default();
         query_params.insert(

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -69,13 +69,6 @@ inventory::submit! {
 
 impl_generate_config_from_default!(PubsubConfig);
 
-lazy_static::lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        rate_limit_num: Some(100),
-        ..Default::default()
-    };
-}
-
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_pubsub")]
 impl SinkConfig for PubsubConfig {

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -20,7 +20,6 @@ use http::{
 };
 use hyper::Body;
 use indexmap::IndexMap;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::io::Write;
@@ -70,15 +69,6 @@ fn default_config(e: Encoding) -> HttpSinkConfig {
         request: Default::default(),
         tls: Default::default(),
     }
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        concurrency: Concurrency::Fixed(10),
-        timeout_secs: Some(30),
-        rate_limit_num: Some(u64::max_value()),
-        ..Default::default()
-    };
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -148,7 +138,12 @@ impl SinkConfig for HttpSinkConfig {
             .bytes(bytesize::mib(10u64))
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.tower.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.tower.unwrap_with(&TowerRequestConfig {
+            concurrency: Concurrency::Fixed(10),
+            timeout_secs: Some(30),
+            rate_limit_num: Some(u64::max_value()),
+            ..Default::default()
+        });
 
         let sink = BatchedHttpSink::new(
             config,

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -7,8 +7,8 @@ use crate::{
         buffer::compression::GZIP_DEFAULT,
         encoding::{EncodingConfig, EncodingConfiguration},
         http::{BatchedHttpSink, HttpSink, RequestConfig},
-        BatchConfig, BatchSettings, Buffer, Compression, Concurrency, EncodedEvent,
-        TowerRequestConfig, UriSerde,
+        BatchConfig, BatchSettings, Buffer, Compression, EncodedEvent, TowerRequestConfig,
+        UriSerde,
     },
     tls::{TlsOptions, TlsSettings},
 };

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -139,9 +139,7 @@ impl SinkConfig for HttpSinkConfig {
             .timeout(1)
             .parse_config(config.batch)?;
         let request = config.request.tower.unwrap_with(&TowerRequestConfig {
-            concurrency: Concurrency::Fixed(10),
             timeout_secs: Some(30),
-            rate_limit_num: Some(u64::max_value()),
             ..Default::default()
         });
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -20,7 +20,6 @@ use crate::{
 use futures::SinkExt;
 use http::{Request, Uri};
 use indoc::indoc;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -55,13 +54,6 @@ struct InfluxDbLogsSink {
     namespace: String,
     tags: HashSet<String>,
     encoding: EncodingConfig<Encoding>,
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        retry_attempts: Some(5),
-        ..Default::default()
-    };
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -106,7 +98,10 @@ impl SinkConfig for InfluxDbLogsConfig {
             .bytes(bytesize::mib(1u64))
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig {
+            retry_attempts: Some(5),
+            ..Default::default()
+        });
 
         let settings = influxdb_settings(
             self.influxdb1_settings.clone(),

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, SinkExt};
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -62,13 +61,6 @@ pub struct InfluxDbConfig {
 
 pub fn default_summary_quantiles() -> Vec<f64> {
     vec![0.5, 0.75, 0.9, 0.95, 0.99]
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        retry_attempts: Some(5),
-        ..Default::default()
-    };
 }
 
 // https://v2.docs.influxdata.com/v2.0/write-data/#influxdb-api
@@ -128,7 +120,10 @@ impl InfluxDbSvc {
             .events(20)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = config.request.unwrap_with(&TowerRequestConfig {
+            retry_attempts: Some(5),
+            ..Default::default()
+        });
 
         let uri = settings.write_uri(endpoint)?;
 

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -61,10 +61,6 @@ inventory::submit! {
     SinkDescription::new::<RemoteWriteConfig>("prometheus_remote_write")
 }
 
-lazy_static::lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = Default::default();
-}
-
 impl_generate_config_from_default!(RemoteWriteConfig);
 
 #[async_trait::async_trait]
@@ -80,7 +76,7 @@ impl SinkConfig for RemoteWriteConfig {
             .events(1_000)
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig::default());
         let buckets = self.buckets.clone();
         let quantiles = self.quantiles.clone();
 

--- a/src/sinks/vector/v2.rs
+++ b/src/sinks/vector/v2.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use futures::{future::BoxFuture, stream, SinkExt, StreamExt, TryFutureExt};
 use http::uri::Uri;
-use lazy_static::lazy_static;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -60,12 +59,6 @@ fn default_config(address: &str) -> VectorConfig {
         request: TowerRequestConfig::default(),
         tls: None,
     }
-}
-
-lazy_static! {
-    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
-        ..Default::default()
-    };
 }
 
 /// grpc doesn't like an address without a scheme, so we default to http if one isn't specified in
@@ -124,7 +117,7 @@ impl VectorConfig {
 
         let healthcheck = healthcheck(healthcheck_client, cx.healthcheck.clone());
 
-        let request = self.request.unwrap_with(&REQUEST_DEFAULTS);
+        let request = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch = BatchSettings::default()
             .events(1000)
             .timeout(1)


### PR DESCRIPTION
This is a follow up from PR #8471. In this commit I've removed any default or
near-default TowerRequestConfig instances from `lazy_static` contexts and
shuffled them into their call-site. I have not changed any of the default
overrides.

The largest change here is the removal of `lazy_static` sites. This macro, while
convenient, introduces serialization into vector -- atomic read which is acq/rel
on x86 -- and I'd like it to be rare in the codebase.

For sinks that set an explicit rate limit I have mostly left these intact,
unless I knew better. That is, some sinks set a rate limit because that is a
documented limit and others set it to be higher than the previous default. If
there was no documentation suggesting that the rate limit was arbitrary I
assumed it was intentionally set and left it be.

Resolves #8470

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>