### PR TITLE
chore(tests): Reenable Humio integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ ifeq ($(AUTOSPAWN), true)
 	@scripts/setup_integration_env.sh humio start
 	sleep 10 # Many services are very slow... Give them a sec..
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features humio-integration-tests --lib "::humio::.*::integration_tests::"
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features humio-integration-tests --lib ::humio::
 ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh humio stop
 endif


### PR DESCRIPTION
Unfortunately, the Humio integration tests haven't been run due to overly restrictive filters in place. Technically, the new filter is too loose, but we currently do so in the other integration tests as well.

The tests are failing locally for me, I'm still investigating how to fix them.