### PR TITLE
docs(vrl): Add missing regex flags

### DIFF
--- a/website/cue/reference/remap/literals/regular_expression.cue
+++ b/website/cue/reference/remap/literals/regular_expression.cue
@@ -28,9 +28,12 @@ remap: literals: regular_expression: {
 				in-browser [Rustexp expression editor and tester](\#(urls.regex_tester)).
 				"""#
 			enum: {
-				"x": "Ignore whitespace"
 				"i": "Case insensitive"
 				"m": "Multi-line mode"
+				"x": "Ignore whitespace"
+				"s": "Allow . to match \n"
+				"U": "Swap the meaning of x* and x*?"
+				"u": "Unicode support (enabled by default)"
 			}
 		}
 		named_captures: {


### PR DESCRIPTION
Noticed by user in discord:
https://discord.com/channels/742820443487993987/746070591097798688/877834630965891082

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
