### PR TITLE
docs(observability): Document utilization metric

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1177,6 +1177,11 @@ components: {
 			}
 		}
 
+		telemetry: metrics: {
+			// Default metrics for each component
+			utilization: components.sources.internal_metrics.output.metrics.utilization
+		}
+
 		how_it_works: {
 			state: {
 				title: "State"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -905,6 +905,12 @@ components: sources: internal_metrics: {
 				}
 			}
 		}
+		utilization: {
+			description:       "A ratio from 0 to 1 of the load on a component. A value of 0 would indicate a completely idle component that is simply waiting for input. A value of 1 would indicate a that is never idle. This value is updated evry 5 seconds."
+			type:              "guage"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		value_limit_reached_total: {
 			description: """
 				The total number of times new values for a key have been rejected because the

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -906,8 +906,8 @@ components: sources: internal_metrics: {
 			}
 		}
 		utilization: {
-			description:       "A ratio from 0 to 1 of the load on a component. A value of 0 would indicate a completely idle component that is simply waiting for input. A value of 1 would indicate a that is never idle. This value is updated evry 5 seconds."
-			type:              "guage"
+			description:       "A ratio from 0 to 1 of the load on a component. A value of 0 would indicate a completely idle component that is simply waiting for input. A value of 1 would indicate a that is never idle. This value is updated every 5 seconds."
+			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}


### PR DESCRIPTION
Closes #8604

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
