### PR TITLE
enhancement(config): Add path to error events during config load

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -264,10 +264,10 @@ fn open_config(path: &Path) -> Option<File> {
         Ok(f) => Some(f),
         Err(error) => {
             if let std::io::ErrorKind::NotFound = error.kind() {
-                error!(message = "Config file not found in path.", path = ?path);
+                error!(message = "Config file not found in path.", ?path);
                 None
             } else {
-                error!(message = "Error opening config file.", %error);
+                error!(message = "Error opening config file.", %error, ?path);
                 None
             }
         }


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #8987

```shell
~/C/g/t/vector on  master [!] is 📦 v0.17.0 via 🦀 v1.54.0
❯ target/debug/vector -c /tmp/test.yaml
Sep 01 12:31:36.917  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info" enable_datadog_tracing=false
Sep 01 12:31:36.920  INFO vector::app: Loading configs. paths=["/tmp/test.yaml"]
Sep 01 12:31:36.920 ERROR vector::config::loading: Error opening config file. error=Permission denied (os error 13) path="/tmp/test.yaml"
Sep 01 12:31:36.920 ERROR vector::cli: Configuration error. error=Config file not found in path: "/tmp/test.yaml".

~/C/g/t/vector on  master [!] is 📦 v0.17.0 via 🦀 v1.54.0
❯ target/debug/vector -C /tmp/
Sep 01 12:31:40.642  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info" enable_datadog_tracing=false
Sep 01 12:31:40.645  INFO vector::app: Loading configs. paths=["/tmp"]
Sep 01 12:31:40.646 ERROR vector::config::loading: Error opening config file. error=Permission denied (os error 13) path="/tmp/fseventsd-uuid"
Sep 01 12:31:40.647 ERROR vector::config::loading: Error opening config file. error=Permission denied (os error 13) path="/tmp/I6FhHMdRDx1K"
Sep 01 12:31:40.648 ERROR vector::config::loading: Error opening config file. error=Permission denied (os error 13) path="/tmp/test.yaml"
Sep 01 12:31:40.650 ERROR vector::config::loading: Error opening config file. error=Operation not supported on socket (os error 102) path="/tmp/appgate.service.501.sock"
Sep 01 12:31:40.651 ERROR vector::config::loading: Error opening config file. error=Permission denied (os error 13) path="/tmp/dec8pnY558ZT"
Sep 01 12:31:40.691 ERROR vector::cli: Configuration error. error=unknown field `apiVersion` at line 1 column 11
Sep 01 12:31:40.691 ERROR vector::cli: Configuration error. error=unknown field `replicas` at line 1 column 9
```

Also noting the `-C` option appears to try and load all files, regardless of extension - which I don't believe is intended?

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
