### PR TITLE
enhancement(external docs): Provide links to VRL examples

### DIFF
--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -633,9 +633,11 @@
 
         {{ with $func.examples }}
         {{ $id := printf "%s-examples" $name }}
-        <div class="mt-4 border rounded py-2 px-3 dark:border-gray-700">
-          <span>
+        <div x-data="{ open: location.hash.startsWith('#{{ $id }}') }" class="mt-4 border rounded py-2 px-3 dark:border-gray-700">
+          <span class="flex justify-between items-center">
             {{ partial "heading.html" (dict "text" "Examples" "level" 4 "id" $id "toc_hide" true) }}
+
+            {{ template "config-toggler" (dict "size" 4) }}
           </span>
 
           <div x-show="open" class="pt-4 flex flex-col space-y-5 overflow-x-scroll">

--- a/docs/layouts/partials/data.html
+++ b/docs/layouts/partials/data.html
@@ -597,9 +597,10 @@
       </div>
 
       {{/* Function spec, etc. */}}
+      {{ $id := printf "%s-function-spec" $name }}
       <div class="mt-3 border rounded-md py-3 px-4 dark:border-gray-700">
-        <span class="font-semibold text-md">
-          Function spec
+        <span>
+          {{ partial "heading.html" (dict "text" "Function spec" "level" 4 "id" $id "toc_hide" true) }}
         </span>
 
         <div class="my-2 font-mono text-sm bg-dark dark:bg-black px-3.5 py-2.5 rounded text-gray-100">
@@ -631,18 +632,15 @@
         </div>
 
         {{ with $func.examples }}
-        <div x-data="{ open: false }" class="mt-4 border rounded py-2 px-3 dark:border-gray-700">
-          <span class="flex justify-between items-center">
-            <span class="font-semibold">
-              Examples
-            </span>
-
-            {{ template "config-toggler" (dict "size" 4) }}
+        {{ $id := printf "%s-examples" $name }}
+        <div class="mt-4 border rounded py-2 px-3 dark:border-gray-700">
+          <span>
+            {{ partial "heading.html" (dict "text" "Examples" "level" 4 "id" $id "toc_hide" true) }}
           </span>
 
           <div x-show="open" class="pt-4 flex flex-col space-y-5 overflow-x-scroll">
             {{ range . }}
-            {{ template "vrl-function-example" . }}
+            {{ template "vrl-function-example" (dict "name" $name "ctx" .) }}
             {{ end }}
           </div>
         </div>
@@ -1427,10 +1425,9 @@
 {{ end }}
 
 {{ define "vrl-function-example" }}
+{{ $id := printf "%s-examples-%s" .name (.ctx.title | urlize) }}
 <div>
-  <span class="font-semibold">
-    {{ .title }}
-  </span>
+  {{ partial "heading.html" (dict "text" .ctx.title "level" 5 "id" $id "toc_hide" true) }}
 
   <div class="flex flex-col space-y-2">
     <div>
@@ -1439,11 +1436,11 @@
       </span>
 
       <div class="text-sm">
-        {{ template "code" .source }}
+        {{ template "code" .ctx.source }}
       </div>
     </div>
 
-    {{ with .return }}
+    {{ with .ctx.return }}
     <div>
       <span class="font-light">
         Return

--- a/docs/layouts/partials/heading.html
+++ b/docs/layouts/partials/heading.html
@@ -3,7 +3,7 @@
 {{ $level := .level | default 2 }}
 {{ $iconSizes := dict "1" "7" "2" "6" "3" "5" "4" "4" "5" "3" "6" "3" }}
 {{ $n := index $iconSizes ($level | string) }}
-<h{{ $level }} x-data="{ show: false }" x-on:mouseover="show = true" x-on:mouseleave="show = false" id="{{ $id }}" class="flex items-center text-dark dark:text-gray-200{{ if .bold }} font-bold{{ end }}">
+<h{{ $level }} x-data="{ show: false }" x-on:mouseover="show = true" x-on:mouseleave="show = false" id="{{ $id }}" class="flex items-center text-dark dark:text-gray-200{{ if .bold }} font-bold{{ end }}{{ if .toc_hide }} js-toc-ignore{{ end }}">
   {{ if .href }}
   <a href="{{ .href }}">
     {{ $text }}


### PR DESCRIPTION
Fixes #8656

This PR adds links to the following for each VRL function:

* The "Function spec" section
* The "Examples" section
* Each example in the examples section

I've opted not to include any of the above in the generated TOC on the right side, as the TOC gets very busy when you include these things. But I could be persuaded otherwise.

The relevant page:

https://deploy-preview-8697--vector-project.netlify.app/docs/reference/vrl/functions

Example link:

https://deploy-preview-8697--vector-project.netlify.app/docs/reference/vrl/functions/#to_int-examples-coerce-to-an-int-timestamp