### PR TITLE
enhancement(helm platform): extra args for vector container

### DIFF
--- a/distribution/helm/vector-agent/templates/daemonset.yaml
+++ b/distribution/helm/vector-agent/templates/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
           args:
             - --config-dir
             - /etc/vector/
+            {{- with .Values.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:

--- a/distribution/helm/vector-agent/values.yaml
+++ b/distribution/helm/vector-agent/values.yaml
@@ -104,6 +104,11 @@ securityContext: {}
 # Extra env vars to pass to the `vector` container.
 env: []
 
+# Extra arguments to pass to the `vector` container.
+args: []
+  # - --quiet
+  # - --verbose
+
 # Tolerations to set for the `Pod`s managed by `DaemonSet`.
 tolerations:
   # This toleration is to have the `DaemonSet` runnable on master nodes.

--- a/distribution/helm/vector-aggregator/templates/statefulset.yaml
+++ b/distribution/helm/vector-aggregator/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
           args:
             - --config-dir
             - /etc/vector/
+            {{- with .Values.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}

--- a/distribution/helm/vector-aggregator/values.yaml
+++ b/distribution/helm/vector-aggregator/values.yaml
@@ -87,6 +87,11 @@ env: []
   #        name: secret
   #        key: password
 
+# Extra arguments to pass to the `vector` container.
+args: []
+  # - --quiet
+  # - --verbose
+
 # Tolerations to set for the `Pod`s managed by `DaemonSet`.
 tolerations:
   # This toleration is to have the `DaemonSet` runnable on master nodes.


### PR DESCRIPTION
Similar to the existing `env` value.

This allows for example to configure the vector loglevel, as this is currently only possible via cli arg, as far as i can tell.

