### PR TITLE
fix(lua transform): Adjust memory use metric to be more clear

### DIFF
--- a/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -17,7 +17,7 @@ Vector's 0.16.0 release includes one breaking change:
 
 We cover it below to help you upgrade quickly:
 
-[##](##) Upgrade Guide
+## Upgrade Guide
 
 ### Datadog Log sink encoding option removed {#encoding}
 

--- a/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/docs/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -13,6 +13,7 @@ badges:
 Vector's 0.16.0 release includes one breaking change:
 
 1. [Datadog Log sink encoding option removed](#encoding)
+1. [Renaming of `memory_use_bytes` internal metric](#memory_use_bytes)
 
 We cover it below to help you upgrade quickly:
 
@@ -44,3 +45,17 @@ inputs = ["datadog_agent"]
 ```
 
 Encoding fields other than `codec` are still valid.
+
+### Renaming of `memory_use_bytes` internal metric {#memory_use_bytes}
+
+Vector previously documented the `internal_metrics` `memory_use_bytes` metric as
+being "The total memory currently being used by Vector (in bytes)."; however,
+this metric was actually published by the `lua` transform and indicated the
+memory use of just the Lua runtime.
+
+To make this more clear, the metric has been renamed from `memory_use_bytes` to
+`lua_memory_use_bytes`. If you were previously using `memory_use_bytes` as
+a measure of the `lua` runtime memory usage, you should update to refer to
+`lua_memory_use_bytes`.
+
+The documentation for this metric has also been updated.

--- a/docs/cue/reference/components/sources/internal_metrics.cue
+++ b/docs/cue/reference/components/sources/internal_metrics.cue
@@ -683,8 +683,8 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		memory_used_bytes: {
-			description:       "The total memory currently being used by Vector (in bytes)."
+		lua_memory_used_bytes: {
+			description:       "The total memory currently being used by the Lua runtime."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags

--- a/docs/cue/reference/components/transforms/lua.cue
+++ b/docs/cue/reference/components/transforms/lua.cue
@@ -486,7 +486,7 @@ components: transforms: lua: {
 	}
 
 	telemetry: metrics: {
-		memory_used_bytes:       components.sources.internal_metrics.output.metrics.memory_used_bytes
+		lua_memory_used_bytes:   components.sources.internal_metrics.output.metrics.lua_memory_used_bytes
 		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -8,7 +8,7 @@ pub struct LuaGcTriggered {
 
 impl InternalEvent for LuaGcTriggered {
     fn emit_metrics(&self) {
-        gauge!("memory_used_bytes", self.used_memory as f64);
+        gauge!("lua_memory_used_bytes", self.used_memory as f64);
     }
 }
 


### PR DESCRIPTION
A [user in
discord](https://discord.com/channels/742820443487993987/746070591097798688/873110527612702741)
was confused about this metric. We document it as the memory used by
Vector, which is not accurate, as the only component that publishes this
metric is the `lua` transform.

To make this more clear and to avoid a collision with the inevitiable
`memory_used_bytes` that Vector will _actually_ publish indicating its
own memory use, I renamed it to `lua_memory_used_bytes`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
