### PR TITLE
enhancement(windows platform): add `--stop-timeout` command-line argument for restart service sub-command

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use structopt::StructOpt;
 
@@ -95,10 +96,32 @@ impl InstallOpts {
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-struct StandardOpts {
+struct RestartOpts {
     /// The name of the service.
     #[structopt(long)]
     name: Option<String>,
+
+    /// How long to wait for the service to stop before starting it back, in seconds.
+    #[structopt(default_value = "60", long)]
+    stop_timeout: u32
+}
+
+impl RestartOpts {
+    fn service_info(&self) -> ServiceInfo {
+        let mut default_service = ServiceInfo::default();
+        let service_name = self.name.as_deref().unwrap_or(DEFAULT_SERVICE_NAME);
+
+        default_service.name = OsString::from(service_name);
+        default_service
+    }
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "kebab-case")]
+struct StandardOpts {
+    /// The name of the service.
+    #[structopt(long)]
+    name: Option<String>
 }
 
 impl StandardOpts {
@@ -123,7 +146,7 @@ enum SubCommand {
     /// Stop the service.
     Stop(StandardOpts),
     /// Restart the service.
-    Restart(StandardOpts),
+    Restart(RestartOpts),
 }
 
 struct ServiceInfo {
@@ -155,7 +178,9 @@ enum ControlAction {
     Uninstall,
     Start,
     Stop,
-    Restart,
+    Restart {
+        stop_timeout: Duration
+    }
 }
 
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
@@ -171,7 +196,10 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             SubCommand::Start(opts) => control_service(&opts.service_info(), ControlAction::Start),
             SubCommand::Stop(opts) => control_service(&opts.service_info(), ControlAction::Stop),
             SubCommand::Restart(opts) => {
-                control_service(&opts.service_info(), ControlAction::Restart)
+                let stop_timeout = Duration::from_secs(opts.stop_timeout as u64);
+                control_service(&opts.service_info(), ControlAction::Restart {
+                    stop_timeout
+                })
             }
         },
         None => {
@@ -209,9 +237,11 @@ fn control_service(service: &ServiceInfo, action: ControlAction) -> exitcode::Ex
             &service_definition,
             vector_windows::service_control::ControlAction::Stop,
         ),
-        ControlAction::Restart => vector_windows::service_control::control(
+        ControlAction::Restart { stop_timeout } => vector_windows::service_control::control(
             &service_definition,
-            vector_windows::service_control::ControlAction::Restart,
+            vector_windows::service_control::ControlAction::Restart {
+                stop_timeout
+            }
         ),
     };
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -103,7 +103,7 @@ struct RestartOpts {
 
     /// How long to wait for the service to stop before starting it back, in seconds.
     #[structopt(default_value = "60", long)]
-    stop_timeout: u32
+    stop_timeout: u32,
 }
 
 impl RestartOpts {
@@ -121,7 +121,7 @@ impl RestartOpts {
 struct StandardOpts {
     /// The name of the service.
     #[structopt(long)]
-    name: Option<String>
+    name: Option<String>,
 }
 
 impl StandardOpts {
@@ -178,9 +178,7 @@ enum ControlAction {
     Uninstall,
     Start,
     Stop,
-    Restart {
-        stop_timeout: Duration
-    }
+    Restart { stop_timeout: Duration },
 }
 
 pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
@@ -197,9 +195,10 @@ pub fn cmd(opts: &Opts) -> exitcode::ExitCode {
             SubCommand::Stop(opts) => control_service(&opts.service_info(), ControlAction::Stop),
             SubCommand::Restart(opts) => {
                 let stop_timeout = Duration::from_secs(opts.stop_timeout as u64);
-                control_service(&opts.service_info(), ControlAction::Restart {
-                    stop_timeout
-                })
+                control_service(
+                    &opts.service_info(),
+                    ControlAction::Restart { stop_timeout },
+                )
             }
         },
         None => {
@@ -239,9 +238,7 @@ fn control_service(service: &ServiceInfo, action: ControlAction) -> exitcode::Ex
         ),
         ControlAction::Restart { stop_timeout } => vector_windows::service_control::control(
             &service_definition,
-            vector_windows::service_control::ControlAction::Restart {
-                stop_timeout
-            }
+            vector_windows::service_control::ControlAction::Restart { stop_timeout },
         ),
     };
 

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -79,9 +79,7 @@ pub mod service_control {
         Uninstall,
         Start,
         Stop,
-        Restart {
-            stop_timeout: Duration
-        }
+        Restart { stop_timeout: Duration },
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -175,7 +173,10 @@ pub mod service_control {
         Ok(())
     }
 
-    fn restart_service(service_def: &ServiceDefinition, stop_timeout: Duration) -> crate::Result<()> {
+    fn restart_service(
+        service_def: &ServiceDefinition,
+        stop_timeout: Duration,
+    ) -> crate::Result<()> {
         let service_access =
             ServiceAccess::QUERY_STATUS | ServiceAccess::START | ServiceAccess::STOP;
         let service = open_service(&service_def, service_access)?;

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -79,7 +79,9 @@ pub mod service_control {
         Uninstall,
         Start,
         Stop,
-        Restart,
+        Restart {
+            stop_timeout: Duration
+        }
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -121,7 +123,7 @@ pub mod service_control {
         match action {
             ControlAction::Start => start_service(&service_def),
             ControlAction::Stop => stop_service(&service_def),
-            ControlAction::Restart => restart_service(&service_def),
+            ControlAction::Restart { stop_timeout } => restart_service(&service_def, stop_timeout),
             ControlAction::Install => install_service(&service_def),
             ControlAction::Uninstall => uninstall_service(&service_def),
         }
@@ -173,7 +175,7 @@ pub mod service_control {
         Ok(())
     }
 
-    fn restart_service(service_def: &ServiceDefinition) -> crate::Result<()> {
+    fn restart_service(service_def: &ServiceDefinition, stop_timeout: Duration) -> crate::Result<()> {
         let service_access =
             ServiceAccess::QUERY_STATUS | ServiceAccess::START | ServiceAccess::STOP;
         let service = open_service(&service_def, service_access)?;
@@ -188,7 +190,7 @@ pub mod service_control {
         let service_status = ensure_state(
             &service,
             ServiceState::Stopped,
-            Duration::from_secs(10),
+            stop_timeout,
             Duration::from_secs(1),
         )?;
         handle_service_exit_code(service_status.exit_code);


### PR DESCRIPTION
On Windows, to restart the service, vector is first going to stop the service and wait for its state to become `Stopped` before starting it back.

The stop timeout delay is currently hardcoded to 10 seconds. However, the service might take longer to stop, making the restart fail (which might cause trouble with automated tools like `ansible`).

This PR introduces a new `--stop-timeout`  command-line argument  with a default  value of 60 seconds (instead of 10 before) to let the user control the timeout.
