### PR TITLE
fix(config): only load valid config files

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -187,9 +187,9 @@ fn load_builder_from_paths(
                     for res in readdir {
                         match res {
                             Ok(direntry) => {
-                                if let Some(file) = open_config(&direntry.path()) {
-                                    // skip any unknown file formats
-                                    if let Ok(format) = Format::from_path(direntry.path()) {
+                                // skip any unknown file formats
+                                if let Ok(format) = Format::from_path(direntry.path()) {
+                                    if let Some(file) = open_config(&direntry.path()) {
                                         inputs.push((file, Some(format)));
                                     }
                                 }


### PR DESCRIPTION
Closes #8994 

This checks the config file has a valid extension (toml, yaml, json) before attempting to load it.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
