### PR TITLE
fix(kubernetes_logs source): Fix regex parsing errors 

### DIFF
--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -5,7 +5,6 @@ use crate::{
         FunctionTransform,
     },
 };
-use bytes::Bytes;
 use derivative::Derivative;
 use shared::TimeZone;
 use snafu::{OptionExt, Snafu};
@@ -101,6 +100,7 @@ pub mod tests {
     use super::super::test_util;
     use super::*;
     use crate::{event::LogEvent, test_util::trace_init, transforms::Transform};
+    use bytes::Bytes;
 
     fn make_long_string(base: &str, len: usize) -> String {
         base.chars().cycle().take(len).collect()
@@ -189,7 +189,7 @@ pub mod tests {
         trace_init();
         test_util::test_parser(
             || Transform::function(Cri::new(TimeZone::Local)),
-            |line| Event::from(line),
+            Event::from,
             cases(),
         );
     }
@@ -199,7 +199,7 @@ pub mod tests {
         trace_init();
         test_util::test_parser(
             || Transform::function(Cri::new(TimeZone::Local)),
-            |bytes| Event::from(bytes),
+            Event::from,
             byte_cases(),
         );
     }

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -204,7 +204,11 @@ pub mod tests {
     fn test_parsing() {
         trace_init();
 
-        test_util::test_parser(|| Transform::function(Docker), cases());
+        test_util::test_parser(
+            || Transform::function(Docker),
+            |message| Event::from(message),
+            cases(),
+        );
     }
 
     #[test]

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -204,11 +204,7 @@ pub mod tests {
     fn test_parsing() {
         trace_init();
 
-        test_util::test_parser(
-            || Transform::function(Docker),
-            |message| Event::from(message),
-            cases(),
-        );
+        test_util::test_parser(|| Transform::function(Docker), Event::from, cases());
     }
 
     #[test]

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -89,7 +89,7 @@ mod tests {
         trace_init();
         test_util::test_parser(
             || Transform::function(Picker::new(TimeZone::Local)),
-            |message| Event::from(message),
+            Event::from,
             cases(),
         );
     }

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -89,6 +89,7 @@ mod tests {
         trace_init();
         test_util::test_parser(
             || Transform::function(Picker::new(TimeZone::Local)),
+            |message| Event::from(message),
             cases(),
         );
     }

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -4,6 +4,7 @@ use crate::{
     event::{Event, LogEvent},
     transforms::Transform,
 };
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 
 /// Build a log event for test purposes.
@@ -28,24 +29,52 @@ pub fn make_log_event(message: &str, timestamp: &str, stream: &str, is_partial: 
     log
 }
 
+/// Build a log event for test purposes.
+/// Message can be a not valid UTF-8 string
+///
+/// The implementation is shared, and therefore consistent across all
+/// the parsers.
+pub fn make_log_event_with_byte_message(
+    message: Bytes,
+    timestamp: &str,
+    stream: &str,
+    is_partial: bool,
+) -> LogEvent {
+    let mut log = LogEvent::default();
+
+    log.insert("message", message);
+
+    let timestamp = DateTime::parse_from_rfc3339(timestamp)
+        .expect("invalid test case")
+        .with_timezone(&Utc);
+    log.insert("timestamp", timestamp);
+
+    log.insert("stream", stream);
+
+    if is_partial {
+        log.insert("_partial", true);
+    }
+    log
+}
+
 /// Shared logic for testing parsers.
 ///
 /// Takes a parser builder and a list of test cases.
-pub fn test_parser<B>(builder: B, cases: Vec<(String, Vec<LogEvent>)>)
+pub fn test_parser<B, L, S>(builder: B, loader: L, cases: Vec<(S, Vec<LogEvent>)>)
 where
     B: Fn() -> Transform,
+    L: Fn(S) -> Event,
 {
     for (message, expected) in cases {
-        let input = Event::from(message);
+        let input = loader(message);
         let mut parser = (builder)();
         let parser = parser.as_function();
 
         let mut output = Vec::new();
         parser.transform(&mut output, input);
-        shared::assert_event_data_eq!(
-            expected.into_iter().map(Event::Log).collect::<Vec<_>>(),
-            output,
-            "expected left, actual right"
-        );
+
+        let expected = expected.into_iter().map(Event::Log).collect::<Vec<_>>();
+
+        shared::assert_event_data_eq!(expected, output, "expected left, actual right");
     }
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Fix for https://github.com/timberio/vector/issues/8606
Change CRI parsing regex to allow capturing invalid UTF-8 symbols and deal extra \n symbol 