### PR TITLE
docs: Add in some files that were dropped in merge

### DIFF
--- a/website/content/en/releases/0.15.2.md
+++ b/website/content/en/releases/0.15.2.md
@@ -1,0 +1,4 @@
+---
+title: Vector v0.15.2 release notes
+weight: 21
+---

--- a/website/cue/reference/releases/0.15.2.cue
+++ b/website/cue/reference/releases/0.15.2.cue
@@ -1,0 +1,61 @@
+package metadata
+
+releases: "0.15.2": {
+	date:     "2021-08-11"
+	codename: ""
+
+	description: """
+		The Vector team is pleased to announce version 0.15.2!
+
+		This release contains a fix for `vector validate` to source environment variables indicating configuration
+		location: `VECTOR_CONFIG`, `VECTOR_CONFIG_YAML`, `VECTOR_CONFIG_JSON`, and `VECTOR_CONFIG_TOML`.
+
+		In v0.15.0, we released a change the SystemD unit file to run `vector validate` before start-up as part of
+		`ExecStartPre`. If users were using, for example, `VECTOR_CONFIG` in `/etc/default/vector` to pass the
+		configuartion location, this would result in Vector failing to boot.
+
+		See the release notes for 0.15.0 for additional changes if upgrading from 0.14.X.
+		"""
+
+	commits: [
+		{sha: "0824874dbd0d8c6fe06cd05213c35e375caf28e3", date: "2021-08-04 14:32:23 UTC", description: "Use env vars with validate command", pr_number: 8577, scopes: ["releasing"], type: "fix", breaking_change: false, author: "Spencer Gilbert", files_count: 1, insertions_count: 19, deletions_count: 4},
+
+	]
+
+	whats_next: [
+		{
+			title:       "Enabling Adaptive Concurrency Control by default"
+			description: """
+				We released [Adaptive Concurrency Control](\(urls.adaptive_request_concurrency_post)) in version 0.11.0
+				of Vector, but, up until now, this feature has been opt-in. We've been collecting user feedback, making
+				enhancements, and expect to enable this feature as the default in 0.16.0. Users will still be able to
+				configure static concurrency controls as they do now.
+				"""
+		},
+		{
+			title: "End to end acknowledgements"
+			description: """
+				We've heard from a number of users that they'd like improved delivery guarantees for events flowing
+				through Vector. We are working on a feature to allow, for components that are able to support it, to
+				only acknowledging data flowing into source components after that data has been sent by any associated
+				sinks. For example, this would avoid acknowledging messages in Kafka until the data in those messages
+				has been sent via all associated sinks.
+
+				This release includes support in additional  source and sink components that support acknowledgements,
+				but it has not yet been fully documented and tested. We expect to officially release this with 0.16.0.
+				"""
+		},
+		{
+			title:       "Kubernetes aggregator role"
+			description: """
+				We are hard at work at expanding the ability to run Vector as an [aggregator in
+				Kubernetes](\(urls.vector_aggregator_role)). This will allow you to build end-to-end observability
+				pipelines in Kubernetes with Vector. Distributing processing on the edge, centralizing it with an
+				aggregator, or both. If you are interested in beta testing, please [join our chat](\(urls.vector_chat))
+				and let us know.
+
+				We do expect this to be released with 0.16.0.
+				"""
+		},
+	]
+}

--- a/website/layouts/partials/docs/component-alias.html
+++ b/website/layouts/partials/docs/component-alias.html
@@ -1,0 +1,12 @@
+{{ $kindSingular := .kind | singularize }}
+
+{{ partial "heading.html" (dict "text" "Alias" "level" 2) }}
+
+<p>
+  This component was previously called the <code>{{ .alias }}</code> {{ $kindSingular }}. Make sure to update your
+  Vector configuration to accommodate the name change:
+</p>
+
+{{ $diff := printf "[%s.my_%s_%s]\n+type = \"%s\"\n-type = \"%s\"" .kind .current (.kind | singularize) .current .alias }}
+
+{{ highlight $diff "diff" "" }}


### PR DESCRIPTION
From https://github.com/timberio/vector/pull/8765

I spot checked the diff of v0.15:docs and master:website and couldn't
see anything else that appeared to be missing.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
