### PR TITLE
fix(css website): github icon should have hover effect in dark mode.

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -290,5 +290,5 @@
 }
 
 footer ion-icon[name="logo-github"]:hover {
-  @apply text-gray-500
+  @apply dark:text-gray-500
 }

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -288,3 +288,7 @@
   padding-bottom: 1px;
   width: 20px;
 }
+
+footer ion-icon[name="logo-github"]:hover {
+  @apply text-gray-500
+}

--- a/website/layouts/partials/social-buttons.html
+++ b/website/layouts/partials/social-buttons.html
@@ -7,7 +7,7 @@
   <span class="sr-only">
     {{ .Name }} icon and link
   </span>
-  <span class="{{ with .Params.dark }}dark:text-{{ . }}{{ end }} text-{{ $iconColor }} hover:text-{{ $hoverColor }}">
+  <span class="{{ with .Params.dark }}dark:text-{{ . }} dark:hover:text-{{ $hoverColor }}{{ end }} text-{{ $iconColor }} hover:text-{{ $hoverColor }}">
     <ion-icon name="logo-{{ .Params.icon }}"></ion-icon>
   </span>
 </a>


### PR DESCRIPTION
Testing:
Github icon in the header should be gray on hover in both dark and light modes.   Tested in Chrome, FF & Safari.