### PR TITLE
fix(css website): Add spacing for top-level TOC elements

### DIFF
--- a/docs/assets/sass/toc.sass
+++ b/docs/assets/sass/toc.sass
@@ -29,6 +29,9 @@
       overflow: hidden
       position: relative
 
+      & > li:not(:first-child)
+        margin-top: $h2-top-margin
+
       li
         list-style: none
 

--- a/docs/assets/sass/variables.sass
+++ b/docs/assets/sass/variables.sass
@@ -23,3 +23,4 @@ $h4-font-size: 0.7rem
 $h3-toc-spacing: 0.35rem
 $h4-toc-spacing: 0.2rem
 $y-padding: 0.25rem
+$h2-top-margin: 0.5rem // Vertical spacing for top-level TOC blocks


### PR DESCRIPTION
In the current site, the TOC is a little crammed, above all because I was struggling to appropriately target nested levels within the TOC class hierarchy. This PR addresses that by adding a top margin only to the top-level items (i.e. the `h2` elements on the page).

Current:

<img width="234" alt="Screen Shot 2021-08-03 at 12 15 35 PM" src="https://user-images.githubusercontent.com/1523104/128072995-f1d03ff6-f952-4380-b092-ed1ae1a81a7d.png">

Proposed:

<img width="202" alt="Screen Shot 2021-08-03 at 12 15 19 PM" src="https://user-images.githubusercontent.com/1523104/128073009-4bf90858-accb-4380-89a0-406c4507ea4a.png">
