### PR TITLE
chore(fluent source): Treat only with stringy map keys

### DIFF
--- a/src/sources/fluent.rs
+++ b/src/sources/fluent.rs
@@ -597,8 +597,10 @@ mod tests {
 
 #[cfg(all(test, feature = "fluent-integration-tests"))]
 mod integration_tests {
+    use crate::config::SourceConfig;
     use crate::config::SourceContext;
     use crate::docker::docker;
+    use crate::sources::fluent::FluentConfig;
     use crate::test_util::{collect_ready, next_addr_for_ip, trace_init, wait_for_tcp};
     use crate::Pipeline;
     use bollard::{
@@ -607,11 +609,11 @@ mod integration_tests {
         models::HostConfig,
         Docker,
     };
-    use chrono::DateTime;
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::HashMap, fs::File, io::Write, net::SocketAddr, time::Duration};
     use tokio::time::sleep;
     use uuid::Uuid;
+    use vector_core::event::Event;
 
     #[tokio::test]
     async fn fluentbit() {

--- a/src/sources/fluent.rs
+++ b/src/sources/fluent.rs
@@ -4,22 +4,25 @@ use crate::{
         log_schema, DataType, GenerateConfig, Resource, SourceConfig, SourceContext,
         SourceDescription,
     },
-    event::{Event, LogEvent, Value},
+    event::{Event, LogEvent},
     internal_events::{FluentMessageDecodeError, FluentMessageReceived},
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsSettings, TlsConfig},
 };
 use bytes::{Buf, Bytes, BytesMut};
-use chrono::{serde::ts_seconds, DateTime, TimeZone, Utc};
 use flate2::read::MultiGzDecoder;
 use rmp_serde::{decode, Deserializer};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, VecDeque},
-    convert::TryInto,
+    collections::VecDeque,
     io::{self, Read},
 };
 use tokio_util::codec::Decoder;
+
+use crate::sources::fluent::message::{
+    FluentEntry, FluentMessage, FluentRecord, FluentTag, FluentTimestamp,
+};
+mod message;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct FluentConfig {
@@ -343,209 +346,14 @@ impl From<FluentFrame> for LogEvent {
     }
 }
 
-/// Fluent msgpack messages can be encoded in one of three ways, each with and without
-/// options, all using arrays to encode the top-level fields.
-///
-/// The spec refers to 4 ways, but really CompressedPackedForward is encoded the same as
-/// PackedForward, it just has an additional decompression step.
-///
-/// Not yet handled are the handshake messages.
-///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#event-modes
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum FluentMessage {
-    Message(FluentTag, FluentTimestamp, FluentRecord),
-    // I attempted to just one variant for each of these, with and without options, using an
-    // `Option` for the last element, but rmp expected the number of elements to match in that case
-    // still (it just allows the last element to be `nil`).
-    MessageWithOptions(
-        FluentTag,
-        FluentTimestamp,
-        FluentRecord,
-        FluentMessageOptions,
-    ),
-    Forward(FluentTag, Vec<FluentEntry>),
-    ForwardWithOptions(FluentTag, Vec<FluentEntry>, FluentMessageOptions),
-    PackedForward(FluentTag, serde_bytes::ByteBuf),
-    PackedForwardWithOptions(FluentTag, serde_bytes::ByteBuf, FluentMessageOptions),
-
-    // should be last as it'll match any other message
-    Heartbeat(rmpv::Value), // should be Nil if heartbeat
-}
-
-/// Server options sent by client.
-///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#option
-#[derive(Default, Debug, Deserialize)]
-#[serde(default)]
-struct FluentMessageOptions {
-    size: Option<u64>,          // client provided hint for the number of entries
-    chunk: Option<String>,      // unused right now, would be used for acks
-    compressed: Option<String>, // this one is required if present
-}
-
-/// Fluent entry consisting of timestamp and record.
-///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#forward-mode
-#[derive(Debug, Deserialize)]
-struct FluentEntry(FluentTimestamp, FluentRecord);
-
-/// Fluent record is just key/value pairs.
-type FluentRecord = BTreeMap<String, FluentValue>;
-
-/// Fluent message tag.
-type FluentTag = String;
-
-/// Value for fluent record key.
-///
-/// Used mostly just to implement value conversion.
-#[derive(Debug, Deserialize, PartialEq)]
-struct FluentValue(rmpv::Value);
-
-impl From<FluentValue> for Value {
-    fn from(value: FluentValue) -> Self {
-        match value.0 {
-            rmpv::Value::Nil => Value::Null,
-            rmpv::Value::Boolean(b) => Value::Boolean(b),
-            rmpv::Value::Integer(i) => i
-                .as_i64()
-                .map(Value::Integer)
-                // unwrap large numbers to string similar to how `From<serde_json::Value> for Value` handles it
-                .unwrap_or_else(|| Value::Bytes(i.to_string().into())),
-            rmpv::Value::F32(f) => Value::Float(f.into()),
-            rmpv::Value::F64(f) => Value::Float(f),
-            rmpv::Value::String(s) => Value::Bytes(s.into_bytes().into()),
-            rmpv::Value::Binary(bytes) => Value::Bytes(bytes.into()),
-            rmpv::Value::Array(values) => Value::Array(
-                values
-                    .into_iter()
-                    .map(|value| Value::from(FluentValue(value)))
-                    .collect(),
-            ),
-            rmpv::Value::Map(values) => {
-                // Per
-                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes
-                // we should expect that keys are always stringy. Ultimately a
-                // lot hinges on what
-                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#grammar
-                // defines 'object' as.
-                //
-                // The current implementation will SILENTLY DROP non-stringy keys.
-                Value::Map(
-                    values
-                        .into_iter()
-                        .filter_map(|(key, value)| {
-                            key.as_str()
-                                .map(|k| (k.to_owned(), Value::from(FluentValue(value))))
-                        })
-                        .collect(),
-                )
-            }
-            rmpv::Value::Ext(code, bytes) => {
-                let mut fields = BTreeMap::new();
-                fields.insert(
-                    String::from("msgpack_extension_code"),
-                    Value::Integer(code.into()),
-                );
-                fields.insert(String::from("bytes"), Value::Bytes(bytes.into()));
-                Value::Map(fields)
-            }
-        }
-    }
-}
-
-/// Fluent message timestamp.
-///
-/// Message timestamps can be a unix timestamp or EventTime messagepack ext.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(untagged)]
-enum FluentTimestamp {
-    #[serde(with = "ts_seconds")]
-    Unix(DateTime<Utc>),
-    Ext(FluentEventTime),
-}
-
-impl From<FluentTimestamp> for Value {
-    fn from(timestamp: FluentTimestamp) -> Self {
-        match timestamp {
-            FluentTimestamp::Unix(timestamp) | FluentTimestamp::Ext(FluentEventTime(timestamp)) => {
-                Value::Timestamp(timestamp)
-            }
-        }
-    }
-}
-
-/// Custom decoder for Fluent's EventTime msgpack extension.
-///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
-#[derive(Clone, Debug, PartialEq)]
-struct FluentEventTime(DateTime<Utc>);
-
-impl<'de> serde::de::Deserialize<'de> for FluentEventTime {
-    fn deserialize<D>(deserializer: D) -> Result<FluentEventTime, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct FluentEventTimeVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for FluentEventTimeVisitor {
-            type Value = FluentEventTime;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("fluent timestamp extension")
-            }
-
-            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: serde::de::Deserializer<'de>,
-            {
-                deserializer.deserialize_tuple(2, self)
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let tag: u32 = seq
-                    .next_element()?
-                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-
-                if tag != 0 {
-                    return Err(serde::de::Error::custom(format!(
-                        "expected extension type 0 for fluent timestamp, got got {}",
-                        tag
-                    )));
-                }
-
-                let bytes: serde_bytes::ByteBuf = seq
-                    .next_element()?
-                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-
-                if bytes.len() != 8 {
-                    return Err(serde::de::Error::custom(format!(
-                        "expected exactly 8 bytes for binary encoded fluent timestamp, got {}",
-                        bytes.len()
-                    )));
-                }
-
-                // length checked right above
-                let seconds = u32::from_be_bytes(bytes[..4].try_into().expect("exactly 4 bytes"));
-                let nanoseconds =
-                    u32::from_be_bytes(bytes[4..].try_into().expect("exactly 4 bytes"));
-
-                Ok(FluentEventTime(Utc.timestamp(seconds.into(), nanoseconds)))
-            }
-        }
-
-        deserializer.deserialize_any(FluentEventTimeVisitor)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::sources::fluent::{DecodeError, FluentConfig, FluentDecoder};
+    use bytes::BytesMut;
+    use chrono::DateTime;
     use shared::{assert_event_data_eq, btreemap};
+    use tokio_util::codec::Decoder;
+    use vector_core::event::{LogEvent, Value};
 
     #[test]
     fn generate_config() {
@@ -789,19 +597,17 @@ mod tests {
 
 #[cfg(all(test, feature = "fluent-integration-tests"))]
 mod integration_tests {
-    use super::*;
-    use crate::{
-        config::SourceContext,
-        docker::docker,
-        test_util::{collect_ready, next_addr_for_ip, trace_init, wait_for_tcp},
-        Pipeline,
-    };
+    use crate::config::SourceContext;
+    use crate::docker::docker;
+    use crate::test_util::{collect_ready, next_addr_for_ip, trace_init, wait_for_tcp};
+    use crate::Pipeline;
     use bollard::{
         container::{Config as ContainerConfig, CreateContainerOptions},
         image::{CreateImageOptions, ListImagesOptions},
         models::HostConfig,
         Docker,
     };
+    use chrono::DateTime;
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::HashMap, fs::File, io::Write, net::SocketAddr, time::Duration};
     use tokio::time::sleep;

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -221,14 +221,14 @@ mod test {
     }
 
     quickcheck! {
-      fn from_u64(input: i64) -> () {
+      fn from_i64(input: i64) -> () {
           assert_eq!(Value::from(FluentValue(rmpv::Value::Integer(rmpv::Integer::from(input)))),
               Value::Integer(input))
         }
     }
 
     quickcheck! {
-        fn from_i64(input: u64) -> () {
+        fn from_u64(input: u64) -> () {
             if input > i64::max_value() as u64 {
                 assert_eq!(Value::from(FluentValue(rmpv::Value::Integer(rmpv::Integer::from(input)))),
                            Value::Bytes(input.to_string().into()))

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -295,7 +295,9 @@ mod test {
 
     quickcheck! {
         fn from_map(input: Vec<(String, i64)>) -> () {
-            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (rmpv::Value::String(rmpv::Utf8String::from(k)), rmpv::Value::Integer(rmpv::Integer::from(v)))).collect();
+            let key_fn = |k| { rmpv::Value::String(rmpv::Utf8String::from(k)) };
+            let val_fn = |k| { rmpv::Value::Integer(rmpv::Integer::from(k)) };
+            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (key_fn(k), val_fn(v))).collect();
             let actual = rmpv::Value::Map(actual_inner);
 
             let mut expected_inner = BTreeMap::new();
@@ -314,7 +316,9 @@ mod test {
             // map. Such maps are a violation of the fluent protocol and we
             // prefer to silently drop keys rather than crash the process.
 
-            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (rmpv::Value::Integer(rmpv::Integer::from(k)), rmpv::Value::Integer(rmpv::Integer::from(v)))).collect();
+            let key_fn = |k| { rmpv::Value::Integer(rmpv::Integer::from(k)) };
+            let val_fn = |k| { rmpv::Value::Integer(rmpv::Integer::from(k)) };
+            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.into_iter().map(|(k,v)| (key_fn(k), val_fn(v))).collect();
             let actual = rmpv::Value::Map(actual_inner);
 
             let expected = Value::Map(BTreeMap::new());

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -1,0 +1,343 @@
+use chrono::serde::ts_seconds;
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use vector_core::event::Value;
+
+/// Fluent msgpack messages can be encoded in one of three ways, each with and
+/// without options, all using arrays to encode the top-level fields.
+///
+/// The spec refers to 4 ways, but really CompressedPackedForward is encoded the
+/// same as PackedForward, it just has an additional decompression step.
+///
+/// Not yet handled are the handshake messages.
+///
+/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#event-modes
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum FluentMessage {
+    Message(FluentTag, FluentTimestamp, FluentRecord),
+    // I attempted to just one variant for each of these, with and without options, using an
+    // `Option` for the last element, but rmp expected the number of elements to match in that case
+    // still (it just allows the last element to be `nil`).
+    MessageWithOptions(
+        FluentTag,
+        FluentTimestamp,
+        FluentRecord,
+        FluentMessageOptions,
+    ),
+    Forward(FluentTag, Vec<FluentEntry>),
+    ForwardWithOptions(FluentTag, Vec<FluentEntry>, FluentMessageOptions),
+    PackedForward(FluentTag, serde_bytes::ByteBuf),
+    PackedForwardWithOptions(FluentTag, serde_bytes::ByteBuf, FluentMessageOptions),
+
+    // should be last as it'll match any other message
+    Heartbeat(rmpv::Value), // should be Nil if heartbeat
+}
+
+/// Server options sent by client.
+///
+/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#option
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+pub(super) struct FluentMessageOptions {
+    size: Option<u64>,     // client provided hint for the number of entries
+    chunk: Option<String>, // unused right now, would be used for acks
+    pub(super) compressed: Option<String>, // this one is required if present
+}
+
+/// Fluent entry consisting of timestamp and record.
+///
+/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#forward-mode
+#[derive(Debug, Deserialize)]
+pub(super) struct FluentEntry(pub(super) FluentTimestamp, pub(super) FluentRecord);
+
+/// Fluent record is just key/value pairs.
+pub(super) type FluentRecord = BTreeMap<String, FluentValue>;
+
+/// Fluent message tag.
+pub(super) type FluentTag = String;
+
+/// Custom decoder for Fluent's EventTime msgpack extension.
+///
+/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct FluentEventTime(DateTime<Utc>);
+
+impl<'de> serde::de::Deserialize<'de> for FluentEventTime {
+    fn deserialize<D>(deserializer: D) -> Result<FluentEventTime, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct FluentEventTimeVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for FluentEventTimeVisitor {
+            type Value = FluentEventTime;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("fluent timestamp extension")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::de::Deserializer<'de>,
+            {
+                deserializer.deserialize_tuple(2, self)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let tag: u32 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+
+                if tag != 0 {
+                    return Err(serde::de::Error::custom(format!(
+                        "expected extension type 0 for fluent timestamp, got got {}",
+                        tag
+                    )));
+                }
+
+                let bytes: serde_bytes::ByteBuf = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+
+                if bytes.len() != 8 {
+                    return Err(serde::de::Error::custom(format!(
+                        "expected exactly 8 bytes for binary encoded fluent timestamp, got {}",
+                        bytes.len()
+                    )));
+                }
+
+                // length checked right above
+                let seconds = u32::from_be_bytes(bytes[..4].try_into().expect("exactly 4 bytes"));
+                let nanoseconds =
+                    u32::from_be_bytes(bytes[4..].try_into().expect("exactly 4 bytes"));
+
+                Ok(FluentEventTime(Utc.timestamp(seconds.into(), nanoseconds)))
+            }
+        }
+
+        deserializer.deserialize_any(FluentEventTimeVisitor)
+    }
+}
+
+/// Value for fluent record key.
+///
+/// Used mostly just to implement value conversion.
+#[derive(Debug, Deserialize, PartialEq)]
+pub(super) struct FluentValue(rmpv::Value);
+
+impl From<FluentValue> for Value {
+    fn from(value: FluentValue) -> Self {
+        match value.0 {
+            rmpv::Value::Nil => Value::Null,
+            rmpv::Value::Boolean(b) => Value::Boolean(b),
+            rmpv::Value::Integer(i) => i
+                .as_i64()
+                .map(Value::Integer)
+                // unwrap large numbers to string similar to how
+                // `From<serde_json::Value> for Value` handles it
+                .unwrap_or_else(|| Value::Bytes(i.to_string().into())),
+            rmpv::Value::F32(f) => Value::Float(f.into()),
+            rmpv::Value::F64(f) => Value::Float(f),
+            rmpv::Value::String(s) => Value::Bytes(s.into_bytes().into()),
+            rmpv::Value::Binary(bytes) => Value::Bytes(bytes.into()),
+            rmpv::Value::Array(values) => Value::Array(
+                values
+                    .into_iter()
+                    .map(|value| Value::from(FluentValue(value)))
+                    .collect(),
+            ),
+            rmpv::Value::Map(values) => {
+                // Per
+                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes
+                // we should expect that keys are always stringy. Ultimately a
+                // lot hinges on what
+                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#grammar
+                // defines 'object' as.
+                //
+                // The current implementation will SILENTLY DROP non-stringy keys.
+                Value::Map(
+                    values
+                        .into_iter()
+                        .filter_map(|(key, value)| {
+                            key.as_str()
+                                .map(|k| (k.to_owned(), Value::from(FluentValue(value))))
+                        })
+                        .collect(),
+                )
+            }
+            rmpv::Value::Ext(code, bytes) => {
+                let mut fields = BTreeMap::new();
+                fields.insert(
+                    String::from("msgpack_extension_code"),
+                    Value::Integer(code.into()),
+                );
+                fields.insert(String::from("bytes"), Value::Bytes(bytes.into()));
+                Value::Map(fields)
+            }
+        }
+    }
+}
+
+/// Fluent message timestamp.
+///
+/// Message timestamps can be a unix timestamp or EventTime messagepack ext.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub(super) enum FluentTimestamp {
+    #[serde(with = "ts_seconds")]
+    Unix(DateTime<Utc>),
+    Ext(FluentEventTime),
+}
+
+impl From<FluentTimestamp> for Value {
+    fn from(timestamp: FluentTimestamp) -> Self {
+        match timestamp {
+            FluentTimestamp::Unix(timestamp) | FluentTimestamp::Ext(FluentEventTime(timestamp)) => {
+                Value::Timestamp(timestamp)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::sources::fluent::message::FluentValue;
+    use approx::assert_relative_eq;
+    use quickcheck::quickcheck;
+    use std::collections::BTreeMap;
+    use vector_core::event::Value;
+
+    quickcheck! {
+      fn from_bool(input: bool) -> () {
+          assert_eq!(Value::from(FluentValue(rmpv::Value::Boolean(input))),
+              Value::Boolean(input))
+        }
+    }
+
+    quickcheck! {
+      fn from_u64(input: i64) -> () {
+          assert_eq!(Value::from(FluentValue(rmpv::Value::Integer(rmpv::Integer::from(input)))),
+              Value::Integer(input))
+        }
+    }
+
+    quickcheck! {
+        fn from_i64(input: u64) -> () {
+            if input > i64::max_value() as u64 {
+                assert_eq!(Value::from(FluentValue(rmpv::Value::Integer(rmpv::Integer::from(input)))),
+                           Value::Bytes(input.to_string().into()))
+            } else {
+                assert_eq!(Value::from(FluentValue(rmpv::Value::Integer(rmpv::Integer::from(input)))),
+                           Value::Integer(input as i64))
+            }
+        }
+    }
+
+    quickcheck! {
+      fn from_f32(input: f32) -> () {
+          let val = Value::from(FluentValue(rmpv::Value::F32(input)));
+          match val {
+              Value::Float(f) => {
+                  if f.is_nan() {
+                      assert!(input.is_nan());
+                  } else {
+                      assert_relative_eq!(input as f64, f);
+                  }
+              }
+              _ => unreachable!(),
+          }
+        }
+    }
+
+    quickcheck! {
+      fn from_f64(input: f64) -> () {
+          let val = Value::from(FluentValue(rmpv::Value::F64(input)));
+          match val {
+              Value::Float(f) => {
+                  if f.is_nan() {
+                      assert!(input.is_nan());
+                  } else {
+                      assert_relative_eq!(input, f);
+                  }
+              }
+              _ => unreachable!(),
+          }
+        }
+    }
+
+    quickcheck! {
+      fn from_string(input: String) -> () {
+          assert_eq!(Value::from(FluentValue(rmpv::Value::String(rmpv::Utf8String::from(input.clone())))),
+                     Value::Bytes(input.into_bytes().into()))
+      }
+    }
+
+    quickcheck! {
+      fn from_binary(input: Vec<u8>) -> () {
+          assert_eq!(Value::from(FluentValue(rmpv::Value::Binary(input.clone()))),
+                     Value::Bytes(input.into()))
+      }
+    }
+
+    quickcheck! {
+      fn from_i64_array(input: Vec<i64>) -> () {
+          let actual: rmpv::Value = rmpv::Value::Array(input.iter().map(|i| rmpv::Value::from(*i)).collect());
+          let expected: Value = Value::Array(input.iter().map(|i| Value::Integer(*i)).collect());
+          assert_eq!(Value::from(FluentValue(actual)), expected);
+      }
+    }
+
+    quickcheck! {
+        fn from_map(input: Vec<(String, i64)>) -> () {
+            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (rmpv::Value::String(rmpv::Utf8String::from(k)), rmpv::Value::Integer(rmpv::Integer::from(v)))).collect();
+            let actual = rmpv::Value::Map(actual_inner);
+
+            let mut expected_inner = BTreeMap::new();
+            for (k,v) in input.into_iter() {
+                expected_inner.insert(k, Value::Integer(v));
+            }
+            let expected = Value::Map(expected_inner);
+
+            assert_eq!(Value::from(FluentValue(actual)), expected);
+      }
+    }
+
+    quickcheck! {
+        fn from_nonstring_key_map(input: Vec<(i64, i64)>) -> () {
+            // Any map that has non-string keys will be coerced into an empty
+            // map. Such maps are a violation of the fluent protocol and we
+            // prefer to silently drop keys rather than crash the process.
+
+            let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (rmpv::Value::Integer(rmpv::Integer::from(k)), rmpv::Value::Integer(rmpv::Integer::from(v)))).collect();
+            let actual = rmpv::Value::Map(actual_inner);
+
+            let expected = Value::Map(BTreeMap::new());
+
+            assert_eq!(Value::from(FluentValue(actual)), expected);
+      }
+    }
+
+    #[test]
+    fn from_nil() {
+        assert_eq!(Value::from(FluentValue(rmpv::Value::Nil)), Value::Null);
+    }
+
+    quickcheck! {
+        fn from_ext(code: i8, bytes: Vec<u8>) -> () {
+            let actual = rmpv::Value::Ext(code, bytes.clone());
+
+            let mut inner = BTreeMap::new();
+            inner.insert("msgpack_extension_code".to_string(), Value::Integer(code.into()));
+            inner.insert("bytes".to_string(), Value::Bytes(bytes.into()));
+            let expected = Value::Map(inner);
+
+            assert_eq!(Value::from(FluentValue(actual)), expected);
+      }
+    }
+}


### PR DESCRIPTION
The fluent protocol suggests that all map instances are String -> object. This,
I believe, allows us to consider map keys as entirely stringy. This resolves an
initial bottleneck in the source, per investigation in #8610.

This change is worth +123 Mb/s when sinking directly into a blackhole. This 
change is worth +59 Mb/s when going through the full configuration outlined 
in #8610 into `http_blackhole`. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
