### PR TITLE
fix(ci): Put collects back

### DIFF
--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -461,14 +461,16 @@ mod integration_tests {
         let hits = response["hits"]["hits"]
             .as_array()
             .expect("Elasticsearch response does not include hits->hits");
-        let mut input = input
+        #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/6909
+        let input = input
             .into_iter()
-            .map(|rec| serde_json::to_value(&rec.into_log()).unwrap());
+            .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
+            .collect::<Vec<_>>();
         for hit in hits {
             let hit = hit
                 .get("_source")
                 .expect("Elasticsearch hit missing _source");
-            assert!(input.any(|e| &e == hit));
+            assert!(input.contains(hit));
         }
     }
 

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -1491,9 +1491,12 @@ mod integration_tests {
             let hits = response["hits"]["hits"]
                 .as_array_mut()
                 .expect("Elasticsearch response does not include hits->hits");
-            let mut input = input
+            #[allow(clippy::needless_collect)]
+            // https://github.com/rust-lang/rust-clippy/issues/6909
+            let input = input
                 .into_iter()
-                .map(|rec| serde_json::to_value(&rec.into_log()).unwrap());
+                .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
+                .collect::<Vec<_>>();
 
             for hit in hits {
                 let hit = hit
@@ -1506,7 +1509,7 @@ mod integration_tests {
                     let timestamp = obj.remove(DATA_STREAM_TIMESTAMP_KEY).unwrap();
                     obj.insert(log_schema().timestamp_key().into(), timestamp);
                 }
-                assert!(input.any(|e| &e == hit));
+                assert!(input.contains(hit));
             }
         }
     }


### PR DESCRIPTION
This was changed to not collect and use Iter#any as part of the Rust
1.55 upgrade, but this turned out to be not correct since `input` is
used in a loop.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
