### PR TITLE
enhancement(blackhole sink)!: print on interval instead of after X events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ scripts/package-lock.json
 target
 node_modules
 tests/data/wasm/*/target
+heaptrack.*
+massif.*

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -8,14 +8,24 @@ use crate::{
 use async_trait::async_trait;
 use futures::{future, stream::BoxStream, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
-use tokio::time::sleep_until;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use tokio::{
+    select,
+    sync::watch,
+    time::{interval, sleep_until},
+};
 use vector_core::event::Event;
 use vector_core::ByteSizeOf;
 
 pub struct BlackholeSink {
-    total_events: usize,
-    total_raw_bytes: usize,
+    total_events: Arc<AtomicUsize>,
+    total_raw_bytes: Arc<AtomicUsize>,
     config: BlackholeConfig,
     acker: Acker,
     last: Option<Instant>,
@@ -25,14 +35,14 @@ pub struct BlackholeSink {
 #[serde(deny_unknown_fields, default)]
 #[derivative(Default)]
 pub struct BlackholeConfig {
-    #[derivative(Default(value = "1000"))]
-    #[serde(default = "default_print_amount")]
-    pub print_amount: usize,
+    #[derivative(Default(value = "1"))]
+    #[serde(default = "default_print_interval_secs")]
+    pub print_interval_secs: u64,
     pub rate: Option<usize>,
 }
 
-fn default_print_amount() -> usize {
-    1_000
+fn default_print_interval_secs() -> u64 {
+    1
 }
 
 inventory::submit! {
@@ -71,8 +81,8 @@ impl BlackholeSink {
     pub fn new(config: BlackholeConfig, acker: Acker) -> Self {
         BlackholeSink {
             config,
-            total_events: 0,
-            total_raw_bytes: 0,
+            total_events: Arc::new(AtomicUsize::new(0)),
+            total_raw_bytes: Arc::new(AtomicUsize::new(0)),
             acker,
             last: None,
         }
@@ -82,7 +92,35 @@ impl BlackholeSink {
 #[async_trait]
 impl StreamSink for BlackholeSink {
     async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let mut chunks = input.chunks(self.config.print_amount);
+        // Spin up a task that does the periodic reporting.  This is decoupled from the main sink so
+        // that rate limiting support can be added more simply without having to interleave it with
+        // the printing.
+        let total_events = Arc::clone(&self.total_events);
+        let total_raw_bytes = Arc::clone(&self.total_raw_bytes);
+        let interval_dur = Duration::from_secs(self.config.print_interval_secs);
+        let (shutdown, mut tripwire) = watch::channel(());
+
+        tokio::spawn(async move {
+            let mut print_interval = interval(interval_dur);
+            loop {
+                select! {
+                    _ = print_interval.tick() => {
+                        info!({
+                            events = total_events.load(Ordering::Relaxed),
+                            raw_bytes_collected = total_raw_bytes.load(Ordering::Relaxed),
+                        }, "Total events collected");
+                    },
+                    _ = tripwire.changed() => break,
+                }
+            }
+
+            info!({
+                events = total_events.load(Ordering::Relaxed),
+                raw_bytes_collected = total_raw_bytes.load(Ordering::Relaxed)
+            }, "Total events collected");
+        });
+
+        let mut chunks = input.ready_chunks(1024);
         while let Some(events) = chunks.next().await {
             if let Some(rate) = self.config.rate {
                 let factor: f32 = 1.0 / rate as f32;
@@ -94,20 +132,21 @@ impl StreamSink for BlackholeSink {
 
             let message_len = events.size_of();
 
-            self.total_events += events.len();
-            self.total_raw_bytes += message_len;
+            let _ = self.total_events.fetch_add(events.len(), Ordering::AcqRel);
+            let _ = self
+                .total_raw_bytes
+                .fetch_add(message_len, Ordering::AcqRel);
 
             emit!(BlackholeEventReceived {
                 byte_size: message_len
             });
 
-            info!({
-                events = self.total_events,
-                raw_bytes_collected = self.total_raw_bytes
-            }, "Total events collected");
-
             self.acker.ack(events.len());
         }
+
+        // Notify the reporting task to shutdown.
+        let _ = shutdown.send(());
+
         Ok(())
     }
 }
@@ -125,7 +164,7 @@ mod tests {
     #[tokio::test]
     async fn blackhole() {
         let config = BlackholeConfig {
-            print_amount: 10,
+            print_interval_secs: 10,
             rate: None,
         };
         let mut sink = BlackholeSink::new(config, Acker::Null);

--- a/src/topology/test/transient_state.rs
+++ b/src/topology/test/transient_state.rs
@@ -78,7 +78,7 @@ async fn closed_source() {
         "out1",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -86,7 +86,7 @@ async fn closed_source() {
         "out2",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -106,7 +106,7 @@ async fn closed_source() {
         "out1",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -141,7 +141,7 @@ async fn remove_sink() {
         "out1",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -149,7 +149,7 @@ async fn remove_sink() {
         "out2",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -168,7 +168,7 @@ async fn remove_sink() {
         "out1",
         &["trans"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -206,7 +206,7 @@ async fn remove_transform() {
         "out1",
         &["trans1"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -214,7 +214,7 @@ async fn remove_transform() {
         "out2",
         &["trans2"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );
@@ -233,7 +233,7 @@ async fn remove_transform() {
         "out1",
         &["trans1"],
         BlackholeConfig {
-            print_amount: 1000,
+            print_interval_secs: 10,
             rate: None,
         },
     );

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -510,7 +510,6 @@ mod tests {
                       # General
                       type = "blackhole"
                       inputs = ["processed_events_total_batch_source"]
-                      print_amount = 100000
                 "#;
 
                 let topology = from_str_config(conf).await;
@@ -560,7 +559,6 @@ mod tests {
                       # General
                       type = "blackhole"
                       inputs = ["events_out_total_batch_source"]
-                      print_amount = 100000
                 "#;
 
             let topology = from_str_config(conf).await;
@@ -611,7 +609,6 @@ mod tests {
                       # General
                       type = "blackhole"
                       inputs = ["processed_bytes_total_batch_source"]
-                      print_amount = 100000
                 "#;
 
                 let topology = from_str_config(conf).await;
@@ -654,7 +651,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["component_added_source_1"]
-                  print_amount = 100000
             "#;
 
             let mut topology = from_str_config(conf).await;
@@ -707,7 +703,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["component_added_source_1", "component_added_source_2"]
-                  print_amount = 100000
             "#;
 
             let c = config::load_from_str(conf, Some(Format::Toml)).unwrap();
@@ -744,7 +739,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["component_removed_source_1", "component_removed_source_2"]
-                  print_amount = 100000
             "#;
 
             let mut topology = from_str_config(conf).await;
@@ -792,7 +786,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["component_removed_source_1"]
-                  print_amount = 100000
             "#;
 
             let c = config::load_from_str(conf, Some(Format::Toml)).unwrap();
@@ -822,7 +815,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["error_gen"]
-                  print_amount = 100000
             "#;
 
             let topology = from_str_config(conf).await;
@@ -877,7 +869,6 @@ mod tests {
                   # General
                   type = "blackhole"
                   inputs = ["error_gen"]
-                  print_amount = 100000
             "#;
 
             let topology = from_str_config(conf).await;
@@ -946,7 +937,6 @@ mod tests {
                 [sinks.out]
                   type = "blackhole"
                   inputs = ["file"]
-                  print_amount = 100000
             "#,
                 checkpoints.path().to_str().unwrap(),
                 path
@@ -993,7 +983,6 @@ mod tests {
                 [sinks.out]
                   type = "blackhole"
                   inputs = ["gen1"]
-                  print_amount = 100000
             "#;
 
             let topology = from_str_config(&conf).await;
@@ -1049,7 +1038,6 @@ mod tests {
                 [sinks.out]
                   type = "blackhole"
                   inputs = ["gen1", "gen2", "gen3", "gen4"]
-                  print_amount = 100000
             "#;
 
             let topology = from_str_config(&conf).await;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -54,7 +54,6 @@ data_dir = "${{VECTOR_DATA_DIR}}"
 [sinks.out]
     inputs = ["in"]
     type = "blackhole"
-    print_amount = 10000
 "#,
         source
     )

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -68,7 +68,6 @@ data_dir = "${{VECTOR_DATA_DIR}}"
 [sinks.out]
     inputs = ["in"]
     type = "blackhole"
-    print_amount = 10000
 "#,
         source
     )

--- a/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
@@ -1,0 +1,29 @@
+---
+date: "2021-10-05"
+title: "0.17 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.17.0"
+authors: ["tobz"]
+pr_numbers: []
+release: "0.17.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.17.0 release includes one **breaking change**:
+
+1. [Blackhole sink configuration changes](#blackhole)
+
+We cover it below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Blackhole sink configuration changes {#blackhole}
+
+We've updated the blackhole sink to print its statistics summary on an interval, rather than after a
+specific number of events.  This provides a consistent reporting experience regardless of the number
+of events coming into the sink, including when _no_ events are coming in.
+
+The configuration field `print_amount` has been removed, and replaced with `print_interval_secs`.
+Additionally, `print_interval_secs` defaults to `1 second`, which has the additional benefit of
+providing a "events per second" indicator out-of-the-box.

--- a/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
@@ -26,4 +26,4 @@ of events coming into the sink, including when _no_ events are coming in.
 
 The configuration field `print_amount` has been removed, and replaced with `print_interval_secs`.
 Additionally, `print_interval_secs` defaults to `1 second`, which has the additional benefit of
-providing a "events per second" indicator out-of-the-box.
+providing a very basic "events per second" indicator out-of-the-box.

--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -40,15 +40,15 @@ components: sinks: blackhole: {
 	}
 
 	configuration: {
-		print_amount: {
+		print_interval_secs: {
 			common:      false
-			description: "The number of events that must be received in order to print a summary of activity."
+			description: "The number of seconds between reporting a summary of activity."
 			required:    false
 			warnings: []
 			type: uint: {
-				default: 1000
-				examples: [1000]
-				unit: null
+				default: 1
+				examples: [10]
+				unit: "seconds"
 			}
 		}
 		rate: {


### PR DESCRIPTION
This PR changes the behavior of the `blackhole` sink so that it prints out its statistics on a configurable interval (defaults to `10s`) instead of printing every N events.  This provides a more even reporting cadence regardless of the load.

We've also slightly tweaked the sink so that it uses `StreamExt::ready_chunks` instead of `chunks`, which ensures responsiveness when the input stream is slow.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>