### PR TITLE
docs(networking): Document global proxy options

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -694,7 +694,7 @@ components: {
 
 			_proxy: {
 				common:      false
-				description: "Configures an HTTP(S) proxy for Vector to use."
+				description: "Configures an HTTP(S) proxy for Vector to use. By default, the globally configured proxy is used."
 				required:    false
 				type: object: options: {
 					enabled: {
@@ -724,9 +724,9 @@ components: {
 						}
 					}
 					no_proxy: {
-						common: false
+						common:      false
 						description: """
-							A list of hosts to avoid proxying globally. Allowed patterns here include:
+							A list of hosts to avoid proxying. Allowed patterns here include:
 
 							Pattern | Example match
 							:-------|:-------------
@@ -736,7 +736,7 @@ components: {
 							[CIDR](\(urls.cidr)) blocks | `192.168.0.0./16` matches requests to any IP addresses in this range
 							Splat | `*` matches all hosts
 							"""
-						required: false
+						required:    false
 						type: array: {
 							default: null
 							items: type: string: {

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -145,6 +145,62 @@ configuration: {
 				syntax: "literal"
 			}
 		}
+
+		proxy: {
+			common:      false
+			description: "Configures an HTTP(S) proxy for Vector to use."
+			required:    false
+			type: object: options: {
+				enabled: {
+					common:      false
+					description: "If false the proxy will be disabled."
+					required:    false
+					type: bool: default: true
+				}
+				http: {
+					common:      false
+					description: "The URL to proxy HTTP requests through."
+					required:    false
+					type: string: {
+						default: null
+						examples: ["http://foo.bar:3128"]
+						syntax: "literal"
+					}
+				}
+				https: {
+					common:      false
+					description: "The URL to proxy HTTPS requests through."
+					required:    false
+					type: string: {
+						default: null
+						examples: ["http://foo.bar:3128"]
+						syntax: "literal"
+					}
+				}
+				no_proxy: {
+					common:      false
+					description: """
+							A list of hosts to avoid proxying. Allowed patterns here include:
+
+							Pattern | Example match
+							:-------|:-------------
+							Domain names | `example.com` matches requests to `example.com`
+							Wildcard domains | `.example.com` matches requests to `example.com` and its subdomains
+							IP addresses | `127.0.0.1` matches requests to 127.0.0.1
+							[CIDR](\(urls.cidr)) blocks | `192.168.0.0./16` matches requests to any IP addresses in this range
+							Splat | `*` matches all hosts
+							"""
+					required:    false
+					type: array: {
+						default: null
+						items: type: string: {
+							examples: ["localhost", ".foo.bar", "*"]
+							syntax: "literal"
+						}
+					}
+				}
+			}
+		}
 	}
 
 	how_it_works: {


### PR DESCRIPTION
It seems like we missed this.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
