### PR TITLE
chore(codecs): Implement `newline_delimited` framing

### DIFF
--- a/src/codecs/framers/character_delimited.rs
+++ b/src/codecs/framers/character_delimited.rs
@@ -54,8 +54,7 @@ impl CharacterDelimitedCodec {
 
     /// Creates a `CharacterDelimitedCodec` with a maximum frame length limit.
     ///
-    /// When more bytes than `max_length` have been read, all bytes will be
-    /// discarded until reaching the next delimiter.
+    /// Any frames longer than `max_length` bytes will be discarded entirely.
     pub const fn new_with_max_length(delimiter: char, max_length: usize) -> Self {
         CharacterDelimitedCodec {
             max_length,

--- a/src/codecs/framers/character_delimited.rs
+++ b/src/codecs/framers/character_delimited.rs
@@ -42,7 +42,7 @@ pub struct CharacterDelimitedCodec {
 }
 
 impl CharacterDelimitedCodec {
-    /// Returns a `CharacterDelimitedCodec` with the specified delimiter.
+    /// Creates a `CharacterDelimitedCodec` with the specified delimiter.
     pub const fn new(delimiter: char) -> Self {
         CharacterDelimitedCodec {
             delimiter,
@@ -52,7 +52,10 @@ impl CharacterDelimitedCodec {
         }
     }
 
-    /// Returns a `CharacterDelimitedCodec` with a maximum frame length limit.
+    /// Creates a `CharacterDelimitedCodec` with a maximum frame length limit.
+    ///
+    /// When more bytes than `max_length` have been read, all bytes will be
+    /// discarded until reaching the next delimiter.
     pub const fn new_with_max_length(delimiter: char, max_length: usize) -> Self {
         CharacterDelimitedCodec {
             max_length,

--- a/src/codecs/framers/mod.rs
+++ b/src/codecs/framers/mod.rs
@@ -2,9 +2,11 @@
 
 mod character_delimited;
 mod length_delimited;
+mod newline_delimited;
 
 pub use character_delimited::{CharacterDelimitedCodec, CharacterDelimitedDecoderConfig};
 pub use length_delimited::{LengthDelimitedCodec, LengthDelimitedDecoderConfig};
+pub use newline_delimited::{NewlineDelimitedCodec, NewlineDelimitedDecoderConfig};
 
 use crate::sources::util::TcpError;
 use ::bytes::Bytes;

--- a/src/codecs/framers/newline_delimited.rs
+++ b/src/codecs/framers/newline_delimited.rs
@@ -42,8 +42,7 @@ impl NewlineDelimitedCodec {
 
     /// Creates a `NewlineDelimitedCodec` with a maximum frame length limit.
     ///
-    /// When more bytes than `max_length` have been read, all bytes will be
-    /// discarded until reaching the next newline.
+    /// Any frames longer than `max_length` bytes will be discarded entirely.
     pub const fn new_with_max_length(max_length: usize) -> Self {
         Self(CharacterDelimitedCodec::new_with_max_length(
             '\n', max_length,

--- a/src/codecs/framers/newline_delimited.rs
+++ b/src/codecs/framers/newline_delimited.rs
@@ -1,0 +1,140 @@
+use crate::codecs::{BoxedFramer, BoxedFramingError, CharacterDelimitedCodec, FramingConfig};
+use bytes::{Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
+use tokio_util::codec::Decoder;
+
+/// Config used to build a `NewlineDelimitedCodec`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct NewlineDelimitedDecoderConfig {
+    /// The maximum length of the byte buffer.
+    ///
+    /// This length does *not* include the trailing delimiter.
+    max_length: Option<usize>,
+}
+
+impl NewlineDelimitedDecoderConfig {
+    /// Creates a new `NewlineDelimitedDecoderConfig`.
+    pub const fn new() -> Self {
+        Self { max_length: None }
+    }
+}
+
+#[typetag::serde(name = "newline_delimited")]
+impl FramingConfig for NewlineDelimitedDecoderConfig {
+    fn build(&self) -> crate::Result<BoxedFramer> {
+        Ok(Box::new(
+            self.max_length
+                .map(NewlineDelimitedCodec::new_with_max_length)
+                .unwrap_or_else(NewlineDelimitedCodec::new),
+        ))
+    }
+}
+
+/// A codec for handling bytes that are delimited by (a) newline(s).
+#[derive(Debug, Clone)]
+pub struct NewlineDelimitedCodec(CharacterDelimitedCodec);
+
+impl NewlineDelimitedCodec {
+    /// Creates a new `NewlineDelimitedCodec`.
+    pub const fn new() -> Self {
+        Self(CharacterDelimitedCodec::new('\n'))
+    }
+
+    /// Creates a `NewlineDelimitedCodec` with a maximum frame length limit.
+    ///
+    /// When more bytes than `max_length` have been read, all bytes will be
+    /// discarded until reaching the next newline.
+    pub const fn new_with_max_length(max_length: usize) -> Self {
+        Self(CharacterDelimitedCodec::new_with_max_length(
+            '\n', max_length,
+        ))
+    }
+}
+
+impl Default for NewlineDelimitedCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Decoder for NewlineDelimitedCodec {
+    type Item = Bytes;
+    type Error = BoxedFramingError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.0.decode(src)
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.0.decode_eof(src)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_bytes_with_newlines() {
+        let mut input = BytesMut::from("foo\nbar\nbaz");
+        let mut decoder = NewlineDelimitedCodec::new();
+
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "bar");
+        assert_eq!(decoder.decode(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn decode_bytes_with_newlines_trailing() {
+        let mut input = BytesMut::from("foo\nbar\nbaz\n");
+        let mut decoder = NewlineDelimitedCodec::new();
+
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "bar");
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "baz");
+        assert_eq!(decoder.decode(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn decode_bytes_with_newlines_and_max_length() {
+        let mut input = BytesMut::from("foo\nbarbara\nbaz\n");
+        let mut decoder = NewlineDelimitedCodec::new_with_max_length(3);
+
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode(&mut input).unwrap(), None);
+        assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "baz");
+        assert_eq!(decoder.decode(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn decode_eof_bytes_with_newlines() {
+        let mut input = BytesMut::from("foo\nbar\nbaz");
+        let mut decoder = NewlineDelimitedCodec::new();
+
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "bar");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "baz");
+    }
+
+    #[test]
+    fn decode_eof_bytes_with_newlines_trailing() {
+        let mut input = BytesMut::from("foo\nbar\nbaz\n");
+        let mut decoder = NewlineDelimitedCodec::new();
+
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "bar");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "baz");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn decode_eof_bytes_with_newlines_and_max_length() {
+        let mut input = BytesMut::from("foo\nbarbara\nbaz\n");
+        let mut decoder = NewlineDelimitedCodec::new_with_max_length(3);
+
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "foo");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
+        assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "baz");
+        assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
+    }
+}

--- a/src/codecs/mod.rs
+++ b/src/codecs/mod.rs
@@ -149,9 +149,7 @@ impl DecodingConfig {
             .framing
             .as_ref()
             .map(|config| config.build())
-            .unwrap_or_else(|| {
-                Err("Fallback to newline delimited framer is not implemented yet.".into())
-            })?;
+            .unwrap_or_else(|| NewlineDelimitedDecoderConfig::new().build())?;
 
         // Build the parser or use a plain bytes parser if not provided.
         let parser: BoxedParser = self


### PR DESCRIPTION
Part of #7463, has been split off from #8236.