### PR TITLE
fix(external docs): Specify syntax for code block

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/vector-installer.md
+++ b/website/content/en/docs/setup/installation/package-managers/vector-installer.md
@@ -5,7 +5,7 @@ short: Vector installer
 
 The Vector installer enables you to install Vector using a platform-agnostic installation script:
 
-```
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | sh
 ```
 


### PR DESCRIPTION
As you can see on [this page](https://vector.dev/docs/setup/installation/package-managers/vector-installer), when you don't specify a language for a code block it comes out looking a bit funny. Just a small nit.