### PR TITLE
chore(releasing): Run Windows builds on our CI runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,7 +189,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz"
 
   build-x86_64-pc-windows-msvc-packages:
-    runs-on: windows-2019
+    runs-on: [self-hosted, windows, x64, general]
     env:
       RUSTFLAGS: "-D warnings -Ctarget-feature=+crt-static"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           path: "./target/artifacts/vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin.tar.gz"
 
   build-x86_64-pc-windows-msvc-packages:
-    runs-on: windows-2019
+    runs-on: [self-hosted, windows, x64, general]
     env:
       RUSTFLAGS: "-D warnings -Ctarget-feature=+crt-static"
     steps:


### PR DESCRIPTION
We seem to be hitting memory pressure on GH's runners.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
