### PR TITLE
fix(template website): Fix log output template

### DIFF
--- a/docs/cue/reference/components/sources/file.cue
+++ b/docs/cue/reference/components/sources/file.cue
@@ -288,7 +288,7 @@ components: sources: file: {
 	]
 
 	how_it_works: {
-		autodiscover: {
+		autodiscovery: {
 			title: "Autodiscovery"
 			body: """
 				Vector will continually look for new files matching any of your

--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -213,7 +213,7 @@
 
   {{/* Source/transform/sink output */}}
   {{ with .component_output }}
-  <div class="p-4">
+  <div class="py-3 px-5">
     {{ with .metrics }}
     <span class="flex items-center justify-between">
       {{ partial "heading.html" (dict "text" "Metrics" "level" 3 "id" "output-metrics" "href" "#output-metrics") }}
@@ -244,7 +244,7 @@
     </span>
 
     <div class="mt-3 border rounded divide-y dark:border-gray-700 dark:divide-gray-700">
-      {{ template "telemetry" . }}
+      {{ template "logs_output" . }}
     </div>
     {{ end }}
   </div>
@@ -1454,6 +1454,70 @@
 </div>
 {{ end }}
 
+{{ define "logs_output" }}
+{{ range $k, $v := . }}
+<div class="py-3 px-5">
+  <span class="flex justify-between items-center">
+    <span class="font-mono font-bold text-dark dark:text-gray-200">
+      {{ partial "heading.html" (dict "text" $k "level" 4) }}
+    </span>
+  </span>
+
+  {{ with $v.description }}
+  <div class="mt-3 prose dark:prose-dark">
+    {{ . | markdownify }}
+  </div>
+  {{ end }}
+
+  {{ with $v.fields }}
+  {{ $id := printf "%s-fields" $k }}
+  <div class="mt-4 font-semibold">
+    {{ partial "heading.html" (dict "text" "Fields" "level" 5 "id" $id) }}
+  </div>
+
+  <div class="mt-2 flex flex-col divide-y dark:divide-gray-700 border rounded dark:border-gray-700">
+
+    {{ range $k, $v := . }}
+    <div class="py-2.5 px-3.5">
+      <span class="flex justify-between items-center">
+        <span class="font-mono font-semibold">
+          {{ $k }}
+        </span>
+
+        <span class="flex space-x-1">
+          {{ if $v.required }}
+          {{ partial "badge.html" (dict "word" "required" "color" "red") }}
+          {{ else }}
+          {{ partial "badge.html" (dict "word" "optional" "color" "blue") }}
+          {{ end }}
+
+          {{ range $k, $v := $v.type }}
+          {{ $isArray := eq $k "array" }}
+          {{ if $isArray }}
+          {{ range $k, $v := $v.items.type }}
+          {{ $name := printf "[%s]" $k }}
+          {{ partial "badge.html" (dict "word" $name "color" "gray") }}
+          {{ end }}
+          {{ else }}
+          {{ partial "badge.html" (dict "word" $k "color" "gray") }}
+          {{ end }}
+          {{ end }}
+        </span>
+      </span>
+
+      {{ with $v.description }}
+      <div class="mt-2 prose dark:prose-dark">
+        {{ . | markdownify }}
+      </div>
+      {{ end }}
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+</div>
+{{ end }}
+{{ end }}
+
 {{ define "telemetry" }}
 {{ range $k, $v := . }}
 <div class="py-4 px-6">
@@ -1490,9 +1554,11 @@
           </span>
         </span>
 
-        <div>
-          {{ $v.description }}
+        {{ with $v.description }}
+        <div class="prose dark:prose-dark">
+          {{ . | markdownify }}
         </div>
+        {{ end }}
       </div>
       {{ end }}
     </div>

--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -1456,10 +1456,12 @@
 
 {{ define "logs_output" }}
 {{ range $k, $v := . }}
+{{ $title := $k | title }}
+{{ $id := printf "%s-log-output" $k }}
 <div class="py-3 px-5">
   <span class="flex justify-between items-center">
-    <span class="font-mono font-bold text-dark dark:text-gray-200">
-      {{ partial "heading.html" (dict "text" $k "level" 4) }}
+    <span class="text-lg">
+      {{ partial "heading.html" (dict "text" $title "level" 4 "id" $id) }}
     </span>
   </span>
 

--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -1500,6 +1500,10 @@
           {{ end }}
           {{ else }}
           {{ partial "badge.html" (dict "word" $k "color" "gray") }}
+
+          {{ with $v.syntax }}
+          {{ partial "badge.html" (dict "word" . "color" "gray") }}
+          {{ end }}
           {{ end }}
           {{ end }}
         </span>
@@ -1509,6 +1513,22 @@
       <div class="mt-2 prose dark:prose-dark">
         {{ . | markdownify }}
       </div>
+      {{ end }}
+
+      {{ range $k, $v := $v.type }}
+      {{ with $v.examples }}
+      <div class="mt-2">
+        <span>
+          Examples
+        </span>
+
+        <div class="mt-1.5 flex flex-col space-y-1 text-sm">
+          {{ range . }}
+          {{ template "code" . }}
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
       {{ end }}
     </div>
     {{ end }}
@@ -1520,7 +1540,7 @@
 
 {{ define "telemetry" }}
 {{ range $k, $v := . }}
-<div class="py-4 px-6">
+<div class="py-3 px-5">
   <span class="flex justify-between items-center">
     <span class="font-mono font-bold text-dark dark:text-gray-200">
       {{ partial "heading.html" (dict "text" $k "level" 4) }}
@@ -1539,7 +1559,7 @@
   <div class="mt-3 border rounded dark:border-gray-700">
     <div class="flex flex-col divide-y dark:divide-gray-700">
       {{ range $k, $v := . }}
-      <div class="py-3 px-4">
+      <div class="py-2.5 px-4">
         <span class="flex justify-between items-center">
           <span class="font-mono font-semibold">
             {{ $k }}


### PR DESCRIPTION
Fixes #8508

In general, the structured data templates could use some touching up, but this provides a decent-enough view layer for now.

Here's an example:

https://deploy-preview-8514--vector-project.netlify.app/docs/reference/configuration/sources/file/#output-logs