### PR TITLE
fix(splunk_hec source): Do not blow up on trailing whitespace

### DIFF
--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -13,8 +13,8 @@ use chrono::{DateTime, TimeZone, Utc};
 use flate2::read::MultiGzDecoder;
 use futures::{stream, FutureExt, SinkExt, StreamExt, TryFutureExt};
 use http::StatusCode;
-use serde::{de, Deserialize, Serialize};
-use serde_json::{de::IoRead, json, Deserializer, Value as JsonValue};
+use serde::{Deserialize, Serialize};
+use serde_json::{de::Read as JsonRead, json, Deserializer, Value as JsonValue};
 use snafu::Snafu;
 use std::{
     collections::HashMap,
@@ -192,7 +192,12 @@ impl SplunkSource {
                             Box::new(body.reader())
                         };
 
-                        let events = stream::iter(EventIterator::new(reader, channel, remote, xff));
+                        let events = stream::iter(EventIterator::new(
+                            Deserializer::from_reader(reader).into_iter::<JsonValue>(),
+                            channel,
+                            remote,
+                            xff,
+                        ));
 
                         // `fn send_all` can be used once https://github.com/rust-lang/futures-rs/issues/2402
                         // is resolved.
@@ -326,9 +331,9 @@ impl SplunkSource {
 }
 /// Constructs one or more events from json-s coming from reader.
 /// If errors, it's done with input.
-struct EventIterator<R: Read> {
+struct EventIterator<'de, R: JsonRead<'de>> {
     /// Remaining request with JSON events
-    data: R,
+    deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
     /// Count of sent events
     events: usize,
     /// Optional channel from headers
@@ -339,15 +344,15 @@ struct EventIterator<R: Read> {
     extractors: [DefaultExtractor; 4],
 }
 
-impl<R: Read> EventIterator<R> {
+impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
     fn new(
-        data: R,
+        deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
         channel: Option<String>,
         remote: Option<SocketAddr>,
         remote_addr: Option<String>,
     ) -> Self {
         EventIterator {
-            data,
+            deserializer,
             events: 0,
             channel: channel.map(Value::from),
             time: Time::Now(Utc::now()),
@@ -367,20 +372,6 @@ impl<R: Read> EventIterator<R> {
                 DefaultExtractor::new("source", SOURCE),
                 DefaultExtractor::new("sourcetype", SOURCETYPE),
             ],
-        }
-    }
-
-    /// As serde_json::from_reader, but doesn't require that all data has to be consumed,
-    /// nor that it has to exist.
-    fn from_reader_take<T>(&mut self) -> Result<Option<T>, serde_json::Error>
-    where
-        T: de::DeserializeOwned,
-    {
-        use serde_json::de::Read;
-        let mut reader = IoRead::new(&mut self.data);
-        match reader.peek()? {
-            None => Ok(None),
-            Some(_) => Deserialize::deserialize(&mut Deserializer::new(reader)).map(Some),
         }
     }
 
@@ -486,20 +477,21 @@ impl<R: Read> EventIterator<R> {
     }
 }
 
-impl<R: Read> Iterator for EventIterator<R> {
+impl<'de, R: JsonRead<'de>> Iterator for EventIterator<'de, R> {
     type Item = Result<Event, Rejection>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.from_reader_take::<JsonValue>() {
-            Ok(Some(json)) => Some(self.build_event(json)),
-            Ok(None) => {
+        match self.deserializer.next() {
+            Some(Ok(json)) => Some(self.build_event(json)),
+            None => {
                 if self.events == 0 {
                     Some(Err(ApiError::NoData.into()))
                 } else {
                     None
                 }
             }
-            Err(error) => {
+            Some(Err(error)) => {
+                dbg!(&error);
                 emit!(SplunkHecRequestBodyInvalid {
                     error: error.into()
                 });
@@ -1260,6 +1252,27 @@ mod tests {
 
         assert_eq!(
             400,
+            post(address, "services/collector/event", message).await
+        );
+
+        let event = collect_n(source, 1).await.remove(0);
+        assert_eq!(event.as_log()[log_schema().message_key()], "first".into());
+        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert_eq!(
+            event.as_log()[log_schema().source_type_key()],
+            "splunk_hec".into()
+        );
+    }
+
+    #[tokio::test]
+    async fn whitespace() {
+        trace_init();
+
+        let message = r#" {"event":"first"} "#;
+        let (source, address) = source().await;
+
+        assert_eq!(
+            200,
             post(address, "services/collector/event", message).await
         );
 

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1264,12 +1264,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn whitespace() {
+    async fn handles_newlines() {
         trace_init();
 
         let message = r#"
-        {"event":"first"}
+{"event":"first"}
         "#;
+        let (source, address) = source().await;
+
+        assert_eq!(
+            200,
+            post(address, "services/collector/event", message).await
+        );
+
+        let event = collect_n(source, 1).await.remove(0);
+        assert_eq!(event.as_log()[log_schema().message_key()], "first".into());
+        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert_eq!(
+            event.as_log()[log_schema().source_type_key()],
+            "splunk_hec".into()
+        );
+    }
+
+    #[tokio::test]
+    async fn handles_spaces() {
+        trace_init();
+
+        let message = r#" {"event":"first"} "#;
         let (source, address) = source().await;
 
         assert_eq!(

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1267,7 +1267,9 @@ mod tests {
     async fn whitespace() {
         trace_init();
 
-        let message = r#" {"event":"first"} "#;
+        let message = r#"
+        {"event":"first"}
+        "#;
         let (source, address) = source().await;
 
         assert_eq!(

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -491,7 +491,6 @@ impl<'de, R: JsonRead<'de>> Iterator for EventIterator<'de, R> {
                 }
             }
             Some(Err(error)) => {
-                dbg!(&error);
                 emit!(SplunkHecRequestBodyInvalid {
                     error: error.into()
                 });


### PR DESCRIPTION
Fixes: #8459

This swaps out our custom stream reading in-lieu of just using
`serde_json::StreamDeserializer` which seems to handle skipping
whitespace just fine.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
