### PR TITLE
chore(dev): Separate out `check-style` check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,6 +354,8 @@ jobs:
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Make slim-builds
         run: make slim-builds
+      - name: Check style
+        run: make check-style
       - name: Check code format || needs.changes.outputs.source == 'true'
         if: needs.changes.outputs.source == 'true'
         run: make check-fmt

--- a/scripts/check-fmt.sh
+++ b/scripts/check-fmt.sh
@@ -10,5 +10,4 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 
-scripts/check-style.sh
 cargo fmt -- --check

--- a/website/content/en/docs/setup/installation/package-managers/helm.md
+++ b/website/content/en/docs/setup/installation/package-managers/helm.md
@@ -148,7 +148,7 @@ helm upgrade vector vector/vector-aggregator \
 To uninstall the Vector helm chart:
 
 ```shell
-helm uninstall vector --namespace vector 
+helm uninstall vector --namespace vector
 ```
 
 ## Management
@@ -160,5 +160,5 @@ helm uninstall vector --namespace vector
 [Agent]: /docs/setup/deployment/roles/#agent
 [sources]: /docs/reference/configuration/sources/
 [sinks]: /docs/reference/configuration/sinks/
-[Aggregator]: /docs/setup/deployment/roles/#aggregator 
+[Aggregator]: /docs/setup/deployment/roles/#aggregator
 [transform]: /docs/reference/configuration/transforms/


### PR DESCRIPTION
Was previously gated to run only on Rust source changes, but this check
seems light enough to just always run it since it applies to all files.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
