### PR TITLE
fix(ci): Overwrite wix install if exists

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -231,7 +231,7 @@ jobs:
           mkdir -p /c/wix
           cd /c/wix
           curl -sSfL https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip > wix-binaries.zip
-          unzip wix-binaries.zip
+          unzip -o wix-binaries.zip
           rm wix-binaries.zip
       - run: choco install llvm
       - name: "Build archive"


### PR DESCRIPTION
Since we moved these to self-hosted runners, wix may already be
installed so we should overwrite it.

I think this should be moved to the image build, but this should fix it
for now.

Failure:

```
Run mkdir -p /c/wix
Archive:  wix-binaries.zip
replace x86/burn.exe? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
Error: Process completed with exit code 1.
```

https://github.com/timberio/vector/runs/3577882554?check_suite_focus=true

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
