### PR TITLE
fix(aws service): more precise aws retry logic

### DIFF
--- a/src/rusoto/mod.rs
+++ b/src/rusoto/mod.rs
@@ -8,6 +8,8 @@ use http::{
     Method, Request, Response, StatusCode,
 };
 use hyper::body::{Body, HttpBody};
+use once_cell::sync::OnceCell;
+use regex::bytes::RegexSet;
 use rusoto_core::{
     request::{
         DispatchSignedRequest, DispatchSignedRequestFuture, HttpDispatchError, HttpResponse,
@@ -339,14 +341,48 @@ impl From<Option<SignedRequestPayload>> for RusotoBody {
     }
 }
 
+static RETRIABLE_CODES: OnceCell<RegexSet> = OnceCell::new();
+
 pub fn is_retriable_error<T>(error: &RusotoError<T>) -> bool {
     match error {
         RusotoError::HttpDispatch(_) => true,
-        RusotoError::Unknown(res)
-            if res.status.is_server_error()
-                || res.status == http::StatusCode::TOO_MANY_REQUESTS =>
-        {
-            true
+        RusotoError::Unknown(response) => {
+            // This header is a direct indication that we should retry the request. Eventually it'd
+            // be nice to actually schedule the retry after the given delay, but for now we just
+            // check that it contains a positive value.
+            if response
+                .headers
+                .get("x-amz-retry-after")
+                .and_then(|value| value.parse::<isize>().ok())
+                .filter(|duration| *duration > 0)
+                .is_some()
+            {
+                return true;
+            }
+
+            // Certain 400-level responses will contain an error code indicating that the request
+            // should be retried. Since we don't retry 400-level responses by default, we'll look
+            // for these specifically before falling back to more general heuristics. Because AWS
+            // services use a mix of XML and JSON response bodies and Rusoto doesn't give us
+            // a parsed representation, we resort to a simple string match.
+            //
+            // S3: RequestTimeout
+            // SQS: RequestExpired, ThrottlingException
+            // ECS: RequestExpired, ThrottlingException
+            // Kinesis: RequestExpired, ThrottlingException
+            // Cloudwatch: RequestExpired, ThrottlingException
+            //
+            // Now just look for those when it's a client_error
+            let re = RETRIABLE_CODES.get_or_init(|| {
+                RegexSet::new(&["RequestTimeout", "RequestExpired", "ThrottlingException"])
+                    .expect("invalid regex")
+            });
+            if response.status.is_client_error() && re.is_match(&response.body) {
+                return true;
+            }
+
+            response.status.is_server_error()
+                || response.status == http::StatusCode::TOO_MANY_REQUESTS
         }
         _ => false,
     }


### PR DESCRIPTION
Closes #9005

I can't say that this is exhaustively tested, but I went through the API docs and some official client implementations to try to dig out some general patterns that we should be able to rely on here.

The most questionable part is the simple string matching instead of actually parsing the body, but the unknown format and structure made that seem tricky. It feels unlikely these error codes would be present in a 400-level response but not be _the_ error code.

I'm also not terribly attached to the mechanics of the matching. Given that the body size could be potentially large, it seemed worthwhile to match in a single pass, hence the `RegexSet`. But that may not be true with the additional complexity of the `OnceCell` and the fact that these will only happen occasionally and alongside a far more expensive HTTP request. I did at least make sure not to use `lazy_static` for @blt 😄 