### PR TITLE
docs(aws_s3 sink): Remove unneeded IAM permission

### DIFF
--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -405,10 +405,6 @@ components: sinks: aws_s3: components._aws & {
 					required_for: ["healthcheck"]
 				},
 				{
-					_action: "ListBuckets"
-					required_for: ["healthcheck"]
-				},
-				{
 					_action: "PutObject"
 				},
 			]


### PR DESCRIPTION
We don't actually use `list_buckets`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
