### PR TITLE
fix(external docs): Update Brewfile.netlify

### DIFF
--- a/docs/Brewfile.netlify
+++ b/docs/Brewfile.netlify
@@ -1,4 +1,2 @@
-tap "cue-lang/tap"
-
 brew "cue-lang/tap/cue"
 brew "htmltest"


### PR DESCRIPTION
Apparently the `tap` directive previously used to install the CUE CLI is no longer necessary, as evinced by some Netlify build errors.