### PR TITLE
docs(sources): Remove utilization metric from sources

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1179,11 +1179,6 @@ components: {
 			}
 		}
 
-		telemetry: metrics: {
-			// Default metrics for each component
-			utilization: components.sources.internal_metrics.output.metrics.utilization
-		}
-
 		how_it_works: {
 			state: {
 				title: "State"

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -596,5 +596,6 @@ components: sinks: [Name=string]: {
 	telemetry: metrics: {
 		events_in_total:  components.sources.internal_metrics.output.metrics.events_in_total
 		events_out_total: components.sources.internal_metrics.output.metrics.events_out_total
+		utilization:      components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -13,5 +13,6 @@ components: transforms: [Name=string]: {
 	telemetry: metrics: {
 		events_in_total:  components.sources.internal_metrics.output.metrics.events_in_total
 		events_out_total: components.sources.internal_metrics.output.metrics.events_out_total
+		utilization:      components.sources.internal_metrics.output.metrics.utilization
 	}
 }


### PR DESCRIPTION
This only applies to transforms and sinks.


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->