### PR TITLE
enhancement(vrl): Add function for retrieving unique elements from an array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,6 +8023,7 @@ dependencies = [
  "grok",
  "hex",
  "hostname",
+ "indexmap",
  "lazy_static",
  "lookup",
  "md-5",

--- a/lib/vrl/compiler/src/value.rs
+++ b/lib/vrl/compiler/src/value.rs
@@ -18,7 +18,7 @@ pub use self::regex::Regex;
 pub use error::Error;
 pub use kind::Kind;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 pub enum Value {
     Bytes(Bytes),
     Integer(i64),
@@ -31,7 +31,7 @@ pub enum Value {
     Null,
 }
 
-// -----------------------------------------------------------------------------
+impl Eq for Value {}
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/lib/vrl/compiler/src/value/regex.rs
+++ b/lib/vrl/compiler/src/value/regex.rs
@@ -1,3 +1,4 @@
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 #[derive(Debug, Clone)]
@@ -6,6 +7,12 @@ pub struct Regex(regex::Regex);
 impl PartialEq for Regex {
     fn eq(&self, other: &Self) -> bool {
         self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Hash for Regex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state)
     }
 }
 

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -19,6 +19,7 @@ csv = { version = "1.1", optional = true }
 grok = { version = "1", optional = true }
 hex = { version = "0.4", optional = true }
 hostname = { version = "0.3", optional = true }
+indexmap = { version = "1.7.0", default-features = false, optional = true}
 lazy_static = { version = "1", optional = true }
 md-5 = { version = "0.9", optional = true }
 nom = { version = "6", optional = true }
@@ -155,6 +156,7 @@ default = [
     "to_timestamp",
     "to_unix_timestamp",
     "truncate",
+    "unique",
     "unnest",
     "upcase",
     "uuid_v4",
@@ -269,6 +271,7 @@ to_syslog_severity = []
 to_timestamp = ["shared/conversion", "chrono"]
 to_unix_timestamp = ["chrono"]
 truncate = []
+unique = ["indexmap"]
 unnest = []
 upcase = []
 uuid_v4 = ["bytes", "uuid"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -109,6 +109,7 @@ criterion_group!(
               to_timestamp,
               to_unix_timestamp,
               truncate,
+              unique,
               // TODO: Cannot pass a Path to bench_function
               //unnest
               // TODO: value is dynamic so we cannot assert equality
@@ -2063,6 +2064,24 @@ bench_function! {
             ellipsis: false,
         ],
         want: Ok("Super"),
+    }
+}
+
+bench_function! {
+    unique => vrl_stdlib::Unique;
+
+    default {
+        args: func_args![
+            value: value!(["bar", "foo", "baz", "foo"]),
+        ],
+        want: Ok(value!(["bar", "foo", "baz"])),
+    }
+
+    mixed_values {
+        args: func_args![
+            value: value!(["foo", [1,2,3], "123abc", 1, true, [1,2,3], "foo", true, 1]),
+        ],
+        want: Ok(value!(["foo", [1,2,3], "123abc", 1, true])),
     }
 }
 

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -224,6 +224,8 @@ mod to_timestamp;
 mod to_unix_timestamp;
 #[cfg(feature = "truncate")]
 mod truncate;
+#[cfg(feature = "unique")]
+mod unique;
 #[cfg(feature = "unnest")]
 mod unnest;
 #[cfg(feature = "upcase")]
@@ -451,6 +453,8 @@ pub use to_timestamp::ToTimestamp;
 pub use to_unix_timestamp::ToUnixTimestamp;
 #[cfg(feature = "truncate")]
 pub use truncate::Truncate;
+#[cfg(feature = "unique")]
+pub use unique::Unique;
 #[cfg(feature = "unnest")]
 pub use unnest::Unnest;
 #[cfg(feature = "upcase")]
@@ -686,6 +690,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ToUnixTimestamp),
         #[cfg(feature = "truncate")]
         Box::new(Truncate),
+        #[cfg(feature = "unique")]
+        Box::new(Unique),
         #[cfg(feature = "unnest")]
         Box::new(Unnest),
         #[cfg(feature = "upcase")]

--- a/lib/vrl/stdlib/src/unique.rs
+++ b/lib/vrl/stdlib/src/unique.rs
@@ -1,0 +1,78 @@
+use vrl::prelude::*;
+
+use indexmap::IndexSet;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Unique;
+
+impl Function for Unique {
+    fn identifier(&self) -> &'static str {
+        "unique"
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "unique",
+            source: r#"unique(["foo", "bar", "foo", "baz"])"#,
+            result: Ok(r#"["foo", "bar", "baz"]"#),
+        }]
+    }
+
+    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(UniqueFn { value }))
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::ARRAY,
+            required: true,
+        }]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UniqueFn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for UniqueFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?.try_array()?;
+
+        let set: IndexSet<_> = value.into_iter().collect();
+
+        Ok(set.into_iter().collect())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().array_mapped::<(), Kind>(map! { (): Kind::all() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        unique => Unique;
+
+        default {
+            args: func_args![
+                value: value!(["bar", "foo", "baz", "foo"]),
+            ],
+            want: Ok(value!(["bar", "foo", "baz"])),
+            tdef: TypeDef::new().array_mapped::<(), Kind>(map! { (): Kind::all() }),
+        }
+
+        mixed_values {
+            args: func_args![
+                value: value!(["foo", [1,2,3], "123abc", 1, true, [1,2,3], "foo", true, 1]),
+            ],
+            want: Ok(value!(["foo", [1,2,3], "123abc", 1, true])),
+            tdef: TypeDef::new().array_mapped::<(), Kind>(map! { (): Kind::all() }),
+        }
+    ];
+}

--- a/website/cue/reference/remap/functions/unique.cue
+++ b/website/cue/reference/remap/functions/unique.cue
@@ -1,0 +1,33 @@
+package metadata
+
+remap: functions: unique: {
+	category: "Enumerate"
+	description: #"""
+		Returns unique values for an array.
+
+		The first occurrence of each element is kept.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array to return unique elements from."
+			required:    true
+			type: ["array"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["array"]
+	}
+
+	examples: [
+		{
+			title: "Unique"
+			source: #"""
+				unique(["foo", "bar", "foo", "baz"])
+				"""#
+			return: ["foo", "bar", "baz"]
+		},
+	]
+}


### PR DESCRIPTION
Leveraging `indexmap::IndexSet` since we are already using that crate in
places. This ensures the unique elements are returned in order and does
not require the elements to have been sorted.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
