### PR TITLE
chore: Add component specification

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -93,7 +93,7 @@ There is leeway in the implementation of these events:
 * Components MAY emit events for batches of Vector events for performance
   reasons, but the resulting telemetry state MUST be equivalent to emitting
   individual events. For example, emitting the `EventsReceived` event for 10
-  events MUST increment the `events_in_total` counter by 10.
+  events MUST increment the `received_events_total` counter by 10.
 
 #### BytesReceived
 
@@ -113,7 +113,7 @@ from the upstream source and before the creation of a Vector event.
   * `path` - If relevant, the HTTP path, excluding query strings.
   * `socket` - If relevant, the socket number that bytes were received from.
 * Metrics
-  * MUST increment the `bytes_in_total` counter by the defined value with
+  * MUST increment the `received_bytes_total` counter by the defined value with
     the defined properties as metric tags.
 * Logs
   * MUST log a `Bytes received.` message at the `trace` level with the
@@ -173,7 +173,7 @@ downstream target regardless if the transmission was successful or not.
     HTTP, this MUST be the host and path only, excluding the query string.
   * `file` - If relevant, the absolute path of the file.
 * Metrics
-  * MUST increment the `bytes_out_total` counter by the defined value with the
+  * MUST increment the `sent_bytes_total` counter by the defined value with the
     defined properties as metric tags.
 * Logs
   * MUST log a `Bytes received.` message at the `trace` level with the

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -52,11 +52,6 @@ transforms, and sinks).
 
 ### Options
 
-#### `address`
-
-When a component binds to an address, it SHOULD expose an `address` option that
-takes a `string` representing a single address.
-
 #### `endpoint(s)`
 
 When a component makes a connection to a downstream target, it MUST

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -116,8 +116,8 @@ from the upstream source and before the creation of a Vector event.
   * MUST increment the `bytes_in_total` counter by the defined value with
     the defined properties as metric tags.
 * Logs
-  * MUST log a `{byte_size} bytes received.` message at the `trace` level with
-    the defined properties as structured data. It MUST NOT be rate limited.
+  * MUST log a `Bytes received.` message at the `trace` level with the
+    defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### EventsRecevied
 
@@ -133,8 +133,8 @@ or receiving one or more Vector events.
   * MUST increment the `received_event_bytes_total` counter by the defined
     `byte_size` property with the other properties as metric tags.
 * Logs
-  * MUST log a `{quantity} events received.` message at the `trace` level with
-    the defined properties as structured data. It MUST NOT be rate limited.
+  * MUST log a `Events received.` message at the `trace` level with the
+    defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### EventsSent
 
@@ -143,16 +143,16 @@ event down stream. This should happen before any transmission preparation, such
 as encoding.
 
 * Properties
-  * `quantity` - The quantity of Vector events.
-  * `byte_size` - The cumulative byte size of all events in JSON representation.
+  * `count` - The count of Vector events.
+  * `byte_size` - The cumulative in-memory byte size of all events sent.
 * Metrics
   * MUST increment the `sent_events_total` counter by the defined value with the
     defined properties as metric tags.
   * MUST increment the `sent_event_bytes_total` counter by the event's byte size
     in JSON representation.
 * Logs
-  * MUST log a `{quantity} events sent.` message at the `trace` level with the
-    defined properties as structured data. It MUST NOT be rate limited.
+  * MUST log a `Events sent.` message at the `trace` level with the
+    defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### BytesSent
 
@@ -173,11 +173,11 @@ downstream target regardless if the transmission was successful or not.
     HTTP, this MUST be the host and path only, excluding the query string.
   * `file` - If relevant, the absolute path of the file.
 * Metrics
-  * MUST increment the `bytes_in_total` counter by the defined value with the
+  * MUST increment the `bytes_out_total` counter by the defined value with the
     defined properties as metric tags.
 * Logs
-  * MUST log a `{byte_size} bytes received.` message at the `trace` level with
-    the defined properties as structured data. It MUST NOT be rate limited.
+  * MUST log a `Bytes received.` message at the `trace` level with the
+    defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### Error
 
@@ -190,18 +190,20 @@ This specification does list a standard set of errors that components must
 implement since errors are specific to the component.
 
 * Properties
-  * `error` - The string representation of the error.
-  * `stage` - The stage at which the error occured. MUST be one of `receiving`,
-    `processing`, `sending`.
+  * `error` - The specifics of the error condition, such as system error code, etc.
+  * `stage` - The stage at which the error occurred. MUST be one of
+    `receiving`, `processing`, or `sending`. This MAY be omitted from
+    being represented explicitly in the event data when the error may
+    only happen at one stage, but MUST be included in the emitted logs
+    and metrics as if it were present.
 * Metrics
   * MUST increment the `errors_total` counter by 1 with the defined properties
     as metric tags.
   * MUST increment the `discarded_events_total` counter by the number of Vector
     events discarded if the error resulted in discarding (dropping) events.
 * Logs
-  * MUST log a `{stage} error: {error}` message at the `error` level with the
-    defined properties as structured data. It SHOULD be rate limited to 10
-    seconds.
+  * MUST log a message at the `error` level with the defined properties
+    as key-value pairs. It SHOULD be rate limited to 10 seconds.
 
 [high user experience expectations]: https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
 [Pull request #8383]: https://github.com/timberio/vector/pull/8383/

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -54,7 +54,7 @@ transforms, and sinks).
 
 #### `address`
 
-When a component binds to an address, it should expose an `address` option that
+When a component binds to an address, it SHOULD expose an `address` option that
 takes a `string` representing a single address.
 
 #### `endpoint(s)`
@@ -80,7 +80,7 @@ meaningful performance improvements as a result of this strategy.
 
 Vector implements an event driven pattern ([RFC 2064]) for internal
 instrumentation. This section lists all required and optional events that a
-component MUST emit. It is expected that components will emit custom events
+component must emit. It is expected that components will emit custom events
 beyond those listed here that reflect component specific behavior.
 
 There is leeway in the implementation of these events:
@@ -93,7 +93,7 @@ There is leeway in the implementation of these events:
 * Components MAY emit events for batches of Vector events for performance
   reasons, but the resulting telemetry state MUST be equivalent to emitting
   individual events. For example, emitting the `EventsReceived` event for 10
-  events MUST increment the `events_in_total` by 10.
+  events MUST increment the `events_in_total` counter by 10.
 
 #### BytesReceived
 
@@ -110,8 +110,8 @@ from the upstream source and before the creation of a Vector event.
       delimiter.
   * `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.)
-  * `address` - If relevant, the bound address that the bytes were received
-    from. For HTTP, this MUST be the host and path only, excluding the query
+  * `address` - If relevant, the local address that the bytes were received
+    on. For HTTP, this MUST be the host and path only, excluding the query
     string.
   * `path` - If relevant, the HTTP path, excluding query strings.
   * `socket` - If relevant, the socket number that bytes were received from.

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -110,16 +110,10 @@ from the upstream source and before the creation of a Vector event.
       delimiter.
   * `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.)
-  * `address` - If relevant, the local address that the bytes were received
-    on. For HTTP, this MUST be the host and path only, excluding the query
-    string.
   * `path` - If relevant, the HTTP path, excluding query strings.
   * `socket` - If relevant, the socket number that bytes were received from.
-  * `remote_address` - If relevant, the remote IP address of the upstream
-    client.
-  * `file` - If relevant, the absolute path of the file.
 * Metrics
-  * MUST increment the `received_bytes_total` counter by the defined value with
+  * MUST increment the `bytes_in_total` counter by the defined value with
     the defined properties as metric tags.
 * Logs
   * MUST log a `{byte_size} bytes received.` message at the `trace` level with

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -201,7 +201,7 @@ implement since errors are specific to the component.
 * Metrics
   * MUST increment the `errors_total` counter by 1 with the defined properties
     as metric tags.
-  * MUST increment the `events_discarded_total` counter by the number of Vector
+  * MUST increment the `discarded_events_total` counter by the number of Vector
     events discarded if the error resulted in discarding (dropping) events.
 * Logs
   * MUST log a `{stage} error: {error}` message at the `error` level with the

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -43,11 +43,12 @@ component MUST emit.
 There is leeway in the implementation of these events:
 
 * Events MAY be augmented with additional component-specific context. For
-  example, the `socket` source adds `mode` attribute as additional context.
-* The naming of the event MAY be component specific. For example,
-  `SocketEventReceived` since the `socket` source adds additional context.
+  example, the `socket` source adds a `mode` attribute as additional context.
+* The naming of the events MAY deviate to satisfy implementation. For example,
+  the `socket` source may rename the `EventRecevied` event to
+  `SocketEventReceived` to add additional socket specific context.
 * Components MAY emit events for batches of Vector events for performance
-  reasons, but the resulting metrics state MUST be equivalent to emitting
+  reasons, but the resulting telemetry state MUST be equivalent to emitting
   individual events. For example, emitting the `EventsReceived` event for 10
   events MUST increment the `events_in_total` by 10.
 
@@ -71,7 +72,7 @@ creating a Vector event.
 
 * Metrics
    * MUST increment the `events_in_total` counter by 1.
-   * SHOULD increment the `event_bytes_in_total` counter by the event's byte
+   * MUST increment the `event_bytes_in_total` counter by the event's byte
      size in JSON representation.
 * Logging
    * MUST log a `Event received.` message at the `trace` level with no rate

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -126,7 +126,7 @@ or receiving one or more Vector events.
 
 * Properties
   * `count` - The count of Vector events.
-  * `byte_size` - The cumulative byte size of all events in JSON representation.
+  * `byte_size` - The cumulative in-memory byte size of all events received.
 * Metrics
   * MUST increment the `received_events_total` counter by the defined `quantity`
     property with the other properties as metric tags.

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -60,7 +60,8 @@ takes a `string` representing a single address.
 #### `endpoint(s)`
 
 When a component sends data to a downstream target, it should expose an
-`endpoint(s)` option that takes a `string` representing one or more endpoints
+`endpoint(s)` option that takes a `string` representing one or more comma
+separated endpoints.
 
 ## Instrumentation
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -131,7 +131,7 @@ from the upstream source and before the creation of a Vector event.
 or receiving one or more Vector events.
 
 * Properties
-  * `quantity` - The quantity of Vector events.
+  * `count` - The count of Vector events.
   * `byte_size` - The cumulative byte size of all events in JSON representation.
 * Metrics
   * MUST increment the `received_events_total` counter by the defined `quantity`

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -1,0 +1,65 @@
+# Component Specification
+
+This document specifies Vector Component behavior (source, transforms, and
+sinks) for the development of Vector.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119].
+
+<!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
+
+1. [Introduction](#introduction)
+1. [How to read this document](#how-to-read-this-document)
+1. [Instrumentation](#instrumentation)
+   1. [Events](#events)
+      1. [EventRecevied](#eventrecevied)
+
+<!-- /MarkdownTOC -->
+
+## Introduction
+
+Vector is a highly flexible observability data pipeline due to its directed
+acyclic graph processing model. Each node in the graph is a Vector Component,
+and in order to meet our [high user experience expectations] each Component must
+adhere to a common set of behaviorial rules. This document aims to clearly
+outline these rules to guide new component development and ongoing maintenance.
+
+## How to read this document
+
+This document is written from the broad perspective of a Vector component.
+Unless otherwise stated, a section applies to all component types, although,
+most sections will be broken along component lines for easy adherence.
+
+## Instrumentation
+
+### Events
+
+Vector implements an [event driven pattern ([RFC 2064]) for internal
+instrumentation. This section lists all required and optional events that a
+component MUST emit.
+
+There is leeway in the implementation of these events:
+
+* Events MAY be augmented with additional component-specific context. For
+  example, the `socket` source adds `mode` attribute as additional context.
+* The naming of the event MAY be component specific. For example,
+  `SocketEventReceived` since the `socket` source adds additional context.
+
+#### EventRecevied
+
+ALL components MUST emit an `EventReceived` event immediately after receiving
+a Vector event with the following telemetry:
+
+* Metrics
+   * MUST increment the `events_in_total` counter by 1.
+   * SHOULD increment the `bytes_in_total` counter by the total number of bytes.
+      * For sources, the total bytes coming off the wire.
+      * For everything else, the event's JSON byte size representation.
+* Logging
+   * MUST log a `Received one event.` message at the `trace` level with no rate
+     limiting.
+
+[high user experience expectations]: https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
+[RFC 2064]: https://github.com/timberio/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
+[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -59,9 +59,10 @@ takes a `string` representing a single address.
 
 #### `endpoint(s)`
 
-When a component sends data to a downstream target, it should expose an
-`endpoint(s)` option that takes a `string` representing one or more comma
-separated endpoints.
+When a component sends data to a downstream target, it MUST expose
+either an `endpoint` option that takes a `string` representing a single
+endpoint, or an `endpoints` option that takes an array of strings
+representing multiple endpoints.
 
 ## Instrumentation
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -119,7 +119,7 @@ from the upstream source and before the creation of a Vector event.
 * Metrics
   * MUST increment the `received_bytes_total` counter by the defined value with
     the defined properties as metric tags.
-* Logging
+* Logs
   * MUST log a `{byte_size} bytes received.` message at the `trace` level with
     the defined properties as structured data. It MUST NOT be rate limited.
 
@@ -136,7 +136,7 @@ or receiving one or more Vector events.
     property with the other properties as metric tags.
   * MUST increment the `received_event_bytes_total` counter by the defined
     `byte_size` property with the other properties as metric tags.
-* Logging
+* Logs
   * MUST log a `{quantity} events received.` message at the `trace` level with
     the defined properties as structured data. It MUST NOT be rate limited.
 
@@ -154,7 +154,7 @@ as encoding.
     defined properties as metric tags.
   * MUST increment the `sent_event_bytes_total` counter by the event's byte size
     in JSON representation.
-* Logging
+* Logs
   * MUST log a `{quantity} events sent.` message at the `trace` level with the
     defined properties as structured data. It MUST NOT be rate limited.
 
@@ -179,7 +179,7 @@ downstream target regardless if the transmission was successful or not.
 * Metrics
   * MUST increment the `bytes_in_total` counter by the defined value with the
     defined properties as metric tags.
-* Logging
+* Logs
   * MUST log a `{byte_size} bytes received.` message at the `trace` level with
     the defined properties as structured data. It MUST NOT be rate limited.
 
@@ -202,6 +202,10 @@ implement since errors are specific to the component.
     as metric tags.
   * MUST increment the `events_discarded_total` counter by the number of Vector
     events discarded if the error resulted in discarding (dropping) events.
+* Logs
+  * MUST log a `{stage} error: {error}` message at the `error` level with the
+    defined properties as structured data. It SHOULD be rate limited to 10
+    seconds.
 
 [high user experience expectations]: https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
 [Pull request #8383]: https://github.com/timberio/vector/pull/8383/

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -37,10 +37,10 @@ outline these rules to guide new component development and ongoing maintenance.
 
 ## Scope
 
-This specification addresses direct component concerns
-
-TODO: limit this document to direct component-level code and not supporting
-infrastructure.
+This specification addresses _direct_ component development and does not cover
+aspects that components inherit "for free". For example, this specification does
+not cover gloal context, such as `component_id`, that all components receive in
+their telemetry by nature of being a Vector compoent.
 
 ## How to read this document
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -186,7 +186,7 @@ named with an `Error` suffix. For example, the `socket` source emits a
 `SocketReceiveError` representing any error that occurs while receiving data off
 of the socket.
 
-This specification does list a standard set of errors that components must
+This specification does not list a standard set of errors that components must
 implement since errors are specific to the component.
 
 * Properties

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -59,9 +59,9 @@ takes a `string` representing a single address.
 
 #### `endpoint(s)`
 
-When a component sends data to a downstream target, it MUST expose
-either an `endpoint` option that takes a `string` representing a single
-endpoint, or an `endpoints` option that takes an array of strings
+When a component makes a connection to a downstream target, it MUST
+expose either an `endpoint` option that takes a `string` representing a
+single endpoint, or an `endpoints` option that takes an array of strings
 representing multiple endpoints.
 
 ## Instrumentation
@@ -110,7 +110,7 @@ from the upstream source and before the creation of a Vector event.
       delimiter.
   * `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.)
-  * `path` - If relevant, the HTTP path, excluding query strings.
+  * `http_path` - If relevant, the HTTP path, excluding query strings.
   * `socket` - If relevant, the socket number that bytes were received from.
 * Metrics
   * MUST increment the `received_bytes_total` counter by the defined value with


### PR DESCRIPTION
Closes #8728
Closes #8709

This introduces the beginnings of a Vector component specification. The immediate need for this is to drive improvements around Vector's internal instrumentation. Issues like #8839, #8710, #8709, and #8693 all expose inconsistencies in Vector's internal instrumentation that presents problems for future work based on this data. 