### PR TITLE
fix(external docs): Add template note to config params

### DIFF
--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -175,7 +175,7 @@ components: sinks: elasticsearch: {
 							Automatically routes events by deriving the data stream name using specific event fields with the `data_stream.type-data_stream.dataset-data_stream.namespace` format.
 
 							If enabled, the data_stream.* event fields will take precedence over the data_stream.type, data_stream.dataset, and data_stream.namespace settings, but will fall back to them if any of the fields are missing from the event.
-						"""
+							"""
 						required: false
 						warnings: []
 						type: bool: default: true

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -136,20 +136,7 @@
         </span>
 
         {{ with $v.examples }}
-        {{ $json := . | jsonify (dict "indent" "  ") }}
-        <div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
-          <span class="flex justify-between items-center">
-            <span class="text-sm">
-              Examples
-            </span>
-
-            {{ template "config-toggler" (dict "size" 4) }}
-          </span>
-
-          <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
-            {{ highlight $json "json" "" }}
-          </div>
-        </div>
+        {{ template "config-examples" (dict "examples" .) }}
         {{ end }}
         {{ end }}
         {{ end }}
@@ -165,20 +152,7 @@
       {{ end }}
 
       {{ with $v.examples }}
-      {{ $json := . | jsonify (dict "indent" "  ") }}
-      <div x-data="{ open: false }" class="mt-3.5 border rounded py-2 px-3 dark:border-gray-700">
-        <span class="flex justify-between items-center">
-          <span class="text-sm">
-            Examples
-          </span>
-
-          {{ template "config-toggler" (dict "size" 4) }}
-        </span>
-
-        <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
-          {{ highlight $json "json" "" }}
-        </div>
-      </div>
+      {{ template "config-examples" (dict "examples" .) }}
       {{ end }}
       {{ end }}
 
@@ -1432,6 +1406,23 @@
     {{ end }}
   </tbody>
 </table>
+{{ end }}
+
+{{ define "config-examples" }}
+{{ $json := .examples | jsonify (dict "indent" "  ") }}
+<div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
+  <span class="flex justify-between items-center">
+    <span class="text-sm">
+      Examples
+    </span>
+
+    {{ template "config-toggler" (dict "size" 4) }}
+  </span>
+
+  <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
+    {{ highlight $json "json" "" }}
+  </div>
+</div>
 {{ end }}
 
 {{ define "config-toggler" }}

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -49,6 +49,9 @@
       </div>
 
       {{ range $k, $v := $v.type }}
+
+
+
       {{ if eq $k "object" }} {{/* Object (with sub-configs) */}}
       <div class="mt-4 border dark:border-gray-700 rounded flex flex-col divide-y dark:divide-gray-700">
         {{ range $k, $v := $v.options }}
@@ -107,7 +110,6 @@
           </div>
           {{ end }}
 
-
           {{ if or $v.default (eq $v.default false) }}
           <div class="mt-4">
             {{ template "default" . }}
@@ -117,30 +119,7 @@
         </div>
         {{ end }}
       </div>
-      {{ end }}
-
-      {{/* Enum */}}
-      {{ with $v.enum }}
-      <div class="mt-3 border rounded py-2 px-3 dark:border-gray-700">
-        <span class="flex justify-between items-center">
-          <span class="font-semibold">
-            Enum options
-          </span>
-
-          <span class="flex items-center space-x-1">
-            {{ partial "badge.html" (dict "word" $k "color" "gray") }}
-            {{ partial "badge.html" (dict "word" $v.syntax "color" "gray") }}
-          </span>
-        </span>
-
-        <div class="mt-4 prose dark:prose-dark max-w-none">
-          {{ template "enum-options-table" . }}
-        </div>
-      </div>
-      {{ end }}
-
-      {{/* Array */}}
-      {{ if eq $k "array" }}
+      {{ else if eq $k "array" }} {{/* Array */}}
       {{ with $v.items }}
       <div class="mt-3 border rounded py-2 px-3 dark:border-gray-700">
         {{ range $k, $v := . }}
@@ -176,6 +155,51 @@
         {{ end }}
       </div>
       {{ end }}
+      {{ else }} {{/* Non-arrays/objects */}}
+      {{ if eq $v.syntax "template" }}
+      <div class="mt-4 text-sm">
+        <strong>Note</strong>: This parameter supports Vector's
+        <a href="/docs/reference/configuration/template-syntax">template syntax</a>, which enables you to use
+        dynamic per-event values.
+      </div>
+      {{ end }}
+
+      {{ with $v.examples }}
+      {{ $json := . | jsonify (dict "indent" "  ") }}
+      <div x-data="{ open: false }" class="mt-3.5 border rounded py-2 px-3 dark:border-gray-700">
+        <span class="flex justify-between items-center">
+          <span class="text-sm">
+            Examples
+          </span>
+
+          {{ template "config-toggler" (dict "size" 4) }}
+        </span>
+
+        <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
+          {{ highlight $json "json" "" }}
+        </div>
+      </div>
+      {{ end }}
+      {{ end }}
+
+      {{/* Enum */}}
+      {{ with $v.enum }}
+      <div class="mt-3 border rounded py-2 px-3 dark:border-gray-700">
+        <span class="flex justify-between items-center">
+          <span class="font-semibold">
+            Enum options
+          </span>
+
+          <span class="flex items-center space-x-1">
+            {{ partial "badge.html" (dict "word" $k "color" "gray") }}
+            {{ partial "badge.html" (dict "word" $v.syntax "color" "gray") }}
+          </span>
+        </span>
+
+        <div class="mt-4 prose dark:prose-dark max-w-none">
+          {{ template "enum-options-table" . }}
+        </div>
+      </div>
       {{ end }}
       {{ end }}
 


### PR DESCRIPTION
Fixes #9003 and #9030

It's nothing fancy but it presents the info we need to present. Example:

https://deploy-preview-9032--vector-project.netlify.app/docs/reference/configuration/sinks/elasticsearch/#index