### PR TITLE
fix(css website): Typography Fixes

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -30,6 +30,17 @@
   }
 }
 
+.hover\:underline {
+  border-bottom: 1px solid transparent;
+}
+
+@variants hover {
+  .underline {
+    text-decoration: none;
+    border-bottom: 1px solid #f44af5;
+  }
+}
+
 [x-cloak] {
   display: none !important;
 }

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -198,7 +198,7 @@ cli: {
 
 				Example:
 
-				```
+				```shell
 				vector graph --config /etc/vector/vector.toml | dot -Tsvg > graph.svg
 				```
 

--- a/website/layouts/partials/banner.html
+++ b/website/layouts/partials/banner.html
@@ -11,7 +11,7 @@
           Vector is joining Datadog!
         </span>
         <span class="block sm:ml-2 sm:inline-block">
-          <a href="/blog/datadog-acquisition" class="text-black font-semibold underline"> Learn more <span aria-hidden="true">&rarr;</span></a>
+          <a href="/blog/datadog-acquisition" class="text-black font-semibold"> Learn more <span aria-hidden="true">&rarr;</span></a>
         </span>
       </p>
     </div>

--- a/website/layouts/partials/home/community.html
+++ b/website/layouts/partials/home/community.html
@@ -37,7 +37,7 @@
 </div>
 
 {{ define "community-button" }}
-<div class="flex items-center space-x-1.5 text-md lg:text-lg">
+<div class="prose flex items-center space-x-1.5 text-md lg:text-lg">
   <ion-icon name="logo-{{ .Params.icon }}" class="text-{{ .Params.color }}{{ with .Params.dark }} dark:text-{{ . }}{{ end }}"></ion-icon>
 
   <a href="{{ .URL }}" class="hover:underline text-gray-400 tracking-tight" target="_blank">

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -73,6 +73,12 @@ module.exports = {
                 margin: 0
               }
             },
+            'ul > li::before': {
+              'background-color': theme('colors.gray.700'),
+            },
+            'ol > li::before': {
+              color: theme('colors.gray.700'),
+            },
             // Spacing between certain shortcode combinations
             '.admonition + .tabs, .svg + .admonition, .highlight + p': {
               'margin-top': '1rem',
@@ -114,8 +120,18 @@ module.exports = {
               }
             },
             color: theme('colors.gray.200'),
-            'p, h1, h2, h3, h4, h5, h6': {
+            'p, h1, h2, h3, h4, h5, h6, li': {
               color: theme('colors.gray.100')
+            },
+            'ul > li': {
+              '&:before': {
+                'background-color': theme('colors.gray.100')
+              }
+            },
+            'ol > li': {
+              '&:before': {
+                color: theme('colors.gray.100')
+              }
             },
             'a, a code, a code:not([class^="language-"])': {
                 color: theme('colors.primary', 'currentColor'),
@@ -136,6 +152,15 @@ module.exports = {
             strong: {
               color: theme('colors.gray.100'),
             },
+          }
+        },
+        sm: {
+          css: {
+            'ul > li >, ol > li >': {
+              '*:first-child, *:last-child': {
+                margin: 0
+              }
+            }
           }
         }
       }),

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -70,7 +70,8 @@ module.exports = {
             },
             'ul > li >': {
               '*:first-child, *:last-child': {
-                margin: 0              }
+                margin: 0
+              }
             },
             // Spacing between certain shortcode combinations
             '.admonition + .tabs, .svg + .admonition, .highlight + p': {

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -68,7 +68,7 @@ module.exports = {
             'a code': {
               'color': 'inherit'
             },
-            'ul > li >': {
+            'ul > li >, ol > li >': {
               '*:first-child, *:last-child': {
                 margin: 0
               }

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -68,6 +68,10 @@ module.exports = {
             'a code': {
               'color': 'inherit'
             },
+            'ul > li >': {
+              '*:first-child, *:last-child': {
+                margin: 0              }
+            },
             // Spacing between certain shortcode combinations
             '.admonition + .tabs, .svg + .admonition, .highlight + p': {
               'margin-top': '1rem',


### PR DESCRIPTION
## What does this PR do?
- Updates `hover:underline` class to use border-bottom
- Updates homepage community section links (2) for visual consistency
- Updates `li` behavior when containing elements such as `code` or `a` as a first or last child

## Pages to checkout in the preview:
Homepage
- https://deploy-preview-8860--vector-project.netlify.app/

`li` with links / code blocks
- https://deploy-preview-8860--vector-project.netlify.app/docs/setup/installation/platforms/docker/
- https://deploy-preview-8860--vector-project.netlify.app/highlights/2021-07-21-0-16-upgrade-guide/#vector_source_sink
- https://deploy-preview-8860--vector-project.netlify.app/docs/administration/validating/
- https://deploy-preview-8860--vector-project.netlify.app/docs/reference/cli/ (bullets at bottom)