### PR TITLE
docs: Remove unpublished metrics from `prometheus_remote_write` source

### DIFF
--- a/docs/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/docs/cue/reference/components/sources/prometheus_remote_write.cue
@@ -95,14 +95,12 @@ components: sources: prometheus_remote_write: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
-		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
-		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
-		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
-		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
+		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
+		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:    components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:   components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total: components.sources.internal_metrics.output.metrics.requests_completed_total
+		requests_received_total:  components.sources.internal_metrics.output.metrics.requests_received_total
+		request_duration_seconds: components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
