### PR TITLE
chore: Update documentation for new concurrency, rate limit values

### DIFF
--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -141,15 +141,9 @@ impl KinesisFirehoseService {
             .events(500)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&TowerRequestConfig {
-            timeout_secs: Some(30),
-            ..Default::default()
-        });
-
+        let request = config.request.unwrap_with(&TowerRequestConfig::default());
         let encoding = config.encoding.clone();
-
         let kinesis = KinesisFirehoseService { client, config };
-
         let sink = request
             .batch_sink(
                 KinesisFirehoseRetryLogic,

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -146,11 +146,7 @@ impl KinesisService {
             .events(500)
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.unwrap_with(&TowerRequestConfig {
-            timeout_secs: Some(30),
-            ..Default::default()
-        });
-
+        let request = config.request.unwrap_with(&TowerRequestConfig::default());
         let encoding = config.encoding.clone();
         let partition_key_field = config.partition_key_field.clone();
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -143,11 +143,10 @@ impl SinkConfig for HttpSinkConfig {
             .bytes(bytesize::mib(10u64))
             .timeout(1)
             .parse_config(config.batch)?;
-        let request = config.request.tower.unwrap_with(&TowerRequestConfig {
-            timeout_secs: Some(30),
-            ..Default::default()
-        });
-
+        let request = config
+            .request
+            .tower
+            .unwrap_with(&TowerRequestConfig::default());
         let sink = BatchedHttpSink::new(
             config,
             Buffer::new(batch.size, Compression::None),

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -97,11 +97,7 @@ impl SinkConfig for HecSinkConfig {
             .bytes(bytesize::mib(1u64))
             .timeout(1)
             .parse_config(self.batch)?;
-        let request = self.request.unwrap_with(&TowerRequestConfig {
-            concurrency: Concurrency::Fixed(10),
-            rate_limit_num: Some(10),
-            ..Default::default()
-        });
+        let request = self.request.unwrap_with(&TowerRequestConfig::default());
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(tls_settings, &cx.proxy)?;
 

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -6,7 +6,7 @@ use crate::{
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
         http::{BatchedHttpSink, HttpSink},
-        BatchConfig, BatchSettings, Buffer, Compression, Concurrency, TowerRequestConfig,
+        BatchConfig, BatchSettings, Buffer, Compression, TowerRequestConfig,
     },
     template::Template,
     tls::{TlsOptions, TlsSettings},

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -370,7 +370,7 @@ components: {
 
 			if enabled {
 				adaptive_concurrency:       bool | *false
-				concurrency:                uint64
+				concurrency:                uint64 | *1024
 				rate_limit_duration_secs:   uint64 | *1
 				rate_limit_num:             uint64 | *9223372036854775807
 				retry_initial_backoff_secs: uint64 | *1

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -40,13 +40,6 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				adaptive_concurrency:       false
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -40,11 +40,6 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
 				timeout_secs:               30
 				headers:                    false
 			}

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -40,7 +40,6 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -40,7 +40,6 @@ components: sinks: aws_kinesis_streams: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -40,11 +40,6 @@ components: sinks: aws_kinesis_streams: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
 				timeout_secs:               30
 				headers:                    false
 			}

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -40,11 +40,7 @@ components: sinks: aws_s3: components._aws & {
 			request: {
 				enabled:                    true
 				concurrency:                50
-				rate_limit_duration_secs:   1
 				rate_limit_num:             250
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -35,12 +35,6 @@ components: sinks: clickhouse: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -22,12 +22,6 @@ components: sinks: datadog_events: {
 			request: {
 				enabled:                    true
 				adaptive_concurrency:       true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -35,12 +35,6 @@ components: sinks: elasticsearch: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    true
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -40,11 +40,7 @@ components: sinks: gcp_cloud_storage: {
 			request: {
 				enabled:                    true
 				concurrency:                25
-				rate_limit_duration_secs:   1
 				rate_limit_num:             1000
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -31,12 +31,6 @@ components: sinks: gcp_pubsub: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             100
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -30,7 +30,6 @@ components: sinks: gcp_stackdriver_logs: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				rate_limit_duration_secs:   1
 				rate_limit_num:             1000
 				headers:                    false
 			}

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -30,12 +30,8 @@ components: sinks: gcp_stackdriver_logs: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             1000
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -30,7 +30,6 @@ components: sinks: gcp_stackdriver_metrics: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				rate_limit_duration_secs:   1
 				rate_limit_num:             1000
 				headers:                    false
 			}

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -30,12 +30,8 @@ components: sinks: gcp_stackdriver_metrics: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             1000
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -30,12 +30,6 @@ components: sinks: honeycomb: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -39,7 +39,6 @@ components: sinks: http: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				timeout_secs:               30
 				headers:                    true
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -39,11 +39,6 @@ components: sinks: http: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                10
-				rate_limit_duration_secs:   1
-				rate_limit_num:             1000
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
 				timeout_secs:               30
 				headers:                    true
 			}

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -29,12 +29,6 @@ components: sinks: influxdb_logs: {
 			}
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: sinks._influxdb.features.send.tls

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -29,12 +29,6 @@ components: sinks: influxdb_metrics: {
 			}
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: sinks._influxdb.features.send.tls

--- a/website/cue/reference/components/sinks/logdna.cue
+++ b/website/cue/reference/components/sinks/logdna.cue
@@ -30,12 +30,6 @@ components: sinks: logdna: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -36,11 +36,6 @@ components: sinks: loki: {
 			request: {
 				enabled:                    true
 				concurrency:                1
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/new_relic_logs.cue
+++ b/website/cue/reference/components/sinks/new_relic_logs.cue
@@ -36,10 +36,6 @@ components: sinks: new_relic_logs: {
 			request: {
 				enabled:                    true
 				concurrency:                100
-				rate_limit_duration_secs:   1
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               30
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -33,11 +33,6 @@ components: sinks: redis: {
 			request: {
 				enabled:                    true
 				concurrency:                1
-				rate_limit_duration_secs:   1
-				rate_limit_num:             65535
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               1
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/sematext_logs.cue
@@ -30,12 +30,6 @@ components: sinks: sematext_logs: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
-				rate_limit_duration_secs:   1
-				rate_limit_num:             5
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: enabled: false

--- a/website/cue/reference/components/sinks/splunk_hec.cue
+++ b/website/cue/reference/components/sinks/splunk_hec.cue
@@ -39,8 +39,6 @@ components: sinks: splunk_hec: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                10
-				rate_limit_num:             10
 				headers:                    false
 			}
 			tls: {

--- a/website/cue/reference/components/sinks/splunk_hec.cue
+++ b/website/cue/reference/components/sinks/splunk_hec.cue
@@ -40,11 +40,7 @@ components: sinks: splunk_hec: {
 			request: {
 				enabled:                    true
 				concurrency:                10
-				rate_limit_duration_secs:   1
 				rate_limit_num:             10
-				retry_initial_backoff_secs: 1
-				retry_max_duration_secs:    10
-				timeout_secs:               60
 				headers:                    false
 			}
 			tls: {


### PR DESCRIPTION
This commit makes a pass on our documention to correct bugs with regard to the
new concurrency and rate limit values introduced in #8471. I have not added
documentation for `retry_attempts` or adjusted any low limits found, see #8687.

This resolves #8661

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
