### PR TITLE
enhancement(loki sink): Validate label names

### DIFF
--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -330,7 +330,10 @@ async fn fetch_status(
 
 fn valid_label_name(label: &Template) -> bool {
     label.is_dynamic() || {
-        // Loki follows prometheus on this
+        // Loki follows prometheus on this https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+        // Although that isn't explicitly said anywhere besides what's in the code.
+        // The closest mention is in section about Parser Expression https://grafana.com/docs/loki/latest/logql/
+        //
         // [a-zA-Z_][a-zA-Z0-9_]*
         let label_trim = label.get_ref().trim();
         let mut label_chars = label_trim.chars();

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -100,6 +100,12 @@ impl SinkConfig for LokiConfig {
             return Err("`labels` must include at least one label.".into());
         }
 
+        for label in self.labels.keys() {
+            if !valid_label_name(label) {
+                return Err(format!("Invalid label name {:?}", label.get_ref()).into());
+            }
+        }
+
         if self.request.concurrency.is_some() {
             warn!("Option `request.concurrency` is not supported.");
         }
@@ -322,6 +328,21 @@ async fn fetch_status(
     Ok(client.send(req).await?.status())
 }
 
+fn valid_label_name(label: &Template) -> bool {
+    label.is_dynamic() || {
+        // Loki follows prometheus on this
+        // [a-zA-Z_][a-zA-Z0-9_]*
+        let label_trim = label.get_ref().trim();
+        let mut label_chars = label_trim.chars();
+        if let Some(ch) = label_chars.next() {
+            (ch.is_ascii_alphabetic() || ch == '_')
+                && label_chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        } else {
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,6 +352,7 @@ mod tests {
     use crate::sinks::util::test::{build_test_server, load_sink};
     use crate::test_util;
     use futures::StreamExt;
+    use std::convert::TryInto;
 
     #[test]
     fn generate_config() {
@@ -467,6 +489,21 @@ mod tests {
         healthcheck(config, client)
             .await
             .expect("healthcheck failed");
+    }
+
+    #[test]
+    fn valid_label_names() {
+        assert!(valid_label_name(&"name".try_into().unwrap()));
+        assert!(valid_label_name(&" name ".try_into().unwrap()));
+        assert!(valid_label_name(&"bee_bop".try_into().unwrap()));
+        assert!(valid_label_name(&"a09b".try_into().unwrap()));
+
+        assert!(!valid_label_name(&"0ab".try_into().unwrap()));
+        assert!(!valid_label_name(&"*".try_into().unwrap()));
+        assert!(!valid_label_name(&"".try_into().unwrap()));
+        assert!(!valid_label_name(&" ".try_into().unwrap()));
+
+        assert!(valid_label_name(&"{{field}}".try_into().unwrap()));
     }
 }
 


### PR DESCRIPTION
Closes #8702

I wasn't able to find some documentation that explicitly says `[a-zA-Z_][a-zA-Z0-9_]*` is the regex, but going through loki code and testing against Grafana Cloud it seems they follow Prometheus convention https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels. The closest mention of this is for LogQL under [Parser Expression](https://grafana.com/docs/loki/latest/logql/).

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
