### PR TITLE
enhancement(external docs): Add component description to component template

### DIFF
--- a/docs/layouts/docs/component.html
+++ b/docs/layouts/docs/component.html
@@ -5,7 +5,6 @@
 {{ define "main" }}
 {{ $tag := .File.BaseFileName }}
 {{ $kind := .CurrentSection.Params.component_type }}
-{{ $kindSingular := $kind | singularize }}
 {{ $config := index (index site.Data.docs.components $kind) $tag }}
 {{ $exampleConfigs := $config.example_configs }}
 <div class="relative max-w-3xl mx-auto px-6 lg:px-8 lg:max-w-7xl mt-8">
@@ -41,17 +40,8 @@
           </div>
           {{ end }}
 
-          {{ with $config.alias }}
-          {{ partial "heading.html" (dict "text" "Alias" "level" 2) }}
-
-          <p>
-            This component was previously called the <code>{{ . }}</code> {{ $kindSingular }}. Make sure to update your
-            Vector configuration to accommodate the name change:
-          </p>
-
-          {{ $diff := printf "[%s.%s]\n+type = \"%s\"\n-type = \"%s\"" $kind $tag $tag . }}
-
-          {{ highlight $diff "diff" "" }}
+          {{ if $config.alias }}
+          {{ partial "docs/component-alias.html" (dict "kind" $kind "alias" $config.alias "current" $tag) }}
           {{ end }}
 
           {{/* Component requirements */}}

--- a/docs/layouts/docs/component.html
+++ b/docs/layouts/docs/component.html
@@ -7,7 +7,6 @@
 {{ $kind := .CurrentSection.Params.component_type }}
 {{ $kindSingular := $kind | singularize }}
 {{ $config := index (index site.Data.docs.components $kind) $tag }}
-{{ $desc := .Description | default $config.description }}
 {{ $exampleConfigs := $config.example_configs }}
 <div class="relative max-w-3xl mx-auto px-6 lg:px-8 lg:max-w-7xl mt-8">
   <div class="lg:grid lg:grid-cols-16 lg:gap-8">
@@ -36,6 +35,12 @@
         {{ partial "docs/component-under-hero.html" . }}
 
         <div class="mt-12 prose dark:prose-dark tracking-tight pb-32">
+          {{ with $config.description }}
+          <div class="prose dark:prose-dark">
+            {{ . | markdownify }}
+          </div>
+          {{ end }}
+
           {{ with $config.alias }}
           {{ partial "heading.html" (dict "text" "Alias" "level" 2) }}
 

--- a/docs/layouts/partials/docs/component-alias.html
+++ b/docs/layouts/partials/docs/component-alias.html
@@ -1,0 +1,12 @@
+{{ $kindSingular := .kind | singularize }}
+
+{{ partial "heading.html" (dict "text" "Alias" "level" 2) }}
+
+<p>
+  This component was previously called the <code>{{ .alias }}</code> {{ $kindSingular }}. Make sure to update your
+  Vector configuration to accommodate the name change:
+</p>
+
+{{ $diff := printf "[%s.my_%s_%s]\n+type = \"%s\"\n-type = \"%s\"" .kind .current (.kind | singularize) .current .alias }}
+
+{{ highlight $diff "diff" "" }}


### PR DESCRIPTION
Some more housekeeping. I could swear that component descriptions were included in the docs, but a Git mishap may have prevented that from going live.