### PR TITLE
enhancement(aws_kinesis_firehose sink): Check batch configuration limits

### DIFF
--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -27,6 +27,11 @@ use std::{
 use tower::Service;
 use tracing_futures::Instrument;
 
+// AWS Kinesis Firehose API accepts payloads up to 4MB or 500 events
+// https://docs.aws.amazon.com/firehose/latest/dev/limits.html
+const MAX_PAYLOAD_SIZE: usize = 4_194_304_usize;
+const MAX_PAYLOAD_EVENTS: usize = 500_usize;
+
 #[derive(Clone)]
 pub struct KinesisFirehoseService {
     client: KinesisFirehoseClient,
@@ -72,6 +77,20 @@ impl GenerateConfig for KinesisFirehoseSinkConfig {
         )
         .unwrap()
     }
+}
+
+#[derive(Debug, PartialEq, Snafu)]
+enum BuildError {
+    #[snafu(display(
+        "Batch max size is too high. The value must be {} bytes or less",
+        MAX_PAYLOAD_SIZE
+    ))]
+    BatchMaxSize,
+    #[snafu(display(
+        "Batch max events is too high. The value must be {} or less",
+        MAX_PAYLOAD_EVENTS
+    ))]
+    BatchMaxEvents,
 }
 
 #[async_trait::async_trait]
@@ -136,11 +155,22 @@ impl KinesisFirehoseService {
         client: KinesisFirehoseClient,
         cx: SinkContext,
     ) -> crate::Result<impl Sink<Event, Error = ()>> {
+        let batch_config = config.batch.use_size_as_bytes()?;
+
+        if batch_config.max_bytes.unwrap_or_default() > MAX_PAYLOAD_SIZE {
+            return Err(Box::new(BuildError::BatchMaxSize));
+        }
+
+        if batch_config.max_events.unwrap_or_default() > MAX_PAYLOAD_EVENTS {
+            return Err(Box::new(BuildError::BatchMaxEvents));
+        }
+
         let batch = BatchSettings::default()
             .bytes(4_000_000)
             .events(500)
             .timeout(1)
-            .parse_config(config.batch)?;
+            .parse_config(batch_config)?;
+
         let request = config.request.unwrap_with(&TowerRequestConfig::default());
         let encoding = config.encoding.clone();
         let kinesis = KinesisFirehoseService { client, config };
@@ -257,6 +287,62 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<KinesisFirehoseSinkConfig>();
+    }
+
+    #[test]
+    fn check_batch_size() {
+        let config = KinesisFirehoseSinkConfig {
+            stream_name: String::from("test"),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
+            encoding: EncodingConfig::from(Encoding::Json),
+            compression: Compression::None,
+            batch: BatchConfig {
+                max_bytes: Some(MAX_PAYLOAD_SIZE + 1),
+                ..Default::default()
+            },
+            request: Default::default(),
+            assume_role: None,
+            auth: Default::default(),
+        };
+
+        let cx = SinkContext::new_test();
+
+        let client = config.create_client(&cx.proxy).unwrap();
+
+        let res = KinesisFirehoseService::new(config, client, cx);
+
+        assert_eq!(
+            res.err().and_then(|e| e.downcast::<BuildError>().ok()),
+            Some(Box::new(BuildError::BatchMaxSize))
+        );
+    }
+
+    #[test]
+    fn check_batch_events() {
+        let config = KinesisFirehoseSinkConfig {
+            stream_name: String::from("test"),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4566".into()),
+            encoding: EncodingConfig::from(Encoding::Json),
+            compression: Compression::None,
+            batch: BatchConfig {
+                max_events: Some(MAX_PAYLOAD_EVENTS + 1),
+                ..Default::default()
+            },
+            request: Default::default(),
+            assume_role: None,
+            auth: Default::default(),
+        };
+
+        let cx = SinkContext::new_test();
+
+        let client = config.create_client(&cx.proxy).unwrap();
+
+        let res = KinesisFirehoseService::new(config, client, cx);
+
+        assert_eq!(
+            res.err().and_then(|e| e.downcast::<BuildError>().ok()),
+            Some(Box::new(BuildError::BatchMaxEvents))
+        );
     }
 
     #[test]


### PR DESCRIPTION
The Firehose API has a limit of 4 MiB or 500 events per request.
Previously we were not enforcing this though so users would see failed
API requests instead.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->