### PR TITLE
docs: Make docs clearer around when IAM permissions are required

### DIFF
--- a/docs/cue/reference/components.cue
+++ b/docs/cue/reference/components.cue
@@ -434,11 +434,11 @@ components: {
 
 	#IAM: {
 		#Policy: {
-			#RequiredFor: "write" | "healthcheck"
+			#RequiredFor: "operation" | "healthcheck"
 
 			// TODO: come up with a less janky URL generation scheme
 			_action:        !=""
-			required_for:   *["write"] | [#RequiredFor, ...#RequiredFor]
+			required_for:   *["operation"] | [#RequiredFor, ...#RequiredFor]
 			docs_url:       !=""
 			required_when?: !=""
 

--- a/docs/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -121,7 +121,7 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 			policies: [
 				{
 					_action: "PutMetricData"
-					required_for: ["healthcheck", "write"]
+					required_for: ["healthcheck", "operation"]
 				},
 			]
 		},

--- a/docs/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/docs/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -284,7 +284,7 @@ components: sinks: gcp_cloud_storage: {
 			policies: [
 				{
 					_action: "objects.create"
-					required_for: ["write"]
+					required_for: ["operation"]
 				},
 				{
 					_action: "objects.get"

--- a/docs/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/docs/cue/reference/components/sinks/gcp_pubsub.cue
@@ -150,7 +150,7 @@ components: sinks: gcp_pubsub: {
 				},
 				{
 					_action: "topics.publish"
-					required_for: ["write"]
+					required_for: ["operation"]
 				},
 			]
 		},

--- a/docs/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/docs/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -281,7 +281,7 @@ components: sinks: gcp_stackdriver_logs: {
 			policies: [
 				{
 					_action: "logEntries.create"
-					required_for: ["healthcheck", "write"]
+					required_for: ["healthcheck", "operation"]
 				},
 			]
 		},

--- a/docs/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/docs/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -172,7 +172,7 @@ components: sinks: gcp_stackdriver_metrics: {
 			policies: [
 				{
 					_action: "timeSeries.create"
-					required_for: ["healthcheck", "write"]
+					required_for: ["healthcheck", "operation"]
 				},
 			]
 		},

--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -1353,7 +1353,9 @@
                   </a>
                 </td>
                 <td>
-                  {{ range .required_for }}<code>{{ . }}</code>{{ end }}
+                  <ul>
+                    {{ range .required_for }}<li><code>{{ . }}</code></li>{{ end }}
+                  </ul>
                 </td>
                 <td>
                   {{ .required_when | markdownify }}


### PR DESCRIPTION
`write` isn't super clear and also not correct when talking about
sources. I chose to use `operation` which I think more closely matches
the distinction `required_for` is trying to make between healthchecks
and normal component operation.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
