### PR TITLE
fix(aws_s3 sink): Fix batching parameters

### DIFF
--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -203,9 +203,9 @@ impl S3SinkConfig {
             .unwrap_or_else(|| DEFAULT_KEY_PREFIX.into())
             .try_into()?;
         let partitioner = KeyPartitioner::new(key_prefix);
-        let batch_size_bytes = NonZeroUsize::new(batch_settings.size.bytes)
-            .ok_or("batch, in bytes, max be greater than 0")?;
-        let batch_size_events = NonZeroUsize::new(batch_settings.size.events);
+        let batch_size_bytes = NonZeroUsize::new(batch_settings.size.bytes);
+        let batch_size_events = NonZeroUsize::new(batch_settings.size.events)
+            .ok_or("batch events must be greater than 0")?;
         let batch_timeout = batch_settings.timeout;
 
         // And now collect all of the S3-specific options and configuration knobs.

--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -51,8 +51,8 @@ pub struct S3Sink<S> {
     acker: Option<Acker>,
     service: Option<S>,
     partitioner: Option<KeyPartitioner>,
-    batch_size_bytes: NonZeroUsize,
-    batch_size_events: Option<NonZeroUsize>,
+    batch_size_bytes: Option<NonZeroUsize>,
+    batch_size_events: NonZeroUsize,
     batch_timeout: Duration,
     options: S3RequestOptions,
 }
@@ -62,8 +62,8 @@ impl<S> S3Sink<S> {
         cx: SinkContext,
         service: S,
         partitioner: KeyPartitioner,
-        batch_size_bytes: NonZeroUsize,
-        batch_size_events: Option<NonZeroUsize>,
+        batch_size_bytes: Option<NonZeroUsize>,
+        batch_size_events: NonZeroUsize,
         batch_timeout: Duration,
         options: S3RequestOptions,
     ) -> Self {
@@ -71,8 +71,8 @@ impl<S> S3Sink<S> {
             acker: Some(cx.acker()),
             service: Some(service),
             partitioner: Some(partitioner),
-            batch_size_bytes,
             batch_size_events,
+            batch_size_bytes,
             batch_timeout,
             options,
         }

--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -115,8 +115,8 @@ where
             input,
             partitioner,
             self.batch_timeout,
-            self.batch_size_bytes,
             self.batch_size_events,
+            self.batch_size_bytes,
         );
         pin!(batcher);
 


### PR DESCRIPTION
These were in the wrong order so the number of bytes was being used as
the number of events and vice-versa.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->