### PR TITLE
fix(observability): add back component_name label

### DIFF
--- a/lib/vector-core/src/metrics/label_filter.rs
+++ b/lib/vector-core/src/metrics/label_filter.rs
@@ -7,6 +7,9 @@ pub(crate) struct VectorLabelFilter;
 impl LabelFilter for VectorLabelFilter {
     fn should_include_label(&self, label: &Label) -> bool {
         let key = label.key();
-        key == "component_id" || key == "component_type" || key == "component_kind"
+        key == "component_id"
+            || key == "component_type"
+            || key == "component_kind"
+            || key == "component_name"
     }
 }


### PR DESCRIPTION
We are preseving this for compatibility but I missed this extra filter
in #8417

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
