### PR TITLE
chore: Slim down `src/types.rs`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,1 @@
-use lazy_static::lazy_static;
-use std::path::PathBuf;
-
-pub use shared::conversion::*;
-
-lazy_static! {
-    pub static ref DEFAULT_CONFIG_PATHS: Vec<PathBuf> = vec!["/etc/vector/vector.toml".into()];
-}
+pub use shared::conversion::{parse_check_conversion_map, parse_conversion_map, Conversion, Error};


### PR DESCRIPTION
While working on #8472 I noticed that we could slim the referenced file
down. The default config paths are no longer used and the wildcard import from
`shared::conversion` was overly broad considering our use of the types from that
sub-crate.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
