### PR TITLE
fix(external docs): Convert Markdown examples into raw text

### DIFF
--- a/docs/cue/reference/components/sources/exec.cue
+++ b/docs/cue/reference/components/sources/exec.cue
@@ -191,11 +191,7 @@ components: sources: exec: {
 			_timestamp: "2020-03-13T20:45:38.119Z"
 			title:      "Exec line"
 			configuration: {}
-			input: """
-				```text
-				(_message)
-				```
-				"""
+			input: _line
 			output: log: {
 				data_stream: "stdout"
 				pid:         5678

--- a/docs/cue/reference/components/sources/file.cue
+++ b/docs/cue/reference/components/sources/file.cue
@@ -273,11 +273,7 @@ components: sources: file: {
 			configuration: {
 				include: ["\(_directory)/**/*.log"]
 			}
-			input: """
-				```text filename="\(_file)"
-				\(_line)
-				```
-				"""
+			input: _line
 			output: log: {
 				file:      _file
 				host:      _values.local_host

--- a/docs/cue/reference/components/sources/fluent.cue
+++ b/docs/cue/reference/components/sources/fluent.cue
@@ -111,11 +111,7 @@ components: sources: fluent: {
 			title: "Dummy message from fluentd"
 			configuration: {}
 			input: """
-				```text
 				2021-05-20 16:23:03.021497000 -0400 dummy: {"message":"dummy"}
-				```
-
-				(this is the fluentd stdout encoding of the dummy message)
 				"""
 			output: log: {
 				host:      _values.remote_host
@@ -128,11 +124,7 @@ components: sources: fluent: {
 			title: "Dummy message from fluent-bit"
 			configuration: {}
 			input: """
-				```text
 				dummy.0: [1621541848.161827000, {"message"=>"dummy"}]
-				```
-
-				(this is the fluent-bit stdout encoding of the dummy message)
 				"""
 			output: log: {
 				host:      _values.remote_host

--- a/docs/cue/reference/components/sources/journald.cue
+++ b/docs/cue/reference/components/sources/journald.cue
@@ -139,9 +139,7 @@ components: sources: journald: {
 
 			configuration: {}
 			input: """
-				```text
 				2019-07-26 20:30:27 reply from 192.168.1.2: offset -0.001791 delay 0.000176, next query 1500s
-				```
 				"""
 			output: [{
 				log: {

--- a/docs/cue/reference/components/sources/kubernetes_logs.cue
+++ b/docs/cue/reference/components/sources/kubernetes_logs.cue
@@ -392,9 +392,7 @@ components: sources: kubernetes_logs: {
 			title: "Sample Output"
 			configuration: {}
 			input: """
-				```text
 				F1015 11:01:46.499073       1 main.go:39] error getting server version: Get \"https://10.96.0.1:443/version?timeout=32s\": dial tcp 10.96.0.1:443: connect: network is unreachable
-				```
 				"""
 			output: log: {
 				"file":                       "/var/log/pods/kube-system_storage-provisioner_93bde4d0-9731-4785-a80e-cd27ba8ad7c2/storage-provisioner/1.log"

--- a/docs/cue/reference/components/sources/stdin.cue
+++ b/docs/cue/reference/components/sources/stdin.cue
@@ -87,11 +87,7 @@ components: sources: stdin: {
 				"""
 			title: "STDIN line"
 			configuration: {}
-			input: """
-				```text
-				\( _line )
-				```
-				"""
+			input: _line
 			output: log: {
 				timestamp: _values.current_timestamp
 				message:   _line

--- a/docs/cue/reference/components/sources/syslog.cue
+++ b/docs/cue/reference/components/sources/syslog.cue
@@ -156,9 +156,7 @@ components: sources: syslog: {
 			title:         "Syslog Eve"
 			configuration: {}
 			input: """
-				```text
 				<13>1 \(_timestamp) \(_hostname) \(_app_name) \(_procid) \(_msgid) [exampleSDID@32473 iut="\(_iut)" eventSource="\(_event_source)" eventID="\(_event_id)"] \(_message)
-				```
 				"""
 			output: log: {
 				severity:    "notice"

--- a/docs/cue/reference/remap/functions/assert.cue
+++ b/docs/cue/reference/remap/functions/assert.cue
@@ -8,10 +8,10 @@ remap: functions: assert: {
 		"""
 	notices: [
 		"""
-		The `assert` function should be used in a standalone fashion and only when you want to abort the program. You
-		should avoid it in logical expressions and other situations in which you want the program to continue if the
-		condition evaluates to `false`.
-		""",
+			The `assert` function should be used in a standalone fashion and only when you want to abort the program. You
+			should avoid it in logical expressions and other situations in which you want the program to continue if the
+			condition evaluates to `false`.
+			""",
 	]
 
 	arguments: [


### PR DESCRIPTION
The Hugo templates expect raw strings rather than Markdown for these fields. This PR updates the CUE sources to reflect that. I also snuck a `cue fmt` into this.