### PR TITLE
docs(socket source, socket sink): Document send/receive buffers

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -368,15 +368,19 @@ components: sinks: [Name=string]: {
 		}
 
 		if features.send != _|_ {
-			if features.send.send_buffer_size != _|_ {
+			if features.send.send_buffer_bytes != _|_ {
 				send_buffer_bytes: {
 					common:      false
 					description: "Configures the send buffer size using the `SO_SNDBUF` option on the socket."
 					required:    false
 					type: uint: {
+						default: null
 						examples: [65536]
+						unit: "bytes"
 					}
-					relevant_when: features.send.send_buffer_bytes.relevant_when
+					if features.send.send_buffer_bytes.relevant_when != _|_ {
+						relevant_when: features.send.send_buffer_bytes.relevant_when
+					}
 				}
 			}
 

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -113,15 +113,19 @@ components: sources: [Name=string]: {
 		}
 
 		if features.receive != _|_ {
-			if features.receive.receive_buffer_size != _|_ {
-				send_buffer_bytes: {
+			if features.receive.receive_buffer_bytes != _|_ {
+				receive_buffer_bytes: {
 					common:      false
 					description: "Configures the receive buffer size using the `SO_RCVBUF` option on the socket."
 					required:    false
 					type: uint: {
+						default: null
 						examples: [65536]
+						unit: "bytes"
 					}
-					relevant_when: features.receive.receive_buffer_bytes.relevant_when
+					if features.receive.receive_buffer_bytes.relevant_when != _|_ {
+						relevant_when: features.receive.receive_buffer_bytes.relevant_when
+					}
 				}
 			}
 


### PR DESCRIPTION
The cue was a bit malformed so it wasn't rendering these options.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
