### PR TITLE
chore(architecture): add per-batch timeout support to Batcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zstd",
  "zstd-safe",
 ]
@@ -662,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ae17cabbc8a38a1e3e4c1a6a664e9a09672dc14d0896fa8d865d3a5a446b07"
+
+[[package]]
 name = "bindgen"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,8 +829,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "thiserror",
- "tokio",
- "tokio-util",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
  "webpki-roots 0.21.1",
  "winapi 0.3.9",
@@ -889,7 +895,7 @@ dependencies = [
  "serde",
  "snafu",
  "tempdir",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-test",
  "tracing 0.1.26",
 ]
@@ -1117,7 +1123,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 1.1.0",
  "serde_json",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.26",
 ]
 
@@ -1165,7 +1171,7 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1274,7 +1280,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir",
 ]
 
@@ -2128,7 +2134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.26",
  "winapi 0.3.9",
 ]
@@ -2480,7 +2486,7 @@ dependencies = [
  "simpl",
  "smpl_jwt",
  "time 0.2.26",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2579,8 +2585,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.26",
 ]
 
@@ -2880,7 +2886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2916,7 +2922,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2 0.4.1",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service",
  "tracing 0.1.26",
  "want",
@@ -2935,7 +2941,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl",
  "tower-layer",
 ]
@@ -2952,7 +2958,7 @@ dependencies = [
  "http",
  "hyper",
  "openssl",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl",
  "tower-service",
 ]
@@ -2969,7 +2975,7 @@ dependencies = [
  "log",
  "rustls 0.19.0",
  "rustls-native-certs",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls",
  "webpki",
 ]
@@ -2982,7 +2988,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io-timeout",
 ]
 
@@ -2995,7 +3001,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-native-tls",
 ]
 
@@ -3009,7 +3015,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project 1.0.8",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3245,7 +3251,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde_json",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.26",
 ]
 
@@ -3275,7 +3281,7 @@ dependencies = [
  "once_cell",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3690,7 +3696,7 @@ dependencies = [
  "parking_lot",
  "quanta",
  "thiserror",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3894,9 +3900,9 @@ dependencies = [
  "strsim 0.10.0",
  "take_mut",
  "thiserror",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder 0.9.0",
@@ -4358,7 +4364,7 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "thiserror",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
 ]
 
@@ -4717,7 +4723,7 @@ checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
 dependencies = [
  "futures 0.3.17",
  "openssl",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl",
  "tokio-postgres",
 ]
@@ -5020,9 +5026,9 @@ dependencies = [
  "prost-derive",
  "rand 0.8.4",
  "regex",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -5283,7 +5289,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slab",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5328,9 +5334,9 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -5434,7 +5440,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-native-tls",
  "tokio-rustls",
  "url",
@@ -5554,7 +5560,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs",
 ]
 
@@ -5572,7 +5578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex 1.0.0",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
@@ -5669,7 +5675,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "sha2",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6514,7 +6520,7 @@ checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
 dependencies = [
  "futures-core",
  "pin-project 1.0.8",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6913,6 +6919,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.11.0"
+source = "git+https://github.com/tokio-rs/tokio#d0dd74a0583b3ed7c8c7f68a4279fe9709bbf158"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "tokio-io"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6930,7 +6945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6951,7 +6966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6963,7 +6978,7 @@ dependencies = [
  "futures 0.3.17",
  "openssl",
  "openssl-sys",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6985,8 +7000,8 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "socket2 0.4.1",
- "tokio",
- "tokio-util",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6996,7 +7011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.0",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki",
 ]
 
@@ -7008,8 +7023,8 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio",
- "tokio-util",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7021,7 +7036,7 @@ dependencies = [
  "async-stream",
  "bytes 1.1.0",
  "futures-core",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
 ]
 
@@ -7035,7 +7050,7 @@ dependencies = [
  "log",
  "native-tls",
  "pin-project 1.0.8",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-native-tls",
  "tungstenite",
 ]
@@ -7052,7 +7067,21 @@ dependencies = [
  "log",
  "pin-project-lite",
  "slab",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "git+https://github.com/tokio-rs/tokio#d0dd74a0583b3ed7c8c7f68a4279fe9709bbf158"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "slab",
+ "tokio 1.11.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -7085,10 +7114,10 @@ dependencies = [
  "pin-project 1.0.8",
  "prost",
  "prost-derive",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower",
  "tower-layer",
  "tower-service",
@@ -7120,9 +7149,9 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "slab",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer",
  "tower-service",
  "tracing 0.1.26",
@@ -7148,7 +7177,7 @@ checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
  "pin-project 1.0.8",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-test",
  "tower-layer",
  "tower-service",
@@ -7342,7 +7371,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -7362,7 +7391,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto",
 ]
 
@@ -7791,12 +7820,12 @@ dependencies = [
  "syslog",
  "syslog_loose",
  "tempfile",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-openssl",
  "tokio-postgres",
  "tokio-stream",
  "tokio-test",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml",
  "tonic",
  "tonic-build",
@@ -7844,7 +7873,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
  "tokio-tungstenite",
  "url",
@@ -7859,6 +7888,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "atomig",
+ "bimap",
  "buffers",
  "bytes 1.1.0",
  "chrono",
@@ -7895,9 +7925,10 @@ dependencies = [
  "serde_json",
  "shared",
  "snafu",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
  "tokio-test",
+ "tokio-util 0.6.7 (git+https://github.com/tokio-rs/tokio)",
  "toml",
  "tracing 0.1.26",
  "tracing-core 0.1.19",
@@ -8143,10 +8174,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio",
+ "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service",
  "tracing 0.1.26",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,12 +662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ae17cabbc8a38a1e3e4c1a6a664e9a09672dc14d0896fa8d865d3a5a446b07"
-
-[[package]]
 name = "bindgen"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7865,7 +7859,6 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "atomig",
- "bimap",
  "buffers",
  "bytes 1.1.0",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "zstd",
  "zstd-safe",
 ]
@@ -829,8 +829,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "thiserror",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tokio-util",
  "url",
  "webpki-roots 0.21.1",
  "winapi 0.3.9",
@@ -895,7 +895,7 @@ dependencies = [
  "serde",
  "snafu",
  "tempdir",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-test",
  "tracing 0.1.26",
 ]
@@ -1123,7 +1123,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 1.1.0",
  "serde_json",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "tracing 0.1.26",
 ]
 
@@ -1171,7 +1171,7 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -1280,7 +1280,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "walkdir",
 ]
 
@@ -2134,7 +2134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tracing 0.1.26",
  "winapi 0.3.9",
 ]
@@ -2486,7 +2486,7 @@ dependencies = [
  "simpl",
  "smpl_jwt",
  "time 0.2.26",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -2585,8 +2585,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tokio-util",
  "tracing 0.1.26",
 ]
 
@@ -2886,7 +2886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -2922,7 +2922,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2 0.4.1",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tower-service",
  "tracing 0.1.26",
  "want",
@@ -2941,7 +2941,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-openssl",
  "tower-layer",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
  "http",
  "hyper",
  "openssl",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-openssl",
  "tower-service",
 ]
@@ -2975,7 +2975,7 @@ dependencies = [
  "log",
  "rustls 0.19.0",
  "rustls-native-certs",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -2988,7 +2988,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-io-timeout",
 ]
 
@@ -3001,7 +3001,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -3015,7 +3015,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project 1.0.8",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde_json",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tracing 0.1.26",
 ]
 
@@ -3281,7 +3281,7 @@ dependencies = [
  "once_cell",
  "serde_json",
  "tempfile",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -3696,7 +3696,7 @@ dependencies = [
  "parking_lot",
  "quanta",
  "thiserror",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -3900,9 +3900,9 @@ dependencies = [
  "strsim 0.10.0",
  "take_mut",
  "thiserror",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-rustls",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder 0.9.0",
@@ -4364,7 +4364,7 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "thiserror",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -4723,7 +4723,7 @@ checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
 dependencies = [
  "futures 0.3.17",
  "openssl",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-openssl",
  "tokio-postgres",
 ]
@@ -5026,9 +5026,9 @@ dependencies = [
  "prost-derive",
  "rand 0.8.4",
  "regex",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "url",
 ]
 
@@ -5289,7 +5289,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slab",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -5334,9 +5334,9 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "url",
 ]
 
@@ -5440,7 +5440,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "url",
@@ -5560,7 +5560,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "xml-rs",
 ]
 
@@ -5578,7 +5578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex 1.0.0",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "zeroize",
 ]
 
@@ -5675,7 +5675,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "sha2",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -6520,7 +6520,7 @@ checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
 dependencies = [
  "futures-core",
  "pin-project 1.0.8",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -6919,15 +6919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.11.0"
-source = "git+https://github.com/tokio-rs/tokio#d0dd74a0583b3ed7c8c7f68a4279fe9709bbf158"
-dependencies = [
- "autocfg",
- "pin-project-lite",
-]
-
-[[package]]
 name = "tokio-io"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6945,7 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -6966,7 +6957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -6978,7 +6969,7 @@ dependencies = [
  "futures 0.3.17",
  "openssl",
  "openssl-sys",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
 ]
 
 [[package]]
@@ -7000,8 +6991,8 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "socket2 0.4.1",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7011,7 +7002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.0",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "webpki",
 ]
 
@@ -7023,8 +7014,8 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7036,7 +7027,7 @@ dependencies = [
  "async-stream",
  "bytes 1.1.0",
  "futures-core",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -7050,16 +7041,16 @@ dependencies = [
  "log",
  "native-tls",
  "pin-project 1.0.8",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-native-tls",
  "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -7067,21 +7058,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "slab",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.7"
-source = "git+https://github.com/tokio-rs/tokio#d0dd74a0583b3ed7c8c7f68a4279fe9709bbf158"
-dependencies = [
- "bytes 1.1.0",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio 1.11.0 (git+https://github.com/tokio-rs/tokio)",
+ "tokio",
 ]
 
 [[package]]
@@ -7114,10 +7091,10 @@ dependencies = [
  "pin-project 1.0.8",
  "prost",
  "prost-derive",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -7149,9 +7126,9 @@ dependencies = [
  "pin-project 1.0.8",
  "rand 0.8.4",
  "slab",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing 0.1.26",
@@ -7177,7 +7154,7 @@ checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
  "pin-project 1.0.8",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-test",
  "tower-layer",
  "tower-service",
@@ -7371,7 +7348,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "url",
 ]
 
@@ -7391,7 +7368,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "trust-dns-proto",
 ]
 
@@ -7820,12 +7797,12 @@ dependencies = [
  "syslog",
  "syslog_loose",
  "tempfile",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-openssl",
  "tokio-postgres",
  "tokio-stream",
  "tokio-test",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "toml",
  "tonic",
  "tonic-build",
@@ -7873,7 +7850,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "url",
@@ -7925,10 +7902,10 @@ dependencies = [
  "serde_json",
  "shared",
  "snafu",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
  "tokio-test",
- "tokio-util 0.6.7 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-util",
  "toml",
  "tracing 0.1.26",
  "tracing-core 0.1.19",
@@ -8174,10 +8151,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util",
  "tower-service",
  "tracing 0.1.26",
 ]

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -10,6 +10,7 @@ async-graphql = { version = "=2.6.4", default-features = false, optional = true 
 async-trait = { version = "0.1", default-features = false }
 atomig = { version = "0.3.1", features = ["derive", "serde"] }
 buffers = { path = "buffers", default-features = false }
+bimap = { version = "0.6.1", default-features = false, features = ["std"] }
 bytes = { version = "1.1.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 db-key = { version = "0.0.5", default-features = false, optional = true }
@@ -41,6 +42,9 @@ shared = { path = "../shared" }
 snafu = { version = "0.6.10", default-features = false }
 tokio = { version = "1.11.0", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, optional = true }
+# Need a release of tokio-util (0.6.8 or above) to pull in these
+# changes: https://github.com/tokio-rs/tokio/pull/4081
+tokio-util = { git = "https://github.com/tokio-rs/tokio", default-features = false, features = ["time"] }
 toml = { version = "0.5.8", default-features = false }
 tracing = { version = "0.1.26", default-features = false }
 tracing-core = { version = "0.1.19", default-features = false }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -42,9 +42,7 @@ shared = { path = "../shared" }
 snafu = { version = "0.6.10", default-features = false }
 tokio = { version = "1.11.0", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, optional = true }
-# Need a release of tokio-util (0.6.8 or above) to pull in these
-# changes: https://github.com/tokio-rs/tokio/pull/4081
-tokio-util = { git = "https://github.com/tokio-rs/tokio", default-features = false, features = ["time"] }
+tokio-util = { version = "0.6.8", default-features = false, features = ["time"] }
 toml = { version = "0.5.8", default-features = false }
 tracing = { version = "0.1.26", default-features = false }
 tracing-core = { version = "0.1.19", default-features = false }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -10,7 +10,6 @@ async-graphql = { version = "=2.6.4", default-features = false, optional = true 
 async-trait = { version = "0.1", default-features = false }
 atomig = { version = "0.3.1", features = ["derive", "serde"] }
 buffers = { path = "buffers", default-features = false }
-bimap = { version = "0.6.1", default-features = false, features = ["std"] }
 bytes = { version = "1.1.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 db-key = { version = "0.0.5", default-features = false, optional = true }

--- a/lib/vector-core/proptest-regressions/stream/batcher.txt
+++ b/lib/vector-core/proptest-regressions/stream/batcher.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b463511e1fcc53b651ebb65bc4a1daf47c63990834d3660b743d2c10041bf335 # shrinks to stream = [0], item_limit = 1, allocation_limit = 8, partitioner = TestPartitioner { key_space: 1 }, timer = TestTimer { responses: [] }
+cc c96fa781162747ea75278abe6880a787d44f609ede07e320de0fa79407ab515f # shrinks to stream = [0], item_limit = 1, allocation_limit = 8, partitioner = TestPartitioner { key_space: 1 }, timer = TestTimer { responses: [] }
+cc 513f69d33fc3a47bbf960cd6822c9c3fad156e871832fdc2a3ead2d240bb9fa6 # shrinks to stream = [0], item_limit = 1, allocation_limit = 8, partitioner = TestPartitioner { key_space: 1 }, timer = TestTimer { responses: [] }

--- a/lib/vector-core/src/partition.rs
+++ b/lib/vector-core/src/partition.rs
@@ -13,5 +13,5 @@ pub trait Partitioner {
     /// The resulting key should ideally be unique for an `Item` or arrived at
     /// in such a way that if two distinct `Item` instances partition to the
     /// same key they are mergable if put into the same collection by this key.
-    fn partition(&self, item: &Self::Item) -> Option<Self::Key>;
+    fn partition(&self, item: &Self::Item) -> Self::Key;
 }

--- a/lib/vector-core/src/stream/batcher.rs
+++ b/lib/vector-core/src/stream/batcher.rs
@@ -648,12 +648,6 @@ mod test {
         }
     }
 
-    // WIP: this currently won't run because we're pointed to a git checkout of tokio-util, which
-    // uses a path-based dependency on tokio; since we use versioned tokio, this creates a mismatch
-    // between the thread-local variables/globals that the timer code uses to find the current
-    // runtime, and as such, `DelayQueue` will never find the right runtime
-    //
-    // we need to get tokio-util 0.6.8 released
     #[tokio::test(start_paused = true)]
     async fn expiration_queue_impl_keyed_timer() {
         // Asserts that ExpirationQueue properly implements KeyedTimer. We are

--- a/lib/vector-core/src/time.rs
+++ b/lib/vector-core/src/time.rs
@@ -2,17 +2,32 @@
 
 use std::task::{Context, Poll};
 
-/// A trait for representing timers
+/// A trait for representing many timer by key
 ///
 /// Embedding time as a type into other types eases property testing and
 /// verification. As such, this simple time type encodes the notion of elapsed
-/// timing with reset.
-pub trait Timer {
+/// timing with reset. Multiple timers are tracked by key -- `K` -- and emitted
+/// as they elapse.
+pub trait KeyedTimer<K> {
+    /// Clear the KeyedTimer
+    ///
+    /// This function clears all keys from the timer. This function will be
+    /// empty afterward and if immediately called `poll_elapsed` will return
+    /// `Poll::Ready(None)`.
+    fn clear(&mut self);
+
+    /// Insert a `K` into the KeyedTimer
+    ///
+    /// This function adds a new key into the timer. If the key previously
+    /// existed for the same key the underlying key-timer is reset.
+    fn insert(&mut self, item_key: K);
+
     // For an example of how property testing can use this type see the
     // `stream::Batcher` property tests.
-    /// Whether the timer has elapsed or not.
+    /// Whether a key-timer has elapsed or not.
     ///
-    /// This function will return `Poll::Pending` if the timer has not yet
-    /// fired, `Poll::Ready(())` if it has.
-    fn poll_elapsed(&mut self, cx: &mut Context) -> Poll<()>;
+    /// This function will return `Poll::Ready(None)` if a key-timer has not yet
+    /// fired (or if the timer is empty), `Poll::Ready(Some(K))` if a key-timer
+    /// has.
+    fn poll_expired(&mut self, cx: &mut Context) -> Poll<Option<K>>;
 }


### PR DESCRIPTION
This PR primarily focuses on changing `vector_core::stream::batcher::Batcher` from a "flush all batches at the same time" to an a per-batch timeout model.  Instead of flushing all batches at the same exact time, which can lead to bursts of activity that apply backpressure to other components in a pipeline, we apply timeouts at the batch level.  This means that the timeout for a batch starts when the batch is created.  As batches are typically constructed due to partitioning of the output -- partitioning based on the value of a field in the event, for example -- they tend to be spread out over time.

Overall, this leads to per-batch timeouts being important for spreading out the load over time, and providing _consistent_ throughput/latency to pipelines.

Additionally, this PR also removes the constraint on `Partitioner` of returning an `Option<Self::Key>`, instead switching purely to `Self::Key`, which allows for partitioner implementations to decide whether or not they must support fallibility.