### PR TITLE
enhancement(template website): Update meta partial urls to exact

### DIFF
--- a/docs/layouts/partials/meta.html
+++ b/docs/layouts/partials/meta.html
@@ -5,6 +5,7 @@
 {{ $img := site.Params.site_logo | absURL }}
 {{ $imgAlt := printf "Logo for %s" site.Title }}
 {{ $twitter := printf "@%s" site.Params.social.twitter_handle }}
+
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="id=edge">
@@ -18,19 +19,20 @@
 {{ hugo.Generator }}
 
 <link rel="shortcut icon" href="{{ $favicon }}">
-<link rel="canonical" href="{{ $url }}">
+<link rel="canonical" href="https://vector.dev{{ $url }}">
 
 {{/* Twitter Card metadata */}}
 <meta name="twitter:card" content="summary">
-<meta name="twitter:image" content="{{ $img }}">
+<meta name="twitter:image" content="https://vector.dev{{ $img }}">
 <meta name="twitter:image:alt" content="{{ $imgAlt }}">
 <meta name="twitter:site" content="{{ $twitter }}">
 <meta name="twitter:creator" content="{{ $twitter }}">
 
 {{/* OpenGraph metadata */}}
 <meta property="og:title" content="{{ .Title }}">
-<meta property="og:image" content="{{ $img }}">
-<meta property="og:url" content="{{ $url }}">
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://vector.dev{{ $url }}">
+<meta property="og:image" content="https://vector.dev{{ $img }}">
 {{ with $desc }}
 <meta property="og:description" content="{{ . }}">
 {{ end }}


### PR DESCRIPTION
Updates partial `meta.html` to use the exact url path for meta data (https://vector.dev/)
- canonical
- og:url
- og:image