### PR TITLE
fix(external docs): Fix MSI installation link

### DIFF
--- a/docs/content/en/docs/setup/installation/package-managers/msi.md
+++ b/docs/content/en/docs/setup/installation/package-managers/msi.md
@@ -9,9 +9,9 @@ MSI is the file format and command line utility for the [Windows Installer][inst
 ## Installation
 
 ```powershell
-powershell Invoke-WebRequest https://packages.timber.io/vector/{{< version >}}/vector-x86_64.msi \
-  -OutFile vector-{{< version >}}-x86_64.msi && \
-  msiexec /i vector-{{< version >}}-x86_64.msi /quiet
+powershell Invoke-WebRequest https://packages.timber.io/vector/{{% version %}}/vector-x86_64.msi \
+  -OutFile vector-{{% version %}}-x86_64.msi && \
+  msiexec /i vector-{{% version %}}-x86_64.msi /quiet
 ```
 
 ## Management


### PR DESCRIPTION
For reasons that are opaque to me, the `{{< version >}}` shortcode invocation isn't working inside this code block, while the alternative syntax (`{{% version %}}`) seems to work fine.

Fixes #8575

PS: ignore the Netlify build errors here. I'm in touch with their support about this.