### PR TITLE
fix(buffers): disk buffer performs overlapping read from leveldb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "futures 0.3.16",
  "leveldb",
  "metrics",
+ "metrics-exporter-prometheus",
  "pin-project 1.0.8",
  "pretty_assertions",
  "quickcheck",
@@ -4073,6 +4074,22 @@ dependencies = [
  "ahash",
  "metrics-macros",
  "proc-macro-hack",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db7052a7cb0b0c0922a1ce499c9e78576763b1d47499ba980a4fe731b96909d"
+dependencies = [
+ "hyper",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "parking_lot",
+ "quanta",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -23,6 +23,7 @@ pretty_assertions = "0.7.2"
 quickcheck = "1.0"
 tempdir = "0.3"
 tokio-test = "0.4.2"
+metrics-exporter-prometheus = "0.6"
 
 [features]
 disk-buffer = ["db-key", "snafu", "leveldb"]

--- a/lib/vector-core/buffers/examples/soak.rs
+++ b/lib/vector-core/buffers/examples/soak.rs
@@ -1,0 +1,143 @@
+use std::{env, fmt, path::{PathBuf}, process, time::Duration};
+
+use buffers::{Variant, WhenFull, bytes::{DecodeBytes, EncodeBytes}};
+use bytes::{Buf, BufMut};
+use futures::{SinkExt, StreamExt};
+use metrics::{counter, increment_counter};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tokio::{pin, select, time::{interval, sleep}};
+
+#[derive(Clone, Copy)]
+pub struct Message<const N: usize> {
+    id: u64,
+    _padding: [u64; N],
+}
+
+impl<const N: usize> Message<N> {
+    fn new(id: u64) -> Self {
+        Message {
+            id,
+            _padding: [0; N],
+        }
+    }
+
+	pub fn id(&self) -> u64 {
+		self.id
+	}
+}
+
+#[derive(Debug)]
+pub enum EncodeError {}
+
+#[derive(Debug)]
+pub enum DecodeError {}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unreachable!()
+    }
+}
+
+impl<const N: usize> EncodeBytes<Message<N>> for Message<N> {
+    type Error = EncodeError;
+
+    fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
+        buffer.put_u64(self.id);
+        for _ in 0..N {
+            // this covers self._padding
+            buffer.put_u64(0);
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> DecodeBytes<Message<N>> for Message<N> {
+    type Error = DecodeError;
+
+    fn decode<B>(mut buffer: B) -> Result<Self, Self::Error>
+    where
+        B: Buf,
+        Self: Sized,
+    {
+        let id = buffer.get_u64();
+        for _ in 0..N {
+            // this covers self._padding
+            let _ = buffer.get_u64();
+        }
+        Ok(Message::new(id))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+	let mut cli_args = env::args().collect::<Vec<_>>();
+	if cli_args.len() != 3 {
+		eprintln!("Usage: soak <data dir> <database size in bytes>");
+		process::exit(1);
+	}
+
+	let _ = PrometheusBuilder::new().install().expect("exporter install should not fail");
+
+	let _ = cli_args.remove(0);
+	let data_dir: PathBuf = cli_args.remove(0).parse().expect("database path must be a valid path");
+	let db_size: usize = cli_args.remove(0).parse().expect("database size must be a non-negative amount");
+	let variant = Variant::Disk {
+		id: "debug".to_owned(),
+		data_dir,
+		max_size: db_size,
+		when_full: WhenFull::DropNewest,
+	};
+
+	let (writer, reader, acker) = buffers::build(variant).expect("failed to create buffer");
+	let _ = tokio::spawn(async move {
+		let mut id = 0;
+		let mut writer = writer.get();
+		loop {
+			let msg = Message::<64>::new(id);
+			id += 1;
+			if let Err(e) = writer.send(msg).await {
+				eprintln!("writer error: {:?}", e);
+				increment_counter!("buffers_soak_msgs_written_error");
+			} else {
+				increment_counter!("buffers_soak_msgs_written_success");
+			}
+		}
+	});
+	let _ = tokio::spawn(async move {
+		pin!(reader);
+
+		let mut unacked = 0;
+		let mut highest_id_seen = 0;
+		let ack_timeout = interval(Duration::from_secs(5));
+		pin!(ack_timeout);
+
+		loop {
+			select! {
+				_ = ack_timeout.tick() => {
+					counter!("buffers_soak_msgs_acked", unacked as u64);
+					acker.ack(unacked);
+					unacked = 0;
+				},
+				Some(msg) = reader.next() => {
+					if msg.id() <= highest_id_seen && msg.id() != 0 {
+						eprintln!("out-of-order reader: got {}, but highest ID seen is {}", msg.id(), highest_id_seen);
+					} else {
+						highest_id_seen = msg.id();
+					}
+					unacked += 1;
+					increment_counter!("buffers_soak_msgs_read");
+				},
+				else => {
+					println!("reader stream terminated");
+					break
+				}
+			}
+		}
+	});
+
+	sleep(Duration::from_secs(24 * 60 * 60)).await;
+}

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
@@ -13,7 +13,7 @@ use leveldb::database::{
     options::{Options, ReadOptions},
     Database,
 };
-use reader::Reader;
+pub use reader::Reader;
 use snafu::ResultExt;
 use std::fmt::Debug;
 use std::{

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -120,7 +120,7 @@ where
 
         if let Some((key, value)) = this.buffer.pop_front() {
             this.unacked_sizes.push_back(value.len());
-            this.read_offset = key.0;
+            this.read_offset = key.0 + 1;
 
             let buffer: Bytes = Bytes::from(value);
             match T::decode(buffer) {


### PR DESCRIPTION
Currently, the disk buffer code will read from LevelDB based on the current read offset, but we set the read offset equal to the ID of the key we last read.  Since writers start at 0 for their write offset, which is set as the ID of the event key when written, this means every time we fill the internal buffer for the reader, we're starting from the last key the reader has read.  Thus, we're overlapping.

Also included is a soak test for the disk buffer, which generates an endless stream of data via a writer, and consumes it via the reader.  This example binary was written to validate the correctness/performance of disk buffers, but was a convenient validation of the reader behavior and proved out the bug being fixed here.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>