### PR TITLE
fix(config): error on duplicate inputs

### DIFF
--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,6 +1,5 @@
 use super::{builder::ConfigBuilder, validation, ComponentId, Config, ExpandType, TransformOuter};
-use indexmap::IndexMap;
-use std::collections::HashSet;
+use indexmap::{IndexMap, IndexSet};
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
@@ -104,7 +103,7 @@ fn expand_globs(config: &mut ConfigBuilder) {
         .keys()
         .chain(config.transforms.keys())
         .cloned()
-        .collect::<HashSet<ComponentId>>();
+        .collect::<IndexSet<ComponentId>>();
 
     for (id, transform) in config.transforms.iter_mut() {
         expand_globs_inner(&mut transform.inputs, id, &candidates);
@@ -134,7 +133,7 @@ impl InputMatcher {
 fn expand_globs_inner(
     inputs: &mut Vec<ComponentId>,
     id: &ComponentId,
-    candidates: &HashSet<ComponentId>,
+    candidates: &IndexSet<ComponentId>,
 ) {
     let raw_inputs = std::mem::take(inputs);
     for raw_input in raw_inputs {

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -139,10 +139,17 @@ fn expand_globs_inner(inputs: &mut Vec<ComponentId>, id: &ComponentId, candidate
                 warn!(message = "Invalid glob pattern for input.", component_id = %id, %error);
                 InputMatcher::String(raw_input.to_string())
             });
+        let mut matched = false;
         for input in candidates {
             if matcher.matches(&input.to_string()) && input != id {
+                matched = true;
                 inputs.push(input.clone())
             }
+        }
+        // If it didn't work as a glob pattern, leave it in the inputs as-is. This lets us give
+        // more accurate error messages about non-existent inputs.
+        if !matched {
+            inputs.push(raw_input)
         }
     }
 }

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,5 +1,6 @@
 use super::{builder::ConfigBuilder, validation, ComponentId, Config, ExpandType, TransformOuter};
 use indexmap::IndexMap;
+use std::collections::HashSet;
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
@@ -103,7 +104,7 @@ fn expand_globs(config: &mut ConfigBuilder) {
         .keys()
         .chain(config.transforms.keys())
         .cloned()
-        .collect::<Vec<ComponentId>>();
+        .collect::<HashSet<ComponentId>>();
 
     for (id, transform) in config.transforms.iter_mut() {
         expand_globs_inner(&mut transform.inputs, id, &candidates);
@@ -130,7 +131,11 @@ impl InputMatcher {
     }
 }
 
-fn expand_globs_inner(inputs: &mut Vec<ComponentId>, id: &ComponentId, candidates: &[ComponentId]) {
+fn expand_globs_inner(
+    inputs: &mut Vec<ComponentId>,
+    id: &ComponentId,
+    candidates: &HashSet<ComponentId>,
+) {
     let raw_inputs = std::mem::take(inputs);
     for raw_input in raw_inputs {
         let matcher = glob::Pattern::new(&raw_input.to_string())

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -113,7 +113,7 @@ pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
             errors.push(format!(
                 "{} \"{}\" has input \"{}\" duplicated {} times",
                 capitalize(output_type),
-                id,
+                key,
                 dup,
                 count,
             ));

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -69,13 +69,26 @@ pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
             ));
         }
 
+        let mut frequencies = HashMap::new();
         for input in inputs {
+            let entry = frequencies.entry(input.clone()).or_insert(0usize);
+            *entry += 1;
             if !config.sources.contains_key(&input) && !config.transforms.contains_key(&input) {
                 errors.push(format!(
-                    "Input \"{}\" for {} \"{}\" doesn't exist.",
+                    "Input \"{}\" for {} \"{}\" doesn't match any components.",
                     input, output_type, id
                 ));
             }
+        }
+
+        for (dup, count) in frequencies.into_iter().filter(|(_name, count)| *count > 1) {
+            errors.push(format!(
+                "{} \"{}\" has input \"{}\" duplicated {} times",
+                capitalize(output_type),
+                id,
+                dup,
+                count,
+            ));
         }
     }
 


### PR DESCRIPTION
Closes #8920

This also cleans up a small error message regression from when we
implemented full input glob patterns. Instead of saying that an input
doesn't match any components, we would say that the component had no
inputs, which isn't quite right.

Signed-off-by: Luke Steensen <luke.steensen@gmail.com>
