### PR TITLE
fix(vrl): Handle quotes in path segments

### DIFF
--- a/lib/lookup/src/lookup_buf/segmentbuf.rs
+++ b/lib/lookup/src/lookup_buf/segmentbuf.rs
@@ -35,7 +35,7 @@ impl From<String> for FieldBuf {
             // There is unfortunately no way to make an owned substring of a string.
             // So we have to take a slice and clone it.
             let len = name.len();
-            name = name[1..len - 1].to_string();
+            name = name[1..len - 1].replace(r#"\""#, r#"""#).to_string();
             requires_quoting = true;
         } else if !field::is_valid_fieldname(&name) {
             requires_quoting = true

--- a/lib/lookup/src/lookup_buf/segmentbuf.rs
+++ b/lib/lookup/src/lookup_buf/segmentbuf.rs
@@ -35,7 +35,7 @@ impl From<String> for FieldBuf {
             // There is unfortunately no way to make an owned substring of a string.
             // So we have to take a slice and clone it.
             let len = name.len();
-            name = name[1..len - 1].replace(r#"\""#, r#"""#).to_string();
+            name = name[1..len - 1].replace(r#"\""#, r#"""#);
             requires_quoting = true;
         } else if !field::is_valid_fieldname(&name) {
             requires_quoting = true


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #8590

@StephenWakely's first guess at a fix seems to work locally - though `make test-vrl` fails for me (timezones!)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
