### PR TITLE
chore(deps): Unpin evmap from fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,9 +1993,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evmap"
 version = "10.0.2"
-source = "git+https://github.com/lukesteensen/evmap.git?rev=45ba973c22715a68c5e99efad4b072421f7ad40b#45ba973c22715a68c5e99efad4b072421f7ad40b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3ea06a83f97d3dc2eb06e51e7a729b418f0717a5558a5c870e3d5156dc558d"
 dependencies = [
- "bytes 1.1.0",
  "hashbag",
  "slab",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ derivative = { version = "2.2.0", default-features = false }
 dirs-next = { version = "2.0.0", default-features = false, optional = true }
 dyn-clone = { version = "1.0.4", default-features = false }
 encoding_rs = { version = "0.8.28", features = ["serde"] }
-evmap = { git = "https://github.com/lukesteensen/evmap.git", rev = "45ba973c22715a68c5e99efad4b072421f7ad40b", default-features = false, features = ["bytes"], optional = true }
+evmap = { version = "10.0.2", default-features = false, optional = true }
 exitcode = { version = "1.1.2", default-features = false }
 flate2 = { version = "1.0.20", default-features = false }
 getset = { version = "0.1.1", default-features = false }


### PR DESCRIPTION
This required aliasing `Bytes` in the `aws_ec2_metadata` transform
because `Bytes` no longer saisfies `ShallowCopy` (and the `bytes`
feature of `evmap` was removed) as of
https://github.com/jonhoo/evmap/commit/416ccef

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
