### PR TITLE
docs(statsd sink): Remove encoding option

### DIFF
--- a/website/cue/reference/components/sinks/statsd.cue
+++ b/website/cue/reference/components/sinks/statsd.cue
@@ -10,10 +10,7 @@ components: sinks: statsd: {
 		healthcheck: sinks.socket.features.healthcheck
 		send: {
 			compression: sinks.socket.features.send.compression
-			encoding: {
-				enabled: true
-				codec: enabled: false
-			}
+			encoding: enabled: false
 			request: sinks.socket.features.send.request
 			send_buffer_bytes: {
 				enabled:       true


### PR DESCRIPTION
This sink does not support it.

Closes #8821

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
