### PR TITLE
fix(processing): Fix handling ipv6 support for apache error regex client part

### DIFF
--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -67,7 +67,7 @@ lazy_static! {
         (?P<severity>[^\[]*))\])\s+                 # Match ary character except `]`, `]` and at least one whitespace.
         (-|\[\s*pid\s*(-|(?P<pid>[^:]*)             # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
         (:\s*tid\s*(?P<thread>[^\[]*))?)\])\s       # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
-        (-|\[\s*client\s*(-|(?P<client>[^:]*):      # Match `-` or `[` followed by `client`, `-` or any character except `:`.
+        (-|\[\s*client\s*(-|(?P<client>.*:?):       # Match `-` or `[` followed by `client`, `-` or any character until the first or last `:` for the port.
         (?P<port>[^\[]*))\])\s                      # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
         (-|(?P<message>.*))                         # Match `-` or any character.
         \s*$                                        # Match any number of whitespaces (to be discarded).

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -253,6 +253,24 @@ mod tests {
             tz: shared::TimeZone::default(),
         }
 
+        error_line_ip_v6 {
+            args: func_args![value: r#"[01/Mar/2021:12:00:19 +0000] [ab:alert] [pid 4803:tid 3814] [client eda7:35d:3ceb:ef1e:2133:e7bf:116e:24cc:24259] I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!"#,
+                             format: "error"
+                             ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-03-01T12:00:19Z").unwrap().into()),
+                "message" => "I'll bypass the haptic COM bandwidth, that should matrix the CSS driver!",
+                "module" => "ab",
+                "severity" => "alert",
+                "pid" => 4803,
+                "thread" => "3814",
+                "client" => "eda7:35d:3ceb:ef1e:2133:e7bf:116e:24cc",
+                "port" => 24259
+            }),
+            tdef: TypeDef::new().fallible().object(type_def_error()),
+            tz: shared::TimeZone::default(),
+        }
+
         error_line_thread_id {
             args: func_args![
                 value: r#"[2021-06-04 15:40:27.138633] [php7:emerg] [pid 4803] [client 95.223.77.60:35106] PHP Parse error:  syntax error, unexpected \'->\' (T_OBJECT_OPERATOR) in /var/www/prod/releases/master-c7225365fd9faa26262cffeeb57b31bd7448c94a/source/index.php on line 14"#,


### PR DESCRIPTION
Currently it could only handle ipv4 and when an ipv6 address comes it
runs into an "failed parsing port" error.

To fix the problem we there just needs to look until the Colon for the port part and look for as many or none Colon so that ipv4 and ipv6 can be handled.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
