### PR TITLE
chore: Remove tracing error span in hot path

### DIFF
--- a/lib/shared/src/datetime.rs
+++ b/lib/shared/src/datetime.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Local, ParseError, TimeZone as _, Utc};
 use chrono_tz::Tz;
 use derivative::Derivative;
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[derivative(Default)]
@@ -58,7 +58,7 @@ pub mod ser_de {
     impl<'de> de::Visitor<'de> for TimeZoneVisitor {
         type Value = TimeZone;
 
-        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "a time zone name")
         }
 

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
 parser = { package = "vrl-parser", path = "../parser" }
-shared = { path = "../../shared", default-features = false }
+shared = { path = "../../shared", default-features = false, features = ["conversion"] }
 lookup = { path = "../../lookup" }
 
 bitflags = "1"


### PR DESCRIPTION
This commit removes a `span!` call with `Level::ERROR` setting from
`FunctionCall::resolve`. My understanding here is that this span did not
terminate into any collector and will not impact user observable remap
behavior. This does, however, add +9Mb/s throughput to the configuration
described in #8512.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
