### PR TITLE
fix(observability): Do not emit `events_in_total` with 0

### DIFF
--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -11,15 +11,6 @@ impl InternalEvent for EventIn {
 }
 
 #[derive(Debug)]
-pub struct EventZeroIn;
-
-impl InternalEvent for EventZeroIn {
-    fn emit_metrics(&self) {
-        counter!("events_in_total", 0);
-    }
-}
-
-#[derive(Debug)]
 pub struct EventOut {
     pub count: usize,
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -7,7 +7,7 @@ use crate::{
     buffers,
     config::{DataType, ProxyConfig, SinkContext, SourceContext},
     event::Event,
-    internal_events::{EventIn, EventOut, EventZeroIn},
+    internal_events::{EventIn, EventOut},
     shutdown::SourceShutdownCoordinator,
     transforms::Transform,
     Pipeline,
@@ -87,7 +87,6 @@ pub async fn build_pieces(
         // force_shutdown_tripwire. That means that if the force_shutdown_tripwire resolves while
         // the server Task is still running the Task will simply be dropped on the floor.
         let server = async {
-            emit!(EventZeroIn);
             match future::try_select(server, force_shutdown_tripwire.unit_error().boxed()).await {
                 Ok(_) => {
                     debug!("Finished.");


### PR DESCRIPTION
In https://github.com/timberio/vector/issues/8713 we observed that the
`file` source only publishes `events_in_total` with the `file` tag:

```
vector_events_in_total{component_kind="source",component_name="file",component_type="file",file="/tmp/logs/9.log",host="COMP-C02DV25MML87"} 10 1628878196694
```

But this initial publish of `events_in_total` at the topology level with
0 was also causing it to look like the `file` source was emitting no
events:

```
vector_events_in_total{component_kind="source",component_name="file",component_type="file",host="COMP-C02DV25MML87"} 0 1628878196694
```

For all of our other internal events we only publish a value when the
first event for that metric is triggered so I don't see why we shouldn't
do the same here.

I verified that `vector top` reports the correct metrics so it must already be summing across the `file` tag.
Closes #8713 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
