### PR TITLE
chore: Small tweaks around the Datadog sink 

### DIFF
--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -150,7 +150,7 @@ impl HttpSink for Service {
             .header("Content-Type", "application/json")
             .header("DD-API-KEY", &api_key[..]);
 
-        let (request, body) = match self.compression {
+        let (request, encoded_body) = match self.compression {
             Compression::None => (request, body),
             Compression::Gzip(level) => {
                 let level = level.unwrap_or(GZIP_FAST);
@@ -168,8 +168,8 @@ impl HttpSink for Service {
         };
 
         request
-            .header("Content-Length", body.len())
-            .body(body)
+            .header("Content-Length", encoded_body.len())
+            .body(encoded_body)
             .map_err(Into::into)
     }
 }

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -101,16 +101,22 @@ impl HttpSink for Service {
     fn encode_event(&self, mut event: Event) -> Option<EncodedEvent<Self::Input>> {
         let log = event.as_mut_log();
 
-        if let Some(message) = log.remove(self.log_schema_message_key) {
-            log.insert_flat("message", message);
+        if self.log_schema_message_key != "message" {
+            if let Some(message) = log.remove(self.log_schema_message_key) {
+                log.insert_flat("message", message);
+            }
         }
 
-        if let Some(timestamp) = log.remove(self.log_schema_timestamp_key) {
-            log.insert_flat("date", timestamp);
+        if self.log_schema_timestamp_key != "date" {
+            if let Some(timestamp) = log.remove(self.log_schema_timestamp_key) {
+                log.insert_flat("date", timestamp);
+            }
         }
 
-        if let Some(host) = log.remove(self.log_schema_host_key) {
-            log.insert_flat("host", host);
+        if self.log_schema_host_key != "host" {
+            if let Some(host) = log.remove(self.log_schema_host_key) {
+                log.insert_flat("host", host);
+            }
         }
 
         self.encoding.apply_rules(&mut event);

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -25,55 +25,15 @@ fn event_with_api_key(msg: &str, key: &str) -> Event {
     e
 }
 
-#[tokio::test]
-async fn smoke_json() {
-    let (expected, output) = smoke_test().await;
-
-    for (i, val) in output.iter().enumerate() {
-        assert_eq!(
-            val.0.headers.get("Content-Type").unwrap(),
-            "application/json"
-        );
-
-        let mut json = serde_json::Deserializer::from_slice(&val.1[..])
-            .into_iter::<serde_json::Value>()
-            .map(|v| v.expect("decoding json"));
-
-        let json = json.next().unwrap();
-
-        // The json we send to Datadog is an array of events.
-        // As we have set batch.max_events to 1, each entry will be
-        // an array containing a single record.
-        let message = json
-            .get(0)
-            .unwrap()
-            .get("message")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        assert_eq!(message, expected[i]);
-    }
-}
-
-async fn smoke_test() -> (Vec<String>, Vec<(http::request::Parts, Bytes)>) {
-    let (expected, rx) = start_test(StatusCode::OK, BatchStatus::Delivered).await;
-
-    let output = rx.take(expected.len()).collect::<Vec<_>>().await;
-
-    (expected, output)
-}
-
-#[tokio::test]
-async fn handles_failure_json() {
-    handles_failure().await;
-}
-
-async fn handles_failure() {
-    let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Failed).await;
-
-    assert!(matches!(rx.try_next(), Err(TryRecvError { .. })));
-}
-
+/// Starts a test sink with random lines running into it
+///
+/// This function starts a Datadog Logs sink with a simplistic configuration and
+/// runs random lines through it, returning a vector of the random lines and a
+/// Receiver populated with the result of the sink's operation.
+///
+/// Testers may set `http_status` and `batch_status`. The first controls what
+/// status code faked HTTP responses will have, the second acts as a check on
+/// the `Receiver`'s status before being returned to the caller.
 async fn start_test(
     http_status: StatusCode,
     batch_status: BatchStatus,
@@ -107,6 +67,62 @@ async fn start_test(
 }
 
 #[tokio::test]
+/// Assert the basic functionality of the sink in good conditions
+///
+/// This test rigs the sink to return StatusCode::OK to responses, checks that
+/// all batches were delivered and then asserts that every message is able to be
+/// deserialized.
+async fn smoke() {
+    let (expected, rx) = start_test(StatusCode::OK, BatchStatus::Delivered).await;
+
+    let output = rx.take(expected.len()).collect::<Vec<_>>().await;
+
+    for (i, val) in output.iter().enumerate() {
+        assert_eq!(
+            val.0.headers.get("Content-Type").unwrap(),
+            "application/json"
+        );
+
+        let mut json = serde_json::Deserializer::from_slice(&val.1[..])
+            .into_iter::<serde_json::Value>()
+            .map(|v| v.expect("decoding json"));
+
+        let json = json.next().unwrap();
+
+        // The json we send to Datadog is an array of events.
+        // As we have set batch.max_events to 1, each entry will be
+        // an array containing a single record.
+        let message = json
+            .get(0)
+            .unwrap()
+            .get("message")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(message, expected[i]);
+    }
+}
+
+#[tokio::test]
+/// Assert delivery error behavior
+///
+/// In the event that delivery fails -- in this case becaues it is FORBIDDEN --
+/// there should be no outbound messages from the sink. That is, receiving from
+/// its Receiver must fail.
+async fn handles_failure() {
+    let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Failed).await;
+    let res = rx.try_next();
+
+    assert!(matches!(res, Err(TryRecvError { .. })));
+}
+
+#[tokio::test]
+/// Assert that metadata API keys are passed correctly
+///
+/// Datadog sink payloads come with an associated API key. This key can be set
+/// per-event or set in the message for an entire payload. This test asserts
+/// that, for successful transmission, the API key set in metadata is
+/// propagated.
 async fn api_key_in_metadata() {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
@@ -128,10 +144,11 @@ async fn api_key_in_metadata() {
 
     let (expected, events) = random_lines_with_stream(100, 10, None);
 
+    let api_key = "0xDECAFBAD";
     let mut events = events.map(|mut e| {
         e.as_mut_log()
             .metadata_mut()
-            .set_datadog_api_key(Some(Arc::from("from_metadata")));
+            .set_datadog_api_key(Some(Arc::from(api_key)));
         Ok(e)
     });
 
@@ -139,7 +156,7 @@ async fn api_key_in_metadata() {
     let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
     for (i, val) in output.iter().enumerate() {
-        assert_eq!(val.0.headers.get("DD-API-KEY").unwrap(), "from_metadata");
+        assert_eq!(val.0.headers.get("DD-API-KEY").unwrap(), api_key);
 
         assert_eq!(
             val.0.headers.get("Content-Type").unwrap(),
@@ -167,6 +184,12 @@ async fn api_key_in_metadata() {
 }
 
 #[tokio::test]
+/// Assert that events with explicit keys have those keys preserved
+///
+/// Datadog sink payloads come with an associated API key. This key can be set
+/// per-event or set in the message for an entire payload. This test asserts
+/// that, for successful transmission, per-event API keys are propagated
+/// correctly.
 async fn multiple_api_keys() {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"


### PR DESCRIPTION
This collection of commits tweaks a number of small things in the Datadog sink. I have added documentation describing the goals of the tests, avoid going through path iteration code if the log schema fields are identically named and expand the writing space for the encoder. 

I had imagined building off this work to introduce more direct serialization -- see https://github.com/timberio/vector/tree/blt-estimate_json_size for a hint of what I was thinking -- but with this commit vector on my machine clocks in at 230Mb/s in the setup described [here](https://github.com/timberio/vector/issues/8263). I'm satisfied that it's time to move on. 

Resolves #8263

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
