### PR TITLE
fix(loki sink): On `404` query top level for healthcheck

### DIFF
--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -281,7 +281,9 @@ impl HttpSink for LokiSink {
 async fn healthcheck(config: LokiConfig, client: HttpClient) -> crate::Result<()> {
     let uri = format!("{}ready", config.endpoint.uri);
 
-    let mut req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
+    let mut req = http::Request::get(uri)
+        .body(hyper::Body::empty())
+        .expect("Building request never fails.");
 
     if let Some(auth) = &config.auth {
         auth.apply(&mut req);
@@ -292,7 +294,7 @@ async fn healthcheck(config: LokiConfig, client: HttpClient) -> crate::Result<()
     let status = match fetch_status("ready", &config, &client).await? {
         // Issue https://github.com/timberio/vector/issues/6463
         http::StatusCode::NOT_FOUND => {
-            warn!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
+            debug!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
             fetch_status("", &config, &client).await?
         }
         status => status,

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -451,7 +451,7 @@ mod tests {
         test_util::trace_init();
         let (config, _cx) = load_sink::<LokiConfig>(
             r#"
-            endpoint = "https://logs-prod-us-central1.grafana.net"
+            endpoint = "http://logs-prod-us-central1.grafana.net"
             encoding = "json"
             labels = {test_name = "placeholder"}
         "#,

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -289,11 +289,35 @@ async fn healthcheck(config: LokiConfig, client: HttpClient) -> crate::Result<()
 
     let res = client.send(req).await?;
 
-    if res.status() != http::StatusCode::OK {
-        return Err(format!("A non-successful status returned: {}", res.status()).into());
+    let status = match fetch_status("ready", &config, &client).await? {
+        // Issue https://github.com/timberio/vector/issues/6463
+        http::StatusCode::NOT_FOUND => {
+            warn!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
+            fetch_status("", &config, &client).await?
+        }
+        status => status,
+    };
+
+    match status {
+        http::StatusCode::OK => Ok(()),
+        _ => Err(format!("A non-successful status returned: {}", res.status()).into()),
+    }
+}
+
+async fn fetch_status(
+    endpoint: &str,
+    config: &LokiConfig,
+    client: &HttpClient,
+) -> crate::Result<http::StatusCode> {
+    let uri = format!("{}{}", config.endpoint.uri, endpoint);
+
+    let mut req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();
+
+    if let Some(auth) = &config.auth {
+        auth.apply(&mut req);
     }
 
-    Ok(())
+    Ok(client.send(req).await?.status())
 }
 
 #[cfg(test)]
@@ -420,6 +444,27 @@ mod tests {
             )),
             output[0].0.headers.get("authorization")
         );
+    }
+
+    #[tokio::test]
+    async fn healthcheck_grafana_cloud() {
+        test_util::trace_init();
+        let (config, _cx) = load_sink::<LokiConfig>(
+            r#"
+            endpoint = "https://logs-prod-us-central1.grafana.net"
+            encoding = "json"
+            labels = {test_name = "placeholder"}
+        "#,
+        )
+        .unwrap();
+
+        let tls = TlsSettings::from_options(&config.tls).expect("could not create TLS settings");
+        let proxy = ProxyConfig::default();
+        let client = HttpClient::new(tls, &proxy).expect("could not create HTTP client");
+
+        healthcheck(config, client)
+            .await
+            .expect("healthcheck failed");
     }
 }
 


### PR DESCRIPTION
Closes #6463

Going through https://github.com/grafana/loki, loki returns one of:
* 500 Internal Server Error https://github.com/grafana/loki/blob/cd79adc8ab0c80c55a0f39b43322839c6ffb05d8/clients/pkg/promtail/server/server.go#L222
* 503 Service Unavailable https://github.com/grafana/loki/blob/cd79adc8ab0c80c55a0f39b43322839c6ffb05d8/pkg/loki/loki.go#L349
* 200 OK

So it should be ok to assume that on 404 we are dealing with Grafana Cloud, so instead we just check if its top level query is reacheable/OK.

We could also check if the provided endpoint ends with `grafana.net`, but that seems a bit fragile.

### TODO

- [x] Is there some better suited endpoint? Some loki specific? EDIT: Not really, non of the endpoints that should always be exposed are.


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
