### PR TITLE
fix(css website): Homepage Mobile Adjustments

### DIFF
--- a/website/layouts/partials/home/community.html
+++ b/website/layouts/partials/home/community.html
@@ -7,7 +7,7 @@
     {{/* Project stats */}}
     <div class="mt-4 md:mt-6 inline-flex divide-x dark:divide-gray-600 w-full lg:w-8/12 xl:w-6/12">
       {{ range $index, $stat := $comm.stats }}
-      <div class="flex flex-col px-1 sm:px-6 lg:px-8 py-2 {{ if eq $index 0 }}pl-0{{ else if eq $index 3 }}pr-0{{ end }} max-w-fourth flex-grow">
+      <div class="flex flex-col px-1 sm:px-6 lg:px-8 py-2 {{ if eq $index 0 }}pl-0{{ else if eq $index 3 }}pr-0{{ end }} max-w-1/4 flex-grow">
         <span class="text-xl sm:text-3xl md:text-4xl lg:text-4.5xl font-light dark:text-gray-100">
           {{ $stat.figure }}
         </span>

--- a/website/layouts/partials/home/community.html
+++ b/website/layouts/partials/home/community.html
@@ -5,14 +5,14 @@
     {{ partial "home/heading.html" (dict "title" $comm.title) }}
 
     {{/* Project stats */}}
-    <div class="mt-4 md:mt-6 inline-flex divide-x dark:divide-gray-600">
-      {{ range $comm.stats }}
-      <div class="flex flex-col px-6 lg:px-8 py-2">
-        <span class="text-3xl md:text-4xl lg:text-4.5xl font-light dark:text-gray-100">
-          {{ .figure }}
+    <div class="mt-4 md:mt-6 inline-flex divide-x dark:divide-gray-600 w-full lg:w-8/12 xl:w-6/12">
+      {{ range $index, $stat := $comm.stats }}
+      <div class="flex flex-col px-1 sm:px-6 lg:px-8 py-2 {{ if eq $index 0 }}pl-0{{ else if eq $index 3 }}pr-0{{ end }} max-w-fourth flex-grow">
+        <span class="text-xl sm:text-3xl md:text-4xl lg:text-4.5xl font-light dark:text-gray-100">
+          {{ $stat.figure }}
         </span>
-        <span class="mt-2 text-sm md:text-base text-gray-400 tracking-tight leading-tight font-semibold">
-          {{ .title }}
+        <span class="mt-2 text-xs sm:text-sm md:text-base text-gray-400 tracking-tight leading-tight font-semibold">
+          {{ $stat.title }}
         </span>
       </div>
       {{ end }}

--- a/website/layouts/partials/home/hero.html
+++ b/website/layouts/partials/home/hero.html
@@ -37,9 +37,10 @@
     <div class="mt-6 md:mt-8 lg:mt-10 inline-flex space-x-2">
       {{ range $links }}
       <a href="{{ .URL }}" class="uppercase font-semibold text-xs md:text-sm tracking-tight shadow-sm py-1 px-3.5 rounded-full hover:shadow bg-gray-200 text-dark hover:bg-primary hover:text-dark dark:bg-primary dark:hover:bg-purple-v">
-        <div class="flex items-center space-x-2">
-          <ion-icon name="{{ .Params.ionicon }}"></ion-icon>
-
+        <div class="flex items-center space-x-2 flex-wrap sm:flex-nowrap justify-center h-full">
+          <div class="text-sm">
+            <ion-icon name="{{ .Params.ionicon }}"></ion-icon>
+          </div>
           <span>
             {{ .Name }}
           </span>

--- a/website/layouts/partials/home/installation.html
+++ b/website/layouts/partials/home/installation.html
@@ -11,7 +11,7 @@
       {{ $install.description }}
     </p>
 
-    <div class="mt-8 lg:mt-10 inline-flex space-x-3 md:space-x-5 lg:space-x-8">
+    <div class="mt-8 lg:mt-10 inline-flex space-x-3 md:space-x-5 lg:space-x-8 w-full justify-center">
       {{ range $install.logos }}
       {{ $logo := printf "/img/logos/%s" .logo }}
       <div class="w-16 md:w-20 lg:w-24 h-auto">

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -33,7 +33,7 @@
                 {{ .Name }}
               </span>
               {{ if .Params.flyout }}
-              <span :class="{ 'transform rotate-180': flyout }" class="cursor-pointer ml-1.5 dark:text-gray-300 text-black" @mouseover="flyout = true">
+              <span :class="{ 'transform rotate-180': flyout }" class="cursor-pointer ml-1.5 dark:text-gray-300 text-black">
                 {{/* Heroicon: outline/chevron-down */}}
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -28,7 +28,7 @@
           <div class="flex space-x-4">
             {{ range $menu }}
             {{ $isActive := hasPrefix $here .URL }}
-            <a href="{{ .URL }}" class="flex items-center tracking-tight px-2.5 rounded-sm text-normal font-normal">
+            <a href="{{ .URL }}" class="flex items-center tracking-tight px-2.5 rounded-sm text-normal font-normal" {{ if .Params.flyout }}@mouseover="flyout = true"{{ end }}>
               <span class="dark:text-gray-300 hover:text-primary-dark dark:hover:text-secondary{{ if $isActive }} dark:text-primary text-secondary{{ end }}">
                 {{ .Name }}
               </span>

--- a/website/layouts/partials/navbar/search-bar.html
+++ b/website/layouts/partials/navbar/search-bar.html
@@ -1,8 +1,8 @@
-<div class="w-full">
+<div class="max-w-xxs flex-grow">
   <label for="search" class="sr-only">
     Search
   </label>
 
-  {{/* Targeted by the global site search in assets/js/site-search.tsx */}}
+  {{/* Targeted by the global site search in assets/js/search.tsx */}}
   <div id="site-search"></div>
 </div>

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -629,6 +629,7 @@ module.exports = {
     maxWidth: (theme, { breakpoints }) => ({
       none: 'none',
       0: '0rem',
+      xxs: '16rem',
       xs: '20rem',
       sm: '24rem',
       md: '28rem',
@@ -640,6 +641,7 @@ module.exports = {
       '5xl': '64rem',
       '6xl': '72rem',
       '7xl': '80rem',
+      fourth: '25%',
       full: '100%',
       min: 'min-content',
       max: 'max-content',

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -641,7 +641,7 @@ module.exports = {
       '5xl': '64rem',
       '6xl': '72rem',
       '7xl': '80rem',
-      fourth: '25%',
+      '1/4': '25%',
       full: '100%',
       min: 'min-content',
       max: 'max-content',


### PR DESCRIPTION
### Navbar
- Update "Docs" button to show dropdown on text hover
- Update width styles on search button section to allow responsiveness on screens > ~ 1200px
  - Fix overflow caused by search

### Homepage
- Update 3 quick links buttons on mobile to wrap, center, and have a slightly larger icon size
- Give installs section a defined width, center
- Style community stats section to be mobile friendly, define width

### Utils
- new `xxs` and `fourth` width breakpoints