### PR TITLE
fix(external docs): Fix malformed heading causing site build to break

### DIFF
--- a/website/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
+++ b/website/content/en/highlights/2021-07-21-0-16-upgrade-guide.md
@@ -22,7 +22,7 @@ And one **deprecation**:
 
 We cover them below to help you upgrade quickly:
 
-[##](##) Upgrade Guide
+## Upgrade guide
 
 ### Component name field renamed to ID {#name-to-id}
 


### PR DESCRIPTION
Somewhere along the line this change was introduced, which breaks the site build (due to the link checker).