### PR TITLE
chore: Update public roadmap URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -48,7 +48,7 @@ force = true
 
 [[redirects]]
 from = "https://roadmap.vector.dev/*"
-to = "https://github.com/timberio/vector/projects/57"
+to = "https://airtable.com/shriTZW5LeOE4cIyJ"
 status = 302
 force = true
 


### PR DESCRIPTION
A new updated public roadmap for https://roadmap.vector.dev