### PR TITLE
enhancement(remap transform): allow providing path to VRL program

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -44,11 +44,12 @@ fn benchmark_remap(c: &mut Criterion) {
     group.bench_function("add_fields/remap", |b| {
         let mut tform: Box<dyn FunctionTransform> = Box::new(
             Remap::new(RemapConfig {
-                source: indoc! {r#".foo = "bar"
+                source: Some(indoc! {r#".foo = "bar"
                     .bar = "baz"
                     .copy = string!(.copy_from)
                 "#}
-                .to_string(),
+                .to_string()),
+                file: None,
                 timezone: TimeZone::default(),
                 drop_on_error: true,
                 drop_on_abort: true,
@@ -110,7 +111,8 @@ fn benchmark_remap(c: &mut Criterion) {
     group.bench_function("parse_json/remap", |b| {
         let mut tform: Box<dyn FunctionTransform> = Box::new(
             Remap::new(RemapConfig {
-                source: ".bar = parse_json!(string!(.foo))".to_owned(),
+                source: Some(".bar = parse_json!(string!(.foo))".to_owned()),
+                file: None,
                 timezone: TimeZone::default(),
                 drop_on_error: true,
                 drop_on_abort: true,
@@ -176,12 +178,13 @@ fn benchmark_remap(c: &mut Criterion) {
     group.bench_function("coerce/remap", |b| {
         let mut tform: Box<dyn FunctionTransform> = Box::new(
             Remap::new(RemapConfig {
-                source: indoc! {r#"
+                source: Some(indoc! {r#"
                     .number = to_int!(.number)
                     .bool = to_bool!(.bool)
                     .timestamp = parse_timestamp!(string!(.timestamp), format: "%d/%m/%Y:%H:%M:%S %z")
                 "#}
-                .to_owned(),
+                .to_owned()),
+                file: None,
                 timezone: TimeZone::default(),
                 drop_on_error: true,
                 drop_on_abort: true,

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -44,11 +44,13 @@ fn benchmark_remap(c: &mut Criterion) {
     group.bench_function("add_fields/remap", |b| {
         let mut tform: Box<dyn FunctionTransform> = Box::new(
             Remap::new(RemapConfig {
-                source: Some(indoc! {r#".foo = "bar"
+                source: Some(
+                    indoc! {r#".foo = "bar"
                     .bar = "baz"
                     .copy = string!(.copy_from)
                 "#}
-                .to_string()),
+                    .to_string(),
+                ),
                 file: None,
                 timezone: TimeZone::default(),
                 drop_on_error: true,

--- a/benches/wasm/mod.rs
+++ b/benches/wasm/mod.rs
@@ -78,11 +78,12 @@ pub fn add_fields(criterion: &mut Criterion) {
             "remap",
             Transform::function(
                 vector::transforms::remap::Remap::new(vector::transforms::remap::RemapConfig {
-                    source: indoc! {r#"
+                    source: Some(indoc! {r#"
                         .test_key = "test_value"
                         .test_key2 = "test_value2"
                     "#}
-                    .to_string(),
+                    .to_string()),
+                    file: None,
                     timezone: shared::TimeZone::default(),
                     drop_on_error: true,
                     drop_on_abort: true,

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -9,9 +9,9 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use shared::TimeZone;
 use snafu::{ResultExt, Snafu};
-use std::path::PathBuf;
 use std::fs::File;
-use std::io::{Read, self};
+use std::io::{self, Read};
+use std::path::PathBuf;
 use vrl::diagnostic::Formatter;
 use vrl::{Program, Runtime, Terminate};
 
@@ -74,7 +74,7 @@ impl Remap {
                     .read_to_string(&mut buffer)
                     .with_context(|| FileReadFailed { path })?;
 
-                    buffer
+                buffer
             }
             _ => return Err(Box::new(BuildError::SourceAndOrFile)),
         };
@@ -151,15 +151,9 @@ pub enum BuildError {
     SourceAndOrFile,
 
     #[snafu(display("Could not open vrl program {:?}: {}", path, source))]
-    FileOpenFailed {
-        path: PathBuf,
-        source: io::Error,
-    },
+    FileOpenFailed { path: PathBuf, source: io::Error },
     #[snafu(display("Could not read vrl program {:?}: {}", path, source))]
-    FileReadFailed {
-        path: PathBuf,
-        source: io::Error,
-    },
+    FileReadFailed { path: PathBuf, source: io::Error },
 }
 
 #[cfg(test)]

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1,3 +1,39 @@
+[transforms.remap_source]
+  inputs = []
+  type = "remap"
+  source = """
+    .message = "foo"
+  """
+[[tests]]
+  name = "remap_source"
+  [tests.input]
+    insert_at = "remap_source"
+    type = "log"
+    [tests.input.log_fields]
+      foo = true
+  [[tests.outputs]]
+    extract_from = "remap_source"
+    [[tests.outputs.conditions]]
+      type = "vrl"
+      source = ".message == \"foo\""
+
+[transforms.remap_file]
+  inputs = []
+  type = "remap"
+  file = "tests/data/remap/program.vrl"
+[[tests]]
+  name = "remap_file"
+  [tests.input]
+    insert_at = "remap_file"
+    type = "log"
+    [tests.input.log_fields]
+      foo = true
+  [[tests.outputs]]
+    extract_from = "remap_file"
+    [[tests.outputs.conditions]]
+      type = "vrl"
+      source = ".message == \"foo\""
+
 [transforms.remap_emit_multiple]
   inputs = []
   type = "remap"

--- a/tests/data/remap/program.vrl
+++ b/tests/data/remap/program.vrl
@@ -1,0 +1,1 @@
+.message = "foo"

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -70,6 +70,8 @@ components: transforms: "remap": {
 		file: {
 			description: """
 				File path to the [Vector Remap Language](\(urls.vrl_reference)) (VRL) program to execute for each event.
+				
+				If a relative path is provided, its root is the current working directory.
 
 				Required if `source` is missing.
 				"""

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -48,8 +48,10 @@ components: transforms: "remap": {
 		source: {
 			description: """
 				The [Vector Remap Language](\(urls.vrl_reference)) (VRL) program to execute for each event.
+
+				Required if `file` is missing.
 				"""
-			required:    true
+			required:    false
 			type: string: {
 				examples: [
 					"""
@@ -61,6 +63,20 @@ components: transforms: "remap": {
 						""",
 				]
 				syntax: "remap_program"
+			}
+		}
+		file: {
+			description: """
+				File path to the [Vector Remap Language](\(urls.vrl_reference)) (VRL) program to execute for each event.
+
+				Required if `source` is missing.
+				"""
+			required:    false
+			type: string: {
+				examples: [
+					"./my/program.vrl",
+				]
+				syntax: "literal"
 			}
 		}
 		drop_on_error: {

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -51,6 +51,7 @@ components: transforms: "remap": {
 
 				Required if `file` is missing.
 				"""
+			common:      true
 			required:    false
 			type: string: {
 				examples: [
@@ -62,7 +63,8 @@ components: transforms: "remap": {
 						.new_name = del(.old_name)
 						""",
 				]
-				syntax: "remap_program"
+				syntax:  "remap_program"
+				default: null
 			}
 		}
 		file: {
@@ -71,12 +73,14 @@ components: transforms: "remap": {
 
 				Required if `source` is missing.
 				"""
+			common:      true
 			required:    false
 			type: string: {
 				examples: [
 					"./my/program.vrl",
 				]
-				syntax: "literal"
+				syntax:  "literal"
+				default: null
 			}
 		}
 		drop_on_error: {


### PR DESCRIPTION
This allows one to provide the VRL program source either as a string, or through an external file.

Note that this differs from the request in #6403. My interpretation of the request was different from what the issue described. I still think this is worth adding.

I'll leave the issue open for a potential follow-up that allows injecting snippets of VRL source inside a VRL program.