### PR TITLE
fix(external docs): Fix rendering of config param examples

### DIFF
--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -136,7 +136,7 @@
         </span>
 
         {{ with $v.examples }}
-        {{ template "config-examples" (dict "examples" .) }}
+        {{ template "config-array-examples" (dict "examples" .) }}
         {{ end }}
         {{ end }}
         {{ end }}
@@ -1409,6 +1409,25 @@
 {{ end }}
 
 {{ define "config-examples" }}
+<div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
+  <span class="flex justify-between items-center">
+    <span class="text-sm">
+      Examples
+    </span>
+
+    {{ template "config-toggler" (dict "size" 4) }}
+  </span>
+
+  <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
+    {{ range .examples }}
+    {{ $json := . | jsonify (dict "indent" "  ") }}
+    {{ highlight $json "json" "" }}
+    {{ end }}
+  </div>
+</div>
+{{ end }}
+
+{{ define "config-array-examples" }}
 {{ $json := .examples | jsonify (dict "indent" "  ") }}
 <div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
   <span class="flex justify-between items-center">


### PR DESCRIPTION
PR #9032 fixed the missing config param examples but in such a way that it presented the example *as an array*, whereas what's needed is separately rendered examples for each.

As an example, [this config](https://vector.dev/docs/reference/configuration/sinks/elasticsearch/#index)'s examples are rendered as an array of strings, whereas each example string needs its own rendering. The fixed version of the same param:

https://deploy-preview-9033--vector-project.netlify.app/docs/reference/configuration/sinks/elasticsearch/#index