### PR TITLE
docs(socket source): Fix references to `unix` to be to `unix_datagram` and `unix_stream`

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -225,7 +225,7 @@ _values: {
 	}
 }
 
-#Protocol: "http" | "tcp" | "udp" | "unix"
+#Protocol: "http" | "tcp" | "udp" | "unix" | "unix_datagram" | "unix_stream"
 
 #Service: {
 	// `description` describes the components with a single paragraph.

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -22,7 +22,7 @@ components: sources: socket: {
 				interface: socket: {
 					direction: "incoming"
 					port:      _port
-					protocols: ["tcp", "unix", "udp"]
+					protocols: ["tcp", "unix_datagram", "unix_stream", "udp"]
 					ssl: "optional"
 				}
 			}
@@ -111,7 +111,7 @@ components: sources: socket: {
 		}
 		path: {
 			description:   "The unix socket path. *This should be an absolute path*."
-			relevant_when: "mode = `unix`"
+			relevant_when: "mode = `unix_datagram` or `unix_stream`"
 			required:      true
 			warnings: []
 			type: string: {


### PR DESCRIPTION
The `unix` option was deprecated and replaced with these.

Closes: #9028



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->